### PR TITLE
Foreman inventory script parent groups

### DIFF
--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -56,7 +56,7 @@ def json_format_dict(data, pretty=False):
 class ForemanInventory(object):
 
     def __init__(self):
-        self.inventory = defaultdict(dict) # A dictionary of groups and the hosts in that group
+        self.inventory = defaultdict(dict)   # A dictionary of groups and the hosts in that group
         self.cache = dict()   # Details about hosts in the inventory
         self.params = dict()  # Params of each host
         self.facts = dict()   # Facts of each host
@@ -498,11 +498,11 @@ class ForemanInventory(object):
         Makes sure non-existing keys are created as needed
         """
 
-        if not group_name in self.inventory.keys():
+        if group_name not in self.inventory.keys():
             self.inventory[group_name] = {item_type: [group_item]}
-        elif not item_type in self.inventory[group_name].keys():
+        elif item_type not in self.inventory[group_name].keys():
             self.inventory[group_name][item_type] = [group_item]
-        elif not group_item in self.inventory[group_name][item_type]:
+        elif group_item not in self.inventory[group_name][item_type]:
             self.inventory[group_name][item_type].append(group_item)
 
     def _update_cache_hostgroup_api(self):
@@ -533,8 +533,10 @@ class ForemanInventory(object):
                     to_text(parent_group_name).lower(),
                 ))
                 # Add inventory entry indicating parent-child relation
-                self._inventory_add_group_item(ansible_parent_group_name, \
-                    ansible_group_name, 'children')
+                self._inventory_add_group_item(
+                    ansible_parent_group_name,
+                    ansible_group_name, 'children'
+                )
 
     def _update_cache_host_api(self, scan_only_new_hosts):
         """Make calls to foreman and save the output in a cache"""

--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -70,6 +70,7 @@ class ForemanInventory(object):
         env_value = os.environ.get('FOREMAN_INI_PATH')
         if env_value is not None:
             self.config_paths.append(os.path.expanduser(os.path.expandvars(env_value)))
+        self.hostgroup_label = 'hostgroup'
 
     def read_settings(self):
         """Reads the settings from the foreman.ini file"""
@@ -489,12 +490,12 @@ class ForemanInventory(object):
             host_params = host_data.get('all_parameters', {})
 
             # Create ansible groups for hostgroup
-            group = 'hostgroup'
-            val = host.get('%s_title' % group) or host.get('%s_name' % group)
+            val = host.get('%s_title' % self.hostgroup_label) or \
+                host.get('%s_name' % self.hostgroup_label)
             if val:
                 safe_key = self.to_safe('%s%s_%s' % (
                     to_text(self.group_prefix),
-                    group,
+                    self.hostgroup_label,
                     to_text(val).lower()
                 ))
                 self.inventory[safe_key].append(dns_name)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Enable the foreman inventory script to send hostgroup parent-child relationships to ansible.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
foreman_inventory_script

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The current version of foreman.py generates host/hostgroup ownership info in JSON format like this:

`group_name: [ hostname1, hostname2, hostnameX ]`

This is supported by ansible, but It does not generate parent-children hostgroup relationships. Ansible expects this information in the following format:

```
group_name: {
    hosts: [ hostname1, hostname2, hostnameX ]
    children: [ child_group ]
}
```

This is problematic, because then ansible cannot inherit variable values from parent groups, requiring the user to keep multiple copies of the same variables in many groups.

This change fixes that. To support the more elaborate ansible format, the internal inventory was changed to be a list of hashes instead of a list of lists, and a new function was introduced (_inventory_add_group_item) which facilitates adding items to the inventory in the correct group (hosts or children).

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
