### PR TITLE
ec2_asg: max_instance_lifetime and respect wait on replace

### DIFF
--- a/changelogs/fragments/66863-ec2_asg-max_instance_lifetime-and-honor-wait-on-replace.yaml
+++ b/changelogs/fragments/66863-ec2_asg-max_instance_lifetime-and-honor-wait-on-replace.yaml
@@ -1,0 +1,5 @@
+minor_changes:
+- 'ec2_asg: Migrated to AnsibleAWSModule'
+- 'ec2_asg: Add support for Max Instance Lifetime'
+bugfixes:
+- 'ec2_asg: Ensure "wait" is honored during replace operations'

--- a/test/integration/targets/ec2_asg/tasks/main.yml
+++ b/test/integration/targets/ec2_asg/tasks/main.yml
@@ -95,7 +95,7 @@
       # was created
       set_fact:
         load_balancer_name: "{{ item }}-lb"
-      with_items: "{{ resource_prefix | regex_findall('.{8}$') }}"
+      loop: "{{ resource_prefix | regex_findall('.{8}$') }}"
 
     # Set up the testing dependencies: VPC, subnet, security group, and two launch configurations
 
@@ -164,7 +164,7 @@
             - "service httpd start"
         security_groups: "{{ sg.group_id }}"
         instance_type: t3.micro
-      with_items:
+      loop:
         - "{{ resource_prefix }}-lc"
         - "{{ resource_prefix }}-lc-2"
 
@@ -314,6 +314,10 @@
         name: "{{ resource_prefix }}-asg"
         state: absent
         wait_timeout: 800
+      register: output
+      retries: 3
+      until: output is succeeded
+      delay: 10
       async: 400
 
     # ============================================================
@@ -411,6 +415,43 @@
 
     # ============================================================
 
+    # Test max_instance_lifetime option
+
+    - name: enable asg max_instance_lifetime
+      ec2_asg:
+        name: "{{ resource_prefix }}-asg"
+        max_instance_lifetime: 604801
+      register: output
+
+    - name: ensure max_instance_lifetime is set
+      assert:
+        that:
+        - output.max_instance_lifetime == 604801
+
+    - name: run without max_instance_lifetime
+      ec2_asg:
+        name: "{{ resource_prefix }}-asg"
+        launch_config_name: "{{ resource_prefix }}-lc"
+
+    - name: ensure max_instance_lifetime not affected by defaults
+      assert:
+        that:
+        - output.max_instance_lifetime == 604801
+
+    - name: disable asg max_instance_lifetime
+      ec2_asg:
+        name: "{{ resource_prefix }}-asg"
+        launch_config_name: "{{ resource_prefix }}-lc"
+        max_instance_lifetime: 0
+      register: output
+
+    - name: ensure max_instance_lifetime is not set
+      assert:
+        that:
+        - not output.max_instance_lifetime
+
+    # ============================================================
+
     # # perform rolling replace with different launch configuration
 
     - name: perform rolling update to new AMI
@@ -434,7 +475,7 @@
     - assert:
         that:
         - "item.value.launch_config_name == '{{ resource_prefix }}-lc-2'"
-      with_dict: "{{ output.instance_facts }}"
+      loop: "{{ output.instance_facts | dict2items }}"
 
     # assert they are all healthy and that the rolling update resulted in the appropriate number of instances
     - assert:
@@ -466,7 +507,7 @@
     - assert:
         that:
         - "item.value.launch_config_name == '{{ resource_prefix }}-lc'"
-      with_dict: "{{ output.instance_facts }}"
+      loop: "{{ output.instance_facts | dict2items }}"
 
     # assert they are all healthy and that the rolling update resulted in the appropriate number of instances
     # there should be the same number of instances as there were before the rolling update was performed
@@ -502,22 +543,21 @@
       poll: 0
       register: asg_job
 
-    - name: get ec2_asg facts for 3 minutes
+    - name: get ec2_asg info for 3 minutes
       ec2_asg_info:
         name: "{{ resource_prefix }}-asg"
       register: output
       loop_control:
           pause: 15
-      with_sequence: count=12
-
-    - set_fact:
-        inst_id_json_query: 'results[*].results[*].instances[*].instance_id'
+      loop: "{{ range(12) | list }}"
 
     # Since we started with 3 servers and replace all of them.
     # We should see 6 servers total.
     - assert:
         that:
-          - "lookup('flattened',output|json_query(inst_id_json_query)).split(',')|unique|length == 6"
+          - output | json_query(inst_id_json_query) | unique | length == 6
+      vars:
+        inst_id_json_query: results[].results[].instances[].instance_id
 
     - name: Ensure ec2_asg task completes
       async_status: jid="{{ asg_job.ansible_job_id }}"
@@ -568,16 +608,15 @@
       register: output
       loop_control:
           pause: 15
-      with_sequence: count=12
-
-    - set_fact:
-        inst_id_json_query: 'results[*].results[*].instances[*].instance_id'
+      loop: "{{ range(12) | list }}"
 
     # Get all instance_ids we saw and assert we saw number expected
     # Should only see 3 (don't replace instances we just created)
     - assert:
         that:
-          - "lookup('flattened',output|json_query(inst_id_json_query)).split(',')|unique|length == 3"
+          - output | json_query(inst_id_json_query) | unique | length == 3
+      vars:
+        inst_id_json_query: results[].results[].instances[].instance_id
 
     - name: Ensure ec2_asg task completes
       async_status: jid="{{ asg_job.ansible_job_id }}"
@@ -673,7 +712,7 @@
       until: removed is not failed
       ignore_errors: yes
       retries: 10
-      with_items:
+      loop:
         - "{{ resource_prefix }}-lc"
         - "{{ resource_prefix }}-lc-2"
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ec2_asg:
- Add MaxInstanceLifetime support (Fixes: #66716)
- `replace_all_instances: yes` now will not wait for instances to start/terminate when `wait_for_instances: no` (Fixes: #65936)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_asg

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
