### PR TITLE
sns_topic: Retry on Topic 'NotFound' Exceptions when attempting to list subscriptions

### DIFF
--- a/changelogs/fragments/67089-sns_topic-notfound-backoff.yaml
+++ b/changelogs/fragments/67089-sns_topic-notfound-backoff.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- sns_topic - Add backoff when we get Topic ``NotFound`` exceptions while listing the subscriptions.

--- a/lib/ansible/modules/cloud/amazon/sns_topic.py
+++ b/lib/ansible/modules/cloud/amazon/sns_topic.py
@@ -264,12 +264,12 @@ class SnsTopicManager(object):
         paginator = self.connection.get_paginator('list_topics')
         return paginator.paginate().build_full_result()['Topics']
 
-    @AWSRetry.jittered_backoff()
+    @AWSRetry.jittered_backoff(catch_extra_error_codes=['NotFound'])
     def _list_topic_subscriptions_with_backoff(self):
         paginator = self.connection.get_paginator('list_subscriptions_by_topic')
         return paginator.paginate(TopicArn=self.topic_arn).build_full_result()['Subscriptions']
 
-    @AWSRetry.jittered_backoff()
+    @AWSRetry.jittered_backoff(catch_extra_error_codes=['NotFound'])
     def _list_subscriptions_with_backoff(self):
         paginator = self.connection.get_paginator('list_subscriptions')
         return paginator.paginate().build_full_result()['Subscriptions']


### PR DESCRIPTION
##### SUMMARY

We attempt to list the subscriptions almost as soon as we've created the topic, "eventual consistency" sometimes bites us ( for example https://app.shippable.com/github/ansible/ansible/runs/158170/118/console )

Add NotFound to the list of backoff conditions for list_subscriptions_by_topic and list_subscriptions where we can reasonably expect something to exist.  Does not add it to list_topics since it's valid for a topic to have already been deleted.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
sns_topic
aws_ses_identity

##### ADDITIONAL INFORMATION
```
09:52 The full traceback is:
09:52 Traceback (most recent call last):
09:52   File "/tmp/ansible_sns_topic_payload_0p8qy4yr/ansible_sns_topic_payload.zip/ansible/modules/cloud/amazon/sns_topic.py", line 377, in _list_topic_subscriptions
09:52   File "/tmp/ansible_sns_topic_payload_0p8qy4yr/ansible_sns_topic_payload.zip/ansible/module_utils/cloud.py", line 150, in retry_func
09:52     raise e
09:52   File "/tmp/ansible_sns_topic_payload_0p8qy4yr/ansible_sns_topic_payload.zip/ansible/module_utils/cloud.py", line 140, in retry_func
09:52     return f(*args, **kwargs)
09:52   File "/tmp/ansible_sns_topic_payload_0p8qy4yr/ansible_sns_topic_payload.zip/ansible/modules/cloud/amazon/sns_topic.py", line 270, in _list_topic_subscriptions_with_backoff
09:52   File "/usr/local/lib/python3.6/dist-packages/botocore/paginate.py", line 449, in build_full_result
09:52     for response in self:
09:52   File "/usr/local/lib/python3.6/dist-packages/botocore/paginate.py", line 255, in __iter__
09:52     response = self._make_request(current_kwargs)
09:52   File "/usr/local/lib/python3.6/dist-packages/botocore/paginate.py", line 332, in _make_request
09:52     return self._method(**current_kwargs)
09:52   File "/usr/local/lib/python3.6/dist-packages/botocore/client.py", line 357, in _api_call
09:52     return self._make_api_call(operation_name, kwargs)
09:52   File "/usr/local/lib/python3.6/dist-packages/botocore/client.py", line 661, in _make_api_call
09:52     raise error_class(parsed_response, operation_name)
09:52 botocore.errorfactory.NotFoundException: An error occurred (NotFound) when calling the ListSubscriptionsByTopic operation: Topic does not exist
09:52 failed: [testhost] (item=complaint) => {
09:52     "ansible_loop_var": "item",
09:52     "boto3_version": "1.9.249",
09:52     "botocore_version": "1.12.249",
09:52     "changed": false,
09:52     "error": {
09:52         "code": "NotFound",
09:52         "message": "Topic does not exist",
09:52         "type": "Sender"
09:52     },
09:52     "invocation": {
09:52         "module_args": {
09:52             "aws_access_key": "ASIA6CCDWXDOPWG3QVEF",
09:52             "aws_secret_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
09:52             "debug_botocore_endpoint_logs": true,
09:52             "delivery_policy": null,
09:52             "display_name": null,
09:52             "ec2_url": null,
09:52             "name": "shippable-158170-118-notification-queue-complaint",
09:52             "policy": null,
09:52             "profile": null,
09:52             "purge_subscriptions": true,
09:52             "region": "us-east-1",
09:52             "security_token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
09:52             "state": "present",
09:52             "subscriptions": [],
09:52             "validate_certs": true
09:52         }
09:52     },
09:52     "item": "complaint",
09:52     "msg": "Couldn't get subscriptions list for topic arn:aws:sns:us-east-1:966509639900:shippable-158170-118-notification-queue-complaint: An error occurred (NotFound) when calling the ListSubscriptionsByTopic operation: Topic does not exist",
09:52     "resource_actions": [
09:52         "sns:ListTopics",
09:52         "sns:ListSubscriptionsByTopic",
09:52         "sns:CreateTopic"
09:52     ],
09:52     "response_metadata": {
09:52         "http_headers": {
09:52             "content-length": "259",
09:52             "content-type": "text/xml",
09:52             "date": "Tue, 04 Feb 2020 13:56:32 GMT",
09:52             "x-amzn-requestid": "1652ffaf-5354-5ccd-803b-a91c29048d84"
09:52         },
09:52         "http_status_code": 404,
09:52         "request_id": "1652ffaf-5354-5ccd-803b-a91c29048d84",
09:52         "retry_attempts": 0
09:52     }
09:52 }
```