### PR TITLE
Forbid `state=(list|info)` in modules via ansible-test sanity check

### DIFF
--- a/changelogs/fragments/66898-sanity-state-list.yaml
+++ b/changelogs/fragments/66898-sanity-state-list.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - 'ansible-test - Add a test to prevent state=list and state=info'
+  - 'ansible-test - Add a test to prevent ``state=list`` and ``state=info``'

--- a/changelogs/fragments/66898-sanity-state-list.yaml
+++ b/changelogs/fragments/66898-sanity-state-list.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - 'ansible-test - Add a test to prevent state=list and state=info'

--- a/docs/docsite/rst/dev_guide/testing_validate-modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_validate-modules.rst
@@ -126,7 +126,7 @@ Codes
   parameter-alias-self                                         Parameters           Error                  argument in argument_spec is specified as its own alias
   parameter-documented-multiple-times                          Documentation        Error                  argument in argument_spec with aliases is documented multiple times
   parameter-list-no-elements                                   Parameters           Error                  argument in argument_spec "type" is specified as ``list`` without defining "elements"
-  parameter-state-invalid-choice                               Parameters           Error                  Argument ``state`` includes ``list`` or ``info`` as a choice.  Functionality should be in an _info module.
+  parameter-state-invalid-choice                               Parameters           Error                  Argument ``state`` includes ``list`` or ``info`` as a choice.  Functionality should be in an ``_info`` or (if further conditions apply) ``_facts`` module.
   python-syntax-error                                          Syntax               Error                  Python ``SyntaxError`` while parsing module
   return-syntax-error                                          Documentation        Error                  ``RETURN`` is not valid YAML, ``RETURN`` fragments missing  or invalid
   subdirectory-missing-init                                    Naming               Error                  Ansible module subdirectories must contain an ``__init__.py``

--- a/docs/docsite/rst/dev_guide/testing_validate-modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_validate-modules.rst
@@ -126,6 +126,7 @@ Codes
   parameter-alias-self                                         Parameters           Error                  argument in argument_spec is specified as its own alias
   parameter-documented-multiple-times                          Documentation        Error                  argument in argument_spec with aliases is documented multiple times
   parameter-list-no-elements                                   Parameters           Error                  argument in argument_spec "type" is specified as ``list`` without defining "elements"
+  parameter-state-invalid-choice                               Parameters           Error                  Argument ``state`` includes ``list`` or ``info`` as a choice.  Functionality should be in an _info module.
   python-syntax-error                                          Syntax               Error                  Python ``SyntaxError`` while parsing module
   return-syntax-error                                          Documentation        Error                  ``RETURN`` is not valid YAML, ``RETURN`` fragments missing  or invalid
   subdirectory-missing-init                                    Naming               Error                  Ansible module subdirectories must contain an ``__init__.py``

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -1212,13 +1212,13 @@ class ModuleValidator(Validator):
                     code='parameter-alias-repeated',
                     msg=msg
                 )
-            if not context and arg == 'state' and data.get('choices'):
-                for bad_state in ['list', 'info']:
-                    if bad_state in data.get('choices'):
-                        self.reporter.error(
-                            path=self.object_path,
-                            code='parameter-state-invalid-choice',
-                            msg="Argument 'state' includes the value '%s' as a valid choice" % bad_state)
+            if not context and arg == 'state':
+                bad_states = set(['list', 'info']) & set(data.get('choices', set()))
+                for bad_state in bad_states:
+                    self.reporter.error(
+                        path=self.object_path,
+                        code='parameter-state-invalid-choice',
+                        msg="Argument 'state' includes the value '%s' as a valid choice" % bad_state)
             if not data.get('removed_in_version', None):
                 args_from_argspec.add(arg)
                 args_from_argspec.update(aliases)

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -1212,6 +1212,13 @@ class ModuleValidator(Validator):
                     code='parameter-alias-repeated',
                     msg=msg
                 )
+            if not context and arg == 'state' and data.get('choices'):
+                for bad_state in ['list', 'info']:
+                    if bad_state in data.get('choices'):
+                        self.reporter.error(
+                            path=self.object_path,
+                            code='parameter-state-invalid-choice',
+                            msg="Argument 'state' includes the value '%s' as a valid choice" % bad_state)
             if not data.get('removed_in_version', None):
                 args_from_argspec.add(arg)
                 args_from_argspec.update(aliases)

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -1218,7 +1218,7 @@ class ModuleValidator(Validator):
                     self.reporter.error(
                         path=self.object_path,
                         code='parameter-state-invalid-choice',
-                        msg="Argument 'state' includes the value '%s' as a valid choice" % bad_state)
+                        msg="Argument 'state' includes the value '%s' as a choice" % bad_state)
             if not data.get('removed_in_version', None):
                 args_from_argspec.add(arg)
                 args_from_argspec.update(aliases)

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -573,7 +573,9 @@ lib/ansible/modules/cloud/amazon/ec2_placement_group_info.py validate-modules:do
 lib/ansible/modules/cloud/amazon/ec2_placement_group_info.py validate-modules:parameter-list-no-elements
 lib/ansible/modules/cloud/amazon/ec2_snapshot_info.py validate-modules:doc-elements-mismatch
 lib/ansible/modules/cloud/amazon/ec2_snapshot_info.py validate-modules:parameter-list-no-elements
+lib/ansible/modules/cloud/amazon/ec2_tag.py validate-modules:parameter-state-invalid-choice
 lib/ansible/modules/cloud/amazon/ec2_transit_gateway_info.py validate-modules:doc-elements-mismatch
+lib/ansible/modules/cloud/amazon/ec2_vol.py validate-modules:parameter-state-invalid-choice
 lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option.py validate-modules:doc-elements-mismatch
 lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option.py validate-modules:parameter-list-no-elements
 lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option_info.py validate-modules:doc-elements-mismatch
@@ -1430,6 +1432,7 @@ lib/ansible/modules/cloud/google/gcpubsub_info.py validate-modules:doc-choices-d
 lib/ansible/modules/cloud/google/gcpubsub_info.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/cloud/google/gcpubsub_info.py validate-modules:doc-missing-type
 lib/ansible/modules/cloud/google/gcpubsub_info.py validate-modules:doc-required-mismatch
+lib/ansible/modules/cloud/google/gcpubsub_info.py validate-modules:parameter-state-invalid-choice
 lib/ansible/modules/cloud/google/gcpubsub_info.py validate-modules:undocumented-parameter
 lib/ansible/modules/cloud/hcloud/hcloud_network_info.py validate-modules:return-syntax-error
 lib/ansible/modules/cloud/hcloud/hcloud_server.py validate-modules:parameter-list-no-elements
@@ -1505,6 +1508,7 @@ lib/ansible/modules/cloud/misc/proxmox_template.py validate-modules:nonexistent-
 lib/ansible/modules/cloud/misc/proxmox_template.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/cloud/misc/rhevm.py validate-modules:doc-required-mismatch
 lib/ansible/modules/cloud/misc/rhevm.py validate-modules:parameter-list-no-elements
+lib/ansible/modules/cloud/misc/rhevm.py validate-modules:parameter-state-invalid-choice
 lib/ansible/modules/cloud/misc/serverless.py validate-modules:parameter-list-no-elements
 lib/ansible/modules/cloud/misc/terraform.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/cloud/misc/terraform.py validate-modules:doc-missing-type
@@ -2045,6 +2049,7 @@ lib/ansible/modules/cloud/rackspace/rax_files.py validate-modules:doc-choices-do
 lib/ansible/modules/cloud/rackspace/rax_files.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/cloud/rackspace/rax_files.py validate-modules:doc-missing-type
 lib/ansible/modules/cloud/rackspace/rax_files.py validate-modules:doc-required-mismatch
+lib/ansible/modules/cloud/rackspace/rax_files.py validate-modules:parameter-state-invalid-choice
 lib/ansible/modules/cloud/rackspace/rax_files.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/cloud/rackspace/rax_files_objects.py use-argspec-type-path
 lib/ansible/modules/cloud/rackspace/rax_files_objects.py validate-modules:doc-default-does-not-match-spec
@@ -2298,6 +2303,7 @@ lib/ansible/modules/cloud/vmware/vmware_guest_network.py validate-modules:parame
 lib/ansible/modules/cloud/vmware/vmware_guest_sendkey.py validate-modules:parameter-list-no-elements
 lib/ansible/modules/cloud/vmware/vmware_guest_serial_port.py validate-modules:parameter-list-no-elements
 lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py validate-modules:doc-required-mismatch
+lib/ansible/modules/cloud/vmware/vmware_host_acceptance.py validate-modules:parameter-state-invalid-choice
 lib/ansible/modules/cloud/vmware/vmware_host_datastore.py validate-modules:doc-required-mismatch
 lib/ansible/modules/cloud/vmware/vmware_host_dns.py validate-modules:parameter-list-no-elements
 lib/ansible/modules/cloud/vmware/vmware_host_facts.py validate-modules:parameter-list-no-elements
@@ -2396,6 +2402,7 @@ lib/ansible/modules/clustering/consul/consul_acl.py validate-modules:parameter-l
 lib/ansible/modules/clustering/consul/consul_kv.py validate-modules:doc-required-mismatch
 lib/ansible/modules/clustering/consul/consul_kv.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/clustering/consul/consul_session.py validate-modules:parameter-list-no-elements
+lib/ansible/modules/clustering/consul/consul_session.py validate-modules:parameter-state-invalid-choice
 lib/ansible/modules/clustering/etcd3.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/clustering/etcd3.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/clustering/k8s/k8s.py validate-modules:doc-default-does-not-match-spec
@@ -6818,6 +6825,7 @@ lib/ansible/modules/remote_management/manageiq/manageiq_policies.py validate-mod
 lib/ansible/modules/remote_management/manageiq/manageiq_policies.py validate-modules:implied-parameter-type-mismatch
 lib/ansible/modules/remote_management/manageiq/manageiq_policies.py validate-modules:invalid-ansiblemodule-schema
 lib/ansible/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-list-no-elements
+lib/ansible/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-state-invalid-choice
 lib/ansible/modules/remote_management/manageiq/manageiq_policies.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/remote_management/manageiq/manageiq_provider.py validate-modules:doc-default-does-not-match-spec
@@ -6831,6 +6839,7 @@ lib/ansible/modules/remote_management/manageiq/manageiq_tags.py validate-modules
 lib/ansible/modules/remote_management/manageiq/manageiq_tags.py validate-modules:implied-parameter-type-mismatch
 lib/ansible/modules/remote_management/manageiq/manageiq_tags.py validate-modules:invalid-ansiblemodule-schema
 lib/ansible/modules/remote_management/manageiq/manageiq_tags.py validate-modules:parameter-list-no-elements
+lib/ansible/modules/remote_management/manageiq/manageiq_tags.py validate-modules:parameter-state-invalid-choice
 lib/ansible/modules/remote_management/manageiq/manageiq_tags.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/remote_management/manageiq/manageiq_tenant.py validate-modules:doc-missing-type
 lib/ansible/modules/remote_management/manageiq/manageiq_tenant.py validate-modules:doc-required-mismatch
@@ -7019,6 +7028,7 @@ lib/ansible/modules/storage/netapp/_na_cdot_volume.py validate-modules:parameter
 lib/ansible/modules/storage/netapp/_na_cdot_volume.py validate-modules:undocumented-parameter
 lib/ansible/modules/storage/netapp/_na_ontap_gather_facts.py validate-modules:doc-missing-type
 lib/ansible/modules/storage/netapp/_na_ontap_gather_facts.py validate-modules:parameter-list-no-elements
+lib/ansible/modules/storage/netapp/_na_ontap_gather_facts.py validate-modules:parameter-state-invalid-choice
 lib/ansible/modules/storage/netapp/_na_ontap_gather_facts.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/storage/netapp/_sf_account_manager.py validate-modules:doc-missing-type
 lib/ansible/modules/storage/netapp/_sf_account_manager.py validate-modules:parameter-type-not-in-doc
@@ -7130,6 +7140,7 @@ lib/ansible/modules/storage/netapp/na_ontap_igroup_initiator.py validate-modules
 lib/ansible/modules/storage/netapp/na_ontap_igroup_initiator.py validate-modules:parameter-list-no-elements
 lib/ansible/modules/storage/netapp/na_ontap_igroup_initiator.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/storage/netapp/na_ontap_info.py validate-modules:parameter-list-no-elements
+lib/ansible/modules/storage/netapp/na_ontap_info.py validate-modules:parameter-state-invalid-choice
 lib/ansible/modules/storage/netapp/na_ontap_interface.py validate-modules:doc-missing-type
 lib/ansible/modules/storage/netapp/na_ontap_interface.py validate-modules:parameter-list-no-elements
 lib/ansible/modules/storage/netapp/na_ontap_interface.py validate-modules:parameter-type-not-in-doc
@@ -7407,10 +7418,12 @@ lib/ansible/modules/system/nosh.py validate-modules:return-syntax-error
 lib/ansible/modules/system/openwrt_init.py validate-modules:doc-missing-type
 lib/ansible/modules/system/openwrt_init.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/system/osx_defaults.py validate-modules:doc-required-mismatch
+lib/ansible/modules/system/osx_defaults.py validate-modules:parameter-state-invalid-choice
 lib/ansible/modules/system/pam_limits.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/system/pamd.py validate-modules:parameter-list-no-elements
 lib/ansible/modules/system/parted.py pylint:blacklisted-name
 lib/ansible/modules/system/parted.py validate-modules:parameter-list-no-elements
+lib/ansible/modules/system/parted.py validate-modules:parameter-state-invalid-choice
 lib/ansible/modules/system/puppet.py use-argspec-type-path
 lib/ansible/modules/system/puppet.py validate-modules:parameter-invalid
 lib/ansible/modules/system/puppet.py validate-modules:parameter-list-no-elements


### PR DESCRIPTION
##### SUMMARY

Our [Developer documentation](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_best_practices.html#scoping-your-module-s
) explicitly states:

``Do not add list or info state options to an existing module - create a new _info or _facts module.``

Enforce this with a sanity test to avoid catching out new contributors using existing modules as a starting point.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

See also #66811 - We missed this in review when the work was based upon an old module.