### PR TITLE
Remove unneeded quotes for nxos documentation

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
@@ -56,7 +56,7 @@ options:
   bfd:
     description:
       - Enables/Disables BFD for a given neighbor.
-      - "Dependency: 'feature bfd'"
+      - Dependency: 'feature bfd'
     version_added: "2.9"
     type: str
     choices: ['enable', 'disable']

--- a/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
@@ -57,7 +57,7 @@ options:
     description:
       - Enables bfd at interface level. This overrides the bfd variable set at the ospf router level.
       - Valid values are 'enable', 'disable' or 'default'.
-      - "Dependency: 'feature bfd'"
+      - Dependency: 'feature bfd'
     version_added: "2.9"
     type: str
     choices: ['enable', 'disable', 'default']

--- a/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
+++ b/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
@@ -93,7 +93,7 @@ options:
   bfd:
     description:
       - Enables BFD on all OSPF interfaces.
-      - "Dependency: 'feature bfd'"
+      - Dependency: 'feature bfd'
     version_added: "2.9"
     type: str
     choices: ['enable', 'disable']

--- a/lib/ansible/modules/network/nxos/nxos_pim.py
+++ b/lib/ansible/modules/network/nxos/nxos_pim.py
@@ -34,7 +34,7 @@ options:
   bfd:
     description:
       - Enables BFD on all PIM interfaces.
-      - "Dependency: 'feature bfd'"
+      - Dependency: 'feature bfd'
     version_added: "2.9"
     type: str
     choices: ['enable', 'disable']

--- a/lib/ansible/modules/network/nxos/nxos_pim_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_pim_interface.py
@@ -44,7 +44,7 @@ options:
     description:
       - Enables BFD for PIM at the interface level. This overrides the bfd variable set at the pim global level.
       - Valid values are 'enable', 'disable' or 'default'.
-      - "Dependency: 'feature bfd'"
+      - Dependency: 'feature bfd'
     version_added: "2.9"
     type: str
     choices: ['enable', 'disable', 'default']


### PR DESCRIPTION
This was caught in our testing of cisco.nxos collections.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>