### PR TITLE
pmrun.py: Recreate the older behavior where the entire success command was quoted

### DIFF
--- a/changelogs/fragments/66929-pmrun-quote-entire-success-command-string.yml
+++ b/changelogs/fragments/66929-pmrun-quote-entire-success-command-string.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pmrun plugin - The success_command string was no longer quoted. This caused unusual use-cases like ``become_flags=su - root -c`` to fail.

--- a/changelogs/fragments/66929-pmrun-quote-entire-success-string.yml
+++ b/changelogs/fragments/66929-pmrun-quote-entire-success-string.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - pmrun plugin - The success string was no longer quoted. This caused unusual use-cases like ``become_flags=su - root -c`` to fail.

--- a/changelogs/fragments/66929-pmrun-quote-entire-success-string.yml
+++ b/changelogs/fragments/66929-pmrun-quote-entire-success-string.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pmrun plugin - The success string was no longer quoted. This caused unusual use-cases like ``become_flags=su - root -c`` to fail.

--- a/lib/ansible/plugins/become/pmrun.py
+++ b/lib/ansible/plugins/become/pmrun.py
@@ -72,4 +72,4 @@ class BecomeModule(BecomeBase):
 
         become = self.get_option('become_exe') or self.name
         flags = self.get_option('become_flags') or ''
-        return '%s %s %s' % (become, flags, self._build_success_command(cmd, shell))
+        return '%s %s \'%s\'' % (become, flags, self._build_success_command(cmd, shell))

--- a/lib/ansible/plugins/become/pmrun.py
+++ b/lib/ansible/plugins/become/pmrun.py
@@ -57,6 +57,7 @@ DOCUMENTATION = """
 """
 
 from ansible.plugins.become import BecomeBase
+from ansible.module_utils.six.moves import shlex_quote
 
 
 class BecomeModule(BecomeBase):
@@ -72,4 +73,4 @@ class BecomeModule(BecomeBase):
 
         become = self.get_option('become_exe') or self.name
         flags = self.get_option('become_flags') or ''
-        return '%s %s \'%s\'' % (become, flags, self._build_success_command(cmd, shell))
+        return '%s %s %s' % (become, flags, shlex_quote(self._build_success_command(cmd, shell)))


### PR DESCRIPTION
##### SUMMARY
Adds a set of quotes around the entire success command. This was the behaviour back in the 2.7.x days. Have a client using pmrun that is blocked from upgrading to current ansible by this. 

The original change that removed the "extra" quotes caused a regression. I don't see how adding these back in would break anything for the few pmrun users out there. 

I'm setting this as a bugfix as it is a regression for an actual user of this plugin, but if that isn't appropriate please let me know.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
pmrun.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before Change:
```
SSH: EXEC sshpass -d9 ssh -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o 'User="svcansible"' -o ConnectTimeout=10 -o ControlPath=/root/.ansible/cp/0e4ca94f55 -tt host.example.com '/bin/sh -c '"'"'pmrun su - root -c /bin/sh -c '"'"'"'"'"'"'"'"'echo BECOME-SUCCESS-shuzxrrmarpilrelhdqileldxrzurzoi ; /usr/bin/python /export/home/svcansible/.ansible/tmp/ansible-tmp-1580344076.66-265998120001699/AnsiballZ_ping.py'"'"'"'"'"'"'"'"' && sleep 0'"'"''
```
After Change:
```
SSH: EXEC sshpass -d9 ssh -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o 'User="svcansible"' -o ConnectTimeout=10 -o ControlPath=/home/allensmi/.ansible/cp/0e4ca94f55 -tt host.example.com '/bin/sh -c '"'"'pmrun su - root -c  '"'"'"'"'"'"'"'"'/bin/sh -c '"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'echo BECOME-SUCCESS-wgsjpfenagisqjuuerrlvkhktnbtllmt ; /usr/bin/python /export/home/svcansible/.ansible/tmp/ansible-tmp-1580369890.14-92289213217361/AnsiballZ_ping.py'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"''"'"'"'"'"'"'"'"' && sleep 0'"'"''
```

2.7.x behaviour:
```
SSH: EXEC sshpass -d7 ssh -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o User=svcansible -o ConnectTimeout=10 -o ControlPath=/root/.ansible/cp/0e4ca94f55 -tt host.example.com '/bin/sh -c '"'"'pmrun su - root -c '"'"'"'"'"'"'"'"'/bin/sh -c '"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'echo BECOME-SUCCESS-rwtwnphglvcmsupmuvemzcxcnzrohpfr; /usr/bin/python /export/home/svcansible/.ansible/tmp/ansible-tmp-1580343509.65-25583205775894/AnsiballZ_ping.py'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"''"'"'"'"'"'"'"'"' && sleep 0'"'"''
```