### PR TITLE
Delete vqfx default vlan

### DIFF
--- a/test/integration/targets/junos_vlans/tests/netconf/_remove_config.yaml
+++ b/test/integration/targets/junos_vlans/tests/netconf/_remove_config.yaml
@@ -5,6 +5,7 @@
 - name: Remove interface config
   junos_config:
     lines:
+      - delete vlan default # required for vqfx
       - delete vlan vlan1
       - delete vlan vlan2
 


### PR DESCRIPTION
##### SUMMARY
This commit deletes vqfx default vlan so it doesn't conflicts with
junos_vlans functional tests, which were meant to be used with vsrx
platform, that lacked such vlan from start.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/319
##### ISSUE TYPE
- Bugfix Pull Request