### PR TITLE
WIP: _text: Added support for utf-8 BOM (#64554)

### DIFF
--- a/lib/ansible/module_utils/_text.py
+++ b/lib/ansible/module_utils/_text.py
@@ -166,7 +166,7 @@ def to_bytes(obj, encoding='utf-8', errors=None, nonstring='simplerepr'):
     return to_bytes(value, encoding, errors)
 
 
-def to_text(obj, encoding='utf-8', errors=None, nonstring='simplerepr'):
+def to_text(obj, encoding='utf-8-sig', errors=None, nonstring='simplerepr'):
     """Make sure that a string is a text string
 
     :arg obj: An object to make sure is a text string.  In most cases this
@@ -174,7 +174,7 @@ def to_text(obj, encoding='utf-8', errors=None, nonstring='simplerepr'):
         ``nonstring='simplerepr'``, this can be used as a traceback-free
         version of ``str(obj)``.
     :kwarg encoding: The encoding to use to transform from a byte string to
-        a text string.  Defaults to using 'utf-8'.
+        a text string.  Defaults to using 'utf-8-sig'.
     :kwarg errors: The error handler to use if the byte string is not
         decodable using the specified encoding.  Any valid `codecs error
         handler <https://docs.python.org/2/library/codecs.html#codec-base-classes>`_

--- a/test/units/module_utils/test_text.py
+++ b/test/units/module_utils/test_text.py
@@ -27,6 +27,7 @@ VALID_STRINGS = (
     # u'くらとみ'
     (b'\xe3\x81\x8f\xe3\x82\x89\xe3\x81\xa8\xe3\x81\xbf', u'\u304f\u3089\u3068\u307f', 'utf-8'),
     (b'\x82\xad\x82\xe7\x82\xc6\x82\xdd', u'\u304f\u3089\u3068\u307f', 'shift-jis'),
+    (b'\xef\xbb\xbf\xe3\x81\x8f\xe3\x82\x89\xe3\x81\xa8\xe3\x81\xbf', u'\u304f\u3089\u3068\u307f', 'utf-8-sig'),
 )
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added support for utf-8 BOM.
Fixes: #64554

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/_text.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Issue #64554 is caused by a utf-8 signature at the beginning of the file.
I fixed it by changing decoding codec from `utf-8` to `utf-8-sig`.
By using `utf-8-sig`, both UTF-8 and UTF-8 BOM can be decoded correctly.