### PR TITLE
vmware: adjust the module/Zuul jobs mapping

### DIFF
--- a/test/integration/targets/vmware_host_active_directory/aliases
+++ b/test/integration/targets/vmware_host_active_directory/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi

--- a/test/integration/targets/vmware_vm_storage_policy_info/aliases
+++ b/test/integration/targets/vmware_vm_storage_policy_info/aliases
@@ -1,4 +1,4 @@
 shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi
+zuul/vmware/vcenter_only


### PR DESCRIPTION
##### SUMMARY

- vmware_host_active_directory: we need an Active Directory to run the
  test
- vmware_vm_storage_policy_info: we just need a vcenter
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

vmware_host_active_directory
vmware_vm_storage_policy_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
