### PR TITLE
Update yarn.py

### DIFF
--- a/lib/ansible/modules/packaging/language/yarn.py
+++ b/lib/ansible/modules/packaging/language/yarn.py
@@ -29,6 +29,7 @@ options:
     description:
       - The name of a node.js library to install
       - If omitted all packages in package.json are installed.
+      - To globally install from local node.js library. Prepend "file:" to the path of the node.js library.
     required: false
   path:
     description:


### PR DESCRIPTION
##### SUMMARY
There was no example of how to globally install a local node_module.

>"To globally install from local node.js library. Prepend "file:" to the path of the node.js library."


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr