### PR TITLE
Explicitly specify junit_family in pytest config

### DIFF
--- a/test/lib/ansible_test/_data/pytest.ini
+++ b/test/lib/ansible_test/_data/pytest.ini
@@ -1,3 +1,9 @@
 [pytest]
 xfail_strict = true
 mock_use_standalone_module = true
+# It was decided to stick with "legacy" (aka "xunit1") for now.
+# Currently used pytest versions all support xunit2 format too.
+# Except the one used under Python 2.6 — it doesn't process this option
+# at all. Ref:
+# https://github.com/ansible/ansible/pull/66445#discussion_r372530176
+junit_family = xunit1


### PR DESCRIPTION
This change hides the deprecation warning and protects from
failures in pytest==6.0.0

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
pytest changes junit_family default since v6. We need to pin the current option for compat.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A