### PR TITLE
local connection plugin - fix TypeError (#66560)

### DIFF
--- a/changelogs/fragments/66560-typeerror-in-local-connection-plugin.yaml
+++ b/changelogs/fragments/66560-typeerror-in-local-connection-plugin.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - local connection plugin - fix TypeError when concatenating paths (https://github.com/ansible/ansible/issues/66560)

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -131,9 +131,12 @@ class Connection(ConnectionBase):
         return (p.returncode, stdout, stderr)
 
     def _ensure_abs(self, path):
-        if not os.path.isabs(path) and self.cwd is not None:
-            path = os.path.normpath(os.path.join(self.cwd, path))
-        return path
+        ''' join the path with optional cwd, always returns path as bytes '''
+        b_path = to_bytes(path, errors='surrogate_or_strict')
+        if not os.path.isabs(b_path) and self.cwd is not None:
+            b_cwd = to_bytes(self.cwd, errors='surrogate_or_strict')
+            b_path = os.path.normpath(os.path.join(b_cwd, b_path))
+        return b_path
 
     def put_file(self, in_path, out_path):
         ''' transfer a file from local to local '''


### PR DESCRIPTION
##### SUMMARY
Fixes #66560

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
local connection plugin

##### ADDITIONAL INFORMATION

Bug was possibly introduced in https://github.com/ansible/ansible/commit/342d77b32d9176e64ddc89ea886e7560fc56503a

There are no existing unit tests for local connection plugin so just manual verification:
```bash
(venv) ➜  ansible git:(66560) ✗ python --version                                     
Python 3.5.2

(venv) ➜  ansible git:(66560) ✗ cat test_playbook.yaml 
---
- hosts: localhost
  connection: local

  tasks:
    - debug: msg=foobar

# Before fix
(venv) ➜  ansible git:(66560) ✗ ansible-playbook -i inventory.yaml test_playbook.yaml

PLAY [localhost] ******************************************************************************************************************************************************************************

TASK [Gathering Facts] ************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: Can't mix strings and bytes in path components
fatal: [localhost]: FAILED! => {"msg": "Unexpected failure during module execution.", "stdout": ""}

PLAY RECAP ************************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0  

# After fix
(venv) ➜  ansible git:(66560) ✗ ansible-playbook -i inventory.yaml test_playbook.yaml

PLAY [localhost] ******************************************************************************************************************************************************************************

TASK [Gathering Facts] ************************************************************************************************************************************************************************
ok: [localhost]

TASK [debug] **********************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "foobar"
}

PLAY RECAP ************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0 

```
