### PR TITLE
Asg mixed instance types

### DIFF
--- a/changelogs/fragments/67045-ec2_asg_mixed_instance_policy.yml
+++ b/changelogs/fragments/67045-ec2_asg_mixed_instance_policy.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ec2_asg - ability to use mixed_instance_policy in launch template driven autoscaling groups 
+  - ec2_asg - Add the ability to use mixed_instance_policy in launch template driven autoscaling groups 

--- a/changelogs/fragments/67045-ec2_asg_mixed_instance_policy.yml
+++ b/changelogs/fragments/67045-ec2_asg_mixed_instance_policy.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ec2_asg - ability to use mixed_instance_policy in launch template driven autoscaling groups 

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -83,7 +83,9 @@ options:
     type: int
   mixed_instances_policy:
     description:
-      - Using mixed intances policy while ASG present
+      - A mixed instance policy to use for the ASG.
+      - Only used when the ASG is configured to use a Launch Template (I(launch_template)).
+      - 'See also U(https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-autoscaling-autoscalinggroup-mixedinstancespolicy.html)'
     required: false
     version_added: "2.10"
     suboptions:

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -437,6 +437,11 @@ min_size:
     returned: success
     type: int
     sample: 1
+mixed_instance_policy:
+    description: Returns the list of used mixed instance policy if set.
+    returned: success
+    type: list
+    sample: ["t3.micro", "t3a.micro"]
 pending_instances:
     description: Number of instances in pending state
     returned: success

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -81,6 +81,15 @@ options:
     description:
       - Maximum number of instances in group, if unspecified then the current group value will be used.
     type: int
+  mixed_instances_policy:
+    description:
+      - Using mixed intances policy while ASG present
+    required: false
+    version_added: "2.8"
+    suboptions:
+      instance_types:
+        description:
+          - A list of instance_types.
   placement_group:
     description:
       - Physical location of your cluster placement group created in Amazon EC2.
@@ -738,6 +747,7 @@ def get_launch_object(connection, ec2_connection):
     launch_object = dict()
     launch_config_name = module.params.get('launch_config_name')
     launch_template = module.params.get('launch_template')
+    mixed_instances_policy = module.params.get('mixed_instances_policy')
     if launch_config_name is None and launch_template is None:
         return launch_object
     elif launch_config_name:
@@ -756,6 +766,20 @@ def get_launch_object(connection, ec2_connection):
             launch_object = {"LaunchTemplate": {"LaunchTemplateId": lt['LaunchTemplateId'], "Version": launch_template['version']}}
         else:
             launch_object = {"LaunchTemplate": {"LaunchTemplateId": lt['LaunchTemplateId'], "Version": str(lt['LatestVersionNumber'])}}
+        launch_object = {'LaunchTemplate': launch_object}
+        if mixed_instances_policy:
+            instance_types = mixed_instances_policy.get('instance_types', [])
+            policy = {
+                'LaunchTemplate': {
+                    'LaunchTemplateSpecification': launch_object
+                }
+            }
+            if instance_types:
+                policy['LaunchTemplate']['Overrides'] = []
+                for instance_type in instance_types:
+                    instance_type_dict = {'InstanceType': instance_type}
+                    policy['LaunchTemplate']['Overrides'].append(instance_type_dict)
+            launch_object['MixedInstancesPolicy'] = policy
         return launch_object
 
 
@@ -951,6 +975,7 @@ def create_autoscaling_group(connection):
     availability_zones = module.params['availability_zones']
     launch_config_name = module.params.get('launch_config_name')
     launch_template = module.params.get('launch_template')
+    mixed_instances_policy = module.params.get('mixed_instances_policy')
     min_size = module.params['min_size']
     max_size = module.params['max_size']
     placement_group = module.params.get('placement_group')
@@ -1028,7 +1053,10 @@ def create_autoscaling_group(connection):
         if 'LaunchConfigurationName' in launch_object:
             ag['LaunchConfigurationName'] = launch_object['LaunchConfigurationName']
         elif 'LaunchTemplate' in launch_object:
-            ag['LaunchTemplate'] = launch_object['LaunchTemplate']
+            if 'MixedInstancesPolicy' in launch_object:
+                ag['MixedInstancesPolicy'] = launch_object['MixedInstancesPolicy']
+            else:
+                ag['LaunchTemplate'] = launch_object['LaunchTemplate']
         else:
             module.fail_json(msg="Missing LaunchConfigurationName or LaunchTemplate",
                              exception=traceback.format_exc())
@@ -1639,6 +1667,11 @@ def main():
                                      launch_template_id=dict(type='str'),
                                  ),
                                  ),
+            mixed_instances_policy=dict(type='dict',
+                                        default=None,
+                                        options=dict(
+                                            instance_types=dict(type='list'),
+                                        )),
             min_size=dict(type='int'),
             max_size=dict(type='int'),
             placement_group=dict(type='str'),

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -85,7 +85,7 @@ options:
     description:
       - Using mixed intances policy while ASG present
     required: false
-    version_added: "2.8"
+    version_added: "2.10"
     suboptions:
       instance_types:
         description:

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -90,6 +90,8 @@ options:
       instance_types:
         description:
           - A list of instance_types.
+        type: list
+    type: dict
   placement_group:
     description:
       - Physical location of your cluster placement group created in Amazon EC2.
@@ -720,6 +722,11 @@ def get_properties(autoscaling_group):
     properties['termination_policies'] = autoscaling_group.get('TerminationPolicies')
     properties['target_group_arns'] = autoscaling_group.get('TargetGroupARNs')
     properties['vpc_zone_identifier'] = autoscaling_group.get('VPCZoneIdentifier')
+    raw_mixed_instance_object = autoscaling_group.get('MixedInstancesPolicy')
+    if raw_mixed_instance_object:
+        raw_mixed_instance_object.get('LaunchTemplate').get('Overrides')
+        properties['mixed_instances_policy'] = [x['InstanceType'] for x in raw_mixed_instance_object.get('LaunchTemplate').get('Overrides')]
+
     metrics = autoscaling_group.get('EnabledMetrics')
     if metrics:
         metrics.sort(key=lambda x: x["Metric"])

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -754,7 +754,6 @@ def get_properties(autoscaling_group):
     properties['vpc_zone_identifier'] = autoscaling_group.get('VPCZoneIdentifier')
     raw_mixed_instance_object = autoscaling_group.get('MixedInstancesPolicy')
     if raw_mixed_instance_object:
-        raw_mixed_instance_object.get('LaunchTemplate').get('Overrides')
         properties['mixed_instances_policy'] = [x['InstanceType'] for x in raw_mixed_instance_object.get('LaunchTemplate').get('Overrides')]
 
     metrics = autoscaling_group.get('EnabledMetrics')

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -463,7 +463,7 @@ min_size:
     type: int
     sample: 1
 mixed_instance_policy:
-    description: Returns the list of used mixed instance policy if set.
+    description: Returns the list of instance types if a mixed instance policy is set.
     returned: success
     type: list
     sample: ["t3.micro", "t3a.micro"]

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -1685,7 +1685,7 @@ def main():
             mixed_instances_policy=dict(type='dict',
                                         default=None,
                                         options=dict(
-                                            instance_types=dict(type='list'),
+                                            instance_types=dict(type='list', elements='str'),
                                         )),
             min_size=dict(type='int'),
             max_size=dict(type='int'),

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -784,7 +784,7 @@ def get_launch_object(connection, ec2_connection):
             instance_types = mixed_instances_policy.get('instance_types', [])
             policy = {
                 'LaunchTemplate': {
-                    'LaunchTemplateSpecification': launch_object["LaunchTemplate"]
+                    'LaunchTemplateSpecification': launch_object['LaunchTemplate']
                 }
             }
             if instance_types:

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -91,6 +91,7 @@ options:
         description:
           - A list of instance_types.
         type: list
+        elements: str
     type: dict
   placement_group:
     description:

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -766,12 +766,12 @@ def get_launch_object(connection, ec2_connection):
             launch_object = {"LaunchTemplate": {"LaunchTemplateId": lt['LaunchTemplateId'], "Version": launch_template['version']}}
         else:
             launch_object = {"LaunchTemplate": {"LaunchTemplateId": lt['LaunchTemplateId'], "Version": str(lt['LatestVersionNumber'])}}
-        launch_object = {'LaunchTemplate': launch_object}
+
         if mixed_instances_policy:
             instance_types = mixed_instances_policy.get('instance_types', [])
             policy = {
                 'LaunchTemplate': {
-                    'LaunchTemplateSpecification': launch_object
+                    'LaunchTemplateSpecification': launch_object["LaunchTemplate"]
                 }
             }
             if instance_types:
@@ -1229,7 +1229,10 @@ def create_autoscaling_group(connection):
         if 'LaunchConfigurationName' in launch_object:
             ag['LaunchConfigurationName'] = launch_object['LaunchConfigurationName']
         elif 'LaunchTemplate' in launch_object:
-            ag['LaunchTemplate'] = launch_object['LaunchTemplate']
+            if 'MixedInstancesPolicy' in launch_object:
+                ag['MixedInstancesPolicy'] = launch_object['MixedInstancesPolicy']
+            else:
+                ag['LaunchTemplate'] = launch_object['LaunchTemplate']
         else:
             try:
                 ag['LaunchConfigurationName'] = as_group['LaunchConfigurationName']

--- a/test/integration/targets/ec2_asg/tasks/main.yml
+++ b/test/integration/targets/ec2_asg/tasks/main.yml
@@ -585,6 +585,44 @@
       until: status is finished
       retries: 200
       delay: 15
+    
+    # we need a launch template, otherwise we cannot test the mixed instance policy
+    - name: create launch template for autoscaling group to test its mixed instance policy
+      ec2_launch_template:
+        template_name: "{{ resource_prefix }}-lt"
+        image_id: "{{ ec2_ami_image }}"
+        instance_type: t3.micro
+        credit_specification:
+          cpu_credits: standard
+        network_interfaces:
+          - associate_public_ip_address: yes
+            delete_on_termination: yes
+            device_index: 0
+            groups:
+              - "{{ sg.group_id }}"
+
+    - name: update autoscaling group with mixed-instance policy
+      ec2_asg:
+        name: "{{ resource_prefix }}-asg"
+        launch_template: 
+          launch_template_name: "{{ resource_prefix }}-lt"
+        desired_capacity: 1
+        min_size: 1
+        max_size: 1
+        vpc_zone_identifier: "{{ testing_subnet.subnet.id }}"
+        state: present
+        mixed_instances_policy:
+          instance_types:
+            - t3.micro
+            - t3a.micro
+        wait_for_instances: yes
+      register: output
+
+    - assert:
+        that:
+          - "output.mixed_instances_policy | length == 2"
+          - "output.mixed_instances_policy[0] == 't3.micro'"
+          - "output.mixed_instances_policy[1] == 't3a.micro'"
 
 # ============================================================
 
@@ -638,6 +676,15 @@
       with_items:
         - "{{ resource_prefix }}-lc"
         - "{{ resource_prefix }}-lc-2"
+
+    - name: delete launch template
+      ec2_launch_template:
+        name: "{{ resource_prefix }}-lt"
+        state: absent
+      register: del_lt
+      retries: 10
+      until: del_lt is not failed
+      ignore_errors: true
 
     - name: remove the security group
       ec2_group:


### PR DESCRIPTION
##### SUMMARY

fix issue: https://github.com/ansible/ansible/issues/56385  
adpot pr: https://github.com/ansible/ansible/pull/55067

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

ec2_asg

##### ADDITIONAL INFORMATION

This pr adds support for `mixed_instances_policy` on launch template driven autoscaling groups.

