### PR TITLE
Add external refs to the GH issue template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,26 @@
+# Ref: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+blank_issues_enabled: true  # default
+contact_links:
+- name: 🔐 Security bug report 🔥
+  url: https://docs.ansible.com/ansible/latest/community/reporting_bugs_and_features.html?utm_medium=github&utm_source=issue_template_chooser
+  about: |
+    Please learn how to report security vulnerabilities here.
+
+    For all security related bugs, email security@ansible.com
+    instead of using this issue tracker and you will receive
+    a prompt response.
+
+    For more information, see
+    https://docs.ansible.com/ansible/latest/community/reporting_bugs_and_features.html
+- name: 📝 Ansible Code of Conduct
+  url: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_template_chooser
+  about: ❤ Be nice to other members of the community. ☮ Behave.
+- name: 💬 Talks to the community
+  url: https://docs.ansible.com/ansible/latest/community/communication.html?utm_medium=github&utm_source=issue_template_chooser#mailing-list-information
+  about: Please ask and answer usage questions here
+- name: ⚡ Working groups
+  url: https://github.com/ansible/community/wiki
+  about: Interedted in improving a specific area? Become a part of a working group!
+- name: 💼 For Enterprise
+  url: https://www.ansible.com/products/engine?utm_medium=github&utm_source=issue_template_chooser
+  about: Red Hat offers supported builds of Ansible Engine

--- a/.github/ISSUE_TEMPLATE/security_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/security_bug_report.md
@@ -1,8 +1,0 @@
----
-name: 🔥 Security bug report
-about: How to report security vulnerabilities
----
-
-For all security related bugs, email security@ansible.com instead of using this issue tracker and you will receive a prompt response.
-
-For more information, see https://docs.ansible.com/ansible/latest/community/reporting_bugs_and_features.html


### PR DESCRIPTION
This change replaces a dummy template for security issues with a
proper reference to the doc. It also adds pointers to a few other
useful community pages.

Ref:
https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR integrates a new GH-specific config for external refs on the https://github.com/ansible/ansible/issues/new/choose page.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
- Feature Pull Request
- Community Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
.github/ISSUE_TEMPLATE/config.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser