### PR TITLE
[get_url] skip checksum during --check

### DIFF
--- a/changelogs/fragments/61369_get_url.yml
+++ b/changelogs/fragments/61369_get_url.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- get_url - skip checksum during ``--check`` (https://github.com/ansible/ansible/issues/61369).

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -358,16 +358,12 @@ def url_filename(url):
     return fn
 
 
-def url_get(module, url, dest, use_proxy, last_mod_time, force, timeout=10, headers=None, tmp_dest=''):
+def url_get(module, url, dest, use_proxy, last_mod_time, force, timeout=10, headers=None, tmp_dest='', method='GET'):
     """
     Download data from the url and store in a temporary file.
 
     Return (tempfile, info about the request)
     """
-    if module.check_mode:
-        method = 'HEAD'
-    else:
-        method = 'GET'
 
     start = datetime.datetime.utcnow()
     rsp, info = fetch_url(module, url, use_proxy=use_proxy, force=force, last_mod_time=last_mod_time, timeout=timeout, headers=headers, method=method)
@@ -573,7 +569,8 @@ def main():
 
     # download to tmpsrc
     start = datetime.datetime.utcnow()
-    tmpsrc, info = url_get(module, url, dest, use_proxy, last_mod_time, force, timeout, headers, tmp_dest)
+    method = 'HEAD' if module.check_mode else 'GET'
+    tmpsrc, info = url_get(module, url, dest, use_proxy, last_mod_time, force, timeout, headers, tmp_dest, method)
     result['elapsed'] = (datetime.datetime.utcnow() - start).seconds
     result['src'] = tmpsrc
 

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -382,6 +382,14 @@
     port: '{{ http_port }}'
     state: started
 
+- name: download src with sha1 checksum url in check mode
+  get_url:
+    url: 'http://localhost:{{ http_port }}/27617.txt'
+    dest: '{{ remote_tmp_dir }}'
+    checksum: 'sha1:http://localhost:{{ http_port }}/sha1sum.txt'
+  register: result_sha1_check_mode
+  check_mode: True
+
 - name: download src with sha1 checksum url
   get_url:
     url: 'http://localhost:{{ http_port }}/27617.txt'
@@ -473,6 +481,7 @@
 - name: Assert that the file was downloaded
   assert:
     that:
+      - result_sha1_check_mode is changed
       - result_sha1 is changed
       - result_sha256 is changed
       - result_sha256_with_dot is changed


### PR DESCRIPTION
Fix get_url failure in check mode (--check) when using the checksum
format <algorithm>:<url>.

Regression introduced in (#20532)

Fixes: #61369

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
