### PR TITLE
Fix UNC path support in the powershell shell plugin

### DIFF
--- a/changelogs/fragments/66604-powershell-unc-paths.yml
+++ b/changelogs/fragments/66604-powershell-unc-paths.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "powershell (shell plugin) - Fix `join_path` to support UNC paths (https://github.com/ansible/ansible/issues/66341)"

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -22,6 +22,7 @@ import re
 import shlex
 import pkgutil
 import xml.etree.ElementTree as ET
+import ntpath
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes, to_text
@@ -93,13 +94,13 @@ class ShellModule(ShellBase):
         return ""
 
     def join_path(self, *args):
-        parts = ['\\'] if args[0].startswith('\\\\') else []
+        # use normpath() to remove doubled slashed and convert forward to backslashes
+        parts = [ntpath.normpath(self._unquote(arg)) for arg in args]
 
-        for arg in args:
-            arg = self._unquote(arg).replace('/', '\\')
-            parts.extend([a for a in arg.split('\\') if a])
-        path = '\\'.join(parts)
-        return path
+        # Becuase ntpath.join treats any component that begins with a backslash as an absolute path,
+        # we have to strip slashes from at least the beginning, otherwise join will ignore all previous
+        # path components except for the drive.
+        return ntpath.join(parts[0], *[part.strip('\\') for part in parts[1:]])
 
     def get_remote_filename(self, pathname):
         # powershell requires that script files end with .ps1

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -99,8 +99,6 @@ class ShellModule(ShellBase):
             arg = self._unquote(arg).replace('/', '\\')
             parts.extend([a for a in arg.split('\\') if a])
         path = '\\'.join(parts)
-        if path.startswith('~'):
-            return path
         return path
 
     def get_remote_filename(self, pathname):

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -93,7 +93,8 @@ class ShellModule(ShellBase):
         return ""
 
     def join_path(self, *args):
-        parts = []
+        parts = ['\\'] if args[0].startswith('\\\\') else []
+
         for arg in args:
             arg = self._unquote(arg).replace('/', '\\')
             parts.extend([a for a in arg.split('\\') if a])

--- a/test/units/plugins/shell/test_powershell.py
+++ b/test/units/plugins/shell/test_powershell.py
@@ -57,6 +57,4 @@ def test_join_path_unc():
     unc_path_parts = ['\\\\host\\share\\dir1\\\\dir2\\','\\dir3/dir4', 'dir5', 'dir6\\']
     expected = '\\\\host\\share\\dir1\\dir2\\dir3\\dir4\\dir5\\dir6'
     actual = pwsh.join_path(*unc_path_parts)
-    print expected
-    print actual
     assert actual == expected

--- a/test/units/plugins/shell/test_powershell.py
+++ b/test/units/plugins/shell/test_powershell.py
@@ -1,4 +1,4 @@
-from ansible.plugins.shell.powershell import _parse_clixml
+from ansible.plugins.shell.powershell import _parse_clixml, ShellModule
 
 
 def test_parse_clixml_empty():
@@ -50,4 +50,13 @@ def test_parse_clixml_multiple_streams():
                       b'</Objs>'
     expected = b"hi info"
     actual = _parse_clixml(multiple_stream, stream="Info")
+    assert actual == expected
+
+def test_join_path_unc():
+    pwsh = ShellModule()
+    unc_path_parts = ['\\\\host\\share\\dir1\\\\dir2\\','\\dir3/dir4', 'dir5', 'dir6\\']
+    expected = '\\\\host\\share\\dir1\\dir2\\dir3\\dir4\\dir5\\dir6'
+    actual = pwsh.join_path(*unc_path_parts)
+    print expected
+    print actual
     assert actual == expected

--- a/test/units/plugins/shell/test_powershell.py
+++ b/test/units/plugins/shell/test_powershell.py
@@ -52,9 +52,10 @@ def test_parse_clixml_multiple_streams():
     actual = _parse_clixml(multiple_stream, stream="Info")
     assert actual == expected
 
+
 def test_join_path_unc():
     pwsh = ShellModule()
-    unc_path_parts = ['\\\\host\\share\\dir1\\\\dir2\\','\\dir3/dir4', 'dir5', 'dir6\\']
+    unc_path_parts = ['\\\\host\\share\\dir1\\\\dir2\\', '\\dir3/dir4', 'dir5', 'dir6\\']
     expected = '\\\\host\\share\\dir1\\dir2\\dir3\\dir4\\dir5\\dir6'
     actual = pwsh.join_path(*unc_path_parts)
     assert actual == expected


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #66341

- The `join_path` method in `powershell.py` didn't preserve the leading double backslashes in UNC paths. A fix was added.
- A test was added for `join_path` that checks for correctness with a UNC path.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
!component =lib/ansible/plugins/shell/powershell.py
