### PR TITLE
Remove unstable from aws_acm integration test.

### DIFF
--- a/test/integration/targets/aws_acm/aliases
+++ b/test/integration/targets/aws_acm/aliases
@@ -1,4 +1,3 @@
 cloud/aws
 aws_acm_info
 shippable/aws/group2
-unstable


### PR DESCRIPTION
##### SUMMARY

Remove unstable from aws_acm integration test.

The quota for the CI account has been increased, so tests are once again passing.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

aws_acm integration test
