### PR TITLE
Docs: clarify that roles do not inherit collections set in a playbook

### DIFF
--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -75,7 +75,7 @@ This works for roles or any type of plugin distributed within the collection:
              msg: '{{ lookup("my_namespace.my_collection.lookup1", 'param1')| my_namespace.my_collection.filter1 }}'
 
 Simplifying module names with the ``collections`` keyword
-===========================
+=========================================================
 
 The ``collections`` keyword lets you define a list of collections that your role or playbook should search for unqualified module and action names. So you can use the ``collections`` keyword, then simply refer to modules and action plugins by their short-form names throughout that role or playbook.
 
@@ -85,7 +85,7 @@ The ``collections`` keyword lets you define a list of collections that your role
 Using ``collections`` in roles
 ------------------------------
 
-Within a role, you can control which collections Ansible searches for the tasks inside the role using the ``collections`` keyword in the role's ``metadata/main.yml``. Ansible will use the collections list defined inside the role even if the playbook that calls the role defines different collections in a separate ``collections`` keyword entry. Roles defined inside a collection always implicitly search their own collection first, so you don't need to use the ``collections`` keyword to access modules, actions, or other roles contained in the same collection. 
+Within a role, you can control which collections Ansible searches for the tasks inside the role using the ``collections`` keyword in the role's ``metadata/main.yml``. Ansible will use the collections list defined inside the role even if the playbook that calls the role defines different collections in a separate ``collections`` keyword entry. Roles defined inside a collection always implicitly search their own collection first, so you don't need to use the ``collections`` keyword to access modules, actions, or other roles contained in the same collection.
 
 .. code-block:: yaml
 
@@ -98,7 +98,7 @@ Within a role, you can control which collections Ansible searches for the tasks 
 Using ``collections`` in playbooks
 ----------------------------------
 
-In a playbook, you can control the collections Ansible searches for modules, action plugins, and roles to execute. However, the called roles define their own collections search order; they do not inherit the calling playbook's settings. This is true even if the role does not define its own ``collections`` keyword.
+In a playbook, you can control the collections Ansible searches for modules and action plugins to execute. However, any roles you call in your playbook define their own collections search order; they do not inherit the calling playbook's settings. This is true even if the role does not define its own ``collections`` keyword.
 
 .. code-block:: yaml
 

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -77,7 +77,7 @@ This works for roles or any type of plugin distributed within the collection:
 The ``collections`` keyword
 ===========================
 
-The ``collections`` keyword lets you define the collections you want your role or playbook to use for modules and for action plugins. Ansible searches those collections first for any modules or action plugins without an FQCN. So you can use the ``collections`` keyword, then call modules and action plugins using their short-form names later in that role or playbook.
+The ``collections`` keyword lets you define a list of collections that your role or playbook should search for unqualified module and action names. So you can use the ``collections`` keyword, then simply refer to modules and action plugins by their short-form names throughout that role or playbook.
 
 .. warning::
    If your playbook uses both the ``collections`` keyword and one or more roles, the roles do not inherit the collections set by the playbook. See below for details.
@@ -85,7 +85,7 @@ The ``collections`` keyword lets you define the collections you want your role o
 Using ``collections`` in roles
 ------------------------------
 
-In a role, you can control which collections Ansible searches for modules and action plugins globally with the ``collections`` keyword. Define the collections in the ``metadata/main.yml`` file within your role, and Ansible will use them for your role every time, in any context. Ansible will use the collections defined by a role even if the playbook that calls the role defines different collections in a separate ``collections`` keyword entry.
+Within a role, you can control which collections Ansible searches for the tasks inside the role using the ``collections`` keyword in the role's ``metadata/main.yml``. Ansible will use the collections list defined inside the role even if the playbook that calls the role defines different collections in a separate ``collections`` keyword entry. Roles defined inside a collection always implicitly search their own collection first, so you don't need to use the ``collections`` keyword to access modules, actions, or other roles contained in the same collection. 
 
 .. code-block:: yaml
 
@@ -98,7 +98,7 @@ In a role, you can control which collections Ansible searches for modules and ac
 Using ``collections`` in playbooks
 ----------------------------------
 
-In a playbook, you can control the collections Ansible searches for modules and action plugins, but only for tasks, not for roles. Some roles rely on particular collections to work properly, so Ansible does not apply ``collections`` from a playbook to any roles within that playbook. This is true even if the role does not define its own ``collections`` keyword.
+In a playbook, you can control the collections Ansible searches for modules, action plugins, and roles to execute. However, the called roles define their own collections search order; they do not inherit the calling playbook's settings. This is true even if the role does not define its own ``collections`` keyword.
 
 .. code-block:: yaml
 
@@ -115,7 +115,7 @@ In a playbook, you can control the collections Ansible searches for modules and 
          - debug:
              msg: '{{ lookup("my_namespace.my_collection.lookup1", 'param1')| my_namespace.my_collection.filter1 }}'
 
-The ``collections`` keyword creates a 'search path' for non-namespaced plugin references. It does not import roles or anything else. Notice that you still need the FQCN for non-action or module plugins.
+The ``collections`` keyword merely creates an ordered 'search path' for non-namespaced plugin and role references. It does not install content or otherwise change Ansible's behavior around the loading of plugins or roles. Note that an FQCN is still required for non-action or module plugins (e.g., lookups, filters, tests).
 
 .. seealso::
 

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -74,9 +74,23 @@ This works for roles or any type of plugin distributed within the collection:
          - debug:
              msg: '{{ lookup("my_namespace.my_collection.lookup1", 'param1')| my_namespace.my_collection.filter1 }}'
 
+The ``collections`` keyword
+===========================
 
-To avoid a lot of typing, you can use the ``collections`` keyword added in Ansible 2.8:
+The ``collections`` keyword lets you define the collections you want your role or playbook to use for modules and for action plugins. Ansible searches those collections first for any modules or action plugins without an FQCN. So you can use the ``collections`` keyword, then call modules and action plugins using their short-form names later in that role or playbook.
 
+.. warning::
+   If your playbook uses both the ``collections`` keyword and one or more roles, the roles do not inherit the collections set by the playbook. See below for details.
+
+Using ``collections`` in roles
+------------------------------
+
+In a role, you can control which collections Ansible searches for modules and action plugins globally with the ``collections`` keyword. Define the collections in the ``metadata/main.yml`` file within your role, and Ansible will use them for your role every time, in any context. Ansible will use the collections defined by a role even if the playbook that calls the role defines different collections in a separate ``collections`` keyword entry.
+
+Using ``collections`` in playbooks
+----------------------------------
+
+In a playbook, you can control the collections Ansible searches for modules and action plugins, but only for tasks, not for roles. Some roles rely on particular collections to work properly, so Ansible does not apply ``collections`` from a playbook to any roles within that playbook. This is true even if the role does not define its own ``collections`` keyword.
 
 .. code-block:: yaml
 
@@ -93,8 +107,7 @@ To avoid a lot of typing, you can use the ``collections`` keyword added in Ansib
          - debug:
              msg: '{{ lookup("my_namespace.my_collection.lookup1", 'param1')| my_namespace.my_collection.filter1 }}'
 
-This keyword creates a 'search path' for non namespaced plugin references. It does not import roles or anything else.
-Notice that you still need the FQCN for non-action or module plugins.
+The ``collections`` keyword creates a 'search path' for non-namespaced plugin references. It does not import roles or anything else. Notice that you still need the FQCN for non-action or module plugins.
 
 .. seealso::
 

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -74,7 +74,7 @@ This works for roles or any type of plugin distributed within the collection:
          - debug:
              msg: '{{ lookup("my_namespace.my_collection.lookup1", 'param1')| my_namespace.my_collection.filter1 }}'
 
-The ``collections`` keyword
+Simplifying module names with the ``collections`` keyword
 ===========================
 
 The ``collections`` keyword lets you define a list of collections that your role or playbook should search for unqualified module and action names. So you can use the ``collections`` keyword, then simply refer to modules and action plugins by their short-form names throughout that role or playbook.

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -87,6 +87,14 @@ Using ``collections`` in roles
 
 In a role, you can control which collections Ansible searches for modules and action plugins globally with the ``collections`` keyword. Define the collections in the ``metadata/main.yml`` file within your role, and Ansible will use them for your role every time, in any context. Ansible will use the collections defined by a role even if the playbook that calls the role defines different collections in a separate ``collections`` keyword entry.
 
+.. code-block:: yaml
+
+   # myrole/metadata/main.yml
+   collections:
+     - my_namespace.first_collection
+     - my_namespace.second_collection
+     - other_namespace.other_collection
+
 Using ``collections`` in playbooks
 ----------------------------------
 


### PR DESCRIPTION
##### SUMMARY
Early adopters of collections have gotten confused about where to use the `collections` keyword to define appropriate collections for a role and for a playbook. Clarify the docs to help future users.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
collections
