### PR TITLE
win_uri: fix up tests

### DIFF
--- a/test/integration/targets/win_uri/tasks/main.yml
+++ b/test/integration/targets/win_uri/tasks/main.yml
@@ -67,7 +67,7 @@
 
 - name: get request with return_content and dest
   win_uri:
-    url: https://{{httpbin_host}}/get
+    url: https://{{httpbin_host}}/base64/{{ '{"key":"value"}' | b64encode }}
     return_content: yes
     dest: '{{ remote_tmp_dir }}\get.json'
   register: get_request_with_dest
@@ -90,7 +90,7 @@
 
 - name: get request with return_content and dest (idempotent)
   win_uri:
-    url: https://{{httpbin_host}}/get
+    url: https://{{httpbin_host}}/base64/{{ '{"key":"value"}' | b64encode }}
     return_content: yes
     dest: '{{ remote_tmp_dir }}\get.json'
   register: get_request_with_dest_again


### PR DESCRIPTION
##### SUMMARY
The win_uri tests was expecting `https://httpbin.org/get` to return the same content on each call but recent changes makes each result unique. This sets a static json string as the return value for idempotency checks.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_uri