### PR TITLE
Docs: Fix collection adjacent folder tree

### DIFF
--- a/docs/docsite/rst/shared_snippets/installing_collections.txt
+++ b/docs/docsite/rst/shared_snippets/installing_collections.txt
@@ -31,7 +31,8 @@ You can also keep a collection adjacent to the current playbook, under a ``colle
 
 .. code-block:: text
 
-    play.yml
+    ./
+    ├── play.yml
     ├── collections/
     │   └── ansible_collections/
     │               └── my_namespace/


### PR DESCRIPTION
##### SUMMARY

Previously folder tree example for collection adjacent to the current playbook were displaying a subfolder below the playbook instead of being a sibling.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
docsite

##### ADDITIONAL INFORMATION

