### PR TITLE
vmware_host_dns: ensure we can run functional tests

### DIFF
--- a/changelogs/fragments/66877-vmware_host_dns.yaml
+++ b/changelogs/fragments/66877-vmware_host_dns.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_host_dns can now set the following empty values, ``domain``, ``search_domains`` and ``dns_servers``. 

--- a/lib/ansible/modules/cloud/vmware/vmware_host_dns.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_dns.py
@@ -222,7 +222,7 @@ class VmwareHostDNS(PyVmomi):
                         else:
                             dns_config.hostName = instance.dnsConfig.hostName
 
-                        if self.search_domains:
+                        if self.search_domains is not None:
                             if instance.dnsConfig.searchDomain != self.search_domains:
                                 host_result['search_domains_previous'] = instance.dnsConfig.searchDomain
                                 host_result['search_domains_changed'] = (
@@ -251,7 +251,7 @@ class VmwareHostDNS(PyVmomi):
 
                             # Check domain
                             host_result['domain'] = self.domain
-                            if self.domain:
+                            if self.domain is not None:
                                 if instance.dnsConfig.domainName != self.domain:
                                     host_result['domain_previous'] = instance.dnsConfig.domainName
                                     changed = True
@@ -262,7 +262,7 @@ class VmwareHostDNS(PyVmomi):
 
                             # Check DNS server(s)
                             host_result['dns_servers'] = self.dns_servers
-                            if self.dns_servers:
+                            if self.dns_servers is not None:
                                 if instance.dnsConfig.address != self.dns_servers:
                                     host_result['dns_servers_previous'] = instance.dnsConfig.address
                                     host_result['dns_servers_changed'] = (
@@ -439,8 +439,8 @@ def main():
         device=dict(type='str'),
         host_name=dict(required=False, type='str'),
         domain=dict(required=False, type='str'),
-        dns_servers=dict(required=False, type='list'),
-        search_domains=dict(required=False, type='list'),
+        dns_servers=dict(required=False, type='list', default=None),
+        search_domains=dict(required=False, type='list', default=None),
         esxi_hostname=dict(required=False, type='str'),
         cluster_name=dict(required=False, type='str'),
         verbose=dict(type='bool', default=False, required=False)

--- a/test/integration/targets/vmware_host_dns/tasks/static.yml
+++ b/test/integration/targets/vmware_host_dns/tasks/static.yml
@@ -9,11 +9,7 @@
         validate_certs: False
         type: 'static'
         host_name: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['host_name'] }}"
-        domain: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['domain_name'] }}"
-        dns_servers: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['ip_address'] }}"
-        search_domains: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['search_domain'] }}"
       register: vmware_host_dns_result_0001
-
     - name: Ensure DNS config wasn't changed
       assert:
         that:
@@ -31,9 +27,6 @@
         validate_certs: False
         type: 'static'
         host_name: newname
-        domain: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['domain_name'] }}"
-        dns_servers: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['ip_address'] }}"
-        search_domains: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['search_domain'] }}"
       register: vmware_host_dns_result_0002
 
     - name: Ensure DNS config was changed
@@ -52,10 +45,7 @@
         password: '{{ esxi_password }}'
         validate_certs: False
         type: 'static'
-        host_name: newname
         domain: new.domain
-        dns_servers: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['ip_address'] }}"
-        search_domains: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['search_domain'] }}"
       register: vmware_host_dns_result_0003
 
     - name: Ensure DNS config was changed
@@ -74,12 +64,9 @@
         password: '{{ esxi_password }}'
         validate_certs: False
         type: 'static'
-        host_name: newname
-        domain: new.domain
         dns_servers:
           - 1.2.3.4
           - 5.6.7.8
-        search_domains: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['search_domain'] }}"
       register: vmware_host_dns_result_0004
 
     - name: Ensure DNS config was changed
@@ -98,11 +85,6 @@
         password: '{{ esxi_password }}'
         validate_certs: False
         type: 'static'
-        host_name: newname
-        domain: new.domain
-        dns_servers:
-          - 1.2.3.4
-          - 5.6.7.8
         search_domains:
           - subdomain.example.local
           - example.local
@@ -146,8 +128,6 @@
         validate_certs: False
         type: 'static'
         domain: new.domain
-        dns_servers: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['ip_address'] }}"
-        search_domains: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['search_domain'] }}"
       register: vmware_host_dns_result_0007
 
     - name: Ensure DNS config was changed
@@ -167,11 +147,9 @@
         cluster_name: "{{ ccr1 }}"
         validate_certs: False
         type: 'static'
-        domain: new.domain
         dns_servers:
           - 1.2.3.4
           - 5.6.7.8
-        search_domains: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['search_domain'] }}"
       register: vmware_host_dns_result_0008
 
     - name: Ensure DNS config was changed
@@ -191,10 +169,6 @@
         cluster_name: "{{ ccr1 }}"
         validate_certs: False
         type: 'static'
-        domain: new.domain
-        dns_servers:
-          - 1.2.3.4
-          - 5.6.7.8
         search_domains:
           - subdomain.example.local
           - example.local
@@ -204,6 +178,45 @@
       assert:
         that:
           - vmware_host_dns_result_0009 is changed
+
+    - name: Revert to original DNS configuration
+      include_tasks: teardown.yaml
+
+    - name: Remove all the DNS servers
+      vmware_host_dns:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        cluster_name: "{{ ccr1 }}"
+        validate_certs: False
+        type: 'static'
+        dns_servers: []
+      register: vmware_host_dns_result_0010
+
+    - name: Ensure DNS config was changed
+      assert:
+        that:
+          - vmware_host_dns_result_0010 is changed
+
+    - name: Remove the domain
+      vmware_host_dns:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        cluster_name: "{{ ccr1 }}"
+        validate_certs: False
+        type: 'static'
+        domain: ''
+      register: vmware_host_dns_result_0011
+
+    - name: Ensure the server has no domain
+      assert:
+        that:
+          - vmware_host_dns_result_0011 is changed
+
+
+    - name: Revert to original DNS configuration
+      include_tasks: teardown.yaml
 
   always:
     - name: Revert to original DNS configuration

--- a/test/integration/targets/vmware_host_dns/tasks/static.yml
+++ b/test/integration/targets/vmware_host_dns/tasks/static.yml
@@ -19,6 +19,9 @@
         that:
           - vmware_host_dns_result_0001 is not changed
 
+    - name: Revert to original DNS configuration
+      include_tasks: teardown.yaml
+
     # Testcase 0002: Ensure changing the hostname directly on the host works
     - name: Ensure changing the hostname directly on the host works
       vmware_host_dns:
@@ -38,6 +41,9 @@
         that:
           - vmware_host_dns_result_0002 is changed
 
+    - name: Revert to original DNS configuration
+      include_tasks: teardown.yaml
+
     # Testcase 0003: Ensure changing the domain directly on the host works
     - name: Ensure changing the domain directly on the host works
       vmware_host_dns:
@@ -56,6 +62,9 @@
       assert:
         that:
           - vmware_host_dns_result_0003 is changed
+
+    - name: Revert to original DNS configuration
+      include_tasks: teardown.yaml
 
     # Testcase 0004: Ensure changing the DNS servers directly on the host works
     - name: Ensure changing the domain directly on the host works
@@ -77,6 +86,9 @@
       assert:
         that:
           - vmware_host_dns_result_0004 is changed
+
+    - name: Revert to original DNS configuration
+      include_tasks: teardown.yaml
 
     # Testcase 0005: Ensure changing the search domain directly on the host works
     - name: Ensure changing the domain directly on the host works
@@ -101,18 +113,8 @@
         that:
           - vmware_host_dns_result_0005 is changed
 
-    # Revert to original DNS configuration with a different search_domains
     - name: Revert to original DNS configuration
-      vmware_host_dns:
-        hostname: '{{ esxi1 }}'
-        username: '{{ esxi_user }}'
-        password: '{{ esxi_password }}'
-        validate_certs: False
-        type: 'static'
-        host_name: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['host_name'] }}"
-        domain: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['domain_name'] }}"
-        dns_servers: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['ip_address'] }}"
-        search_domains: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['search_domain'] }}"
+      include_tasks: teardown.yaml
 
     # Testcase 0006: Ensure DNS config on the cluster is idempotent for static
     - name: Apply configuration on a cluster
@@ -132,16 +134,7 @@
           - vmware_host_dns_result_0006 is changed
 
     - name: Revert to original DNS configuration
-      vmware_host_dns:
-        hostname: '{{ esxi1 }}'
-        username: '{{ esxi_user }}'
-        password: '{{ esxi_password }}'
-        validate_certs: False
-        type: 'static'
-        host_name: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['host_name'] }}"
-        domain: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['domain_name'] }}"
-        dns_servers: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['ip_address'] }}"
-        search_domains: "{{ dns['results'][0]['hosts_dns_info'][esxi1]['search_domain'] }}"
+      include_tasks: teardown.yaml
 
     # Testcase 0007: Ensure changing the domain on the cluster works
     - name: Ensure changing the domain on the cluster works
@@ -161,6 +154,9 @@
       assert:
         that:
           - vmware_host_dns_result_0007 is changed
+
+    - name: Revert to original DNS configuration
+      include_tasks: teardown.yaml
 
     # Testcase 0008: Ensure changing the DNS servers on the cluster works
     - name: Ensure changing the DNS servers on the cluster works
@@ -182,6 +178,9 @@
       assert:
         that:
           - vmware_host_dns_result_0008 is changed
+
+    - name: Revert to original DNS configuration
+      include_tasks: teardown.yaml
 
     # Testcase 0009: Ensure changing the search domains on the cluster works
     - name: Ensure changing the search domains on the cluster works
@@ -207,19 +206,5 @@
           - vmware_host_dns_result_0009 is changed
 
   always:
-    # Revert to original DNS configuration
     - name: Revert to original DNS configuration
-      vmware_host_dns:
-        hostname: '{{ vcenter_hostname }}'
-        username: '{{ vcenter_username }}'
-        password: '{{ vcenter_password }}'
-        esxi_hostname: "{{ item }}"
-        validate_certs: False
-        type: 'static'
-        host_name: "{{ dns['results'][index]['hosts_dns_info'][item]['host_name'] }}"
-        domain: "{{ dns['results'][index]['hosts_dns_info'][item]['domain_name'] }}"
-        dns_servers: "{{ dns['results'][index]['hosts_dns_info'][item]['ip_address'] }}"
-        search_domains: "{{ dns['results'][index]['hosts_dns_info'][item]['search_domain'] }}"
-      loop: "{{ esxi_hosts }}"
-      loop_control:
-        index_var: index
+      include_tasks: teardown.yaml

--- a/test/integration/targets/vmware_host_dns/tasks/teardown.yaml
+++ b/test/integration/targets/vmware_host_dns/tasks/teardown.yaml
@@ -1,0 +1,15 @@
+- name: Revert to original DNS configuration
+  vmware_host_dns:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    esxi_hostname: "{{ item }}"
+    validate_certs: False
+    type: 'static'
+    host_name: "{{ dns['results'][index]['hosts_dns_info'][item]['host_name'] }}"
+    domain: "{{ dns['results'][index]['hosts_dns_info'][item]['domain_name'] }}"
+    dns_servers: "{{ dns['results'][index]['hosts_dns_info'][item]['ip_address'] }}"
+    search_domains: "{{ dns['results'][index]['hosts_dns_info'][item]['search_domain'] }}"
+  loop: "{{ esxi_hosts }}"
+  loop_control:
+    index_var: index


### PR DESCRIPTION
##### SUMMARY

Reset the state of the configuration before every step of the test,
this will help to troubleshoot inconsistency during the test. The test is failing in the CI,
but pass just fine locally.

In addition, the module was not able to reset properly the state of the ESXi host.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_host_dns