### PR TITLE
Remove misleading slash on prefix examples

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_lifecycle.py
+++ b/lib/ansible/modules/cloud/amazon/s3_lifecycle.py
@@ -141,7 +141,7 @@ EXAMPLES = '''
 - s3_lifecycle:
     name: mybucket
     expiration_days: 30
-    prefix: /logs/
+    prefix: logs/
     status: enabled
     state: present
 
@@ -150,7 +150,7 @@ EXAMPLES = '''
     name: mybucket
     transition_days: 7
     expiration_days: 90
-    prefix: /logs/
+    prefix: logs/
     status: enabled
     state: present
 
@@ -161,27 +161,27 @@ EXAMPLES = '''
     name: mybucket
     transition_date: "2020-12-30T00:00:00.000Z"
     expiration_date: "2030-12-30T00:00:00.000Z"
-    prefix: /logs/
+    prefix: logs/
     status: enabled
     state: present
 
 # Disable the rule created above
 - s3_lifecycle:
     name: mybucket
-    prefix: /logs/
+    prefix: logs/
     status: disabled
     state: present
 
 # Delete the lifecycle rule created above
 - s3_lifecycle:
     name: mybucket
-    prefix: /logs/
+    prefix: logs/
     state: absent
 
 # Configure a lifecycle rule to transition all backup files older than 31 days in /backups/ to standard infrequent access class.
 - s3_lifecycle:
     name: mybucket
-    prefix: /backups/
+    prefix: backups/
     storage_class: standard_ia
     transition_days: 31
     state: present
@@ -190,7 +190,7 @@ EXAMPLES = '''
 # Configure a lifecycle rule to transition files to infrequent access after 30 days and glacier after 90
 - s3_lifecycle:
     name: mybucket
-    prefix: /logs/
+    prefix: logs/
     state: present
     status: enabled
     transitions:


### PR DESCRIPTION
##### SUMMARY
S3 lifecycle rule prefixes starting with slash (/) have no effects. If an S3 bucket contains a file 'apache.log' under the (virtual) folder 'logs/', for the lifecycle rule to be effective the prefix to be configured must be 'logs/'. If you put '/logs/' (with a trailing slash) as a prefix the file will never be matched by the lifecycle rule.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
