### PR TITLE
Revert "Remove yaml stdout_callback from network tests"

### DIFF
--- a/test/integration/network-integration.cfg
+++ b/test/integration/network-integration.cfg
@@ -4,6 +4,7 @@
 [defaults]
 host_key_checking = False
 log_path = /tmp/ansible-test.out
+stdout_callback = yaml
 
 [ssh_connection]
 ssh_args = '-o UserKnownHostsFile=/dev/null'


### PR DESCRIPTION
Reverts ansible/ansible#67149

I didn't properly update the commit message on previous commit