### PR TITLE
[2.9] gitlab_project_variable: Remove sensitive information

### DIFF
--- a/changelogs/fragments/gitlab_project_variable.yml
+++ b/changelogs/fragments/gitlab_project_variable.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Redact GitLab Project variables which might include sensetive information such as password, api_keys and other project related details.

--- a/lib/ansible/modules/source_control/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab_project_variable.py
@@ -206,7 +206,7 @@ def main():
         api_token=dict(type='str', required=True, no_log=True),
         project=dict(type='str', required=True),
         purge=dict(type='bool', required=False, default=False),
-        vars=dict(type='dict', required=False, default=dict()),
+        vars=dict(type='dict', required=False, default=dict(), no_log=True),
         state=dict(type='str', default="present", choices=["absent", "present"])
     )
 


### PR DESCRIPTION
##### SUMMARY

Redact GitLab Project variables which might include sensetive information
such as password, api_keys and other project related details.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit 84b68aa05feb6af91731c75ad0fa04264235e751)


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/gitlab_project_variable.yml
lib/ansible/modules/source_control/gitlab_project_variable.py
