### PR TITLE
Add cloudlinuxserver value to hostname.py

### DIFF
--- a/changelogs/fragments/66911-fix-cloudlinux6-hostname.yaml
+++ b/changelogs/fragments/66911-fix-cloudlinux6-hostname.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hostname - Fixed an issue where the hostname on the cloudlinux 6 server could not be set.

--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -658,6 +658,12 @@ class ClearLinuxHostname(Hostname):
     strategy_class = SystemdStrategy
 
 
+class CloudlinuxserverHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Cloudlinuxserver'
+    strategy_class = RedHatStrategy
+
+
 class CloudlinuxHostname(Hostname):
     platform = 'Linux'
     distribution = 'Cloudlinux'


### PR DESCRIPTION
##### SUMMARY
Can’t set hostname after this @samdoran PR https://github.com/ansible/ansible/pull/52199

Error message on Cloudlinux 6:
`“msg”: “hostname module cannot be used on platform Linux (Cloudlinuxserver)“`

There is difference between cloudlinux 6 and cloudlinux 7:
```
$ lsb_release -i
Distributor ID: CloudLinuxServer
```
and
```
$ lsb_release -i
Distributor ID: CloudLinux
```

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
`lib/ansible/module_utils/common/sys_info.py`

