### PR TITLE
vmware_rest_client: define 'port' parameter

### DIFF
--- a/lib/ansible/module_utils/vmware_rest_client.py
+++ b/lib/ansible/module_utils/vmware_rest_client.py
@@ -101,6 +101,9 @@ class VmwareRestClient(object):
                           fallback=(env_fallback, ['VMWARE_PASSWORD']),
                           aliases=['pass', 'pwd'],
                           no_log=True),
+            port=dict(type='int',
+                      default=443,
+                      fallback=(env_fallback, ['VMWARE_PORT'])),
             protocol=dict(type='str',
                           default='https',
                           choices=['https', 'http']),
@@ -117,6 +120,7 @@ class VmwareRestClient(object):
         username = self.params.get('username')
         password = self.params.get('password')
         hostname = self.params.get('hostname')
+        port = self.params.get('port')
         session = requests.Session()
         session.verify = self.params.get('validate_certs')
 
@@ -125,7 +129,7 @@ class VmwareRestClient(object):
                                       " Please read the documentation for more information.")
 
         client = create_vsphere_client(
-            server=hostname,
+            server="%s:%s" % (hostname, port),
             username=username,
             password=password,
             session=session)

--- a/lib/ansible/plugins/doc_fragments/vmware_rest_client.py
+++ b/lib/ansible/plugins/doc_fragments/vmware_rest_client.py
@@ -33,6 +33,13 @@ options:
     - If the value is not specified in the task, the value of environment variable C(VMWARE_VALIDATE_CERTS) will be used instead.
     type: bool
     default: yes
+  port:
+    description:
+    - The port number of the vSphere vCenter.
+    - If the value is not specified in the task, the value of environment variable C(VMWARE_PORT) will be used instead.
+    type: int
+    default: 443
+    version_added: '2.10'
   protocol:
     description:
     - The connection to protocol.


### PR DESCRIPTION
##### SUMMARY

Ensure the `vmware_rest_client` based modules accept the `port`
parameter.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware