### PR TITLE
AnsibleAWSModule related cleanup - redshift

### DIFF
--- a/changelogs/fragments/66779-redshift-backoff.yml
+++ b/changelogs/fragments/66779-redshift-backoff.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- 'redshift: Add AWSRetry calls for errors outside our control'

--- a/hacking/aws_config/testing_policies/database-policy.json
+++ b/hacking/aws_config/testing_policies/database-policy.json
@@ -12,6 +12,15 @@
             }
         },
         {
+            "Action": "iam:CreateServiceLinkedRole",
+            "Effect": "Allow",
+            "Resource": "arn:aws:iam::*:role/aws-service-role/redshift.amazonaws.com/AWSServiceRoleForRedshift",
+            "Condition": {
+                "StringLike": {
+                    "iam:AWSServiceName": "redshift.amazonaws.com"}
+                }
+        },
+        {
             "Sid": "AllowRDSReadEverywhere",
             "Effect": "Allow",
             "Action": [

--- a/lib/ansible/modules/cloud/amazon/redshift.py
+++ b/lib/ansible/modules/cloud/amazon/redshift.py
@@ -261,8 +261,9 @@ cluster:
 try:
     import botocore
 except ImportError:
-    pass  # handled by AnsibleAWSModule
-from ansible.module_utils.ec2 import ec2_argument_spec, snake_dict_to_camel_dict
+    pass  # caught by AnsibleAWSModule
+
+from ansible.module_utils.ec2 import snake_dict_to_camel_dict
 from ansible.module_utils.aws.core import AnsibleAWSModule, is_boto3_error_code
 
 
@@ -505,8 +506,7 @@ def modify_cluster(module, redshift):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         command=dict(choices=['create', 'facts', 'delete', 'modify'], required=True),
         identifier=dict(required=True),
         node_type=dict(choices=['ds1.xlarge', 'ds1.8xlarge', 'ds2.xlarge',
@@ -538,7 +538,7 @@ def main():
         enhanced_vpc_routing=dict(type='bool', default=False),
         wait=dict(type='bool', default=False),
         wait_timeout=dict(type='int', default=300),
-    ))
+    )
 
     required_if = [
         ('command', 'delete', ['skip_final_cluster_snapshot']),

--- a/test/integration/targets/redshift/aliases
+++ b/test/integration/targets/redshift/aliases
@@ -1,3 +1,2 @@
-unstable
 cloud/aws
 shippable/aws/group1


### PR DESCRIPTION
##### SUMMARY

Boto3 modules already using AnsibleAWSModule are currently running chunks of duplicate/deprecated code.

AnsibleAWSModule related cleanup:
- remove ec2_argument_spec() use (AnsibleAWSModule adds it automatically)
- remove HAS_BOTO3 (AnsibleAWSModule handles it)
- fetch boto3 clients using module.client()
- remove unused imports
- use AWSRetry to better handle 'operation-in-progress' failures.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

redshift

##### ADDITIONAL INFORMATION

Follow up to #65987