### PR TITLE
Backport declared support for Python 3.8 @ Trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -311,6 +311,7 @@ static_setup_params = dict(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: System :: Installation/Setup',
         'Topic :: System :: Systems Administration',
         'Topic :: Utilities',


### PR DESCRIPTION
##### SUMMARY
Declare Python 3.8 support

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
setup.py

##### ADDITIONAL INFORMATION
(cherry picked from commit ee290bf5b17e80973787bbbc0dac46e2a2311681)
