### PR TITLE
Add ip protocol in Solaris/illumos ipadm_prop supported protocols

### DIFF
--- a/lib/ansible/modules/network/illumos/ipadm_prop.py
+++ b/lib/ansible/modules/network/illumos/ipadm_prop.py
@@ -88,7 +88,7 @@ value:
 from ansible.module_utils.basic import AnsibleModule
 
 
-SUPPORTED_PROTOCOLS = ['ipv4', 'ipv6', 'icmp', 'tcp', 'udp', 'sctp']
+SUPPORTED_PROTOCOLS = ['ip', 'ipv4', 'ipv6', 'icmp', 'tcp', 'udp', 'sctp']
 
 
 class Prop(object):


### PR DESCRIPTION
 case: ipadm show-prop -p _respond_to_echo_broadcast ip

##### SUMMARY
Add support of IP protocol in supported protocol which is needed in such following cases:
ipadm show-prop -p _respond_to_echo_broadcast ip

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ipadm_prop

