### PR TITLE
zabbix_template - enable new update rule to delete missing linked templates

### DIFF
--- a/changelogs/fragments/66747-zabbix_template-newupdaterule-deletemissinglinkedtemplate.yml
+++ b/changelogs/fragments/66747-zabbix_template-newupdaterule-deletemissinglinkedtemplate.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - zabbix_template - adding new update rule templateLinkage.deleteMissing for newer zabbix versions (https://github.com/ansible/ansible/pull/66747).
+  

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -605,6 +605,10 @@ class Template(object):
             if LooseVersion(api_version).version[:2] <= LooseVersion('3.2').version:
                 update_rules['applications']['updateExisting'] = True
 
+            if ( LooseVersion(api_version).version[:3] >= LooseVersion('4.0.16').version ) or \
+                ( LooseVersion(api_version).version[:3] >= LooseVersion('4.4.4').version ):
+               update_rules['templateLinkage']['deleteMissing'] = True
+
             import_data = {'format': template_type, 'source': template_content, 'rules': update_rules}
             self._zapi.configuration.import_(import_data)
         except ZabbixAPIException as e:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -605,8 +605,12 @@ class Template(object):
             if LooseVersion(api_version).version[:2] <= LooseVersion('3.2').version:
                 update_rules['applications']['updateExisting'] = True
 
-            if (LooseVersion(api_version).version[:3] >= LooseVersion('4.0.16').version) or \
-               (LooseVersion(api_version).version[:3] >= LooseVersion('4.4.4').version):
+            # templateLinkage.deleteMissing only available in 4.0 branch higher .16 and higher 4.4.4
+            # it's not available in 4.2 branches or lower 4.0.16
+            if LooseVersion(api_version).version[:2] == LooseVersion('4.0').version and \
+               LooseVersion(api_version).version[:3] >= LooseVersion('4.0.16').version:
+                update_rules['templateLinkage']['deleteMissing'] = True
+            if LooseVersion(api_version).version[:3] >= LooseVersion('4.4.4').version:
                 update_rules['templateLinkage']['deleteMissing'] = True
 
             import_data = {'format': template_type, 'source': template_content, 'rules': update_rules}

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -605,9 +605,9 @@ class Template(object):
             if LooseVersion(api_version).version[:2] <= LooseVersion('3.2').version:
                 update_rules['applications']['updateExisting'] = True
 
-            if ( LooseVersion(api_version).version[:3] >= LooseVersion('4.0.16').version ) or \
-                ( LooseVersion(api_version).version[:3] >= LooseVersion('4.4.4').version ):
-               update_rules['templateLinkage']['deleteMissing'] = True
+            if (LooseVersion(api_version).version[:3] >= LooseVersion('4.0.16').version) or \
+               (LooseVersion(api_version).version[:3] >= LooseVersion('4.4.4').version):
+                update_rules['templateLinkage']['deleteMissing'] = True
 
             import_data = {'format': template_type, 'source': template_content, 'rules': update_rules}
             self._zapi.configuration.import_(import_data)


### PR DESCRIPTION
##### SUMMARY
New update rule is available from 4.0.16 and 4.4.4 up. Add check for version and enable new update rule.

fixes #66720

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zabbix_template

##### ADDITIONAL INFORMATION
Using new update rule set to true, linked templates getting unlinked if removed from xml/json files.