### PR TITLE
vmware_guest_network: idempotency with state=absent

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_network.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_network.py
@@ -526,7 +526,8 @@ class PyVmomiHelper(PyVmomi):
                             self.change_detected = True
                             self.config_spec.deviceChange.append(nic_spec)
                 else:
-                    self.module.fail_json(msg='Unable to find the specified network adapter: %s' % network)
+                    if network['state'].lower() != 'absent':
+                        self.module.fail_json(msg='Unable to find the specified network adapter: %s' % network)
 
     def reconfigure_vm_network(self, vm_obj):
         network_list = self.sanitize_network_params()

--- a/test/integration/targets/vmware_guest_network/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_network/tasks/main.yml
@@ -139,11 +139,29 @@
 
   - debug: var=add_netadapter_instanceuuid
 
-  - name: assert the new netowrk adapters were added to VM
+  - name: assert the new network adapters were added to VM
     assert:
       that:
         - add_netadapter_instanceuuid is changed
         - "{{ add_netadapter_instanceuuid.network_data | length | int }} == {{ netadapter_num | int + 2 }}"
+
+  - name: delete one specified network adapter
+    vmware_guest_network:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      name: test_vm1
+      networks:
+        - state: absent
+          mac: "bb:50:56:58:59:60"
+    register: del_netadapter
+
+  - name: assert the network adapter was removed
+    assert:
+      that:
+        - del_netadapter is changed
+        - "{{ del_netadapter.network_data | length | int }} == {{ netadapter_num | int + 1 }}"
 
   - name: delete again one specified network adapter
     vmware_guest_network:
@@ -162,7 +180,7 @@
   - name: assert the network adapter was removed
     assert:
       that:
-        - del_again_netadapter is changed
+        - not (del_again_netadapter is changed)
         - "{{ del_again_netadapter.network_data | length | int }} == {{ netadapter_num | int + 1 }}"
 
   - name: disable DirectPath I/O on a Vmxnet3 adapter


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible/pull/67228

##### SUMMARY

Ensure the idempotency of the module if we try to delete a NIC two times
in a row.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_guest_network