### PR TITLE
galaxy: fix AttributeError on empty requirements.yml

### DIFF
--- a/changelogs/fragments/66726-galaxy-fix-attribute-error.yml
+++ b/changelogs/fragments/66726-galaxy-fix-attribute-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - galaxy - Fix an AttributeError on ansible-galaxy install with an empty requirements.yml (https://github.com/ansible/ansible/issues/66725).

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -428,7 +428,7 @@ class GalaxyCLI(CLI):
                     "Failed to parse the requirements yml at '%s' with the following error:\n%s"
                     % (to_native(requirements_file), to_native(err)))
 
-        if requirements_file is None:
+        if file_requirements is None:
             raise AnsibleError("No requirements found in file '%s'" % to_native(requirements_file))
 
         def parse_role_req(requirement):


### PR DESCRIPTION
##### SUMMARY
Fixes #66725 
Simple kind of typo fix causes an AttributeError

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
galaxy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
after fix

```paste below
 $ ansible-galaxy install -r requirements.yml -v  
Using /home/rmoser/Projects/puzzle/ansible-puzzle/ansible.cfg as config file
ERROR! No requirements found in file 'requirements.yml'
```
