### PR TITLE
Remove implicit template delimiters

### DIFF
--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -350,7 +350,7 @@ class Constructable(object):
         ''' helper method for plugins to compose variables for Ansible based on jinja2 expression and inventory vars'''
         t = self.templar
         t.available_variables = variables
-        return t.template('%s%s%s' % (t.environment.variable_start_string, template, t.environment.variable_end_string), disable_lookups=True)
+        return t.template('%s' % (template), disable_lookups=True)
 
     def _set_composite_vars(self, compose, variables, host, strict=False):
         ''' loops over compose entries to create vars for hosts '''

--- a/test/units/plugins/inventory/test_constructed.py
+++ b/test/units/plugins/inventory/test_constructed.py
@@ -41,7 +41,7 @@ def test_group_by_value_only(inventory_module):
         {
             'prefix': '',
             'separator': '',
-            'key': 'bar'
+            'key': '{{ bar }}'
         }
     ]
     inventory_module._add_host_to_keyed_groups(
@@ -61,11 +61,11 @@ def test_keyed_group_separator(inventory_module):
         {
             'prefix': 'farmer',
             'separator': '_old_',
-            'key': 'farmer'
+            'key': '{{ farmer }}'
         },
         {
             'separator': 'mmmmmmmmmm',
-            'key': 'barn'
+            'key': '{{ barn }}'
         }
     ]
     inventory_module._add_host_to_keyed_groups(
@@ -84,7 +84,7 @@ def test_keyed_group_empty_construction(inventory_module):
     keyed_groups = [
         {
             'separator': 'mmmmmmmmmm',
-            'key': 'barn'
+            'key': '{{ barn }}'
         }
     ]
     inventory_module._add_host_to_keyed_groups(
@@ -102,7 +102,7 @@ def test_keyed_group_host_confusion(inventory_module):
         {
             'separator': '',
             'prefix': '',
-            'key': 'species'
+            'key': '{{ species }}'
         }
     ]
     inventory_module._add_host_to_keyed_groups(
@@ -123,7 +123,7 @@ def test_keyed_parent_groups(inventory_module):
     keyed_groups = [
         {
             'prefix': 'region',
-            'key': 'region',
+            'key': '{{ region }}',
             'parent_group': 'region_list'
         }
     ]
@@ -146,18 +146,18 @@ def test_parent_group_templating(inventory_module):
     host = inventory_module.inventory.get_host('cow')
     keyed_groups = [
         {
-            'key': 'sound',
+            'key': '{{ sound }}',
             'prefix': 'sound',
             'parent_group': '{{ nickname }}'
         },
         {
-            'key': 'nickname',
+            'key': '{{ nickname }}',
             'prefix': '',
             'separator': '',
             'parent_group': 'nickname'  # statically-named parent group, conflicting with hostvar
         },
         {
-            'key': 'nickname',
+            'key': '{{ nickname }}',
             'separator': '',
             'parent_group': '{{ location | default("field") }}'
         }

--- a/test/units/plugins/inventory/test_openstack.py
+++ b/test/units/plugins/inventory/test_openstack.py
@@ -31,7 +31,7 @@ from ansible.template import Templar
 config_data = {
     'plugin': 'openstack',
     'compose': {
-        'composed_var': '"testvar-" + testvar',
+        'composed_var': '{{ "testvar-" + testvar}}',
     },
     'groups': {
         'testgroup': '"host" in inventory_hostname',
@@ -39,7 +39,7 @@ config_data = {
     'keyed_groups':
     [{
         'prefix': 'keyed',
-        'key': 'testvar',
+        'key': '{{ testvar }}',
     }]
 }
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When composing a variable the starting and ending template delimiters were automatically inserted restricting the use of jinja syntax.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/inventory/__init__.py`

##### ADDITIONAL INFORMATION
Given the below inventory, `ansible_host` must be the public IP if it is defined.
```
web1 ansible_host=10.10.10.1  public_v4=12.13.14.15 private_v4=10.10.10.1
web2 ansible_host=10.10.10.2  public_v4='' private_v4=10.10.10.2
```

This PR allows for the following use of the constructed plugin.
```
---
plugin: constructed
strict: yes
compose:
  ansible_host: "{% if public_v4 == '' %}{{private_v4}}{% else %}{{ public_v4 }}{% endif %}"
```
This produces the following inventory output. 
```
"hostvars": {
            "web1": {
                "ansible_host": "12.13.14.15",
                "private_v4": "10.10.10.1",
                "public_v4": "12.13.14.15"
            },
            "web2": {
                "ansible_host": "10.10.10.2",
                "private_v4": "10.10.10.2",
                "public_v4": ""
            }
}
```
