### PR TITLE
Move url option from util to individual modules

### DIFF
--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.WebRequest.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.WebRequest.psm1
@@ -519,7 +519,6 @@ Function Merge-WebRequestSpec {
 }
 
 $ansible_web_request_options = @{
-    url = @{ type="str"; required=$true }
     method = @{ type="str" }
     follow_redirects = @{ type="str"; choices=@("all","none","safe"); default="safe" }
     headers = @{ type="dict" }

--- a/lib/ansible/modules/windows/win_get_url.ps1
+++ b/lib/ansible/modules/windows/win_get_url.ps1
@@ -13,6 +13,7 @@
 
 $spec = @{
     options = @{
+        url = @{ type="str"; required=$true }
         dest = @{ type='path'; required=$true }
         force = @{ type='bool'; default=$true }
         checksum = @{ type='str' }

--- a/lib/ansible/modules/windows/win_uri.ps1
+++ b/lib/ansible/modules/windows/win_uri.ps1
@@ -12,6 +12,7 @@
 
 $spec = @{
     options = @{
+       url = @{ type = "str"; required = $true }
        content_type = @{ type = "str" }
        body = @{ type = "raw" }
        dest = @{ type = "path" }
@@ -73,7 +74,7 @@ if ($removes -and -not (Test-AnsiblePath -Path $removes)) {
     $module.ExitJson()
 }
 
-$client = Get-AnsibleWebRequest -Module $module
+$client = Get-AnsibleWebRequest -Uri $url -Module $module
 
 if ($null -ne $content_type) {
     $client.ContentType = $content_type

--- a/lib/ansible/plugins/doc_fragments/url_windows.py
+++ b/lib/ansible/plugins/doc_fragments/url_windows.py
@@ -12,11 +12,6 @@ class ModuleDocFragment(object):
     # Standard files documentation fragment
     DOCUMENTATION = r'''
 options:
-  url:
-    description:
-    - The URL to make the request with.
-    required: yes
-    type: str
   method:
     description:
     - The HTTP Method of the request.


### PR DESCRIPTION
##### SUMMARY
Having the `url` option part of the WebRequest util makes it less flexible for modules that want to take advantage of the shared code but internally create the URL to request. This keeps the win_get_url and win_uri modules with the same interface but could potentially break any 3rd party modules that rely on this util. Considering this is a brand new util added in 2.9 I would be surprised if it was actually used outside of Ansible.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Ansible.ModuleUtils.WebRequest