### PR TITLE
Change package name in docker_setup integration test

### DIFF
--- a/test/integration/targets/setup_docker/tasks/RedHat-8.yml
+++ b/test/integration/targets/setup_docker/tasks/RedHat-8.yml
@@ -6,6 +6,10 @@
     name: "{{ docker_prereq_packages }}"
     state: present
   notify: cleanup docker
+  register: result
+  until: result is success
+  retries: 10
+  delay: 2
 
 - name: Set-up repository
   command: dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo

--- a/test/integration/targets/setup_docker/vars/RedHat-8.yml
+++ b/test/integration/targets/setup_docker/vars/RedHat-8.yml
@@ -1,5 +1,5 @@
 docker_prereq_packages:
-  - dnf-utils
+  - yum-utils
   - device-mapper-persistent-data
   - lvm2
   - libseccomp


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It seems like `dnf-utils` no longer exists in the CentOS 8 Base repository.

Fixes #66546 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/setup_docker`