### PR TITLE
zabbix_proxy interface option documentation and argspec fixes

### DIFF
--- a/changelogs/fragments/66837-zabbix-proxy-interface.yml
+++ b/changelogs/fragments/66837-zabbix-proxy-interface.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_proxy - ``interface`` sub-options ``type`` and ``main`` are now deprecated and will be removed in Ansible 2.14.

--- a/changelogs/fragments/66837-zabbix-proxy-interface.yml
+++ b/changelogs/fragments/66837-zabbix-proxy-interface.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - zabbix_proxy - ``interface`` sub-options ``type`` and ``main`` are now deprecated and will be removed in Ansible 2.14.
+  - zabbix_proxy - ``interface`` sub-options ``type`` and ``main`` are now deprecated and will be removed in Ansible 2.14. Also, the values passed to ``interface`` are now checked for correct types and unexpected keys.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -100,6 +100,7 @@ Noteworthy module changes
 * The deprecated ``recurse`` option in :ref:`pacman <pacman_module>` module has been removed, you should use ``extra_args=--recursive`` instead.
 * :ref:`vmware_guest_custom_attributes <vmware_guest_custom_attributes_module>` module does not require VM name which was a required parameter for releases prior to Ansible 2.10.
 * :ref:`zabbix_action <zabbix_action_module>` no longer requires ``esc_period`` and ``event_source`` arguments when ``state=absent``.
+* :ref:`zabbix_proxy <zabbix_proxy_module>` deprecates ``interface`` sub-options ``type`` and ``main`` when proxy type is set to passive via ``status=passive``. Make sure these suboptions are removed from your playbook as they were never supported by Zabbix in the first place.
 * :ref:`gitlab_user <gitlab_user_module>` no longer requires ``name``, ``email`` and ``password`` arguments when ``state=absent``.
 * :ref:`win_pester <win_pester_module>` no longer runs all ``*.ps1`` file in the directory specified due to it executing potentially unknown scripts. It will follow the default behaviour of only running tests for files that are like ``*.tests.ps1`` which is built into Pester itself
 * :ref:`win_find <win_find_module>` has been refactored to better match the behaviour of the ``find`` module. Here is what has changed:


### PR DESCRIPTION
##### SUMMARY
Zabbix proxy doesn't support sub-options `type` and `main` when proxy type is set to passive. It never did in the first place, these sub-options were probably copied from zabbix_host module. 

Discovered in #66176 , but changes were rejected due to patch introducing a lot of changes at the same time. Contributing it in the separate PR with a porting guide entry as discussed in the before mentioned PR.

Explicit reference to comments related to this problem here:
* [comment1](https://github.com/ansible/ansible/pull/66176#discussion_r363035827)
* [comment2](https://github.com/ansible/ansible/pull/66176#discussion_r363035871)
* [comment3](https://github.com/ansible/ansible/pull/66176#issuecomment-571730352)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_proxy