### PR TITLE
Maven Central requires TLS

### DIFF
--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -59,7 +59,7 @@ options:
             - The URL of the Maven Repository to download from.
             - Use s3://... if the repository is hosted on Amazon S3, added in version 2.2.
             - Use file://... if the repository is local, added in version 2.6
-        default: http://repo1.maven.org/maven2
+        default: https://repo1.maven.org/maven2
     username:
         description:
             - The username to authenticate as to the Maven Repository. Use AWS secret key of the repository is hosted on S3
@@ -553,7 +553,7 @@ def main():
             version_by_spec=dict(default=None),
             classifier=dict(default=''),
             extension=dict(default='jar'),
-            repository_url=dict(default='http://repo1.maven.org/maven2'),
+            repository_url=dict(default='https://repo1.maven.org/maven2'),
             username=dict(default=None, aliases=['aws_secret_key']),
             password=dict(default=None, no_log=True, aliases=['aws_secret_access_key']),
             headers=dict(type='dict'),
@@ -577,7 +577,7 @@ def main():
 
     repository_url = module.params["repository_url"]
     if not repository_url:
-        repository_url = "http://repo1.maven.org/maven2"
+        repository_url = "https://repo1.maven.org/maven2"
     try:
         parsed_url = urlparse(repository_url)
     except AttributeError as e:

--- a/test/units/modules/packaging/language/test_maven_artifact.py
+++ b/test/units/modules/packaging/language/test_maven_artifact.py
@@ -65,6 +65,6 @@ def test_find_version_by_spec(mocker, version_by_spec, version_choosed):
     _getContent.return_value = maven_metadata_example
 
     artifact = maven_artifact.Artifact("junit", "junit", None, version_by_spec, "jar")
-    mvn_downloader = maven_artifact.MavenDownloader(basic.AnsibleModule, "http://repo1.maven.org/maven2")
+    mvn_downloader = maven_artifact.MavenDownloader(basic.AnsibleModule, "https://repo1.maven.org/maven2")
 
     assert mvn_downloader.find_version_by_spec(artifact) == version_choosed


### PR DESCRIPTION
As of Jan 15, Maven Central requires TLS.

Fixes: #66609

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
