### PR TITLE
[WIP]Update network_cli to support paramiko connection in collection

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -352,7 +352,11 @@ class Connection(NetworkConnectionBase):
     @property
     def paramiko_conn(self):
         if self._paramiko_conn is None:
-            self._paramiko_conn = connection_loader.get('paramiko', self._play_context, '/dev/null')
+            for fq_conn_name in ['ansible.netcommon.paramiko', 'paramiko']:
+                self._paramiko_conn = connection_loader.get(fq_conn_name, self._play_context, '/dev/null')
+                if self._paramiko_conn is not None:
+                    break
+
             self._paramiko_conn.set_options(direct={'look_for_keys': not bool(self._play_context.password and not self._play_context.private_key_file)})
         return self._paramiko_conn
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  Try to load paramkio connection plugin from ansible.netcommon
   collection.
*  Fallback to original connection name to be backaward compatible with 2.9
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
network_cli

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
