### PR TITLE
Ability to pick options values from env vars on gitlab_runners inventory plugin

### DIFF
--- a/lib/ansible/plugins/inventory/gitlab_runners.py
+++ b/lib/ansible/plugins/inventory/gitlab_runners.py
@@ -33,6 +33,7 @@ DOCUMENTATION = '''
             description: The URL of the GitLab server, with protocol (i.e. http or https).
             env:
               - name: GITLAB_SERVER_URL
+                version_added: '2.10'
             type: str
             required: true
             default: https://gitlab.com

--- a/lib/ansible/plugins/inventory/gitlab_runners.py
+++ b/lib/ansible/plugins/inventory/gitlab_runners.py
@@ -31,11 +31,15 @@ DOCUMENTATION = '''
               - gitlab_runners
         server_url:
             description: The URL of the GitLab server, with protocol (i.e. http or https).
+            env:
+              - name: GITLAB_SERVER_URL
             type: str
             required: true
             default: https://gitlab.com
         api_token:
             description: GitLab token for logging in.
+            env:
+              - name: GITLAB_API_TOKEN
             type: str
             aliases:
               - private_token


### PR DESCRIPTION
Add env vars capability for server_url and api_token

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Permit env var input for server_url and api_token options values 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/inventory/gitlab_runners
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
