### PR TITLE
Add documentation about vars used in roles at the play level

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
@@ -158,6 +158,8 @@ You can pass other keywords to the ``roles`` option:
 
 When you add a tag to the ``role`` option, Ansible applies the tag to ALL tasks within the role.
 
+When using ``vars:`` within the ``roles:`` section of a playbook, the variables are added to the play variables, making them available to all tasks within the play before and after the role. This behavior can be changed by :ref:`DEFAULT_PRIVATE_ROLE_VARS`.
+
 Including roles: dynamic re-use
 -------------------------------
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #66610 

The behavior of `vars:` when used with `roles:` wasn't clear. Added documentation to explain the behavior with a link to how to change it via a config setting.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`docs/docsite/rst/user_guide/playbooks_reuse_roles.rst`