### PR TITLE
Fixes #65038 by removing default for node parameter

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
@@ -51,7 +51,6 @@ options:
   node:
     description:
       - erlang node name of the rabbit we wish to configure
-    default: rabbit
     version_added: "1.2"
   configure_priv:
     description:
@@ -249,7 +248,7 @@ def main():
         read_priv=dict(default='^$'),
         force=dict(default='no', type='bool'),
         state=dict(default='present', choices=['present', 'absent']),
-        node=dict(default='rabbit'),
+        node=dict(default=None),
         update_password=dict(default='on_create', choices=['on_create', 'always'])
     )
     module = AnsibleModule(

--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_vhost.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_vhost.py
@@ -30,7 +30,6 @@ options:
   node:
     description:
       - erlang node name of the rabbit we wish to configure
-    default: rabbit
     version_added: "1.2"
   tracing:
     description:
@@ -67,7 +66,9 @@ class RabbitMqVhost(object):
 
     def _exec(self, args, run_in_check_mode=False):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
-            cmd = [self._rabbitmqctl, '-q', '-n', self.node]
+            cmd = [self._rabbitmqctl, '-q']
+            if self.node:
+                cmd.extend(['-n', self.node])
             rc, out, err = self.module.run_command(cmd + args, check_rc=True)
             return out.splitlines()
         return list()
@@ -112,7 +113,7 @@ def main():
         name=dict(required=True, aliases=['vhost']),
         tracing=dict(default='off', aliases=['trace'], type='bool'),
         state=dict(default='present', choices=['present', 'absent']),
-        node=dict(default='rabbit'),
+        node=dict(default=None),
     )
 
     module = AnsibleModule(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

rabbitmq_vhost
rabbitmq_user

##### ADDITIONAL INFORMATION

As detailed in #65038, the rabbitmq_vhost module fails on rabbitmq 3.8 instances due to a bad default. It appears rabbitmq_user got the same issue.

Removing the default value from the "node" parameter let the underlying rabbitmqctl cli make its own default choice, which works with 3.8. Untested on 3.7 and lower.
