### PR TITLE
VMware: Change node_wwn and port_wwn for FC HBA to hexadecimal value

### DIFF
--- a/changelogs/fragments/66692-vmware_host_vmhba_info_fix_63045.yml
+++ b/changelogs/fragments/66692-vmware_host_vmhba_info_fix_63045.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_host_vmhba_info - fixed node_wwn and port_wwn for FC HBA to hexadecimal format(https://github.com/ansible/ansible/issues/63045).

--- a/lib/ansible/modules/cloud/vmware/vmware_host_vmhba_info.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_vmhba_info.py
@@ -120,6 +120,11 @@ hosts_vmhbas_info:
         }
 '''
 
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware import vmware_argument_spec, PyVmomi
 
@@ -167,11 +172,17 @@ class HostVmhbaMgr(PyVmomi):
                     hba_info['model'] = hba.model
                     hba_info['driver'] = hba.driver
                     try:
-                        hba_info['node_wwn'] = self.format_number(hba.nodeWorldWideName)
+                        if isinstance(hba, (vim.host.FibreChannelHba, vim.host.FibreChannelOverEthernetHba)):
+                            hba_info['node_wwn'] = self.format_number('%X' % hba.nodeWorldWideName)
+                        else:
+                            hba_info['node_wwn'] = self.format_number(hba.nodeWorldWideName)
                     except AttributeError:
                         pass
                     try:
-                        hba_info['port_wwn'] = self.format_number(hba.portWorldWideName)
+                        if isinstance(hba, (vim.host.FibreChannelHba, vim.host.FibreChannelOverEthernetHba)):
+                            hba_info['port_wwn'] = self.format_number('%X' % hba.portWorldWideName)
+                        else:
+                            hba_info['port_wwn'] = self.format_number(hba.portWorldWideName)
                     except AttributeError:
                         pass
                     try:


### PR DESCRIPTION
##### SUMMARY
node_wwn and port_wwn for FC HBA were output in decimal format and were truncated and were not accurate information.
So change to hexadecimal format.

Fixes https://github.com/ansible/ansible/issues/63045

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
vmware_host_vmhba_info.py

