### PR TITLE
Removed deprecated items in Windows modules

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -32,6 +32,8 @@ Deprecated
 ==========
 
 * Windows Server 2008 and 2008 R2 will no longer be supported or tested in the next Ansible release, see :ref:`windows_faq_server2008`.
+* The :ref:`win_stat <win_stat_module>` module has removed the deprecated ``get_md55`` option and ``md5`` return value.
+* The :ref:`win_psexec <win_psexec_module>` module has removed the deprecated ``extra_opts`` option.
 
 
 Modules

--- a/lib/ansible/modules/windows/win_psexec.ps1
+++ b/lib/ansible/modules/windows/win_psexec.ps1
@@ -27,7 +27,6 @@ $spec = @{
         session = @{ type='int' }
         priority = @{ type='str'; choices=@( 'background', 'low', 'belownormal', 'abovenormal', 'high', 'realtime' ) }
         timeout = @{ type='int' }
-        extra_opts = @{ type='list'; removed_in_version = '2.10' }
     }
 }
 
@@ -49,7 +48,6 @@ $interactive = $module.Params.interactive
 $session = $module.Params.session
 $priority = $module.Params.Priority
 $timeout = $module.Params.timeout
-$extra_opts = $module.Params.extra_opts
 
 $module.Result.changed = $true
 
@@ -120,13 +118,6 @@ If ($null -ne $priority) {
 If ($null -ne $timeout) {
     $arguments.Add("-n")
     $arguments.Add($timeout)
-}
-
-# Add additional advanced options
-If ($extra_opts) {
-    ForEach ($opt in $extra_opts) {
-        $arguments.Add($opt)
-    }
 }
 
 $arguments.Add("-accepteula")

--- a/lib/ansible/modules/windows/win_psexec.py
+++ b/lib/ansible/modules/windows/win_psexec.py
@@ -29,12 +29,6 @@ options:
     - The location of the PsExec utility (in case it is not located in your PATH).
     type: path
     default: psexec.exe
-  extra_opts:
-    description:
-    - Specify additional options to add onto the PsExec invocation.
-    - This module was undocumented in older releases and will be removed in
-      Ansible 2.10.
-    type: list
   hostnames:
     description:
     - The hostnames to run the command.

--- a/lib/ansible/modules/windows/win_stat.ps1
+++ b/lib/ansible/modules/windows/win_stat.ps1
@@ -59,7 +59,6 @@ $spec = @{
         path = @{ type='path'; required=$true; aliases=@( 'dest', 'name' ) }
         get_checksum = @{ type='bool'; default=$true }
         checksum_algorithm = @{ type='str'; default='sha1'; choices=@( 'md5', 'sha1', 'sha256', 'sha384', 'sha512' ) }
-        get_md5 = @{ type='bool'; default=$false; removed_in_version='2.9' }
         follow = @{ type='bool'; default=$false }
     }
     supports_check_mode = $true
@@ -68,7 +67,6 @@ $spec = @{
 $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 
 $path = $module.Params.path
-$get_md5 = $module.Params.get_md5
 $get_checksum = $module.Params.get_checksum
 $checksum_algorithm = $module.Params.checksum_algorithm
 $follow = $module.Params.follow
@@ -111,7 +109,6 @@ If ($null -ne $info) {
         # owner = set outsite this dict in case it fails
         # sharename = a directory and isshared is True
         # checksum = a file and get_checksum: True
-        # md5 = a file and get_md5: True
     }
     try {
         $stat.owner = $info.GetAccessControl().Owner
@@ -144,13 +141,6 @@ If ($null -ne $info) {
         $stat.isreg = $true
         $stat.size = $info.Length
 
-        if ($get_md5) {
-            try {
-                $stat.md5 = Get-FileChecksum -path $path -algorithm "md5"
-            } catch {
-                $module.FailJson("Failed to get MD5 hash of file, remove get_md5 to ignore this error: $($_.Exception.Message)", $_)
-            }
-        }
         if ($get_checksum) {
             try {
                 $stat.checksum = Get-FileChecksum -path $path -algorithm $checksum_algorithm

--- a/lib/ansible/modules/windows/win_stat.py
+++ b/lib/ansible/modules/windows/win_stat.py
@@ -27,18 +27,6 @@ options:
         type: path
         required: yes
         aliases: [ dest, name ]
-    get_md5:
-        description:
-            - Whether to return the checksum sum of the file. Between Ansible 1.9
-              and Ansible 2.2 this is no longer an MD5, but a SHA1 instead. As of Ansible
-              2.3 this is back to an MD5. Will return None if host is unable to
-              use specified algorithm.
-            - The default of this option changed from C(yes) to C(no) in Ansible 2.5
-              and will be removed altogether in Ansible 2.9.
-            - Use C(get_checksum=yes) with C(checksum_algorithm=md5) to return an
-              md5 hash under the C(checksum) return value.
-        type: bool
-        default: no
     get_checksum:
         description:
             - Whether to return a checksum of the file (default sha1)
@@ -220,11 +208,6 @@ stat:
             returned: success, path exists and the path is a symbolic link or junction point
             type: str
             sample: ..\link
-        md5:
-            description: The MD5 checksum of a file (Between Ansible 1.9 and Ansible 2.2 this was returned as a SHA1 hash), will be removed in Ansible 2.9.
-            returned: success, path exist, path is a file, get_md5 == True
-            type: str
-            sample: 09cb79e8fc7453c84a07f644e441fd81623b7f98
         nlink:
             description: Number of links to the file (hard links).
             returned: success, path exists

--- a/test/integration/targets/win_stat/tasks/tests.yml
+++ b/test/integration/targets/win_stat/tasks/tests.yml
@@ -24,23 +24,10 @@
     - stat_file.stat.isshared == False
     - stat_file.stat.lastaccesstime == 1477984205
     - stat_file.stat.lastwritetime == 1477984205
-    - stat_file.stat.md5 is not defined
     - stat_file.stat.nlink == 1
     - stat_file.stat.owner == 'BUILTIN\Administrators'
     - stat_file.stat.path == win_stat_dir + '\\nested\\file.ps1'
     - stat_file.stat.size == 3
-
-# get_md5 will be undocumented in 2.9, remove this test then
-- name: test win_stat module on file with md5
-  win_stat:
-    path: '{{win_stat_dir}}\nested\file.ps1'
-    get_md5: True
-  register: stat_file_md5
-
-- name: check actual for file without md5
-  assert:
-    that:
-    - stat_file_md5.stat.checksum == 'a9993e364706816aba3e25717850c26c9cd0d89d'
 
 - name: test win_stat module on file with sha256
   win_stat:
@@ -100,7 +87,6 @@
     - stat_file_hidden.stat.isshared == False
     - stat_file_hidden.stat.lastaccesstime == 1477984205
     - stat_file_hidden.stat.lastwritetime == 1477984205
-    - stat_file_hidden.stat.md5 is not defined
     - stat_file_hidden.stat.nlink == 1
     - stat_file_hidden.stat.owner == 'BUILTIN\Administrators'
     - stat_file_hidden.stat.path == win_stat_dir + '\\nested\\hidden.ps1'
@@ -131,7 +117,6 @@
     - stat_readonly.stat.isshared == False
     - stat_readonly.stat.lastaccesstime == 1477984205
     - stat_readonly.stat.lastwritetime == 1477984205
-    - stat_readonly.stat.md5 is not defined
     - stat_readonly.stat.nlink == 1
     - stat_readonly.stat.owner == 'BUILTIN\Administrators'
     - stat_readonly.stat.path == win_stat_dir + '\\nested\\read-only.ps1'
@@ -162,7 +147,6 @@
     - stat_hard_link.stat.isshared == False
     - stat_hard_link.stat.lastaccesstime == 1477984205
     - stat_hard_link.stat.lastwritetime == 1477984205
-    - stat_hard_link.stat.md5 is not defined
     - stat_hard_link.stat.nlink == 2
     - stat_hard_link.stat.owner == 'BUILTIN\Administrators'
     - stat_hard_link.stat.path == win_stat_dir + '\\nested\\hard-link.ps1'
@@ -193,7 +177,6 @@
     - stat_directory.stat.isshared == False
     - stat_directory.stat.lastaccesstime == 1477984205
     - stat_directory.stat.lastwritetime == 1477984205
-    - stat_directory.stat.md5 is not defined
     - stat_directory.stat.nlink == 1
     - stat_directory.stat.owner == 'BUILTIN\Administrators'
     - stat_directory.stat.path == win_stat_dir + '\\nested'
@@ -224,7 +207,6 @@
     - stat_directory_empty.stat.isshared == False
     - stat_directory_empty.stat.lastaccesstime == 1477984205
     - stat_directory_empty.stat.lastwritetime == 1477984205
-    - stat_directory_empty.stat.md5 is not defined
     - stat_directory_empty.stat.nlink == 1
     - stat_directory_empty.stat.owner == 'BUILTIN\Administrators'
     - stat_directory_empty.stat.path == win_stat_dir + '\\folder'
@@ -255,7 +237,6 @@
     - stat_directory_space.stat.isshared == False
     - stat_directory_space.stat.lastaccesstime == 1477984205
     - stat_directory_space.stat.lastwritetime == 1477984205
-    - stat_directory_space.stat.md5 is not defined
     - stat_directory_space.stat.nlink == 1
     - stat_directory_space.stat.owner == 'BUILTIN\Administrators'
     - stat_directory_space.stat.path == win_stat_dir + '\\folder space'
@@ -286,7 +267,6 @@
     - stat_hidden.stat.isshared == False
     - stat_hidden.stat.lastaccesstime == 1477984205
     - stat_hidden.stat.lastwritetime == 1477984205
-    - stat_hidden.stat.md5 is not defined
     - stat_hidden.stat.nlink == 1
     - stat_hidden.stat.owner == 'BUILTIN\Administrators'
     - stat_hidden.stat.path == win_stat_dir + '\\hidden'
@@ -317,7 +297,6 @@
     - stat_shared.stat.isshared == True
     - stat_shared.stat.lastaccesstime == 1477984205
     - stat_shared.stat.lastwritetime == 1477984205
-    - stat_shared.stat.md5 is not defined
     - stat_shared.stat.nlink == 1
     - stat_shared.stat.owner == 'BUILTIN\Administrators'
     - stat_shared.stat.path == win_stat_dir + '\\shared'
@@ -353,7 +332,6 @@
     - stat_symlink.stat.owner == 'BUILTIN\\Administrators'
     - stat_symlink.stat.path == win_stat_dir + '\\link'
     - stat_symlink.stat.checksum is not defined
-    - stat_symlink.stat.md5 is not defined
 
 - name: test win_stat on file symlink
   win_stat:
@@ -382,7 +360,6 @@
     - stat_file_symlink.stat.lastwritetime is defined
     - stat_file_symlink.stat.lnk_source == win_stat_dir + '\\nested\\file.ps1'
     - stat_file_symlink.stat.lnk_target == win_stat_dir + '\\nested\\file.ps1'
-    - stat_file_symlink.stat.md5 is not defined
     - stat_file_symlink.stat.nlink == 1
     - stat_file_symlink.stat.owner == 'BUILTIN\\Administrators'
     - stat_file_symlink.stat.path == win_stat_dir + '\\file-link.txt'
@@ -413,7 +390,6 @@
     - stat_file_symlink_follow.stat.isshared == False
     - stat_file_symlink_follow.stat.lastaccesstime is defined
     - stat_file_symlink_follow.stat.lastwritetime is defined
-    - stat_file_symlink_follow.stat.md5 is not defined
     - stat_file_symlink_follow.stat.nlink == 1
     - stat_file_symlink_follow.stat.owner == 'BUILTIN\\Administrators'
     - stat_file_symlink_follow.stat.path == win_stat_dir + '\\nested\\file.ps1'
@@ -447,7 +423,6 @@
     - stat_rel_symlink.stat.owner == 'BUILTIN\\Administrators'
     - stat_rel_symlink.stat.path == win_stat_dir + '\\nested\\nested\\link-rel'
     - stat_rel_symlink.stat.checksum is not defined
-    - stat_rel_symlink.stat.md5 is not defined
 
 - name: test win_stat on relative multiple symlink with follow
   win_stat:
@@ -477,7 +452,6 @@
     - stat_symlink_follow.stat.owner == 'BUILTIN\\Administrators'
     - stat_symlink_follow.stat.path == win_stat_dir + '\\link-dest'
     - stat_symlink_follow.stat.checksum is not defined
-    - stat_symlink_follow.stat.md5 is not defined
 
 - name: test win_stat on junction
   win_stat:
@@ -574,7 +548,6 @@
 - name: get stat of pagefile
   win_stat:
     path: '{{pagefile_path.stdout_lines[0]}}'
-    get_md5: no
     get_checksum: no
   register: pagefile_stat
   when: pagefile_path.stdout_lines|count != 0
@@ -636,7 +609,6 @@
     - user_file.stat.isshared == False
     - user_file.stat.lastaccesstime == 1477984205
     - user_file.stat.lastwritetime == 1477984205
-    - user_file.stat.md5 is not defined
     - user_file.stat.nlink == 1
     - user_file.stat.owner == 'BUILTIN\\Administrators'
     - user_file.stat.path == win_stat_dir + '\\nested\\file.ps1'
@@ -672,4 +644,3 @@
     - user_symlink.stat.owner == 'BUILTIN\\Administrators'
     - user_symlink.stat.path == win_stat_dir + '\\link'
     - user_symlink.stat.checksum is not defined
-    - user_symlink.stat.md5 is not defined


### PR DESCRIPTION
##### SUMMARY
Removed the `get_md5` option for `win_stat` (meant to be done in 2.9) and the `extra_opts` option for `win_psexec`.

Fixes https://github.com/ansible/ansible/issues/67015
Fixes https://github.com/ansible/ansible/issues/67014

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_psexec
win_stat