### PR TITLE
Add option to include specific zones only for ec2.py Route53 domain scan

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -76,6 +76,10 @@ route53 = False
 # 'route53_excluded_zones' as a comma-separated list.
 # route53_excluded_zones = samplezone1.com, samplezone2.com
 
+# Alternatively, set 'route53_included_zones' to only scan specific zones.
+# This option will override route53_excluded_zones parameter.
+# route53_included_zones = samplezone3.com
+
 # By default, only EC2 instances in the 'running' state are returned. Set
 # 'all_instances' to True to return all instances regardless of state.
 all_instances = False

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -232,6 +232,7 @@ DEFAULTS = {
     'replace_dash_in_groups': 'True',
     'route53': 'False',
     'route53_excluded_zones': '',
+    'route53_included_zones': '',
     'route53_hostnames': '',
     'stack_filters': 'False',
     'vpc_destination_variable': 'ip_address'
@@ -390,6 +391,8 @@ class Ec2Inventory(object):
 
         self.route53_excluded_zones = []
         self.route53_excluded_zones = [a for a in config.get('ec2', 'route53_excluded_zones').split(',') if a]
+        self.route53_included_zones = []
+        self.route53_included_zones = [a for a in config.get('ec2', 'route53_included_zones').split(',') if a]
 
         # Include RDS instances?
         self.rds_enabled = config.getboolean('ec2', 'rds')
@@ -1451,7 +1454,10 @@ class Ec2Inventory(object):
             r53_conn = route53.Route53Connection()
         all_zones = r53_conn.get_zones()
 
-        route53_zones = [zone for zone in all_zones if zone.name[:-1] not in self.route53_excluded_zones]
+        if self.route53_included_zones:
+            route53_zones = [zone for zone in all_zones if zone.name[:-1] in self.route53_included_zones]
+        else:
+            route53_zones = [zone for zone in all_zones if zone.name[:-1] not in self.route53_excluded_zones]
 
         self.route53_records = {}
 


### PR DESCRIPTION
##### SUMMARY
Add new configuration option 'route53_included_zones' in ec2.py

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ec2.py

##### ADDITIONAL INFORMATION
ec2.py started to fail on an AWS account with "DNSServerError: 400 Bad Request" error.

AWS has a hard limit of 5 requests per second for Route53 requests **per AWS account per region**, as described here - [https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html). When an AWS account has many Route53 zones set up and 'route53' config parameter is enabled, ec2.py will hit this quota limit, because it will try to scan all zones as fast as it can. 

One way to overcome this is to 'blacklist' all other zones that are not needed with 'route_53_excluded_zones' parameter. However, it is hard to keep this list up to date when new zones are added often.

This PR allows to specify a 'whitelist' of zones to be scanned, instead of a 'blacklist'. The config key is named 'route53_included_zones', and this will override the 'route_53_excluded_zones'. 

This helps because usually a small subset of Route53 zones need to be scanned by ec2.py, and it is possible to avoid maintaining a blacklist.

Default behaviour does not change unless 'route53_included_zones' is defined.