### PR TITLE
Remove yaml stdout_callback from network tests

### DIFF
--- a/test/integration/network-integration.cfg
+++ b/test/integration/network-integration.cfg
@@ -4,7 +4,6 @@
 [defaults]
 host_key_checking = False
 log_path = /tmp/ansible-test.out
-stdout_callback = yaml
 
 [ssh_connection]
 ssh_args = '-o UserKnownHostsFile=/dev/null'


### PR DESCRIPTION
Currently, yaml stdout_callback is not in base.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>