### PR TITLE
prepare_vmware_tests: no waiting loop during DS probing

### DIFF
--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_datastore.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_datastore.yml
@@ -27,6 +27,10 @@
     validate_certs: no
   with_items: "{{ esxi_hosts }}"
 
+- vmware_host_scanhba:
+    refresh_storage: true
+    cluster_name: '{{ ccr1 }}'
+
 - name: The vcenter needs a bit of time to refresh the DS list
   vmware_datastore_info:
     validate_certs: false


### PR DESCRIPTION
##### SUMMARY

For a refresh of the datastore list on the vcenter, this before we
check the present of the newly attached datastores.

A lot of tests depend on the presence of the DS, and this little
change allow us to save =~ 45s everytime.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

prepare_vmware_tests
vmware