### PR TITLE
AWS ELB: Return empty list when no load balancer name was found

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_classic_lb_info.py
+++ b/lib/ansible/modules/cloud/amazon/elb_classic_lb_info.py
@@ -165,7 +165,12 @@ except ImportError:
 @AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
 def list_elbs(connection, names):
     paginator = connection.get_paginator('describe_load_balancers')
-    load_balancers = paginator.paginate(LoadBalancerNames=names).build_full_result().get('LoadBalancerDescriptions', [])
+    try:
+        load_balancers = paginator.paginate(LoadBalancerNames=names).build_full_result().get('LoadBalancerDescriptions', [])
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == 'LoadBalancerNotFound':
+            return []
+
     results = []
 
     for lb in load_balancers:


### PR DESCRIPTION
##### SUMMARY
When trying to describe a LoadBalancer that doesn't exist, the module crash. Instead of that behavior, this commit will return an empty list when no load balancer is found, allowing to deal next tasks by reading the output of the module.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/elb_classic_lb_info.py
