### PR TITLE
zabbix_template - fixing errors linked templates and dump/imports

### DIFF
--- a/changelogs/fragments/66463-zabbix_template-fix-error-linktemplate-and-importdump.yml
+++ b/changelogs/fragments/66463-zabbix_template-fix-error-linktemplate-and-importdump.yml
@@ -2,5 +2,5 @@
 
 bugfixes:
   - zabbix_template - fixed error when providing empty ``link_templates`` to the module (see https://github.com/ansible/ansible/issues/66417)
-  - zabbix_template fix for error on dump/import of templates
+  - zabbix_template - fixed invalid (non-importable) output provided by exporting XML (see https://github.com/ansible/ansible/issues/66466)
   

--- a/changelogs/fragments/66463-zabbix_template-fix-error-linktemplate-and-importdump.yml
+++ b/changelogs/fragments/66463-zabbix_template-fix-error-linktemplate-and-importdump.yml
@@ -1,0 +1,6 @@
+---
+
+bugfixes:
+  - zabbix_template fix for error on linked templates and their removal
+  - zabbix_template fix for error on dump/import of templates
+  

--- a/changelogs/fragments/66463-zabbix_template-fix-error-linktemplate-and-importdump.yml
+++ b/changelogs/fragments/66463-zabbix_template-fix-error-linktemplate-and-importdump.yml
@@ -1,6 +1,6 @@
 ---
 
 bugfixes:
-  - zabbix_template fix for error on linked templates and their removal
+  - zabbix_template - fixed error when providing empty ``link_templates`` to the module (see https://github.com/ansible/ansible/issues/66417)
   - zabbix_template fix for error on dump/import of templates
   

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -530,7 +530,7 @@ class Template(object):
                     template.remove(element)
 
         # Filter new lines and indentation
-        xml_root_text = list(line.strip() for line in ET.tostring(parsed_xml_root).split('\n'))
+        xml_root_text = list(line.strip() for line in ET.tostring(parsed_xml_root, encoding='utf8', method='xml').decode().split('\n'))
         return ''.join(xml_root_text)
 
     def load_json_template(self, template_json):

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -406,10 +406,16 @@ class Template(object):
             if set(template_groups) != set(existing_groups):
                 changed = True
 
+        if 'templates' not in existing_template['zabbix_export']['templates'][0]:
+            existing_template['zabbix_export']['templates'][0]['templates'] = []
+
         # Check if any new templates would be linked or any existing would be unlinked
         exist_child_templates = [t['name'] for t in existing_template['zabbix_export']['templates'][0]['templates']]
         if link_templates is not None:
             if set(link_templates) != set(exist_child_templates):
+                changed = True
+        else:
+            if set([]) != set(exist_child_templates):
                 changed = True
 
         # Mark that there will be changes when at least one existing template will be unlinked
@@ -433,6 +439,8 @@ class Template(object):
 
         if link_template_ids is not None:
             template_changes.update({'templates': link_template_ids})
+        else:
+            template_changes.update({'templates': []})
 
         if clear_template_ids is not None:
             template_changes.update({'templates_clear': clear_template_ids})


### PR DESCRIPTION
##### SUMMARY
fixes #66417

Line 409 fixes KeyError if existing template has no linked templates - as Zabbix API isn't returning an empty array either.
Line 417 is needed to mark as changed if new/modified template has no linked but existing one has.
Line 442 is needed to actually update even if link_templates was None.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_template

##### ADDITIONAL INFORMATION
Tested against Zabbix 4.4.4 with Ansible 2.9.2 and python 3.6.9
