### PR TITLE
VMware: Match state param in vmware_guest and vmware_guest_powerstate

### DIFF
--- a/changelogs/fragments/55653-vmware_guest_powerstate.yml
+++ b/changelogs/fragments/55653-vmware_guest_powerstate.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Add powerstates to match vmware_guest_powerstate module with vmware_guest (https://github.com/ansible/ansible/issues/55653).

--- a/test/integration/targets/vmware_guest/tasks/check_mode.yml
+++ b/test/integration/targets/vmware_guest/tasks/check_mode.yml
@@ -15,11 +15,15 @@
     - absent
     - present
     - poweredoff
+    - powered-off
     - poweredon
+    - powered-on
     - restarted
     - suspended
     - shutdownguest
+    - shutdown-guest
     - rebootguest
+    - reboot-guest
   register: check_mode_state
   check_mode: yes
 
@@ -44,7 +48,9 @@
   with_items:
     - present
     - poweredoff
+    - powered-off
     - poweredon
+    - powered-on
     - restarted
     - suspended
   register: check_mode_state


### PR DESCRIPTION
##### SUMMARY

Added 'powered-on', 'powered-off', 'shutdown-guest', 'reboot-guest' state
values in vmware_guest module in order to match vmware_guest_powerstate module.

Fixes: #55653

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/55653-vmware_guest_powerstate.yml
lib/ansible/modules/cloud/vmware/vmware_guest.py
test/integration/targets/vmware_guest/tasks/check_mode.yml
