### PR TITLE
fix(scaleway): use jsonify for application/json content-type only

### DIFF
--- a/changelogs/fragments/66957-scaleway-jsonify-only-for-json-requests.yml
+++ b/changelogs/fragments/66957-scaleway-jsonify-only-for-json-requests.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- 'scaleway: use jsonify unmarshaller only for application/json requests to avoid breaking the multiline configuration with requests in text/plain (https://github.com/ansible/ansible/issues/65036)'

--- a/lib/ansible/module_utils/scaleway.py
+++ b/lib/ansible/module_utils/scaleway.py
@@ -118,10 +118,12 @@ class Scaleway(object):
     def send(self, method, path, data=None, headers=None, params=None):
         url = self._url_builder(path=path, params=params)
         self.warn(url)
-        data = self.module.jsonify(data)
 
         if headers is not None:
             self.headers.update(headers)
+
+        if self.headers['Content-Type'] == "application/json":
+            data = self.module.jsonify(data)
 
         resp, info = fetch_url(
             self.module, url, data=data, headers=self.headers, method=method,


### PR DESCRIPTION
##### SUMMARY
by default, the data is not modified and is sent as specified unless the content type is application / json.

Fixes #65036

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/module_utils/scaleway.py`

##### ADDITIONAL INFORMATION
I'm using the [scaleway_user_data](https://docs.ansible.com/ansible/latest/modules/scaleway_user_data_module.html) module, but i can't passed a multi-line configuration, because it's convert to json format.

##### EXPECTED RESULT
```
$ curl -XGET -H "X-Auth-Token: $SCW_SECRET_TOKEN" https://cp-par1.scaleway.com/servers/$SCW_SERVER_ID/user_data/cloud-init

#cloud-config
apt_update: true
write_files:
- path: /etc/ssh/sshd_config
  content: |
    Port 55555
    Protocol 2
    PasswordAuthentication no
    ChallengeResponseAuthentication no
    UsePAM no
    X11Forwarding yes
    PrintMotd no
    AcceptEnv LANG LC_*
    Subsystem	sftp	/usr/lib/openssh/sftp-server
```

##### STEPS TO REPRODUCE
Task:
```
  - name: set cloud-init user-data
    scaleway_user_data:
      api_url: "https://api.scaleway.com/instance/v1/zones/fr-par-1"
      api_token: "{{ lookup('env','SCW_SECRET_KEY') }}"
      server_id: "{{ lookup('env','SCW_SERVER_ID') }}"
      region: "par1"
      user_data:
        cloud-init: |
          #cloud-config
          apt_update: true
          write_files:
          - path: /etc/ssh/sshd_config
            content: |
              Port 2222
              Protocol 2
              PasswordAuthentication no
              ChallengeResponseAuthentication no
              UsePAM no
              X11Forwarding yes
              PrintMotd no
              AcceptEnv LANG LC_*
              Subsystem	sftp	/usr/lib/openssh/sftp-server
          runcmd:
          - systemctl restart sshd
```

Unexpected result:
```
$ curl -XGET -H "X-Auth-Token: $SCW_SECRET_TOKEN" https://cp-par1.scaleway.com/servers/$SCW_SERVER_ID/user_data/cloud-init

"#cloud-config\napt_update: true\nwrite_files:\n- path: /etc/ssh/sshd_config\n  content: |\n    Port 55555\n    Protocol 2\n    PasswordAuthentication no\n    ChallengeResponseAuthentication no\n    UsePAM no ..."
```

Cloud-init not worked:
```
2020-01-30 11:02:49,625 - __init__.py[WARNING]: Unhandled non-multipart (text/x-not-multipart) userdata: 'b'"#cloud-config\\\\napt_upda'...'
```