### PR TITLE
[stable-2.9] pamd: Fix AttributeError when removing the first or last rule (#66398)

### DIFF
--- a/changelogs/fragments/66398-pamd_fix-attributeerror-when-removing-first-line.yml
+++ b/changelogs/fragments/66398-pamd_fix-attributeerror-when-removing-first-line.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "pamd - Bugfix for attribute error when removing the first or last line"

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -351,6 +351,8 @@ class PamdRule(PamdLine):
     valid_control_actions = ['ignore', 'bad', 'die', 'ok', 'done', 'reset']
 
     def __init__(self, rule_type, rule_control, rule_path, rule_args=None):
+        self.prev = None
+        self.next = None
         self._control = None
         self._args = None
         self.rule_type = rule_type
@@ -478,7 +480,8 @@ class PamdService(object):
             if current_line.matches(rule_type, rule_control, rule_path):
                 if current_line.prev is not None:
                     current_line.prev.next = current_line.next
-                    current_line.next.prev = current_line.prev
+                    if current_line.next is not None:
+                        current_line.next.prev = current_line.prev
                 else:
                     self._head = current_line.next
                     current_line.next.prev = None

--- a/test/units/modules/system/test_pamd.py
+++ b/test/units/modules/system/test_pamd.py
@@ -134,6 +134,12 @@ session    required pam_unix.so"""
         auth       required pam_env.so
 """
 
+        self.no_header_system_auth_string = """auth       required pam_env.so
+auth       sufficient pam_unix.so nullok try_first_pass
+auth       requisite pam_succeed_if.so uid
+auth       required pam_deny.so
+"""
+
         self.pamd = PamdService(self.system_auth_string)
 
     def test_properly_parsed(self):
@@ -352,4 +358,15 @@ session    required pam_unix.so"""
         # Second run should not change anything
         self.assertFalse(self.pamd.remove('account', 'required', 'pam_unix.so'))
         test_rule = PamdRule('account', 'required', 'pam_unix.so')
+        self.assertNotIn(str(test_rule), str(self.pamd))
+
+    def test_remove_first_rule(self):
+        no_header_service = PamdService(self.no_header_system_auth_string)
+        self.assertTrue(no_header_service.remove('auth', 'required', 'pam_env.so'))
+        test_rule = PamdRule('auth', 'required', 'pam_env.so')
+        self.assertNotIn(str(test_rule), str(no_header_service))
+
+    def test_remove_last_rule(self):
+        self.assertTrue(self.pamd.remove('session', 'required', 'pam_unix.so'))
+        test_rule = PamdRule('session', 'required', 'pam_unix.so')
         self.assertNotIn(str(test_rule), str(self.pamd))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Backport of #66398  for Ansible 2.9
(cherry picked from commit a4b59d021368285490f7cda50c11ac4f7a8030b5)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/system/pamd.py
