### PR TITLE
[stable-2.7] Add test constraint for setuptools. (#66426)

### DIFF
--- a/changelogs/fragments/ansible-test-setuptools-constraint.yml
+++ b/changelogs/fragments/ansible-test-setuptools-constraint.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test no longer tries to install ``setuptools`` 45+ on Python 2.x since those versions are unsupported

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -510,7 +510,11 @@
 
   - name: install distribute in the virtualenv
     pip:
-      name: distribute
+      # using -c for constraints is not supported as long as tests are executed using the centos6 container
+      # since the pip version in the venv is not upgraded and is too old (6.0.8)
+      name:
+        - distribute
+        - setuptools<45  # setuptools 45 and later require python 3.5 or later
       virtualenv: "{{ output_dir }}/pipenv"
       state: present
 

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -28,3 +28,4 @@ virtualenv < 16.0.0 ; python_version < '2.7' # virtualenv 16.0.0 and later requi
 pyopenssl < 18.0.0 ; python_version < '2.7' # pyOpenSSL 18.0.0 and later require python 2.7 or later
 pyfmg == 0.6.1 # newer versions do not pass current unit tests
 pycparser < 2.19 ; python_version < '2.7' # pycparser 2.19 and later require python 2.7 or later
+setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require python 3.5 or later


### PR DESCRIPTION
##### SUMMARY

* Add test constraint for setuptools.

* Update pip test to work on centos6 container.

Backport of https://github.com/ansible/ansible/pull/66426

(cherry picked from commit 51e5b714e040dd21b1528866d0e13d2672160678)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
