### PR TITLE
Make nios_txt_record use text field for object lookup

### DIFF
--- a/lib/ansible/modules/net_tools/nios/nios_txt_record.py
+++ b/lib/ansible/modules/net_tools/nios/nios_txt_record.py
@@ -106,7 +106,7 @@ def main():
     ib_spec = dict(
         name=dict(required=True, ib_req=True),
         view=dict(default='default', aliases=['dns_view'], ib_req=True),
-        text=dict(type='str'),
+        text=dict(type='str', ib_req=True),
         ttl=dict(type='int'),
         extattrs=dict(type='dict'),
         comment=dict(),


### PR DESCRIPTION
##### SUMMARY

Up until now, nios_txt_record assumed that the name and view parameters uniquely described a TXT record. What this meant is that it was impossible to have more than one TXT record with a certain name.

Changes in this commit expand the set of parameters that uniquely identify the TXT record with a text field.

This PR fixes #62377 for Ansible 2.8

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

nios_txt_record

##### ADDITIONAL INFORMATION

The playbook that demonstrates the fix:

```yaml
---
- name: Testing nios_txt_record
  hosts: localhost
  gather_facts: false

  tasks:
    - name: Add a TXT record
      nios_txt_record:
        name: bla.tadej.sem
        text: text1
        provider:
          host: 172.16.93.148
          username: admin
          password: infoblox

    - name: Add another TXT record
      nios_txt_record:
        name: bla.tadej.sem
        text: text2
        provider:
          host: 172.16.93.148
          username: admin
          password: infoblox
```

Currently, the second TXT record will overwrite the first entry and we end up with a single TXT record at the end of the play. After the changes from the PR are applied, both records will be added.