### PR TITLE
Update aws_batch_job_definition.py to change the example doc

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_batch_job_definition.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_job_definition.py
@@ -188,7 +188,7 @@ EXAMPLES = '''
     state: present
   tasks:
 - name: My Batch Job Definition
-  batch_job_definition:
+  aws_batch_job_definition:
     job_definition_name: My Batch Job Definition
     state: present
     type: container
@@ -216,7 +216,7 @@ output:
   description: "returns what action was taken, whether something was changed, invocation and response"
   returned: always
   sample:
-    batch_job_definition_action: none
+    aws_batch_job_definition_action: none
     changed: false
     response:
       job_definition_arn: "arn:aws:batch:...."


### PR DESCRIPTION
##### SUMMARY
<!--- The example to call the method batch_job_definition is bad, the good method name is aws_batch_job_definition-->


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
