### PR TITLE
fixes ANSIBLE_DUPLICATE_YAML_DICT_KEY=error crashes

### DIFF
--- a/changelogs/fragments/66786-fix-duplicate-yaml-key-error.yaml
+++ b/changelogs/fragments/66786-fix-duplicate-yaml-key-error.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - DUPLICATE_YAML_DICT_KEY - Fix error output when configuration option DUPLICATE_YAML_DICT_KEY is set to error
+    (https://github.com/ansible/ansible/issues/65366)

--- a/lib/ansible/parsing/yaml/constructor.py
+++ b/lib/ansible/parsing/yaml/constructor.py
@@ -76,7 +76,10 @@ class AnsibleConstructor(SafeConstructor):
                 if C.DUPLICATE_YAML_DICT_KEY == 'warn':
                     display.warning(msg)
                 elif C.DUPLICATE_YAML_DICT_KEY == 'error':
-                    raise ConstructorError(to_native(msg))
+                    raise ConstructorError(context=None, context_mark=None,
+                                           problem=to_native(msg),
+                                           problem_mark=node.start_mark,
+                                           note=None)
                 else:
                     # when 'ignore'
                     display.debug(msg)


### PR DESCRIPTION
##### SUMMARY
Fixes #65366

This PR fixes a bug where setting ANSIBLE_DUPLICATE_YAML_DICT_KEY=error would report a cryptic message rather than the expected error as described in the bug report 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
yaml parsing

##### ADDITIONAL INFORMATION


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste 

Before fix:
ERROR! Unexpected Exception, this is probably a bug: 'NoneType' object has no attribute 'line'

After fix:
ERROR! Syntax Error while loading YAML.
  While constructing a mapping from /home/thoavery/ansible/playbooks/vars.yml, line 7, column 5, found a duplicate dict key (ID). Using last defined value only.

The error appears to be in '/home/thoavery/ansible/playbooks/vars.yml': line 7, column 5, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

Customers:
  - <<: *default-customer
    ^ here

```
