### PR TITLE
vmware_host_ipv6/test: reset status before new check

### DIFF
--- a/test/integration/targets/vmware_host_ipv6/tasks/main.yml
+++ b/test/integration/targets/vmware_host_ipv6/tasks/main.yml
@@ -49,6 +49,16 @@
           - host_ipv6_info_check_mode is defined
           - not (host_ipv6_info_check_mode is changed)
 
+    - name: Reset the status again
+      vmware_host_ipv6:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        cluster_name: "{{ ccr1 }}"
+        validate_certs: no
+        state: disabled
+      register: host_ipv6_info
+
     - name: Enable IPv6 support for all hosts in given cluster
       vmware_host_ipv6:
         hostname: "{{ vcenter_hostname }}"


### PR DESCRIPTION
##### SUMMARY

Ensure a disable IPv6 before we try to re-enable it. This to get a
consistent result.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_host_ipv6