### PR TITLE
Add section to aws devel guidelines about module_defaults

### DIFF
--- a/docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst
@@ -153,6 +153,18 @@ or:
        if not HAS_BOTO3:
            module.fail_json(msg='boto3 and botocore are required for this module')
 
+Supporting Module Defaults
+--------------------------
+
+The existing AWS modules support using :ref:`module_defaults <module_defaults>` for common 
+authentication parameters.  To do the same for your new module, add an entry for it in
+``lib/ansible/config/module_defaults.yml``.  These entries take the form of:
+
+.. code-block:: yaml
+
+  aws_module_name:
+  - aws
+
 Connecting to AWS
 =================
 


### PR DESCRIPTION
##### SUMMARY
Ensure contributors know their new module will need to be added to the module_defaults list.

It might be useful to add a general dev guide section about supporting module_defaults but I couldn't decide the right place to do so.  Maybe `developing_modules_in_groups.rst`?

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst

