### PR TITLE
Switch intersphinx label from jinja2 to jinja

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -274,4 +274,4 @@ autoclass_content = 'both'
 # location for the mappning to live) will confuse it.
 intersphinx_mapping = {'python': ('https://docs.python.org/2/', (None, '../python2.inv')),
                        'python3': ('https://docs.python.org/3/', (None, '../python3.inv')),
-                       'jinja2': ('http://jinja.pocoo.org/docs/', (None, '../jinja.inv'))}
+                       'jinja': ('http://jinja.palletsprojects.com/', (None, '../jinja.inv'))}

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1352,7 +1352,7 @@ To create a namespaced UUIDv5 using the default Ansible namespace '361E6D51-FAEC
 
 .. versionadded:: 1.9
 
-To make use of one attribute from each item in a list of complex variables, use the :func:`Jinja2 map filter<jinja:map>`::
+To make use of one attribute from each item in a list of complex variables, use the :func:`Jinja2 map filter <jinja:map>`::
 
     # get a comma-separated list of the mount points (e.g. "/,/mnt/stuff") on a host
     {{ ansible_mounts | map(attribute='mount') | join(',') }}

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -4,7 +4,7 @@
 Filters
 *******
 
-Filters let you transform data inside template expressions. This page documents mainly Ansible-specific filters, but you can use any of the standard filters shipped with Jinja2 - see `builtin filters`_ in the official Jinja2 template documentation. You can also use `Python methods`_ to manipulate variables. A few useful filters are typically added with each new Ansible release. The development documentation shows
+Filters let you transform data inside template expressions. This page documents mainly Ansible-specific filters, but you can use any of the standard filters shipped with Jinja2 - see the list of :ref:`builtin filters <jinja:builtin-filters>` in the official Jinja2 template documentation. You can also use :ref:`Python methods <jinja:python-methods>` to manipulate variables. A few useful filters are typically added with each new Ansible release. The development documentation shows
 how to create custom Ansible filters as plugins, though we generally welcome new filters into the core code so everyone can use them.
 
 Templating happens on the Ansible controller, **not** on the target host, so filters execute on the controller and manipulate data locally.
@@ -1352,7 +1352,7 @@ To create a namespaced UUIDv5 using the default Ansible namespace '361E6D51-FAEC
 
 .. versionadded:: 1.9
 
-To make use of one attribute from each item in a list of complex variables, use the "map" filter (see the `Jinja2 map() docs`_ for more)::
+To make use of one attribute from each item in a list of complex variables, use the :func:`Jinja2 map filter<jinja:map>`::
 
     # get a comma-separated list of the mount points (e.g. "/,/mnt/stuff") on a host
     {{ ansible_mounts | map(attribute='mount') | join(',') }}
@@ -1416,13 +1416,6 @@ This can then be used to reference hashes in Pod specifications::
                     name: {{ my_secret | k8s_config_resource_name }}
 
 .. versionadded:: 2.8
-
-
-.. _Jinja2 map() docs: https://jinja.palletsprojects.com/templates/#map
-
-.. _builtin filters: https://jinja.palletsprojects.com/templates/#builtin-filters
-
-.. _Python methods: https://jinja.palletsprojects.com/templates/#python-methods
 
 .. _PyYAML library: https://pyyaml.org/
 

--- a/docs/docsite/rst/user_guide/playbooks_python_version.rst
+++ b/docs/docsite/rst/user_guide/playbooks_python_version.rst
@@ -22,7 +22,7 @@ representation that Ansible can turn back into a list.
 In Python3, those methods return a :ref:`dictionary view <python3:dict-views>` object. The
 string representation that Jinja2 returns for dictionary views cannot be parsed back
 into a list by Ansible.  It is, however, easy to make this portable by
-using the :func:`list <jinja2:list>` filter whenever using :meth:`dict.keys`,
+using the :func:`list <jinja:list>` filter whenever using :meth:`dict.keys`,
 :meth:`dict.values`, or :meth:`dict.items`::
 
     vars:
@@ -60,5 +60,5 @@ Python3 dictionaries do not have these methods. Use :meth:`dict.keys`, :meth:`di
 
 .. seealso::
     * The :ref:`pb-py-compat-dict-views` entry for information on
-      why the :func:`list filter <jinja2:list>` is necessary
+      why the :func:`list filter <jinja:list>` is necessary
       here.


### PR DESCRIPTION
And make use of the intersphinx jinja label on the playbooks_filters
page

The upstream of jinja recently renamed their package name from jinja2 to jinja.  Since very few docs are using this label, might as well change the intersphinx label over to match.

On the playbooks_filters page, there are some places where we used an explicit link to the jinja docs.  We can now use intersphinx label instead.

/cc @samccann 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION

