### PR TITLE
grafana_plugin fix error on missing plugin_version

### DIFF
--- a/changelogs/fragments/67043-grafana_plugin-fix-if-missing-plugin_version.yml
+++ b/changelogs/fragments/67043-grafana_plugin-fix-if-missing-plugin_version.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - grafana_plugin - fix error on missing plugin_version ( see https://github.com/ansible/ansible/pull/67043 )

--- a/lib/ansible/modules/monitoring/grafana/grafana_plugin.py
+++ b/lib/ansible/modules/monitoring/grafana/grafana_plugin.py
@@ -206,7 +206,7 @@ def grafana_plugin(module, params):
             if line.find(params['name']):
                 if line.find(' @ ') != -1:
                     line = line.rstrip()
-                    plugin_name, plugin_version = line.split(' @ ')
+                    plugin_name, plugin_version = line.split('@')
                 else:
                     plugin_version = None
                 return {'msg': 'Grafana plugin {0} installed : {1}'.format(params['name'], cmd),


### PR DESCRIPTION
##### SUMMARY
Fixes #67042

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
grafana_plugin

##### ADDITIONAL INFORMATION
See issue #67042 

Running with this fix reports on first installation:

```
changed: [****] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "grafana_plugin_url": "/tmp/grafana-grafana-polystat-panel-v1.1.0-0-ga6cdad4.zip",
            "grafana_plugins_dir": null,
            "grafana_repo": null,
            "name": "grafana-polystat-panel",
            "state": "present",
            "version": null
        }
    },
    "msg": "Grafana plugin grafana-polystat-panel installed : /sbin/grafana-cli --pluginUrl /tmp/grafana-grafana-polystat-panel-v1.1.0-0-ga6cdad4.zip plugins install grafana-polysta
t-panel",
    "version": ""
}
```

and on rerun:

```
ok: [****] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "grafana_plugin_url": "/tmp/grafana-grafana-polystat-panel-v1.1.0-0-ga6cdad4.zip",
            "grafana_plugins_dir": null,
            "grafana_repo": null,
            "name": "grafana-polystat-panel",
            "state": "present",
            "version": null
        }
    },
    "msg": "Grafana plugin already installed",
    "version": "1.1.0"
}
```