### PR TITLE
aws_az_info: Fix rename deprecaction warning

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_az_info.py
+++ b/lib/ansible/modules/cloud/amazon/aws_az_info.py
@@ -92,8 +92,8 @@ def main():
     )
 
     module = AnsibleModule(argument_spec=argument_spec)
-    if module._name == 'aws_acm_facts':
-        module.deprecate("The 'aws_az_facts' module has been renamed to 'aws_az_info'", version='2.13')
+    if module._name == 'aws_az_facts':
+        module.deprecate("The 'aws_az_facts' module has been renamed to 'aws_az_info'", version='2.14')
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 required for this module')


### PR DESCRIPTION
##### SUMMARY

During the mass-rename from _facts to _info there was a Copy&Paste mistake.  As a result calling aws_az_facts hasn't been triggering a deprecation warning.

Since 2.9.0-2.9.3 weren't spitting out a deprecation warning I've bumped the final deadline from 2.13 to 2.14

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
aws_az_info

##### ADDITIONAL INFORMATION