### PR TITLE
ecs_tag: remove state=list

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_tag.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_tag.py
@@ -15,7 +15,7 @@ short_description: create and remove tags on Amazon ECS resources
 notes:
     - none
 description:
-    - Creates, removes and lists tags for Amazon ECS resources.
+    - Creates and removes tags for Amazon ECS resources.
     - Resources are referenced by their cluster name.
 version_added: '2.10'
 author:
@@ -41,9 +41,8 @@ options:
   state:
     description:
       - Whether the tags should be present or absent on the resource.
-      - Use C(list) to interrogate the tags of an ECS resource.
     default: present
-    choices: ['present', 'absent', 'list']
+    choices: ['present', 'absent']
     type: str
   tags:
     description:
@@ -70,13 +69,6 @@ EXAMPLES = r'''
     tags:
       Name: ubervol
       env: prod
-
-- name: Retrieve all tags on a cluster
-  ecs_tag:
-    cluster_name: mycluster
-    resource: http_task
-    resource_type: task
-    state: list
 
 - name: Remove the Env tag
   ecs_tag:
@@ -168,7 +160,7 @@ def main():
         resource=dict(required=False),
         tags=dict(type='dict'),
         purge_tags=dict(type='bool', default=False),
-        state=dict(default='present', choices=['present', 'absent', 'list']),
+        state=dict(default='present', choices=['present', 'absent']),
         resource_type=dict(default='cluster', choices=['cluster', 'task', 'service', 'task_definition', 'container'])
     )
     required_if = [('state', 'present', ['tags']), ('state', 'absent', ['tags'])]
@@ -192,9 +184,6 @@ def main():
     resource_arn = get_arn(ecs, module, cluster_name, resource_type, resource)
 
     current_tags = get_tags(ecs, module, resource_arn)
-
-    if state == 'list':
-        module.exit_json(changed=False, tags=current_tags)
 
     add_tags, remove = compare_aws_tags(current_tags, tags, purge_tags=purge_tags)
 

--- a/test/integration/targets/ecs_tag/tasks/main.yml
+++ b/test/integration/targets/ecs_tag/tasks/main.yml
@@ -56,21 +56,6 @@
 
     # Test tagging cluster resource
 
-    - name: cluster tags - list when there are none
-      ecs_tag:
-        cluster_name: "{{ resource_prefix}}"
-        resource: "{{ resource_prefix}}"
-        resource_type: cluster
-        state: list
-      register: taglist
-
-    - name: cluster tags - Should be an empty list
-      assert:
-        that:
-          - taglist.tags|list|length == 0
-          - taglist.failed == false
-          - taglist.changed == false
-
     - name: cluster tags - Add tags to cluster
       ecs_tag:
         cluster_name: "{{resource_prefix}}"
@@ -208,21 +193,6 @@
         that:
           - taglist.changed == false
           - taglist.tags.Name == "service-{{ resource_prefix }}"
-
-    - name: service tags - retrieve all tags on a service
-      ecs_tag:
-        cluster_name: "{{resource_prefix}}"
-        resource: "{{ecs_service_creation.service.serviceName}}"
-        resource_type: service
-        state: list
-      register: taglist
-
-    - name: services tags - should have 1 tag
-      assert:
-        that:
-          - taglist.tags|list|length == 1
-          - taglist.failed == false
-          - taglist.changed == false
 
     - name: service tags - remove service tags
       ecs_tag:


### PR DESCRIPTION
##### SUMMARY
See #66603

`state=list` for new modules is a no-no. please create a _info module for that feature.

```
<tremble> resmo, That supposed to be a no-no?
<bcoca> yes, its a 'nono'
 tremble tadeboro tarnacious thaumos thnee till_ tima timburke tinita tinova tomaluca95 toshywoshy trane traumschule tumble twouters tylerkb 
<felixfontein> new modules shouldn't do that, there should be a _info module instead
<resmo> yes, I know, creating a fix PR
<tremble> Probably worth a sanity test...
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ecs_tag

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
