### PR TITLE
eos_config: Make "replace: block" work.

### DIFF
--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -421,7 +421,15 @@ def main():
         config_diff = response['config_diff']
 
         if config_diff:
-            commands = config_diff.split('\n')
+            if module.params['replace'] == 'block' and not module.params['parents']:
+                commands = candidate.split('\n')
+            if module.params['replace'] == 'block' and module.params['parents']:
+                commands = []
+                for parent in module.params['parents']:
+                    commands.append(parent)
+                commands.extend(candidate.split('\n'))
+            else:
+                commands = config_diff.split('\n')
 
             if module.params['before']:
                 commands[:0] = module.params['before']

--- a/test/integration/targets/dellos10_config/tests/cli/sublevel_block.yaml
+++ b/test/integration/targets/dellos10_config/tests/cli/sublevel_block.yaml
@@ -13,7 +13,7 @@
     provider: "{{ cli }}"
     match: none
 
-- name: configure sub level command using block resplace
+- name: configure sub level command using block replace
   dellos10_config:
     lines:
       - seq 5 permit ip host 192.0.2.1 any count byte

--- a/test/integration/targets/dellos6_config/tests/cli/sublevel_block.yaml
+++ b/test/integration/targets/dellos6_config/tests/cli/sublevel_block.yaml
@@ -13,7 +13,7 @@
     provider: "{{ cli }}"
     match: none
 
-- name: configure sub level command using block resplace
+- name: configure sub level command using block replace
   dellos6_config:
     lines:
       - 1000 permit ip 192.0.2.1 0.0.0.0 any log

--- a/test/integration/targets/eos_config/tests/cli/sublevel_block.yaml
+++ b/test/integration/targets/eos_config/tests/cli/sublevel_block.yaml
@@ -30,10 +30,10 @@
     that:
       - "result.changed == true"
       - "'ip access-list test' in result.updates"
-      - "'10 permit ip host 192.0.2.1 any log' in result.updates"
-      - "'20 permit ip host 192.0.2.2 any log' in result.updates"
-      - "'30 permit ip host 192.0.2.3 any log' in result.updates"
-      - "'40 permit ip host 192.0.2.4 any log' in result.updates"
+      - "'   10 permit ip host 192.0.2.1 any log' in result.updates"
+      - "'   20 permit ip host 192.0.2.2 any log' in result.updates"
+      - "'   30 permit ip host 192.0.2.3 any log' in result.updates"
+      - "'   40 permit ip host 192.0.2.4 any log' in result.updates"
 
 - name: check sub level command using block replace
   eos_config:

--- a/test/integration/targets/eos_config/tests/cli/sublevel_block.yaml
+++ b/test/integration/targets/eos_config/tests/cli/sublevel_block.yaml
@@ -13,7 +13,7 @@
     match: none
   become: yes
 
-- name: configure sub level command using block resplace
+- name: configure sub level command using block replace
   eos_config:
     lines:
       - 10 permit ip host 192.0.2.1 any log

--- a/test/integration/targets/eos_config/tests/cli/sublevel_exact.yaml
+++ b/test/integration/targets/eos_config/tests/cli/sublevel_exact.yaml
@@ -34,11 +34,11 @@
     that:
       - "result.changed == true"
       - "'ip access-list test' in result.updates"
-      - "'10 permit ip host 192.0.2.1 any log' in result.updates"
-      - "'20 permit ip host 192.0.2.2 any log' in result.updates"
-      - "'30 permit ip host 192.0.2.3 any log' in result.updates"
-      - "'40 permit ip host 192.0.2.4 any log' in result.updates"
-      - "'50 permit ip host 192.0.2.5 any log' not in result.updates"
+      - "'   10 permit ip host 192.0.2.1 any log' in result.updates"
+      - "'   20 permit ip host 192.0.2.2 any log' in result.updates"
+      - "'   30 permit ip host 192.0.2.3 any log' in result.updates"
+      - "'   40 permit ip host 192.0.2.4 any log' in result.updates"
+      - "'   50 permit ip host 192.0.2.5 any log' not in result.updates"
 
 - name: check sub level command using exact match
   eos_config:

--- a/test/integration/targets/eos_config/tests/eapi/sublevel_block.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/sublevel_block.yaml
@@ -12,7 +12,7 @@
     match: none
   become: yes
 
-- name: configure sub level command using block resplace
+- name: configure sub level command using block replace
   eos_config:
     lines:
       - 10 permit ip host 192.0.2.1 any log

--- a/test/integration/targets/eos_smoke/tests/cli/common_config.yaml
+++ b/test/integration/targets/eos_smoke/tests/cli/common_config.yaml
@@ -55,7 +55,7 @@
         parents: ip access-list test
         before: no ip access-list test
         after: exit
-        match: strict
+        match: none
         provider: "{{ cli }}"
       become: yes
 
@@ -78,10 +78,10 @@
         that:
           - "result.changed == true"
           - "'ip access-list test' in result.updates"
-          - "'10 permit ip host 192.0.2.1 any log' in result.updates"
-          - "'20 permit ip host 192.0.2.2 any log' in result.updates"
-          - "'30 permit ip host 192.0.2.3 any log' in result.updates"
-          - "'40 permit ip host 192.0.2.4 any log' in result.updates"
+          - "'   10 permit ip host 192.0.2.1 any log' in result.updates"
+          - "'   20 permit ip host 192.0.2.2 any log' in result.updates"
+          - "'   30 permit ip host 192.0.2.3 any log' in result.updates"
+          - "'   40 permit ip host 192.0.2.4 any log' in result.updates"
 
     - name: check sub level command using block replace
       eos_config:

--- a/test/integration/targets/ios_config/tests/cli/sublevel_block.yaml
+++ b/test/integration/targets/ios_config/tests/cli/sublevel_block.yaml
@@ -12,7 +12,7 @@
     after: ['exit']
     match: none
 
-- name: configure sub level command using block resplace
+- name: configure sub level command using block replace
   ios_config:
     lines:
       - permit ip host 192.0.2.1 any log

--- a/test/integration/targets/iosxr_config/tests/cli/sublevel_block.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/sublevel_block.yaml
@@ -11,7 +11,7 @@
     before: ['no ipv4 access-list test']
     match: none
 
-- name: configure sub level command using block resplace
+- name: configure sub level command using block replace
   iosxr_config:
     commands:
       - 10 permit ipv4 host 192.0.2.1 any log

--- a/test/integration/targets/iosxr_smoke/tests/cli/common_config.yaml
+++ b/test/integration/targets/iosxr_smoke/tests/cli/common_config.yaml
@@ -12,7 +12,7 @@
     before: ['no ipv4 access-list test']
     match: none
 
-- name: configure sub level command using block resplace
+- name: configure sub level command using block replace
   iosxr_config:
     commands:
       - 10 permit ipv4 host 192.0.2.1 any log


### PR DESCRIPTION
As documented, the eos_config module as well as many others based on
ansible.module_utils.network.common.config.NetworkConfig take a parameter,
"replace". The choice value "block" says "If the replace argument is set to
I(block) then the entire command block is pushed to the device in configuration
mode if any line is not correct".

However, in practice, this doesn't seem to actually be happening.
The reports inside of ansible/ansible#29716 seem to be reflective of this issue.

While this commit fixes the issue for eos_config, the underlying issue probably
still remains inside of
ansible.module_utils.network.common.config.NetworkConfig.

To reproduce this issue, configure an Arista EOS device (version 4.21+ or so),
and setup some NTP servers.
For example:

	eos_config:
	  diff_against: session
	  replace: block
	  before:
	    - default ntp
	  lines:
	    - ntp server vrf MANAGEMENT 10.1.1.1 iburst
	    - ntp server vrf MANAGEMENT 10.2.2.2 iburst
	    - ntp server vrf MANAGEMENT 10.3.3.3 iburst

Run against a device with one of those servers missing:

	.....
	ntp server vrf MANAGEMENT 10.1.1.1 iburst
	ntp server vrf MANAGEMENT 10.3.3.3 iburst
	.....

Results in a diff like:

	--- system:/running-config
	+++ session:/ansible_1574184327-session-config
	@@ -31,6 +31,7 @@
         !
	 ntp source vrf MANAGEMENT Management1
	-ntp server vrf MANAGEMENT 10.1.1.1 iburst
	-ntp server vrf MANAGEMENT 10.3.3.3 iburst
	+ntp server vrf MANAGEMENT 10.2.2.2 iburst
	 !

Because the "before" line still ran ("default ntp"), which removes any
configured NTP servers. However, critically, ansible doesn't respect the
"replace: block" parameter and apply all lines to the device, and instead only
applies the lines that it detects as missing.