### PR TITLE
[BACKPORT 2.9] Fix user_agent string not getting set

### DIFF
--- a/changelogs/fragments/66914-purefa_user_string.yaml
+++ b/changelogs/fragments/66914-purefa_user_string.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+ - pure - fix incorrect user_string setting in module_utils file (https://github.com/ansible/ansible/pull/66914)

--- a/lib/ansible/module_utils/pure.py
+++ b/lib/ansible/module_utils/pure.py
@@ -90,7 +90,8 @@ def get_blade(module):
         blade.disable_verify_ssl()
         try:
             blade.login(api)
-            if API_AGENT_VERSION in blade.api_version.list_versions().versions:
+            versions = blade.api_version.list_versions().versions
+            if API_AGENT_VERSION in versions:
                 blade._api_client.user_agent = user_agent
         except rest.ApiException as e:
             module.fail_json(msg="Pure Storage FlashBlade authentication failed. Check your credentials")
@@ -99,7 +100,8 @@ def get_blade(module):
         blade.disable_verify_ssl()
         try:
             blade.login(environ.get('PUREFB_API'))
-            if API_AGENT_VERSION in blade.api_version.list_versions().versions:
+            versions = blade.api_version.list_versions().versions
+            if API_AGENT_VERSION in versions:
                 blade._api_client.user_agent = user_agent
         except rest.ApiException as e:
             module.fail_json(msg="Pure Storage FlashBlade authentication failed. Check your credentials")


### PR DESCRIPTION
(cherry picked from commit cb9e24fbd24bf392fcd79ca75538876fdaf6f23f)

##### SUMMARY
Fix an issue where the `user_agent` string is not being correctly set.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils/pure.py