### PR TITLE
[stable-2.8] Add test constraint for setuptools. (#66426)

### DIFF
--- a/changelogs/fragments/ansible-test-setuptools-constraint.yml
+++ b/changelogs/fragments/ansible-test-setuptools-constraint.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test no longer tries to install ``setuptools`` 45+ on Python 2.x since those versions are unsupported

--- a/test/integration/targets/inventory_kubevirt_conformance/constraints.txt
+++ b/test/integration/targets/inventory_kubevirt_conformance/constraints.txt
@@ -1,0 +1,1 @@
+setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require python 3.5 or later

--- a/test/integration/targets/inventory_kubevirt_conformance/runme.sh
+++ b/test/integration/targets/inventory_kubevirt_conformance/runme.sh
@@ -9,7 +9,7 @@ fi
 set -eux
 
 source virtualenv.sh
-pip install openshift
+pip install openshift -c constraints.txt
 
 ./server.py &
 

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -504,7 +504,11 @@
 
   - name: install distribute in the virtualenv
     pip:
-      name: distribute
+      # using -c for constraints is not supported as long as tests are executed using the centos6 container
+      # since the pip version in the venv is not upgraded and is too old (6.0.8)
+      name:
+        - distribute
+        - setuptools<45  # setuptools 45 and later require python 3.5 or later
       virtualenv: "{{ output_dir }}/pipenv"
       state: present
 

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -36,6 +36,7 @@ lxml < 4.3.0 ; python_version < '2.7' # lxml 4.3.0 and later require python 2.7 
 pyvmomi < 6.0.0 ; python_version < '2.7' # pyvmomi 6.0.0 and later require python 2.7 or later
 pyone == 1.1.9 # newer versions do not pass current integration tests
 botocore >= 1.10.0 # adds support for the following AWS services: secretsmanager, fms, and acm-pca
+setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require python 3.5 or later
 
 # freeze pylint and its requirements for consistent test results
 astroid == 2.2.5


### PR DESCRIPTION
##### SUMMARY

* Add test constraint for setuptools.

* Update pip test to work on centos6 container.

Backport of https://github.com/ansible/ansible/pull/66426

(cherry picked from commit 51e5b714e040dd21b1528866d0e13d2672160678)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
