### PR TITLE
azure_rm_rg_info: fix KeyError: 'ansible_facts'

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup_info.py
@@ -184,7 +184,7 @@ class AzureRMResourceGroupInfo(AzureRMModuleBase):
 
         if is_old_facts:
             self.results['ansible_facts'] = dict(
-              azure_resourcegroups=result
+                azure_resourcegroups=result
             )
         self.results['resourcegroups'] = result
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup_info.py
@@ -183,7 +183,9 @@ class AzureRMResourceGroupInfo(AzureRMModuleBase):
                 item['resources'] = self.list_by_rg(item['name'])
 
         if is_old_facts:
-            self.results['ansible_facts']['azure_resourcegroups'] = result
+            self.results['ansible_facts'] = dict(
+              azure_resourcegroups=result
+            )
         self.results['resourcegroups'] = result
 
         return self.results


### PR DESCRIPTION
Fix facts for using old azure_rm_resourcegroup_facts, 

##### SUMMARY

Fixes #66727

Adds the `ansible_facts` as a sub map to fix the KeyError

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
azure / azure_rm_resourcegroup_info

##### ADDITIONAL INFORMATION
None