### PR TITLE
[2.9] galaxy: fix AttributeError on empty requirements.yml (#66726)

### DIFF
--- a/changelogs/fragments/66726-galaxy-fix-attribute-error.yml
+++ b/changelogs/fragments/66726-galaxy-fix-attribute-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - galaxy - Fix an AttributeError on ansible-galaxy install with an empty requirements.yml (https://github.com/ansible/ansible/issues/66725).

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -423,7 +423,7 @@ class GalaxyCLI(CLI):
                     "Failed to parse the requirements yml at '%s' with the following error:\n%s"
                     % (to_native(requirements_file), to_native(err)))
 
-        if requirements_file is None:
+        if file_requirements is None:
             raise AnsibleError("No requirements found in file '%s'" % to_native(requirements_file))
 
         def parse_role_req(requirement):


### PR DESCRIPTION
### SUMMARY
Backport of #66726
* galaxy: fix AttributeError on empty requirements.yml
* add changelog 
(cherry picked from commit 9e8fb5b7f535dabfe9cb365091bab7831e5ae5f2)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
galaxy

