### PR TITLE
Bugfix of 65525: proxysql in check_config TypeError: tuple indices must be integers, not str

### DIFF
--- a/lib/ansible/modules/database/proxysql/proxysql_backend_servers.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_backend_servers.py
@@ -259,6 +259,10 @@ class ProxySQLServer(object):
 
         cursor.execute(query_string, query_data)
         check_count = cursor.fetchone()
+
+        if isinstance(check_count, tuple):
+            return int(check_count[0]) > 0
+
         return (int(check_count['host_count']) > 0)
 
     def get_server_config(self, cursor):

--- a/lib/ansible/modules/database/proxysql/proxysql_global_variables.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_global_variables.py
@@ -119,6 +119,10 @@ def check_config(variable, value, cursor):
 
     cursor.execute(query_string, query_data)
     check_count = cursor.fetchone()
+
+    if isinstance(check_count, tuple):
+        return int(check_count[0]) > 0
+
     return (int(check_count['variable_count']) > 0)
 
 


### PR DESCRIPTION

##### SUMMARY
Fixes: #65525 
proxysql in check_config TypeError: tuple indices must be integers, not str

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/proxysql/proxysql_backend_servers.py```
```lib/ansible/modules/database/proxysql/proxysql_global_variables.py```
