### PR TITLE
Fix virtual private gateway filters reference link

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_vgw_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_vgw_info.py
@@ -24,7 +24,7 @@ options:
   filters:
     description:
       - A dict of filters to apply. Each dict item consists of a filter key and a filter value.
-        See U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRouteTables.html) for possible filters.
+        See U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVpnGateways.html) for possible filters.
     type: dict
   vpn_gateway_ids:
     description:


### PR DESCRIPTION
##### SUMMARY
Fix virtual private gateway filters reference link that now points to route table documentation.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
The documentation currently points to route table filters AWS documentation. This PR fixes it by referencing Virtual Private Gateway filters AWS document.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
