### PR TITLE
synchronize - honor become_user in rsync command

### DIFF
--- a/changelogs/fragments/29698-synchronize-become-user.yml
+++ b/changelogs/fragments/29698-synchronize-become-user.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- synchronize - Fix so become_user is used in the generated rsync command
+  (https://github.com/ansible/ansible/issues/29698).

--- a/test/units/plugins/action/fixtures/synchronize/basic_become/meta.yaml
+++ b/test/units/plugins/action/fixtures/synchronize/basic_become/meta.yaml
@@ -25,7 +25,7 @@ asserts:
     - "self.execute_called"
     - "self.final_module_args['_local_rsync_path'] == 'rsync'"
     # this is a crucial aspect of this scenario ...
-    - "self.final_module_args['rsync_path'] == 'sudo rsync'"
+    - "self.final_module_args['rsync_path'] == 'sudo -u root rsync'"
     - "self.final_module_args['src'] == '/tmp/deleteme'"
     - "self.final_module_args['dest'] == 'root@el6host:/tmp/deleteme'"
     - "self.task.become == True"

--- a/test/units/plugins/action/fixtures/synchronize/basic_become_user/meta.yaml
+++ b/test/units/plugins/action/fixtures/synchronize/basic_become_user/meta.yaml
@@ -2,9 +2,10 @@ task_args:
     src: /tmp/deleteme
     dest: /tmp/deleteme
     #rsync_path: rsync
-_task:
-    become: None
-    become_method: None
+# _task:
+#     become: True
+#     become_method: sudo
+#     become_user: other_user
 fixtures:
     taskvars_in: task_vars_in.json
     taskvars_out: task_vars_out.json
@@ -13,8 +14,7 @@ connection:
 _play_context:
     become: True
     become_method: sudo
-    remote_addr: el6host
-    remote_user: root
+    become_user: other_user
 hostvars:
     '127.0.0.1': {}
     '::1': {}
@@ -25,14 +25,12 @@ asserts:
     - "self.execute_called"
     - "self.final_module_args['_local_rsync_path'] == 'rsync'"
     # this is a crucial aspect of this scenario ...
-    - "self.final_module_args['rsync_path'] == 'sudo -u root rsync'"
+    - "self.final_module_args['rsync_path'] == 'sudo -u other_user rsync'"
     - "self.final_module_args['src'] == '/tmp/deleteme'"
-    - "self.final_module_args['dest'] == 'root@el6host:/tmp/deleteme'"
+    - "self.final_module_args['dest'] == 'deploy_user@el6host:/tmp/deleteme'"
     - "self.task.become == None"
     - "self.task.become_user == None"
     - "self._play_context.shell == 'sh'"
-    - "self._play_context.remote_addr == 'el6host'"
-    - "self._play_context.remote_user == 'root'"
     - "self._play_context.become == False"
-    - "self._play_context.become_user == 'root'"
+    - "self._play_context.become_user == 'other_user'"
     - "self._play_context.password == None"

--- a/test/units/plugins/action/fixtures/synchronize/basic_become_user/task_args_out.json
+++ b/test/units/plugins/action/fixtures/synchronize/basic_become_user/task_args_out.json
@@ -1,0 +1,6 @@
+{
+  "dest": "root@el6host:/tmp/deleteme", 
+  "src": "/tmp/deleteme", 
+  "rsync_path": "sudo -u otheruser rsync", 
+  "_local_rsync_path": "rsync"
+}

--- a/test/units/plugins/action/fixtures/synchronize/basic_become_user/task_vars_in.json
+++ b/test/units/plugins/action/fixtures/synchronize/basic_become_user/task_vars_in.json
@@ -1,0 +1,151 @@
+{
+  "ansible_pipelining": false, 
+  "ansible_docker_extra_args": "", 
+  "ansible_scp_extra_args": "", 
+  "ansible_user": "deploy_user", 
+  "ansible_play_hosts": [
+    "el6host"
+  ], 
+  "ansible_connection": "smart", 
+  "ansible_ssh_common_args": "", 
+  "environment": [], 
+  "inventory_hostname": "el6host", 
+  "vars": {
+    "ansible_check_mode": false, 
+    "inventory_hostname": "el6host", 
+    "inventory_file": "inventory", 
+    "inventory_hostname_short": "el6host", 
+    "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+    "role_names": [], 
+    "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+    "environment": [], 
+    "play_hosts": [
+      "el6host"
+    ], 
+    "ansible_play_hosts": [
+      "el6host"
+    ], 
+    "hostvars": {
+      "el6host": {
+        "inventory_file": "inventory", 
+        "group_names": [
+          "ungrouped"
+        ], 
+        "groups": {
+          "ungrouped": [
+            "el6host"
+          ], 
+          "all": [
+            "el6host"
+          ]
+        }, 
+        "inventory_hostname": "el6host", 
+        "inventory_hostname_short": "el6host", 
+        "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "omit": "__omit_place_holder__b3ac1e6ebeed06f4be0c1edca3dca34036cf7f57", 
+        "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "ansible_ssh_user": "deploy_user", 
+        "ansible_check_mode": false, 
+        "ansible_version": {
+          "major": 2, 
+          "full": "2.2.0", 
+          "string": "2.2.0", 
+          "minor": 2, 
+          "revision": 0
+        }
+      }
+    }, 
+    "groups": {
+      "ungrouped": [
+        "el6host"
+      ], 
+      "all": [
+        "el6host"
+      ]
+    }, 
+    "group_names": [
+      "ungrouped"
+    ], 
+    "omit": "__omit_place_holder__b3ac1e6ebeed06f4be0c1edca3dca34036cf7f57", 
+    "ansible_version": {
+      "major": 2, 
+      "full": "2.2.0", 
+      "string": "2.2.0", 
+      "minor": 2, 
+      "revision": 0
+    }, 
+    "ansible_ssh_user": "deploy_user"
+  }, 
+  "ansible_accelerate_port": 5099, 
+  "roledir": null, 
+  "ansible_ssh_extra_args": "", 
+  "ansible_ssh_host": "el6host", 
+  "ansible_current_hosts": [
+    "el6host"
+  ], 
+  "hostvars": {
+    "el6host": {
+      "inventory_file": "inventory", 
+      "group_names": [
+        "ungrouped"
+      ], 
+      "groups": {
+        "ungrouped": [
+          "el6host"
+        ], 
+        "all": [
+          "el6host"
+        ]
+      }, 
+      "inventory_hostname": "el6host", 
+      "inventory_hostname_short": "el6host", 
+      "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "omit": "__omit_place_holder__b3ac1e6ebeed06f4be0c1edca3dca34036cf7f57", 
+      "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "ansible_ssh_user": "deploy_user", 
+      "ansible_check_mode": false, 
+      "ansible_version": {
+        "major": 2, 
+        "full": "2.2.0", 
+        "string": "2.2.0", 
+        "minor": 2, 
+        "revision": 0
+      }
+    }
+  }, 
+  "group_names": [
+    "ungrouped"
+  ], 
+  "ansible_version": {
+    "major": 2, 
+    "full": "2.2.0", 
+    "string": "2.2.0", 
+    "minor": 2, 
+    "revision": 0
+  }, 
+  "ansible_ssh_pipelining": false, 
+  "inventory_file": "inventory", 
+  "ansible_module_compression": "ZIP_DEFLATED", 
+  "ansible_failed_hosts": [], 
+  "ansible_check_mode": false, 
+  "groups": {
+    "ungrouped": [
+      "el6host"
+    ], 
+    "all": [
+      "el6host"
+    ]
+  }, 
+  "ansible_host": "el6host", 
+  "ansible_shell_executable": "/bin/sh", 
+  "inventory_hostname_short": "el6host", 
+  "omit": "__omit_place_holder__b3ac1e6ebeed06f4be0c1edca3dca34036cf7f57", 
+  "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+  "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+  "ansible_ssh_user": "deploy_user", 
+  "role_names": [], 
+  "play_hosts": [
+    "el6host"
+  ], 
+  "ansible_sftp_extra_args": ""
+}

--- a/test/units/plugins/action/fixtures/synchronize/basic_become_user/task_vars_out.json
+++ b/test/units/plugins/action/fixtures/synchronize/basic_become_user/task_vars_out.json
@@ -1,0 +1,156 @@
+{
+  "ansible_pipelining": false, 
+  "ansible_docker_extra_args": "", 
+  "ansible_scp_extra_args": "", 
+  "ansible_user": "deploy_user", 
+  "ansible_play_hosts": [
+    "el6host"
+  ], 
+  "ansible_connection": "smart", 
+  "ansible_ssh_common_args": "", 
+  "environment": [], 
+  "inventory_hostname": "el6host", 
+  "vars": {
+    "ansible_check_mode": false, 
+    "inventory_hostname": "el6host", 
+    "inventory_file": "inventory", 
+    "inventory_hostname_short": "el6host", 
+    "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+    "role_names": [], 
+    "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+    "environment": [], 
+    "play_hosts": [
+      "el6host"
+    ], 
+    "ansible_play_hosts": [
+      "el6host"
+    ], 
+    "hostvars": {
+      "el6host": {
+        "inventory_file": "inventory", 
+        "group_names": [
+          "ungrouped"
+        ], 
+        "groups": {
+          "ungrouped": [
+            "el6host", 
+            "::1"
+          ], 
+          "all": [
+            "el6host", 
+            "::1"
+          ]
+        }, 
+        "inventory_hostname": "el6host", 
+        "inventory_hostname_short": "el6host", 
+        "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "omit": "__omit_place_holder__b3ac1e6ebeed06f4be0c1edca3dca34036cf7f57", 
+        "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "ansible_ssh_user": "deploy_user", 
+        "ansible_check_mode": false, 
+        "ansible_version": {
+          "major": 2, 
+          "full": "2.2.0", 
+          "string": "2.2.0", 
+          "minor": 2, 
+          "revision": 0
+        }
+      }
+    }, 
+    "groups": {
+      "ungrouped": [
+        "el6host"
+      ], 
+      "all": [
+        "el6host"
+      ]
+    }, 
+    "group_names": [
+      "ungrouped"
+    ], 
+    "omit": "__omit_place_holder__b3ac1e6ebeed06f4be0c1edca3dca34036cf7f57", 
+    "ansible_version": {
+      "major": 2, 
+      "full": "2.2.0", 
+      "string": "2.2.0", 
+      "minor": 2, 
+      "revision": 0
+    }, 
+    "ansible_ssh_user": "deploy_user"
+  }, 
+  "ansible_accelerate_port": 5099, 
+  "roledir": null, 
+  "ansible_ssh_extra_args": "", 
+  "ansible_ssh_host": "el6host", 
+  "ansible_current_hosts": [
+    "el6host"
+  ], 
+  "hostvars": {
+    "el6host": {
+      "inventory_file": "inventory", 
+      "group_names": [
+        "ungrouped"
+      ], 
+      "groups": {
+        "ungrouped": [
+          "el6host", 
+          "::1"
+        ], 
+        "all": [
+          "el6host", 
+          "::1"
+        ]
+      }, 
+      "inventory_hostname": "el6host", 
+      "inventory_hostname_short": "el6host", 
+      "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "omit": "__omit_place_holder__b3ac1e6ebeed06f4be0c1edca3dca34036cf7f57", 
+      "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "ansible_ssh_user": "deploy_user", 
+      "ansible_check_mode": false, 
+      "ansible_version": {
+        "major": 2, 
+        "full": "2.2.0", 
+        "string": "2.2.0", 
+        "minor": 2, 
+        "revision": 0
+      }
+    }
+  }, 
+  "group_names": [
+    "ungrouped"
+  ], 
+  "ansible_version": {
+    "major": 2, 
+    "full": "2.2.0", 
+    "string": "2.2.0", 
+    "minor": 2, 
+    "revision": 0
+  }, 
+  "ansible_ssh_pipelining": false, 
+  "inventory_file": "inventory", 
+  "ansible_module_compression": "ZIP_DEFLATED", 
+  "ansible_failed_hosts": [], 
+  "ansible_check_mode": false, 
+  "groups": {
+    "ungrouped": [
+      "el6host"
+    ], 
+    "all": [
+      "el6host"
+    ]
+  }, 
+  "ansible_host": "el6host", 
+  "ansible_shell_executable": "/bin/sh", 
+  "inventory_hostname_short": "el6host", 
+  "omit": "__omit_place_holder__b3ac1e6ebeed06f4be0c1edca3dca34036cf7f57", 
+  "ansible_python_interpreter": "/usr/bin/python", 
+  "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+  "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+  "ansible_ssh_user": "deploy_user", 
+  "role_names": [], 
+  "play_hosts": [
+    "el6host"
+  ], 
+  "ansible_sftp_extra_args": ""
+}

--- a/test/units/plugins/action/test_synchronize.py
+++ b/test/units/plugins/action/test_synchronize.py
@@ -216,6 +216,11 @@ class TestSynchronizeAction(unittest.TestCase):
         x.runtest(fixturepath=os.path.join(self.fixturedir, 'basic_become'))
 
     @patch('ansible.plugins.action.synchronize.connection_loader', FakePluginLoader)
+    def test_basic_become_user(self):
+        x = SynchronizeTester()
+        x.runtest(fixturepath=os.path.join(self.fixturedir, 'basic_become_user'))
+
+    @patch('ansible.plugins.action.synchronize.connection_loader', FakePluginLoader)
     def test_basic_become_cli(self):
         # --become on the cli sets _play_context.become
         x = SynchronizeTester()

--- a/test/units/plugins/action/test_synchronize.py
+++ b/test/units/plugins/action/test_synchronize.py
@@ -100,15 +100,17 @@ class SynchronizeTester(object):
 
     ''' A wrapper for mocking out synchronize environments '''
 
-    task = TaskMock()
-    connection = ConnectionMock()
-    _play_context = PlayContextMock()
-    loader = None
-    templar = None
-    shared_loader_obj = SharedLoaderMock()
+    def __init__(self):
+        self.task = TaskMock()
+        self.connection = ConnectionMock()
+        self._play_context = PlayContextMock()
 
-    final_task_vars = None
-    execute_called = False
+        self.loader = None
+        self.templar = None
+        self.shared_loader_obj = SharedLoaderMock()
+
+        self.final_task_vars = None
+        self.execute_called = False
 
     def _execute_module(self, module_name, module_args=None, task_vars=None):
         self.execute_called = True

--- a/test/units/plugins/action/test_synchronize.py
+++ b/test/units/plugins/action/test_synchronize.py
@@ -123,7 +123,7 @@ class SynchronizeTester(object):
         metapath = os.path.join(fixturepath, 'meta.yaml')
         with open(metapath, 'rb') as f:
             fdata = f.read()
-        test_meta = yaml.load(fdata)
+        test_meta = yaml.safe_load(fdata)
 
         # load initial play context vars
         if '_play_context' in test_meta:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #29698 by changing `sudo rsync` to `sudo -u {{ become_user }} rsync` in `lib/ansible/plugins/action/synchronize.py`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
synchronize

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

- I did not add a check for `become_user` not being `None` (synchronize.py:375), since my impression is that `become_user` will always be defined, with the default value being "root". Please let me know if this assumption is not valid.

- Added a test "basic_become_user", which is only a slight modification of the existing "basic_become" test.

- I then ran into a problem where values from one test would spill over to the next test. To fix this, I moved the initialization of mocks in `SynchronizeTester` into a new constructor method. It doesn't seem right to keep their state from test to test.

- When modifying the test, I also got a little bit confused about why the `basic_become` test (`test/units/plugins/action/fixtures/synchronize/basic_become/meta.yaml`) sets `become` on `_task` in addition to `_play_context`, and in general why `TaskMock` includes the `become*` properties. They do not seem to be used in `synchronize.py` and also do not seem to be defined on the Task class. But I'm not sure if I understand the full interplay between Task and PlayContext, so I didn't change anything for now. Can create a separate issue for this if you think it might be an issue.