### PR TITLE
Adding bigip_cipher_rules/_groups and cipherGroup option to bigip_profile_client_ssl

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_cipher_group.py
+++ b/lib/ansible/modules/network/f5/bigip_cipher_group.py
@@ -1,0 +1,489 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import logging
+logging.basicConfig( level=logging.DEBUG, filename='/tmp/bigip_cipher_group.py.log')
+logger = logging.getLogger("bigip_cipher_group")
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'certified'}
+
+DOCUMENTATION = r'''
+---
+module: bigip_cipher_group
+short_description: Manages cipher groups on a BIG-IP
+description:
+  - Manages cipher groups on a BIG-IP.
+  - see: https://clouddocs.f5.com/api/icontrol-rest/APIRef_tm_ltm_cipher_group.html
+version_added: 2.10
+options:
+  name:
+    description:
+      - Specifies the name of the cipher group.
+    type: str
+    required: True
+  allow:
+    description:
+      - Specifies cipher rules C(cipher_rules) which define ciphers that are included. 
+    type: list
+    default: []
+  exclude:
+    description:
+      - Specifies cipher rules C(cipher_rules) which define a subset of the allowed
+        ciphers that are excluded. 
+    type: list
+    default: []
+  require:
+    description:
+      - Specifies cipher rules C(cipher_rules) which restrict the allowed ciphers to
+        the ones in those cipher rules.
+    type: list
+    default: []
+  ordering:
+    description:
+      - Specifies in which order mechanism the cipher list ist processed by the client. 
+    type: str
+    choices:
+      - default
+      - speed
+      - strength
+      - fips
+      - hardware
+  state:
+    description:
+      - When C(present), ensures that the profile exists.
+      - When C(absent), ensures the profile is removed.
+    type: str
+    choices:
+      - present
+      - absent
+    default: present
+  partition:
+    description:
+      - Device partition to manage resources on.
+    type: str
+    default: Common
+notes:
+  - Requires BIG-IP software version >= 12
+extends_documentation_fragment: f5
+author:
+  - @diLLec
+'''
+
+EXAMPLES = r'''
+- name: Create Cipher Group based on Intermediate Cipher List
+  bigip_cipher_group:
+    state: present
+    name: cgroup_test
+    allow: 
+    - crule_intermediate_ciphers
+    ordering: speed
+  delegate_to: localhost
+
+- name: Create Cipher Group based on Intermediate Cipher List excluding the 128bit ciphers
+  bigip_cipher_group:
+    state: present
+    name: cgroup_test
+    allow: 
+    - crule_intermediate_ciphers
+    exclude:  
+    - crule_AES128_ciphers
+    ordering: speed
+  delegate_to: localhost
+'''
+
+RETURN = r'''
+
+'''
+
+import os
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.six import iteritems
+
+try:
+    from library.module_utils.network.f5.bigip import F5RestClient
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import fq_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    from library.module_utils.network.f5.common import flatten_boolean
+    from library.module_utils.network.f5.common import transform_name
+    from library.module_utils.network.f5.common import is_empty_list
+except ImportError:
+    from ansible.module_utils.network.f5.bigip import F5RestClient
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import fq_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    from ansible.module_utils.network.f5.common import flatten_boolean
+    from ansible.module_utils.network.f5.common import transform_name
+    from ansible.module_utils.network.f5.common import is_empty_list
+
+
+class Parameters(AnsibleF5Parameters):
+    api_map = {
+    }
+
+    api_attributes = [
+        'ordering',
+        'allow',
+        'exclude',
+        'require',
+    ]
+
+    returnables = [
+        'ordering',
+        'allow',
+        'exclude',
+        'require',
+    ]
+
+    updatables = [
+        'ordering',
+        'allow',
+        'exclude',
+        'require',
+    ]
+
+
+class ModuleParameters(Parameters):
+    def save_crule_list_return(self, crule_parameter):
+        if crule_parameter not in self._values or self._values[crule_parameter] is None:
+            return []
+        else:
+            return [fq_name(self.partition, p) for p in self._values[crule_parameter]]
+
+    @property
+    def allow(self):
+        return self.save_crule_list_return("allow")
+
+    @property
+    def exclude(self):
+        return self.save_crule_list_return("exclude")
+
+    @property
+    def require(self):
+        return self.save_crule_list_return("require")
+
+
+class ApiParameters(Parameters):
+    def save_crule_list_return(self, crule_parameter):
+        if crule_parameter not in self._values or self._values[crule_parameter] is None:
+            return []
+        else:
+            return [fq_name(p['partition'], p['name']) for p in self._values[crule_parameter]]
+
+    @property
+    def allow(self):
+        return self.save_crule_list_return("allow")
+
+    @property
+    def exclude(self):
+        return self.save_crule_list_return("exclude")
+
+    @property
+    def require(self):
+        return self.save_crule_list_return("require")
+
+
+class Changes(Parameters):
+    def to_return(self):
+        result = {}
+        try:
+            for returnable in self.returnables:
+                result[returnable] = getattr(self, returnable)
+            result = self._filter_params(result)
+        except Exception:
+            pass
+        return result
+
+
+class UsableChanges(Changes):
+    pass
+
+
+class ReportableChanges(Changes):
+    pass
+
+
+class Difference(object):
+    def __init__(self, want, have=None):
+        self.want = want
+        self.have = have
+
+    def compare(self, param):
+        try:
+            result = getattr(self, param)
+            return result
+        except AttributeError:
+            result = self.__default(param)
+            return result
+
+    def __default(self, param):
+        attr1 = getattr(self.want, param)
+        try:
+            attr2 = getattr(self.have, param)
+            if attr1 != attr2:
+                logger.info("param[%s] differs: %s | %s" %(param, attr1, attr2))
+                return attr1
+            else:
+                logger.info("param[%s] same: %s | %s" % (param,attr1, attr2))
+        except AttributeError:
+            return attr1
+
+    def to_tuple(self, items):
+        result = []
+        for x in items:
+            tmp = [(str(k), str(v)) for k, v in iteritems(x)]
+            result += tmp
+        return result
+
+    def _diff_complex_items(self, want, have):
+        if want == [] and have is None:
+            return None
+        if want is None:
+            return None
+        w = self.to_tuple(want)
+        h = self.to_tuple(have)
+        if set(w).issubset(set(h)):
+            return None
+        else:
+            return want
+
+
+class ModuleManager(object):
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = F5RestClient(**self.module.params)
+        self.want = ModuleParameters(params=self.module.params)
+        self.have = ApiParameters()
+        self.changes = UsableChanges()
+
+    def _set_changed_options(self):
+        changed = {}
+        for key in Parameters.returnables:
+            if getattr(self.want, key) is not None:
+                changed[key] = getattr(self.want, key)
+        if changed:
+            self.changes = UsableChanges(params=changed)
+
+    def _update_changed_options(self):
+        diff = Difference(self.want, self.have)
+        updatables = Parameters.updatables
+        changed = dict()
+        for k in updatables:
+            change = diff.compare(k)
+            logger.info("compare: %s -> change: %s" % (k, change))
+            if change is None:
+                continue
+            else:
+                if isinstance(change, dict):
+                    changed.update(change)
+                else:
+                    changed[k] = change
+        if changed:
+            self.changes = UsableChanges(params=changed)
+            return True
+        return False
+
+    def should_update(self):
+        result = self._update_changed_options()
+        if result:
+            return True
+        return False
+
+    def exec_module(self):
+        changed = False
+        result = dict()
+        state = self.want.state
+
+        if state == "present":
+            changed = self.present()
+        elif state == "absent":
+            changed = self.absent()
+
+        reportable = ReportableChanges(params=self.changes.to_return())
+        changes = reportable.to_return()
+        result.update(**changes)
+        result.update(dict(changed=changed))
+        self._announce_deprecations(result)
+        return result
+
+    def _announce_deprecations(self, result):
+        warnings = result.pop('__warnings', [])
+        for warning in warnings:
+            self.client.module.deprecate(
+                msg=warning['msg'],
+                version=warning['version']
+            )
+
+    def present(self):
+        if self.exists():
+            return self.update()
+        else:
+            return self.create()
+
+    def exists(self):
+        uri = "https://{0}:{1}/mgmt/tm/ltm/cipher/group/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError:
+            return False
+        if resp.status == 404 or 'code' in response and response['code'] == 404:
+            return False
+        return True
+
+    def update(self):
+        self.have = self.read_current_from_device()
+        if not self.should_update():
+            return False
+        if self.module.check_mode:
+            return True
+        self.update_on_device()
+        return True
+
+    def remove(self):
+        if self.module.check_mode:
+            return True
+        self.remove_from_device()
+        if self.exists():
+            raise F5ModuleError("Failed to delete the resource.")
+        return True
+
+    def create(self):
+        self._set_changed_options()
+        if self.module.check_mode:
+            return True
+        self.create_on_device()
+        return True
+
+    def create_on_device(self):
+        params = self.changes.api_params()
+        params['name'] = self.want.name
+        params['partition'] = self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/ltm/cipher/group/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port']
+        )
+        resp = self.client.api.post(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] in [400, 403, 404]:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+
+    def update_on_device(self):
+        params = self.changes.api_params()
+        uri = "https://{0}:{1}/mgmt/tm/ltm/cipher/group/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        resp = self.client.api.patch(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] in [400, 404]:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+
+    def absent(self):
+        if self.exists():
+            return self.remove()
+        return False
+
+    def remove_from_device(self):
+        uri = "https://{0}:{1}/mgmt/tm/ltm/cipher/group/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        response = self.client.api.delete(uri)
+        if response.status == 200:
+            return True
+        raise F5ModuleError(response.content)
+
+    def read_current_from_device(self):
+        uri = "https://{0}:{1}/mgmt/tm/ltm/cipher/group/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        return ApiParameters(params=response)
+
+
+class ArgumentSpec(object):
+    def __init__(self):
+        self.supports_check_mode = True
+        argument_spec = dict(
+            name=dict(required=True),
+            allow=dict(type='list'),
+            exclude=dict(type='list'),
+            require=dict(type='list'),
+            ordering=dict(type='str',
+                          choices=['default', 'speed', 'strength', 'fips', 'hardware']),
+            partition=dict(
+                default='Common',
+                fallback=(env_fallback, ['F5_PARTITION'])
+            ),
+            state=dict(
+                default='present',
+                choices=['present', 'absent']
+            ),
+        )
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
+
+
+def main():
+    spec = ArgumentSpec()
+
+    module = AnsibleModule(
+        argument_spec=spec.argument_spec,
+        supports_check_mode=spec.supports_check_mode,
+    )
+
+    try:
+        mm = ModuleManager(module=module)
+        results = mm.exec_module()
+        module.exit_json(**results)
+    except F5ModuleError as ex:
+        module.fail_json(msg=str(ex))
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/f5/bigip_cipher_group.py
+++ b/lib/ansible/modules/network/f5/bigip_cipher_group.py
@@ -8,16 +8,15 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
-                    'supported_by': 'certified'}
+                    'supported_by': 'community'}
 
 DOCUMENTATION = r'''
 ---
 module: bigip_cipher_group
 short_description: Manages cipher groups on a BIG-IP
 description:
-  - Manages cipher groups on a BIG-IP.
-  - see: https://clouddocs.f5.com/api/icontrol-rest/APIRef_tm_ltm_cipher_group.html
-version_added: 2.10
+  - Manages cipher groups on a BIG-IP (https://clouddocs.f5.com/api/icontrol-rest/APIRef_tm_ltm_cipher_group.html).
+version_added: "2.10"
 options:
   name:
     description:
@@ -32,7 +31,7 @@ options:
   exclude:
     description:
       - Specifies cipher rules C(cipher_rules) which define a subset of the allowed
-        ciphers that are excluded. 
+        ciphers that are excluded.
     type: list
     default: []
   require:
@@ -70,7 +69,7 @@ notes:
   - Requires BIG-IP software version >= 12
 extends_documentation_fragment: f5
 author:
-  - diLLec
+  - Michael Kluge (@diLLec)
 '''
 
 EXAMPLES = r'''
@@ -87,16 +86,15 @@ EXAMPLES = r'''
   bigip_cipher_group:
     state: present
     name: cgroup_test
-    allow: 
+    allow:
     - crule_intermediate_ciphers
-    exclude:  
+    exclude:
     - crule_AES128_ciphers
     ordering: speed
   delegate_to: localhost
 '''
 
 RETURN = r'''
-
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/network/f5/bigip_cipher_group.py
+++ b/lib/ansible/modules/network/f5/bigip_cipher_group.py
@@ -6,10 +6,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import logging
-logging.basicConfig( level=logging.DEBUG, filename='/tmp/bigip_cipher_group.py.log')
-logger = logging.getLogger("bigip_cipher_group")
-
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'certified'}
@@ -49,6 +45,7 @@ options:
     description:
       - Specifies in which order mechanism the cipher list ist processed by the client. 
     type: str
+    default: default
     choices:
       - default
       - speed
@@ -101,8 +98,6 @@ EXAMPLES = r'''
 RETURN = r'''
 
 '''
-
-import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import env_fallback
@@ -232,10 +227,7 @@ class Difference(object):
         try:
             attr2 = getattr(self.have, param)
             if attr1 != attr2:
-                logger.info("param[%s] differs: %s | %s" %(param, attr1, attr2))
                 return attr1
-            else:
-                logger.info("param[%s] same: %s | %s" % (param,attr1, attr2))
         except AttributeError:
             return attr1
 
@@ -281,7 +273,6 @@ class ModuleManager(object):
         changed = dict()
         for k in updatables:
             change = diff.compare(k)
-            logger.info("compare: %s -> change: %s" % (k, change))
             if change is None:
                 continue
             else:
@@ -450,11 +441,12 @@ class ArgumentSpec(object):
         self.supports_check_mode = True
         argument_spec = dict(
             name=dict(required=True),
-            allow=dict(type='list'),
-            exclude=dict(type='list'),
-            require=dict(type='list'),
+            allow=dict(type='list', default=[]),
+            exclude=dict(type='list', default=[]),
+            require=dict(type='list', default=[]),
             ordering=dict(type='str',
-                          choices=['default', 'speed', 'strength', 'fips', 'hardware']),
+                          choices=['default', 'speed', 'strength', 'fips', 'hardware'],
+                          default='default'),
             partition=dict(
                 default='Common',
                 fallback=(env_fallback, ['F5_PARTITION'])

--- a/lib/ansible/modules/network/f5/bigip_cipher_group.py
+++ b/lib/ansible/modules/network/f5/bigip_cipher_group.py
@@ -25,7 +25,7 @@ options:
     required: True
   allow:
     description:
-      - Specifies cipher rules C(cipher_rules) which define ciphers that are included. 
+      - Specifies cipher rules C(cipher_rules) which define ciphers that are included.
     type: list
     default: []
   exclude:
@@ -42,7 +42,7 @@ options:
     default: []
   ordering:
     description:
-      - Specifies in which order mechanism the cipher list ist processed by the client. 
+      - Specifies in which order mechanism the cipher list ist processed by the client.
     type: str
     default: default
     choices:
@@ -77,7 +77,7 @@ EXAMPLES = r'''
   bigip_cipher_group:
     state: present
     name: cgroup_test
-    allow: 
+    allow:
     - crule_intermediate_ciphers
     ordering: speed
   delegate_to: localhost

--- a/lib/ansible/modules/network/f5/bigip_cipher_group.py
+++ b/lib/ansible/modules/network/f5/bigip_cipher_group.py
@@ -70,7 +70,7 @@ notes:
   - Requires BIG-IP software version >= 12
 extends_documentation_fragment: f5
 author:
-  - @diLLec
+  - diLLec
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/network/f5/bigip_cipher_rule.py
+++ b/lib/ansible/modules/network/f5/bigip_cipher_rule.py
@@ -8,16 +8,15 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
-                    'supported_by': 'certified'}
+                    'supported_by': 'community'}
 
 DOCUMENTATION = r'''
 ---
 module: bigip_cipher_rule
 short_description: Manages cipher rules on a BIG-IP
 description:
-  - Manages cipher rules on a BIG-IP.
-  - see: https://clouddocs.f5.com/api/icontrol-rest/APIRef_tm_ltm_cipher_rule.html
-version_added: 2.10
+  - Manages cipher rules on a BIG-IP (https://clouddocs.f5.com/api/icontrol-rest/APIRef_tm_ltm_cipher_rule.html).
+version_added: "2.10"
 options:
   name:
     description:
@@ -27,7 +26,7 @@ options:
   cipher:
     description:
       - Specifies the cipher string which this cipher rule uses to propagate ciphers
-        to cipher groups. 
+        to cipher groups.
     type: str
     default: "DEFAULT"
   state:
@@ -48,7 +47,8 @@ notes:
   - Requires BIG-IP software version >= 12
 extends_documentation_fragment: f5
 author:
-  - diLLec
+  - Michael Kluge (@diLLec)
+
 '''
 
 EXAMPLES = r'''
@@ -376,7 +376,7 @@ class ArgumentSpec(object):
         self.supports_check_mode = True
         argument_spec = dict(
             name=dict(required=True),
-            cipher=dict(type='str'),
+            cipher=dict(type='str', default="DEFAULT"),
             partition=dict(
                 default='Common',
                 fallback=(env_fallback, ['F5_PARTITION'])

--- a/lib/ansible/modules/network/f5/bigip_cipher_rule.py
+++ b/lib/ansible/modules/network/f5/bigip_cipher_rule.py
@@ -6,7 +6,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'certified'}
@@ -64,7 +63,7 @@ EXAMPLES = r'''
   bigip_cipher_rule:
     state: present
     name: default
-    cipher: ECDHE:TLS13-AES128-GCM-SHA256:TLS13-AES256-GCM-SHA384:TLS13-CHACHA20-POLY1305-SHA256:!TLSv1:!EXPORT:!DHE:!3DES:-MD5:-SSLv3:-RC4:!ECDHE-RSA-AES128-CBC-SHA:!ECDHE-RSA-AES256-CBC-SHA
+    cipher: ECDHE:TLS13-AES128-GCM-SHA256::!TLSv1:!EXPORT:!DHE:!3DES:-MD5:-SSLv3:-RC4:!ECDHE-RSA-AES128-CBC-SHA
   delegate_to: localhost
 '''
 
@@ -75,8 +74,6 @@ ciphers:
   type: str
   sample: "!SSLv3:!SSLv2:ECDHE+AES-GCM+SHA256:ECDHE-RSA-AES128-CBC-SHA"
 '''
-
-import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import env_fallback

--- a/lib/ansible/modules/network/f5/bigip_cipher_rule.py
+++ b/lib/ansible/modules/network/f5/bigip_cipher_rule.py
@@ -1,0 +1,414 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'certified'}
+
+DOCUMENTATION = r'''
+---
+module: bigip_cipher_rule
+short_description: Manages cipher rules on a BIG-IP
+description:
+  - Manages cipher rules on a BIG-IP.
+  - see: https://clouddocs.f5.com/api/icontrol-rest/APIRef_tm_ltm_cipher_rule.html
+version_added: 2.10
+options:
+  name:
+    description:
+      - Specifies the name of the cipher rule.
+    type: str
+    required: True
+  cipher:
+    description:
+      - Specifies the cipher string which this cipher rule uses to propagate ciphers
+        to cipher groups. 
+    type: str
+    default: "DEFAULT"
+  state:
+    description:
+      - When C(present), ensures that the cipher rule exists.
+      - When C(absent), ensures the cipher rule is removed.
+    type: str
+    choices:
+      - present
+      - absent
+    default: present
+  partition:
+    description:
+      - Device partition to manage resources on.
+    type: str
+    default: Common
+notes:
+  - Requires BIG-IP software version >= 12
+extends_documentation_fragment: f5
+author:
+  - @diLLec
+'''
+
+EXAMPLES = r'''
+- name: Create cipher rule with default set
+  bigip_cipher_rule:
+    state: present
+    name: default
+    cipher: DEFAULT
+  delegate_to: localhost
+
+- name: Create cipher rule with Intermediate Cipher Set and TLS13
+  bigip_cipher_rule:
+    state: present
+    name: default
+    cipher: ECDHE:TLS13-AES128-GCM-SHA256:TLS13-AES256-GCM-SHA384:TLS13-CHACHA20-POLY1305-SHA256:!TLSv1:!EXPORT:!DHE:!3DES:-MD5:-SSLv3:-RC4:!ECDHE-RSA-AES128-CBC-SHA:!ECDHE-RSA-AES256-CBC-SHA
+  delegate_to: localhost
+'''
+
+RETURN = r'''
+ciphers:
+  description: The ciphers applied to the profile.
+  returned: changed
+  type: str
+  sample: "!SSLv3:!SSLv2:ECDHE+AES-GCM+SHA256:ECDHE-RSA-AES128-CBC-SHA"
+'''
+
+import os
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.six import iteritems
+
+try:
+    from library.module_utils.network.f5.bigip import F5RestClient
+    from library.module_utils.network.f5.common import F5ModuleError
+    from library.module_utils.network.f5.common import AnsibleF5Parameters
+    from library.module_utils.network.f5.common import fq_name
+    from library.module_utils.network.f5.common import f5_argument_spec
+    from library.module_utils.network.f5.common import flatten_boolean
+    from library.module_utils.network.f5.common import transform_name
+    from library.module_utils.network.f5.common import is_empty_list
+except ImportError:
+    from ansible.module_utils.network.f5.bigip import F5RestClient
+    from ansible.module_utils.network.f5.common import F5ModuleError
+    from ansible.module_utils.network.f5.common import AnsibleF5Parameters
+    from ansible.module_utils.network.f5.common import fq_name
+    from ansible.module_utils.network.f5.common import f5_argument_spec
+    from ansible.module_utils.network.f5.common import flatten_boolean
+    from ansible.module_utils.network.f5.common import transform_name
+    from ansible.module_utils.network.f5.common import is_empty_list
+
+
+class Parameters(AnsibleF5Parameters):
+    api_map = {
+    }
+
+    api_attributes = [
+        'cipher',
+    ]
+
+    returnables = [
+        'cipher',
+    ]
+
+    updatables = [
+        'cipher',
+    ]
+
+
+class ModuleParameters(Parameters):
+    pass
+
+
+class ApiParameters(Parameters):
+    pass
+
+
+class Changes(Parameters):
+    def to_return(self):
+        result = {}
+        try:
+            for returnable in self.returnables:
+                result[returnable] = getattr(self, returnable)
+            result = self._filter_params(result)
+        except Exception:
+            pass
+        return result
+
+
+class UsableChanges(Changes):
+    pass
+
+
+class ReportableChanges(Changes):
+    pass
+
+
+class Difference(object):
+    def __init__(self, want, have=None):
+        self.want = want
+        self.have = have
+
+    def compare(self, param):
+        try:
+            result = getattr(self, param)
+            return result
+        except AttributeError:
+            result = self.__default(param)
+            return result
+
+    def __default(self, param):
+        attr1 = getattr(self.want, param)
+        try:
+            attr2 = getattr(self.have, param)
+            if attr1 != attr2:
+                return attr1
+        except AttributeError:
+            return attr1
+
+    def to_tuple(self, items):
+        result = []
+        for x in items:
+            tmp = [(str(k), str(v)) for k, v in iteritems(x)]
+            result += tmp
+        return result
+
+    def _diff_complex_items(self, want, have):
+        if want == [] and have is None:
+            return None
+        if want is None:
+            return None
+        w = self.to_tuple(want)
+        h = self.to_tuple(have)
+        if set(w).issubset(set(h)):
+            return None
+        else:
+            return want
+
+
+class ModuleManager(object):
+    def __init__(self, *args, **kwargs):
+        self.module = kwargs.get('module', None)
+        self.client = F5RestClient(**self.module.params)
+        self.want = ModuleParameters(params=self.module.params)
+        self.have = ApiParameters()
+        self.changes = UsableChanges()
+
+    def _set_changed_options(self):
+        changed = {}
+        for key in Parameters.returnables:
+            if getattr(self.want, key) is not None:
+                changed[key] = getattr(self.want, key)
+        if changed:
+            self.changes = UsableChanges(params=changed)
+
+    def _update_changed_options(self):
+        diff = Difference(self.want, self.have)
+        updatables = Parameters.updatables
+        changed = dict()
+        for k in updatables:
+            change = diff.compare(k)
+            if change is None:
+                continue
+            else:
+                if isinstance(change, dict):
+                    changed.update(change)
+                else:
+                    changed[k] = change
+        if changed:
+            self.changes = UsableChanges(params=changed)
+            return True
+        return False
+
+    def should_update(self):
+        result = self._update_changed_options()
+        if result:
+            return True
+        return False
+
+    def exec_module(self):
+        changed = False
+        result = dict()
+        state = self.want.state
+
+        if state == "present":
+            changed = self.present()
+        elif state == "absent":
+            changed = self.absent()
+
+        reportable = ReportableChanges(params=self.changes.to_return())
+        changes = reportable.to_return()
+        result.update(**changes)
+        result.update(dict(changed=changed))
+        self._announce_deprecations(result)
+        return result
+
+    def _announce_deprecations(self, result):
+        warnings = result.pop('__warnings', [])
+        for warning in warnings:
+            self.client.module.deprecate(
+                msg=warning['msg'],
+                version=warning['version']
+            )
+
+    def present(self):
+        if self.exists():
+            return self.update()
+        else:
+            return self.create()
+
+    def exists(self):
+        uri = "https://{0}:{1}/mgmt/tm/ltm/cipher/rule/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError:
+            return False
+        if resp.status == 404 or 'code' in response and response['code'] == 404:
+            return False
+        return True
+
+    def update(self):
+        self.have = self.read_current_from_device()
+        if not self.should_update():
+            return False
+        if self.module.check_mode:
+            return True
+        self.update_on_device()
+        return True
+
+    def remove(self):
+        if self.module.check_mode:
+            return True
+        self.remove_from_device()
+        if self.exists():
+            raise F5ModuleError("Failed to delete the resource.")
+        return True
+
+    def create(self):
+        self._set_changed_options()
+        if self.module.check_mode:
+            return True
+        self.create_on_device()
+        return True
+
+    def create_on_device(self):
+        params = self.changes.api_params()
+        params['name'] = self.want.name
+        params['partition'] = self.want.partition
+        uri = "https://{0}:{1}/mgmt/tm/ltm/cipher/rule/".format(
+            self.client.provider['server'],
+            self.client.provider['server_port']
+        )
+        resp = self.client.api.post(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] in [400, 403, 404]:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+
+    def update_on_device(self):
+        params = self.changes.api_params()
+        uri = "https://{0}:{1}/mgmt/tm/ltm/cipher/rule/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        resp = self.client.api.patch(uri, json=params)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] in [400, 404]:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+
+    def absent(self):
+        if self.exists():
+            return self.remove()
+        return False
+
+    def remove_from_device(self):
+        uri = "https://{0}:{1}/mgmt/tm/ltm/cipher/rule/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        response = self.client.api.delete(uri)
+        if response.status == 200:
+            return True
+        raise F5ModuleError(response.content)
+
+    def read_current_from_device(self):
+        uri = "https://{0}:{1}/mgmt/tm/ltm/cipher/rule/{2}".format(
+            self.client.provider['server'],
+            self.client.provider['server_port'],
+            transform_name(self.want.partition, self.want.name)
+        )
+        resp = self.client.api.get(uri)
+        try:
+            response = resp.json()
+        except ValueError as ex:
+            raise F5ModuleError(str(ex))
+
+        if 'code' in response and response['code'] == 400:
+            if 'message' in response:
+                raise F5ModuleError(response['message'])
+            else:
+                raise F5ModuleError(resp.content)
+        return ApiParameters(params=response)
+
+
+class ArgumentSpec(object):
+    def __init__(self):
+        self.supports_check_mode = True
+        argument_spec = dict(
+            name=dict(required=True),
+            cipher=dict(type='str'),
+            partition=dict(
+                default='Common',
+                fallback=(env_fallback, ['F5_PARTITION'])
+            ),
+            state=dict(
+                default='present',
+                choices=['present', 'absent']
+            ),
+        )
+        self.argument_spec = {}
+        self.argument_spec.update(f5_argument_spec)
+        self.argument_spec.update(argument_spec)
+
+
+def main():
+    spec = ArgumentSpec()
+
+    module = AnsibleModule(
+        argument_spec=spec.argument_spec,
+        supports_check_mode=spec.supports_check_mode,
+    )
+
+    try:
+        mm = ModuleManager(module=module)
+        results = mm.exec_module()
+        module.exit_json(**results)
+    except F5ModuleError as ex:
+        module.fail_json(msg=str(ex))
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/f5/bigip_cipher_rule.py
+++ b/lib/ansible/modules/network/f5/bigip_cipher_rule.py
@@ -48,7 +48,7 @@ notes:
   - Requires BIG-IP software version >= 12
 extends_documentation_fragment: f5
 author:
-  - @diLLec
+  - diLLec
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/network/f5/bigip_profile_client_ssl.py
+++ b/lib/ansible/modules/network/f5/bigip_profile_client_ssl.py
@@ -7,7 +7,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'certified'}
@@ -491,14 +490,14 @@ class ModuleParameters(Parameters):
 
     @property
     def ciphers(self):
-        if 'cipherGroup' in self._values:
+        if 'cipherGroup' in self._values and self._values['cipherGroup'] not in (None, ''):
             # This may be a API fix as specifying cipherGroup and not cipher = "" results in the error
             # "Profile ... cannot contain both ciphers and a cipher-group"
-            return ""
-        elif 'ciphers' in self._values:
+            return None
+        elif 'ciphers' in self._values and self._values['ciphers'] not in (None, ''):
             return self._values['ciphers']
         else:
-            return None
+            return ""
 
     @property
     def parent(self):

--- a/lib/ansible/modules/network/f5/bigip_profile_client_ssl.py
+++ b/lib/ansible/modules/network/f5/bigip_profile_client_ssl.py
@@ -36,7 +36,7 @@ options:
     description:
       - Specifies a cipherGroup for that clientssl profile.
     type: str
-    version_added: 2.10
+    version_added: "2.10"
   ciphers:
     description:
       - Specifies the list of ciphers that the system supports. When creating a new

--- a/lib/ansible/modules/network/f5/bigip_profile_client_ssl.py
+++ b/lib/ansible/modules/network/f5/bigip_profile_client_ssl.py
@@ -32,6 +32,10 @@ options:
         parent on the C(Common) partition.
     type: str
     default: /Common/clientssl
+  cipherGroup:
+    description:
+      - Specifies a cipherGroup for that clientssl profile. 
+    type: str
   ciphers:
     description:
       - Specifies the list of ciphers that the system supports. When creating a new
@@ -388,6 +392,7 @@ class Parameters(AnsibleF5Parameters):
     }
 
     api_attributes = [
+        'cipherGroup',
         'ciphers',
         'certKeyChain',
         'defaultsFrom',
@@ -410,6 +415,7 @@ class Parameters(AnsibleF5Parameters):
     ]
 
     returnables = [
+        'cipherGroup',
         'ciphers',
         'allow_non_ssl',
         'options',
@@ -432,6 +438,7 @@ class Parameters(AnsibleF5Parameters):
     ]
 
     updatables = [
+        'cipherGroup',
         'ciphers',
         'cert_key_chain',
         'allow_non_ssl',
@@ -480,6 +487,17 @@ class ModuleParameters(Parameters):
         else:
             result = self._cert_filename(fq_name(self.partition, item['chain']))
         return result
+
+    @property
+    def ciphers(self):
+        if 'cipherGroup' in self._values:
+            # This may be a API fix as specifying cipherGroup and not cipher = "" results in the error
+            # "Profile ... cannot contain both ciphers and a cipher-group"
+            return ""
+        elif 'ciphers' in self._values:
+            return self._values['ciphers']
+        else:
+            return None
 
     @property
     def parent(self):

--- a/lib/ansible/modules/network/f5/bigip_profile_client_ssl.py
+++ b/lib/ansible/modules/network/f5/bigip_profile_client_ssl.py
@@ -34,8 +34,9 @@ options:
     default: /Common/clientssl
   cipherGroup:
     description:
-      - Specifies a cipherGroup for that clientssl profile. 
+      - Specifies a cipherGroup for that clientssl profile.
     type: str
+    version_added: 2.10
   ciphers:
     description:
       - Specifies the list of ciphers that the system supports. When creating a new
@@ -1040,6 +1041,7 @@ class ArgumentSpec(object):
             name=dict(required=True),
             parent=dict(default='/Common/clientssl'),
             ciphers=dict(),
+            cipherGroup=dict(),
             allow_non_ssl=dict(type='bool'),
             secure_renegotiation=dict(
                 choices=['require', 'require-strict', 'request']


### PR DESCRIPTION
##### SUMMARY
This will ad the parameter cipherGroup to bigip_profile_client_ssl as without that option TLSv1.3 cannot be active on the clientssl profile.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cipherGroup Parametzer

##### ADDITIONAL INFORMATION
```paste below
# create a cipher rule/group
lb_cipher_groups:
  - name: "cgroup_test"
    allow:
      - "crule_test"
    ordering: "speed"

lb_cipher_rules:
  - name: "crule_test"
    cipher:
      - "ECDHE"
      - "TLS13-AES128-GCM-SHA256"
      - "TLS13-AES256-GCM-SHA384"
      - "TLS13-CHACHA20-POLY1305-SHA256"
      - "!TLSv1"
      - "!EXPORT"
      - "!DHE"
      - "!3DES"
      - "-MD5"
      - "-SSLv3"
      - "-RC4"
      - "!ECDHE-RSA-AES128-CBC-SHA"
      - "!ECDHE-RSA-AES256-CBC-SHA"

- name: "create cipher rules"
  bigip_cipher_rule:
    state: present
    name: "{{ lb_cipher_rule.name }}"
    cipher: "{{ lb_cipher_rule.cipher | join(':') }}"
    provider: "{{ f5_provider_rest }}"
    partition: "Common"
    delegate_to: localhost
  loop: "{{ lb_cipher_rules }}"
  loop_control:
    label: "{{ lb_cipher_rule }}"
    loop_var: "lb_cipher_rule"

- name: "create cipher groups"
  bigip_cipher_group:
    state: present
    name: "{{ lb_cipher_group.name }}"
    allow: "{{ lb_cipher_group.allow }}"
    exclude: "{{ lb_cipher_group.exclude | default(omit) }}"
    require: "{{ lb_cipher_group.require | default(omit) }}"
    ordering: "{{ lb_cipher_group.ordering }}"
    provider: "{{ f5_provider_rest }}"
    partition: "Common"
    delegate_to: localhost
  loop: "{{ lb_cipher_groups }}"
  loop_control:
    label: "{{ lb_cipher_group }}"
    loop_var: "lb_cipher_group"

# create the clientssl profile (using the change in this pull request)
lb_profiles_client_ssl:
  - name:  "clientssl_test"
    parent: /Common/clientssl
    cipherGroup: "cgroup_test"
    ciphers: ""
    options:
      - no-tlsv1
      - no-tlsv1.1
      - no-sslv3
      - no-dtls   # no TLS for UDP
      - single-dh-use
      - dont-insert-empty-fragments

- name: "ensure client_ssl profiles are configured for {{ lb_partition }}"
  bigip_profile_client_ssl:
    name: "{{ item.name }}"
    parent: "{{ item.parent | default("/Common/clientssl") }}"
    partition: "{{ lb_partition }}"
    cipherGroup: "{{ item.cipherGroup | default(omit) }}"
    ciphers: "{{ item.ciphers | default(omit) }}"
    options: "{{ item.options | default(omit) }}"
    server_name: "{{ item.server_name | default(omit) }}"
    sni_default: "{{ item.sni_default | default(omit) }}"
    cert_key_chain: "{{ item.cert_key_chain | default(omit) }}"
    client_certificate: "{{ item.client_certificate | default(omit) }}"
    client_auth_frequency: "{{ item.client_auth_frequency | default(omit) }}"
    trusted_cert_authority: "{{ item.trusted_cert_authority | default(omit) }}"
    advertised_cert_authority: "{{ item.advertised_cert_authority | default(omit) }}"
    provider: "{{ f5_provider_rest }}"
  delegate_to: localhost
  loop: "{{ lb_profiles_client_ssl }}"
  loop_control:
    label: "{{ item.name }}"
```
