### PR TITLE
vmware_guest_network/test: disable the test

### DIFF
--- a/test/integration/targets/vmware_guest_network/aliases
+++ b/test/integration/targets/vmware_guest_network/aliases
@@ -2,3 +2,5 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+# until we figure out why vmware_guest_tools_wait fails in the CI
+disabled


### PR DESCRIPTION
##### SUMMARY

The test fails in the CI with a timeout. It's still unclear if this
comes from:

- the ESXi environment
- the amount of the RAM
- the ISO image itself

Ideally, we should have a light VM with the vmware-tools.
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_guest_network
vmware_guest_tools_wait
<!--- Write the short name of the module, plugin, task or feature below -->