### PR TITLE
fixed zabbix no longer returning macros as part of the template

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -425,6 +425,9 @@ class Template(object):
                     changed = True
                     break
 
+        if 'macros' not in existing_template['zabbix_export']['templates'][0]:
+            existing_template['zabbix_export']['templates'][0]['macros'] = []
+
         if template_macros is not None:
             existing_macros = existing_template['zabbix_export']['templates'][0]['macros']
             if template_macros != existing_macros:


### PR DESCRIPTION
##### SUMMARY
It seems that since Zabbix 4.4, API call `configuration.export` no longer returns `macros: []` as part of the templates. It is missing completely now.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_template

##### ADDITIONAL INFORMATION
Second task will fail with Zabbix 4.4 and possible higher versions too (haven't tested):

```yaml
        - name: Create template 00_temp1 existing
          zabbix_template:
            server_url: '{{ zbx_server_url }}'
            login_user: '{{ zbx_user }}'
            login_password: '{{ zbx_password }}'
            validate_certs: '{{ zbx_validate_certs }}'
            template_name: 00_temp1
            template_groups: Templates
            state: present
   
        - name: Update template 00_temp1 with macros
          zabbix_template:
            server_url: '{{ zbx_server_url }}'
            login_user: '{{ zbx_user }}'
            login_password: '{{ zbx_password }}'
            validate_certs: '{{ zbx_validate_certs }}'
            template_name: 00_temp1
            template_groups: Templates
            macros:
              - macro: '{$MACROTEST}'
                value: abc
            state: present
```

This is handled the same way for missing `templates: []` section in template export too on line 409. Fix made this way for consistency in the code.