### PR TITLE
Update zabbix_host.py

### DIFF
--- a/changelogs/fragments/66860-zabbix-api-inventory_mode-usage-fix.yml
+++ b/changelogs/fragments/66860-zabbix-api-inventory_mode-usage-fix.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - zabbix_host - The Zabbix API changed the way to get the current "inventory_mode" of the host between [4.0.0, 4.4.1). 
+ This fix makes the module take that into consideration.

--- a/changelogs/fragments/66860-zabbix-api-inventory_mode-usage-fix.yml
+++ b/changelogs/fragments/66860-zabbix-api-inventory_mode-usage-fix.yml
@@ -1,3 +1,2 @@
 bugfixes:
-  - zabbix_host - The Zabbix API changed the way to get the current "inventory_mode" of the host between [4.0.0, 4.4.1). 
- This fix makes the module take that into consideration.
+  - zabbix_host - The Zabbix API changed the way to get the current "inventory_mode" of the host between [4.0.0, 4.4.1). This fix makes the module take that into consideration.

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -557,8 +557,8 @@ class Host(object):
 
         if inventory_mode:
             if host['inventory']:
-                # The way to read the inventory_mode is different on versions between [4.0.0, 4.4.0)
-                if LooseVersion(self._zbx_api_version) >= LooseVersion('4.0.0') and LooseVersion(self._zbx_api_version) < LooseVersion('4.4.0'):
+                # The way to read the inventory_mode is different on versions between [4.0.0, 4.4.1)
+                if LooseVersion(self._zbx_api_version) >= LooseVersion('4.0.0') and LooseVersion(self._zbx_api_version) < LooseVersion('4.4.1'):
                     if int(host['inventory']['inventory_mode']) != self.inventory_mode_numeric(inventory_mode):
                         return True
                 else:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -557,8 +557,8 @@ class Host(object):
 
         if inventory_mode:
             if host['inventory']:
-                # The way to read the inventory_mode is different on versions between [4.0.0, 4.4.1)
-                if LooseVersion(self._zbx_api_version) >= LooseVersion('4.0.0') and LooseVersion(self._zbx_api_version) < LooseVersion('4.4.1'):
+                # The way to read the inventory_mode is different on versions older than 4.4.1
+                if LooseVersion(self._zbx_api_version) < LooseVersion('4.4.1'):
                     if int(host['inventory']['inventory_mode']) != self.inventory_mode_numeric(inventory_mode):
                         return True
                 else:

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -558,7 +558,7 @@ class Host(object):
         if inventory_mode:
             if LooseVersion(self._zbx_api_version) <= LooseVersion('4.4.0'):
                 if host['inventory']:
-                    if int(host['inventory']['inventory_mode']) != self.inventory_mode_numeric(inventory_mode):
+                    if int(host['inventory_mode']) != self.inventory_mode_numeric(inventory_mode):
                         return True
                 elif inventory_mode != 'disabled':
                     return True

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -556,15 +556,16 @@ class Host(object):
                 return True
 
         if inventory_mode:
-            if LooseVersion(self._zbx_api_version) <= LooseVersion('4.4.0'):
-                if host['inventory']:
+            if host['inventory']:
+                # The way to read the inventory_mode is different on versions between [4.0.0, 4.4.0)
+                if LooseVersion(self._zbx_api_version) >= LooseVersion('4.0.0') and LooseVersion(self._zbx_api_version) < LooseVersion('4.4.0'):
+                    if int(host['inventory']['inventory_mode']) != self.inventory_mode_numeric(inventory_mode):
+                        return True
+                else
                     if int(host['inventory_mode']) != self.inventory_mode_numeric(inventory_mode):
                         return True
-                elif inventory_mode != 'disabled':
-                    return True
-            else:
-                if int(host['inventory_mode']) != self.inventory_mode_numeric(inventory_mode):
-                    return True
+            elif inventory_mode != 'disabled':
+                return True
 
         if inventory_zabbix:
             proposed_inventory = copy.deepcopy(host['inventory'])

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -561,7 +561,7 @@ class Host(object):
                 if LooseVersion(self._zbx_api_version) >= LooseVersion('4.0.0') and LooseVersion(self._zbx_api_version) < LooseVersion('4.4.0'):
                     if int(host['inventory']['inventory_mode']) != self.inventory_mode_numeric(inventory_mode):
                         return True
-                else
+                else:
                     if int(host['inventory_mode']) != self.inventory_mode_numeric(inventory_mode):
                         return True
             elif inventory_mode != 'disabled':


### PR DESCRIPTION
##### SUMMARY
Wrong usage of the "inventory_mode" makes the module always fail if the host has an inventory already. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_host.py

##### ADDITIONAL INFORMATION
The "inventory_mode" is part of the host object and not the inventory. (ref: https://www.zabbix.com/documentation/current/manual/api/reference/host/object)


