### PR TITLE
Remove Server 2008 from CI - 2.7

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -19,29 +19,21 @@ matrix:
     - env: T=units/3.6
     - env: T=units/3.7
 
-    - env: T=windows/2008/1
-    - env: T=windows/2008-R2/1
     - env: T=windows/2012/1
     - env: T=windows/2012-R2/1
     - env: T=windows/2016/1
     - env: T=windows/2019/1
 
-    - env: T=windows/2008/2
-    - env: T=windows/2008-R2/2
     - env: T=windows/2012/2
     - env: T=windows/2012-R2/2
     - env: T=windows/2016/2
     - env: T=windows/2019/2
 
-    - env: T=windows/2008/3
-    - env: T=windows/2008-R2/3
     - env: T=windows/2012/3
     - env: T=windows/2012-R2/3
     - env: T=windows/2016/3
     - env: T=windows/2019/3
 
-    - env: T=windows/2008/4
-    - env: T=windows/2008-R2/4
     - env: T=windows/2012/4
     - env: T=windows/2012-R2/4
     - env: T=windows/2016/4


### PR DESCRIPTION
##### SUMMARY
AWS no longer allows the use of the 2008 AMIs, this PR removes it from our Shippable matrix.

Backport of subset of https://github.com/ansible/ansible/pull/66257

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test