### PR TITLE
This was changed to python 2.7 but should have remained python 2.6

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
@@ -16,7 +16,7 @@ To contribute a module to Ansible, you must:
 
 * write your module in either Python or Powershell for Windows
 * use the ``AnsibleModule`` common code
-* support Python 2.7 and Python 3.5 - if your module cannot support Python 2.7, explain the required minimum Python version and rationale in the requirements section in ``DOCUMENTATION``
+* support Python 2.6 and Python 3.5 - if your module cannot support Python 2.6, explain the required minimum Python version and rationale in the requirements section in ``DOCUMENTATION``
 * use proper :ref:`Python 3 syntax <developing_python_3>`
 * follow `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ Python style conventions - see :ref:`testing_pep8` for more information
 * license your module under the GPL license (GPLv3 or later)

--- a/docs/docsite/rst/dev_guide/developing_modules_in_groups.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_in_groups.rst
@@ -25,7 +25,7 @@ Although it's tempting to get straight into coding, there are a few things to be
 
 * Read though all the pages linked off :ref:`developing_modules_general`; paying particular focus to the :ref:`developing_modules_checklist`.
 * New modules must be PEP 8 compliant. See :ref:`testing_pep8` for more information.
-* Starting with Ansible version 2.7, all new modules must :ref:`support Python 2.7+ and Python 3.5+ <developing_python_3>`. If this is an issue, please contact us (see the "Speak to us" section later in this document to learn how).
+* Starting with Ansible version 2.4, all new modules must :ref:`support Python 2.6+ and Python 3.5+ <developing_python_3>`. If this is an issue, please contact us (see the "Speak to us" section later in this document to learn how).
 * Have a look at the existing modules and how they've been named in the :ref:`all_modules`, especially in the same functional area (such as cloud, networking, databases).
 * Shared code can be placed into ``lib/ansible/module_utils/``
 * Shared documentation (for example describing common arguments) can be placed in ``lib/ansible/plugins/doc_fragments/``.


### PR DESCRIPTION
* Modules are still python-2.6+ unless there's a compelling reason not
  to be.

This was probably changed due to miscommunication when the dev guide was updated.  The split between controller and module requirements is confusing.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
This is the commit where it was first written: https://github.com/ansible/ansible/pull/44098/commits/8452016b81dda70c8632ce2d700ddd944b16fd2d  I vaguely recall a conversation with acozine so perhaps she asked me about it and I thought we were talking about the controller?  In any case, it should be python-2.6 for modules and python-2.7 for the controllerside.  These docs are for modules so the change to use Python-2.6 should be correct.