### PR TITLE
Better handling of user local option

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -934,7 +934,7 @@ class User(object):
                 for line in reversed_lines:
                     if line.startswith(to_bytes(name_test)):
                         info = line.split(to_bytes(":"))
-                        passwd  = info[1].decode()
+                        passwd = info[1].decode()
                         expires = int(info[7].decode()) if info[7] else ''
                         return passwd, expires
 
@@ -1782,7 +1782,7 @@ class SunOS(User):
 
     def remove_user(self):
         cmd = [self.module.get_bin_path('userdel', True)]
-        if self.local and re.match('^11\.[1-4]', os.uname()[3]):
+        if self.local and re.match('^11[.][1-4]', os.uname()[3]):
             cmd.extend(['-S', 'files'])
         if self.remove:
             cmd.append('-r')
@@ -1792,7 +1792,7 @@ class SunOS(User):
 
     def create_user(self):
         cmd = [self.module.get_bin_path('useradd', True)]
-        if self.local and re.match('^11\.[1-4]', os.uname()[3]):
+        if self.local and re.match('^11[.][1-4]', os.uname()[3]):
             cmd.extend(['-S', 'files'])
 
         if self.uid is not None:
@@ -1895,7 +1895,7 @@ class SunOS(User):
 
     def modify_user_usermod(self):
         cmd = [self.module.get_bin_path('usermod', True)]
-        if self.local and re.match('^11\.[1-4]', os.uname()[3]):
+        if self.local and re.match('^11[.][1-4]', os.uname()[3]):
             cmd.extend(['-S', 'files'])
         cmd_len = len(cmd)
         info = self.user_info()


### PR DESCRIPTION
- Force "-S files repository" when local option is set and OS is Solaris >= 11.1
- Force passwd and shadow files lookup for user info when local is set

##### SUMMARY
As mentioned in user_exists() method, the pwd module does not distinguish between
local and directory accounts. When a user is both defined in a Directory (ldap, AD, ...) and locally,
the return info can be different leading to infinity change state
So search locally is forced when local flag is set

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module user

##### ADDITIONAL INFORMATION
On Solaris 11.x, when local option is set, the option -S should be used, especially when a user can be both defined locally and in a LDAP for example

Here's an extract from the Solaris useradd man page
-S repository

           The valid repositories are files, ldap.  The  repository  specifies
           which  name  service  will  be  updated.  The default repository is
           files. When the repository is files, the authorizations,  profiles,
           and roles can be present in other name service repositories and can
           be assigned to a user in the files repository. When the  repository
           is  ldap,  both  the LDAP server and client must be configured with
           EnableShadowUpdate=true. Also, all the assignable  attributes  must
           be present in the ldap repository.

For the same reason, when using pwd.getpwnam or spwd.getspnam, the info could come from the ldap if it is primary set in nsswitch.conf. Therefore  /etc/passwd and /etc/shadow lookup should be forced when local option is set 
