### PR TITLE
Add validate_collection_path function

### DIFF
--- a/changelogs/fragments/galaxy-add-path-validation-utility-function.yaml
+++ b/changelogs/fragments/galaxy-add-path-validation-utility-function.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-galaxy - add ``validate_collection_path()`` utility function ()

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -23,7 +23,9 @@ from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.galaxy import Galaxy, get_collections_galaxy_meta_info
 from ansible.galaxy.api import GalaxyAPI
 from ansible.galaxy.collection import build_collection, install_collections, publish_collection, \
-    validate_collection_name
+    validate_collection_name,
+    validate_collection_path,
+)
 from ansible.galaxy.login import GalaxyLogin
 from ansible.galaxy.role import GalaxyRole
 from ansible.galaxy.token import BasicAuthToken, GalaxyToken, KeycloakToken, NoTokenSentinel
@@ -827,9 +829,7 @@ class GalaxyCLI(CLI):
                                 "collections paths '%s'. The installed collection won't be picked up in an Ansible "
                                 "run." % (to_text(output_path), to_text(":".join(collections_path))))
 
-            if os.path.split(output_path)[1] != 'ansible_collections':
-                output_path = os.path.join(output_path, 'ansible_collections')
-
+            output_path = validate_collection_path(output_path)
             b_output_path = to_bytes(output_path, errors='surrogate_or_strict')
             if not os.path.exists(b_output_path):
                 os.makedirs(b_output_path)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -22,7 +22,10 @@ from ansible.cli.arguments import option_helpers as opt_help
 from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.galaxy import Galaxy, get_collections_galaxy_meta_info
 from ansible.galaxy.api import GalaxyAPI
-from ansible.galaxy.collection import build_collection, install_collections, publish_collection, \
+from ansible.galaxy.collection import (
+    build_collection,
+    install_collections,
+    publish_collection,
     validate_collection_name,
     validate_collection_path,
 )

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -461,6 +461,19 @@ def validate_collection_name(name):
                        "characters from [a-zA-Z0-9_] only." % name)
 
 
+def validate_collection_path(collection_path):
+    """ Ensure a given path ends with 'ansible_collection'
+
+    :param collection_path: The path that should end in 'ansible_collection'
+    :return: collection_path ending in 'ansible_collection' if it does not already.
+    """
+
+    if os.path.split(collection_path)[1] != 'ansible_collections':
+        path = os.path.join(collection_path, 'ansible_collections')
+
+    return path
+
+
 @contextmanager
 def _tempdir():
     b_temp_path = tempfile.mkdtemp(dir=to_bytes(C.DEFAULT_LOCAL_TMP, errors='surrogate_or_strict'))

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -462,10 +462,10 @@ def validate_collection_name(name):
 
 
 def validate_collection_path(collection_path):
-    """ Ensure a given path ends with 'ansible_collection'
+    """ Ensure a given path ends with 'ansible_collections'
 
-    :param collection_path: The path that should end in 'ansible_collection'
-    :return: collection_path ending in 'ansible_collection' if it does not already.
+    :param collection_path: The path that should end in 'ansible_collections'
+    :return: collection_path ending in 'ansible_collections' if it does not already.
     """
 
     if os.path.split(collection_path)[1] != 'ansible_collections':

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -469,9 +469,9 @@ def validate_collection_path(collection_path):
     """
 
     if os.path.split(collection_path)[1] != 'ansible_collections':
-        path = os.path.join(collection_path, 'ansible_collections')
+        return os.path.join(collection_path, 'ansible_collections')
 
-    return path
+    return collection_path
 
 
 @contextmanager


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Utility function for ensuring a collection target ends with `ansible_collection`. This is a common snippet of code that myself and @s-hertel are using in our work on adding features to `ansible-galaxy collection` sub commands.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/cli/galaxy.py`
`lib/ansible/galaxy/collection.py`