### PR TITLE
Added -LogPath param from Install-ADDSForest to win_domain module

### DIFF
--- a/lib/ansible/modules/windows/win_domain.ps1
+++ b/lib/ansible/modules/windows/win_domain.ps1
@@ -31,6 +31,7 @@ $domain_netbios_name = Get-AnsibleParam -obj $params -name "domain_netbios_name"
 $safe_mode_admin_password = Get-AnsibleParam -obj $params -name "safe_mode_password" -failifempty $true
 $database_path = Get-AnsibleParam -obj $params -name "database_path" -type "path"
 $sysvol_path = Get-AnsibleParam -obj $params -name "sysvol_path" -type "path"
+$log_path = Get-AnsibleParam -obj $params -name "log_path" -type "path"
 $create_dns_delegation = Get-AnsibleParam -obj $params -name "create_dns_delegation" -type "bool"
 $domain_mode = Get-AnsibleParam -obj $params -name "domain_mode" -type "str"
 $forest_mode = Get-AnsibleParam -obj $params -name "forest_mode" -type "str"
@@ -101,6 +102,10 @@ if (-not $forest) {
 
     if ($sysvol_path) {
         $install_params.SysvolPath = $sysvol_path
+    }
+    
+    if ($log_path) {
+        $install_params.LogPath = $log_path
     }
 
     if ($domain_netbios_name) {

--- a/lib/ansible/modules/windows/win_domain.ps1
+++ b/lib/ansible/modules/windows/win_domain.ps1
@@ -103,7 +103,7 @@ if (-not $forest) {
     if ($sysvol_path) {
         $install_params.SysvolPath = $sysvol_path
     }
-    
+
     if ($log_path) {
         $install_params.LogPath = $log_path
     }

--- a/lib/ansible/modules/windows/win_domain.py
+++ b/lib/ansible/modules/windows/win_domain.py
@@ -41,6 +41,12 @@ options:
     - If not set then the default path is C(%SYSTEMROOT%\NTDS).
     type: path
     version_added: '2.5'
+  log_path:
+    description:
+    - Specifies the fully qualified, non-UNC path to a directory on a fixed disk of the local computer where the log file for this operation is written.
+    - If not set then the default path is C(%SYSTEMROOT%\NTDS).
+    type: path
+    version_added: '2.10'
   sysvol_path:
     description:
     - The path to a directory on a fixed disk of the Windows host where the


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Logpath is currently omitted from the win_domain module despite being a valid parameter in powershell. We cannot use this module currently due to this issue.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_domain
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Install-ADDSForest: https://docs.microsoft.com/en-us/powershell/module/addsdeployment/install-addsforest?view=win10-ps
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
