### PR TITLE
Fix Keycloak error on Python3

### DIFF
--- a/lib/ansible/module_utils/identity/keycloak/keycloak.py
+++ b/lib/ansible/module_utils/identity/keycloak/keycloak.py
@@ -34,6 +34,7 @@ import json
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.six.moves.urllib.error import HTTPError
+from ansible.module_utils._text import to_native
 
 URL_TOKEN = "{url}/realms/{realm}/protocol/openid-connect/token"
 URL_CLIENT = "{url}/admin/realms/{realm}/clients/{id}"
@@ -86,9 +87,9 @@ def get_token(base_url, validate_certs, auth_realm, client_id,
     payload = dict(
         (k, v) for k, v in temp_payload.items() if v is not None)
     try:
-        r = json.load(open_url(auth_url, method='POST',
-                               validate_certs=validate_certs,
-                               data=urlencode(payload)))
+        r = json.loads(to_native(open_url(auth_url, method='POST',
+                                          validate_certs=validate_certs,
+                                          data=urlencode(payload)).read()))
     except ValueError as e:
         raise KeycloakError(
             'API returned invalid JSON when trying to obtain access token from %s: %s'
@@ -129,8 +130,8 @@ class KeycloakAPI(object):
             clientlist_url += '?clientId=%s' % filter
 
         try:
-            return json.load(open_url(clientlist_url, method='GET', headers=self.restheaders,
-                                      validate_certs=self.validate_certs))
+            return json.loads(to_native(open_url(clientlist_url, method='GET', headers=self.restheaders,
+                                                 validate_certs=self.validate_certs).read()))
         except ValueError as e:
             self.module.fail_json(msg='API returned incorrect JSON when trying to obtain list of clients for realm %s: %s'
                                       % (realm, str(e)))
@@ -160,8 +161,8 @@ class KeycloakAPI(object):
         client_url = URL_CLIENT.format(url=self.baseurl, realm=realm, id=id)
 
         try:
-            return json.load(open_url(client_url, method='GET', headers=self.restheaders,
-                                      validate_certs=self.validate_certs))
+            return json.loads(to_native(open_url(client_url, method='GET', headers=self.restheaders,
+                                                 validate_certs=self.validate_certs).read()))
 
         except HTTPError as e:
             if e.code == 404:
@@ -245,8 +246,8 @@ class KeycloakAPI(object):
         url = URL_CLIENTTEMPLATES.format(url=self.baseurl, realm=realm)
 
         try:
-            return json.load(open_url(url, method='GET', headers=self.restheaders,
-                                      validate_certs=self.validate_certs))
+            return json.loads(to_native(open_url(url, method='GET', headers=self.restheaders,
+                                                 validate_certs=self.validate_certs).read()))
         except ValueError as e:
             self.module.fail_json(msg='API returned incorrect JSON when trying to obtain list of client templates for realm %s: %s'
                                       % (realm, str(e)))
@@ -264,8 +265,8 @@ class KeycloakAPI(object):
         url = URL_CLIENTTEMPLATE.format(url=self.baseurl, id=id, realm=realm)
 
         try:
-            return json.load(open_url(url, method='GET', headers=self.restheaders,
-                                      validate_certs=self.validate_certs))
+            return json.loads(to_native(open_url(url, method='GET', headers=self.restheaders,
+                                                 validate_certs=self.validate_certs).read()))
         except ValueError as e:
             self.module.fail_json(msg='API returned incorrect JSON when trying to obtain client templates %s for realm %s: %s'
                                       % (id, realm, str(e)))
@@ -357,8 +358,8 @@ class KeycloakAPI(object):
         """
         groups_url = URL_GROUPS.format(url=self.baseurl, realm=realm)
         try:
-            return json.load(open_url(groups_url, method="GET", headers=self.restheaders,
-                                      validate_certs=self.validate_certs))
+            return json.loads(to_native(open_url(groups_url, method="GET", headers=self.restheaders,
+                                                 validate_certs=self.validate_certs).read()))
         except Exception as e:
             self.module.fail_json(msg="Could not fetch list of groups in realm %s: %s"
                                       % (realm, str(e)))
@@ -374,8 +375,8 @@ class KeycloakAPI(object):
         """
         groups_url = URL_GROUP.format(url=self.baseurl, realm=realm, groupid=gid)
         try:
-            return json.load(open_url(groups_url, method="GET", headers=self.restheaders,
-                                      validate_certs=self.validate_certs))
+            return json.loads(to_native(open_url(groups_url, method="GET", headers=self.restheaders,
+                                                 validate_certs=self.validate_certs).read()))
 
         except HTTPError as e:
             if e.code == 404:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix Keycloak error on Python3

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
* keycloak_client
* keycloak_clienttemplate
* keycloak_group

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

```
ansible 2.9.2
  python version = 3.5.2 (default, Oct  8 2019, 13:06:37) [GCC 5.4.0 20160609]
```

<!--- Paste verbatim command output below, e.g. before and after your change -->

Error shown without fix:
```
The full traceback is:
  File "/tmp/ansible_keycloak_client_payload_slgunjdp/ansible_keycloak_client_payload.zip/ansible/modules/identity/keycloak/keycloak_client.py", line 727, in main
  File "/tmp/ansible_keycloak_client_payload_slgunjdp/ansible_keycloak_client_payload.zip/ansible/module_utils/identity/keycloak/keycloak.py", line 98, in get_token
    % (auth_url, str(e)))

fatal: [127.0.0.1]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "admin_url": null,
            "attributes": null,
            "auth_client_id": "admin-cli",
            "auth_client_secret": null,
            "auth_keycloak_url": "https://***/auth",
            "auth_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "auth_realm": "master",
            "auth_username": "admin",
            "authorization_services_enabled": null,
            "authorization_settings": null,
            "base_url": null,
            "bearer_only": null,
            "client_authenticator_type": null,
            "client_id": "artifactory",
            "client_template": null,
            "consent_required": null,
            "default_roles": null,
            "description": null,
            "direct_access_grants_enabled": null,
            "enabled": null,
            "frontchannel_logout": null,
            "full_scope_allowed": null,
            "id": null,
            "implicit_flow_enabled": null,
            "name": null,
            "node_re_registration_timeout": null,
            "not_before": null,
            "protocol": null,
            "protocol_mappers": null,
            "public_client": null,
            "realm": "master",
            "redirect_uris": null,
            "registered_nodes": null,
            "registration_access_token": null,
            "root_url": null,
            "secret": null,
            "service_accounts_enabled": null,
            "standard_flow_enabled": null,
            "state": "present",
            "surrogate_auth_required": null,
            "use_template_config": null,
            "use_template_mappers": null,
            "use_template_scope": null,
            "validate_certs": false,
            "web_origins": null
        }
    },
    "msg": "Could not obtain access token from https://***/auth/realms/master/protocol/openid-connect/token: the JSON object must be str, not 'bytes'"
}
```