### PR TITLE
vmware_guest_network/test: create the dvswitch

### DIFF
--- a/test/integration/targets/vmware_guest_network/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_network/tasks/main.yml
@@ -9,6 +9,8 @@
     vars:
       setup_attach_host: true
       setup_datastore: true
+      setup_dvs_portgroup: true
+      setup_dvswitch: true
 
   - name: Create VMs
     vmware_guest:


### PR DESCRIPTION
##### SUMMARY

Ensure the DVSwitch and the portgroup are created by
`prepare_vmware_tests`.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_guest_network