### PR TITLE
Remove `with` statement for pytest-mock unit tests

### DIFF
--- a/test/units/module_utils/facts/hardware/test_sunos_get_uptime_facts.py
+++ b/test/units/module_utils/facts/hardware/test_sunos_get_uptime_facts.py
@@ -11,7 +11,7 @@ def test_sunos_get_uptime_facts(mocker):
 
     inst = sunos.SunOSHardware(module)
 
-    with mocker.patch('time.time', return_value=1567052602.5089788):
-        expected = int(time.time()) - 1548249689
-        result = inst.get_uptime_facts()
-        assert expected == result['uptime_seconds']
+    mocker.patch('time.time', return_value=1567052602.5089788)
+    expected = int(time.time()) - 1548249689
+    result = inst.get_uptime_facts()
+    assert expected == result['uptime_seconds']

--- a/test/units/plugins/lookup/test_aws_secret.py
+++ b/test/units/plugins/lookup/test_aws_secret.py
@@ -70,8 +70,8 @@ def test_lookup_variable(mocker, dummy_credentials):
     boto3_double.Session.return_value.client.return_value.get_secret_value.return_value = simple_variable_success_response
     boto3_client_double = boto3_double.Session.return_value.client
 
-    with mocker.patch.object(boto3, 'session', boto3_double):
-        retval = lookup.run(["simple_variable"], None, **dummy_credentials)
+    mocker.patch.object(boto3, 'session', boto3_double)
+    retval = lookup.run(["simple_variable"], None, **dummy_credentials)
     assert(retval[0] == '{"secret":"simplesecret"}')
     boto3_client_double.assert_called_with('secretsmanager', 'eu-west-1', aws_access_key_id='notakey',
                                            aws_secret_access_key="notasecret", aws_session_token=None)
@@ -86,5 +86,5 @@ def test_warn_denied_variable(mocker, dummy_credentials):
     boto3_double.Session.return_value.client.return_value.get_secret_value.side_effect = ClientError(error_response, operation_name)
 
     with pytest.raises(AnsibleError):
-        with mocker.patch.object(boto3, 'session', boto3_double):
-            lookup_loader.get('aws_secret').run(["denied_variable"], None, **dummy_credentials)
+        mocker.patch.object(boto3, 'session', boto3_double)
+        lookup_loader.get('aws_secret').run(["denied_variable"], None, **dummy_credentials)

--- a/test/units/plugins/lookup/test_aws_ssm.py
+++ b/test/units/plugins/lookup/test_aws_ssm.py
@@ -90,8 +90,8 @@ def test_lookup_variable(mocker):
     boto3_double.Session.return_value.client.return_value.get_parameters.return_value = simple_variable_success_response
     boto3_client_double = boto3_double.Session.return_value.client
 
-    with mocker.patch.object(boto3, 'session', boto3_double):
-        retval = lookup.run(["simple_variable"], {}, **dummy_credentials)
+    mocker.patch.object(boto3, 'session', boto3_double)
+    retval = lookup.run(["simple_variable"], {}, **dummy_credentials)
     assert(retval[0] == "simplevalue")
     boto3_client_double.assert_called_with('ssm', 'eu-west-1', aws_access_key_id='notakey',
                                            aws_secret_access_key="notasecret", aws_session_token=None)
@@ -106,10 +106,10 @@ def test_path_lookup_variable(mocker):
     get_path_fn.return_value = path_success_response
     boto3_client_double = boto3_double.Session.return_value.client
 
-    with mocker.patch.object(boto3, 'session', boto3_double):
-        args = copy(dummy_credentials)
-        args["bypath"] = 'true'
-        retval = lookup.run(["/testpath"], {}, **args)
+    mocker.patch.object(boto3, 'session', boto3_double)
+    args = copy(dummy_credentials)
+    args["bypath"] = 'true'
+    retval = lookup.run(["/testpath"], {}, **args)
     assert(retval[0]["/testpath/won"] == "simple_value_won")
     assert(retval[0]["/testpath/too"] == "simple_value_too")
     boto3_client_double.assert_called_with('ssm', 'eu-west-1', aws_access_key_id='notakey',
@@ -129,8 +129,8 @@ def test_return_none_for_missing_variable(mocker):
     boto3_double = mocker.MagicMock()
     boto3_double.Session.return_value.client.return_value.get_parameters.return_value = missing_variable_response
 
-    with mocker.patch.object(boto3, 'session', boto3_double):
-        retval = lookup.run(["missing_variable"], {}, **dummy_credentials)
+    mocker.patch.object(boto3, 'session', boto3_double)
+    retval = lookup.run(["missing_variable"], {}, **dummy_credentials)
     assert(retval[0] is None)
 
 
@@ -145,8 +145,8 @@ def test_match_retvals_to_call_params_even_with_some_missing_variables(mocker):
     boto3_double = mocker.MagicMock()
     boto3_double.Session.return_value.client.return_value.get_parameters.return_value = some_missing_variable_response
 
-    with mocker.patch.object(boto3, 'session', boto3_double):
-        retval = lookup.run(["simple", "missing_variable", "/testpath/won", "simple"], {}, **dummy_credentials)
+    mocker.patch.object(boto3, 'session', boto3_double)
+    retval = lookup.run(["simple", "missing_variable", "/testpath/won", "simple"], {}, **dummy_credentials)
     assert(retval == ["simple_value", None, "simple_value_won", "simple_value"])
 
 
@@ -162,5 +162,5 @@ def test_warn_denied_variable(mocker):
     boto3_double.Session.return_value.client.return_value.get_parameters.side_effect = ClientError(error_response, operation_name)
 
     with pytest.raises(AnsibleError):
-        with mocker.patch.object(boto3, 'session', boto3_double):
-            lookup.run(["denied_variable"], {}, **dummy_credentials)
+        mocker.patch.object(boto3, 'session', boto3_double)
+        lookup.run(["denied_variable"], {}, **dummy_credentials)


### PR DESCRIPTION
Fixes tests which use `pytest-mock` to work with newer `pytest-mock` than the CI docker image currently uses.

As per:
https://github.com/pytest-dev/pytest-mock#note-about-usage-as-context-manager
pytest-mock is not meant to be used within a `with` context or as a
decorator. Instead, pytest-mock will automatically unpatch the mocked
methods when each test is complete.

In newer pytest-mock, this use actually throws an exception and causes
the tests to fail.

This hasn't been hit in Ansible's CI yet, because the docker image
that the tests run in uses an older version of pytest-mock. However,
there is no constraint on the upper bound of pytest-mock in
test/lib/ansible_test/_data/requirements/constraints.txt which means
that when running the tests locally, outside of that docker image, the
tests never pass.

This patch removes the `with` context in each such case.

Signed-off-by: Rick Elrod <rick@elrod.me>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tests

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Before the change
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
(venv) [fedora@relrod-test1 ansible]$ pytest test/units/module_utils/facts/hardware/test_sunos_get_uptime_facts.py 
[...]
E           ValueError: Using mocker in a with context is not supported. https://github.com/pytest-dev/pytest-mock#note-about-usage-as-context-manager
```

After the change:

```
(venv) [fedora@relrod-test1 ansible]$ pytest test/units/module_utils/facts/hardware/test_sunos_get_uptime_facts.py 
============================= test session starts =============================
platform linux -- Python 3.7.6, pytest-5.3.4, py-1.8.1, pluggy-0.13.1
rootdir: /home/fedora/ansible
plugins: xdist-1.31.0, mock-2.0.0, f5-sdk-3.0.21, forked-1.1.3
collected 1 item                                                              

test/units/module_utils/facts/hardware/test_sunos_get_uptime_facts.py . [100%]

============================== 1 passed in 0.13s ==============================
```