### PR TITLE
Add a content parameter to aws_s3 put operation

### DIFF
--- a/lib/ansible/module_utils/aws/s3.py
+++ b/lib/ansible/module_utils/aws/s3.py
@@ -49,6 +49,7 @@ def calculate_etag(module, filename, etag, s3, bucket, obj, version=None):
     else:  # Compute the MD5 sum normally
         return '"{0}"'.format(module.md5(filename))
 
+
 def calculate_etag_content(module, content, etag, s3, bucket, obj, version=None):
     if not HAS_MD5:
         return None
@@ -74,7 +75,7 @@ def calculate_etag_content(module, content, etag, s3, bucket, obj, version=None)
                 except (BotoCoreError, ClientError) as e:
                     module.fail_json_aws(e, msg="Failed to get head object")
                 length = int(head['ContentLength'])
-                digests.append(md5(content[offset:offset+length]))
+                digests.append(md5(content[offset:offset + length]))
                 offset += length
 
         digest_squared = md5(b''.join(m.digest() for m in digests))

--- a/lib/ansible/module_utils/aws/s3.py
+++ b/lib/ansible/module_utils/aws/s3.py
@@ -80,4 +80,4 @@ def calculate_etag_content(module, content, etag, s3, bucket, obj, version=None)
         digest_squared = md5(b''.join(m.digest() for m in digests))
         return '"{0}-{1}"'.format(digest_squared.hexdigest(), len(digests))
     else:  # Compute the MD5 sum normally
-        return '"{0}"'.format(module.md5(filename))
+        return '"{0}"'.format(md5(content).hexdigest())

--- a/lib/ansible/module_utils/aws/s3.py
+++ b/lib/ansible/module_utils/aws/s3.py
@@ -67,16 +67,15 @@ def calculate_etag_content(module, content, etag, s3, bucket, obj, version=None)
         if version:
             s3_kwargs['VersionId'] = version
 
-        with open(filename, 'rb') as f:
-            for part_num in range(1, parts + 1):
-                s3_kwargs['PartNumber'] = part_num
-                try:
-                    head = s3.head_object(**s3_kwargs)
-                except (BotoCoreError, ClientError) as e:
-                    module.fail_json_aws(e, msg="Failed to get head object")
-                length = int(head['ContentLength'])
-                digests.append(md5(content[offset:offset + length]))
-                offset += length
+        for part_num in range(1, parts + 1):
+            s3_kwargs['PartNumber'] = part_num
+            try:
+                head = s3.head_object(**s3_kwargs)
+            except (BotoCoreError, ClientError) as e:
+                module.fail_json_aws(e, msg="Failed to get head object")
+            length = int(head['ContentLength'])
+            digests.append(md5(content[offset:offset + length]))
+            offset += length
 
         digest_squared = md5(b''.join(m.digest() for m in digests))
         return '"{0}-{1}"'.format(digest_squared.hexdigest(), len(digests))

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -311,11 +311,12 @@ s3_keys:
 
 import mimetypes
 import os
+import io
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 from ssl import SSLError
 from ansible.module_utils.basic import to_text, to_native
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.aws.s3 import calculate_etag, HAS_MD5
+from ansible.module_utils.aws.s3 import calculate_etag, calculate_etag_content, HAS_MD5
 from ansible.module_utils.ec2 import get_aws_connection_info, boto3_conn
 
 try:

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -556,7 +556,9 @@ def upload_s3file(module, s3, bucket, obj, expiry, metadata, encrypt, headers, s
         if src is not None:
             s3.upload_file(Filename=src, Bucket=bucket, Key=obj, ExtraArgs=extra)
         else:
-            f = io.BytesIO(content)
+            # that's the drawback of using a string parameter...
+            # we have to encode it first
+            f = io.BytesIO(content.encode('utf-8'))
             s3.upload_fileobj(Fileobj=f, Bucket=bucket, Key=obj, ExtraArgs=extra)
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Unable to complete PUT operation.")

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -154,7 +154,7 @@ options:
       - The content to PUT into an object.
       - Either I(content) or I(src) must be specified for a PUT operation. Ignored otherwise.
     version_added: "2.10"
-    type: bytes
+    type: str
   ignore_nonexistent_bucket:
     description:
       - "Overrides initial bucket lookups in case bucket or iam policies are restrictive. Example: a user may have the
@@ -707,14 +707,14 @@ def main():
         dualstack=dict(default='no', type='bool'),
         rgw=dict(default='no', type='bool'),
         src=dict(),
-        content=dict(type='bytes'),
+        content=dict(),
         ignore_nonexistent_bucket=dict(default=False, type='bool'),
         encryption_kms_key_id=dict()
     )
     module = AnsibleAWSModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
-        required_if=[['mode', 'put', ['src', 'object']],
+        required_if=[['mode', 'put', ['object']],
                      ['mode', 'get', ['dest', 'object']],
                      ['mode', 'getstr', ['object']],
                      ['mode', 'geturl', ['object']]],

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -152,6 +152,8 @@ options:
   content:
     description:
       - The content to PUT into an object.
+      - This parameter will be treated as a string and converted to UTF-8 before sending it to S3.
+        To send binary data, use the I(src) parameter instead.
       - Either I(content) or I(src) must be specified for a PUT operation. Ignored otherwise.
     version_added: "2.10"
     type: str

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -353,7 +353,7 @@ def key_check(module, s3, bucket, obj, version=None, validate=True):
     return exists
 
 
-def etag_compare(module, s3, bucket, obj, local_file=None, version=None, content=None):
+def etag_compare(module, s3, bucket, obj, version=None, local_file=None, content=None):
     s3_etag = get_etag(s3, bucket, obj, version=version)
     if local_file is not None:
         local_etag = calculate_etag(module, local_file, s3_etag, s3, bucket, obj, version)
@@ -821,7 +821,7 @@ def main():
         if path_check(dest) and overwrite != 'always':
             if overwrite == 'never':
                 module.exit_json(msg="Local object already exists and overwrite is disabled.", changed=False)
-            if etag_compare(module, dest, s3, bucket, obj, version=version):
+            if etag_compare(module, s3, bucket, obj, version=version, local_file=dest):
                 module.exit_json(msg="Local and remote object are identical, ignoring. Use overwrite=always parameter to force.", changed=False)
 
         try:

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -849,7 +849,7 @@ def main():
             create_bucket(module, s3, bucket, location)
 
         if keyrtn and overwrite != 'always':
-            if overwrite == 'never' or etag_compare(module, s3, bucket, obj, local_file=src, content=content):
+            if overwrite == 'never' or etag_compare(module, s3, bucket, obj, version=version, local_file=src, content=content):
                 # Return the download URL for the existing object
                 get_download_url(module, s3, bucket, obj, expiry, changed=False)
 

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -352,7 +352,7 @@ def key_check(module, s3, bucket, obj, version=None, validate=True):
     return exists
 
 
-def etag_compare(module, local_file=None, s3, bucket, obj, version=None, content=None):
+def etag_compare(module, s3, bucket, obj, local_file=None, version=None, content=None):
     s3_etag = get_etag(s3, bucket, obj, version=version)
     if local_file is not None:
         local_etag = calculate_etag(module, local_file, s3_etag, s3, bucket, obj, version)
@@ -523,7 +523,7 @@ def option_in_extra_args(option):
         return allowed_extra_args[temp_option]
 
 
-def upload_s3file(module, s3, bucket, obj, src=None, expiry, metadata, encrypt, headers, content=None):
+def upload_s3file(module, s3, bucket, obj, expiry, metadata, encrypt, headers, src=None, content=None):
     if module.check_mode:
         module.exit_json(msg="PUT operation skipped - running in check mode", changed=True)
     try:

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -146,8 +146,15 @@ options:
   src:
     description:
       - The source file path when performing a PUT operation.
+      - Either I(content) or I(src) must be specified for a PUT operation. Ignored otherwise.
     version_added: "1.3"
     type: str
+  content:
+    description:
+      - The content to PUT into an object.
+      - Either I(content) or I(src) must be specified for a PUT operation. Ignored otherwise.
+    version_added: "2.10"
+    type: bytes
   ignore_nonexistent_bucket:
     description:
       - "Overrides initial bucket lookups in case bucket or iam policies are restrictive. Example: a user may have the
@@ -175,6 +182,13 @@ EXAMPLES = '''
     bucket: mybucket
     object: /my/desired/key.txt
     src: /usr/local/myfile.txt
+    mode: put
+
+- name: PUT operation from a rendered template
+  aws_s3:
+    bucket: mybucket
+    object: /object.yaml
+    content: "{{ lookup('template', 'templates/object.yaml.j2') }}"
     mode: put
 
 - name: Simple PUT operation in Ceph RGW S3

--- a/test/integration/targets/aws_s3/tasks/main.yml
+++ b/test/integration/targets/aws_s3/tasks/main.yml
@@ -567,7 +567,7 @@
         bucket: "{{ bucket_name + '.bucket' }}"
         object: put-content.txt
         mode: put
-        content: >
+        content: >-
           test content
         <<: *aws_connection_info
       register: result

--- a/test/integration/targets/aws_s3/tasks/main.yml
+++ b/test/integration/targets/aws_s3/tasks/main.yml
@@ -562,6 +562,60 @@
               - result is not changed
       when: ansible_system == 'Linux' or ansible_distribution == 'MacOSX'
 
+    - name: create an object from static content
+      aws_s3:
+        bucket: "{{ bucket_name + '.bucket' }}"
+        object: put-content.txt
+        mode: put
+        content: >
+          test content
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: fetch test content
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: getstr
+        object: put-content.txt
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result.contents == "test content"
+
+    - set_fact:
+        put_template_text: test template
+
+    - name: create an object from a template
+      aws_s3:
+        bucket: "{{ bucket_name + '.bucket' }}"
+        object: /put-template.txt
+        mode: put
+        content: "{{ lookup('template', 'templates/put-template.txt.j2') }}"
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: fetch template content
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: getstr
+        object: put-template.txt
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result.contents == "{{ lookup('template', 'templates/put-template.txt.j2') }}"
+
   always:
     - name: remove uploaded files
       aws_s3:

--- a/test/integration/targets/aws_s3/tasks/main.yml
+++ b/test/integration/targets/aws_s3/tasks/main.yml
@@ -564,7 +564,7 @@
 
     - name: create an object from static content
       aws_s3:
-        bucket: "{{ bucket_name + '.bucket' }}"
+        bucket: "{{ bucket_name }}"
         object: put-content.txt
         mode: put
         content: >-
@@ -593,8 +593,8 @@
 
     - name: create an object from a template
       aws_s3:
-        bucket: "{{ bucket_name + '.bucket' }}"
-        object: /put-template.txt
+        bucket: "{{ bucket_name }}"
+        object: put-template.txt
         mode: put
         content: "{{ lookup('template', 'templates/put-template.txt.j2') }}"
         <<: *aws_connection_info
@@ -628,6 +628,8 @@
         - delete.txt
         - delete_encrypt.txt
         - delete_encrypt_kms.txt
+        - put-content.txt
+        - put-template.txt
       ignore_errors: yes
 
     - name: delete temporary files
@@ -639,6 +641,13 @@
     - name: delete the bucket
       aws_s3:
         bucket: "{{ bucket_name }}"
+        mode: delete
+        <<: *aws_connection_info
+      ignore_errors: yes
+
+    - name: delete the dot bucket
+      aws_s3:
+        bucket: "{{ bucket_name + '.bucket' }}"
         mode: delete
         <<: *aws_connection_info
       ignore_errors: yes

--- a/test/integration/targets/aws_s3/templates/put-template.txt.j2
+++ b/test/integration/targets/aws_s3/templates/put-template.txt.j2
@@ -1,0 +1,2 @@
+template:
+{{ put_template_text }}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add support for uploading S3 objects from in-memory content in addition to on-disk files.

Fixes #67086
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_s3

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Example usage:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: PUT operation from a rendered template
  aws_s3:
    bucket: mybucket
    object: /object.yaml
    content: "{{ lookup('template', 'templates/object.yaml.j2') }}"
    mode: put
```
