### PR TITLE
Backport of 66806: mysql_variables not supporting variables name with dot

### DIFF
--- a/changelogs/fragments/66806-mysql_variables_not_support_variables_with_dot.yml
+++ b/changelogs/fragments/66806-mysql_variables_not_support_variables_with_dot.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_variable - fix the module doesn't support variables name with dot (https://github.com/ansible/ansible/issues/54239).

--- a/lib/ansible/module_utils/database.py
+++ b/lib/ansible/module_utils/database.py
@@ -129,7 +129,7 @@ def pg_quote_identifier(identifier, id_type):
 
 def mysql_quote_identifier(identifier, id_type):
     identifier_fragments = _identifier_parse(identifier, quote_char='`')
-    if len(identifier_fragments) > _MYSQL_IDENTIFIER_TO_DOT_LEVEL[id_type]:
+    if (len(identifier_fragments) - 1) > _MYSQL_IDENTIFIER_TO_DOT_LEVEL[id_type]:
         raise SQLParseError('MySQL does not support %s with more than %i dots' % (id_type, _MYSQL_IDENTIFIER_TO_DOT_LEVEL[id_type]))
 
     special_cased_fragments = []

--- a/lib/ansible/modules/database/mysql/mysql_variables.py
+++ b/lib/ansible/modules/database/mysql/mysql_variables.py
@@ -139,7 +139,7 @@ def main():
     value = module.params["value"]
     if mysqlvar is None:
         module.fail_json(msg="Cannot run without variable to operate with")
-    if match('^[0-9a-z_]+$', mysqlvar) is None:
+    if match('^[0-9a-z_.]+$', mysqlvar) is None:
         module.fail_json(msg="invalid variable name \"%s\"" % mysqlvar)
     if mysql_driver is None:
         module.fail_json(msg=mysql_driver_fail_msg)


### PR DESCRIPTION
##### SUMMARY
Backport of #66806 : mysql_variables not supporting variables name with dot

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/mysql/mysql_variables.py```
