### PR TITLE
Use the async_timeout as the named pipe timeout too.

### DIFF
--- a/lib/ansible/executor/powershell/async_wrapper.ps1
+++ b/lib/ansible/executor/powershell/async_wrapper.ps1
@@ -147,7 +147,7 @@ try {
 
     Write-AnsibleLog "INFO - waiting for async process to connect to named pipe for 5 seconds" "async_wrapper"
     $wait_async = $pipe.BeginWaitForConnection($null, $null)
-    $wait_async.AsyncWaitHandle.WaitOne(5000) > $null
+    $wait_async.AsyncWaitHandle.WaitOne(60000) > $null
     if (-not $wait_async.IsCompleted) {
         throw "timeout while waiting for child process to connect to named pipe"
     }


### PR DESCRIPTION
##### SUMMARY
This doesn't quite fix #65001, because you can't configure the timeout, but it does help on our skinny Azure VMs when hitting the same issue of async timeouts.

I couldn't work out how to thread a configuration parameter through to this area with the time I had to look at it, but that would be a better solution.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/executor/powershell/async_wrapper.ps1`

##### ADDITIONAL INFORMATION
See the issue, I guess, #65001 is quite detailed.
