### PR TITLE
vcenter provider: don't bind container on <1024 port

### DIFF
--- a/test/lib/ansible_test/_internal/cloud/vcenter.py
+++ b/test/lib/ansible_test/_internal/cloud/vcenter.py
@@ -153,8 +153,7 @@ class VcenterProvider(CloudProvider):
             if not self.args.docker and not container_id:
                 # publish the simulator ports when not running inside docker
                 publish_ports = [
-                    '-p', '80:80',
-                    '-p', '443:443',
+                    '-p', '1443:443',
                     '-p', '8080:8080',
                     '-p', '8989:8989',
                     '-p', '5000:5000',  # control port for flask app in simulator
@@ -263,6 +262,10 @@ class VcenterEnvironment(CloudEnvironment):
                 vcenter_username='user',
                 vcenter_password='pass',
             )
+            # Shippable starts ansible-test from withing an existing container,
+            # and in this case, we don't have to change the vcenter port.
+            if not self.args.docker and not get_docker_container_id():
+                ansible_vars['vcenter_port'] = '1443'
 
         for key, value in ansible_vars.items():
             if key.endswith('_password'):
@@ -276,6 +279,7 @@ class VcenterEnvironment(CloudEnvironment):
                     'hostname': ansible_vars['vcenter_hostname'],
                     'username': ansible_vars['vcenter_username'],
                     'password': ansible_vars['vcenter_password'],
+                    'port': ansible_vars.get('vcenter_port', '443'),
                     'validate_certs': ansible_vars.get('vmware_validate_certs', 'no'),
                 },
             },


### PR DESCRIPTION
##### SUMMARY

Bind the govcsim service on port 1443, this way we don't need root privilege
to start the container. This allow us to use ansible-test with podman seamlessly.
The commit also avoid the mapping of port 80. We don't need it.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

test/lib/ansible_test/_internal/cloud/vcenter.py
vmware
<!--- Write the short name of the module, plugin, task or feature below -->
