### PR TITLE
ovirt_job: add when job is detected but in state finished

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_job.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_job.py
@@ -199,7 +199,7 @@ def main():
         job = get_entity(jobs_service, module.params['description'])
         changed = False
         if state in ['present', 'started']:
-            if job is None:
+            if job is None or job.status in [otypes.JobStatus.FINISHED, otypes.JobStatus.FAILED]:
                 job = jobs_service.add(build_job(module.params['description']))
                 changed = True
             changed = attach_steps(module, job.id, jobs_service) or changed

--- a/lib/ansible/modules/cloud/ovirt/ovirt_job.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_job.py
@@ -36,6 +36,7 @@ options:
     description:
         description:
             - "Description of the job."
+            - "When task with same description has already finished and you rerun taks it will create new job."
         required: true
     state:
         description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I had issue in one of our roles (https://github.com/ovirt/ovirt-ansible-cluster-upgrade)
when job was already existing but already finished it did not create new job
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
