### PR TITLE
hostname - Add Void Linux distribution

### DIFF
--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -802,6 +802,12 @@ class OsmcHostname(Hostname):
     strategy_class = SystemdStrategy
 
 
+class VoidLinuxHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Void'
+    strategy_class = DebianStrategy
+
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(


### PR DESCRIPTION
##### SUMMARY

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

hostname module

##### ADDITIONAL INFORMATION

Setting the `hostname` failed on Void Linux since Ansible didn't detect that distro. Here's the necessary definition to auto-detect it.