### PR TITLE
vmware_export_ovf: increase default timeout

### DIFF
--- a/changelogs/fragments/vmware_export_ovf.yaml
+++ b/changelogs/fragments/vmware_export_ovf.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - vmware_export_ovf - timeout value is actually in seconds, not minutes
+  - vmware_export_ovf - increase default timeout to 30s

--- a/lib/ansible/modules/cloud/vmware/vmware_export_ovf.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_export_ovf.py
@@ -78,9 +78,9 @@ options:
     type: bool
   download_timeout:
     description:
-    - The user defined timeout in minute of exporting file.
-    - If the vmdk file is too large to export in 10 minutes, specify the value larger than 10, the maximum value is 60.
-    default: 10
+    - The user defined timeout in second of exporting file.
+    - If the vmdk file is too large, you can increase the value.
+    default: 30
     type: int
     version_added: '2.9'
 extends_documentation_fragment: vmware.documentation
@@ -163,7 +163,7 @@ class VMwareExportVmOvf(PyVmomi):
         # set lease progress update interval to 15 seconds
         self.lease_interval = 15
         self.facts = {'device_files': []}
-        self.download_timeout = 10
+        self.download_timeout = None
 
     def create_export_dir(self, vm_obj):
         self.ovf_dir = os.path.join(self.params['export_dir'], vm_obj.name)
@@ -217,8 +217,7 @@ class VMwareExportVmOvf(PyVmomi):
         export_with_iso = False
         if 'export_with_images' in self.params and self.params['export_with_images']:
             export_with_iso = True
-        if 60 > self.params['download_timeout'] > 10:
-            self.download_timeout = self.params['download_timeout']
+        self.download_timeout = self.params['download_timeout']
 
         ovf_files = []
         # get http nfc lease firstly
@@ -332,7 +331,7 @@ def main():
         datacenter=dict(type='str', default='ha-datacenter'),
         export_dir=dict(type='path', required=True),
         export_with_images=dict(type='bool', default=False),
-        download_timeout=dict(type='int', default=10),
+        download_timeout=dict(type='int', default=30),
     )
 
     module = AnsibleModule(argument_spec=argument_spec,


### PR DESCRIPTION
##### SUMMARY

I consistently reach a timeout with the current (10s) timeout. This
commit increases the default value to 30s, this should simplify the life
of our users.
Also, the documentation was incorrect. The value is in second, not minute.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_export_ovf