### PR TITLE
Bump minimum openstacksdk version for openstack modules

### DIFF
--- a/changelogs/fragments/64495-bump-min-openstacksdk.yml
+++ b/changelogs/fragments/64495-bump-min-openstacksdk.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - openstack modules - bump the minimum openstacksdk version
+    to support the dns_domain parameter added to os_network

--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -108,7 +108,7 @@ def openstack_module_kwargs(**kwargs):
     return ret
 
 
-def openstack_cloud_from_module(module, min_version='0.12.0'):
+def openstack_cloud_from_module(module, min_version='0.29.0'):
     from distutils.version import StrictVersion
     try:
         # Due to the name shadowing we should import other way
@@ -119,9 +119,9 @@ def openstack_cloud_from_module(module, min_version='0.12.0'):
         module.fail_json(msg='openstacksdk is required for this module')
 
     if min_version:
-        min_version = max(StrictVersion('0.12.0'), StrictVersion(min_version))
+        min_version = max(StrictVersion('0.29.0'), StrictVersion(min_version))
     else:
-        min_version = StrictVersion('0.12.0')
+        min_version = StrictVersion('0.29.0')
 
     if StrictVersion(sdk_version.__version__) < min_version:
         module.fail_json(

--- a/lib/ansible/plugins/doc_fragments/openstack.py
+++ b/lib/ansible/plugins/doc_fragments/openstack.py
@@ -88,7 +88,7 @@ options:
     version_added: "2.3"
 requirements:
   - python >= 2.7
-  - openstacksdk >= 0.12.0
+  - openstacksdk >= 0.29.0
 notes:
   - The standard OpenStack environment variables, such as C(OS_USERNAME)
     may be used instead of providing explicit values.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
With the addition of [a], the minimum openstacksdk version needs to
be bumped to include [b], or the os_network module will return the
error:

TypeError: create_network() got an unexpected keyword argument 'dns_domain'

[a] https://github.com/ansible/ansible/commit/6c74e29618a6872bc0da66e4992cfcd9cebf6acc
[b] https://github.com/openstack/openstacksdk/commit/a3e846e2b9301f4ae725e97b21b4313bfcc81d10
Fixes: #64495
Fixes: #64841
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/cloud/openstack/os_network.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
