### PR TITLE
ec2.py should honor boto profile for RDS instances

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -685,6 +685,8 @@ class Ec2Inventory(object):
         if not HAS_BOTO3:
             self.fail_with_error("Working with RDS instances requires boto3 - please install boto3 and try again",
                                  "getting RDS instances")
+        if self.boto_profile:
+            self.credentials['profile_name'] = self.boto_profile
 
         client = ec2_utils.boto3_inventory_conn('client', 'rds', region, **self.credentials)
         db_instances = client.describe_db_instances()
@@ -724,6 +726,9 @@ class Ec2Inventory(object):
         if not HAS_BOTO3:
             self.fail_with_error("Working with RDS clusters requires boto3 - please install boto3 and try again",
                                  "getting RDS clusters")
+
+        if self.boto_profile:
+            self.credentials['profile_name'] = self.boto_profile
 
         client = ec2_utils.boto3_inventory_conn('client', 'rds', region, **self.credentials)
 


### PR DESCRIPTION
##### SUMMARY

ec2.py dynamic inventory does not seem to honor boto profile configured in `ec2.ini` and uses the default boto profile for RDS instances.

Fixes #66708 


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
[ec2.py](https://github.com/ansible/ansible/blob/stable-2.9/contrib/inventory/ec2.py)


