### PR TITLE
Fix rabbitmq_user permission reading with RabbitMQ 3.8

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
@@ -176,6 +176,9 @@ class RabbitMqUser(object):
         """Get permissions of the user from RabbitMQ."""
         perms_out = [perm for perm in self._exec(['list_user_permissions', self.username], True) if perm.strip()]
 
+        if perms_out[0] == "vhost\tconfigure\twrite\tread":
+            perms_out.pop(0)
+
         perms_list = list()
         for perm in perms_out:
             vhost, configure_priv, write_priv, read_priv = perm.split('\t')


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
RabbitMQ 3.8 prints table headers by default with
```
# rabbitmqctl list_user_permissions myuser

vhost   configure       write   read
/       .*      .*      .*      .*
```
which currently makes the module think `vhost` is a name of a vhost. There's no version detection logic in place, so this could be simply fixed by checking if the table header line is the first one.

Fixes #66421 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
rabbitmq_user

