### PR TITLE
ansible-test: add ability to specify an alt docker binary

### DIFF
--- a/changelogs/fragments/ansible-test-docker-binary.yml
+++ b/changelogs/fragments/ansible-test-docker-binary.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test can now use an alternative ``docker`` binary with the ``--docker-binary`` optional parameter

--- a/test/lib/ansible_test/_internal/cli.py
+++ b/test/lib/ansible_test/_internal/cli.py
@@ -575,6 +575,8 @@ def parse_args():
                      metavar='MINUTES',
                      help='timeout for future ansible-test commands (0 clears)')
 
+    add_extra_docker_options(env)
+
     if argcomplete:
         argcomplete.autocomplete(parser, always_complete_options=False, validator=lambda i, k: True)
 
@@ -774,6 +776,10 @@ def add_extra_docker_options(parser, integration=True):
                         default=None,
                         help='set seccomp confinement for the test container: %(choices)s')
 
+    docker.add_argument('--docker-binary',
+                        default='docker',
+                        help='Docker command to use (e.g: podman, docker, )', type=str)
+
     if not integration:
         return
 
@@ -784,6 +790,11 @@ def add_extra_docker_options(parser, integration=True):
     # noinspection PyTypeChecker
     docker.add_argument('--docker-memory',
                         help='memory limit for docker in bytes', type=int)
+
+    docker.add_argument('--docker-binary',
+                        default='docker',
+                        help='Docker command to use (e.g: podman, docker, )', type=str)
+
 
 
 def complete_target(prefix, parsed_args, **_):

--- a/test/lib/ansible_test/_internal/cloud/acme.py
+++ b/test/lib/ansible_test/_internal/cloud/acme.py
@@ -47,6 +47,7 @@ class ACMEProvider(CloudProvider):
         else:
             self.image = 'quay.io/ansible/acme-test-container:1.9.0'
         self.container_name = ''
+        self.docker_binary = args.docker_binary
 
     def _wait_for_service(self, protocol, acme_host, port, local_part, name):
         """Wait for an endpoint to accept connections."""
@@ -74,7 +75,7 @@ class ACMEProvider(CloudProvider):
         :type targets: tuple[TestTarget]
         :type exclude: list[str]
         """
-        docker = find_executable('docker', required=False)
+        docker = find_executable(self.docker_binary, required=False)
 
         if docker:
             return

--- a/test/lib/ansible_test/_internal/cloud/cs.py
+++ b/test/lib/ansible_test/_internal/cloud/cs.py
@@ -55,6 +55,7 @@ class CsCloudProvider(CloudProvider):
         self.endpoint = ''
         self.host = ''
         self.port = 0
+        self.docker_binary = args.docker_binary
 
     def filter(self, targets, exclude):
         """Filter out the cloud tests when the necessary config and resources are not available.
@@ -64,7 +65,7 @@ class CsCloudProvider(CloudProvider):
         if os.path.isfile(self.config_static_path):
             return
 
-        docker = find_executable('docker', required=False)
+        docker = find_executable(self.docker_binary, required=False)
 
         if docker:
             return

--- a/test/lib/ansible_test/_internal/cloud/foreman.py
+++ b/test/lib/ansible_test/_internal/cloud/foreman.py
@@ -58,6 +58,7 @@ class ForemanProvider(CloudProvider):
 
         self.image = self.__container_from_env or self.DOCKER_IMAGE
         self.container_name = ''
+        self.docker_binary = args.docker_binary
 
     def filter(self, targets, exclude):
         """Filter out the tests with the necessary config and res unavailable.
@@ -65,8 +66,7 @@ class ForemanProvider(CloudProvider):
         :type targets: tuple[TestTarget]
         :type exclude: list[str]
         """
-        docker_cmd = 'docker'
-        docker = find_executable(docker_cmd, required=False)
+        docker = find_executable(args.docker_binary, required=False)
 
         if docker:
             return

--- a/test/lib/ansible_test/_internal/cloud/nios.py
+++ b/test/lib/ansible_test/_internal/cloud/nios.py
@@ -58,6 +58,7 @@ class NiosProvider(CloudProvider):
 
         self.image = self.__container_from_env or self.DOCKER_IMAGE
         self.container_name = ''
+        self.docker_binary = args.docker_binary
 
     def filter(self, targets, exclude):
         """Filter out the tests with the necessary config and res unavailable.
@@ -65,8 +66,7 @@ class NiosProvider(CloudProvider):
         :type targets: tuple[TestTarget]
         :type exclude: list[str]
         """
-        docker_cmd = 'docker'
-        docker = find_executable(docker_cmd, required=False)
+        docker = find_executable(self.docker_binary, required=False)
 
         if docker:
             return

--- a/test/lib/ansible_test/_internal/cloud/openshift.py
+++ b/test/lib/ansible_test/_internal/cloud/openshift.py
@@ -48,6 +48,7 @@ class OpenShiftCloudProvider(CloudProvider):
         # The image must be pinned to a specific version to guarantee CI passes with the version used.
         self.image = 'openshift/origin:v3.9.0'
         self.container_name = ''
+        self.docker_binary = args.docker_binary
 
     def filter(self, targets, exclude):
         """Filter out the cloud tests when the necessary config and resources are not available.
@@ -57,7 +58,7 @@ class OpenShiftCloudProvider(CloudProvider):
         if os.path.isfile(self.config_static_path):
             return
 
-        docker = find_executable('docker', required=False)
+        docker = find_executable(self.docker_binary, required=False)
 
         if docker:
             return

--- a/test/lib/ansible_test/_internal/cloud/vcenter.py
+++ b/test/lib/ansible_test/_internal/cloud/vcenter.py
@@ -56,6 +56,7 @@ class VcenterProvider(CloudProvider):
         self.insecure = False
         self.proxy = None
         self.platform = 'vcenter'
+        self.docker_binary = args.docker_binary
 
     def filter(self, targets, exclude):
         """Filter out the cloud tests when the necessary config and resources are not available.
@@ -63,7 +64,7 @@ class VcenterProvider(CloudProvider):
         :type exclude: list[str]
         """
         if self.vmware_test_platform == 'govcsim' or (self.vmware_test_platform == '' and not os.path.isfile(self.config_static_path)):
-            docker = find_executable('docker', required=False)
+            docker = find_executable(self.docker_binary, required=False)
 
             if docker:
                 return

--- a/test/lib/ansible_test/_internal/config.py
+++ b/test/lib/ansible_test/_internal/config.py
@@ -57,6 +57,7 @@ class EnvironmentConfig(CommonConfig):
         self.docker_keep_git = args.docker_keep_git if 'docker_keep_git' in args else False  # type: bool
         self.docker_seccomp = args.docker_seccomp if 'docker_seccomp' in args else None  # type: str
         self.docker_memory = args.docker_memory if 'docker_memory' in args else None
+        self.docker_binary = args.docker_binary if 'docker_binary' in args else None
 
         if self.docker_seccomp is None:
             self.docker_seccomp = get_docker_completion().get(self.docker_raw, {}).get('seccomp', 'default')

--- a/test/lib/ansible_test/_internal/delegation.py
+++ b/test/lib/ansible_test/_internal/delegation.py
@@ -389,7 +389,7 @@ def delegate_remote(args, exclude, require, integration_targets):
     else:
         use_httptester = args.httptester and any('needs/httptester/' in target.aliases for target in integration_targets)
 
-    if use_httptester and not docker_available():
+    if use_httptester and not docker_available(args):
         display.warning('Assuming --disable-httptester since `docker` is not available.')
         use_httptester = False
 

--- a/test/lib/ansible_test/_internal/docker_util.py
+++ b/test/lib/ansible_test/_internal/docker_util.py
@@ -25,11 +25,11 @@ from .config import (
 BUFFER_SIZE = 256 * 256
 
 
-def docker_available():
+def docker_available(args):
     """
     :rtype: bool
     """
-    return find_executable('docker', required=False)
+    return find_executable(args.docker_binary, required=False)
 
 
 def get_docker_container_id():
@@ -279,7 +279,7 @@ def docker_command(args, cmd, capture=False, stdin=None, stdout=None, always=Fal
     :rtype: str | None, str | None
     """
     env = docker_environment()
-    return run_command(args, ['docker'] + cmd, env=env, capture=capture, stdin=stdin, stdout=stdout, always=always)
+    return run_command(args, [args.docker_binary] + cmd, env=env, capture=capture, stdin=stdin, stdout=stdout, always=always)
 
 
 def docker_environment():

--- a/test/lib/ansible_test/_internal/env.py
+++ b/test/lib/ansible_test/_internal/env.py
@@ -69,6 +69,7 @@ class EnvConfig(CommonConfig):
         self.show = args.show
         self.dump = args.dump
         self.timeout = args.timeout
+        self.docker_binary = args.docker_binary
 
         if not self.show and not self.dump and self.timeout is None:
             # default to --show if no options were given
@@ -257,7 +258,7 @@ def get_docker_details(args):
     :type args: CommonConfig
     :rtype: dict[str, any]
     """
-    docker = find_executable('docker', required=False)
+    docker = find_executable(args.docker_binary, required=False)
     info = None
     version = None
 

--- a/test/lib/ansible_test/_internal/executor.py
+++ b/test/lib/ansible_test/_internal/executor.py
@@ -634,7 +634,7 @@ def command_windows_integration(args):
         # if running under Docker delegation, the httptester may have already been started
         docker_httptester = bool(os.environ.get("HTTPTESTER", False))
 
-        if use_httptester and not docker_available() and not docker_httptester:
+        if use_httptester and not docker_available(args) and not docker_httptester:
             display.warning('Assuming --disable-httptester since `docker` is not available.')
         elif use_httptester:
             if docker_httptester:


### PR DESCRIPTION
##### SUMMARY

Add a new `--docker-binary` argument to be able to specify an
alternative `docker` command. This is handy for instance for those who
use `podman` instead of `docker`.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ansible-test
<!--- Write the short name of the module, plugin, task or feature below -->