### PR TITLE
Zabbix host tags & macros integration tests + zbx server version increase

### DIFF
--- a/test/integration/targets/setup_zabbix/defaults/main.yml
+++ b/test/integration/targets/setup_zabbix/defaults/main.yml
@@ -3,10 +3,11 @@ db_name: 'zabbix'
 db_user: 'zabbix'
 db_password: 'fLhijUs3PgekNhwJ'
 
-zabbix_version: 4.0
+zabbix_version: 4.4
 zabbix_apt_repository: 'deb http://repo.zabbix.com/zabbix/{{ zabbix_version }}/{{ ansible_distribution.lower() }}/ {{ ansible_distribution_release }} main'
 zabbix_apt_repository_key: 'http://repo.zabbix.com/zabbix-official-repo.key'
 
 zabbix_packages:
     - zabbix-server-mysql
     - zabbix-frontend-php
+    - zabbix-apache-conf

--- a/test/integration/targets/zabbix_host/tasks/zabbix_host_doc.yml
+++ b/test/integration/targets/zabbix_host/tasks/zabbix_host_doc.yml
@@ -43,6 +43,16 @@
         ip: 10.1.1.1
         dns: ""
         port: "12345"
+    macros:
+      - macro: '{$EXAMPLEMACRO}'
+        value: ExampleMacroValue
+      - macro: EXAMPLEMACRO2
+        value: ExampleMacroValue2
+        description: Example desc that work only with Zabbix 4.4 and higher
+    tags:
+      - tag: ExampleHostsTag
+      - tag: ExampleHostsTag2
+        value: ExampleTagValue
   register: zabbix_host1
 
 - name: Update an existing host's tls settings

--- a/test/integration/targets/zabbix_host/tasks/zabbix_host_tests.yml
+++ b/test/integration/targets/zabbix_host/tasks/zabbix_host_tests.yml
@@ -48,6 +48,15 @@
     tls_psk_identity: test
     tls_connect: 2
     tls_psk: 123456789abcdef123456789abcdef12
+    macros:
+      - macro: MACRO1
+        value: test1
+      - macro: '{$MACRO2}'
+        value: test2
+    tags:
+      - tag: Tag1
+      - tag: Tag2
+        value: test2
   register: zabbix_host1
 
 - name: expect to succeed and that things changed
@@ -103,6 +112,15 @@
     tls_psk_identity: test
     tls_connect: 2
     tls_psk: 123456789abcdef123456789abcdef12
+    macros:
+      - macro: MACRO1
+        value: test1
+      - macro: '{$MACRO2}'
+        value: test2
+    tags:
+      - tag: Tag1
+      - tag: Tag2
+        value: test2
   register: zabbix_host1
 
 - name: updating with same values should be idempotent
@@ -831,6 +849,296 @@
   assert:
       that:
           - "zabbix_host1 is changed"
+
+- name: "test: add new set of user macros to the host"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    macros:
+      - macro: '{$NEWMACRO1}'
+        value: test123
+      - macro: NEWMACRO2
+        value: abc
+  register: zabbix_host1
+
+- name: expect to succeed and that things have changed
+  assert:
+      that:
+          - "zabbix_host1 is changed"
+
+- name: "test: add new set of user macros to the host (again - lowercase)"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    macros:
+      - macro: '{$newmacro1}'
+        value: test123
+      - macro: newmacro2
+        value: abc
+  register: zabbix_host1
+
+- name: expect to succeed and that things have not changed
+  assert:
+      that:
+          - "zabbix_host1 is not changed"
+
+- name: "test: update one of the user macros present on the host"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    macros:
+      - macro: '{$NEWMACRO1}'
+        value: test1234
+      - macro: NEWMACRO2
+        value: abc
+  register: zabbix_host1
+
+- name: expect to succeed and that things have changed
+  assert:
+      that:
+          - "zabbix_host1 is changed"
+
+- name: "test: update one of the user macros with description"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    macros:
+      - macro: '{$NEWMACRO1}'
+        value: test1234
+        description: Example Description
+      - macro: NEWMACRO2
+        value: abc
+  register: zabbix_host1
+
+- name: expect to succeed and that things have changed
+  assert:
+      that:
+          - "zabbix_host1 is changed"
+
+- name: "test: update one of the user macros with description (again)"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    macros:
+      - macro: '{$NEWMACRO1}'
+        value: test1234
+        description: Example Description
+      - macro: NEWMACRO2
+        value: abc
+  register: zabbix_host1
+
+- name: expect to succeed and that things have not changed
+  assert:
+      that:
+          - "zabbix_host1 is not changed"
+
+- name: "test: update one of the user macros by removing description"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    macros:
+      - macro: '{$NEWMACRO1}'
+        value: test1234
+      - macro: NEWMACRO2
+        value: abc
+  register: zabbix_host1
+
+- name: expect to succeed and that things have changed
+  assert:
+      that:
+          - "zabbix_host1 is changed"
+
+- name: "test: add user macro while keeping previous ones with force=no"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    force: no
+    macros:
+      - macro: '{$NEWMACRO3}'
+        value: testing
+  register: zabbix_host1
+
+- name: expect to succeed and that things have changed
+  assert:
+      that:
+          - "zabbix_host1 is changed"
+
+- name: "test: add the same user macros (again)"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    macros:
+      - macro: '{$NEWMACRO1}'
+        value: test1234
+      - macro: NEWMACRO2
+        value: abc
+      - macro: '{$NEWMACRO3}'
+        value: testing
+  register: zabbix_host1
+
+- name: expect to succeed and that things have not changed
+  assert:
+      that:
+          - "zabbix_host1 is not changed"
+
+- name: "test: wipe out all of the user macros"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    macros: []
+  register: zabbix_host1
+
+- name: expect to succeed and that things have changed
+  assert:
+      that:
+          - "zabbix_host1 is changed"
+
+- name: "test: wipe out all of the user macros (again)"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    macros: []
+  register: zabbix_host1
+
+- name: expect to succeed and that things have not changed
+  assert:
+      that:
+          - "zabbix_host1 is not changed"
+
+- name: "test: add new set of tags to the host"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    tags:
+      - tag: NEWTAG1
+      - tag: NewTag2
+        value: abc
+  register: zabbix_host1
+
+- name: expect to succeed and that things have changed
+  assert:
+      that:
+          - "zabbix_host1 is changed"
+
+- name: "test: add new set of tags to the host (again)"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    tags:
+      - tag: NEWTAG1
+      - tag: NewTag2
+        value: abc
+  register: zabbix_host1
+
+- name: expect to succeed and that things have not changed
+  assert:
+      that:
+          - "zabbix_host1 is not changed"
+
+- name: "test: update one of the tags present on the host"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    tags:
+      - tag: NEWTAG1
+      - tag: NewTag2
+        value: abcd
+  register: zabbix_host1
+
+- name: expect to succeed and that things have changed
+  assert:
+      that:
+          - "zabbix_host1 is changed"
+
+- name: "test: add tag while keeping previous ones with force=no"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    force: no
+    tags:
+      - tag: newtag3
+        value: testing
+  register: zabbix_host1
+
+- name: expect to succeed and that things have changed
+  assert:
+      that:
+          - "zabbix_host1 is changed"
+
+- name: "test: add the same tags (again)"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    tags:
+      - tag: NEWTAG1
+      - tag: NewTag2
+        value: abcd
+      - tag: newtag3
+        value: testing
+  register: zabbix_host1
+
+- name: expect to succeed and that things have not changed
+  assert:
+      that:
+          - "zabbix_host1 is not changed"
+
+- name: "test: wipe out all of the tags"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    tags: []
+  register: zabbix_host1
+
+- name: expect to succeed and that things have changed
+  assert:
+      that:
+          - "zabbix_host1 is changed"
+
+- name: "test: wipe out all of the tags (again)"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    tags: []
+  register: zabbix_host1
+
+- name: expect to succeed and that things have not changed
+  assert:
+      that:
+          - "zabbix_host1 is not changed"
 
 - name: "test: attempt to delete host created earlier"
   zabbix_host:

--- a/test/integration/targets/zabbix_template/tasks/main.yml
+++ b/test/integration/targets/zabbix_template/tasks/main.yml
@@ -43,7 +43,7 @@
         - 'Templates'
       link_templates:
         - 'Template App Zabbix Proxy'
-        - 'Template App Zabbix Agent'
+        - 'Template Module Zabbix agent'
       state: present
     register: update_zabbix_template_result
 
@@ -64,8 +64,8 @@
       that:
         - gather_template_result.template_json.zabbix_export.groups.0.name == 'Linux servers'
         - gather_template_result.template_json.zabbix_export.groups.1.name == 'Templates'
-        - gather_template_result.template_json.zabbix_export.templates.0.templates.0.name == 'Template App Zabbix Agent'
-        - gather_template_result.template_json.zabbix_export.templates.0.templates.1.name == 'Template App Zabbix Proxy'
+        - gather_template_result.template_json.zabbix_export.templates.0.templates.0.name == 'Template App Zabbix Proxy'
+        - gather_template_result.template_json.zabbix_export.templates.0.templates.1.name == 'Template Module Zabbix agent'
 
   - name: Add macros to Zabbix template.
     zabbix_template:
@@ -78,7 +78,7 @@
         - 'Templates'
       link_templates:
         - 'Template App Zabbix Proxy'
-        - 'Template App Zabbix Agent'
+        - 'Template Module Zabbix agent'
       macros:
         - macro: '{$EXAMPLE_MACRO1}'
           value: 1000
@@ -104,8 +104,8 @@
       that:
         - gather_template_result.template_json.zabbix_export.groups.0.name == 'Linux servers'
         - gather_template_result.template_json.zabbix_export.groups.1.name == 'Templates'
-        - gather_template_result.template_json.zabbix_export.templates.0.templates.0.name == 'Template App Zabbix Agent'
-        - gather_template_result.template_json.zabbix_export.templates.0.templates.1.name == 'Template App Zabbix Proxy'
+        - gather_template_result.template_json.zabbix_export.templates.0.templates.0.name == 'Template App Zabbix Proxy'
+        - gather_template_result.template_json.zabbix_export.templates.0.templates.1.name == 'Template Module Zabbix agent'
         - gather_template_result.template_json.zabbix_export.templates.0.macros.0.macro == '{$EXAMPLE_MACRO1}'
         - gather_template_result.template_json.zabbix_export.templates.0.macros.0.value == '1000'
         - gather_template_result.template_json.zabbix_export.templates.0.macros.1.macro == '{$EXAMPLE_MACRO2}'


### PR DESCRIPTION
##### SUMMARY
Increased Zabbix server version to 4.4 to allow testing of host tags (not supported in lower version) and made some compatibility adjustments in other roles to work with newer version.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
test/integration/targets/setup_zabbix
test/integration/targets/zabbix_host
test/integration/targets/zabbix_template