### PR TITLE
all: remove all the the duplicate words

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tags.rst
@@ -309,7 +309,7 @@ For example:
        debug: msg="{{ showmevar }}"
        tags: [ never, debug ]
 
-The rarely-used debug task in the example above only runs when you specifically request the the ``debug`` or ``never`` tags.
+The rarely-used debug task in the example above only runs when you specifically request the ``debug`` or ``never`` tags.
 
 .. _using_tags:
 

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -298,7 +298,7 @@ class GalaxyAPI:
             done = (data.get('next_link', None) is None)
 
             # https://github.com/ansible/ansible/issues/64355
-            # api_server contains part of the API path but next_link includes the the /api part so strip it out.
+            # api_server contains part of the API path but next_link includes the /api part so strip it out.
             url_info = urlparse(self.api_server)
             base_url = "%s://%s/" % (url_info.scheme, url_info.netloc)
 

--- a/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_distribution.py
@@ -436,7 +436,7 @@ options:
       suboptions:
         error_code:
           type: int
-          description: The error code the the custom error page is for.
+          description: The error code the custom error page is for.
         error_caching_min_ttl:
           type: int
           description: The length of time (in seconds) that CloudFront will cache status codes for.

--- a/lib/ansible/modules/cloud/google/gcp_bigquery_table.py
+++ b/lib/ansible/modules/cloud/google/gcp_bigquery_table.py
@@ -66,7 +66,7 @@ options:
         type: str
       table_id:
         description:
-        - The ID of the the table.
+        - The ID of the table.
         required: false
         type: str
   clustering:
@@ -544,7 +544,7 @@ tableReference:
       type: str
     tableId:
       description:
-      - The ID of the the table.
+      - The ID of the table.
       returned: success
       type: str
 clustering:

--- a/lib/ansible/modules/cloud/google/gcp_bigquery_table_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_bigquery_table_info.py
@@ -128,7 +128,7 @@ resources:
           type: str
         tableId:
           description:
-          - The ID of the the table.
+          - The ID of the table.
           returned: success
           type: str
     clustering:

--- a/lib/ansible/modules/cloud/google/gcp_compute_snapshot.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_snapshot.py
@@ -236,7 +236,7 @@ description:
   type: str
 storageBytes:
   description:
-  - A size of the the storage used by the snapshot. As snapshots share storage, this
+  - A size of the storage used by the snapshot. As snapshots share storage, this
     number is expected to change with snapshot creation/deletion.
   returned: success
   type: int

--- a/lib/ansible/modules/cloud/google/gcp_compute_snapshot_info.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_snapshot_info.py
@@ -144,7 +144,7 @@ resources:
       type: str
     storageBytes:
       description:
-      - A size of the the storage used by the snapshot. As snapshots share storage,
+      - A size of the storage used by the snapshot. As snapshots share storage,
         this number is expected to change with snapshot creation/deletion.
       returned: success
       type: int

--- a/lib/ansible/modules/cloud/kubevirt/kubevirt_template.py
+++ b/lib/ansible/modules/cloud/kubevirt/kubevirt_template.py
@@ -41,7 +41,7 @@ options:
             - List of any valid API objects, such as a I(DeploymentConfig), I(Service), etc. The object
               will be created exactly as defined here, with any parameter values substituted in prior to creation.
               The definition of these objects can reference parameters defined earlier.
-            - As part of the the list user can pass also I(VirtualMachine) kind. When passing I(VirtualMachine)
+            - As part of the list user can pass also I(VirtualMachine) kind. When passing I(VirtualMachine)
               user must use Ansible structure of the parameters not the Kubernetes API structure. For more information
               please take a look at M(kubevirt_vm) module and at EXAMPLES section, where you can see example.
         type: list

--- a/lib/ansible/modules/cloud/vmware/vmware_host_dns.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_dns.py
@@ -52,7 +52,7 @@ options:
     type: str
   domain:
     description:
-    - The domain name to be used for the the ESXi host.
+    - The domain name to be used for the ESXi host.
     type: str
   dns_servers:
     description:

--- a/lib/ansible/modules/network/aireos/aireos_config.py
+++ b/lib/ansible/modules/network/aireos/aireos_config.py
@@ -139,7 +139,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/aruba/aruba_config.py
+++ b/lib/ansible/modules/network/aruba/aruba_config.py
@@ -160,7 +160,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/asa/asa_config.py
+++ b/lib/ansible/modules/network/asa/asa_config.py
@@ -127,7 +127,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/cli/cli_config.py
+++ b/lib/ansible/modules/network/cli/cli_config.py
@@ -133,7 +133,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/cloudengine/ce_config.py
+++ b/lib/ansible/modules/network/cloudengine/ce_config.py
@@ -136,7 +136,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/cnos/cnos_config.py
+++ b/lib/ansible/modules/network/cnos/cnos_config.py
@@ -133,7 +133,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/dellos10/dellos10_config.py
+++ b/lib/ansible/modules/network/dellos10/dellos10_config.py
@@ -127,7 +127,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/dellos6/dellos6_config.py
+++ b/lib/ansible/modules/network/dellos6/dellos6_config.py
@@ -125,7 +125,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/dellos9/dellos9_config.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_config.py
@@ -126,7 +126,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/edgeos/edgeos_config.py
+++ b/lib/ansible/modules/network/edgeos/edgeos_config.py
@@ -93,7 +93,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/enos/enos_config.py
+++ b/lib/ansible/modules/network/enos/enos_config.py
@@ -134,7 +134,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -192,7 +192,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/exos/exos_config.py
+++ b/lib/ansible/modules/network/exos/exos_config.py
@@ -151,7 +151,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/f5/bigip_apm_policy_fetch.py
+++ b/lib/ansible/modules/network/f5/bigip_apm_policy_fetch.py
@@ -43,7 +43,7 @@ options:
     default: profile_access
   force:
     description:
-      - If C(no), the file will only be transferred if it does not exist in the the destination.
+      - If C(no), the file will only be transferred if it does not exist in the destination.
     type: bool
     default: yes
   partition:

--- a/lib/ansible/modules/network/f5/bigip_asm_policy_fetch.py
+++ b/lib/ansible/modules/network/f5/bigip_asm_policy_fetch.py
@@ -57,7 +57,7 @@ options:
     type: bool
   force:
     description:
-      - If C(no), the file will only be transferred if it does not exist in the the destination.
+      - If C(no), the file will only be transferred if it does not exist in the destination.
     default: yes
     type: bool
   partition:

--- a/lib/ansible/modules/network/f5/bigip_imish_config.py
+++ b/lib/ansible/modules/network/f5/bigip_imish_config.py
@@ -187,7 +187,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
         type: str

--- a/lib/ansible/modules/network/f5/bigip_software_install.py
+++ b/lib/ansible/modules/network/f5/bigip_software_install.py
@@ -445,7 +445,7 @@ class ModuleManager(object):
                 pass
 
     def wait_for_software_install_on_device(self):
-        # We need to delay this slightly in case the the volume needs to be
+        # We need to delay this slightly in case the volume needs to be
         # created first
         for dummy in range(10):
             try:

--- a/lib/ansible/modules/network/f5/bigiq_device_discovery.py
+++ b/lib/ansible/modules/network/f5/bigiq_device_discovery.py
@@ -105,7 +105,7 @@ options:
     description:
       - List of modules to be discovered and imported into the device.
       - These modules must be provisioned on the target device otherwise operation will fail.
-      - The C(ltm) module must always be specified when performing discovery or re-discovery of the the device.
+      - The C(ltm) module must always be specified when performing discovery or re-discovery of the device.
       - When C(asm) or C(afm) are specified C(shared_security) module needs to also be declared.
     type: list
     choices:

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -190,7 +190,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -152,7 +152,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/ironware/ironware_config.py
+++ b/lib/ansible/modules/network/ironware/ironware_config.py
@@ -139,7 +139,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -144,7 +144,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -155,7 +155,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/nos/nos_config.py
+++ b/lib/ansible/modules/network/nos/nos_config.py
@@ -139,7 +139,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -192,7 +192,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/onyx/onyx_config.py
+++ b/lib/ansible/modules/network/onyx/onyx_config.py
@@ -109,7 +109,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/slxos/slxos_config.py
+++ b/lib/ansible/modules/network/slxos/slxos_config.py
@@ -164,7 +164,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/sros/sros_config.py
+++ b/lib/ansible/modules/network/sros/sros_config.py
@@ -135,7 +135,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/voss/voss_config.py
+++ b/lib/ansible/modules/network/voss/voss_config.py
@@ -159,7 +159,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/network/vyos/vyos_config.py
+++ b/lib/ansible/modules/network/vyos/vyos_config.py
@@ -97,7 +97,7 @@ options:
     suboptions:
       filename:
         description:
-          - The filename to be used to store the backup configuration. If the the filename
+          - The filename to be used to store the backup configuration. If the filename
             is not given it will be generated based on the hostname, current time and date
             in format defined by <hostname>_config.<current-date>@<current-time>
       dir_path:

--- a/lib/ansible/modules/storage/netapp/na_ontap_volume_autosize.py
+++ b/lib/ansible/modules/storage/netapp/na_ontap_volume_autosize.py
@@ -331,7 +331,7 @@ class NetAppOntapVolumeAutosize(object):
         if not self.use_rest:
             netapp_utils.ems_log_event("na_ontap_volume_autosize", self.server)
         if self.use_rest:
-            # we only have the volume name, we need to the the uuid for the volume
+            # we only have the volume name, we need to the uuid for the volume
             uuid = self.get_volume_uuid()
         current = self.get_volume_autosize(uuid=uuid)
         converted_parameters = copy.deepcopy(self.parameters)

--- a/lib/ansible/modules/windows/win_mapped_drive.py
+++ b/lib/ansible/modules/windows/win_mapped_drive.py
@@ -51,7 +51,7 @@ options:
   username:
     description:
     - The username that is used when testing the initial connection.
-    - This is never saved with a mapped drive, the the M(win_credential) module
+    - This is never saved with a mapped drive, the M(win_credential) module
       to persist a username and password for a host.
     - This is required if the mapped drive requires authentication with
       custom credentials and become, or CredSSP cannot be used.

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -207,7 +207,7 @@ class Connection(NetworkConnectionBase):
         super(Connection, self).__init__(play_context, new_stdin, *args, **kwargs)
 
         # If network_os is not specified then set the network os to auto
-        # This will be used to trigger the the use of guess_network_os when connecting.
+        # This will be used to trigger the use of guess_network_os when connecting.
         self._network_os = self._network_os or 'auto'
 
         self.netconf = netconf_loader.get(self._network_os, self)


### PR DESCRIPTION
##### Summary
This replaces all duplicate instances of "the the" with "the". Originally found when reading 
documentation and then fixed for all.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
all

##### ADDITIONAL INFORMATION

n/a