### PR TITLE
Fix case sensitivity for lookup()

### DIFF
--- a/changelogs/fragments/66464-lookup-case-sensitivity-fix.yml
+++ b/changelogs/fragments/66464-lookup-case-sensitivity-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix case sensitivity for ``lookup()`` (https://github.com/ansible/ansible/issues/66464)

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -110,6 +110,10 @@ Noteworthy module changes
 Plugins
 =======
 
+Lookup plugin names case-sensitivity
+------------------------------------
+
+* Prior to Ansible ``2.10`` lookup plugin names passed in as an argument to the ``lookup()`` function were treated as case-insensitive as opposed to lookups invoked via ``with_<lookup_name>``. ``2.10`` brings consistency to ``lookup()`` and ``with_`` to be both case-sensitive.
 
 Noteworthy plugin changes
 -------------------------

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -749,7 +749,7 @@ class Templar:
         return self._lookup(name, *args, **kwargs)
 
     def _lookup(self, name, *args, **kwargs):
-        instance = self._lookup_loader.get(name.lower(), loader=self._loader, templar=self)
+        instance = self._lookup_loader.get(name, loader=self._loader, templar=self)
 
         if instance is not None:
             wantlist = kwargs.pop('wantlist', False)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This brings consistency to `lookup()`, `with_` and `ansible-doc`.

Fixes #66464
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/template/__init__.py `