### PR TITLE
Mark the hacking AWS policies as owned by team_aws

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1920,6 +1920,8 @@ files:
     support: community
   test/utils/shippable/:
     notified: mattclay
+  hacking/aws_config/:
+    maintainers: $team_aws
   hacking/report.py:
     notified: mattclay
   shippable.yml:


### PR DESCRIPTION
##### SUMMARY

Mark the hacking AWS policies as owned by team_aws

For practical purposes this is documentation of the AWS policies needed to run the AWS integration tests.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

.github/BOTMETA.yml

##### ADDITIONAL INFORMATION
