### PR TITLE
sqs_queue - Move to boto3 and add support for various extra features

### DIFF
--- a/changelogs/fragments/66795-sqs_queue-boto3.yaml
+++ b/changelogs/fragments/66795-sqs_queue-boto3.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+- 'sqs_queue: updated to use boto3 instead of boto'
+- 'sqs_queue: Add support for tagging, KMS and FIFO queues'

--- a/hacking/aws_config/testing_policies/compute-policy.json
+++ b/hacking/aws_config/testing_policies/compute-policy.json
@@ -264,6 +264,18 @@
               "lightsail:StopInstance"
             ],
             "Resource": "arn:aws:lightsail:*:*:*"
-        }
+        },
+        {
+            "Sid": "AllowSQS",
+            "Effect": "Allow",
+            "Action": [
+                "sqs:GetQueueURL",
+                "sqs:CreateQueue",
+                "sqs:GetQueueAttributes",
+                "sqs:DeleteQueue",
+                "sqs:SetQueueAttributes"
+            ],
+            "Resource": "arn:aws:sqs:*:*:*"
+        },
     ]
 }

--- a/lib/ansible/modules/cloud/amazon/sqs_queue.py
+++ b/lib/ansible/modules/cloud/amazon/sqs_queue.py
@@ -229,20 +229,26 @@ ARGUMENT_SPEC = dict(
     state=dict(type='str', default='present', choices=['present', 'absent']),
     name=dict(required=True, type='str'),
     queue_type=dict(type='str', default='standard', choices=['standard', 'fifo']),
-    delay_seconds=dict(type='int', aliases=['delivery_delay'], return_name='delivery_delay'),
+    delay_seconds=dict(type='int', aliases=['delivery_delay']),
     maximum_message_size=dict(type='int'),
     message_retention_period=dict(type='int'),
     policy=dict(type='dict'),
-    receive_message_wait_time_seconds=dict(type='int', aliases=['receive_message_wait_time'], return_name='receive_message_wait_time'),
+    receive_message_wait_time_seconds=dict(type='int', aliases=['receive_message_wait_time']),
     redrive_policy=dict(type='dict'),
-    visibility_timeout=dict(type='int', aliases=['default_visibility_timeout'], return_name='default_visibility_timeout'),
+    visibility_timeout=dict(type='int', aliases=['default_visibility_timeout']),
     kms_master_key_id=dict(type='str'),
-    kms_data_key_reuse_period_seconds=dict(type='int', aliases=['kms_data_key_reuse_period'], return_name='kms_data_key_reuse_period'),
+    kms_data_key_reuse_period_seconds=dict(type='int', aliases=['kms_data_key_reuse_period']),
     content_based_deduplication=dict(type='bool'),
     tags=dict(type='dict'),
     purge_tags=dict(type='bool', default=False),
 )
 NON_ATTRIBUTES = ('name', 'state', 'queue_type', 'tags', 'purge_tags')
+COMPATABILITY_KEYS = dict(
+    delay_seconds='delivery_delay',
+    receive_message_wait_time_seconds='receive_message_wait_time',
+    visibility_timeout='default_visibility_timeout',
+    kms_data_key_reuse_period_seconds='kms_data_key_reuse_period',
+)
 
 
 def get_queue_name(module, is_fifo=False):
@@ -293,7 +299,7 @@ def create_or_update_sqs_queue(client, module):
 
     # provide backwards compatibility
     for key in list(result.keys()):
-        return_name = ARGUMENT_SPEC.get(key, {}).get('return_name')
+        return_name = COMPATABILITY_KEYS.get(key)
         if return_name:
             result[return_name] = result.pop(key)
 

--- a/lib/ansible/modules/cloud/amazon/sqs_queue.py
+++ b/lib/ansible/modules/cloud/amazon/sqs_queue.py
@@ -99,7 +99,7 @@ options:
     description:
       - Remove tags not listed in C(tags)
     type: bool
-    default: True
+    default: false
     version_added: "2.8"
 extends_documentation_fragment:
     - aws
@@ -233,7 +233,7 @@ ARGUMENT_SPEC = dict(
     kms_data_key_reuse_period_seconds=dict(type='int', aliases=['kms_data_key_reuse_period'], return_name='kms_data_key_reuse_period'),
     content_based_deduplication=dict(type='bool'),
     tags=dict(type='dict'),
-    purge_tags=dict(type='bool', default=True),
+    purge_tags=dict(type='bool', default=False),
 )
 NON_ATTRIBUTES = ('name', 'state', 'queue_type', 'tags', 'purge_tags')
 

--- a/lib/ansible/modules/cloud/amazon/sqs_queue.py
+++ b/lib/ansible/modules/cloud/amazon/sqs_queue.py
@@ -253,9 +253,9 @@ def get_queue_url(client, name):
     try:
         return client.get_queue_url(QueueName=name)['QueueUrl']
     except ClientError as e:
-        if e.response['Error']['Code'] != 'AWS.SimpleQueueService.NonExistentQueue':
-            raise
-        return None
+        if e.response['Error']['Code'] == 'AWS.SimpleQueueService.NonExistentQueue':
+            return None
+        raise
 
 
 def describe_queue(client, queue_url):

--- a/lib/ansible/modules/cloud/amazon/sqs_queue.py
+++ b/lib/ansible/modules/cloud/amazon/sqs_queue.py
@@ -209,6 +209,20 @@ EXAMPLES = '''
     queue_type: fifo
     content_based_deduplication: yes
 
+# Tag queue
+- sqs_queue:
+    name: fifo-queue
+    region: ap-southeast-2
+    tags:
+      example: SomeValue
+
+# Configure Encryption, automatically uses a new data key every hour
+- sqs_queue:
+    name: fifo-queue
+    region: ap-southeast-2
+    kms_master_key_id: alias/MyQueueKey
+    kms_data_key_reuse_period_seconds: 3600
+
 # Delete SQS queue
 - sqs_queue:
     name: my-queue

--- a/lib/ansible/modules/cloud/amazon/sqs_queue.py
+++ b/lib/ansible/modules/cloud/amazon/sqs_queue.py
@@ -41,13 +41,17 @@ options:
   queue_type:
     description:
       - Standard or FIFO queue.
+      - I(queue_type) can only be set at queue creation and will otherwise be
+        ignored.
     choices: ['standard', 'fifo']
     default: 'standard'
-    version_added: "2.8"
+    version_added: "2.10"
+    type: str
   visibility_timeout:
     description:
       - The default visibility timeout in seconds.
     aliases: [default_visibility_timeout]
+    type: int
   message_retention_period:
     description:
       - The message retention period in seconds.
@@ -60,10 +64,12 @@ options:
     description:
       - The delivery delay in seconds.
     aliases: [delivery_delay]
+    type: int
   receive_message_wait_time_seconds:
     description:
       - The receive message wait time in seconds.
     aliases: [receive_message_wait_time]
+    type: int
   policy:
     description:
       - The JSON dict policy to attach to queue.
@@ -77,30 +83,31 @@ options:
   kms_master_key_id:
     description:
       - The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK.
-    version_added: "2.8"
+    version_added: "2.10"
     type: str
   kms_data_key_reuse_period_seconds:
     description:
       - The length of time, in seconds, for which Amazon SQS can reuse a data key to encrypt or decrypt messages before calling AWS KMS again.
     aliases: [kms_data_key_reuse_period]
-    version_added: "2.8"
+    version_added: "2.10"
     type: int
   content_based_deduplication:
     type: bool
     description: Enables content-based deduplication. Used for FIFOs only.
-    version_added: "2.8"
-    default: False
+    version_added: "2.10"
+    default: false
   tags:
     description:
       - Tag dict to apply to the queue (requires botocore 1.5.40 or above).
-    version_added: "2.8"
+      - To remove all tags set I(tags={}) and I(purge_tags=true).
+    version_added: "2.10"
     type: dict
   purge_tags:
     description:
-      - Remove tags not listed in C(tags)
+      - Remove tags not listed in I(tags).
     type: bool
     default: false
-    version_added: "2.8"
+    version_added: "2.10"
 extends_documentation_fragment:
     - aws
     - ec2
@@ -216,7 +223,7 @@ from ansible.module_utils.ec2 import camel_dict_to_snake_dict, compare_aws_tags,
 try:
     from botocore.exceptions import BotoCoreError, ClientError, ParamValidationError
 except ImportError:
-    pass
+    pass  # handled by AnsibleAWSModule
 
 ARGUMENT_SPEC = dict(
     state=dict(type='str', default='present', choices=['present', 'absent']),

--- a/lib/ansible/modules/cloud/amazon/sqs_queue.py
+++ b/lib/ansible/modules/cloud/amazon/sqs_queue.py
@@ -446,7 +446,7 @@ def main():
 
     argument_spec = dict(
         state=dict(type='str', default='present', choices=['present', 'absent']),
-        name=dict(required=True, type='str'),
+        name=dict(type='str', required=True),
         queue_type=dict(type='str', default='standard', choices=['standard', 'fifo']),
         delay_seconds=dict(type='int', aliases=['delivery_delay']),
         maximum_message_size=dict(type='int'),

--- a/lib/ansible/modules/cloud/amazon/sqs_queue.py
+++ b/lib/ansible/modules/cloud/amazon/sqs_queue.py
@@ -374,7 +374,7 @@ def update_sqs_queue(module, client, queue_url):
         if attribute not in new_attributes.keys():
             continue
 
-        if new_attributes.get(attribute) == None:
+        if new_attributes.get(attribute) is None:
             continue
 
         new_value = new_attributes[attribute]
@@ -411,7 +411,7 @@ def delete_sqs_queue(client, module):
 
     result['changed'] = bool(queue_url)
     if not module.check_mode:
-         AWSRetry.jittered_backoff()(client.delete_queue)(QueueUrl=queue_url)
+        AWSRetry.jittered_backoff()(client.delete_queue)(QueueUrl=queue_url)
 
     return result
 
@@ -464,7 +464,7 @@ def main():
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
 
     state = module.params.get('state')
-    retry_decorator=AWSRetry.jittered_backoff(catch_extra_error_codes=['AWS.SimpleQueueService.NonExistentQueue'])
+    retry_decorator = AWSRetry.jittered_backoff(catch_extra_error_codes=['AWS.SimpleQueueService.NonExistentQueue'])
     try:
         client = module.client('sqs', retry_decorator=retry_decorator)
         if state == 'present':

--- a/test/integration/targets/sqs_queue/tasks/main.yml
+++ b/test/integration/targets/sqs_queue/tasks/main.yml
@@ -63,11 +63,11 @@
       assert:
         that:
           - create_result.changed
-          - create_result.default_visibility_timeout == "900"
-          - create_result.delivery_delay == "900"
-          - create_result.maximum_message_size == "9009"
-          - create_result.message_retention_period == "900"
-          - create_result.receive_message_wait_time == "10"
+          - create_result.default_visibility_timeout == 900
+          - create_result.delivery_delay == 900
+          - create_result.maximum_message_size == 9009
+          - create_result.message_retention_period == 900
+          - create_result.receive_message_wait_time == 10
           - create_result.policy.Version == "2012-10-17"
           - create_result.policy.Statement.Effect == "Allow"
           - create_result.policy.Statement.Action == "*"

--- a/test/integration/targets/sqs_queue/tasks/main.yml
+++ b/test/integration/targets/sqs_queue/tasks/main.yml
@@ -1,114 +1,106 @@
 ---
-- name: set up aws connection info
-  set_fact:
-    aws_connection_info: &aws_connection_info
+- name: Main test block
+  module_defaults:
+    group/aws:
       aws_access_key: "{{ aws_access_key }}"
       aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token }}"
+      security_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
-  no_log: yes
-- block:
-  - name: Test creating SQS queue
-    sqs_queue:
-      name: "{{ resource_prefix }}{{ 1000 | random }}"
-      <<: *aws_connection_info
-    register: create_result
-  - name: Assert SQS queue created
-    assert:
-      that:
-        - create_result.changed
-        - create_result.region == "{{ aws_region }}"
-  always:
-  - name: Test deleting SQS queue
-    sqs_queue:
-      name: "{{ create_result.name }}"
-      state: absent
-      <<: *aws_connection_info
-    register: delete_result
-    retries: 3
-    delay: 3
-    until: delete_result.changed
-  - name: Assert SQS queue deleted
-    assert:
-      that:
-        - delete_result.changed
-  - name: Test delete SQS queue that doesn't exist
-    sqs_queue:
-      name: "{{ resource_prefix }}{{ 1000 | random }}"
-      state: absent
-      <<: *aws_connection_info
-    register: delete_result
-  - name: Assert delete non-existant queue returns cleanly
-    assert:
-      that:
-        - delete_result.changed == False
-- name: Test queue features
   block:
-    - name: Test create queue with attributes
+  - block:
+    - name: Test creating SQS queue
       sqs_queue:
         name: "{{ resource_prefix }}{{ 1000 | random }}"
-        default_visibility_timeout: 900
-        delivery_delay: 900
-        maximum_message_size: 9009
-        message_retention_period: 900
-        receive_message_wait_time: 10
-        policy:
-          Version: "2012-10-17"
-          Statement:
-            Effect: Allow
-            Action: "*"
-        <<: *aws_connection_info
       register: create_result
-    - name: Assert queue created with configuration
+    - name: Assert SQS queue created
       assert:
         that:
           - create_result.changed
-          - create_result.default_visibility_timeout == 900
-          - create_result.delivery_delay == 900
-          - create_result.maximum_message_size == 9009
-          - create_result.message_retention_period == 900
-          - create_result.receive_message_wait_time == 10
-          - create_result.policy.Version == "2012-10-17"
-          - create_result.policy.Statement.Effect == "Allow"
-          - create_result.policy.Statement.Action == "*"
-  always:
-    - name: Cleaning up queue
+          - create_result.region == "{{ aws_region }}"
+    always:
+    - name: Test deleting SQS queue
       sqs_queue:
         name: "{{ create_result.name }}"
         state: absent
-        <<: *aws_connection_info
       register: delete_result
       retries: 3
       delay: 3
       until: delete_result.changed
-- name: Test queue with redrive
-  block:
-    - name: Creating dead letter queue
-      sqs_queue:
-        name: "{{ resource_prefix }}{{ 1000 | random }}"
-        <<: *aws_connection_info
-      register: dead_letter_queue
-    - name: Test create queue with redrive_policy
-      sqs_queue:
-        name: "{{ resource_prefix }}{{ 1000 | random }}"
-        redrive_policy:
-          maxReceiveCount: 5
-          deadLetterTargetArn: "{{ dead_letter_queue.queue_arn }}"
-        <<: *aws_connection_info
-      register: create_result
-    - name: Assert queue created with configuration
+    - name: Assert SQS queue deleted
       assert:
         that:
-          - create_result.changed
-  always:
-    - name: Cleaning up queue
+          - delete_result.changed
+    - name: Test delete SQS queue that doesn't exist
       sqs_queue:
-        name: "{{ item.name }}"
+        name: "{{ resource_prefix }}{{ 1000 | random }}"
         state: absent
-        <<: *aws_connection_info
       register: delete_result
-      retries: 3
-      delay: 3
-      with_items:
-        - { name: "{{ create_result.name }}" }
-        - { name: "{{ dead_letter_queue.name }}" }
+    - name: Assert delete non-existant queue returns cleanly
+      assert:
+        that:
+          - delete_result.changed == False
+  - name: Test queue features
+    block:
+      - name: Test create queue with attributes
+        sqs_queue:
+          name: "{{ resource_prefix }}{{ 1000 | random }}"
+          default_visibility_timeout: 900
+          delivery_delay: 900
+          maximum_message_size: 9009
+          message_retention_period: 900
+          receive_message_wait_time: 10
+          policy:
+            Version: "2012-10-17"
+            Statement:
+              Effect: Allow
+              Action: "*"
+        register: create_result
+      - name: Assert queue created with configuration
+        assert:
+          that:
+            - create_result.changed
+            - create_result.default_visibility_timeout == 900
+            - create_result.delivery_delay == 900
+            - create_result.maximum_message_size == 9009
+            - create_result.message_retention_period == 900
+            - create_result.receive_message_wait_time == 10
+            - create_result.policy.Version == "2012-10-17"
+            - create_result.policy.Statement.Effect == "Allow"
+            - create_result.policy.Statement.Action == "*"
+    always:
+      - name: Cleaning up queue
+        sqs_queue:
+          name: "{{ create_result.name }}"
+          state: absent
+        register: delete_result
+        retries: 3
+        delay: 3
+        until: delete_result.changed
+  - name: Test queue with redrive
+    block:
+      - name: Creating dead letter queue
+        sqs_queue:
+          name: "{{ resource_prefix }}{{ 1000 | random }}"
+        register: dead_letter_queue
+      - name: Test create queue with redrive_policy
+        sqs_queue:
+          name: "{{ resource_prefix }}{{ 1000 | random }}"
+          redrive_policy:
+            maxReceiveCount: 5
+            deadLetterTargetArn: "{{ dead_letter_queue.queue_arn }}"
+        register: create_result
+      - name: Assert queue created with configuration
+        assert:
+          that:
+            - create_result.changed
+    always:
+      - name: Cleaning up queue
+        sqs_queue:
+          name: "{{ item.name }}"
+          state: absent
+        register: delete_result
+        retries: 3
+        delay: 3
+        with_items:
+          - { name: "{{ create_result.name }}" }
+          - { name: "{{ dead_letter_queue.name }}" }

--- a/test/integration/targets/sqs_queue/tasks/main.yml
+++ b/test/integration/targets/sqs_queue/tasks/main.yml
@@ -65,8 +65,8 @@
             - create_result.message_retention_period == 900
             - create_result.receive_message_wait_time == 10
             - create_result.policy.Version == "2012-10-17"
-            - create_result.policy.Statement.Effect == "Allow"
-            - create_result.policy.Statement.Action == "*"
+            - create_result.policy.Statement[0].Effect == "Allow"
+            - create_result.policy.Statement[0].Action == "*"
     always:
       - name: Cleaning up queue
         sqs_queue:


### PR DESCRIPTION
##### SUMMARY

Based upon the work by @sbj-ss in #50686 

- Migrate to boto3
- Migrate to AnsibleAWSModule
- Add support for tagging
- Add support for KMS / encryption
- Add support for FIFO queues

Additionally:
- Move tests to use module_defaults
- Add Hacking policy for SQS management

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

sqs_queue

##### ADDITIONAL INFORMATION

Fixes #41260 
Fixes #43775
Fixes #50686 
Fixes #26592
Fixes #28754
Fixes #55179