### PR TITLE
removed_in_version is broken

### DIFF
--- a/changelogs/fragments/66918-removed_in_version-fix.yml
+++ b/changelogs/fragments/66918-removed_in_version-fix.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- "Module arguments in suboptions which were marked as deprecated with ``removed_in_version`` did not result in a warning."
+- "The warning for module arguments deprecated with ``removed_in_version`` contained the strings ``msg`` and ``version`` instead of their values."

--- a/changelogs/fragments/66918-removed_in_version-fix.yml
+++ b/changelogs/fragments/66918-removed_in_version-fix.yml
@@ -1,3 +1,2 @@
 bugfixes:
 - "Module arguments in suboptions which were marked as deprecated with ``removed_in_version`` did not result in a warning."
-- "The warning for module arguments deprecated with ``removed_in_version`` contained the strings ``msg`` and ``version`` instead of their values."

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1428,8 +1428,8 @@ class AnsibleModule(object):
             self.fail_json(msg="Failure when processing no_log parameters. Module invocation will be hidden. "
                                "%s" % to_native(te), invocation={'module_args': 'HIDDEN DUE TO FAILURE'})
 
-        for msg, version in list_deprecations(spec, param):
-            deprecate(msg, version)
+        for message in list_deprecations(spec, param):
+            deprecate(message['msg'], message['version'])
 
     def _check_arguments(self, spec=None, param=None, legal_inputs=None):
         self._syslog_facility = 'LOG_USER'

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -142,7 +142,7 @@ def list_deprecations(argument_spec, params, prefix=''):
                 if isinstance(sub_arguments, Mapping):
                     sub_arguments = [sub_arguments]
                 if isinstance(sub_arguments, list):
-                    sub_prefix = prefix + arg_name + "' -> '"
+                    sub_prefix = "%s%s' -> '" % (prefix, arg_name)
                     for sub_params in sub_arguments:
                         if isinstance(sub_params, Mapping):
                             deprecations.extend(list_deprecations(sub_argument_spec, sub_params, prefix=sub_prefix))

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -115,7 +115,7 @@ def list_no_log_values(argument_spec, params):
     return no_log_values
 
 
-def list_deprecations(argument_spec, params):
+def list_deprecations(argument_spec, params, prefix=''):
     """Return a list of deprecations
 
     :arg argument_spec: An argument spec dictionary from a module
@@ -129,11 +129,23 @@ def list_deprecations(argument_spec, params):
 
     deprecations = []
     for arg_name, arg_opts in argument_spec.items():
-        if arg_opts.get('removed_in_version') is not None and arg_name in params:
-            deprecations.append({
-                'msg': "Param '%s' is deprecated. See the module docs for more information" % arg_name,
-                'version': arg_opts.get('removed_in_version')
-            })
+        if arg_name in params:
+            if arg_opts.get('removed_in_version') is not None:
+                deprecations.append({
+                    'msg': "Param '%s' is deprecated. See the module docs for more information" % (prefix + arg_name),
+                    'version': arg_opts.get('removed_in_version')
+                })
+            # Check sub-argument spec
+            sub_argument_spec = arg_opts.get('options')
+            if sub_argument_spec is not None:
+                sub_arguments = params[arg_name]
+                if isinstance(sub_arguments, Mapping):
+                    sub_arguments = [sub_arguments]
+                if isinstance(sub_arguments, list):
+                    sub_prefix = prefix + arg_name + "' -> '"
+                    for sub_params in sub_arguments:
+                        if isinstance(sub_params, Mapping):
+                            deprecations.extend(list_deprecations(sub_argument_spec, sub_params, prefix=sub_prefix))
 
     return deprecations
 

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -130,9 +130,13 @@ def list_deprecations(argument_spec, params, prefix=''):
     deprecations = []
     for arg_name, arg_opts in argument_spec.items():
         if arg_name in params:
+            if prefix:
+                sub_prefix = '%s["%s"]' % (prefix, arg_name)
+            else:
+                sub_prefix = arg_name
             if arg_opts.get('removed_in_version') is not None:
                 deprecations.append({
-                    'msg': "Param '%s' is deprecated. See the module docs for more information" % (prefix + arg_name),
+                    'msg': "Param '%s' is deprecated. See the module docs for more information" % sub_prefix,
                     'version': arg_opts.get('removed_in_version')
                 })
             # Check sub-argument spec
@@ -142,7 +146,6 @@ def list_deprecations(argument_spec, params, prefix=''):
                 if isinstance(sub_arguments, Mapping):
                     sub_arguments = [sub_arguments]
                 if isinstance(sub_arguments, list):
-                    sub_prefix = "%s%s' -> '" % (prefix, arg_name)
                     for sub_params in sub_arguments:
                         if isinstance(sub_params, Mapping):
                             deprecations.extend(list_deprecations(sub_argument_spec, sub_params, prefix=sub_prefix))

--- a/test/units/module_utils/common/parameters/test_list_deprecations.py
+++ b/test/units/module_utils/common/parameters/test_list_deprecations.py
@@ -22,14 +22,22 @@ def params():
 
 def test_list_deprecations():
     argument_spec = {
-        'old': {'type': 'str', 'removed_in_version': '2.5'}
+        'old': {'type': 'str', 'removed_in_version': '2.5'},
+        'foo': {'type': 'dict', 'options': {'old' = {'type': 'str', 'removed_in_version': 1.0}}},
+        'bar': {'type': 'list', 'elements': 'dict', 'options': {'old' = {'type': 'str', 'removed_in_version': '2.10'}}},
     }
 
     params = {
         'name': 'rod',
         'old': 'option',
+        'foo': {'old': 'value'},
+        'bar': [{'old': 'value'}, {}],
     }
     result = list_deprecations(argument_spec, params)
-    for item in result:
-        assert item['msg'] == "Param 'old' is deprecated. See the module docs for more information"
-        assert item['version'] == '2.5'
+    assert len(result) == 3
+    assert result[0]['msg'] == "Param 'old' is deprecated. See the module docs for more information"
+    assert result[0]['version'] == '2.5'
+    assert result[1]['msg'] == "Param 'foo' -> 'old' is deprecated. See the module docs for more information"
+    assert result[1]['version'] == 1.0
+    assert result[2]['msg'] == "Param 'bar' -> 'old' is deprecated. See the module docs for more information"
+    assert result[2]['version'] == '2.10'

--- a/test/units/module_utils/common/parameters/test_list_deprecations.py
+++ b/test/units/module_utils/common/parameters/test_list_deprecations.py
@@ -23,8 +23,8 @@ def params():
 def test_list_deprecations():
     argument_spec = {
         'old': {'type': 'str', 'removed_in_version': '2.5'},
-        'foo': {'type': 'dict', 'options': {'old' = {'type': 'str', 'removed_in_version': 1.0}}},
-        'bar': {'type': 'list', 'elements': 'dict', 'options': {'old' = {'type': 'str', 'removed_in_version': '2.10'}}},
+        'foo': {'type': 'dict', 'options': {'old': {'type': 'str', 'removed_in_version': 1.0}}},
+        'bar': {'type': 'list', 'elements': 'dict', 'options': {'old': {'type': 'str', 'removed_in_version': '2.10'}}},
     }
 
     params = {
@@ -35,9 +35,10 @@ def test_list_deprecations():
     }
     result = list_deprecations(argument_spec, params)
     assert len(result) == 3
-    assert result[0]['msg'] == "Param 'old' is deprecated. See the module docs for more information"
-    assert result[0]['version'] == '2.5'
+    result.sort(key=lambda entry: entry['msg'])
+    assert result[0]['msg'] == "Param 'bar' -> 'old' is deprecated. See the module docs for more information"
+    assert result[0]['version'] == '2.10'
     assert result[1]['msg'] == "Param 'foo' -> 'old' is deprecated. See the module docs for more information"
     assert result[1]['version'] == 1.0
-    assert result[2]['msg'] == "Param 'bar' -> 'old' is deprecated. See the module docs for more information"
-    assert result[2]['version'] == '2.10'
+    assert result[2]['msg'] == "Param 'old' is deprecated. See the module docs for more information"
+    assert result[2]['version'] == '2.5'

--- a/test/units/module_utils/common/parameters/test_list_deprecations.py
+++ b/test/units/module_utils/common/parameters/test_list_deprecations.py
@@ -36,9 +36,9 @@ def test_list_deprecations():
     result = list_deprecations(argument_spec, params)
     assert len(result) == 3
     result.sort(key=lambda entry: entry['msg'])
-    assert result[0]['msg'] == "Param 'bar' -> 'old' is deprecated. See the module docs for more information"
+    assert result[0]['msg'] == """Param 'bar["old"]' is deprecated. See the module docs for more information"""
     assert result[0]['version'] == '2.10'
-    assert result[1]['msg'] == "Param 'foo' -> 'old' is deprecated. See the module docs for more information"
+    assert result[1]['msg'] == """Param 'foo["old"]' is deprecated. See the module docs for more information"""
     assert result[1]['version'] == 1.0
     assert result[2]['msg'] == "Param 'old' is deprecated. See the module docs for more information"
     assert result[2]['version'] == '2.5'


### PR DESCRIPTION
##### SUMMARY
`removed_in_version` has two bugs:
 1. suboptions are not considered (see https://github.com/ansible/ansible/pull/66837#issuecomment-579837902);
 2. the message is distorted, since the dict `{'msg': xxx, 'version': yyy}` is interpreted as a tuple `msg, version`, which results in `msg == 'msg'` and `version == 'version'`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/common/parameters.py
lib/ansible/module_utils/basic.py
