### PR TITLE
Bug: Openstack router: could not update router when project is provided

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_router.py
+++ b/lib/ansible/modules/cloud/openstack/os_router.py
@@ -240,7 +240,7 @@ def _needs_update(cloud, module, router, network, internal_subnet_ids, internal_
     # check external interfaces
     if module.params['external_fixed_ips']:
         for new_iface in module.params['external_fixed_ips']:
-            subnet = cloud.get_subnet(new_iface['subnet'], filters)
+            subnet = cloud.get_subnet(new_iface['subnet'])
             exists = False
 
             # compare the requested interface with existing, looking for an existing match


### PR DESCRIPTION
##### BUG when updating openstack router

When the project is provided in the arguments of the module and the subnet of the external_fixed_ips belong to another project, the router can be created but update crash.
There is a difference between creating and updating a router:
* **if the router does not exists**, the subnet of `external_fixed_ips` **is found** because the method `get_subnet` is not filtered with `tenant_id`
* **if the router exists**, the subnet of `external_fixed_ips` **is not found** because `get_subnet` is filtered with `tenant_id`
 
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
* module cloud/opentack/os_router

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
