### PR TITLE
Add new option for YUM4/DNF repositories

### DIFF
--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -115,6 +115,11 @@ options:
     description:
       - A URL pointing to the ASCII-armored GPG key file for the repository.
       - It can also be a list of multiple URLs.
+  module_hotfixes:
+    description:
+      - Disable module RPM filtering and make all RPMs from the repository
+        available. The default is False.
+    version_added: '2.10'
   http_caching:
     description:
       - Determines how upstream HTTP caches are instructed to handle any HTTP
@@ -415,6 +420,7 @@ class YumRepo(object):
         'gpgcakey',
         'gpgcheck',
         'gpgkey',
+        'module_hotfixes',
         'http_caching',
         'include',
         'includepkgs',
@@ -568,6 +574,7 @@ def main():
         gpgcakey=dict(),
         gpgcheck=dict(type='bool'),
         gpgkey=dict(type='list'),
+        module_hotfixes=dict(type='bool'),
         http_caching=dict(choices=['all', 'packages', 'none']),
         include=dict(),
         includepkgs=dict(type='list'),


### PR DESCRIPTION
##### SUMMARY

YUM4/DNF introduce a new option in repo files called `module_hotfixes` which is used in the wild by upstream MariaDB on their CentOS 8/RHEL 8 packages.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum_repository

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

 Documentation reference: https://dnf.readthedocs.io/en/stable/conf_ref.html

**module_hotfixes**

`boolean`

Set this to True to disable module RPM filtering and make all RPMs from the repository available. The default is False. This allows user to create a repository with cherry-picked hotfixes that are included in a package set on a modular system.

<!--- Paste verbatim command output below, e.g. before and after your change -->
