### PR TITLE
Make cloudfront_info work with Python3 …

### DIFF
--- a/changelogs/fragments/66695-cloudfront-info-python3-fix.yml
+++ b/changelogs/fragments/66695-cloudfront-info-python3-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Make cloudfront_info module work with Python 3

--- a/lib/ansible/modules/cloud/amazon/cloudfront_info.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_info.py
@@ -504,7 +504,7 @@ class CloudFrontServiceManager:
         try:
             distribution_id = ""
             distributions = self.list_distributions(False)
-            distributions += self.list_streaming_distributions(False)
+            distributions.update(self.list_streaming_distributions(False))
             for dist in distributions:
                 if 'Items' in dist['Aliases']:
                     for alias in dist['Aliases']['Items']:


### PR DESCRIPTION
…by using `dict.update(dict)` instead of `dict += dict`.

##### SUMMARY
Bugfix for running module with Python 3, where `dict + dict` is no longer possible. See here for example https://bytes.com/topic/python/answers/623147-combining-two-dictionaries

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloudfront_info

##### ADDITIONAL INFORMATION
Fixes error when running module with `domain_name_alias:` param. Resulting in this errors message:

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: unsupported operand type(s) for +=: 'dict' and 'dict'
```

Running Python 3.7.