### PR TITLE
[stable-2.8] Add constraints for Jinja2 on Python 2.6. (#66826)

### DIFF
--- a/changelogs/fragments/ansible-test-jinja2-python-2.6.yml
+++ b/changelogs/fragments/ansible-test-jinja2-python-2.6.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now limits Jinja2 installs to version 2.10 and earlier on Python 2.6

--- a/test/integration/targets/inventory_aws_conformance/runme.sh
+++ b/test/integration/targets/inventory_aws_conformance/runme.sh
@@ -4,7 +4,7 @@ set -eux
 
 source virtualenv.sh
 
-pip install "python-dateutil>=2.1,<2.7.0" jmespath "Jinja2>=2.10"
+pip install "python-dateutil>=2.1,<2.7.0" jmespath "Jinja2==2.10"
 
 # create boto3 symlinks
 ln -s "$(pwd)/lib/boto" "$(pwd)/lib/boto3"

--- a/test/integration/targets/template_jinja2_latest/requirements.txt
+++ b/test/integration/targets/template_jinja2_latest/requirements.txt
@@ -1,0 +1,2 @@
+jinja2 < 2.11 ; python_version < '2.7' # jinja2 2.11 and later require python 2.7 or later
+jinja2 ; python_version >= '2.7'

--- a/test/integration/targets/template_jinja2_latest/runme.sh
+++ b/test/integration/targets/template_jinja2_latest/runme.sh
@@ -4,7 +4,7 @@ set -eux
 
 source virtualenv.sh
 
-pip install -U jinja2
+pip install -U -r requirements.txt
 
 ANSIBLE_ROLES_PATH=../
 export ANSIBLE_ROLES_PATH

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -2,6 +2,7 @@ coverage >= 4.2, < 5.0.0, != 4.3.2 ; python_version <= '3.7' # features in 4.2+ 
 coverage >= 4.5.4, < 5.0.0 ; python_version > '3.7' # coverage had a bug in < 4.5.4 that would cause unit tests to hang in Python 3.8, coverage 5.0+ incompatible
 cryptography < 2.2 ; python_version < '2.7' # cryptography 2.2 drops support for python 2.6
 deepdiff < 4.0.0 ; python_version < '3' # deepdiff 4.0.0 and later require python 3
+jinja2 < 2.11 ; python_version < '2.7' # jinja2 2.11 and later require python 2.7 or later
 urllib3 < 1.24 ; python_version < '2.7' # urllib3 1.24 and later require python 2.7 or later
 pywinrm >= 0.3.0 # message encryption support
 sphinx < 1.6 ; python_version < '2.7' # sphinx 1.6 and later require python 2.7 or later


### PR DESCRIPTION
##### SUMMARY

* Add constraint for Jinja2 on Python 2.6.
* Fix constraint in inventory_aws_conformance test.
* Add constrraints for template_jinja2_latest test.

Backport of https://github.com/ansible/ansible/pull/66826

(cherry picked from commit 965854fbd2107ddc1449d9463c47f1e0f8525727)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
