### PR TITLE
Group ids are strings now

### DIFF
--- a/lib/ansible/modules/remote_management/manageiq/manageiq_group.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_group.py
@@ -330,7 +330,7 @@ class ManageIQgroup(object):
 
         return dict(
             changed=True,
-            msg="deleted group %s with id %i" % (group['description'], group['id']))
+            msg="deleted group %s with id %s" % (group['description'], group['id']))
 
     def edit_group(self, group, description, role, tenant, norm_managed_filters, managed_filters_merge_mode,
                    belongsto_filters, belongsto_filters_merge_mode):


### PR DESCRIPTION
##### SUMMARY
BugFix removing group from manageiq. Fixes the following error when removing an existing group from manageiq:
```
/ansible_manageiq_group_payload.zip/ansible/modules/manageiq_group.py\", line 611, in main\n  File \"/tmp/ansible_manageiq_group_payload_jaf95mih/ansible_manageiq_group_payload.zip/ansible/modules/manageiq_group.py\", line 333, in delete_group\nTypeError: %i format: a number is required, not str\n" 
```
 
##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
manageiq_group

##### ADDITIONAL INFORMATION
none