### PR TITLE
wait_for_connection: also retry interpreter discovery (#67040)

### DIFF
--- a/changelogs/fragments/wait_for_connection-interpreter-discovery-retry.yaml
+++ b/changelogs/fragments/wait_for_connection-interpreter-discovery-retry.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- wait_for_connection - with pipelining enabled, interpreter discovery would
+  fail if the first connection attempt was not successful

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -79,6 +79,9 @@ class ActionModule(ActionBase):
         def ping_module_test(connect_timeout):
             ''' Test ping module, if available '''
             display.vvv("wait_for_connection: attempting ping module test")
+            # re-run interpreter discovery if we ran it in the first iteration
+            if self._discovered_interpreter_key:
+                task_vars['ansible_facts'].pop(self._discovered_interpreter_key, None)
             # call connection reset between runs if it's there
             try:
                 self._connection.reset()


### PR DESCRIPTION
self._discovered_interpreter_key is None unless a previous iteration
has attempted discovery.  In that case, force re-discovery, as the
previous attempt certainly failed.

(cherry picked from commit fd954a9c5c05c7149eb23271529ff070f2b1f9dc)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
