### PR TITLE
Remove default 20 items limit to runners list on gitlab_runners inventory plugin

### DIFF
--- a/lib/ansible/plugins/inventory/gitlab_runners.py
+++ b/lib/ansible/plugins/inventory/gitlab_runners.py
@@ -96,7 +96,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             if self.get_option('filter'):
                 runners = gl.runners.all(scope=self.get_option('filter'))
             else:
-                runners = gl.runners.all()
+                runners = gl.runners.all(all=True)
             for runner in runners:
                 host = str(runner['id'])
                 ip_address = runner['ip_address']


### PR DESCRIPTION
Remove default 20 items limit to runners list

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove default 20 items limit to runners list by adding "all" bool to True in gl.runners.all [ref](https://github.com/python-gitlab/python-gitlab/blob/df485a92b713a0f2f983c72d9d41ea3a771abf88/gitlab/v4/objects.py#L4922)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/inventory/gitlab_runners
