### PR TITLE
vmware_cluster_facts does not set hosts key

### DIFF
--- a/test/integration/targets/vmware_cluster_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_cluster_facts/tasks/main.yml
@@ -46,7 +46,6 @@
   assert:
     that:
         - cluster_result.clusters
-        - cluster_result.clusters[ccr1].hosts is defined
         - not cluster_result.changed
 
 - <<: *vc_cluster_data


### PR DESCRIPTION
##### SUMMARY

Since https://github.com/ansible/ansible/pull/61006 `vmware_cluster_info`
exposes a new key called `hosts`. The deprecated module
`vmware_cluster_facts` keeps the previous behaviour, and so we must keep
its test-suite unchanged.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_cluster_facts