### PR TITLE
win_domain_controller - add a deprecation warning for the log_path option

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -74,6 +74,7 @@ The following functionality will be removed in Ansible 2.14. Please update updat
 * :ref:`redfish_config <redfish_config_module>`: the ``bios_attribute_name`` and ``bios_attribute_value`` options will be removed. To maintain the existing behavior use the ``bios_attributes`` option instead.
 * :ref:`clc_aa_policy <clc_aa_policy_module>`: the ``wait`` parameter will be removed. It has always been ignored by the module.
 * :ref:`redfish_config <redfish_config_module>`, :ref:`redfish_command <redfish_command_module>`: the behavior to select the first System, Manager, or Chassis resource to modify when multiple are present will be removed. Use the new ``resource_id`` option to specify target resource to modify.
+* :ref:`win_domain_controller <win_domain_controller_module>`: the ``log_path`` option will be removed. This was undocumented and only related to debugging information for module development.
 
 
 

--- a/lib/ansible/modules/windows/win_domain_controller.ps1
+++ b/lib/ansible/modules/windows/win_domain_controller.ps1
@@ -110,6 +110,10 @@ $install_dns = Get-AnsibleParam -obj $params -name "install_dns" -type "bool"
 $state = Get-AnsibleParam -obj $params -name "state" -validateset ("domain_controller", "member_server") -failifempty $result
 
 $log_path = Get-AnsibleParam -obj $params -name "log_path"
+if ($log_path) {
+    $msg = "Param 'log_path' is deprecated. See the module docs for more information"
+    Add-DeprecationWarning -obj $result -message $msg -version "2.14"
+}
 $_ansible_check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -default $false
 
 $global:log_path = $log_path

--- a/lib/ansible/modules/windows/win_domain_controller.py
+++ b/lib/ansible/modules/windows/win_domain_controller.py
@@ -77,6 +77,12 @@ options:
       see U(https://docs.microsoft.com/en-us/powershell/module/addsdeployment/install-addsdomaincontroller).
     type: bool
     version_added: '2.10'
+  log_path:
+    description:
+    - The path to log any debug information when running the module.
+    - This option is deprecated and should not be used, it will be removed in Ansible 2.14.
+    - This does not relate to the C(-LogPath) paramter of the install controller cmdlet.
+    type: str
 seealso:
 - module: win_domain
 - module: win_domain_computer
@@ -103,7 +109,6 @@ EXAMPLES = r'''
     domain_admin_password: password123!
     safe_mode_password: password123!
     state: domain_controller
-    log_path: C:\ansible_win_domain_controller.txt
 
 # ensure a server is not a domain controller
 # note that without an action wrapper, in the case where a DC is demoted,
@@ -116,7 +121,6 @@ EXAMPLES = r'''
     domain_admin_password: password123!
     local_admin_password: password123!
     state: member_server
-    log_path: C:\ansible_win_domain_controller.txt
 
 - name: Promote server as a read only domain controller
   win_domain_controller:


### PR DESCRIPTION
### SUMMARY
The `log_path` option in `win_domain_controller` was undocumented and was only designed for debugging the module itself when developing it. This option is marked for removal in Ansible 2.14 as it collides with a potential future option to control the `-LogPath` parameter of the cmdlet used to install the controller feature.

Related to https://github.com/ansible/ansible/issues/59348.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_domain_controller