### PR TITLE
[stable-2.7] Add constraints for Jinja2 on Python 2.6. (#66826)

### DIFF
--- a/changelogs/fragments/ansible-test-jinja2-python-2.6.yml
+++ b/changelogs/fragments/ansible-test-jinja2-python-2.6.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now limits Jinja2 installs to version 2.10 and earlier on Python 2.6

--- a/test/integration/targets/template_jinja2_latest/requirements.txt
+++ b/test/integration/targets/template_jinja2_latest/requirements.txt
@@ -1,0 +1,2 @@
+jinja2 < 2.11 ; python_version < '2.7' # jinja2 2.11 and later require python 2.7 or later
+jinja2 ; python_version >= '2.7'

--- a/test/integration/targets/template_jinja2_latest/runme.sh
+++ b/test/integration/targets/template_jinja2_latest/runme.sh
@@ -16,7 +16,7 @@ virtualenv --system-site-packages --python "${PYTHON}" "${MYTMPDIR}/jinja2"
 
 source "${MYTMPDIR}/jinja2/bin/activate"
 
-pip install -U jinja2
+pip install -U -r requirements.txt
 
 ANSIBLE_ROLES_PATH="$(dirname "$(pwd)")"
 export ANSIBLE_ROLES_PATH

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -1,6 +1,7 @@
 coverage >= 4.2, < 5.0.0, != 4.3.2 # features in 4.2+ required, avoid known bug in 4.3.2 on python 2.6, coverage 5.0+ incompatible
 cryptography < 2.2 ; python_version < '2.7' # cryptography 2.2 drops support for python 2.6
 deepdiff < 4.0.0 ; python_version < '3' # deepdiff 4.0.0 and later require python 3
+jinja2 < 2.11 ; python_version < '2.7' # jinja2 2.11 and later require python 2.7 or later
 urllib3 < 1.24 ; python_version < '2.7' # urllib3 1.24 and later require python 2.7 or later
 pywinrm >= 0.3.0 # message encryption support
 astroid == 1.5.3 ; python_version >= '3.5' # newer versions of astroid require newer versions of pylint to avoid bugs


### PR DESCRIPTION
##### SUMMARY

* Add constraint for Jinja2 on Python 2.6.
* Add constrraints for template_jinja2_latest test.

Backport of https://github.com/ansible/ansible/pull/66826

(cherry picked from commit 965854fbd2107ddc1449d9463c47f1e0f8525727)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
