### PR TITLE
vcenter_folder use same parent folder selection

### DIFF
--- a/test/integration/targets/vcenter_folder/tasks/main.yml
+++ b/test/integration/targets/vcenter_folder/tasks/main.yml
@@ -113,6 +113,15 @@
     - datastore
     - network
 
+- debug:
+    msg: "{{ all_folder_results }}"
+
+- name: ensure everything for {{ dc1 }}
+  assert:
+    that:
+        - all_folder_results.changed
+        - not recreate_folders.changed
+
 - name: Create a 3rd level of directory
   vcenter_folder:
     hostname: "{{ vcenter_hostname }}"
@@ -124,23 +133,60 @@
     parent_folder: vm_folder/sub_vm_folder
     state: present
   register: yet_another_level
-- debug: var=yet_another_level
-
 
 - debug:
-    msg: "{{ all_folder_results }}"
+    var: yet_another_level
 
-- name: ensure everything for {{ dc1 }}
+- name: ensure 3e level of directory was created
   assert:
     that:
-        - all_folder_results.changed
-        - not recreate_folders.changed
+      - yet_another_level.changed
 
 ## Testcase: Delete all types of folder
 #
 # Doesn't work with vcsim. Looks like UnregisterAndDestroy isn't supported.
 - when: vcsim is not defined
   block:
+  - name: Delete 3rd level of directory
+    vcenter_folder:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: no
+      datacenter: "{{ dc1 }}"
+      folder_name: yet_another_level
+      parent_folder: vm_folder/sub_vm_folder
+      state: absent
+    register: yet_another_level
+
+  - debug:
+      var: yet_another_level
+
+  - name: ensure 3e level of directory was removed
+    assert:
+      that:
+        - yet_another_level.changed
+
+  - name: Delete 3rd level of directory again
+    vcenter_folder:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: no
+      datacenter: "{{ dc1 }}"
+      folder_name: yet_another_level
+      parent_folder: vm_folder/sub_vm_folder
+      state: absent
+    register: yet_another_level
+
+  - debug:
+      var: yet_another_level
+
+  - name: ensure 3e level of directory was already removed
+    assert:
+      that:
+        - not yet_another_level.changed
+
   - name: Delete all types of folder
     vcenter_folder:
       hostname: "{{ vcenter_hostname }}"


### PR DESCRIPTION
##### SUMMARY
A different parent folder selection is used for state absent and for state present. The state present allow specify a full path for the folder for a better folder selection. This method is reused for folder removal. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
Bugfix Pull Request

##### COMPONENT NAME
vcenter_folder

##### ADDITIONAL INFORMATION
Before when calling the module with
```
...
"parent_folder": "Tenants/DI9",
"folder_type": "vm",
"state": "absent",
...
```
would result in 
```
    "msg": "Parent folder Tenants/DI9 does not exist",
```

This is now fixed of the parent folder `Tenants/DI9` does exist 
