### PR TITLE
Fix flake8 error with test_eos_lacp_interfaces

### DIFF
--- a/test/units/modules/network/eos/test_eos_lacp_interfaces.py
+++ b/test/units/modules/network/eos/test_eos_lacp_interfaces.py
@@ -136,8 +136,6 @@ class TestEosLacpInterfacesModule(TestEosModule):
                 rate="fast"
             )], state="overridden"
         ))
-        commands = ['interface Ethernet1', 'lacp port-priority 45', 'lacp rate normal',
-                    'interface Ethernet2', 'lacp rate normal']
         self.execute_module(changed=False, commands=[])
 
     def test_eos_lacp_interfaces_deleted(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix F841 local variable 'commands' is assigned to but never used

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
eos_lacp_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```