### PR TITLE
Fixes IOS resource module config filter to include instead of section

### DIFF
--- a/lib/ansible/module_utils/network/ios/facts/interfaces/interfaces.py
+++ b/lib/ansible/module_utils/network/ios/facts/interfaces/interfaces.py
@@ -39,6 +39,9 @@ class InterfacesFacts(object):
 
         self.generated_spec = utils.generate_dict(facts_argument_spec)
 
+    def get_acl_data(self, connection):
+        return connection.get('sh running-config | include interface|description|duplex|mtu|shutdown|speed')
+
     def populate_facts(self, connection, ansible_facts, data=None):
         """ Populate the facts for interfaces
         :param connection: the device connection
@@ -50,7 +53,7 @@ class InterfacesFacts(object):
         objs = []
 
         if not data:
-            data = connection.get('show running-config | section ^interface')
+            data = self.get_acl_data(connection)
         # operate on a collection of resource x
         config = data.split('interface ')
         for conf in config:

--- a/lib/ansible/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py
+++ b/lib/ansible/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py
@@ -38,6 +38,9 @@ class L2_InterfacesFacts(object):
 
         self.generated_spec = utils.generate_dict(facts_argument_spec)
 
+    def get_acl_data(self, connection):
+        return connection.get('sh running-config | include interface|switchport')
+
     def populate_facts(self, connection, ansible_facts, data=None):
         """ Populate the facts for interfaces
         :param connection: the device connection
@@ -49,7 +52,7 @@ class L2_InterfacesFacts(object):
         objs = []
 
         if not data:
-            data = connection.get('show running-config | section ^interface')
+            data = self.get_acl_data(connection)
         # operate on a collection of resource x
         config = data.split('interface ')
         for conf in config:

--- a/lib/ansible/module_utils/network/ios/facts/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/ios/facts/l3_interfaces/l3_interfaces.py
@@ -39,6 +39,9 @@ class L3_InterfacesFacts(object):
 
         self.generated_spec = utils.generate_dict(facts_argument_spec)
 
+    def get_acl_data(self, connection):
+        return connection.get('sh running-config | include interface|ip address|no ip address|ipv6 address')
+
     def populate_facts(self, connection, ansible_facts, data=None):
         """ Populate the facts for l3 interfaces
         :param connection: the device connection
@@ -50,7 +53,7 @@ class L3_InterfacesFacts(object):
         objs = []
 
         if not data:
-            data = connection.get('show running-config | section ^interface')
+            data = self.get_acl_data(connection)
         # operate on a collection of resource x
         config = data.split('interface ')
         for conf in config:

--- a/lib/ansible/modules/network/ios/ios_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_interfaces.py
@@ -100,19 +100,16 @@ EXAMPLES = """
 # Before state:
 # -------------
 #
-# vios#show running-config | section ^interface
+# vios#sh running-config | include interface|description|duplex|mtu|shutdown|speed
 # interface GigabitEthernet0/1
 #  description Configured by Ansible
-#  no ip address
 #  duplex auto
 #  speed auto
 # interface GigabitEthernet0/2
 #  description This is test
-#  no ip address
 #  duplex auto
 #  speed 1000
 # interface GigabitEthernet0/3
-#  no ip address
 #  duplex auto
 #  speed auto
 
@@ -133,21 +130,18 @@ EXAMPLES = """
 # After state:
 # ------------
 #
-# vios#show running-config | section ^interface
+# vios#sh running-config | include interface|description|duplex|mtu|shutdown|speed
 # interface GigabitEthernet0/1
 #  description Configured by Ansible
-#  no ip address
 #  duplex auto
 #  speed auto
 # interface GigabitEthernet0/2
 #  description Configured and Merged by Ansible Network
-#  no ip address
 #  duplex auto
 #  speed 1000
 # interface GigabitEthernet0/3
 #  description Configured and Merged by Ansible Network
 #  mtu 2800
-#  no ip address
 #  shutdown
 #  duplex full
 #  speed 100
@@ -157,19 +151,16 @@ EXAMPLES = """
 # Before state:
 # -------------
 #
-# vios#show running-config | section ^interface
+# vios#sh running-config | include interface|description|duplex|mtu|shutdown|speed
 # interface GigabitEthernet0/1
-#  no ip address
 #  duplex auto
 #  speed auto
 # interface GigabitEthernet0/2
 #  description Configured by Ansible Network
-#  no ip address
 #  duplex auto
 #  speed 1000
 # interface GigabitEthernet0/3
 #  mtu 2000
-#  no ip address
 #  shutdown
 #  duplex full
 #  speed 100
@@ -188,20 +179,17 @@ EXAMPLES = """
 # After state:
 # -------------
 #
-# vios#show running-config | section ^interface
+# vios#sh running-config | include interface|description|duplex|mtu|shutdown|speed
 # interface GigabitEthernet0/1
-#  no ip address
 #  duplex auto
 #  speed auto
 # interface GigabitEthernet0/2
 #  description Configured by Ansible Network
-#  no ip address
 #  duplex auto
 #  speed 1000
 # interface GigabitEthernet0/3
 #  description Configured and Replaced by Ansible Network
 #  mtu 2500
-#  no ip address
 #  shutdown
 #  duplex full
 #  speed 1000
@@ -211,21 +199,18 @@ EXAMPLES = """
 # Before state:
 # -------------
 #
-# vios#show running-config | section ^interface#
+# vios#sh running-config | include interface|description|duplex|mtu|shutdown|speed#
 # interface GigabitEthernet0/1
 #  description Configured by Ansible
-#  no ip address
 #  duplex auto
 #  speed auto
 # interface GigabitEthernet0/2
 #  description This is test
-#  no ip address
 #  duplex auto
 #  speed 1000
 # interface GigabitEthernet0/3
 #  description Configured by Ansible
 #  mtu 2800
-#  no ip address
 #  shutdown
 #  duplex full
 #  speed 100
@@ -246,20 +231,17 @@ EXAMPLES = """
 # After state:
 # -------------
 #
-# vios#show running-config | section ^interface
+# vios#sh running-config | include interface|description|duplex|mtu|shutdown|speed
 # interface GigabitEthernet0/1
-#  no ip address
 #  duplex auto
 #  speed auto
 # interface GigabitEthernet0/2
 #  description Configured and Overridden by Ansible Network
-#  no ip address
 #  duplex auto
 #  speed 1000
 # interface GigabitEthernet0/3
 #  description Configured and Overridden by Ansible Network
 #  mtu 2000
-#  no ip address
 #  shutdown
 #  duplex full
 #  speed 100
@@ -269,20 +251,17 @@ EXAMPLES = """
 # Before state:
 # -------------
 #
-# vios#show running-config | section ^interface
+# vios#sh running-config | include interface|description|duplex|mtu|shutdown|speed
 # interface GigabitEthernet0/1
-#  no ip address
 #  duplex auto
 #  speed auto
 # interface GigabitEthernet0/2
 #  description Configured by Ansible Network
-#  no ip address
 #  duplex auto
 #  speed 1000
 # interface GigabitEthernet0/3
 #  description Configured by Ansible Network
 #  mtu 2500
-#  no ip address
 #  shutdown
 #  duplex full
 #  speed 1000
@@ -296,19 +275,16 @@ EXAMPLES = """
 # After state:
 # -------------
 #
-# vios#show running-config | section ^interface
+# vios#sh running-config | include interface|description|duplex|mtu|shutdown|speed
 # interface GigabitEthernet0/1
-#  no ip address
 #  duplex auto
 #  speed auto
 # interface GigabitEthernet0/2
-#  no ip address
 #  duplex auto
 #  speed auto
 # interface GigabitEthernet0/3
 #  description Configured by Ansible Network
 #  mtu 2500
-#  no ip address
 #  shutdown
 #  duplex full
 #  speed 1000
@@ -319,20 +295,17 @@ EXAMPLES = """
 # Before state:
 # -------------
 #
-# vios#show running-config | section ^interface
+# vios#sh running-config | include interface|description|duplex|mtu|shutdown|speed
 # interface GigabitEthernet0/1
-#  no ip address
 #  duplex auto
 #  speed auto
 # interface GigabitEthernet0/2
 #  description Configured by Ansible Network
-#  no ip address
 #  duplex auto
 #  speed 1000
 # interface GigabitEthernet0/3
 #  description Configured by Ansible Network
 #  mtu 2500
-#  no ip address
 #  shutdown
 #  duplex full
 #  speed 1000
@@ -344,17 +317,14 @@ EXAMPLES = """
 # After state:
 # -------------
 #
-# vios#show running-config | section ^interface
+# vios#sh running-config | include interface|description|duplex|mtu|shutdown|speed
 # interface GigabitEthernet0/1
-#  no ip address
 #  duplex auto
 #  speed auto
 # interface GigabitEthernet0/2
-#  no ip address
 #  duplex auto
 #  speed auto
 # interface GigabitEthernet0/3
-#  no ip address
 #  duplex auto
 #  speed auto
 

--- a/lib/ansible/modules/network/ios/ios_l2_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_l2_interfaces.py
@@ -110,15 +110,10 @@ EXAMPLES = """
 # Before state:
 # -------------
 #
-# viosl2#show running-config | section ^interface
+# viosl2#sh running-config | include interface|switchport
 # interface GigabitEthernet0/1
-#  description Configured by Ansible
-#  negotiation auto
 # interface GigabitEthernet0/2
-#  description This is test
 #  switchport access vlan 20
-#  media-type rj45
-#  negotiation auto
 
 - name: Merge provided configuration with device configuration
   ios_l2_interfaces:
@@ -137,35 +132,25 @@ EXAMPLES = """
 # After state:
 # ------------
 #
-# viosl2#show running-config | section ^interface
+# viosl2#sh running-config | include interface|switchport
 # interface GigabitEthernet0/1
-#  description Configured by Ansible
 #  switchport access vlan 10
-#  negotiation auto
 # interface GigabitEthernet0/2
-#  description This is test
 #  switchport trunk allowed vlan 10-20,40
 #  switchport trunk encapsulation dot1q
 #  switchport trunk native vlan 20
 #  switchport trunk pruning vlan 10,20
-#  media-type rj45
-#  negotiation auto
 
 # Using replaced
 
 # Before state:
 # -------------
 #
-# viosl2#show running-config | section ^interface
+# viosl2#sh running-config | include interface|switchport
 # interface GigabitEthernet0/1
-#  description Configured by Ansible
 #  switchport access vlan 20
-#  negotiation auto
 # interface GigabitEthernet0/2
-#  description This is test
 #  switchport access vlan 20
-#  media-type rj45
-#  negotiation auto
 
 - name: Replaces device configuration of listed l2 interfaces with provided configuration
   ios_l2_interfaces:
@@ -181,38 +166,28 @@ EXAMPLES = """
 # After state:
 # -------------
 #
-# viosl2#show running-config | section ^interface
+# viosl2#sh running-config | include interface|switchport
 # interface GigabitEthernet0/1
-#  description Configured by Ansible
 #  switchport access vlan 20
-#  negotiation auto
 # interface GigabitEthernet0/2
-#  description This is test
 #  switchport trunk allowed vlan 20-25,40
 #  switchport trunk encapsulation isl
 #  switchport trunk native vlan 20
 #  switchport trunk pruning vlan 10
-#  media-type rj45
-#  negotiation auto
 
 # Using overridden
 
 # Before state:
 # -------------
 #
-# viosl2#show running-config | section ^interface
+# viosl2#sh running-config | include interface|switchport
 # interface GigabitEthernet0/1
-#  description Configured by Ansible
 #  switchport trunk encapsulation dot1q
 #  switchport trunk native vlan 20
-#  negotiation auto
 # interface GigabitEthernet0/2
-#  description This is test
 #  switchport access vlan 20
 #  switchport trunk encapsulation dot1q
 #  switchport trunk native vlan 20
-#  media-type rj45
-#  negotiation auto
 
 - name: Override device configuration of all l2 interfaces with provided configuration
   ios_l2_interfaces:
@@ -225,35 +200,25 @@ EXAMPLES = """
 # After state:
 # -------------
 #
-# viosl2#show running-config | section ^interface
+# viosl2#sh running-config | include interface|switchport
 # interface GigabitEthernet0/1
-#  description Configured by Ansible
-#  negotiation auto
 # interface GigabitEthernet0/2
-#  description This is test
 #  switchport access vlan 20
-#  media-type rj45
-#  negotiation auto
 
 # Using Deleted
 
 # Before state:
 # -------------
 #
-# viosl2#show running-config | section ^interface
+# viosl2#sh running-config | include interface|switchport
 # interface GigabitEthernet0/1
-#  description Configured by Ansible
 #  switchport access vlan 20
-#  negotiation auto
 # interface GigabitEthernet0/2
-#  description This is test
 #  switchport access vlan 20
 #  switchport trunk allowed vlan 20-40,60,80
 #  switchport trunk encapsulation dot1q
 #  switchport trunk native vlan 10
 #  switchport trunk pruning vlan 10
-#  media-type rj45
-#  negotiation auto
 
 - name: Delete IOS L2 interfaces as in given arguments
   ios_l2_interfaces:
@@ -264,19 +229,14 @@ EXAMPLES = """
 # After state:
 # -------------
 #
-# viosl2#show running-config | section ^interface
+# viosl2#sh running-config | include interface|switchport
 # interface GigabitEthernet0/1
-#  description Configured by Ansible
-#  negotiation auto
 # interface GigabitEthernet0/2
-#  description This is test
 #  switchport access vlan 20
 #  switchport trunk allowed vlan 20-40,60,80
 #  switchport trunk encapsulation dot1q
 #  switchport trunk native vlan 10
 #  switchport trunk pruning vlan 10
-#  media-type rj45
-#  negotiation auto
 
 
 # Using Deleted without any config passed
@@ -285,20 +245,15 @@ EXAMPLES = """
 # Before state:
 # -------------
 #
-# viosl2#show running-config | section ^interface
+# viosl2#sh running-config | include interface|switchport
 # interface GigabitEthernet0/1
-#  description Configured by Ansible
 #  switchport access vlan 20
-#  negotiation auto
 # interface GigabitEthernet0/2
-#  description This is test
 #  switchport access vlan 20
 #  switchport trunk allowed vlan 20-40,60,80
 #  switchport trunk encapsulation dot1q
 #  switchport trunk native vlan 10
 #  switchport trunk pruning vlan 10
-#  media-type rj45
-#  negotiation auto
 
 - name: Delete IOS L2 interfaces as in given arguments
   ios_l2_interfaces:
@@ -307,14 +262,9 @@ EXAMPLES = """
 # After state:
 # -------------
 #
-# viosl2#show running-config | section ^interface
+# viosl2#sh running-config | include interface|switchport
 # interface GigabitEthernet0/1
-#  description Configured by Ansible
-#  negotiation auto
 # interface GigabitEthernet0/2
-#  description This is test
-#  media-type rj45
-#  negotiation auto
 
 """
 

--- a/lib/ansible/modules/network/ios/ios_l3_interfaces.py
+++ b/lib/ansible/modules/network/ios/ios_l3_interfaces.py
@@ -118,22 +118,14 @@ EXAMPLES = """
 # Before state:
 # -------------
 #
-# vios#show running-config | section ^interface
+# vios#sh running-config | include interface|ip address|no ip address|ipv6 address
 # interface GigabitEthernet0/1
-#  description Configured by Ansible
 #  ip address 10.1.1.1 255.255.255.0
-#  duplex auto
-#  speed auto
 # interface GigabitEthernet0/2
-#  description This is test
 #  no ip address
-#  duplex auto
-#  speed 1000
 # interface GigabitEthernet0/3
-#  description Configured by Ansible Network
 #  no ip address
 # interface GigabitEthernet0/3.100
-#  encapsulation dot1Q 20
 
 - name: Merge provided configuration with device configuration
   ios_l3_interfaces:
@@ -156,23 +148,15 @@ EXAMPLES = """
 # After state:
 # ------------
 #
-# vios#show running-config | section ^interface
+# vios#sh running-config | include interface|ip address|no ip address|ipv6 address
 # interface GigabitEthernet0/1
-#  description Configured by Ansible
 #  ip address 10.1.1.1 255.255.255.0
 #  ip address 192.168.0.1 255.255.255.0 secondary
-#  duplex auto
-#  speed auto
 # interface GigabitEthernet0/2
-#  description This is test
 #  ip address 192.168.0.2 255.255.255.0
-#  duplex auto
-#  speed 1000
 # interface GigabitEthernet0/3
-#  description Configured by Ansible Network
 #  ipv6 address FD5D:12C9:2201:1::1/64
 # interface GigabitEthernet0/3.100
-#  encapsulation dot1Q 20
 #  ip address 192.168.0.3 255.255.255.0
 
 # Using replaced
@@ -180,22 +164,14 @@ EXAMPLES = """
 # Before state:
 # -------------
 #
-# vios#show running-config | section ^interface
+# vios#sh running-config | include interface|ip address|no ip address|ipv6 address
 # interface GigabitEthernet0/1
-#  description Configured by Ansible
 #  ip address 10.1.1.1 255.255.255.0
-#  duplex auto
-#  speed auto
 # interface GigabitEthernet0/2
-#  description This is test
 #  no ip address
-#  duplex auto
-#  speed 1000
 # interface GigabitEthernet0/3
-#  description Configured by Ansible Network
 #  ip address 192.168.2.0 255.255.255.0
 # interface GigabitEthernet0/3.100
-#  encapsulation dot1Q 20
 #  ip address 192.168.0.2 255.255.255.0
 
 - name: Replaces device configuration of listed interfaces with provided configuration
@@ -218,22 +194,14 @@ EXAMPLES = """
 # After state:
 # ------------
 #
-# vios#show running-config | section ^interface
+# vios#sh running-config | include interface|ip address|no ip address|ipv6 address
 # interface GigabitEthernet0/1
-#  description Configured by Ansible
 #  ip address 10.1.1.1 255.255.255.0
-#  duplex auto
-#  speed auto
 # interface GigabitEthernet0/2
-#  description This is test
 #  ip address 192.168.2.1 255.255.255.0
-#  duplex auto
-#  speed 1000
 # interface GigabitEthernet0/3
-#  description Configured by Ansible Network
 #  ip address dhcp client-id GigabitEthernet0/2 hostname test.com
 # interface GigabitEthernet0/3.100
-#  encapsulation dot1Q 20
 #  ip address 192.168.0.2 255.255.255.0
 #  ip address 192.168.0.3 255.255.255.0 secondary
 
@@ -242,22 +210,14 @@ EXAMPLES = """
 # Before state:
 # -------------
 #
-# vios#show running-config | section ^interface
+# vios#sh running-config | include interface|ip address|no ip address|ipv6 address
 # interface GigabitEthernet0/1
-#  description Configured by Ansible
 #  ip address 10.1.1.1 255.255.255.0
-#  duplex auto
-#  speed auto
 # interface GigabitEthernet0/2
-#  description This is test
 #  ip address 192.168.2.1 255.255.255.0
-#  duplex auto
-#  speed 1000
 # interface GigabitEthernet0/3
-#  description Configured by Ansible Network
 #  ipv6 address FD5D:12C9:2201:1::1/64
 # interface GigabitEthernet0/3.100
-#  encapsulation dot1Q 20
 #  ip address 192.168.0.2 255.255.255.0
 
 - name: Override device configuration of all interfaces with provided configuration
@@ -274,21 +234,13 @@ EXAMPLES = """
 # After state:
 # ------------
 #
-# vios#show running-config | section ^interface
+# vios#sh running-config | include interface|ip address|no ip address|ipv6 address
 # interface GigabitEthernet0/1
-#  description Configured by Ansible
 #  no ip address
-#  duplex auto
-#  speed auto
 # interface GigabitEthernet0/2
-#  description This is test
 #  ip address 192.168.0.1 255.255.255.0
-#  duplex auto
-#  speed 1000
 # interface GigabitEthernet0/3
-#  description Configured by Ansible Network
 # interface GigabitEthernet0/3.100
-#  encapsulation dot1Q 20
 #  ipv6 address autoconfig
 
 # Using Deleted
@@ -296,24 +248,15 @@ EXAMPLES = """
 # Before state:
 # -------------
 #
-# vios#show running-config | section ^interface
+# vios#sh running-config | include interface|ip address|no ip address|ipv6 address
 # interface GigabitEthernet0/1
 #  ip address 192.0.2.10 255.255.255.0
-#  shutdown
-#  duplex auto
-#  speed auto
 # interface GigabitEthernet0/2
-#  description Configured by Ansible Network
 #  ip address 192.168.1.0 255.255.255.0
 # interface GigabitEthernet0/3
-#  description Configured by Ansible Network
 #  ip address 192.168.0.1 255.255.255.0
-#  shutdown
-#  duplex full
-#  speed 10
 #  ipv6 address FD5D:12C9:2201:1::1/64
 # interface GigabitEthernet0/3.100
-#  encapsulation dot1Q 20
 #  ip address 192.168.0.2 255.255.255.0
 
 - name: "Delete attributes of given interfaces (NOTE: This won't delete the interface itself)"
@@ -326,24 +269,15 @@ EXAMPLES = """
 # After state:
 # -------------
 #
-# vios#show running-config | section ^interface
+# vios#sh running-config | include interface|ip address|no ip address|ipv6 address
 # interface GigabitEthernet0/1
 #  no ip address
-#  shutdown
-#  duplex auto
-#  speed auto
 # interface GigabitEthernet0/2
-#  description Configured by Ansible Network
 #  no ip address
 # interface GigabitEthernet0/3
-#  description Configured by Ansible Network
 #  ip address 192.168.0.1 255.255.255.0
-#  shutdown
-#  duplex full
-#  speed 10
 #  ipv6 address FD5D:12C9:2201:1::1/64
 # interface GigabitEthernet0/3.100
-#  encapsulation dot1Q 20
 
 # Using Deleted without any config passed
 #"(NOTE: This will delete all of configured L3 resource module attributes from each configured interface)"
@@ -352,24 +286,15 @@ EXAMPLES = """
 # Before state:
 # -------------
 #
-# vios#show running-config | section ^interface
+# vios#sh running-config | include interface|ip address|no ip address|ipv6 address
 # interface GigabitEthernet0/1
 #  ip address 192.0.2.10 255.255.255.0
-#  shutdown
-#  duplex auto
-#  speed auto
 # interface GigabitEthernet0/2
-#  description Configured by Ansible Network
 #  ip address 192.168.1.0 255.255.255.0
 # interface GigabitEthernet0/3
-#  description Configured by Ansible Network
 #  ip address 192.168.0.1 255.255.255.0
-#  shutdown
-#  duplex full
-#  speed 10
 #  ipv6 address FD5D:12C9:2201:1::1/64
 # interface GigabitEthernet0/3.100
-#  encapsulation dot1Q 20
 #  ip address 192.168.0.2 255.255.255.0
 
 - name: "Delete L3 attributes of ALL interfaces together (NOTE: This won't delete the interface itself)"
@@ -379,22 +304,13 @@ EXAMPLES = """
 # After state:
 # -------------
 #
-# vios#show running-config | section ^interface
+# vios#sh running-config | include interface|ip address|no ip address|ipv6 address
 # interface GigabitEthernet0/1
 #  no ip address
-#  shutdown
-#  duplex auto
-#  speed auto
 # interface GigabitEthernet0/2
-#  description Configured by Ansible Network
 #  no ip address
 # interface GigabitEthernet0/3
-#  description Configured by Ansible Network
-#  shutdown
-#  duplex full
-#  speed 10
 # interface GigabitEthernet0/3.100
-#  encapsulation dot1Q 20
 
 """
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes IOS resource module config filter to include instead of the section, fixes the issue #66647
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_interfaces
ios_l2_interfaces
ios_l3_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
