### PR TITLE
[stable-2.9] display - remove extra new line after warning message (#65199)

### DIFF
--- a/changelogs/fragments/warnings-remove-extra-newline.yaml
+++ b/changelogs/fragments/warnings-remove-extra-newline.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - display - remove extra new line after warnings (https://github.com/ansible/ansible/pull/65199)

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -151,14 +151,15 @@ class Display(with_metaclass(Singleton, object)):
         """
 
         nocolor = msg
-        if color:
-            msg = stringc(msg, color)
 
         if not log_only:
             if not msg.endswith(u'\n') and newline:
                 msg2 = msg + u'\n'
             else:
                 msg2 = msg
+
+            if color:
+                msg2 = stringc(msg2, color)
 
             msg2 = to_bytes(msg2, encoding=self._output_encoding(stderr=stderr))
             if sys.version_info >= (3,):

--- a/test/units/utils/display/test_display.py
+++ b/test/units/utils/display/test_display.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+from ansible.utils.display import Display
+
+
+def test_display_basic_message(capsys, mocker):
+    # Disable logging
+    mocker.patch('ansible.utils.display.logger', return_value=None)
+
+    d = Display()
+    d.display(u'Some displayed message')
+    out, err = capsys.readouterr()
+    assert out == 'Some displayed message\n'
+    assert err == ''

--- a/test/units/utils/display/test_warning.py
+++ b/test/units/utils/display/test_warning.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible.utils.display import Display
+
+
+@pytest.fixture
+def warning_message():
+    warning_message = 'bad things will happen'
+    expected_warning_message = '[WARNING]: {0}\n'.format(warning_message)
+    return warning_message, expected_warning_message
+
+
+def test_warning(capsys, mocker, warning_message):
+    warning_message, expected_warning_message = warning_message
+
+    mocker.patch('ansible.utils.color.ANSIBLE_COLOR', True)
+    mocker.patch('ansible.utils.color.parsecolor', return_value=u'1;35')  # value for 'bright purple'
+
+    d = Display()
+    d.warning(warning_message)
+    out, err = capsys.readouterr()
+    assert d._warns == {expected_warning_message: 1}
+    assert err == '\x1b[1;35m{0}\x1b[0m\n\x1b[1;35m\x1b[0m'.format(expected_warning_message.rstrip('\n'))
+
+
+def test_warning_no_color(capsys, mocker, warning_message):
+    warning_message, expected_warning_message = warning_message
+
+    mocker.patch('ansible.utils.color.ANSIBLE_COLOR', False)
+
+    d = Display()
+    d.warning(warning_message)
+    out, err = capsys.readouterr()
+    assert d._warns == {expected_warning_message: 1}
+    assert err == expected_warning_message


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #65199 for Ansible 2.9
(cherry picked from commit 8e195adda5)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/utils/display.py`