### PR TITLE
get_url: remove deprecated headers string format

### DIFF
--- a/changelogs/fragments/61891-get_url-remove-deprecated-string-headers.yml
+++ b/changelogs/fragments/61891-get_url-remove-deprecated-string-headers.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - get_url - Remove deprecated string format support for the headers option (https://github.com/ansible/ansible/issues/61891)

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -123,8 +123,8 @@ options:
         - Add custom HTTP headers to a request in hash/dict format.
         - The hash/dict format was added in Ansible 2.6.
         - Previous versions used a C("key:value,key:value") string format.
-        - The C("key:value,key:value") string format is deprecated and will be removed in version 2.10.
-    type: raw
+        - The C("key:value,key:value") string format is deprecated and has been removed in version 2.10.
+    type: dict
     version_added: '2.0'
   url_username:
     description:
@@ -436,7 +436,7 @@ def main():
         sha256sum=dict(type='str', default=''),
         checksum=dict(type='str', default=''),
         timeout=dict(type='int', default=10),
-        headers=dict(type='raw'),
+        headers=dict(type='dict'),
         tmp_dest=dict(type='path'),
     )
 
@@ -462,6 +462,7 @@ def main():
     checksum = module.params['checksum']
     use_proxy = module.params['use_proxy']
     timeout = module.params['timeout']
+    headers = module.params['headers']
     tmp_dest = module.params['tmp_dest']
 
     result = dict(
@@ -472,18 +473,6 @@ def main():
         elapsed=0,
         url=url,
     )
-
-    # Parse headers to dict
-    if isinstance(module.params['headers'], dict):
-        headers = module.params['headers']
-    elif module.params['headers']:
-        try:
-            headers = dict(item.split(':', 1) for item in module.params['headers'].split(','))
-            module.deprecate('Supplying `headers` as a string is deprecated. Please use dict/hash format for `headers`', version='2.10')
-        except Exception:
-            module.fail_json(msg="The string representation for the `headers` parameter requires a key:value,key:value syntax to be properly parsed.", **result)
-    else:
-        headers = None
 
     dest_is_dir = os.path.isdir(dest)
     last_mod_time = None

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -417,33 +417,6 @@
     url: https://{{ httpbin_host }}
     dest: "{{ remote_tmp_dir }}"
 
-- name: Test headers string
-  get_url:
-    url: https://{{ httpbin_host }}/headers
-    headers: Foo:bar,Baz:qux
-    dest: "{{ remote_tmp_dir }}/headers_string.json"
-
-- name: Get downloaded file
-  slurp:
-    src: "{{ remote_tmp_dir }}/headers_string.json"
-  register: result
-
-- name: Test headers string
-  assert:
-    that:
-      - (result.content | b64decode | from_json).headers.get('Foo') == 'bar'
-      - (result.content | b64decode | from_json).headers.get('Baz') == 'qux'
-
-- name: Test headers string invalid format
-  get_url:
-    url: https://{{ httpbin_host }}/headers
-    headers: Foo
-    dest: "{{ remote_tmp_dir }}/headers_string_invalid.json"
-  register: invalid_string_headers
-  failed_when:
-    - invalid_string_headers is successful
-    - invalid_string_headers.msg != "The string representation for the `headers` parameter requires a key:value,key:value syntax to be properly parsed."
-
 - name: Test headers dict
   get_url:
     url: https://{{ httpbin_host }}/headers


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #61891
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/modules/net_tools/basics/get_url.py`