### PR TITLE
zabbix_action - allowing string for esc_period

### DIFF
--- a/changelogs/fragments/66841-zabbix_action-allowstrfor-esc_period.yml
+++ b/changelogs/fragments/66841-zabbix_action-allowstrfor-esc_period.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - zabbix_action - allow str values for ``esc_period`` options (https://github.com/ansible/ansible/pull/66841).

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
@@ -68,7 +68,6 @@ options:
             - Accepts seconds, time unit with suffix and user macro since => Zabbix 3.4
             - Required when C(state=present).
         required: false
-        type: 'str'
     conditions:
         type: list
         description:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_action.py
@@ -63,9 +63,12 @@ options:
         default: true
     esc_period:
         description:
-            - Default operation step duration. Must be greater than 60 seconds. Accepts seconds, time unit with suffix and user macro.
+            - Default operation step duration. Must be greater than 60 seconds.
+            - Accepts only seconds in int for <= Zabbix 3.2
+            - Accepts seconds, time unit with suffix and user macro since => Zabbix 3.4
             - Required when C(state=present).
         required: false
+        type: 'str'
     conditions:
         type: list
         description:
@@ -226,7 +229,8 @@ options:
                 description:
                     - Duration of an escalation step in seconds.
                     - Must be greater than 60 seconds.
-                    - Accepts seconds, time unit with suffix and user macro.
+                    - Accepts only seconds in int for <= Zabbix 3.2
+                    - Accepts seconds, time unit with suffix and user macro since => Zabbix 3.4
                     - If set to 0 or 0s, the default action escalation period will be used.
                 default: 0s
             esc_step_from:
@@ -396,7 +400,7 @@ EXAMPLES = '''
     event_source: 'trigger'
     state: present
     status: enabled
-    esc_period: 60
+    esc_period: 1m
     conditions:
       - type: 'trigger_name'
         operator: 'like'
@@ -429,7 +433,7 @@ EXAMPLES = '''
     event_source: 'trigger'
     state: present
     status: enabled
-    esc_period: 60
+    esc_period: 1h
     conditions:
       - type: 'trigger_severity'
         operator: '>='
@@ -1687,7 +1691,7 @@ def main():
             http_login_user=dict(type='str', required=False, default=None),
             http_login_password=dict(type='str', required=False, default=None, no_log=True),
             validate_certs=dict(type='bool', required=False, default=True),
-            esc_period=dict(type='int', required=False),
+            esc_period=dict(type='str', required=False),
             timeout=dict(type='int', default=10),
             name=dict(type='str', required=True),
             event_source=dict(type='str', required=False, choices=['trigger', 'discovery', 'auto_registration', 'internal']),
@@ -1738,7 +1742,7 @@ def main():
                             'set_host_inventory_mode',
                         ]
                     ),
-                    esc_period=dict(type='int', required=False),
+                    esc_period=dict(type='str', required=False),
                     esc_step_from=dict(type='int', required=False, default=1),
                     esc_step_to=dict(type='int', required=False, default=1),
                     operation_condition=dict(

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -2717,7 +2717,6 @@ lib/ansible/modules/monitoring/statusio_maintenance.py validate-modules:paramete
 lib/ansible/modules/monitoring/uptimerobot.py validate-modules:doc-missing-type
 lib/ansible/modules/monitoring/zabbix/zabbix_action.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/monitoring/zabbix/zabbix_action.py validate-modules:doc-default-does-not-match-spec
-lib/ansible/modules/monitoring/zabbix/zabbix_action.py validate-modules:doc-default-incompatible-type
 lib/ansible/modules/monitoring/zabbix/zabbix_action.py validate-modules:doc-elements-mismatch
 lib/ansible/modules/monitoring/zabbix/zabbix_action.py validate-modules:doc-required-mismatch
 lib/ansible/modules/monitoring/zabbix/zabbix_action.py validate-modules:missing-suboption-docs


### PR DESCRIPTION
##### SUMMARY
Fixes #51345

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_action

##### ADDITIONAL INFORMATION
In my opinion a specific check for the value type regarding the Zabbix version isn't needed. If one doesn't read the readme and is using a string for <= 3.2 the API request would fail and an error is raised.

If I should add one please comment.