### PR TITLE
Revert "Make cloudfront_info work with Python3 …"

### DIFF
--- a/changelogs/fragments/66695-cloudfront-info-python3-fix.yml
+++ b/changelogs/fragments/66695-cloudfront-info-python3-fix.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - Make cloudfront_info module work with Python 3

--- a/lib/ansible/modules/cloud/amazon/cloudfront_info.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_info.py
@@ -504,7 +504,7 @@ class CloudFrontServiceManager:
         try:
             distribution_id = ""
             distributions = self.list_distributions(False)
-            distributions.update(self.list_streaming_distributions(False))
+            distributions += self.list_streaming_distributions(False)
             for dist in distributions:
                 if 'Items' in dist['Aliases']:
                     for alias in dist['Aliases']['Items']:


### PR DESCRIPTION
Reverts ansible/ansible#66695

After testing again today I realized my change caused issues. Changing it back solved the issue. Also I couldn't reproduce the initial issue anymore I was trying to fix with this change. As it appears `distributions` is always a `list` and never a `dict`. So don't know how I could provoke the error described in ansible/ansible#66695 (where merging dicts was the issue).

So I think it should be reverted.