### PR TITLE
nxos_igmp_interface: Remove deprecated keys oif_prefix and oif_source

### DIFF
--- a/changelogs/fragments/67186_remove_deprecated_keys_nxos.yaml
+++ b/changelogs/fragments/67186_remove_deprecated_keys_nxos.yaml
@@ -1,0 +1,3 @@
+---
+removed_features:
+  - Removed previously deprecated keys ``oif_prefix`` and ``oif_source`` from nxos_igmp_interface (https://github.com/ansible/ansible/pull/67186).

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -115,6 +115,8 @@ Noteworthy module changes
 * :ref:`docker_container <docker_container_module>` no longer passes information on non-anonymous volumes or binds as ``Volumes`` to the Docker daemon. This increases compatibility with the ``docker`` CLI program. Note that if you specify ``volumes: strict`` in ``comparisons``, this could cause existing containers created with docker_container from Ansible 2.9 or earlier to restart.
 * :ref:`docker_container <docker_container_module>`'s support for port ranges was adjusted to be more compatible to the ``docker`` command line utility: a one-port container range combined with a multiple-port host range will no longer result in only the first host port be used, but the whole range being passed to Docker so that a free port in that range will be used.
 * :ref:`purefb_fs <purefb_fs_module>` no longer supports the deprecated ``nfs`` option. This has been superceeded by ``nfsv3``.
+* :ref:`nxos_igmp_interface <nxos_igmp_interface_module>` no longer supports the deprecated ``oif_prefix`` and ``oif_source`` options. These have been superceeded by ``oif_ps``.
+
 
 Plugins
 =======

--- a/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
@@ -122,14 +122,6 @@ options:
         description:
             - Configure a routemap for static outgoing interface (OIF) or
               keyword 'default'.
-    oif_prefix:
-        description:
-            - This argument is deprecated, please use oif_ps instead.
-              Configure a prefix for static outgoing interface (OIF).
-    oif_source:
-        description:
-            - This argument is deprecated, please use oif_ps instead.
-              Configure a source for static outgoing interface (OIF).
     oif_ps:
         description:
             - Configure prefixes and sources for static outgoing interface (OIF). This
@@ -495,8 +487,6 @@ def main():
         report_llg=dict(type='bool'),
         immediate_leave=dict(type='bool'),
         oif_routemap=dict(required=False, type='str'),
-        oif_prefix=dict(required=False, type='str', removed_in_version='2.10'),
-        oif_source=dict(required=False, type='str', removed_in_version='2.10'),
         oif_ps=dict(required=False, type='raw'),
         restart=dict(type='bool', default=False),
         state=dict(choices=['present', 'absent', 'default'],
@@ -504,10 +494,7 @@ def main():
     )
 
     argument_spec.update(nxos_argument_spec)
-    mutually_exclusive = [('oif_ps', 'oif_prefix'),
-                          ('oif_ps', 'oif_source'),
-                          ('oif_ps', 'oif_routemap'),
-                          ('oif_prefix', 'oif_routemap')]
+    mutually_exclusive = [('oif_ps', 'oif_routemap')]
 
     module = AnsibleModule(argument_spec=argument_spec,
                            mutually_exclusive=mutually_exclusive,
@@ -517,17 +504,8 @@ def main():
 
     state = module.params['state']
     interface = module.params['interface']
-    oif_prefix = module.params['oif_prefix']
-    oif_source = module.params['oif_source']
     oif_routemap = module.params['oif_routemap']
     oif_ps = module.params['oif_ps']
-
-    if oif_source and not oif_prefix:
-        module.fail_json(msg='oif_prefix required when setting oif_source')
-    elif oif_source and oif_prefix:
-        oif_ps = [{'source': oif_source, 'prefix': oif_prefix}]
-    elif not oif_source and oif_prefix:
-        oif_ps = [{'prefix': oif_prefix}]
 
     intf_type = get_interface_type(interface)
     if get_interface_mode(interface, intf_type, module) == 'layer2':
@@ -583,7 +561,7 @@ def main():
     if state == 'absent':
         for each in CANNOT_ABSENT:
             if each in proposed:
-                module.fail_json(msg='only params: oif_prefix, oif_source, '
+                module.fail_json(msg='only params: '
                                      'oif_ps, oif_routemap can be used when '
                                      'state=absent')
 

--- a/test/integration/targets/nxos_igmp_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_igmp_interface/tests/common/sanity.yaml
@@ -46,9 +46,9 @@
       report_llg: true
       immediate_leave: true
       group_timeout: 300
-      # deprecated
-      oif_prefix: 239.255.255.2
-      oif_source: 192.0.2.1
+      oif_ps:
+        - source: 192.0.2.1
+          prefix: 239.255.255.2
       state: present
     register: result
 


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Fixes https://github.com/ansible/ansible/issues/67012

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request (???)

##### COMPONENT NAME
nxos_igmp_interface.py
