### PR TITLE
Rename private function in collection.py

### DIFF
--- a/changelogs/fragments/galaxy-collection-rename-private-function.yaml
+++ b/changelogs/fragments/galaxy-collection-rename-private-function.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - >
+    rename ``_find_existing_collections()`` to ``find_existing_collections()`` to reflect
+    its use across multiple files

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -428,7 +428,7 @@ def install_collections(collections, output_path, apis, validate_certs, ignore_e
     :param force: Re-install a collection if it has already been installed.
     :param force_deps: Re-install a collection as well as its dependencies if they have already been installed.
     """
-    existing_collections = _find_existing_collections(output_path)
+    existing_collections = find_existing_collections(output_path)
 
     with _tempdir() as b_temp_path:
         display.display("Process install dependency map")
@@ -760,7 +760,7 @@ def _build_collection_tar(b_collection_path, b_tar_path, collection_manifest, fi
         display.display('Created collection for %s at %s' % (collection_name, to_text(b_tar_path)))
 
 
-def _find_existing_collections(path):
+def find_existing_collections(path):
     collections = []
 
     b_path = to_bytes(path, errors='surrogate_or_strict')

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -542,7 +542,7 @@ def test_find_existing_collections(tmp_path_factory, monkeypatch):
     mock_warning = MagicMock()
     monkeypatch.setattr(Display, 'warning', mock_warning)
 
-    actual = collection._find_existing_collections(test_dir)
+    actual = collection.find_existing_collections(test_dir)
 
     assert len(actual) == 2
     for actual_collection in actual:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Make `find_existing_collections()` a public function since it is being used across mulitple files now to support listing and verifying collections.

In support of #65022 and #65618
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/galaxy/collection.py`