### PR TITLE
Add new configuration parameter to make Windows async startup timeout configurable

### DIFF
--- a/changelogs/fragments/65001-allow_configuring_async_startup_timeout.yml
+++ b/changelogs/fragments/65001-allow_configuring_async_startup_timeout.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - Add a new config parameter, ANSIBLE_WIN_ASYNC_STARTUP_TIMEOUT, which allows configuration of the named pipe connection
+  - Add a new config parameter, WIN_ASYNC_STARTUP_TIMEOUT, which allows configuration of the named pipe connection
     timeout under Windows when launching async tasks.

--- a/changelogs/fragments/65001-allow_configuring_async_startup_timeout.yml
+++ b/changelogs/fragments/65001-allow_configuring_async_startup_timeout.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Add a new config parameter, ANSIBLE_WIN_ASYNC_STARTUP_TIMEOUT, which allows configuration of the named pipe connection
+    timeout under Windows when launching async tasks.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -886,21 +886,6 @@ DEFAULT_NETCONF_PLUGIN_PATH:
   ini:
   - {key: netconf_plugins, section: defaults}
   type: pathspec
-DEFAULT_WIN_ASYNC_STARTUP_TIMEOUT:
-  name: Windows Async Startup Timeout
-  default: 5
-  description:
-    - For asynchronous tasks in Ansible (covered in Asynchronous Actions and Polling),
-      this is how long, in seconds, to wait for the task spawned by Ansible to connect back to the named pipe used
-      on Windows systems. The default is 5 seconds. This can be too low on slower systems, or systems under heavy load.
-    - This is not the total time an async command can run for, but is a separate timeout to wait for an async command to
-      start. The task will only start to be timed against its async_timeout once it has connected to the pipe, so the
-      overall maximum duration the task can take will be extended by the amount specified here.
-  env: [{name: ANSIBLE_WIN_ASYNC_STARTUP_TIMEOUT}]
-  ini:
-    - {key: win_async_startup_timeout, section: defaults}
-  type: integer
-  version_added: '2.10'
 DEFAULT_NO_LOG:
   name: No log
   default: False
@@ -1861,6 +1846,23 @@ VARIABLE_PRECEDENCE:
   - {key: precedence, section: defaults}
   type: list
   version_added: "2.4"
+WIN_ASYNC_STARTUP_TIMEOUT:
+  name: Windows Async Startup Timeout
+  default: 5
+  description:
+    - For asynchronous tasks in Ansible (covered in Asynchronous Actions and Polling),
+      this is how long, in seconds, to wait for the task spawned by Ansible to connect back to the named pipe used
+      on Windows systems. The default is 5 seconds. This can be too low on slower systems, or systems under heavy load.
+    - This is not the total time an async command can run for, but is a separate timeout to wait for an async command to
+      start. The task will only start to be timed against its async_timeout once it has connected to the pipe, so the
+      overall maximum duration the task can take will be extended by the amount specified here.
+  env: [{name: ANSIBLE_WIN_ASYNC_STARTUP_TIMEOUT}]
+  ini:
+    - {key: win_async_startup_timeout, section: defaults}
+  type: integer
+  vars:
+    - {name: ansible_win_async_startup_timeout}
+  version_added: '2.10'
 YAML_FILENAME_EXTENSIONS:
   name: Valid YAML extensions
   default: [".yml", ".yaml", ".json"]

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -898,7 +898,7 @@ DEFAULT_WIN_ASYNC_STARTUP_TIMEOUT:
       overall maximum duration the task can take will be extended by the amount specified here.
   env: [{name: ANSIBLE_WIN_ASYNC_STARTUP_TIMEOUT}]
   ini:
-    - {key: named_pipe_timeout, section: defaults}
+    - {key: win_async_startup_timeout, section: defaults}
   type: integer
   version_added: '2.10'
 DEFAULT_NO_LOG:

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -886,6 +886,21 @@ DEFAULT_NETCONF_PLUGIN_PATH:
   ini:
   - {key: netconf_plugins, section: defaults}
   type: pathspec
+DEFAULT_WIN_ASYNC_STARTUP_TIMEOUT:
+  name: Windows Async Startup Timeout
+  default: 5
+  description:
+    - For asynchronous tasks in Ansible (covered in Asynchronous Actions and Polling),
+      this is how long, in seconds, to wait for the task spawned by Ansible to connect back to the named pipe used
+      on Windows systems. The default is 5 seconds. This can be too low on slower systems, or systems under heavy load.
+    - This is not the total time an async command can run for, but is a separate timeout to wait for an async command to
+      start. The task will only start to be timed against its async_timeout once it has connected to the pipe, so the
+      overall maximum duration the task can take will be extended by the amount specified here.
+  env: [{name: ANSIBLE_WIN_ASYNC_STARTUP_TIMEOUT}]
+  ini:
+    - {key: named_pipe_timeout, section: defaults}
+  type: integer
+  version_added: '2.10'
 DEFAULT_NO_LOG:
   name: No log
   default: False

--- a/lib/ansible/executor/powershell/async_wrapper.ps1
+++ b/lib/ansible/executor/powershell/async_wrapper.ps1
@@ -145,11 +145,14 @@ try {
     $result_json = ConvertTo-Json -InputObject $result -Depth 99 -Compress
     Set-Content $results_path -Value $result_json
 
-    Write-AnsibleLog "INFO - waiting for async process to connect to named pipe for 5 seconds" "async_wrapper"
+    $np_timeout = $Payload.async_named_pipe_timeout * 1000
+    Write-AnsibleLog "INFO - waiting for async process to connect to named pipe for $np_timeout milliseconds" "async_wrapper"
     $wait_async = $pipe.BeginWaitForConnection($null, $null)
-    $wait_async.AsyncWaitHandle.WaitOne(5000) > $null
+    $wait_async.AsyncWaitHandle.WaitOne($np_timeout) > $null
     if (-not $wait_async.IsCompleted) {
-        throw "timeout while waiting for child process to connect to named pipe"
+        throw """Ansible encountered a timeout while waiting for the async task to start and connect to the named
+         pipe. This can be affected by the performance of the target - you can increase this timeout using
+         ANSIBLE_NAMED_PIPE_TIMEOUT if this keeps happening."""
     }
     $pipe.EndWaitForConnection($wait_async)
 

--- a/lib/ansible/executor/powershell/async_wrapper.ps1
+++ b/lib/ansible/executor/powershell/async_wrapper.ps1
@@ -145,14 +145,15 @@ try {
     $result_json = ConvertTo-Json -InputObject $result -Depth 99 -Compress
     Set-Content $results_path -Value $result_json
 
-    $np_timeout = $Payload.async_named_pipe_timeout * 1000
+    $np_timeout = $Payload.win_async_startup_timeout * 1000
     Write-AnsibleLog "INFO - waiting for async process to connect to named pipe for $np_timeout milliseconds" "async_wrapper"
     $wait_async = $pipe.BeginWaitForConnection($null, $null)
     $wait_async.AsyncWaitHandle.WaitOne($np_timeout) > $null
     if (-not $wait_async.IsCompleted) {
-        throw """Ansible encountered a timeout while waiting for the async task to start and connect to the named
-         pipe. This can be affected by the performance of the target - you can increase this timeout using
-         ANSIBLE_NAMED_PIPE_TIMEOUT if this keeps happening."""
+        $msg = "Ansible encountered a timeout while waiting for the async task to start and connect to the named"
+        $msg += "pipe. This can be affected by the performance of the target - you can increase this timeout using"
+        $msg += "DEFAULT_WIN_ASYNC_STARTUP_TIMEOUT if this keeps happening."
+        throw $msg
     }
     $pipe.EndWaitForConnection($wait_async)
 

--- a/lib/ansible/executor/powershell/async_wrapper.ps1
+++ b/lib/ansible/executor/powershell/async_wrapper.ps1
@@ -145,14 +145,15 @@ try {
     $result_json = ConvertTo-Json -InputObject $result -Depth 99 -Compress
     Set-Content $results_path -Value $result_json
 
-    $np_timeout = $Payload.win_async_startup_timeout * 1000
+    $np_timeout = $Payload.async_startup_timeout * 1000
     Write-AnsibleLog "INFO - waiting for async process to connect to named pipe for $np_timeout milliseconds" "async_wrapper"
     $wait_async = $pipe.BeginWaitForConnection($null, $null)
     $wait_async.AsyncWaitHandle.WaitOne($np_timeout) > $null
     if (-not $wait_async.IsCompleted) {
         $msg = "Ansible encountered a timeout while waiting for the async task to start and connect to the named"
         $msg += "pipe. This can be affected by the performance of the target - you can increase this timeout using"
-        $msg += "DEFAULT_WIN_ASYNC_STARTUP_TIMEOUT if this keeps happening."
+        $msg += "WIN_ASYNC_STARTUP_TIMEOUT or just for this host using the win_async_startup_timeout hostvar if "
+        $msg += "this keeps happening."
         throw $msg
     }
     $pipe.EndWaitForConnection($wait_async)

--- a/lib/ansible/executor/powershell/module_manifest.py
+++ b/lib/ansible/executor/powershell/module_manifest.py
@@ -294,6 +294,7 @@ def _create_powershell_wrapper(b_module_data, module_path, module_args,
         exec_manifest["actions"].insert(0, 'async_wrapper')
         exec_manifest["async_jid"] = str(random.randint(0, 999999999999))
         exec_manifest["async_timeout_sec"] = async_timeout
+        exec_manifest["async_named_pipe_timeout"] = C.config.get_config_value('DEFAULT_WIN_ASYNC_STARTUP_TIMEOUT')
 
     if become and become_method == 'runas':
         finder.scan_exec_script('exec_wrapper')

--- a/lib/ansible/executor/powershell/module_manifest.py
+++ b/lib/ansible/executor/powershell/module_manifest.py
@@ -294,7 +294,7 @@ def _create_powershell_wrapper(b_module_data, module_path, module_args,
         exec_manifest["actions"].insert(0, 'async_wrapper')
         exec_manifest["async_jid"] = str(random.randint(0, 999999999999))
         exec_manifest["async_timeout_sec"] = async_timeout
-        exec_manifest["async_named_pipe_timeout"] = C.config.get_config_value('DEFAULT_WIN_ASYNC_STARTUP_TIMEOUT')
+        exec_manifest["win_async_startup_timeout"] = C.DEFAULT_WIN_ASYNC_STARTUP_TIMEOUT
 
     if become and become_method == 'runas':
         finder.scan_exec_script('exec_wrapper')

--- a/lib/ansible/executor/powershell/module_manifest.py
+++ b/lib/ansible/executor/powershell/module_manifest.py
@@ -294,7 +294,7 @@ def _create_powershell_wrapper(b_module_data, module_path, module_args,
         exec_manifest["actions"].insert(0, 'async_wrapper')
         exec_manifest["async_jid"] = str(random.randint(0, 999999999999))
         exec_manifest["async_timeout_sec"] = async_timeout
-        exec_manifest["win_async_startup_timeout"] = C.DEFAULT_WIN_ASYNC_STARTUP_TIMEOUT
+        exec_manifest["async_startup_timeout"] = C.config.get_config_value("WIN_ASYNC_STARTUP_TIMEOUT", variables=task_vars)
 
     if become and become_method == 'runas':
         finder.scan_exec_script('exec_wrapper')


### PR DESCRIPTION
##### SUMMARY
Actually fix #65001 by creating a new config parameter and using it to configure the length of time waited for an async task to start on Windows and connect back to the named pipe.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/executor/powershell/async_wrapper.ps1`

##### ADDITIONAL INFORMATION
Thanks to @jborean93 for the guidance on where to define the config parameter.

New parameter name ANSIBLE_WIN_ASYNC_STARTUP_TIMEOUT takes the timeout in whole seconds, which is multiplied up to milliseconds for the timeout command.