### PR TITLE
facts virtual: detect KVM when product_name is 'KVM Server'

### DIFF
--- a/changelogs/fragments/66780-facts-detect-kvm-server.yml
+++ b/changelogs/fragments/66780-facts-detect-kvm-server.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - facts - fix detection of virtualization type when dmi product name is KVM Server

--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -93,7 +93,7 @@ class LinuxVirtual(Virtual):
 
         product_name = get_file_content('/sys/devices/virtual/dmi/id/product_name')
 
-        if product_name in ('KVM', 'Bochs', 'AHV'):
+        if product_name in ('KVM', 'KVM Server', 'Bochs', 'AHV'):
             virtual_facts['virtualization_type'] = 'kvm'
             return virtual_facts
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Facts module for Linux failed to detect `'virtualization_type': 'kvm'` since dmi `product_name` contained `KVM Server`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

`lib/ansible/module_utils/facts/virtual/linux.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

On a virtual server from [netcup](https://www.netcup.de/), the fact gathering setup module was not able to collect virtualization information:

```
'virtualization_type': 'NA',
'virtualization_role': 'NA'
```

However, `systemd-detect-virt` was able to detect `kvm`.

It turned out, `/sys/devices/virtual/dmi/id/product_name` contains `KVM Server`, which was not on Ansible's whitelist.

This PR adds `KVM Server` to the checks. Results afterwards:

```
'virtualization_role': 'guest',
'virtualization_type': 'kvm'
```
