### PR TITLE
Backport of 66995: mysql_user doesnt support privileges with underscore

### DIFF
--- a/changelogs/fragments/66974-mysql_user_doesnt_support_privs_with_underscore.yml
+++ b/changelogs/fragments/66974-mysql_user_doesnt_support_privs_with_underscore.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_user - fix support privileges with underscore (https://github.com/ansible/ansible/issues/66974).

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -232,16 +232,12 @@ VALID_PRIVS = frozenset(('CREATE', 'DROP', 'GRANT', 'GRANT OPTION',
                          'SUPER', 'ALL', 'ALL PRIVILEGES', 'USAGE', 'REQUIRESSL',
                          'CREATE ROLE', 'DROP ROLE', 'APPLICATION_PASSWORD_ADMIN',
                          'AUDIT_ADMIN', 'BACKUP_ADMIN', 'BINLOG_ADMIN',
-                         'BINLOG_ENCRYPTION_ADMIN', 'CLONE_ADMIN', 'CONNECTION_ADMIN',
+                         'BINLOG_ENCRYPTION_ADMIN', 'CONNECTION_ADMIN',
                          'ENCRYPTION_KEY_ADMIN', 'FIREWALL_ADMIN', 'FIREWALL_USER',
-                         'GROUP_REPLICATION_ADMIN', 'INNODB_REDO_LOG_ARCHIVE',
-                         'NDB_STORED_USER', 'PERSIST_RO_VARIABLES_ADMIN',
-                         'REPLICATION_APPLIER', 'REPLICATION_SLAVE_ADMIN',
-                         'RESOURCE_GROUP_ADMIN', 'RESOURCE_GROUP_USER',
+                         'GROUP_REPLICATION_ADMIN', 'PERSIST_RO_VARIABLES_ADMIN',
+                         'REPLICATION_SLAVE_ADMIN', 'RESOURCE_GROUP_ADMIN', 'RESOURCE_GROUP_USER',
                          'ROLE_ADMIN', 'SESSION_VARIABLES_ADMIN', 'SET_USER_ID',
-                         'SYSTEM_USER', 'SYSTEM_VARIABLES_ADMIN', 'SYSTEM_USER',
-                         'TABLE_ENCRYPTION_ADMIN', 'VERSION_TOKEN_ADMIN',
-                         'XA_RECOVER_ADMIN', 'LOAD FROM S3', 'SELECT INTO S3'))
+                         'SYSTEM_VARIABLES_ADMIN', 'VERSION_TOKEN_ADMIN', 'XA_RECOVER_ADMIN'))
 
 
 class InvalidPrivsError(Exception):

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -108,6 +108,9 @@ seealso:
 - name: MySQL access control and account management reference
   description: Complete reference of the MySQL access control and account management documentation.
   link: https://dev.mysql.com/doc/refman/8.0/en/access-control.html
+- name: MySQL provided privileges reference
+  description: Complete reference of the MySQL provided privileges documentation.
+  link: https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html
 
 author:
 - Jonathan Mainguy (@Jmainguy)
@@ -227,15 +230,18 @@ VALID_PRIVS = frozenset(('CREATE', 'DROP', 'GRANT', 'GRANT OPTION',
                          'PROCESS', 'PROXY', 'RELOAD', 'REPLICATION CLIENT',
                          'REPLICATION SLAVE', 'SHOW DATABASES', 'SHUTDOWN',
                          'SUPER', 'ALL', 'ALL PRIVILEGES', 'USAGE', 'REQUIRESSL',
-                         'CREATE ROLE', 'DROP ROLE', 'APPLICATION PASSWORD ADMIN',
-                         'AUDIT ADMIN', 'BACKUP ADMIN', 'BINLOG ADMIN',
-                         'BINLOG ENCRYPTION ADMIN', 'CONNECTION ADMIN',
-                         'ENCRYPTION KEY ADMIN', 'FIREWALL ADMIN', 'FIREWALL USER',
-                         'GROUP REPLICATION ADMIN', 'PERSIST RO VARIABLES ADMIN',
-                         'REPLICATION SLAVE ADMIN', 'RESOURCE GROUP ADMIN',
-                         'RESOURCE GROUP USER', 'ROLE ADMIN', 'SET USER ID',
-                         'SESSION VARIABLES ADMIN', 'SYSTEM VARIABLES ADMIN',
-                         'VERSION TOKEN ADMIN', 'XA RECOVER ADMIN'))
+                         'CREATE ROLE', 'DROP ROLE', 'APPLICATION_PASSWORD_ADMIN',
+                         'AUDIT_ADMIN', 'BACKUP_ADMIN', 'BINLOG_ADMIN',
+                         'BINLOG_ENCRYPTION_ADMIN', 'CLONE_ADMIN', 'CONNECTION_ADMIN',
+                         'ENCRYPTION_KEY_ADMIN', 'FIREWALL_ADMIN', 'FIREWALL_USER',
+                         'GROUP_REPLICATION_ADMIN', 'INNODB_REDO_LOG_ARCHIVE',
+                         'NDB_STORED_USER', 'PERSIST_RO_VARIABLES_ADMIN',
+                         'REPLICATION_APPLIER', 'REPLICATION_SLAVE_ADMIN',
+                         'RESOURCE_GROUP_ADMIN', 'RESOURCE_GROUP_USER',
+                         'ROLE_ADMIN', 'SESSION_VARIABLES_ADMIN', 'SET_USER_ID',
+                         'SYSTEM_USER', 'SYSTEM_VARIABLES_ADMIN', 'SYSTEM_USER',
+                         'TABLE_ENCRYPTION_ADMIN', 'VERSION_TOKEN_ADMIN',
+                         'XA_RECOVER_ADMIN', 'LOAD FROM S3', 'SELECT INTO S3'))
 
 
 class InvalidPrivsError(Exception):


### PR DESCRIPTION
##### SUMMARY
Backport of #66995 : mysql_user doesnt support privileges with underscore

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/mysql/mysql_user.py```
