### PR TITLE
Correct path to ansible-test requirements file

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/azure-requirements.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/azure-requirements.rst
@@ -5,4 +5,4 @@ Update the Azure integration test requirements file when changes are made to the
 
 .. code-block:: bash
 
-    cp packaging/requirements/requirements-azure.txt test/runner/requirements/integration.cloud.azure.txt
+    cp packaging/requirements/requirements-azure.txt test/lib/ansible_test/_data/requirements/integration.cloud.azure.txt

--- a/docs/docsite/rst/dev_guide/testing/sanity/test-constraints.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/test-constraints.rst
@@ -1,4 +1,4 @@
 test-constraints
 ================
 
-Constraints for test requirements should be in ``test/runner/requirements/constraints.txt``.
+Constraints for test requirements should be in ``test/lib/ansible_test/_data/requirements/constraints.txt``.

--- a/docs/docsite/rst/dev_guide/testing_compile.rst
+++ b/docs/docsite/rst/dev_guide/testing_compile.rst
@@ -64,7 +64,7 @@ The dependencies can be installed using the ``--requirements`` argument. For exa
 
 
 
-The full list of requirements can be found at `test/runner/requirements <https://github.com/ansible/ansible/tree/devel/test/runner/requirements>`_. Requirements files are named after their respective commands. See also the `constraints <https://github.com/ansible/ansible/blob/devel/test/runner/requirements/constraints.txt>`_ applicable to all commands.
+The full list of requirements can be found at `test/lib/ansible_test/_data/requirements <https://github.com/ansible/ansible/tree/devel/test/lib/ansible_test/_data/requirements>`_. Requirements files are named after their respective commands. See also the `constraints <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/requirements/constraints.txt>`_ applicable to all commands.
 
 
 Extending compile tests

--- a/docs/docsite/rst/dev_guide/testing_documentation.rst
+++ b/docs/docsite/rst/dev_guide/testing_documentation.rst
@@ -29,7 +29,7 @@ To ensure that your module documentation matches your ``argument_spec``:
 
    .. code-block:: bash
 
-      pip install --user -r test/runner/requirements/sanity.txt
+      pip install --user -r test/lib/ansible_test/_data/requirements/sanity.txt
 
 #. run the ``validate-modules`` test::
 


### PR DESCRIPTION
##### SUMMARY
The requirements path was old due to file relocation. Relocation was done in ansible repo commit d651bda12390e46c85c4487859f030ed8851867a.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
