### PR TITLE
To fix the duplication of IPV6 address with replace state in ios_l3_interfaces module

### DIFF
--- a/lib/ansible/module_utils/network/ios/utils/utils.py
+++ b/lib/ansible/module_utils/network/ios/utils/utils.py
@@ -62,23 +62,35 @@ def dict_to_set(sample_dict):
 def filter_dict_having_none_value(want, have):
     # Generate dict with have dict value which is None in want dict
     test_dict = dict()
-    test_key_dict = dict()
     name = want.get('name')
     if name:
         test_dict['name'] = name
     diff_ip = False
-    want_ip = ''
     for k, v in iteritems(want):
         if isinstance(v, dict):
             for key, value in iteritems(v):
+                test_key_dict = dict()
                 if value is None:
                     dict_val = have.get(k).get(key)
+                    test_key_dict.update({key: dict_val})
+                elif k == 'ipv6' and value.lower() != have.get(k)[0].get(key).lower():
+                    # as multiple IPV6 address can be configured on same
+                    # interface, for replace state in place update will
+                    # actually create new entry, which isn't as expected
+                    # for replace state, so in case of IPV6 address
+                    # every time 1st delete the existing IPV6 config and
+                    # then apply the new change
+                    dict_val = have.get(k)[0].get(key)
                     test_key_dict.update({key: dict_val})
                 test_dict.update({k: test_key_dict})
         if isinstance(v, list):
             for key, value in iteritems(v[0]):
+                test_key_dict = dict()
                 if value is None:
                     dict_val = have.get(k).get(key)
+                    test_key_dict.update({key: dict_val})
+                elif k == 'ipv6' and value.lower() != have.get(k)[0].get(key).lower():
+                    dict_val = have.get(k)[0].get(key)
                     test_key_dict.update({key: dict_val})
                 test_dict.update({k: test_key_dict})
             # below conditions checks are added to check if

--- a/test/integration/targets/ios_l3_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/ios_l3_interfaces/tests/cli/replaced.yaml
@@ -18,6 +18,8 @@
             - address: 198.51.100.1/24
               secondary: True
             - address: 198.51.100.2/24
+            ipv6:
+            - address: 2001:db8:1:1::/64
         state: replaced
       register: result
 

--- a/test/integration/targets/ios_l3_interfaces/vars/main.yaml
+++ b/test/integration/targets/ios_l3_interfaces/vars/main.yaml
@@ -63,6 +63,7 @@ replaced:
     - "no ipv6 address"
     - "ip address 198.51.100.1 255.255.255.0 secondary"
     - "ip address 198.51.100.2 255.255.255.0"
+    - "ipv6 address 2001:db8:1:1::/64"
 
   after:
     - name: loopback888
@@ -77,6 +78,8 @@ replaced:
       - address: 198.51.100.1 255.255.255.0
         secondary: true
       - address: 198.51.100.2 255.255.255.0
+      ipv6:
+      - address: 2001:db8:1:1::/64
       name: GigabitEthernet0/2
 
 overridden:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To fix the issue #66530, where replace state was behaving as merge state for IPV6 address, and this happens coz interface can have multiple IPV6 addresses, so in place replace logic wasn't working as expected.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_l3_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
