### PR TITLE
hashi_vault lookup plugin refresh, add aws iam login auth method, bugfixes

### DIFF
--- a/changelogs/fragments/66735-hashi-vault-output-aws-params.yaml
+++ b/changelogs/fragments/66735-hashi-vault-output-aws-params.yaml
@@ -1,0 +1,13 @@
+bugfixes:
+  - hashi_vault - when a non-token authentication method like ldap or userpass failed, but a valid token was loaded anyway (via env or token file), the token was used to attempt authentication, hiding the failure of the requested auth method.
+  - hashi_vault - if used via `with_hashi_vault` and a list of (say) 4 secrets to retrieve, only the first one would be retrieved and returned 4 times.
+minor_changes:
+  - hashi_vault - `secret` can now be an unnamed argument if it's specified first in the term string (see examples).
+  - hashi_vault - previously all options had to be supplied via key=value pairs in the term string; now a mix of string and parameters can be specified (see examples).
+  - hashi_vault - new option `return_format` added to control how secrets are returned, including options for multiple secrets and returning raw values with metadata.
+  - hashi_vault - `token` is now an explicit option (and the default) in the choices for `auth_method`
+  - hashi_vault - previous (undocumented) behavior was to attempt to read token from `~/.vault-token` if not specified. This is now controlled through `token_path` and `token_file` options (defaults will mimic previous behavior).
+  - hashi_vault - INI and additional ENV sources made available for some new and old options.
+  - hashi_vault - uses newer authentication calls in the HVAC library and falls back to older ones with deprecation warnings.
+  - hashi_vault - AWS IAM auth method added. Accepts standard ansible AWS params and only loads AWS libraries when needed.
+  

--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -96,12 +96,10 @@ DOCUMENTATION = """
       description:
         - Controls how multiple key/value pairs in a path are treated on return.
         - C(dict) returns a single dict containing the key/value pairs (same behavior as before 2.10).
-        - C(pairs) returns a list of dicts that each contain a single key/value pair, which may be more convenient in loops.
         - C(values) returns a list of all the values only. Use when you don't care about the keys.
         - C(raw) returns the actual API result, which includes metadata and may have the data nested in other keys.
       choices:
         - dict
-        - pairs
         - values
         - raw
       default: dict
@@ -182,11 +180,6 @@ EXAMPLES = """
   debug:
     msg: "A secret value: {{ item }}"
   loop: "{{ query('hashi_vault', 'secret/data/manysecrets', token=my_token_var, url='http://myvault_url:8200', return_format='values') }}"
-
-- name: return secrets as a list of single-item dicts
-  debug:
-    var: item
-  loop: "{{ query('hashi_vault', 'secret/data/manysecrets as=pairs', token=my_token_var, url='http://myvault_url:8200') }}"
 
 - name: return raw secret from API, including metadata
   set_fact:
@@ -321,9 +314,6 @@ class HashiVault:
             data = data['data']
         except KeyError:
             pass
-
-        if return_as == 'pairs':
-            return [dict([pair]) for pair in data['data'].items()]
 
         if return_as == 'values':
             return list(data['data'].values())

--- a/test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/defaults/main.yml
+++ b/test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/defaults/main.yml
@@ -2,3 +2,4 @@
 vault_gen_path: 'gen/testproject'
 vault_kv1_path: 'kv1/testproject'
 vault_kv2_path: 'kv2/data/testproject'
+vault_kv2_multi_path: 'kv2/data/testmulti'

--- a/test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
+++ b/test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
@@ -114,6 +114,9 @@
                   path "{{ vault_kv2_path }}/secret3" {
                     capabilities = ["deny"]
                   }
+                  path "{{ vault_kv2_multi_path }}/secrets" {
+                    capabilities = ["read"]
+                  }
 
             - name: 'Create generic secrets'
               command: '{{ vault_cmd }} write {{ vault_gen_path }}/secret{{ item }} value=foo{{ item }}'
@@ -126,6 +129,9 @@
             - name: 'Create KV v2 secrets'
               command: '{{ vault_cmd }} kv put {{ vault_kv2_path | regex_replace("/data") }}/secret{{ item }} value=foo{{ item }}'
               loop: [1, 2, 3]
+
+            - name: 'Create multiple KV v2 secrets under one path'
+              command: '{{ vault_cmd }} kv put {{ vault_kv2_multi_path | regex_replace("/data") }}/secrets value1=foo1 value2=foo2 value3=foo3'
 
             - name: setup approle auth
               import_tasks: approle_setup.yml

--- a/test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
+++ b/test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
@@ -12,7 +12,6 @@
         kv2_secret2_as_raw: "{{ lookup('hashi_vault', vault_kv2_path ~ '/secret2 ' ~  conn_params, auth_method='token', token=user_token, return_format='raw') }}"
         kv2_secrets_as_dict: "{{ lookup('hashi_vault', vault_kv2_multi_path ~ '/secrets ' ~  conn_params, auth_method='token', token=user_token) }}"
         kv2_secrets_as_values: "{{ query('hashi_vault', vault_kv2_multi_path ~ '/secrets ' ~  conn_params, auth_method='token', token=user_token, return_format='values') }}"
-        kv2_secrets_as_pairs: "{{ query('hashi_vault', vault_kv2_multi_path ~ '/secrets ' ~ conn_params, auth_method='token', token=user_token, return_format='pairs') }}"
 
     - name: 'Check secret generic values'
       fail:
@@ -48,12 +47,6 @@
         msg: 'Return value was not list or items do not match.'
       when: (kv2_secrets_as_values | type_debug != 'list') or ('foo{{ item }}' not in kv2_secrets_as_values)
       loop: [1, 2, 3]
-
-    - name: "Check multiple secrets as pairs"
-      fail:
-        msg: 'Return value was not list of dicts or dict did not contain 1 item'
-      when: (item | type_debug != 'dict') or (item | length != 1)
-      loop: "{{ kv2_secrets_as_pairs }}"
 
     - name: "Check multiple secrets as dict"
       fail:

--- a/test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
+++ b/test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
@@ -9,6 +9,10 @@
         kv1_secret2: "{{ lookup('hashi_vault', conn_params ~ 'secret=' ~ vault_kv1_path ~ '/secret2 token=' ~ user_token) }}"
         kv2_secret1: "{{ lookup('hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret1 auth_method=token token=' ~ user_token) }}"
         kv2_secret2: "{{ lookup('hashi_vault', conn_params ~ 'secret=' ~ vault_kv2_path ~ '/secret2 token=' ~ user_token) }}"
+        kv2_secret2_as_raw: "{{ lookup('hashi_vault', vault_kv2_path ~ '/secret2 ' ~  conn_params, auth_method='token', token=user_token, return_format='raw') }}"
+        kv2_secrets_as_dict: "{{ lookup('hashi_vault', vault_kv2_multi_path ~ '/secrets ' ~  conn_params, auth_method='token', token=user_token) }}"
+        kv2_secrets_as_values: "{{ query('hashi_vault', vault_kv2_multi_path ~ '/secrets ' ~  conn_params, auth_method='token', token=user_token, return_format='values') }}"
+        kv2_secrets_as_pairs: "{{ query('hashi_vault', vault_kv2_multi_path ~ '/secrets ' ~ conn_params, auth_method='token', token=user_token, return_format='pairs') }}"
 
     - name: 'Check secret generic values'
       fail:
@@ -24,6 +28,38 @@
       fail:
         msg: 'unexpected secret values'
       when: kv2_secret1['value'] != 'foo1' or kv2_secret2['value'] != 'foo2'
+
+    - name: 'Check kv2 secret raw return value'
+      fail:
+        msg:
+      when: >-
+        'data' not in kv2_secret2_as_raw
+        or 'data' not in kv2_secret2_as_raw['data']
+        or 'metadata' not in kv2_secret2_as_raw['data']
+
+    - name: "Check multiple secrets as dict"
+      fail:
+        msg: 'Return value was not dict or items do not match.'
+      when: (kv2_secrets_as_dict | type_debug != 'dict') or (kv2_secrets_as_dict['value{{ item }}'] != 'foo{{ item }}')
+      loop: [1, 2, 3]
+
+    - name: "Check multiple secrets as values"
+      fail:
+        msg: 'Return value was not list or items do not match.'
+      when: (kv2_secrets_as_values | type_debug != 'list') or ('foo{{ item }}' not in kv2_secrets_as_values)
+      loop: [1, 2, 3]
+
+    - name: "Check multiple secrets as pairs"
+      fail:
+        msg: 'Return value was not list of dicts or dict did not contain 1 item'
+      when: (item | type_debug != 'dict') or (item | length != 1)
+      loop: "{{ kv2_secrets_as_pairs }}"
+
+    - name: "Check multiple secrets as dict"
+      fail:
+        msg: 'Return value was not dict or items do not match.'
+      when: (kv2_secrets_as_dict | type_debug != 'dict') or (kv2_secrets_as_dict['value{{ item }}'] != 'foo{{ item }}')
+      loop: [1, 2, 3]
 
     - name: 'Failure expected when erroneous credentials are used'
       vars:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds support for the AWS IAM Login auth method in Hashicorp Vault. Along the way ran into some small bugs and possible improvements and so it ended up being a larger change.

## Outward Facing Changes
- Added INI sources for some of the parameters like the vault URL, role ID, and some of the newer params.
- [BUG] Previously, this plugin didn't work correctly when used with `with_`. If you passed `with_hashi_vault` a list of terms strings, it would look up the first one, and then for each subsequent one it would ignore what was passed and return the first result again. This is fixed.
- When passing params through the term string, you can now pass secrets as an unnamed argument, if it comes first. Example: ``{{ lookup('hashi_vault', 'secret=secret/hello:value') }}`` is the same as `{{ lookup('hashi_vault', 'secret/hello:value') }}`. Nicer syntax overall, and works well with `with_` if you have a large list of secrets for some reason.
- New option `return_format` with alias `as` can be used to control how a secret listing is returned (especially when you ask for a path that contains multiple key/value returns). Previous behavior was to return the single `dict` of key-value pairs. This is now the default. The choices are:
    * `dict` (same as previous behavior)
    * `raw`: return the raw output from the API, including metadata
    * `values`: return a list of all values (discard keys)
  
  `raw` is useful if you need the metadata from a secret. `values` is friendlier in loops when keys are unimportant.
- All parameters can now be passed in as params, not just in the term string, so you can do: `{{ lookup('hashi_vault', 'secret/hello:value', auth_method='ldap', username='itsame', password=secret_var) }}`
- While token auth was available before, it was not listed explicitly in the `auth_method` option choices, so now it is the "official" default (it already was the default before effectively, so operation won't change).
- If vault token was not supplied before, it was looked up in `~/.vault-token` (which is usually set by the vault CLI), however this wasn't documented. This is now explicit, and there are 2 options which you can set to control where it looks for the file, `token_path` (the directory) and `token_file`.
- `token_path` also retrieves its value from `$HOME` effectively making that the default, which also preserves previous behavior, and the value can be set in INI as well.
- `token_file` defaults to `.vault-token` and can also be set in INI.
- If your version of the HVAC library uses a deprecated method name for your chosen `auth_type`,  you'll see deprecation warnings because they changed the interface in newer versions. The plugin now checks and calls the newest one available.
- [BUG] sometimes trying to use a specific auth method with invalid params / credentials would implicitly use a token, even when not supplied, by loading it from env or file. This is no longer the case. `token` is only used now when `auth_method == 'token'` either by explicitly setting it or by not setting any `auth_method` (default is `token`).
- AWS IAM auth method is added. This plugin now pulls in the standard aws auth options via doc fragments.
- If you using IAM auth without explicit credentials, botocore is used to try to load credentials. If trying to use a boto profile, boto3 is used. If neither of those methods are used, the boto libraries are not required and not loaded.
- Documentation and examples are updated
- Friendly error messages restored / added for non-existent secrets and permission denied errors 

## Internal Changes
- Improved term processing to account for term array, for secret being unnamed if first
- All options loaded through the `LookupBase` provided options methods. This is a huge improvement that eliminates all manual checking for env vars, required params, ini values, aliases, etc., as the LookupBase helper method does all this for us, based on the documentation of options.
- Some refactoring, putting initial term and options processing into methods, and adding individual validation methods for each auth method that check required options and do deep argument transformation where necessary (loading `token` from file for example).
- Creating the `HvacClient` does not automatically authenticate now; a separate `.authenticate()` method has been added. This is paving the way for re-use of an authenticated connection to retrieve several/many secrets, though that pattern won't be implemented in this PR.
- `get()` method always returns a list now, even for single items. This makes it easier to provide a flattened list from the plugin by extending return value list.
- removed no longer used `**kwargs` from authentication methods.
- new internal comments on how to add authentication methods.
- new tests added for return format that also use options outside the term string, and secret paths without `secret=`.
- a kv v2 path containing multiple k/v pairs has been added in the tests which can be used with more tests from other contributors.
- [FUTURE] Also thinking about moving the HVAC class to a module_util so that it can be shared among other plugins and modules later, but this won't be in this PR.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/plugins/lookup/hashi_vault.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
## Compatibility
Despite the changes, as far as I can tell the plugin will remain 100%* backward compatible with the current iteration, so all existing uses and calls should still work *(with the exception of using `with_` with more than 1 value, because it was returning incorrect data before).
