### PR TITLE
Enforce new setuptools for building official dists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,7 @@ install_manpages:
 
 .PHONY: sdist_check
 sdist_check:
+	$(PYTHON) -c 'import setuptools, sys; sys.exit(int(not (tuple(map(int, setuptools.__version__.split("."))) > (39, 2, 0))))'
 	$(PYTHON) packaging/sdist/check-link-behavior.py
 
 .PHONY: sdist


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Earlier I submitted https://github.com/ansible/ansible/pull/38523 / https://github.com/ansible/ansible/pull/38700 so that sdists would contain proper metadata displayed on PyPI.

But it turned out that we're still uploading tarballs that don't have `python_requires` and `project_urls` which misleads other projects that rely on this metadata.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sdist

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
While end-users still can use old setuptools to produce this tarball, we must use the proper version in order to include the required metadata with our official dist.