### PR TITLE
Use UTF-8 without a BOM for win coverage (#66510) - 2.9

### DIFF
--- a/changelogs/fragments/win-coverage-out-encoding.yaml
+++ b/changelogs/fragments/win-coverage-out-encoding.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-test windows coverage - Ensure coverage reports are UTF-8 encoded without a BOM

--- a/lib/ansible/executor/powershell/coverage_wrapper.ps1
+++ b/lib/ansible/executor/powershell/coverage_wrapper.ps1
@@ -176,7 +176,9 @@ try {
         $code_cov_json = ConvertTo-Json -InputObject $coverage_info -Compress
 
         Write-AnsibleLog "INFO - Outputting coverage json to '$coverage_output_path'" "coverage_wrapper"
-        Set-Content -LiteralPath $coverage_output_path -Value $code_cov_json -Encoding $file_encoding
+        # Ansible controller expects these files to be UTF-8 without a BOM, use .NET for this.
+        $utf8_no_bom = New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false
+        [System.IO.File]::WriteAllbytes($coverage_output_path, $utf8_no_bom.GetBytes($code_cov_json))
     }
 } finally {
     try {


### PR DESCRIPTION
(cherry picked from commit e459eac565d9b3f679102e8382df4609150893ca)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/66510

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test