### PR TITLE
[stable-2.9] podman - fix rootless container copy no pause (#66583)

### DIFF
--- a/changelogs/fragments/66263-podman-connection-no-pause-rootless.yml
+++ b/changelogs/fragments/66263-podman-connection-no-pause-rootless.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - podman connection plugin - fix to handle the new default copy pause rootless containers from upstream (https://github.com/ansible/ansible/issues/66263)

--- a/lib/ansible/plugins/connection/podman.py
+++ b/lib/ansible/plugins/connection/podman.py
@@ -133,10 +133,18 @@ class Connection(ConnectionBase):
         display.vvv("PUT %s TO %s" % (in_path, out_path), host=self._container_id)
         if not self._mount_point:
             rc, stdout, stderr = self._podman(
-                "cp", [in_path, self._container_id + ":" + out_path], use_container_id=False)
+                "cp", [in_path, self._container_id + ":" + out_path], use_container_id=False
+            )
             if rc != 0:
-                raise AnsibleError("Failed to copy file from %s to %s in container %s\n%s" % (
-                    in_path, out_path, self._container_id, stderr))
+                if 'cannot copy into running rootless container with pause set' in to_native(stderr):
+                    rc, stdout, stderr = self._podman(
+                        "cp", ["--pause=false", in_path, self._container_id + ":" + out_path], use_container_id=False
+                    )
+                    if rc != 0:
+                        raise AnsibleError(
+                            "Failed to copy file from %s to %s in container %s\n%s" % (
+                                in_path, out_path, self._container_id, stderr)
+                        )
         else:
             real_out_path = self._mount_point + to_bytes(out_path, errors='surrogate_or_strict')
             shutil.copyfile(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #66583 for Ansible 2.9
(cherry picked from commit 077a8b4898)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/connection/podman.py`