### PR TITLE
Cloudscale Regions and Zones Support

### DIFF
--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_floating_ip.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_floating_ip.py
@@ -59,7 +59,7 @@ options:
   region:
     description:
       - The region in which the floating IP resides. If omitted, the region of
-        the project default zone is used. This parameter B(must) be omitted if
+        the project default zone is used. This parameter must be omitted if
         I(type) is set to C(global).
     type: str
   prefix_length:

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_floating_ip.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_floating_ip.py
@@ -59,8 +59,8 @@ options:
   region:
     description:
       - The region in which the floating IP resides. If omitted, the region of
-        the project default zone is used. This parameter must be omitted if the
-        type of the floating ip is 'global'.
+        the project default zone is used. This parameter B(must) be omitted if
+        I(type) is set to C(global).
     type: str
   prefix_length:
     description:
@@ -101,6 +101,7 @@ EXAMPLES = '''
     prefix_length: 56
     server: 47cec963-fcd2-482f-bdb6-24461b2d47b1
     api_token: xxxxxx
+    region: lpg1
   register: floating_ip
 
 # Assign an existing floating network to a different server

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_floating_ip.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_floating_ip.py
@@ -53,14 +53,14 @@ options:
   type:
     description:
       - The type of the floating IP.
-    chioces: [ regional, global ]
+    choices: [ regional, global ]
     type: str
     default: regional
   region:
     description:
-      - The region in which the floating IP resides. If omitted, the region of
-        the project default zone is used. This parameter must be omitted if
-        I(type) is set to C(global).
+      - Region in which the floating IP resides (e.g. C(lgp) or C(rma)).
+        If omitted, the region of the project default zone is used.
+        This parameter must be omitted if I(type) is set to C(global).
     type: str
   prefix_length:
     description:

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_floating_ip.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_floating_ip.py
@@ -153,7 +153,7 @@ ip:
   type: str
   sample: 185.98.122.176
 region:
-  description: The region of the floating IP address or network.
+  description: The region of the floating IP.
   returned: success when state == present
   type: dict
   sample: {'slug': 'lpg'}

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_floating_ip.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_floating_ip.py
@@ -26,7 +26,9 @@ notes:
   - This module requires the ipaddress python library. This library is included in Python since version 3.3. It is available as a
     module on PyPI for earlier versions.
 version_added: "2.5"
-author: "Gaudenz Steinlin (@gaudenz)"
+author:
+  - Gaudenz Steinlin (@gaudenz)
+  - Denis Krienbühl (@href)
 options:
   state:
     description:

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_floating_ip.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_floating_ip.py
@@ -159,6 +159,7 @@ region:
   returned: success when state == present
   type: dict
   sample: {'slug': 'lpg'}
+  version_added: '2.10'
 state:
   description: The current status of the floating IP.
   returned: success

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_floating_ip.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_floating_ip.py
@@ -58,12 +58,14 @@ options:
     choices: [ regional, global ]
     type: str
     default: regional
+    version_added: '2.10'
   region:
     description:
       - Region in which the floating IP resides (e.g. C(lgp) or C(rma)).
         If omitted, the region of the project default zone is used.
         This parameter must be omitted if I(type) is set to C(global).
     type: str
+    version_added: '2.10'
   prefix_length:
     description:
       - Only valid if I(ip_version) is 6.
@@ -254,7 +256,7 @@ def main():
         ip=dict(aliases=('network', ), type='str'),
         ip_version=dict(choices=(4, 6), type='int'),
         server=dict(type='str'),
-        type=dict(type='str', choices=('regional', 'global')),
+        type=dict(type='str', choices=('regional', 'global'), default='regional'),
         region=dict(type='str'),
         prefix_length=dict(choices=(56,), type='int'),
         reverse_ptr=dict(type='str'),

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
@@ -30,6 +30,7 @@ version_added: '2.3'
 author:
   - Gaudenz Steinlin (@gaudenz)
   - René Moser (@resmo)
+  - Denis Krienbühl (@href)
 options:
   state:
     description:

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
@@ -57,7 +57,7 @@ options:
     type: str
   zone:
     description:
-      - Zone to launch the server in (e.g. C(lgp1) or C(rma1))
+      - Zone in which the server resides (e.g. C(lgp1) or C(rma1)).
     type: str
     version_added: '2.10'
   volume_size_gb:

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
@@ -57,7 +57,7 @@ options:
     type: str
   zone:
     description:
-      - Zone to launch the server in (e.g. 'lgp1' or 'rma1')
+      - Zone to launch the server in (e.g. C(lgp1) or C(rma1))
     type: str
     version_added: '2.10'
   volume_size_gb:

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
@@ -55,6 +55,11 @@ options:
     description:
       - Image used to create the server.
     type: str
+  zone:
+    description:
+      - Zone to launch the server in (e.g. 'lgp1' or 'rma1')
+    type: str
+    version_added: '2.10'
   volume_size_gb:
     description:
       - Size of the root volume in GB.
@@ -131,6 +136,7 @@ EXAMPLES = '''
     flavor: flex-4
     ssh_keys: ssh-rsa XXXXXXXXXX...XXXX ansible@cloudscale
     server_groups: shiny-group
+    zone: lpg1
     use_private_network: True
     bulk_volume_size_gb: 100
     api_token: xxxxxx
@@ -143,6 +149,7 @@ EXAMPLES = '''
     flavor: flex-8
     ssh_keys: ssh-rsa XXXXXXXXXXX ansible@cloudscale
     server_groups: shiny-group
+    zone: lpg1
     api_token: xxxxxx
 
 
@@ -218,6 +225,12 @@ image:
   returned: success when not state == absent
   type: dict
   sample: { "default_username": "ubuntu", "name": "Ubuntu 18.04 LTS", "operating_system": "Ubuntu", "slug": "ubuntu-18.04" }
+zone:
+  description: The zone this server is running in
+  returned: success when not state == absent
+  type: dict
+  sample: { 'slug': 'lpg1' }
+  version_added: '2.10'
 volumes:
   description: List of volumes attached to the server
   returned: success when not state == absent
@@ -511,6 +524,7 @@ def main():
         uuid=dict(),
         flavor=dict(),
         image=dict(),
+        zone=dict(),
         volume_size_gb=dict(type='int', default=10),
         bulk_volume_size_gb=dict(type='int'),
         ssh_keys=dict(type='list'),

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
@@ -227,7 +227,7 @@ image:
   type: dict
   sample: { "default_username": "ubuntu", "name": "Ubuntu 18.04 LTS", "operating_system": "Ubuntu", "slug": "ubuntu-18.04" }
 zone:
-  description: The zone this server is running in
+  description: The zone used for booting this server
   returned: success when not state == absent
   type: dict
   sample: { 'slug': 'lpg1' }

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server_group.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server_group.py
@@ -38,6 +38,11 @@ options:
       - Type of the server group.
     default: anti-affinity
     type: str
+  zone:
+    description:
+      - Zone of the server group.
+    type: str
+    version_added: '2.10'
   state:
     description:
       - State of the server group.
@@ -58,6 +63,13 @@ EXAMPLES = '''
   cloudscale_server_group:
     name: my-name
     type: anti-affinity
+    api_token: xxxxxx
+
+- name: Ensure server group in a specific zone
+  cloudscale_server_group:
+    name: my-rma-group
+    type: anti-affinity
+    zone: lpg1
     api_token: xxxxxx
 
 - name: Ensure a server group is absent
@@ -89,6 +101,11 @@ type:
   returned: if available
   type: str
   sample: anti-affinity
+zone:
+  description: The zone of the server group
+  returned: success
+  type: dict
+  sample: { 'slug': 'rma1' }
 servers:
   description: A list of servers that are part of the server group.
   returned: if available
@@ -130,6 +147,7 @@ class AnsibleCloudscaleServerGroup(AnsibleCloudscaleBase):
         data = {
             'name': self._module.params.get('name'),
             'type': self._module.params.get('type'),
+            'zone': self._module.params.get('zone'),
             'tags': self._module.params.get('tags'),
         }
         if not self._module.check_mode:
@@ -193,6 +211,7 @@ def main():
         name=dict(),
         uuid=dict(),
         type=dict(default='anti-affinity'),
+        zone=dict(),
         tags=dict(type='dict'),
         state=dict(default='present', choices=['absent', 'present']),
     ))

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server_group.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server_group.py
@@ -41,7 +41,7 @@ options:
     type: str
   zone:
     description:
-      - Zone in which the server resides (e.g. C(lgp1) or C(rma1)).
+      - Zone slug of the server group (e.g. C(lgp1) or C(rma1)).
     type: str
     version_added: '2.10'
   state:

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server_group.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server_group.py
@@ -21,6 +21,7 @@ description:
   - Create, update and remove server groups.
 author:
   - René Moser (@resmo)
+  - Denis Krienbühl (@href)
 version_added: '2.8'
 options:
   name:

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server_group.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server_group.py
@@ -40,7 +40,7 @@ options:
     type: str
   zone:
     description:
-      - Zone of the server group.
+      - Zone in which the server resides (e.g. C(lgp1) or C(rma1)).
     type: str
     version_added: '2.10'
   state:

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server_group.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server_group.py
@@ -107,6 +107,7 @@ zone:
   returned: success
   type: dict
   sample: { 'slug': 'rma1' }
+  version_added: '2.10'
 servers:
   description: A list of servers that are part of the server group.
   returned: if available

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_volume.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_volume.py
@@ -56,6 +56,11 @@ options:
         Defaults to C(ssd) on volume creation.
     choices: [ ssd, bulk ]
     type: str
+  zone:
+    description:
+      - Zone in which the volume resides. Cannot be changed after creating
+      the volume. Defaults to the project default zone.
+    type: str
   server_uuids:
     description:
       - UUIDs of the servers this volume is attached to. Set this to C([]) to
@@ -76,6 +81,7 @@ EXAMPLES = '''
 - name: Create an SSD volume
   cloudscale_volume:
     name: my_ssd_volume
+    zone: 'lpg1'
     size_gb: 50
     api_token: xxxxxx
   register: my_ssd_volume
@@ -92,6 +98,7 @@ EXAMPLES = '''
 - name: Create and attach volume to server
   cloudscale_volume:
     name: my_ssd_volume
+    zone: 'lpg1'
     size_gb: 50
     server_uuids:
       - ea3b39a3-77a8-4d0b-881d-0bb00a1e7f48
@@ -138,6 +145,11 @@ type:
   returned: state == present
   type: str
   sample: bulk
+zone:
+  description: The zone of the volume.
+  returned: state == present
+  type: dict
+  sample: {'slug': 'lpg1'}
 server_uuids:
   description: The UUIDs of the servers this volume is attached to.
   returned: state == present
@@ -189,6 +201,7 @@ class AnsibleCloudscaleVolume(AnsibleCloudscaleBase):
         data = {
             'name': self._module.params.get('name'),
             'type': self._module.params.get('type'),
+            'zone': self._module.params.get('zone'),
             'size_gb': self._module.params.get('size_gb') or 'ssd',
             'server_uuids': self._module.params.get('server_uuids') or [],
             'tags': self._module.params.get('tags'),
@@ -262,6 +275,7 @@ def main():
         state=dict(default='present', choices=('present', 'absent')),
         name=dict(),
         uuid=dict(),
+        zone=dict(),
         size_gb=dict(type='int'),
         type=dict(choices=('ssd', 'bulk')),
         server_uuids=dict(type='list', aliases=['server_uuid']),

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_volume.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_volume.py
@@ -59,7 +59,7 @@ options:
   zone:
     description:
       - Zone in which the volume resides. Cannot be changed after creating
-      the volume. Defaults to the project default zone.
+        the volume. Defaults to the project default zone.
     type: str
   server_uuids:
     description:

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_volume.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_volume.py
@@ -29,6 +29,7 @@ version_added: '2.8'
 author:
   - Gaudenz Steinlin (@gaudenz)
   - René Moser (@resmo)
+  - Denis Krienbühl (@href)
 options:
   state:
     description:

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_volume.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_volume.py
@@ -58,8 +58,8 @@ options:
     type: str
   zone:
     description:
-      - Zone in which the volume resides. Cannot be changed after creating
-        the volume. Defaults to the project default zone.
+      - Zone in which the volume resides (e.g. C(lgp1) or C(rma1)). Cannot be
+        changed after creating the volume. Defaults to the project default zone.
     type: str
   server_uuids:
     description:

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_volume.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_volume.py
@@ -62,6 +62,7 @@ options:
       - Zone in which the volume resides (e.g. C(lgp1) or C(rma1)). Cannot be
         changed after creating the volume. Defaults to the project default zone.
     type: str
+    version_added: '2.10'
   server_uuids:
     description:
       - UUIDs of the servers this volume is attached to. Set this to C([]) to

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_volume.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_volume.py
@@ -152,6 +152,7 @@ zone:
   returned: state == present
   type: dict
   sample: {'slug': 'lpg1'}
+  version_added: '2.10'
 server_uuids:
   description: The UUIDs of the servers this volume is attached to.
   returned: state == present

--- a/test/integration/targets/cloudscale_common/defaults/main.yml
+++ b/test/integration/targets/cloudscale_common/defaults/main.yml
@@ -11,3 +11,9 @@ cloudscale_test_flavor: 'flex-2'
 # SSH key to use for test servers
 cloudscale_test_ssh_key: |
   ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSPmiqkvDH1/+MDAVDZT8381aYqp73Odz8cnD5hegNhqtXajqtiH0umVg7HybX3wt1HjcrwKJovZURcIbbcDvzdH2bnYbF93T4OLXA0bIfuIp6M86x1iutFtXdpN3TTicINrmSXEE2Ydm51iMu77B08ZERjVaToya2F7vC+egfoPvibf7OLxE336a5tPCywavvNihQjL8sjgpDT5AAScjb3YqK/6VLeQ18Ggt8/ufINsYkb+9/Ji/3OcGFeflnDXq80vPUyF3u4iIylob6RSZenC38cXmQB05tRNxS1B6BXCjMRdy0v4pa7oKM2GA4ADKpNrr0RI9ed+peRFwmsclH test@ansible
+
+# The zone to use to test servers
+cloudscale_test_zone: 'lpg1'
+
+# The region to use to request floating IPs
+cloudscale_test_region: 'lpg'

--- a/test/integration/targets/cloudscale_floating_ip/tasks/floating_ip.yml
+++ b/test/integration/targets/cloudscale_floating_ip/tasks/floating_ip.yml
@@ -16,18 +16,18 @@
       - (item.ip_version == 4 and floating_ip.ip | ipv4) or (item.ip_version == 6 and floating_ip.ip | ipv6)
       - floating_ip.server == test01.uuid
 
-- name: Check floating IP indempotence
+- name: Check floating IP idempotence
   cloudscale_floating_ip:
     server: '{{ test01.uuid }}'
     ip: '{{ floating_ip.ip }}'
     region: '{{ cloudscale_test_region }}'
-  register: floating_ip_indempotence
-- name: Verify floating IP indempotence
+  register: floating_ip_idempotence
+- name: Verify floating IP idempotence
   assert:
     that:
-      - floating_ip_indempotence is successful
-      - floating_ip_indempotence is not changed
-      - floating_ip_indempotence.server == test01.uuid
+      - floating_ip_idempotence is successful
+      - floating_ip_idempotence is not changed
+      - floating_ip_idempotence.server == test01.uuid
       - floating_ip.region.slug == '{{ cloudscale_test_region }}'
 
 - name: Request global floating IP
@@ -105,12 +105,12 @@
       - release_ip is changed
       - release_ip.state == 'absent'
 
-- name: Release floating IP indempotence
+- name: Release floating IP idempotence
   cloudscale_floating_ip:
     ip: '{{ floating_ip.ip }}'
     state: 'absent'
   register: release_ip
-- name: Verify release floating IPs indempotence
+- name: Verify release floating IPs idempotence
   assert:
     that:
       - release_ip is successful

--- a/test/integration/targets/cloudscale_floating_ip/tasks/floating_ip.yml
+++ b/test/integration/targets/cloudscale_floating_ip/tasks/floating_ip.yml
@@ -1,15 +1,17 @@
-- name: Request floating IP
+- name: Request regional floating IP
   cloudscale_floating_ip:
     server: '{{ test01.uuid }}'
     ip_version: '{{ item.ip_version }}'
     reverse_ptr: '{{ item.reverse_ptr | default(omit) }}'
     prefix_length: '{{ item.prefix_length | default(omit) }}'
+    region: '{{ cloudscale_test_region }}'
   register: floating_ip
 - name: Verify request floating IP
   assert:
     that:
       - floating_ip is successful
       - floating_ip is changed
+      - floating_ip.region.slug == '{{ cloudscale_test_region }}'
       - (item.ip_version == 4 and floating_ip.ip | ipv4) or (item.ip_version == 6 and floating_ip.ip | ipv6)
       - floating_ip.server == test01.uuid
 
@@ -17,6 +19,7 @@
   cloudscale_floating_ip:
     server: '{{ test01.uuid }}'
     ip: '{{ floating_ip.ip }}'
+    region: '{{ cloudscale_test_region }}'
   register: floating_ip_indempotence
 - name: Verify floating IP indempotence
   assert:
@@ -24,6 +27,41 @@
       - floating_ip_indempotence is successful
       - floating_ip_indempotence is not changed
       - floating_ip_indempotence.server == test01.uuid
+      - floating_ip.region.slug == '{{ cloudscale_test_region }}'
+
+# - name: Request global floating IP (the recommended variant)
+#   cloudscale_floating_ip:
+#     server: '{{ test01.uuid }}'
+#     ip_version: '{{ item.ip_version }}'
+#     reverse_ptr: '{{ item.reverse_ptr | default(omit) }}'
+#     prefix_length: '{{ item.prefix_length | default(omit) }}'
+#     region: 'global'
+#   register: global_floating_ip
+# - name: Verify request floating IP
+#   assert:
+#     that:
+#       - global_floating_ip is successful
+#       - global_floating_ip is changed
+#       - global_floating_ip.region is None
+#       - (item.ip_version == 4 and global_floating_ip.ip | ipv4) or (item.ip_version == 6 and global_floating_ip.ip | ipv6)
+#       - global_floating_ip.server == test01.uuid
+
+# - name: Request global floating IP (the alternate approach)
+#   cloudscale_floating_ip:
+#     server: '{{ test01.uuid }}'
+#     ip_version: '{{ item.ip_version }}'
+#     reverse_ptr: '{{ item.reverse_ptr | default(omit) }}'
+#     prefix_length: '{{ item.prefix_length | default(omit) }}'
+#     region: null
+#   register: global_floating_ip
+# - name: Verify request floating IP
+#   assert:
+#     that:
+#       - global_floating_ip is successful
+#       - global_floating_ip is changed
+#       - global_floating_ip.region is None
+#       - (item.ip_version == 4 and global_floating_ip.ip | ipv4) or (item.ip_version == 6 and global_floating_ip.ip | ipv6)
+#       - global_floating_ip.server == test01.uuid
 
 - name: Check network parameter alias
   cloudscale_floating_ip:

--- a/test/integration/targets/cloudscale_floating_ip/tasks/floating_ip.yml
+++ b/test/integration/targets/cloudscale_floating_ip/tasks/floating_ip.yml
@@ -5,6 +5,7 @@
     reverse_ptr: '{{ item.reverse_ptr | default(omit) }}'
     prefix_length: '{{ item.prefix_length | default(omit) }}'
     region: '{{ cloudscale_test_region }}'
+
   register: floating_ip
 - name: Verify request floating IP
   assert:
@@ -29,39 +30,35 @@
       - floating_ip_indempotence.server == test01.uuid
       - floating_ip.region.slug == '{{ cloudscale_test_region }}'
 
-# - name: Request global floating IP (the recommended variant)
-#   cloudscale_floating_ip:
-#     server: '{{ test01.uuid }}'
-#     ip_version: '{{ item.ip_version }}'
-#     reverse_ptr: '{{ item.reverse_ptr | default(omit) }}'
-#     prefix_length: '{{ item.prefix_length | default(omit) }}'
-#     region: 'global'
-#   register: global_floating_ip
-# - name: Verify request floating IP
-#   assert:
-#     that:
-#       - global_floating_ip is successful
-#       - global_floating_ip is changed
-#       - global_floating_ip.region is None
-#       - (item.ip_version == 4 and global_floating_ip.ip | ipv4) or (item.ip_version == 6 and global_floating_ip.ip | ipv6)
-#       - global_floating_ip.server == test01.uuid
+- name: Request global floating IP
+  cloudscale_floating_ip:
+    server: '{{ test01.uuid }}'
+    ip_version: '{{ item.ip_version }}'
+    reverse_ptr: '{{ item.reverse_ptr | default(omit) }}'
+    prefix_length: '{{ item.prefix_length | default(omit) }}'
+    type: 'global'
+  register: global_floating_ip
+- name: Verify global floating IP
+  assert:
+    that:
+      - global_floating_ip is successful
+      - global_floating_ip is changed
+      - global_floating_ip.region == None
+      - global_floating_ip.type == 'global'
+      - (item.ip_version == 4 and global_floating_ip.ip | ipv4) or (item.ip_version == 6 and global_floating_ip.ip | ipv6)
+      - global_floating_ip.server == test01.uuid
 
-# - name: Request global floating IP (the alternate approach)
-#   cloudscale_floating_ip:
-#     server: '{{ test01.uuid }}'
-#     ip_version: '{{ item.ip_version }}'
-#     reverse_ptr: '{{ item.reverse_ptr | default(omit) }}'
-#     prefix_length: '{{ item.prefix_length | default(omit) }}'
-#     region: null
-#   register: global_floating_ip
-# - name: Verify request floating IP
-#   assert:
-#     that:
-#       - global_floating_ip is successful
-#       - global_floating_ip is changed
-#       - global_floating_ip.region is None
-#       - (item.ip_version == 4 and global_floating_ip.ip | ipv4) or (item.ip_version == 6 and global_floating_ip.ip | ipv6)
-#       - global_floating_ip.server == test01.uuid
+- name: Release global floating IP
+  cloudscale_floating_ip:
+    ip: '{{ global_floating_ip.ip }}'
+    state: 'absent'
+  register: global_floating_ip
+- name: Verify release of global floating IP
+  assert:
+    that:
+      - global_floating_ip is successful
+      - global_floating_ip is changed
+      - global_floating_ip.state == 'absent'
 
 - name: Check network parameter alias
   cloudscale_floating_ip:

--- a/test/integration/targets/cloudscale_floating_ip/tasks/main.yml
+++ b/test/integration/targets/cloudscale_floating_ip/tasks/main.yml
@@ -6,6 +6,7 @@
         flavor: '{{ cloudscale_test_flavor }}'
         image: '{{ cloudscale_test_image }}'
         ssh_keys: '{{ cloudscale_test_ssh_key }}'
+        zone: '{{ cloudscale_test_zone }}'
       register: test01
 
     - name: Create a second server
@@ -14,6 +15,7 @@
         flavor: '{{ cloudscale_test_flavor }}'
         image: '{{ cloudscale_test_image }}'
         ssh_keys: '{{ cloudscale_test_ssh_key }}'
+        zone: '{{ cloudscale_test_zone }}'
       register: test02
 
     - include_tasks: floating_ip.yml

--- a/test/integration/targets/cloudscale_floating_ip/tasks/unassigned.yml
+++ b/test/integration/targets/cloudscale_floating_ip/tasks/unassigned.yml
@@ -4,6 +4,7 @@
     ip_version: 6
     server: '{{ test01.uuid }}'
     reverse_ptr: '{{ cloudscale_resource_prefix }}-unassigned.example.com'
+    region: '{{ cloudscale_test_region }}'
   register: floating_ip
 
 # The only way to have an unassigned floating IP is to delete the server

--- a/test/integration/targets/cloudscale_server/tasks/tests.yml
+++ b/test/integration/targets/cloudscale_server/tasks/tests.yml
@@ -3,6 +3,7 @@
   cloudscale_server_group:
     name: '{{ cloudscale_resource_prefix }}-group-{{ item }}'
     type: anti-affinity
+    zone: '{{ cloudscale_test_zone }}'
   with_sequence: count=2
 
 - name: Test create a running server in check mode
@@ -12,6 +13,7 @@
     image: '{{ cloudscale_test_image }}'
     ssh_keys: '{{ cloudscale_test_ssh_key }}'
     server_groups: '{{ cloudscale_resource_prefix }}-group-1'
+    zone: '{{ cloudscale_test_zone }}'
     tags:
       project: ansible-test
       stage: production
@@ -31,6 +33,7 @@
     image: '{{ cloudscale_test_image }}'
     ssh_keys: '{{ cloudscale_test_ssh_key }}'
     server_groups: '{{ cloudscale_resource_prefix }}-group-1'
+    zone: '{{ cloudscale_test_zone }}'
     tags:
       project: ansible-test
       stage: production
@@ -42,6 +45,7 @@
       - server is changed
       - server.state == 'running'
       - server.server_groups.0.name == '{{ cloudscale_resource_prefix }}-group-1'
+      - server.zone.slug == '{{ cloudscale_test_zone }}'
       - server.tags.project == 'ansible-test'
       - server.tags.stage == 'production'
       - server.tags.sla == '24-7'
@@ -53,6 +57,7 @@
     image: '{{ cloudscale_test_image }}'
     ssh_keys: '{{ cloudscale_test_ssh_key }}'
     server_groups: '{{ cloudscale_resource_prefix }}-group-1'
+    zone: '{{ cloudscale_test_zone }}'
     tags:
       project: ansible-test
       stage: production
@@ -64,6 +69,7 @@
       - server is not changed
       - server.state == 'running'
       - server.server_groups.0.name == '{{ cloudscale_resource_prefix }}-group-1'
+      - server.zone.slug == '{{ cloudscale_test_zone }}'
       - server.tags.project == 'ansible-test'
       - server.tags.stage == 'production'
       - server.tags.sla == '24-7'
@@ -348,6 +354,7 @@
     image: '{{ cloudscale_test_image }}'
     ssh_keys: '{{ cloudscale_test_ssh_key }}'
     server_groups: '{{ cloudscale_resource_prefix }}-group-1'
+    zone: '{{ cloudscale_test_zone }}'
     use_public_network: no
     use_private_network: yes
     state: stopped
@@ -366,6 +373,7 @@
     image: '{{ cloudscale_test_image }}'
     ssh_keys: '{{ cloudscale_test_ssh_key }}'
     server_groups: '{{ cloudscale_resource_prefix }}-group-1'
+    zone: '{{ cloudscale_test_zone }}'
     use_public_network: no
     use_private_network: yes
     state: stopped
@@ -375,6 +383,7 @@
     that:
       - server_stopped is changed
       - server_stopped.state == 'stopped'
+      - server_stopped.zone.slug == '{{ cloudscale_test_zone }}'
       - server_stopped.anti_affinity_with.0.uuid == running_server_uuid
       - server_stopped.interfaces.0.type == 'private'
       - server_stopped.server_groups.0.name == '{{ cloudscale_resource_prefix }}-group-1'
@@ -386,6 +395,7 @@
     image: '{{ cloudscale_test_image }}'
     ssh_keys: '{{ cloudscale_test_ssh_key }}'
     server_groups: '{{ cloudscale_resource_prefix }}-group-1'
+    zone: '{{ cloudscale_test_zone }}'
     use_public_network: no
     use_private_network: yes
     state: stopped
@@ -395,6 +405,7 @@
     that:
       - server_stopped is not changed
       - server_stopped.state == 'stopped'
+      - server_stopped.zone.slug == '{{ cloudscale_test_zone }}'
       - server_stopped.anti_affinity_with.0.uuid == running_server_uuid
       - server_stopped.interfaces.0.type == 'private'
       - server_stopped.server_groups.0.name == '{{ cloudscale_resource_prefix }}-group-1'
@@ -415,6 +426,7 @@
     that:
       - server_stopped is not changed
       - server_stopped.state == 'stopped'
+      - server_stopped.zone.slug == '{{ cloudscale_test_zone }}'
       - server_stopped.anti_affinity_with.0.uuid == running_server_uuid
       - server_stopped.interfaces.0.type == 'private'
       - server_stopped.server_groups.0.name == '{{ cloudscale_resource_prefix }}-group-1'

--- a/test/integration/targets/cloudscale_server_group/tasks/tests.yml
+++ b/test/integration/targets/cloudscale_server_group/tasks/tests.yml
@@ -18,6 +18,7 @@
 - name: Create server group
   cloudscale_server_group:
     name: '{{ cloudscale_resource_prefix }}-grp'
+    zone: '{{ cloudscale_test_zone }}'
     tags:
       project: ansible-test
       stage: production
@@ -29,6 +30,7 @@
       - grp is changed
       - grp.type == 'anti-affinity'
       - grp.name == '{{ cloudscale_resource_prefix }}-grp'
+      - grp.zone.slug == '{{ cloudscale_test_zone }}'
       - grp.uuid
       - grp.tags.project == 'ansible-test'
       - grp.tags.stage == 'production'
@@ -41,6 +43,7 @@
 - name: Create server group idempotence
   cloudscale_server_group:
     name: '{{ cloudscale_resource_prefix }}-grp'
+    zone: '{{ cloudscale_test_zone }}'
     tags:
       project: ansible-test
       stage: production
@@ -51,6 +54,7 @@
     that:
       - grp is not changed
       - grp.name == '{{ cloudscale_resource_prefix }}-grp'
+      - grp.zone.slug == '{{ cloudscale_test_zone }}'
       - grp.uuid == server_group_uuid
       - grp.tags.project == 'ansible-test'
       - grp.tags.stage == 'production'
@@ -72,6 +76,7 @@
       - grp is changed
       - grp.name == '{{ cloudscale_resource_prefix }}-grp'
       - grp.uuid == server_group_uuid
+      - grp.zone.slug == '{{ cloudscale_test_zone }}'
       - grp.tags.project == 'ansible-test'
       - grp.tags.stage == 'production'
       - grp.tags.sla == '24-7'
@@ -91,6 +96,7 @@
       - grp is changed
       - grp.name == '{{ cloudscale_resource_prefix }}-grp2'
       - grp.uuid == server_group_uuid
+      - grp.zone.slug == '{{ cloudscale_test_zone }}'
       - grp.tags.project == 'ansible-test'
       - grp.tags.stage == 'staging'
       - grp.tags.sla == '8-5'
@@ -110,6 +116,7 @@
       - grp is not changed
       - grp.name == '{{ cloudscale_resource_prefix }}-grp2'
       - grp.uuid == server_group_uuid
+      - grp.zone.slug == '{{ cloudscale_test_zone }}'
       - grp.tags.project == 'ansible-test'
       - grp.tags.stage == 'staging'
       - grp.tags.sla == '8-5'

--- a/test/integration/targets/cloudscale_volume/tasks/setup.yml
+++ b/test/integration/targets/cloudscale_volume/tasks/setup.yml
@@ -3,6 +3,7 @@
   cloudscale_server:
     name: '{{ cloudscale_resource_prefix }}-server'
     flavor: '{{ cloudscale_test_flavor }}'
+    zone: '{{ cloudscale_test_zone }}'
     image: '{{ cloudscale_test_image }}'
     ssh_keys: '{{ cloudscale_test_ssh_key }}'
   register: server

--- a/test/integration/targets/cloudscale_volume/tasks/tests.yml
+++ b/test/integration/targets/cloudscale_volume/tasks/tests.yml
@@ -2,6 +2,7 @@
 - name: Create volume in check mode
   cloudscale_volume:
     name: '{{ cloudscale_resource_prefix }}-vol'
+    zone: '{{ cloudscale_test_zone }}'
     size_gb: 50
     tags:
       project: ansible-test
@@ -19,6 +20,7 @@
 - name: Create volume
   cloudscale_volume:
     name: '{{ cloudscale_resource_prefix }}-vol'
+    zone: '{{ cloudscale_test_zone }}'
     size_gb: 50
     tags:
       project: ansible-test
@@ -32,6 +34,7 @@
       - vol is changed
       - vol.size_gb == 50
       - vol.name == '{{ cloudscale_resource_prefix }}-vol'
+      - vol.zone.slug == '{{ cloudscale_test_zone }}'
       - vol.tags.project == 'ansible-test'
       - vol.tags.stage == 'production'
       - vol.tags.sla == '24-7'
@@ -39,6 +42,7 @@
 - name: Create volume indempotence
   cloudscale_volume:
     name: '{{ cloudscale_resource_prefix }}-vol'
+    zone: '{{ cloudscale_test_zone }}'
     size_gb: 50
     tags:
       project: ansible-test
@@ -52,6 +56,7 @@
       - vol is not changed
       - vol.size_gb == 50
       - vol.name == '{{ cloudscale_resource_prefix }}-vol'
+      - vol.zone.slug == '{{ cloudscale_test_zone }}'
       - vol.tags.project == 'ansible-test'
       - vol.tags.stage == 'production'
       - vol.tags.sla == '24-7'
@@ -180,6 +185,7 @@
   cloudscale_volume:
     name: '{{ cloudscale_resource_prefix }}-bulk'
     type: bulk
+    zone: '{{ cloudscale_test_zone }}'
     size_gb: 100
     server_uuids:
       - '{{ server.uuid }}'

--- a/test/integration/targets/cloudscale_volume/tasks/tests.yml
+++ b/test/integration/targets/cloudscale_volume/tasks/tests.yml
@@ -39,7 +39,7 @@
       - vol.tags.stage == 'production'
       - vol.tags.sla == '24-7'
 
-- name: Create volume indempotence
+- name: Create volume idempotence
   cloudscale_volume:
     name: '{{ cloudscale_resource_prefix }}-vol'
     zone: '{{ cloudscale_test_zone }}'
@@ -49,7 +49,7 @@
       stage: production
       sla: 24-7
   register: vol
-- name: 'VERIFY: Create volume indempotence'
+- name: 'VERIFY: Create volume idempotence'
   assert:
     that:
       - vol is successful
@@ -88,13 +88,13 @@
       - vol is changed
       - server.uuid in vol.server_uuids
 
-- name: Attach existing volume by name to server indempotence
+- name: Attach existing volume by name to server idempotence
   cloudscale_volume:
     name: '{{ cloudscale_resource_prefix }}-vol'
     server_uuids:
       - '{{ server.uuid }}'
   register: vol
-- name: 'VERIFY: Attach existing volume by name to server indempotence'
+- name: 'VERIFY: Attach existing volume by name to server idempotence'
   assert:
     that:
       - vol is successful
@@ -126,12 +126,12 @@
       - vol is changed
       - vol.size_gb == 100
 
-- name: Resize attached volume by UUID indempotence
+- name: Resize attached volume by UUID idempotence
   cloudscale_volume:
     uuid: '{{ vol.uuid }}'
     size_gb: 100
   register: vol
-- name: 'VERIFY: Resize attached volume by UUID indempotence'
+- name: 'VERIFY: Resize attached volume by UUID idempotence'
   assert:
     that:
       - vol is successful
@@ -167,12 +167,12 @@
       - deleted.uuid == vol.uuid
       - deleted.name == '{{ cloudscale_resource_prefix }}-vol'
 
-- name: Delete attached volume by UUID indempotence
+- name: Delete attached volume by UUID idempotence
   cloudscale_volume:
     uuid: '{{ vol.uuid }}'
     state: 'absent'
   register: deleted
-- name: 'VERIFY: Delete attached volume by UUID indempotence'
+- name: 'VERIFY: Delete attached volume by UUID idempotence'
   assert:
     that:
       - deleted is successful


### PR DESCRIPTION
##### SUMMARY
Adds support for [cloudscale.ch](https://cloudscale.ch)'s regions and zones.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- `cloudscale_floating_ip`
- `cloudscale_server`
- `cloudscale_server_group`
- `cloudscale_volume`

##### ADDITIONAL INFORMATION
This change brings our Ansible modules closer to feature parity with our official REST api. Additionally it includes some spelling fixes.

This is my first change to Ansible, please feel free to request additional adjustments to my PR.