### PR TITLE
[plugins/inventory/linode] access_token parsing

### DIFF
--- a/lib/ansible/plugins/inventory/linode.py
+++ b/lib/ansible/plugins/inventory/linode.py
@@ -195,11 +195,11 @@ class InventoryModule(BaseInventoryPlugin):
         """Dynamically parse Linode the cloud inventory."""
         super(InventoryModule, self).parse(inventory, loader, path)
 
+        config_data = self._read_config_data(path)
         self._build_client()
 
         self._get_instances_inventory()
 
-        config_data = self._read_config_data(path)
         regions, types = self._get_query_options(config_data)
         self._filter_by_config(regions, types)
 


### PR DESCRIPTION
##### SUMMARY
Read config before calling `self.get_option('access_token')`

Fixes #66874

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/inventory/linode

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
