### PR TITLE
[pkgin] #475, #66501 Add support for full version package name in pkgin module

### DIFF
--- a/lib/ansible/modules/packaging/os/pkgin.py
+++ b/lib/ansible/modules/packaging/os/pkgin.py
@@ -200,6 +200,7 @@ def query_package(module, name):
     # Search failed, so return None
     return None
 
+
 def format_action_message(module, action, count):
     vars = {"actioned": action,
             "count": count}
@@ -270,7 +271,7 @@ def install_packages(module, packages):
         query_result = query_package(module, package)
         if query_result:
             continue
-        elif query_result == None:
+        elif query_result is None:
             module.fail_json(msg="failed to find package %s for installation" % package)
 
         rc, out, err = module.run_command(


### PR DESCRIPTION
##### SUMMARY
Extended pkgin module to check also against the full version package name in the `query_package` function, to allow for installation of full versioned package names.

In query_package, differentiate for non-existing packages and non-installed packages.
This allows for an appropriate error on the `install_package` invocation; where a non-existing package leads to an informative error plus failure of the install, and non-installed package leads to installing such package.

Fixes #475
Fixes #66501

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pkgin

##### ADDITIONAL INFORMATION
* pkgin query_package(..) understands now also package name with version (my-package-1.2nb123456).
* pkgin query_package(..) will distinct between not-installed and not-found packages.
* pkgin install_package(..) fails with proper error if a non-existing package is attempted to be installed.
