### PR TITLE
onyx_linkagg module: Fixed choices in element spec of 'state'

### DIFF
--- a/lib/ansible/modules/network/onyx/onyx_linkagg.py
+++ b/lib/ansible/modules/network/onyx/onyx_linkagg.py
@@ -127,7 +127,7 @@ class OnyxLinkAggModule(BaseOnyxModule):
             name=dict(type='str'),
             members=dict(type='list'),
             mode=dict(default='on', choices=['active', 'on', 'passive']),
-            state=dict(default='present', choices=['present', 'absent']),
+            state=dict(default='present', choices=['present', 'absent', 'up', 'down']),
         )
 
     @classmethod


### PR DESCRIPTION
##### SUMMARY

From the [document](https://docs.ansible.com/ansible/latest/modules/onyx_linkagg_module.html#parameters) of `onyx_linkagg` module, `state` choices should be one of (`present`, `absent`, `up`, `down`). And the logic to handle to those choices is already implemented.

However, element spec validation fails to accept (`up`, `down`) as choices.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
onyx_linkagg

##### ADDITIONAL INFORMATION
```
$ ansible --version 
ansible 2.9.2
  config file = None
```
