### PR TITLE
vmware_guest_serial_port: avoid autoselect_datastore

### DIFF
--- a/test/integration/targets/vmware_guest_serial_port/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_serial_port/tasks/main.yml
@@ -24,7 +24,7 @@
     disk:
       - size: 1gb
         type: thin
-        autoselect_datastore: True
+        datastore: "{{ rw_datastore }}"
     state: present
   register: create_vm_for_test
 


### PR DESCRIPTION
##### SUMMARY

Avoid `autoselect_datastore` until https://github.com/ansible/ansible/issues/58541
get fixed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware
prepare_vmware_tests