### PR TITLE
When no pool quantity is set, then do not set quantity to 1 (#66807)

### DIFF
--- a/changelogs/fragments/66807-redhat_subscription-no-default-quantity.yaml
+++ b/changelogs/fragments/66807-redhat_subscription-no-default-quantity.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - redhat_subscription - do not set the default quantity to ``1`` when no quantity is provided (https://github.com/ansible/ansible/issues/66478)

--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -515,7 +515,9 @@ class Rhsm(RegistrationBase):
 
         for pool_id, quantity in sorted(pool_ids.items()):
             if pool_id in available_pool_ids:
-                args = [SUBMAN_CMD, 'attach', '--pool', pool_id, '--quantity', quantity]
+                args = [SUBMAN_CMD, 'attach', '--pool', pool_id]
+                if quantity is not None:
+                    args.extend(['--quantity', to_native(quantity)])
                 rc, stderr, stdout = self.module.run_command(args, check_rc=True)
             else:
                 self.module.fail_json(msg='Pool ID: %s not in list of available pools' % pool_id)
@@ -839,8 +841,8 @@ def main():
                 module.fail_json(msg='Unable to parse pool_ids option.')
             pool_id, quantity = list(value.items())[0]
         else:
-            pool_id, quantity = value, 1
-        pool_ids[pool_id] = str(quantity)
+            pool_id, quantity = value, None
+        pool_ids[pool_id] = quantity
     consumer_type = module.params["consumer_type"]
     consumer_name = module.params["consumer_name"]
     consumer_id = module.params["consumer_id"]

--- a/test/units/modules/packaging/os/test_redhat_subscription.py
+++ b/test/units/modules/packaging/os/test_redhat_subscription.py
@@ -557,8 +557,7 @@ Entitlement Type:    Physical
                     [
                         '/testbin/subscription-manager',
                         'attach',
-                        '--pool', 'ff8080816b8e967f016b8e99632804a6',
-                        '--quantity', '1'
+                        '--pool', 'ff8080816b8e967f016b8e99632804a6'
                     ],
                     {'check_rc': True},
                     (0, '', '')
@@ -567,8 +566,7 @@ Entitlement Type:    Physical
                     [
                         '/testbin/subscription-manager',
                         'attach',
-                        '--pool', 'ff8080816b8e967f016b8e99747107e9',
-                        '--quantity', '1'
+                        '--pool', 'ff8080816b8e967f016b8e99747107e9'
                     ],
                     {'check_rc': True},
                     (0, '', '')
@@ -658,7 +656,6 @@ Entitlement Type:    Physical
                         '/testbin/subscription-manager',
                         'attach',
                         '--pool', 'ff8080816b8e967f016b8e99632804a6',
-                        '--quantity', '1'
                     ],
                     {'check_rc': True},
                     (0, '', '')


### PR DESCRIPTION
##### SUMMARY
* Fixes #66478
* When no quantity is set, then candlepin server usually uses
   default value 1. When more quantities are required, then
   candlepin server can automatically choose correct minimal
   value.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
redhat_subscribtion

##### ADDITIONAL INFORMATION
- cherry picked from commit 6f1bb37feb81acd99157f5ba0933fecd747015a2
