### PR TITLE
removed the multiline if condition as it seems unnecessary and also prevents the warning message

### DIFF
--- a/contrib/inventory/cobbler.py
+++ b/contrib/inventory/cobbler.py
@@ -215,8 +215,7 @@ class CobblerInventory(object):
                 for (iname, ivalue) in iteritems(interfaces):
                     if ivalue['management'] or not ivalue['static']:
                         this_dns_name = ivalue.get('dns_name', None)
-                        if this_dns_name is not None and this_dns_name:
-                            dns_name = this_dns_name
+                        dns_name = this_dns_name if this_dns_name else ''
 
             if dns_name == '' or dns_name is None:
                 continue

--- a/contrib/inventory/cobbler.py
+++ b/contrib/inventory/cobbler.py
@@ -215,7 +215,7 @@ class CobblerInventory(object):
                 for (iname, ivalue) in iteritems(interfaces):
                     if ivalue['management'] or not ivalue['static']:
                         this_dns_name = ivalue.get('dns_name', None)
-                        if this_dns_name is not None and this_dns_name is not "":
+                        if this_dns_name is not None and this_dns_name:
                             dns_name = this_dns_name
 
             if dns_name == '' or dns_name is None:


### PR DESCRIPTION
##### SUMMARY
Fixes #66537 

##### ISSUE TYPE
- Bugfix Pull Request 

##### COMPONENT NAME
contrib/inventory/cobbler.py

##### ADDITIONAL INFORMATION
Removes the comparision of variable 'this_dns_name' with None and empty string and replaces it with a single line if else using the boolean comparision of a string.

```     
Before:                   
if this_dns_name is not None and this_dns_name:
    dns_name = this_dns_name
```
```
After:
dns_name = this_dns_name if this_dns_name else ''
```