### PR TITLE
module (pause) is missing interpreter line

### DIFF
--- a/lib/ansible/modules/utilities/logic/pause.py
+++ b/lib/ansible/modules/utilities/logic/pause.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 


### PR DESCRIPTION
##### SUMMARY

Running pause via `self._execute_module` results with this:

```
fatal: [localhost]: FAILED! => {"msg": "module (pause) is missing interpreter line"}
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

pause

##### ADDITIONAL INFORMATION

Looking at the other modules adjacent to pause it looks like everything else has an interpreter line already set.
