### PR TITLE
vmware_export_ovf/test: don't use a rescue block in test

### DIFF
--- a/test/integration/targets/prepare_vmware_tests/tasks/setup_attach_hosts.yml
+++ b/test/integration/targets/prepare_vmware_tests/tasks/setup_attach_hosts.yml
@@ -9,7 +9,7 @@
     esxi_hostname: '{{ item }}'
     esxi_username: '{{ esxi_user }}'
     esxi_password: '{{ esxi_password }}'
-    state: present
+    state: add_or_reconnect
   with_items: "{{ esxi_hosts }}"
 
 - name: Disable the Maintenance Mode

--- a/test/integration/targets/vmware_export_ovf/aliases
+++ b/test/integration/targets/vmware_export_ovf/aliases
@@ -1,4 +1,4 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_only
+zuul/vmware/vcenter_1esxi

--- a/test/integration/targets/vmware_export_ovf/tasks/main.yml
+++ b/test/integration/targets/vmware_export_ovf/tasks/main.yml
@@ -61,7 +61,7 @@
       that:
         - "ovf_template.changed == true"
         - "ovf_template.instance.device_files | length >= 1"
-  rescue:
+  always:
   - name: Clean up the temporary dir
     file:
       path: "{{ temp_dir.path }}"


### PR DESCRIPTION
##### SUMMARY

By using a `rescue` block, we can potentially hide a really problem in the
block and return a success. This is a bit problematic for a functional
test.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_export_ovf