### PR TITLE
VMware: consider category id while handling multiple tag with same name

### DIFF
--- a/changelogs/fragments/66340-vmware_tag.yml
+++ b/changelogs/fragments/66340-vmware_tag.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Handle multiple tags name with different category id in vmware_tag module (https://github.com/ansible/ansible/issues/66340).


### PR DESCRIPTION
##### SUMMARY

Use category id in consideration if there are multiple tags with same
name.

Fixes: #66340

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/66340-vmware_tag.yml
lib/ansible/modules/cloud/vmware/vmware_tag.py
