### PR TITLE
Fix fact gathering for nxos_telemetry sensor-groups

### DIFF
--- a/lib/ansible/module_utils/network/nxos/cmdref/telemetry/telemetry.py
+++ b/lib/ansible/module_utils/network/nxos/cmdref/telemetry/telemetry.py
@@ -104,7 +104,7 @@ path:
   _exclude: ['N3K', 'N5K', 'N6k', 'N7k']
   multiple: true
   kind: dict
-  getval: path (?P<name>\\S+)( depth (?P<depth>\\S+))?( query-condition (?P<query_condition>\\S+))?( filter-condition (?P<filter_condition>\\S+))?$
+  getval: path (?P<name>(\\S+|".*"))( depth (?P<depth>\\S+))?( query-condition (?P<query_condition>\\S+))?( filter-condition (?P<filter_condition>\\S+))?$
   setval: path {name} depth {depth} query-condition {query_condition} filter-condition {filter_condition}
   default:
     name: ~

--- a/test/integration/targets/nxos_telemetry/tests/common/deleted.yaml
+++ b/test/integration/targets/nxos_telemetry/tests/common/deleted.yaml
@@ -35,8 +35,8 @@
         - { id: 10, destination: {ip: 192.168.0.1, port: 50001, protocol: Grpc, encoding: gPB}}
         - { id: 10, destination: {ip: 192.168.0.2, port: 60001, protocol: gRPC, encoding: gpb}}
       sensor_groups:
-        - { id: 8, data_source: NX-API, path: {name: sys/bgp, depth: 0, query_condition: foo, filter_condition: foo}}
-        - { id: 2, data_source: NX-API, path: {name: sys/bgp/inst, depth: unbounded, query_condition: foo, filter_condition: foo}}
+        - { id: 8, data_source: NX-API, path: {name: '"show bgp l2vpn evpn summary"', depth: 0, query_condition: foo, filter_condition: foo}}
+        - { id: 2, data_source: NX-API, path: {name: '"show ip bgp neighbors"', depth: unbounded, query_condition: foo, filter_condition: foo}}
         - { id: 55, data_source: DME, path: {name: 'sys/bgp/inst/dom-default/peer-[10.10.10.11]/ent-[10.10.10.11]', depth: 0, query_condition: foo, filter_condition: foo}}
         - { id: 55, data_source: DME, path: {name: sys/ospf, depth: 0, query_condition: foo, filter_condition: 'or(eq(ethpmPhysIf.operSt,"down"),eq(ethpmPhysIf.operSt,"up"))'}}
       subscriptions:

--- a/test/integration/targets/nxos_telemetry/tests/common/merged.yaml
+++ b/test/integration/targets/nxos_telemetry/tests/common/merged.yaml
@@ -44,8 +44,8 @@
           - { id: 10, destination: {ip: 192.168.0.1, port: 50001, protocol: Grpc, encoding: gPB}}
           - { id: 10, destination: {ip: 192.168.0.2, port: 60001, protocol: gRPC, encoding: gpb}}
         sensor_groups:
-          - { id: 8, data_source: NX-API, path: {name: sys/bgp, depth: 0, query_condition: foo, filter_condition: foo}}
-          - { id: 2, data_source: NX-API, path: {name: sys/bgp/inst, depth: unbounded, query_condition: foo, filter_condition: foo}}
+          - { id: 8, data_source: NX-API, path: {name: '"show bgp l2vpn evpn summary"', depth: 0, query_condition: foo, filter_condition: foo}}
+          - { id: 2, data_source: NX-API, path: {name: '"show ip bgp neighbors"', depth: unbounded, query_condition: foo, filter_condition: foo}}
           - { id: 55, data_source: DME, path: {name: 'sys/bgp/inst/dom-default/peer-[10.10.10.11]/ent-[10.10.10.11]', depth: 0, query_condition: foo, filter_condition: foo}}
           - { id: 55, data_source: DME, path: {name: sys/ospf, depth: 0, query_condition: foo, filter_condition: 'or(eq(ethpmPhysIf.operSt,"down"),eq(ethpmPhysIf.operSt,"up"))'}}
         subscriptions:
@@ -72,10 +72,10 @@
         - "'ip address 192.168.0.2 port 60001 protocol grpc encoding gpb' in result.commands"
         - "'sensor-group 8' in result.commands"
         - "'data-source NX-API' in result.commands"
-        - "'path sys/bgp depth 0 query-condition foo filter-condition foo' in result.commands"
+        - result.commands is search("path .*show bgp l2vpn evpn summary.* depth 0 query-condition foo filter-condition foo")
         - "'sensor-group 2' in result.commands"
         - "'data-source NX-API' in result.commands"
-        - "'path sys/bgp/inst depth unbounded query-condition foo filter-condition foo' in result.commands"
+        - result.commands is search("path .*show ip bgp neighbors.* depth unbounded query-condition foo filter-condition foo")
         - "'sensor-group 55' in result.commands"
         - "'data-source DME' in result.commands"
         - "'path sys/bgp/inst/dom-default/peer-[10.10.10.11]/ent-[10.10.10.11] depth 0 query-condition foo filter-condition foo' in result.commands"
@@ -137,8 +137,8 @@
           - { id: 10, destination: {ip: 192.168.0.1, port: 50001, protocol: Grpc, encoding: gPB}}
           - { id: 10, destination: {ip: 192.168.0.2, port: 60001, protocol: gRPC, encoding: gpb}}
         sensor_groups:
-          - { id: 8, data_source: NX-API, path: {name: sys/bgp, depth: 0, query_condition: foo, filter_condition: foo}}
-          - { id: 2, data_source: NX-API, path: {name: sys/bgp/inst, depth: unbounded, query_condition: foo, filter_condition: foo}}
+          - { id: 8, data_source: NX-API, path: {name: '"show bgp l2vpn evpn summary"', depth: 0, query_condition: foo, filter_condition: foo}}
+          - { id: 2, data_source: NX-API, path: {name: '"show ip bgp neighbors"', depth: unbounded, query_condition: foo, filter_condition: foo}}
           - { id: 55, data_source: DME, path: {name: 'sys/bgp/inst/dom-default/peer-[10.10.10.11]/ent-[10.10.10.11]', depth: 0, query_condition: foo, filter_condition: foo}}
           - { id: 55, data_source: DME, path: {name: sys/ospf, depth: 0, query_condition: foo, filter_condition: 'or(eq(ethpmPhysIf.operSt,"down"),eq(ethpmPhysIf.operSt,"up"))'}}
         subscriptions:

--- a/test/integration/targets/nxos_telemetry/tests/common/replaced.yaml
+++ b/test/integration/targets/nxos_telemetry/tests/common/replaced.yaml
@@ -42,10 +42,10 @@
         destination-group 99
         sensor-group 2
           data-source NX-API
-          path sys/bgp/inst depth unbounded query-condition foo filter-condition foo
+          path "show bgp l2vpn evpn summary" depth unbounded query-condition foo filter-condition foo
         sensor-group 8
           data-source NX-API
-          path sys/bgp depth 0 query-condition foo filter-condition foo
+          path "show ip bgp neighbors" depth 0 query-condition foo filter-condition foo
         sensor-group 55
           data-source DME
           path sys/bgp/inst/dom-default/peer-[10.10.10.11]/ent-[10.10.10.11] depth 0 query-condition foo filter-condition foo
@@ -107,7 +107,7 @@
           - id: 100
             data_source: NX-API
             path:
-              name: sys/bgp/inst
+              name: '"show bgp l2vpn evpn summary"'
               depth: unbounded
               query_condition: foo
               filter_condition: foo
@@ -147,7 +147,7 @@
         - "'ip address 192.168.0.1 port 65001 protocol grpc encoding gpb' in result.commands"
         - "'ip address 192.168.0.3 port 55001 protocol grpc encoding gpb' in result.commands"
         - "'sensor-group 100' in result.commands"
-        - "'path sys/bgp/inst depth unbounded query-condition foo filter-condition foo' in result.commands"
+        - result.commands is search("path .*show bgp l2vpn evpn summary.* depth unbounded query-condition foo filter-condition foo")
         - "'data-source NX-API' in result.commands"
         - "'subscription 99' in result.commands"
         - "'snsr-grp 100 sample-interval 2000' in result.commands"

--- a/test/units/modules/network/nxos/fixtures/nxos_telemetry/N9K_SGs.cfg
+++ b/test/units/modules/network/nxos/fixtures/nxos_telemetry/N9K_SGs.cfg
@@ -1,0 +1,19 @@
+feature telemetry
+
+telemetry
+  sensor-group 1
+    path sys/ch depth 4
+    path sys/procsys depth 1
+  sensor-group 2
+    data-source NX-API
+    path "show bgp l2vpn evpn summary"
+    path "show isis adjacency"
+    path "show mac address-table count" depth 2
+    path "show bgp sessions"
+  sensor-group 3
+    data-source NX-API
+    path "show interface ethernet1/1-52"
+  sensor-group 4
+    path sys/bd depth 2
+    path sys/eps/epId-1/nws depth 2
+    path sys/eps/epId-1/peers depth 2

--- a/test/units/modules/network/nxos/test_nxos_telemetry.py
+++ b/test/units/modules/network/nxos/test_nxos_telemetry.py
@@ -609,6 +609,27 @@ class TestNxosTelemetryModule(TestNxosModule):
         set_module_args(args, ignore_provider_arg)
         self.execute_module(changed=False)
 
+    def test_tms_sensorgroup_quotes_merged_idempotent_n9k(self):
+        # Assumes feature telemetry is enabled
+        # TMS sensorgroup config is present with quotes in NX-API path.
+        self.execute_show_command.return_value = load_fixture('nxos_telemetry', 'N9K_SGs.cfg')
+        self.get_platform_shortname.return_value = 'N9K'
+        args = build_args([
+            {'id': '2',
+             'data_source': 'NX-API',
+             'path': {'name': '"show mac address-table count"', 'depth': 2},
+             },
+            {'id': '3',
+             'data_source': 'NX-API',
+             'path': {'name': '"show interface ethernet1/1-52"'},
+             },
+            {'id': '1',
+             'path': {'name': 'sys/procsys', 'depth': 1},
+             },
+        ], 'sensor_groups')
+        set_module_args(args, ignore_provider_arg)
+        self.execute_module(changed=False)
+
     def test_tms_sensorgroup_vxlan_idempotent_n9k(self):
         # TMS sensorgroup config present.
         self.execute_show_command.return_value = load_fixture('nxos_telemetry', 'N9K.cfg')


### PR DESCRIPTION
##### SUMMARY
Please cherry-pick this into `stable-2.9`

This fixes a bug in fact gathering for the `nxos_telemetry` resource module.  If the sensor-group collector source is `NX-API` and the path has a show command inside of double-quotes the module was failing to detect it in the running config.  This fixes the problem and adds unit and integration tests.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_telemetry