### PR TITLE
Changed wildcard-fqdn in doc

### DIFF
--- a/lib/ansible/modules/network/fortios/fortios_firewall_ssl_ssh_profile.py
+++ b/lib/ansible/modules/network/fortios/fortios_firewall_ssl_ssh_profile.py
@@ -513,7 +513,7 @@ options:
                             - address6
                             - wildcard-fqdn
                             - regex
-                    wildcard_fqdn:
+                    wildcard-fqdn:
                         description:
                             - Exempt servers by wildcard FQDN. Source firewall.wildcard-fqdn.custom.name firewall.wildcard-fqdn.group.name.
                         type: str
@@ -689,7 +689,7 @@ EXAMPLES = '''
             id:  "64"
             regex: "<your_own_value>"
             type: "fortiguard-category"
-            wildcard_fqdn: "<your_own_value> (source firewall.wildcard-fqdn.custom.name firewall.wildcard-fqdn.group.name)"
+            wildcard-fqdn: "<your_own_value> (source firewall.wildcard-fqdn.custom.name firewall.wildcard-fqdn.group.name)"
         ssl_exemptions_log: "disable"
         ssl_server:
          -


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changed wildcard-fqdn in the document. It's a typo that we used underscore "_" in the name.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixed https://github.com/ansible/ansible/issues/66077
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Module: fortios_firewall_ssl_ssh_profile
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
