### PR TITLE
vmware_vswitch/test: clean up vmswitch_0002

### DIFF
--- a/test/integration/targets/vmware_vswitch/tasks/main.yml
+++ b/test/integration/targets/vmware_vswitch/tasks/main.yml
@@ -11,16 +11,7 @@
 
   # TODO: akasurde: VCSIM does not suport network manager system
   - name: Ensure the vswitch is not already here
-    vmware_vswitch:
-      validate_certs: no
-      hostname: '{{ item.host }}'
-      username: '{{ esxi_user }}'
-      password: '{{ esxi_password }}'
-      switch: '{{ item.switch }}'
-      state: absent
-    with_items:
-      - {host: "{{ esxi1 }}", switch: "vmswitch_0001"}
-      - {host: "{{ esxi2 }}", switch: "vmswitch_0002"}
+    include_tasks: teardown.yml
 
   - name: Add a nic to a switch
     vmware_vswitch:
@@ -91,3 +82,5 @@
   - assert:
       that:
       - add_vswitch_with_host_system is changed
+  always:
+  - include_tasks: teardown.yml

--- a/test/integration/targets/vmware_vswitch/tasks/teardown.yml
+++ b/test/integration/targets/vmware_vswitch/tasks/teardown.yml
@@ -1,0 +1,16 @@
+- name: Remove the vSwitches (ESXi1)
+  vmware_vswitch:
+    hostname: '{{ esxi1 }}'
+    username: '{{ esxi_user }}'
+    password: '{{ esxi_password }}'
+    switch_name: vmswitch_0001
+    state: absent
+
+- name: Remove the vSwitches (ESXi2)
+  vmware_vswitch:
+    hostname: '{{ esxi2 }}'
+    username: '{{ esxi_user }}'
+    password: '{{ esxi_password }}'
+    switch_name: vmswitch_0002
+    state: absent
+  when: esxi2 is defined


### PR DESCRIPTION
##### SUMMARY

Ensure `vmswitch_0002` get removed from ESXi2 at the end of the test.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_vswitch