### PR TITLE
Mention role defaults file in variable precedence list

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/user_guide/playbooks_variables.rst
@@ -1009,7 +1009,7 @@ If multiple variables of the same name are defined in different places, they get
 Here is the order of precedence from least to greatest (the last listed variables winning prioritization):
 
   #. command line values (eg "-u user")
-  #. role defaults [1]_
+  #. role defaults (defined in role/defaults/main.yml) [1]_
   #. inventory file or script group vars [2]_
   #. inventory group_vars/all [3]_
   #. playbook group_vars/all [3]_


### PR DESCRIPTION
##### SUMMARY
I only knew about the `role/vars/` dir and didn't know about the `role/defaults/` dir, so ran into the same error as mentioned in this comment here: https://github.com/ansible/ansible/issues/10922#issuecomment-99899857

Having the `role/defaults/` dir mentioned specifically in this list would have helped me understand this sooner.

##### ISSUE TYPE
- Docs Pull Requests
