### PR TITLE
Bugfix of 54239: mysql_variables not supporting variables name with dot

### DIFF
--- a/changelogs/fragments/66806-mysql_variables_not_support_variables_with_dot.yml
+++ b/changelogs/fragments/66806-mysql_variables_not_support_variables_with_dot.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_variable - fix the module doesn't support variables name with dot (https://github.com/ansible/ansible/issues/54239).

--- a/lib/ansible/module_utils/database.py
+++ b/lib/ansible/module_utils/database.py
@@ -129,7 +129,7 @@ def pg_quote_identifier(identifier, id_type):
 
 def mysql_quote_identifier(identifier, id_type):
     identifier_fragments = _identifier_parse(identifier, quote_char='`')
-    if len(identifier_fragments) > _MYSQL_IDENTIFIER_TO_DOT_LEVEL[id_type]:
+    if (len(identifier_fragments) - 1) > _MYSQL_IDENTIFIER_TO_DOT_LEVEL[id_type]:
         raise SQLParseError('MySQL does not support %s with more than %i dots' % (id_type, _MYSQL_IDENTIFIER_TO_DOT_LEVEL[id_type]))
 
     special_cased_fragments = []

--- a/lib/ansible/modules/database/mysql/mysql_variables.py
+++ b/lib/ansible/modules/database/mysql/mysql_variables.py
@@ -204,7 +204,7 @@ def main():
 
     if mysqlvar is None:
         module.fail_json(msg="Cannot run without variable to operate with")
-    if match('^[0-9a-z_]+$', mysqlvar) is None:
+    if match('^[0-9a-z_.]+$', mysqlvar) is None:
         module.fail_json(msg="invalid variable name \"%s\"" % mysqlvar)
     if mysql_driver is None:
         module.fail_json(msg=mysql_driver_fail_msg)

--- a/test/integration/targets/mysql_variables/tasks/mysql_variables.yml
+++ b/test/integration/targets/mysql_variables/tasks/mysql_variables.yml
@@ -394,3 +394,19 @@
   register: result
 
 - include: assert_var.yml changed=true output={{result}} var_name={{set_name}} var_value='{{def_val}}'
+
+# Bugfix of https://github.com/ansible/ansible/issues/54239
+- name: set variable containing dot
+  mysql_variables:
+    login_unix_socket: '{{ mysql_socket }}'
+    login_user: root
+    login_password: '{{ root_pass }}'
+    variable: validate_password.policy
+    value: LOW
+    mode: persist_only
+  register: result
+
+- assert:
+    that:
+    - result is changed
+    - result.queries == ["SET PERSIST_ONLY `validate_password`.`policy` = LOW"]


### PR DESCRIPTION
##### SUMMARY
Fixes: https://github.com/ansible/ansible/issues/54239
mysql_variables not supporting variables name with dot

Look at the changed line
```
if len(identifier_fragments) > _MYSQL_IDENTIFIER_TO_DOT_LEVEL[id_type]:
```
If we pass ```validate_password.policy``` as a value, the identifier_fragments will be
```
[\'`validate_password`\', \'`policy`\']
```
So it seems to be a certain bug to raise an error and i added ```- 1``` to fix this

After fixing it is:
```
changed: [noname] => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    }, 
    "changed": true, 
    "invocation": {
        "module_args": {
            "ca_cert": null, 
            "client_cert": null, 
            "client_key": null, 
            "config_file": "/root/.my.cnf", 
            "connect_timeout": 30, 
            "login_host": "localhost", 
            "login_password": null, 
            "login_port": 3306, 
            "login_unix_socket": null, 
            "login_user": "root", 
            "mode": "global", 
            "value": "LOW", 
            "variable": "validate_password.policy"
        }
    }, 
    "msg": "Variable change succeeded prev_value=MEDIUM", 
    "queries": [
        "SET GLOBAL `validate_password`.`policy` = LOW"
    ]
}
META: ran handlers

```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/mysql/mysql_variables.py```
