### PR TITLE
included_file: Fix printing item label

### DIFF
--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -94,11 +94,11 @@ class IncludedFile:
                     if index_var and index_var in include_result:
                         task_vars[index_var] = special_vars[index_var] = include_result[index_var]
                     if '_ansible_item_label' in include_result:
-                        task_vars['_ansible_item_label'] = special_vars['_ansible_item_label'] = include_result['_ansible_item_label']
+                        include_args['_ansible_item_label'] = special_vars['_ansible_item_label'] = include_result['_ansible_item_label']
                     if 'ansible_loop' in include_result:
                         task_vars['ansible_loop'] = special_vars['ansible_loop'] = include_result['ansible_loop']
                     if original_task.no_log and '_ansible_no_log' not in include_args:
-                        task_vars['_ansible_no_log'] = special_vars['_ansible_no_log'] = original_task.no_log
+                        include_args['_ansible_no_log'] = special_vars['_ansible_no_log'] = original_task.no_log
 
                     # get search path for this task to pass to lookup plugins that may be used in pathing to
                     # the included file

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -350,7 +350,7 @@ class CallbackModule(CallbackBase):
 
     def v2_playbook_on_include(self, included_file):
         msg = 'included: %s for %s' % (included_file._filename, ", ".join([h.name for h in included_file._hosts]))
-        if 'item' in included_file._args:
+        if '_ansible_item_label' in included_file._args:
             msg += " => (item=%s)" % (self._get_item_label(included_file._args),)
         self._display.display(msg, color=C.COLOR_SKIP)
 

--- a/test/integration/targets/callback_default/.include.yml
+++ b/test/integration/targets/callback_default/.include.yml
@@ -1,0 +1,4 @@
+---
+- name: Just print an item if defined
+  command: echo {{ item }}
+  when: item is defined

--- a/test/integration/targets/callback_default/callback_default.out.default.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.default.stdout
@@ -58,7 +58,35 @@ changed: [testhost]
 
 TASK [Second free task] ********************************************************
 changed: [testhost]
+included: $PWD/.include.yml for testhost
+
+TASK [Just print an item if defined] *******************************************
+skipping: [testhost]
+included: $PWD/.include.yml for testhost => (item=one)
+included: $PWD/.include.yml for testhost => (item=two)
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+included: $PWD/.include.yml for testhost => (item=foo-one)
+included: $PWD/.include.yml for testhost => (item=foo-two)
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+included: $PWD/.include.yml for testhost => (item=(censored due to no_log))
+included: $PWD/.include.yml for testhost => (item=(censored due to no_log))
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+testhost                   : ok=25   changed=15   unreachable=0    failed=0    skipped=2    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stdout
@@ -55,7 +55,35 @@ changed: [testhost]
 
 TASK [Second free task] ********************************************************
 changed: [testhost]
+included: $PWD/.include.yml for testhost
+
+TASK [Just print an item if defined] *******************************************
+skipping: [testhost]
+included: $PWD/.include.yml for testhost => (item=one)
+included: $PWD/.include.yml for testhost => (item=two)
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+included: $PWD/.include.yml for testhost => (item=foo-one)
+included: $PWD/.include.yml for testhost => (item=foo-two)
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+included: $PWD/.include.yml for testhost => (item=(censored due to no_log))
+included: $PWD/.include.yml for testhost => (item=(censored due to no_log))
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+testhost                   : ok=25   changed=15   unreachable=0    failed=0    skipped=2    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_ok.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_ok.stdout
@@ -49,7 +49,35 @@ changed: [testhost]
 
 TASK [Second free task] ********************************************************
 changed: [testhost]
+included: $PWD/.include.yml for testhost
+
+TASK [Just print an item if defined] *******************************************
+skipping: [testhost]
+included: $PWD/.include.yml for testhost => (item=one)
+included: $PWD/.include.yml for testhost => (item=two)
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+included: $PWD/.include.yml for testhost => (item=foo-one)
+included: $PWD/.include.yml for testhost => (item=foo-two)
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+included: $PWD/.include.yml for testhost => (item=(censored due to no_log))
+included: $PWD/.include.yml for testhost => (item=(censored due to no_log))
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+testhost                   : ok=25   changed=15   unreachable=0    failed=0    skipped=2    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_skipped.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_skipped.stdout
@@ -54,7 +54,32 @@ changed: [testhost]
 
 TASK [Second free task] ********************************************************
 changed: [testhost]
+included: $PWD/.include.yml for testhost
+included: $PWD/.include.yml for testhost => (item=one)
+included: $PWD/.include.yml for testhost => (item=two)
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+included: $PWD/.include.yml for testhost => (item=foo-one)
+included: $PWD/.include.yml for testhost => (item=foo-two)
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+included: $PWD/.include.yml for testhost => (item=(censored due to no_log))
+included: $PWD/.include.yml for testhost => (item=(censored due to no_log))
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+testhost                   : ok=25   changed=15   unreachable=0    failed=0    skipped=2    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok.stdout
@@ -45,7 +45,32 @@ changed: [testhost]
 
 TASK [Second free task] ********************************************************
 changed: [testhost]
+included: $PWD/.include.yml for testhost
+included: $PWD/.include.yml for testhost => (item=one)
+included: $PWD/.include.yml for testhost => (item=two)
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+included: $PWD/.include.yml for testhost => (item=foo-one)
+included: $PWD/.include.yml for testhost => (item=foo-two)
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+included: $PWD/.include.yml for testhost => (item=(censored due to no_log))
+included: $PWD/.include.yml for testhost => (item=(censored due to no_log))
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
+
+TASK [Just print an item if defined] *******************************************
+changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+testhost                   : ok=25   changed=15   unreachable=0    failed=0    skipped=2    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/runme.sh
+++ b/test/integration/targets/callback_default/runme.sh
@@ -23,6 +23,9 @@ run_test() {
 		2> >(set +x; tee "${OUTFILE}.${testname}.stderr" >&2)
 	# Scrub deprication warning that shows up in Python 2.6 on CentOS 6
 	sed -i -e '/RandomPool_DeprecationWarning/d' "${OUTFILE}.${testname}.stderr"
+	# include_tasks and such tasks print absolute path to the playbook
+	# which makes it impossible to store the output
+	sed -i -e "s~$PWD~\$PWD~" "${OUTFILE}.${testname}.stdout"
 
 	diff -u "${ORIGFILE}.${testname}.stdout" "${OUTFILE}.${testname}.stdout" || diff_failure
 	diff -u "${ORIGFILE}.${testname}.stderr" "${OUTFILE}.${testname}.stderr" || diff_failure

--- a/test/integration/targets/callback_default/test.yml
+++ b/test/integration/targets/callback_default/test.yml
@@ -82,3 +82,27 @@
 
     - name: Second free task
       command: echo foo
+
+    - name: Include task
+      include_tasks: .include.yml
+
+    - name: Include task in a loop
+      include_tasks: .include.yml
+      loop:
+        - one
+        - two
+
+    - name: Include task in a loop with label
+      include_tasks: .include.yml
+      loop:
+        - one
+        - two
+      loop_control:
+        label: foo-{{ item }}
+
+    - name: Include task in a loop with no_log
+      include_tasks: .include.yml
+      loop:
+        - one
+        - two
+      no_log: yes


### PR DESCRIPTION
I don't think this ever worked before…

With the simple playbook like:

```yaml
---
hosts: localhost
gather_facts: no
tasks:
  - include_tasks: test.yml
    loop: [1, 2]
  - include_tasks: test.yml
    loop: [1, 2]
    no_log: yes
```

Before:

```
…
included: /var/tmp/test.yml for localhost
included: /var/tmp/test.yml for localhost
…
included: /var/tmp/test.yml for localhost
included: /var/tmp/test.yml for localhost
…
```

After:

```
…
included: /var/tmp/test.yml for localhost => (item=1)
included: /var/tmp/test.yml for localhost => (item=2)
…
included: /var/tmp/test.yml for localhost => (item=(censored due to no_log))
included: /var/tmp/test.yml for localhost => (item=(censored due to no_log))
…
```

Fixes: 50905b980d8b119d8a98e2b783c954e3c61d87be
Signed-off-by: Igor Raits <i.gnatenko.brain@gmail.com>

##### SUMMARY
I am not sure if it stopped working because something has changed between 2.7.0 and 2.9.x, but I think it was just a typo and bad testing (or no testing at all).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
included_file, callback