### PR TITLE
Adding win_zip module along with integration tests

### DIFF
--- a/lib/ansible/modules/windows/win_zip.ps1
+++ b/lib/ansible/modules/windows/win_zip.ps1
@@ -1,0 +1,253 @@
+#!powershell
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#Requires -Module Ansible.ModuleUtils.Legacy
+#Requires -Version 5.0
+
+Set-StrictMode -Version 2.0
+
+$ErrorActionPreference = "Stop"
+#TODO/Future Enhancements
+#-------------------------
+# - support recurse or just content for dirs
+# - support multiple source files and dirs and globs
+# - "force" option to overwrite existing zip file
+# - Provide an 'update' parameter to add or remove files from the zip
+# - Support other archive types - $pcx_extensions = @('.bz2', '.gz', '.msu', '.tar', '.zip')
+
+# Notes
+# -----
+# The operations should be atomic - the zip shouldn't be created if anything fails
+
+# Initialize it here as it's used for the failifempty
+$result = @{
+    changed = $false
+    source_deleted = $false
+}
+
+$params = Parse-Args $args -supports_check_mode $true
+$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
+
+$src = Get-AnsibleParam -obj $params -name "src" -type "path" -failifempty $true -resultobj $result -aliases path
+$dest = Get-AnsibleParam -obj $params -name "dest" -type "path" -failifempty $true -resultobj $result -aliases zip_file
+$delete_src = Get-AnsibleParam -obj $params -name "delete_src" -type "bool" -default $false -aliases rm
+$creates = Get-AnsibleParam -obj $params -name "creates" -type "path"
+
+# Fixes a fail error message (when the task actually succeeds) for a
+# "Convert-ToJson: The converted JSON string is in bad format"
+# This happens when JSON is parsing a string that ends with a "\",
+# which is possible when specifying a directory to download to.
+# This catches that possible error, before assigning the JSON $result
+$result.dest = $dest -replace '\\$',''
+$result.src = $src -replace '\\$',''
+
+if ($creates) {
+    $result.creates = $creates
+}
+
+function Remove-BrokenZip([string]$dest) {
+    #Removes the broken zip
+    Remove-Item -LiteralPath $dest -Force -ErrorAction SilentlyContinue
+}
+
+function Remove-Source([string]$src) {
+    try {
+        if (-not $check_mode) {
+            if (Test-Path -LiteralPath $src) {
+                # -recurse won't cause issues for files
+                Remove-Item -LiteralPath $src -Recurse -Force -ErrorAction Stop
+            }
+        }
+        #$result.changed = $true
+        $result.source_deleted = $true
+    }
+    catch {
+        Remove-BrokenZip $dest
+        Fail-Json -obj $result -message "Error removing source '$src': $($_.Exception.Message)"
+    }
+
+}
+
+function Find-LargeFiles([string]$src, [ref]$large_files, [int]$max_size=2097152000) {
+    #$large_files = New-Object -Type System.Collections.ArrayList
+
+    if (Test-Path -LiteralPath $src -PathType Container) {
+        $items = Get-ChildItem -LiteralPath $src -Recurse
+        foreach ($item in $items) {
+            if (($item.GetType()).Name -eq "FileInfo") {
+                if ($item.length -ge $max_size) {
+                    ($large_files.Value).Add($item.FullName) | Out-Null
+                }
+            }
+        }
+    }
+    else {
+        $item = Get-Item -LiteralPath $src
+        if ($item.Length -ge $max_size) {
+            ($large_files.Value).Add($item.FullName) | Out-Null
+        }
+    }
+}
+
+function New-ZipFile {
+	param(
+	[Parameter(Mandatory=$True)]
+	[string]$src,
+	[Parameter(Mandatory=$True)]
+	[string]$dest,
+	[Parameter(Mandatory=$True)]
+	[CompressionUtils]$utils_available
+	)
+
+    switch ($utils_available)
+    {
+        "PowerShell" {
+            try {
+                if (-not $check_mode) {
+                    Compress-Archive -LiteralPath $src -DestinationPath $dest -CompressionLevel Optimal -ErrorAction Stop
+                }
+                #$result.changed = $true
+            }
+            catch {
+                Remove-BrokenZip $dest
+                Fail-Json -obj $result -message "Error creating zip file '$dest': $($_.Exception.Message)"
+            }
+        }
+        "DotNet" {
+            try {
+                # add type here is only needed for force testing dotnet in the calling main code
+                Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Stop| Out-Null
+                Add-Type -AssemblyName System.IO.Compression -ErrorAction Stop | Out-Null
+
+                if (Test-Path -LiteralPath $src -PathType Container)
+                {
+                    if (-not $check_mode) {
+                        [System.IO.Compression.ZipFile]::CreateFromDirectory($src, $dest)
+                    }
+                    #$result.changed = $true
+                }
+                else {
+                    if (-not $check_mode) {
+                        $archive = [System.IO.Compression.ZipFile]::Open($dest, [System.IO.Compression.ZipArchiveMode]::Create, [System.Text.Encoding]::UTF8)
+                        $filename = (Get-Item -LiteralPath $src).Name
+                        [System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile($archive, $src, $filename, 0) | Out-Null
+                    }
+                    #$result.changed = $true
+                }
+            }
+            catch {
+                # If zip is opened but something fails afterwards, it will be left on disk. Need to cleanup
+                # Duplicated here and not just finally because we have to dispose it before we can delete it
+                # or the unmanaged file is locked
+                if ((Get-Variable -Name archive -ErrorAction SilentlyContinue) -and ($null -ne $archive)) {
+                    $archive.Dispose()
+                }
+                Remove-BrokenZip $dest
+                Fail-Json -obj $result -message "Error creating zip file '$dest': $($_.Exception.Message)"
+
+            }
+            finally {
+                # Call dispose to get rid of the unmanaged object
+                if ((Get-Variable -Name archive -ErrorAction SilentlyContinue) -and ($null -ne $archive)) {
+                    $archive.Dispose()
+                }
+            }
+        }
+        "Undefined" { # This should never be hit as we check, but leave in just in case the early check is modified.
+            #Fail-Json -obj $result -message "Could not find any available compression utilities: $($_.Exception.Message)"
+            Fail-Json -obj $result -message "Could not find any available compression utilities: PowerShell 5.0 and .NET Framework 4.5 are minimally required.  Please install the Windows Management Framework 5.0 or higher."
+        }
+    }
+
+}
+
+# BEGIN: Determine which type of compression utils to use: PowerShell, .NET or COM (to follow dev standards)
+# Try PowerShell native first, then .NET 4.5
+Add-Type -ErrorAction SilentlyContinue -TypeDefinition @"
+    public enum CompressionUtils
+    {
+        PowerShell,
+        DotNet,
+        Undefined
+    }
+"@
+
+$try_dotnet = $false
+try {
+    # Determines if the Compress-Archive command is available (preferred use)
+    # if not will check if dotnet libs are available (.NET 4.5 or greater)
+    Get-Command -Name Compress-Archive | Out-Null
+    $utils_available = [CompressionUtils]::PowerShell
+}
+catch {
+    $try_dotnet = $true
+}
+
+if ($try_dotnet) {
+    try {
+        # determines if .net 4.5 is available, if this fails we can't
+        # fall back to the legacy COM Shell.Application to extract the zip because
+        # the options don't allow it to be suppressed in the UI
+        Add-Type -AssemblyName System.IO.Compression.FileSystem | Out-Null
+        Add-Type -AssemblyName System.IO.Compression | Out-Null
+        $utils_available = [CompressionUtils]::DotNet
+    }
+    catch {
+        # default to Undefined
+        $utils_available = [CompressionUtils]::Undefined
+    }
+
+}
+
+$result.utils_used = $utils_available.ToString()
+# END: Determine which type of compression utils to use: PowerShell or .NET or COM (to follow dev standards)
+
+if ($utils_available -eq [CompressionUtils]::Undefined) {
+    Fail-Json -obj $result -message "Could not find any available compression utilities: PowerShell 5.0 and .NET Framework 4.5 are minimally required.  Please install the Windows Management Framework 5.0 or higher."
+}
+
+# Validate that the extension of the destination zip file is 'zip' - only one supported right now
+$src_ext = (Split-Path $dest -Leaf).Split('.')[-1]
+if ($src_ext -ne "zip") {
+    Fail-Json -obj $result -message "The destination zip file specified '$dest' must have an extension of '.zip'."
+}
+
+# Validate src path exists
+# Ansible.ModuleUtils.Legacy.psm1 checks this for a type of 'PATH' so right now this is duplicate
+# but will help if the type is changed to 'LIST' to support single or multiple src values
+# Also may want to look at adding support here for expanding environment vars when moving to list
+# https://github.com/ansible/ansible/blob/v2.4.1.0-1/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1#L209
+
+If (-not (Test-Path -LiteralPath $src)) {
+    Fail-Json -obj $result -message "The source path specified '$src' could not be found."
+}
+
+# Ensure dest zip DOES NOT exist unless creates attribute specified (TODO: support "FORCE" option)
+if ($creates -and (Test-Path -LiteralPath $creates)) {
+    Exit-Json -obj $result -message "The destination zip file '$dest' specified in the creates attribute exists.  Nothing changed"
+}
+elseif (Test-Path -LiteralPath $dest) {
+    Fail-Json -obj $result -message "The destination zip file specified '$dest' already exists. Adding files to existing zips not yet supported"
+}
+
+# Ensure we don't have any files over 2GB in size (PowerShell & .NET Limitation)
+$large_files = New-Object -Type System.Collections.ArrayList
+Find-LargeFiles -src $src -large_files ([ref]$large_files)
+
+if ($large_files) {
+    $result.large_files = $large_files.ToArray()
+    Fail-Json -obj $result -message "At least one file in $src is over maximum size 2,097,152,000 bytes.  See large_files attribute for full list"
+}
+
+# Attempt to create the zip file
+New-ZipFile -src $src -dest $dest -utils_available $utils_available
+
+# handle delete_src task option
+if ($delete_src) {
+    Remove-Source $src
+}
+
+$result.changed = $true
+
+Exit-Json $result

--- a/lib/ansible/modules/windows/win_zip.py
+++ b/lib/ansible/modules/windows/win_zip.py
@@ -1,0 +1,103 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: win_zip
+version_added: "2.10"
+short_description: Zip a file or directory (recursively)
+description:
+    - Zips a single file into a zip file, or a directory (recursively) into a zip file.
+    - For non-Windows targets, use the M(archive) module instead.
+requirements:
+    - .NET 4.5 or higher
+    - PowerShell 5.0 or higher
+notes:
+    - The underlying PowerShell and .NET libraries impose a limit on the max file size (2GB) that can be compressed.
+    - The module scans the source (recursively for directories) before zipping and fails with an error if any are over the maximum size.
+    - Due to limitations in Windows COM Shell.Application, only the NET and PowerShell versions listed are supported.
+    - Check Mode is supported
+options:
+    creates:
+        description:
+            - If this file or directory exists the specified dest will not be created.
+        type: str
+        required: false
+    delete_src:
+        description:
+            - Whether to delete the source file or directory after source is zipped.  Directories are deleted recursively.
+        type: bool
+        required: false
+        default: false
+        aliases: [ rm ]
+    dest:
+        description:
+            - The absolute path of the zip file to create.
+        type: str
+        required: true
+        aliases: [ zip_file ]
+    src:
+        description:
+            - The absolute path of the file or directory to zip.
+        type: str
+        required: true
+        aliases: [ path ]
+author:
+    - Jim Ficarra (@jimfic)
+'''
+
+EXAMPLES = r'''
+- name: Zip up single file
+  win_zip:
+   src: "c:\\mydir\\myfile.txt"
+   dest: "c:\\archivepath\\myfile.zip"
+
+- name: Zip up a directory
+  win_zip:
+    src: "c:\\mydir"
+    dest: "c:\\archivepath\\mydir.zip"
+
+- name: Zip up a directory and delete the source
+  win_zip:
+    src: "c:\\mydir"
+    dest: "c:\\archivepath\\mydir.zip"
+    delete_src: true
+'''
+
+RETURN = r'''
+dest:
+    description: The specified target zip file
+    returned: always
+    type: str
+    sample: "c:\\archivepath\\myfile.zip"
+large_files:
+    description: A list of files that exceeded maximum size
+    returned: failure
+    type: list
+    sample:
+src:
+    description: The specified source for compression
+    returned: always
+    type: str
+    sample: "c:\\mydir"
+source_deleted:
+    description: Whether the source path specified in the src attribute was deleted
+    returned: always
+    type: bool
+    sample: false
+utils_used:
+    description: Which underlying tools were used (PowerShell or .NET)
+    returned: always
+    type: str
+    sample: "PowerShell"
+'''

--- a/test/integration/targets/win_zip/aliases
+++ b/test/integration/targets/win_zip/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/test/integration/targets/win_zip/defaults/main.yml
+++ b/test/integration/targets/win_zip/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+temp_dir: "c:\\ziptemp"
+target_zip_destfile: "{{ temp_dir }}\\myfile.zip"

--- a/test/integration/targets/win_zip/tasks/assert_exists.yml
+++ b/test/integration/targets/win_zip/tasks/assert_exists.yml
@@ -1,0 +1,10 @@
+---
+- name: Stat the file or dir
+  win_stat:
+    path: "{{ target }}"
+  register: target_output
+
+- name: Assert file or dir exists
+  assert:
+    that:
+      - "target_output.stat.exists"

--- a/test/integration/targets/win_zip/tasks/assert_not_exists.yml
+++ b/test/integration/targets/win_zip/tasks/assert_not_exists.yml
@@ -1,0 +1,10 @@
+---
+- name: Stat the file or dir
+  win_stat:
+    path: "{{ target }}"
+  register: target_output
+
+- name: Assert file or dir was deleted
+  assert:
+    that:
+      - "not target_output.stat.exists"

--- a/test/integration/targets/win_zip/tasks/cleanup.yml
+++ b/test/integration/targets/win_zip/tasks/cleanup.yml
@@ -1,0 +1,10 @@
+---
+- name: Remove working dir
+  win_file:
+    path: "{{ working_dir }}"
+    state: absent
+
+- name: Remove zip file
+  win_file:
+    path: "{{ target_zip_destfile }}"
+    state: absent

--- a/test/integration/targets/win_zip/tasks/create_dir_structure.yml
+++ b/test/integration/targets/win_zip/tasks/create_dir_structure.yml
@@ -1,0 +1,45 @@
+---
+- name: Create temp dir
+  win_file:
+    path: "{{ temp_dir }}"
+    state: directory
+
+- name: Create working dir
+  win_tempfile:
+    state: directory
+    path: "{{ temp_dir}}"
+  register: wd_output
+
+- name: set working_dir var
+  set_fact:
+    working_dir: "{{ wd_output.path }}"
+
+- name: create dir structure
+  win_file:
+    path: "{{ working_dir }}\\dir1\\dir1_1\\dir1_1_1"
+    state: directory
+
+- name: Create files in structure
+  win_file:
+    path: "{{ item }}"
+    state: touch
+  with_items:
+    - "{{ working_dir }}\\dir1\\test1.txt"
+    - "{{ working_dir }}\\dir1\\test2.txt"
+    - "{{ working_dir }}\\dir1\\dir1_1\\test1.txt"
+    - "{{ working_dir }}\\dir1\\dir1_1\\test2.txt"
+    - "{{ working_dir }}\\dir1\\dir1_1\\dir1_1_1\\test1.txt"
+    - "{{ working_dir }}\\dir1\\dir1_1\\dir1_1_1\\test2.txt"
+
+- name: Create content in files
+  win_lineinfile:
+    path: "{{ item }}"
+    state: present
+    line: "some content"
+  with_items:
+    - "{{ working_dir }}\\dir1\\test1.txt"
+    - "{{ working_dir }}\\dir1\\test2.txt"
+    - "{{ working_dir }}\\dir1\\dir1_1\\test1.txt"
+    - "{{ working_dir }}\\dir1\\dir1_1\\test2.txt"
+    - "{{ working_dir }}\\dir1\\dir1_1\\dir1_1_1\\test1.txt"
+    - "{{ working_dir }}\\dir1\\dir1_1\\dir1_1_1\\test2.txt"

--- a/test/integration/targets/win_zip/tasks/main.yml
+++ b/test/integration/targets/win_zip/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- block:
+    - name: Include create_dir_structure
+      include_tasks: create_dir_structure.yml
+
+    - name: Include test_single_file
+      include_tasks: test_file_zip.yml
+
+    - name: Include test_single_file
+      include_tasks: test_dir_zip.yml
+
+    - name: Include test_creates_param
+      include_tasks: test_creates_param.yml
+
+    - name: Include test_delete_src_param
+      include_tasks: test_delete_src_param.yml
+
+  always:
+    - name: Include cleanup
+      include_tasks: cleanup.yml

--- a/test/integration/targets/win_zip/tasks/test_creates_param.yml
+++ b/test/integration/targets/win_zip/tasks/test_creates_param.yml
@@ -1,0 +1,26 @@
+---
+- name: Test create param
+  debug:
+    msg: "Test create param"
+
+- name: create file that zip would create
+  win_file:
+    path: "{{ target_zip_destfile }}"
+    state: touch
+
+- name: Zip dir with creates param
+  win_zip:
+    src: "{{ working_dir }}\\dir1"
+    dest: "{{ target_zip_destfile }}"
+    creates: "{{ target_zip_destfile }}"
+  register: param_output
+
+- name: Assert zip didn't execute
+  assert:
+    that:
+      - "not param_output|changed"
+
+- name: Remove zip file
+  win_file:
+    path: "{{ target_zip_destfile }}"
+    state: absent

--- a/test/integration/targets/win_zip/tasks/test_delete_src_param.yml
+++ b/test/integration/targets/win_zip/tasks/test_delete_src_param.yml
@@ -1,0 +1,33 @@
+---
+# Test deletes param
+# Keep this one at end since it deletes the dirs
+- name: Test delete_src param
+  debug:
+    msg: "Test delete_src param"
+
+- name: Zip up directory
+  win_zip:
+    src: "{{ working_dir }}\\dir1"
+    dest: "{{ target_zip_destfile }}"
+    delete_src: true
+  register: zipdeletesrc_output
+
+- name: Assert task is changed
+  assert:
+    that:
+      - "zipdeletesrc_output|changed"
+
+- name: Assert zip exists
+  include_tasks: assert_exists.yml
+  vars:
+    target: "{{ target_zip_destfile }}"
+
+- name: Assert original dir was deleted
+  include_tasks: assert_not_exists.yml
+  vars:
+    target: "{{ working_dir }}\\dir1"
+
+- name: Remove zip file
+  win_file:
+    path: "{{ target_zip_destfile }}"
+    state: absent

--- a/test/integration/targets/win_zip/tasks/test_dir_zip.yml
+++ b/test/integration/targets/win_zip/tasks/test_dir_zip.yml
@@ -1,0 +1,30 @@
+---
+- name: Test Zipping directory
+  debug:
+    msg: "Testing zip of directory"
+
+- name: Zip up directory
+  win_zip:
+    src: "{{ working_dir }}\\dir1"
+    dest: "{{ target_zip_destfile }}"
+  register: dirzip_task
+
+- name: Assert task is changed
+  assert:
+    that:
+      - "dirzip_task|changed"
+
+- name: Assert zip exists
+  include_tasks: assert_exists.yml
+  vars:
+    target: "{{ target_zip_destfile }}"
+
+- name: Assert original dir wasn't deleted
+  include_tasks: assert_exists.yml
+  vars:
+    target: "{{ working_dir }}\\dir1"
+
+- name: Remove zip file
+  win_file:
+    path: "{{ target_zip_destfile }}"
+    state: absent

--- a/test/integration/targets/win_zip/tasks/test_file_zip.yml
+++ b/test/integration/targets/win_zip/tasks/test_file_zip.yml
@@ -1,0 +1,30 @@
+---
+- name: Test Zipping file
+  debug:
+    msg: "Testing zip of single file"
+
+- name: Zip up single file
+  win_zip:
+    src: "{{ working_dir }}\\dir1\\test1.txt"
+    dest: "{{ target_zip_destfile }}"
+  register: filezip_task
+
+- name: Assert task is changed
+  assert:
+    that:
+      - "filezip_task|changed"
+
+- name: Assert zip exists
+  include_tasks: assert_exists.yml
+  vars:
+    target: "{{ target_zip_destfile }}"
+
+- name: Assert original dir wasn't deleted
+  include_tasks: assert_exists.yml
+  vars:
+    target: "{{ working_dir }}\\dir1"
+
+- name: Remove zip file
+  win_file:
+    path: "{{ target_zip_destfile }}"
+    state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Addition of win_zip module to support zipping and to complement the win_unzip. Initial support is to allow zipping of a file or a directory recursively but can be expanded upon.  There is an inherent 2GB file size limit on each source file in .NET and PowerShell (which relies on .NET underneath)

It was not possible to support COM Shell.Application as the least common denominator (as in win_unzip) because the API call required UI interaction that did not have options to suppress.  As such a design decision was made to support PowerShell first, and .NET 4.5 or higher second.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_zip

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

- Zips a single file into a zip file, or a directory (recursively) into a zip file.

- Options include 'creates' for idempotence as well as 'delete_src' to remove the source file/directory after zipping.

- Check Mode is supported

Please note that as I am submitting this as a Comcast Employee, internal approval/process was required to submit this.  As such, I am required to submit this verbiage with the PR:

> We are only granting a copyright license, and no other licenses, to all users and developers of the project, present and future, pursuant to the license of the project.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
