### PR TITLE
mysql_db: add skip_lock_tables option

### DIFF
--- a/changelogs/fragments/66688-mysql_db_add_skip_lock_tables_option.yml
+++ b/changelogs/fragments/66688-mysql_db_add_skip_lock_tables_option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_db - add ``skip_lock_tables`` option (https://github.com/ansible/ansible/pull/66688).

--- a/test/integration/targets/mysql_db/tasks/state_dump_import.yml
+++ b/test/integration/targets/mysql_db/tasks/state_dump_import.yml
@@ -66,6 +66,7 @@
     login_unix_socket: '{{ mysql_socket }}'
     force: yes
     master_data: 1
+    skip_lock_tables: yes
   register: result
 
 - name: assert successful completion of dump operation


### PR DESCRIPTION
##### SUMMARY
mysql_db: add skip_lock_tables option

Fixes: https://github.com/ansible/ansible/pull/33145

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/mysql/mysql_db.py```
