### PR TITLE
Minor AWS argument checks  (required_if / mutually_exclusive) fixups

### DIFF
--- a/changelogs/fragments/66966-ec2-group-and-group_id.yml
+++ b/changelogs/fragments/66966-ec2-group-and-group_id.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- 'ec2: deprecate allowing both group and group_id - currently we ignore group_id if both are passed.'

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -79,6 +79,7 @@ The following functionality will change in Ansible 2.14. Please update update yo
 
 * The :ref:`docker_container <docker_container_module>` module has a new option, ``container_default_behavior``, whose default value will change from ``compatibility`` to ``no_defaults``. Set to an explicit value to avoid deprecation warnings.
 * The :ref:`docker_container <docker_container_module>` module's ``network_mode`` option will be set by default to the name of the first network in ``networks`` if at least one network is given and ``networks_cli_compatible`` is ``true`` (will be default from Ansible 2.12 on). Set to an explicit value to avoid deprecation warnings if you specify networks and set ``networks_cli_compatible`` to ``true``. The current default (not specifying it) is equivalent to the value ``default``.
+* :ref:`ec2 <ec2_module>`: the ``group`` and ``group_id`` options will become mutually exclusive.  Currently ``group_id`` is ignored if you pass both.
 * :ref:`iam_policy <iam_policy_module>`: the default value for the ``skip_duplicates`` option will change from ``true`` to ``false``.  To maintain the existing behavior explicitly set it to ``true``.
 * :ref:`iam_role <iam_role_module>`: the ``purge_policies`` option (also know as ``purge_policy``) default value will change from ``true`` to ``false``
 * :ref:`elb_network_lb <elb_network_lb_module>`: the default behaviour for the ``state`` option will change from ``absent`` to ``present``.  To maintain the existing behavior explicitly set state to ``absent``.

--- a/lib/ansible/modules/cloud/amazon/aws_netapp_cvs_snapshots.py
+++ b/lib/ansible/modules/cloud/amazon/aws_netapp_cvs_snapshots.py
@@ -126,7 +126,7 @@ class AwsCvsNetappSnapshot(object):
         self.module = AnsibleModule(
             argument_spec=self.argument_spec,
             required_if=[
-                ('state', 'present', ['state', 'name', 'fileSystemId']),
+                ('state', 'present', ['name', 'fileSystemId']),
             ],
             supports_check_mode=True
         )

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -1672,7 +1672,8 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         mutually_exclusive=[
-            ['group_name', 'group_id'],
+            # Can be uncommented when we finish the deprecation cycle.
+            # ['group', 'group_id'],
             ['exact_count', 'count'],
             ['exact_count', 'state'],
             ['exact_count', 'instance_ids'],
@@ -1683,6 +1684,12 @@ def main():
             ['network_interfaces', 'vpc_subnet_id'],
         ],
     )
+
+    if module.params.get('group') and module.params.get('group_id'):
+        module.deprecate(
+            msg='Support for passing both group and group_id has been deprecated. '
+            'Currently group_id is ignored, in future passing both will result in an error',
+            version='2.14')
 
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')

--- a/lib/ansible/modules/cloud/amazon/rds_instance.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance.py
@@ -325,7 +325,9 @@ options:
     restore_time:
         description:
           - If using I(creation_source=instance) this indicates the UTC date and time to restore from the source instance.
-            For example, "2009-09-07T23:45:00Z". May alternatively set C(use_latest_restore_time) to True.
+            For example, "2009-09-07T23:45:00Z".
+          - May alternatively set I(use_latest_restore_time=True).
+          - Only one of I(use_latest_restorable_time) and I(restore_time) may be provided.
         type: str
     s3_bucket_name:
         description:
@@ -406,8 +408,8 @@ options:
         type: str
     use_latest_restorable_time:
         description:
-          - Whether to restore the DB instance to the latest restorable backup time. Only one of I(use_latest_restorable_time)
-            and I(restore_to_time) may be provided.
+          - Whether to restore the DB instance to the latest restorable backup time.
+          - Only one of I(use_latest_restorable_time) and I(restore_time) may be provided.
         type: bool
         aliases:
           - restore_from_latest
@@ -1153,7 +1155,7 @@ def main():
     ]
     mutually_exclusive = [
         ('s3_bucket_name', 'source_db_instance_identifier', 'snapshot_identifier'),
-        ('use_latest_restorable_time', 'restore_to_time'),
+        ('use_latest_restorable_time', 'restore_time'),
         ('availability_zone', 'multi_az'),
     ]
 


### PR DESCRIPTION
##### SUMMARY

#66961 picked up on some minor mistakes in the module argument checks.  This fixes them

- aws_netapp_cvs_snapshots : required_if required 'state' to be set if state was set
- ec2 : allowed both group and group_id (but would ignore group_id if group was set)
- rds_instance : allowed both restore_time and use_latest_restorable_time (which would cause a boto3 error)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

aws_netapp_cvs_snapshots
ec2
rds_instance

##### ADDITIONAL INFORMATION