### PR TITLE
Document difference between ec2 and ec2_instance modules

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -18,7 +18,7 @@ description:
     - Creates or terminates ec2 instances.
     - >
       Note: This module uses the older boto Python module to interact with the EC2 API.
-      It will still receive bug fixes, but no new features.
+      M(ec2) will still receive bug fixes, but no new features.
       Consider using the M(ec2_instance) module instead.
       If M(ec2_instance) does not support a feature you need that is available in M(ec2), please
       file a feature request.

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -16,6 +16,12 @@ module: ec2
 short_description: create, terminate, start or stop an instance in ec2
 description:
     - Creates or terminates ec2 instances.
+    - >
+      Note: This module uses the older boto Python module to interact with the EC2 API.
+      It will still receive bug fixes, but no new features.
+      Consider using the M(ec2_instance) module instead.
+      If M(ec2_instance) does not support a feature that is available in M(ec2), please
+      file a feature request.
 version_added: "0.9"
 options:
   key_name:

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -20,7 +20,7 @@ description:
       Note: This module uses the older boto Python module to interact with the EC2 API.
       It will still receive bug fixes, but no new features.
       Consider using the M(ec2_instance) module instead.
-      If M(ec2_instance) does not support a feature that is available in M(ec2), please
+      If M(ec2_instance) does not support a feature you need that is available in M(ec2), please
       file a feature request.
 version_added: "0.9"
 options:


### PR DESCRIPTION
##### SUMMARY
This PR adds a note to the `ec2` module documentation describing the the difference betwen `ec2` and `ec2_instance`.
It recommends usage of the `ec2_instance` module where possible, and to submit feature requests when functionality is not available.

Fixes #64610

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr