### PR TITLE
ecs_task.py support fargate use of public_ip_enabled

### DIFF
--- a/changelogs/fragments/66797-ecstask-assign-ip-enabled.yml
+++ b/changelogs/fragments/66797-ecstask-assign-ip-enabled.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ecs_task - fixed issue where ecs_task.py did not allow assign_public_ip which is needed for FARGATE support

--- a/lib/ansible/modules/cloud/amazon/ecs_task.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_task.py
@@ -86,8 +86,7 @@ options:
               - Whether the task's elastic network interface receives a public IP address.
               - This option requires botocore >= 1.8.4.
             version_added: 2.9
-            type: bool         
-
+            type: bool
     launch_type:
         description:
           - The launch type on which to run your service.
@@ -375,7 +374,6 @@ def main():
             security_groups=dict(type='list', elements='str'),
             assign_public_ip=dict(type='bool')
         )),
-        network_configuration=dict(required=False, type='dict'),
         launch_type=dict(required=False, choices=['EC2', 'FARGATE']),
         tags=dict(required=False, type='dict')
     )

--- a/lib/ansible/modules/cloud/amazon/ecs_task.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_task.py
@@ -64,6 +64,7 @@ options:
         required: False
         type: str
     network_configuration:
+        description:
          - Network configuration of the service. Only applicable for task definitions created with I(network_mode=awsvpc).
          - I(assign_public_ip) requires botocore >= 1.8.4
         version_added: 2.6


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changes ecs_task.py to support assign_public_ip (bool) under network configuration because this is a needed field for FARGATE support and was missed by the original developer for FARGATE support.

(replaces pull request #66797 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #66781 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
modules/cloud/amazon/ecs_task.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
