### PR TITLE
Add pacman support to package_facts

### DIFF
--- a/changelogs/fragments/66596-package_facts-add-pacman-support.yaml
+++ b/changelogs/fragments/66596-package_facts-add-pacman-support.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - package_facts.py - Add support for Pacman package manager.

--- a/lib/ansible/modules/packaging/os/package_facts.py
+++ b/lib/ansible/modules/packaging/os/package_facts.py
@@ -23,7 +23,7 @@ options:
       - Since 2.8 this is a list and can support multiple package managers per system.
       - The 'portage' and 'pkg' options were added in version 2.8.
     default: ['auto']
-    choices: ['auto', 'rpm', 'apt', 'portage', 'pkg']
+    choices: ['auto', 'rpm', 'apt', 'portage', 'pkg', 'pacman']
     required: False
     type: list
   strategy:
@@ -206,6 +206,8 @@ ansible_facts:
         }
 '''
 
+import re
+
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.process import get_bin_path
@@ -268,6 +270,44 @@ class APT(LibMgr):
     def get_package_details(self, package):
         ac_pkg = self.pkg_cache[package].installed
         return dict(name=package, version=ac_pkg.version, arch=ac_pkg.architecture, category=ac_pkg.section, origin=ac_pkg.origins[0].origin)
+
+
+class PACMAN(CLIMgr):
+
+    CLI = 'pacman'
+
+    def list_installed(self):
+        rc, out, err = module.run_command([self._cli, '-Qi'], environ_update=dict(LC_ALL='C'))
+        if rc != 0 or err:
+            raise Exception("Unable to list packages rc=%s : %s" % (rc, err))
+        return out.split("\n\n")[:-1]
+
+    def get_package_details(self, package):
+        # parse values of details might extend over several lines
+        raw_pkg_details = {}
+        last_detail = None
+        for line in package.splitlines():
+            m = re.match(r"([\w ]*[\w]) +: (.*)", line)
+            if m:
+                last_detail = m.group(1)
+                raw_pkg_details[last_detail] = m.group(2)
+            else:
+                # append value to previous detail
+                raw_pkg_details[last_detail] = raw_pkg_details[last_detail] + "  " + line.lstrip()
+
+        provides = None
+        if raw_pkg_details['Provides'] != 'None':
+            provides = [
+                p.split('=')[0]
+                for p in raw_pkg_details['Provides'].split('  ')
+            ]
+
+        return {
+            'name': raw_pkg_details['Name'],
+            'version': raw_pkg_details['Version'],
+            'arch': raw_pkg_details['Architecture'],
+            'provides': provides,
+        }
 
 
 class PKG(CLIMgr):

--- a/lib/ansible/modules/packaging/os/package_facts.py
+++ b/lib/ansible/modules/packaging/os/package_facts.py
@@ -283,7 +283,7 @@ class PACMAN(CLIMgr):
         return out.split("\n\n")[:-1]
 
     def get_package_details(self, package):
-        # parse values of details might extend over several lines
+        # parse values of details that might extend over several lines
         raw_pkg_details = {}
         last_detail = None
         for line in package.splitlines():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add Pacman package manager to `package_facts`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/packaging/os/package_facts.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Example:

```yml
    - name: Gather pacman package facts
      package_facts:
        manager: pacman

    - name: Print the pacman package facts
      debug:
        var: ansible_facts.packages
```

Result:

```json
{
    ...
    "zeromq": [
        {
            "arch": "x86_64",
            "name": "zeromq",
            "provides": null,
            "source": "pacman",
            "version": "4.3.2-1"
        }
    ],
    "zip": [
        {
            "arch": "x86_64",
            "name": "zip",
            "provides": null,
            "source": "pacman",
            "version": "3.0-8"
        }
    ]
    ...
}
```