### PR TITLE
Gitlab: add support for merge_method on projects

### DIFF
--- a/lib/ansible/modules/source_control/gitlab/gitlab_project.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project.py
@@ -71,6 +71,7 @@ options:
     type: str
     choices: ["merge", "rebase_merge", "ff"]
     default: merge
+    version_added: "2.10"
   wiki_enabled:
     description:
       - If an wiki for this project should be available or not.

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project.py
@@ -67,9 +67,9 @@ options:
   merge_method:
     description:
       - What requirements are placed upon merges.
-      - Possible values are merge, rebase_merge (Merge commit with semi-linear history), ff (fast-forward merges only)
+      - Possible values are C(merge), C(rebase_merge) (Merge commit with semi-linear history), C(ff) (fast-forward merges only)
     type: str
-    choices: ["merge", "rebase_merge", "ff"]
+    choices: ["ff", "merge", "rebase_merge"]
     default: merge
     version_added: "2.10"
   wiki_enabled:

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project.py
@@ -64,6 +64,15 @@ options:
       - Possible values are true and false.
     type: bool
     default: yes
+  merge_method:
+    description:
+      - What requirements are placed upon merges. For example, must the merge be a fast-forward commit?
+      - Possible values: 
+        - merge
+        - rebase_merge (Merge commit with semi-linear history)
+        - ff (fast-forward merges only)
+      - type: str
+      - choices: ["merge", "rebase_merge", "ff"]
   wiki_enabled:
     description:
       - If an wiki for this project should be available or not.
@@ -120,6 +129,7 @@ EXAMPLES = '''
     name: my_first_project
     group: ansible
     issues_enabled: False
+    merge_method: rebase_merge
     wiki_enabled: True
     snippets_enabled: True
     import_url: http://git.example.com/example/lab.git
@@ -190,6 +200,7 @@ class GitLabProject(object):
                 'description': options['description'],
                 'issues_enabled': options['issues_enabled'],
                 'merge_requests_enabled': options['merge_requests_enabled'],
+                'merge_method': options['merge_method'],
                 'wiki_enabled': options['wiki_enabled'],
                 'snippets_enabled': options['snippets_enabled'],
                 'visibility': options['visibility'],
@@ -201,6 +212,7 @@ class GitLabProject(object):
                 'description': options['description'],
                 'issues_enabled': options['issues_enabled'],
                 'merge_requests_enabled': options['merge_requests_enabled'],
+                'merge_method': options['merge_method'],
                 'wiki_enabled': options['wiki_enabled'],
                 'snippets_enabled': options['snippets_enabled'],
                 'visibility': options['visibility']})
@@ -280,6 +292,7 @@ def main():
         description=dict(type='str'),
         issues_enabled=dict(type='bool', default=True),
         merge_requests_enabled=dict(type='bool', default=True),
+        merge_method=dict(type='str', default='merge', choices=["merge", "rebase_merge", "ff"]),
         wiki_enabled=dict(type='bool', default=True),
         snippets_enabled=dict(default=True, type='bool'),
         visibility=dict(type='str', default="private", choices=["internal", "private", "public"], aliases=["visibility_level"]),
@@ -308,6 +321,7 @@ def main():
     project_description = module.params['description']
     issues_enabled = module.params['issues_enabled']
     merge_requests_enabled = module.params['merge_requests_enabled']
+    merge_method = module.params['merge_method']
     wiki_enabled = module.params['wiki_enabled']
     snippets_enabled = module.params['snippets_enabled']
     visibility = module.params['visibility']
@@ -350,6 +364,7 @@ def main():
                                                 "description": project_description,
                                                 "issues_enabled": issues_enabled,
                                                 "merge_requests_enabled": merge_requests_enabled,
+                                                "merge_method": merge_method,
                                                 "wiki_enabled": wiki_enabled,
                                                 "snippets_enabled": snippets_enabled,
                                                 "visibility": visibility,

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project.py
@@ -67,12 +67,10 @@ options:
   merge_method:
     description:
       - What requirements are placed upon merges. For example, must the merge be a fast-forward commit?
-      - Possible values: 
-        - merge
-        - rebase_merge (Merge commit with semi-linear history)
-        - ff (fast-forward merges only)
+      - Possible values are merge, rebase_merge (Merge commit with semi-linear history), ff (fast-forward merges only)
       - type: str
       - choices: ["merge", "rebase_merge", "ff"]
+      - default: merge
   wiki_enabled:
     description:
       - If an wiki for this project should be available or not.

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project.py
@@ -66,11 +66,11 @@ options:
     default: yes
   merge_method:
     description:
-      - What requirements are placed upon merges. For example, must the merge be a fast-forward commit?
+      - What requirements are placed upon merges.
       - Possible values are merge, rebase_merge (Merge commit with semi-linear history), ff (fast-forward merges only)
-      - type: str
-      - choices: ["merge", "rebase_merge", "ff"]
-      - default: merge
+    type: str
+    choices: ["merge", "rebase_merge", "ff"]
+    default: merge
   wiki_enabled:
     description:
       - If an wiki for this project should be available or not.

--- a/test/units/modules/source_control/gitlab/gitlab.py
+++ b/test/units/modules/source_control/gitlab/gitlab.py
@@ -352,7 +352,7 @@ PROJECT API
 @urlmatch(scheme="http", netloc="localhost", path="/api/v4/projects", method="get")
 def resp_find_project(url, request):
     headers = {'content-type': 'application/json'}
-    content = ('[{"id": 1,"description": null, "default_branch": "master",'
+    content = ('[{"id": 1,"description": null, "default_branch": "master", "merge_method": "merge",'
                '"ssh_url_to_repo": "git@example.com:diaspora/diaspora-client.git",'
                '"http_url_to_repo": "http://example.com/diaspora/diaspora-client.git",'
                '"web_url": "http://example.com/diaspora/diaspora-client",'
@@ -370,7 +370,7 @@ def resp_find_project(url, request):
 @urlmatch(scheme="http", netloc="localhost", path="/api/v4/projects/1", method="get")
 def resp_get_project(url, request):
     headers = {'content-type': 'application/json'}
-    content = ('{"id": 1,"description": null, "default_branch": "master",'
+    content = ('{"id": 1,"description": null, "default_branch": "master", "merge_method": "merge",'
                '"ssh_url_to_repo": "git@example.com:diaspora/diaspora-client.git",'
                '"http_url_to_repo": "http://example.com/diaspora/diaspora-client.git",'
                '"web_url": "http://example.com/diaspora/diaspora-client",'
@@ -388,7 +388,7 @@ def resp_get_project(url, request):
 @urlmatch(scheme="http", netloc="localhost", path="/api/v4/projects/foo-bar%2Fdiaspora-client", method="get")
 def resp_get_project_by_name(url, request):
     headers = {'content-type': 'application/json'}
-    content = ('{"id": 1,"description": null, "default_branch": "master",'
+    content = ('{"id": 1,"description": null, "default_branch": "master", "merge_method": "merge",'
                '"ssh_url_to_repo": "git@example.com:diaspora/diaspora-client.git",'
                '"http_url_to_repo": "http://example.com/diaspora/diaspora-client.git",'
                '"web_url": "http://example.com/diaspora/diaspora-client",'
@@ -406,7 +406,7 @@ def resp_get_project_by_name(url, request):
 @urlmatch(scheme="http", netloc="localhost", path="/api/v4/groups/1/projects", method="get")
 def resp_find_group_project(url, request):
     headers = {'content-type': 'application/json'}
-    content = ('[{"id": 1,"description": null, "default_branch": "master",'
+    content = ('[{"id": 1,"description": null, "default_branch": "master", "merge_method": "merge",'
                '"ssh_url_to_repo": "git@example.com:diaspora/diaspora-client.git",'
                '"http_url_to_repo": "http://example.com/diaspora/diaspora-client.git",'
                '"web_url": "http://example.com/diaspora/diaspora-client",'
@@ -424,7 +424,7 @@ def resp_find_group_project(url, request):
 @urlmatch(scheme="http", netloc="localhost", path="/api/v4/groups/1/projects/1", method="get")
 def resp_get_group_project(url, request):
     headers = {'content-type': 'application/json'}
-    content = ('{"id": 1,"description": null, "default_branch": "master",'
+    content = ('{"id": 1,"description": null, "default_branch": "master", "merge_method": "merge",'
                '"ssh_url_to_repo": "git@example.com:diaspora/diaspora-client.git",'
                '"http_url_to_repo": "http://example.com/diaspora/diaspora-client.git",'
                '"web_url": "http://example.com/diaspora/diaspora-client",'
@@ -442,7 +442,7 @@ def resp_get_group_project(url, request):
 @urlmatch(scheme="http", netloc="localhost", path="/api/v4/projects", method="post")
 def resp_create_project(url, request):
     headers = {'content-type': 'application/json'}
-    content = ('{"id": 1,"description": null, "default_branch": "master",'
+    content = ('{"id": 1,"description": null, "default_branch": "master", "merge_method": "merge",'
                '"ssh_url_to_repo": "git@example.com:diaspora/diaspora-client.git",'
                '"http_url_to_repo": "http://example.com/diaspora/diaspora-client.git",'
                '"web_url": "http://example.com/diaspora/diaspora-client",'

--- a/test/units/modules/source_control/gitlab/test_gitlab_project.py
+++ b/test/units/modules/source_control/gitlab/test_gitlab_project.py
@@ -90,6 +90,26 @@ class TestGitlabProject(GitlabModuleTestCase):
         self.assertEqual(changed, False)
         self.assertEqual(newProject.name, "New Name")
 
+    @with_httmock(resp_get_project)
+    def test_update_project_merge_method(self):
+        project = self.gitlab_instance.projects.get(1)
+
+        # merge_method should be 'merge' by default
+        self.assertEqual(project.merge_method, "merge")
+
+        changed, newProject = self.moduleUtil.updateProject(project, {"name": "New Name", "merge_method": "rebase_merge"})
+
+        self.assertEqual(changed, True)
+        self.assertEqual(type(newProject), Project)
+        self.assertEqual(newProject.name, "New Name")
+        self.assertEqual(newProject.merge_method, "rebase_merge")
+
+        changed, newProject = self.moduleUtil.updateProject(project, {"name": "New Name", "merge_method": "rebase_merge"})
+
+        self.assertEqual(changed, False)
+        self.assertEqual(newProject.name, "New Name")
+        self.assertEqual(newProject.merge_method, "rebase_merge")
+
     @with_httmock(resp_get_group)
     @with_httmock(resp_get_project_by_name)
     @with_httmock(resp_delete_project)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Resolves #66812 

This PR will add the new `merge_method` setting for gitlab projects, which allows for using the 3 out of the box merge methods available in Gitlab.

I have used the same setting names that are set in the underlying gitlab API.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
source_control: Gitlab
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Playbooks can now contain `merge_method`, like this:
```yaml
tasks:
  gitlab:
    name: my_repo
    merge_method: rebase_merge
```

