### PR TITLE
Use UTF-8 without a BOM for win coverage

### DIFF
--- a/changelogs/fragments/win-coverage-out-encoding.yaml
+++ b/changelogs/fragments/win-coverage-out-encoding.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-test windows coverage - Ensure coverage reports are UTF-8 encoded without a BOM

--- a/lib/ansible/executor/powershell/coverage_wrapper.ps1
+++ b/lib/ansible/executor/powershell/coverage_wrapper.ps1
@@ -176,7 +176,9 @@ try {
         $code_cov_json = ConvertTo-Json -InputObject $coverage_info -Compress
 
         Write-AnsibleLog "INFO - Outputting coverage json to '$coverage_output_path'" "coverage_wrapper"
-        Set-Content -LiteralPath $coverage_output_path -Value $code_cov_json -Encoding $file_encoding
+        # Ansible controller expects these files to be UTF-8 without a BOM, use .NET for this.
+        $utf8_no_bom = New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false
+        [System.IO.File]::WriteAllbytes($coverage_output_path, $utf8_no_bom.GetBytes($code_cov_json))
     }
 } finally {
     try {


### PR DESCRIPTION
##### SUMMARY
While the module and module util files need to be UTF-8 with a BOM for the PowerShell engine as per https://github.com/ansible/ansible/pull/65086, the actual coverage reports that are generated and sent back to Ansible should not contain the BOM. The coverage report reads the file as `utf-8` without the BOM so ensure the files are in that encoding.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test