### PR TITLE
Fix a typo in hcloud_image_info and hcloud_location_info

### DIFF
--- a/lib/ansible/modules/cloud/hcloud/hcloud_image_info.py
+++ b/lib/ansible/modules/cloud/hcloud/hcloud_image_info.py
@@ -196,7 +196,7 @@ def main():
         ansible_info = {
             'hcloud_imagen_facts': result['hcloud_image_info']
         }
-        module.exit_json(ansible_s=ansible_info)
+        module.exit_json(ansible_facts=ansible_info)
     else:
         ansible_info = {
             'hcloud_image_info': result['hcloud_image_info']

--- a/lib/ansible/modules/cloud/hcloud/hcloud_location_info.py
+++ b/lib/ansible/modules/cloud/hcloud/hcloud_location_info.py
@@ -157,7 +157,7 @@ def main():
         ansible_info = {
             'hcloud_location_facts': result['hcloud_location_info']
         }
-        module.exit_json(ansible_s=ansible_info)
+        module.exit_json(ansible_facts=ansible_info)
     else:
         ansible_info = {
             'hcloud_location_info': result['hcloud_location_info']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There is a small typo in the hcloud_image_info and hcloud_location info modules when using them as the old hcloud_* _facts module
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hcloud_image_info
hcloud_location_info
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```

/site_note: (This was found in the cfgmgmtcamp workshop from @Akasurde and @ganeshrn (Thank you for the workshop!)