### PR TITLE
file - change warning to error when 'src' is given without 'state'

### DIFF
--- a/changelogs/fragments/file-change-src-without-state-to-error.yaml
+++ b/changelogs/fragments/file-change-src-without-state-to-error.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - file - specifying ``src`` without ``state`` is now an error

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -291,15 +291,10 @@ def additional_parameter_handling(params):
         raise ParameterError(results={"msg": "recurse option requires state to be 'directory'",
                                       "path": params["path"]})
 
-    # Make sure that src makes sense with the state
+    # Fail if 'src' but no 'state' is specified
     if params['src'] and params['state'] not in ('link', 'hard'):
-        params['src'] = None
-        module.warn("The src option requires state to be 'link' or 'hard'.  This will become an"
-                    " error in Ansible 2.10")
-
-        # In 2.10, switch to this
-        # raise ParameterError(results={"msg": "src option requires state to be 'link' or 'hard'",
-        #                               "path": params["path"]})
+        raise ParameterError(results={'msg': "src option requires state to be 'link' or 'hard'",
+                                      'path': params['path']})
 
 
 def get_state(path):

--- a/test/integration/targets/file/tasks/state_link.yml
+++ b/test/integration/targets/file/tasks/state_link.yml
@@ -345,3 +345,18 @@
         - "{{ output_dir }}/test_follow1_link"
 
 # END #56928
+
+
+# Test failure with src and no state parameter
+- name: Specify src without state
+  file:
+    src: "{{ output_file }}"
+    dest: "{{ output_dir }}/link.txt"
+  ignore_errors: yes
+  register: src_state
+
+- name: Ensure src without state failed
+  assert:
+    that:
+      - src_state is failed
+      - "'src option requires state to be' in src_state.msg"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This has been a warning and is now an error in 2.10.
Added integration tests.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/files/file.py`