### PR TITLE
Add a to_list filter for strings or lists

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -98,6 +98,16 @@ def to_bool(a):
         return True
     return False
 
+def to_list(item):
+    ''' given a list, just return it; given a dict, throw an exception; given an undefined object, return an empty list; given anything else, enclose the item in a list '''
+    if isinstance(item, list):
+        return item
+    elif isinstance(item, dict):
+        raise AnsibleFilterError('Please use dict2items() for operating on dicts')
+    elif item in (None, 'None', 'null'):
+        return []
+    else:
+        return [ item ]
 
 def to_datetime(string, format="%Y-%m-%d %H:%M:%S"):
     return datetime.datetime.strptime(string, format)
@@ -637,6 +647,7 @@ class FilterModule(object):
             # types
             'bool': to_bool,
             'to_datetime': to_datetime,
+	    'to_list': to_list,
 
             # date formatting
             'strftime': strftime,

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -98,8 +98,14 @@ def to_bool(a):
         return True
     return False
 
+
 def to_list(item):
-    ''' given a list, just return it; given a dict, throw an exception; given an undefined object, return an empty list; given anything else, enclose the item in a list '''
+    '''
+    given a list, just return it;
+    given a dict, throw an exception;
+    given an undefined object, return an empty list;cw
+    given anything else, enclose the item in a list
+    '''
     if isinstance(item, list):
         return item
     elif isinstance(item, dict):
@@ -107,7 +113,8 @@ def to_list(item):
     elif item in (None, 'None', 'null'):
         return []
     else:
-        return [ item ]
+        return [item]
+
 
 def to_datetime(string, format="%Y-%m-%d %H:%M:%S"):
     return datetime.datetime.strptime(string, format)

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -647,7 +647,7 @@ class FilterModule(object):
             # types
             'bool': to_bool,
             'to_datetime': to_datetime,
-	    'to_list': to_list,
+            'to_list': to_list,
 
             # date formatting
             'strftime': strftime,

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -103,7 +103,7 @@ def to_list(item):
     '''
     given a list, just return it;
     given a dict, throw an exception;
-    given an undefined object, return an empty list;cw
+    given an undefined object, return an empty list;
     given anything else, enclose the item in a list
     '''
     if isinstance(item, list):


### PR DESCRIPTION
##### SUMMARY

Add a filter that can turn a string into a list of with a single element.  The filter is a noop on lists.  It returns an empty list if passed `None` or similar.  I initially considered mimicing `dict2items` when passed a `dict`, but ultimately decided that behavior was ambiguous and changed it to raise an exception so there aren't two filters that do the same thing.

This is a fairly standard function in other templating languages.  The `.list` method on a string in `jinja2` crashes through to Python's "a string is a character array" which is unexpected in a **templating context**.  There are multiple stackoverflow questions of people bumping into this problem and it's been a thorn in my side for a while.

See "Additional Information" for a single use case, take a breath, and use your imagination.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

`filters/core.py`

##### ADDITIONAL INFORMATION

Several modules support the ability to pass a list or a string as a
parameter.  As an example, and this is *only* one of countless times
I've tripped into this, let's say I have a variable `yum_packages`.
That was populated by someone reading the docs for the `yum` module and
seeing the examples where `name:` can be a string or a list.  If I was
only doing a single `package` or `yum` command, it'd be safe to have
that variable defined as a list or a string:

```yaml
- name: "Install required package(s)"
  yum:
    name: "{{ yum_packages }}"
    state: latest
```

Now, let's say I want to `loop` on that list.  Without this filter, I'd
need to:

```yaml
- name: "Version lock package(s)"
  command: "yum versionlock add *:{{ package }}*"
  loop: "{{ yum_packages if isinstance(yum_packages,list) else [yum_packages] }}"
  loop_control:
    loop_var: package
```

This is fine once, but if there are multiple operations, there's a lot
of copy/paste, which violates DRY and makes these operations more
unapproachable and tightly coupled.

With this filter enabled, that becomes:

```yaml
- name: "Version lock package(s)"
  command: "yum versionlock add *:{{ package }}*"
  loop: "{{ yum_packages|to_list }}"
  loop_control:
    loop_var: package
```

And for consistency, I can even adjust the original task to:

```yaml
- name: "Install required package(s)"
  yum:
    name: "{{ yum_packages|to_list }}"
    state: latest
```
