### PR TITLE
Improve net_put error handling and add 'compare' option

### DIFF
--- a/changelogs/fragments/66887-net_put-compare-bugfix-improvements.yaml
+++ b/changelogs/fragments/66887-net_put-compare-bugfix-improvements.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - net_put - fix exception when transferring binary files that already exist at destination
+minor_changes:
+  - net_put - Add 'compare' option to optionally skip comparing src and dest files

--- a/lib/ansible/modules/network/files/net_put.py
+++ b/lib/ansible/modules/network/files/net_put.py
@@ -52,6 +52,16 @@ options:
     default: binary
     choices: ['binary', 'text']
     version_added: "2.7"
+  compare:
+    description:
+      - If set to I(yes) it is checked if the file already exists at
+        I(dest). If it does exist and has the same checksum, no action will be
+        taken. This should be set to I(no) for large files, as it requires the
+        destination file to be transferred to the executing host for checksum
+        comparison.
+    type: bool
+    default: 'yes'
+    version_added: "2.10"
 
 requirements:
     - "scp"

--- a/lib/ansible/plugins/action/net_put.py
+++ b/lib/ansible/plugins/action/net_put.py
@@ -99,7 +99,7 @@ class ActionModule(ActionBase):
         if dest is None:
             dest = src_file_path_name
 
-        compare = self._task.args.get('compare')
+        compare = self._task.args.get('compare', True)
         if compare:
             changed = self._handle_existing_file(conn, output_file, dest, proto, sock_timeout)
             if changed is False:


### PR DESCRIPTION
##### SUMMARY
net_put failed when the destination file already existed and file
contents are binary. net_put now opens the files in binary mode. To
preserve memory file contents are now read in chunks to update the sha1
checksum.

A new option 'compare' was added to optionally skip comparing the new
file with the already existing file at the destination. We use net_put
to push large files which means that we wait quite a long time for the
old file to be transferred back to the executing host for comparison.

Finally the error handling was made more robust. The initial problem
(file was openend in text mode instead of binary) was masked by a 'catch
all' try/except. These were removed.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
net_put