### PR TITLE
AnsibleAWSModule add 'region' method

### DIFF
--- a/changelogs/fragments/66988-ansibleawsmodule-region.yaml
+++ b/changelogs/fragments/66988-ansibleawsmodule-region.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- 'AnsibleAWSModule - Add a helper (region) so that modules which migrate to using module.client() can still access the region information'

--- a/lib/ansible/module_utils/aws/core.py
+++ b/lib/ansible/module_utils/aws/core.py
@@ -75,7 +75,8 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_native
-from ansible.module_utils.ec2 import HAS_BOTO3, camel_dict_to_snake_dict, ec2_argument_spec, boto3_conn, get_aws_connection_info
+from ansible.module_utils.ec2 import HAS_BOTO3, camel_dict_to_snake_dict, ec2_argument_spec, boto3_conn
+from ansible.module_utils.ec2 import get_aws_connection_info, get_aws_region
 
 # We will also export HAS_BOTO3 so end user modules can use it.
 __all__ = ('AnsibleAWSModule', 'HAS_BOTO3', 'is_boto3_error_code')
@@ -188,6 +189,10 @@ class AnsibleAWSModule(object):
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(self, boto3=True)
         return boto3_conn(self, conn_type='resource', resource=service,
                           region=region, endpoint=ec2_url, **aws_connect_kwargs)
+
+    @property
+    def region(self, boto3=True):
+        return get_aws_region(self, boto3)
 
     def fail_json_aws(self, exception, msg=None):
         """call fail_json with processed exception

--- a/lib/ansible/modules/cloud/amazon/ec2_vol_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vol_info.py
@@ -67,7 +67,7 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import AWSRetry, get_aws_connection_info
+from ansible.module_utils.ec2 import AWSRetry
 from ansible.module_utils.ec2 import boto3_tag_list_to_ansible_dict, ansible_dict_to_boto3_filter_list, camel_dict_to_snake_dict
 
 
@@ -119,12 +119,9 @@ def list_ec2_volumes(connection, module):
     except ClientError as e:
         module.fail_json_aws(e, msg="Failed to describe volumes.")
 
-    # We add region to the volume info so we need it here
-    region = get_aws_connection_info(module, boto3=True)[0]
-
     for volume in all_volumes["Volumes"]:
         volume = camel_dict_to_snake_dict(volume, ignore_list=['Tags'])
-        volume_dict_array.append(get_volume_info(volume, region))
+        volume_dict_array.append(get_volume_info(volume, module.region))
     module.exit_json(volumes=volume_dict_array)
 
 


### PR DESCRIPTION
##### SUMMARY

As we migrate to AnsibleAWSModule there are fewer use-cases for fetching the full aws connection properties, however, there are times when we need access to region.  This PR Refactors get_aws_connection_info a little and exposes "region" directly from AnsibleAWSModule

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

lib/ansible/module_utils/aws/core.py
lib/ansible/module_utils/ec2.py

##### ADDITIONAL INFORMATION

@s-hertel My implementation of what we discussed on IRC