### PR TITLE
include_vars - fix stack trace when run ad-hoc with dirs parameter

### DIFF
--- a/changelogs/fragments/include_vars-ad-hoc-stack-trace-fix.yaml
+++ b/changelogs/fragments/include_vars-ad-hoc-stack-trace-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - include_vars - fix stack trace when passing ``dirs`` in an ad-hoc command (https://github.com/ansible/ansible/issues/62633)

--- a/lib/ansible/plugins/action/include_vars.py
+++ b/lib/ansible/plugins/action/include_vars.py
@@ -158,10 +158,11 @@ class ActionModule(ActionBase):
                 )
                 self.source_dir = path_to_use
         else:
-            current_dir = (
-                "/".join(self._task._ds._data_source.split('/')[:-1])
-            )
-            self.source_dir = path.join(current_dir, self.source_dir)
+            if hasattr(self._task._ds, '_data_source'):
+                current_dir = (
+                    "/".join(self._task._ds._data_source.split('/')[:-1])
+                )
+                self.source_dir = path.join(current_dir, self.source_dir)
 
     def _traverse_dir_depth(self):
         """ Recursively iterate over a directory and sort the files in

--- a/test/integration/targets/include_vars-ad-hoc/aliases
+++ b/test/integration/targets/include_vars-ad-hoc/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group2

--- a/test/integration/targets/include_vars-ad-hoc/dir/inc.yml
+++ b/test/integration/targets/include_vars-ad-hoc/dir/inc.yml
@@ -1,0 +1,1 @@
+porter: cable

--- a/test/integration/targets/include_vars-ad-hoc/runme.sh
+++ b/test/integration/targets/include_vars-ad-hoc/runme.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ansible testhost -i ../../inventory -m include_vars -a 'dir/inc.yml' "$@"
+ansible testhost -i ../../inventory -m include_vars -a 'dir=dir' "$@"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There are a number of other parameters that result in stack traces as well when `include_vars` is used ad-hoc. I'm not sure if we're interested in fixing them all since this module isn't meant to be run ad-hoc.

Fixes #62633
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/action/include_vars.py`