### PR TITLE
ansible-test - Add 'get' to the list of bad choices for state

### DIFF
--- a/changelogs/fragments/66921-sanity-state-get.yaml
+++ b/changelogs/fragments/66921-sanity-state-get.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - 'ansible-test - Add a test to prevent ``state=get``'

--- a/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
@@ -16,7 +16,7 @@ Scoping your module(s)
 Especially if you want to contribute your module(s) back to Ansible Core, make sure each module includes enough logic and functionality, but not too much. If you're finding these guidelines tricky, consider :ref:`whether you really need to write a module <module_dev_should_you>` at all.
 
 * Each module should have a concise and well-defined functionality. Basically, follow the UNIX philosophy of doing one thing well.
-* Do not add ``list`` or ``info`` state options to an existing module - create a new ``_info`` or ``_facts`` module.
+* Do not add ``get``, ``list`` or ``info`` state options to an existing module - create a new ``_info`` or ``_facts`` module.
 * Modules should not require that a user know all the underlying options of an API/tool to be used. For instance, if the legal values for a required module parameter cannot be documented, the module does not belong in Ansible Core.
 * Modules should encompass much of the logic for interacting with a resource. A lightweight wrapper around a complex API forces users to offload too much logic into their playbooks. If you want to connect Ansible to a complex API, :ref:`create multiple modules <developing_modules_in_groups>` that interact with smaller individual pieces of the API.
 * Avoid creating a module that does the work of other modules; this leads to code duplication and divergence, and makes things less uniform, unpredictable and harder to maintain. Modules should be the building blocks. If you are asking 'how can I have a module execute other modules' ... you want to write a role.

--- a/docs/docsite/rst/dev_guide/testing_validate-modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_validate-modules.rst
@@ -126,7 +126,7 @@ Codes
   parameter-alias-self                                         Parameters           Error                  argument in argument_spec is specified as its own alias
   parameter-documented-multiple-times                          Documentation        Error                  argument in argument_spec with aliases is documented multiple times
   parameter-list-no-elements                                   Parameters           Error                  argument in argument_spec "type" is specified as ``list`` without defining "elements"
-  parameter-state-invalid-choice                               Parameters           Error                  Argument ``state`` includes ``list`` or ``info`` as a choice.  Functionality should be in an ``_info`` or (if further conditions apply) ``_facts`` module.
+  parameter-state-invalid-choice                               Parameters           Error                  Argument ``state`` includes ``get``, ``list`` or ``info`` as a choice.  Functionality should be in an ``_info`` or (if further conditions apply) ``_facts`` module.
   python-syntax-error                                          Syntax               Error                  Python ``SyntaxError`` while parsing module
   return-syntax-error                                          Documentation        Error                  ``RETURN`` is not valid YAML, ``RETURN`` fragments missing  or invalid
   subdirectory-missing-init                                    Naming               Error                  Ansible module subdirectories must contain an ``__init__.py``

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -1213,7 +1213,7 @@ class ModuleValidator(Validator):
                     msg=msg
                 )
             if not context and arg == 'state':
-                bad_states = set(['list', 'info']) & set(data.get('choices', set()))
+                bad_states = set(['list', 'info', 'get']) & set(data.get('choices', set()))
                 for bad_state in bad_states:
                     self.reporter.error(
                         path=self.object_path,

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -650,6 +650,7 @@ lib/ansible/modules/cloud/amazon/redshift.py validate-modules:parameter-list-no-
 lib/ansible/modules/cloud/amazon/redshift_subnet_group.py validate-modules:doc-elements-mismatch
 lib/ansible/modules/cloud/amazon/redshift_subnet_group.py validate-modules:parameter-list-no-elements
 lib/ansible/modules/cloud/amazon/route53.py validate-modules:parameter-list-no-elements
+lib/ansible/modules/cloud/amazon/route53.py validate-modules:parameter-state-invalid-choice
 lib/ansible/modules/cloud/amazon/route53_info.py validate-modules:doc-elements-mismatch
 lib/ansible/modules/cloud/amazon/route53_info.py validate-modules:parameter-list-no-elements
 lib/ansible/modules/cloud/amazon/s3_bucket_notification.py validate-modules:doc-elements-mismatch
@@ -7389,6 +7390,7 @@ lib/ansible/modules/system/dconf.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/system/filesystem.py pylint:blacklisted-name
 lib/ansible/modules/system/filesystem.py validate-modules:doc-missing-type
 lib/ansible/modules/system/gconftool2.py pylint:blacklisted-name
+lib/ansible/modules/system/gconftool2.py validate-modules:parameter-state-invalid-choice
 lib/ansible/modules/system/gconftool2.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/system/getent.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/system/hostname.py validate-modules:invalid-ansiblemodule-schema
@@ -7462,6 +7464,7 @@ lib/ansible/modules/system/user.py validate-modules:doc-default-incompatible-typ
 lib/ansible/modules/system/user.py validate-modules:parameter-list-no-elements
 lib/ansible/modules/system/user.py validate-modules:use-run-command-not-popen
 lib/ansible/modules/system/vdo.py validate-modules:doc-required-mismatch
+lib/ansible/modules/system/xfconf.py validate-modules:parameter-state-invalid-choice
 lib/ansible/modules/system/xfconf.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/utilities/logic/async_status.py use-argspec-type-path
 lib/ansible/modules/utilities/logic/async_status.py validate-modules!skip


### PR DESCRIPTION
##### SUMMARY

(Originally suggested by @felixfontein on #66898)
Adds 'get' to the list of states that will generate a sanity test failure.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
ansible-test

##### ADDITIONAL INFORMATION

Follow up to #66898 after an IRC discussion.

> mattclay> tremble: Adding get to the list seems like a good idea.
> jtanner> not a fan of verbs as states
> bcoca> hate verbs as states