### PR TITLE
synchronize - fix password authentication

### DIFF
--- a/changelogs/fragments/56629-synchronize-password-auth.yaml
+++ b/changelogs/fragments/56629-synchronize-password-auth.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - synchronize - fix password authentication on Python 2 (https://github.com/ansible/ansible/issues/56629)

--- a/changelogs/fragments/56629-synchronize-password-auth.yaml
+++ b/changelogs/fragments/56629-synchronize-password-auth.yaml
@@ -1,2 +1,6 @@
 bugfixes:
   - synchronize - fix password authentication on Python 2 (https://github.com/ansible/ansible/issues/56629)
+  - >
+    AnsibleModule.run_command() - set ``close_fds`` to ``False`` on Python 2 if ``pass_fds`` are passed to
+    ``run_command()``. Since ``subprocess.Popen()`` on Python 2 does not have the ``pass_fds`` option,
+    there is no way to exclude a specific list of file descriptors from being closed.

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2452,9 +2452,10 @@ class AnsibleModule(object):
             are expanded before running the command. When ``True`` a string such as
             ``$SHELL`` will be expanded regardless of escaping. When ``False`` and
             ``use_unsafe_shell=False`` no path or variable expansion will be done.
-        :kw pass_fds: When running on python3 this argument
+        :kw pass_fds: When running on Python 3 this argument
             dictates which file descriptors should be passed
-            to an underlying ``Popen`` constructor.
+            to an underlying ``Popen`` constructor. On Python 2, this will
+            set ``close_fds`` to False.
         :kw before_communicate_callback: This function will be called
             after ``Popen`` object will be created
             but before communicating to the process.
@@ -2565,6 +2566,8 @@ class AnsibleModule(object):
         )
         if PY3 and pass_fds:
             kwargs["pass_fds"] = pass_fds
+        elif PY2 and pass_fds:
+            kwargs['close_fds'] = False
 
         # store the pwd
         prev_dir = os.getcwd()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
On Python 2, leave all file descriptions open since there is no mechanism to close specific file descriptions with `subprocess.Popen()` on Python 2.

The fix is done in `run_command()` rather than the `synchronize` module itself, making this fix available for all callers of `run_command()` rather than placing burden of checking the Python version on the caller.

Add unit tests.

Fixes #56629
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/basic.py`