### PR TITLE
Bump minimum openstacksdk version when using os_network/dns_domain

### DIFF
--- a/changelogs/fragments/64495-os_network-openstacksdk-min.yml
+++ b/changelogs/fragments/64495-os_network-openstacksdk-min.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - bump the minimum openstacksdk version when os_network
+    uses the dns_domain argument


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
With the addition of [a], the minimum openstacksdk version needs to
be bumped to include [b], or the os_network module will return the
error:

TypeError: create_network() got an unexpected keyword argument 'dns_domain'

To handle this, we fail the module if the dns_domain argument is used
and the minimum openstacksdk version for that argument is not met.

[a] https://github.com/ansible/ansible/commit/6c74e29618a6872bc0da66e4992cfcd9cebf6acc
[b] https://github.com/openstack/openstacksdk/commit/a3e846e2b9301f4ae725e97b21b4313bfcc81d10

Fixes: #64495
Fixes: #64841
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/cloud/openstack/os_network.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
