### PR TITLE
Fix unarchive integration test failure due to rpm error

### DIFF
--- a/test/integration/targets/unarchive/aliases
+++ b/test/integration/targets/unarchive/aliases
@@ -1,4 +1,3 @@
 needs/root
 shippable/posix/group2
 destructive
-unstable

--- a/test/integration/targets/unarchive/handlers/main.yml
+++ b/test/integration/targets/unarchive/handlers/main.yml
@@ -1,9 +1,9 @@
 - name: remove python TLS packages
-  yum:
+  pip:
     name:
-      - python-urllib3
-      - python2-ndg_httpsclient
+      - cryptography
+      - ndg_httpsclient
       - pyOpenSSL
-      - 'python-backports*'
-      - python-six
+      - six
+      - urllib3
     state: absent

--- a/test/integration/targets/unarchive/handlers/main.yml
+++ b/test/integration/targets/unarchive/handlers/main.yml
@@ -1,9 +1,0 @@
-- name: remove python TLS packages
-  pip:
-    name:
-      - cryptography
-      - ndg_httpsclient
-      - pyOpenSSL
-      - six
-      - urllib3
-    state: absent

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -634,10 +634,11 @@
   file: path={{remote_tmp_dir}}/test-unarchive-tar-gz state=directory
 
 - name: Install packages to make TLS connections work on CentOS 6
-  yum:
+  pip:
     name:
-      - python-urllib3
-      - python2-ndg_httpsclient
+      - urllib3==1.10.2
+      - ndg_httpsclient==0.4.4
+      - pyOpenSSL==16.2.0
     state: present
   when:
     - ansible_facts.distribution == 'CentOS'

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -643,7 +643,6 @@
   when:
     - ansible_facts.distribution == 'CentOS'
     - not ansible_facts.python.has_sslcontext
-  notify: remove python TLS packages
 
 - name: unarchive a tar from an URL
   unarchive:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Install and cleanup packages needed for modern TLS connections in Python 2.6 via `pip` rather than `yum`. This prevents test failures that could be introduced by other tests in the group installing `requests`, `urllib3`, etc. via `pip` since `rpm` does not like when other package managers modify its files.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/unarchive`