### PR TITLE
Migrate a batch of AWS modules to AnsibleAWSModule (1)

### DIFF
--- a/lib/ansible/module_utils/aws/batch.py
+++ b/lib/ansible/module_utils/aws/batch.py
@@ -47,6 +47,9 @@ class AWSConnection(object):
 
     def __init__(self, ansible_obj, resources, boto3=True):
 
+        ansible_obj.deprecate("The 'ansible.module_utils.aws.batch.AWSConnection' class is deprecated please use 'AnsibleAWSModule.client()'",
+                              version='2.14')
+
         self.region, self.endpoint, aws_connect_kwargs = get_aws_connection_info(ansible_obj, boto3=boto3)
 
         self.resource_client = dict()

--- a/lib/ansible/modules/cloud/amazon/aws_az_info.py
+++ b/lib/ansible/modules/cloud/amazon/aws_az_info.py
@@ -71,11 +71,7 @@ availability_zones:
 '''
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-
-import traceback
-from ansible.module_utils._text import to_native
-from ansible.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec, boto3_conn
-from ansible.module_utils.ec2 import AWSRetry, ansible_dict_to_boto3_filter_list, camel_dict_to_snake_dict, HAS_BOTO3
+from ansible.module_utils.ec2 import AWSRetry, ansible_dict_to_boto3_filter_list, camel_dict_to_snake_dict
 
 try:
     from botocore.exceptions import ClientError, BotoCoreError

--- a/lib/ansible/modules/cloud/amazon/aws_az_info.py
+++ b/lib/ansible/modules/cloud/amazon/aws_az_info.py
@@ -84,11 +84,8 @@ except ImportError:
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            filters=dict(default={}, type='dict')
-        )
+    argument_spec = dict(
+        filters=dict(default={}, type='dict')
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec)

--- a/lib/ansible/modules/cloud/amazon/aws_az_info.py
+++ b/lib/ansible/modules/cloud/amazon/aws_az_info.py
@@ -109,12 +109,8 @@ def main():
         availability_zones = connection.describe_availability_zones(
             Filters=ansible_dict_to_boto3_filter_list(sanitized_filters)
         )
-    except ClientError as e:
-        module.fail_json(msg="Unable to describe availability zones: {0}".format(to_native(e)),
-                         exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
-    except BotoCoreError as e:
-        module.fail_json(msg="Unable to describe availability zones: {0}".format(to_native(e)),
-                         exception=traceback.format_exc())
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg="Unable to describe availability zones.")
 
     # Turn the boto3 result into ansible_friendly_snaked_names
     snaked_availability_zones = [camel_dict_to_snake_dict(az) for az in availability_zones['AvailabilityZones']]

--- a/lib/ansible/modules/cloud/amazon/aws_az_info.py
+++ b/lib/ansible/modules/cloud/amazon/aws_az_info.py
@@ -80,7 +80,7 @@ from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list, camel_di
 try:
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
-    pass  # will be detected by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 
 def main():
@@ -94,9 +94,6 @@ def main():
     module = AnsibleAWSModule(argument_spec=argument_spec)
     if module._name == 'aws_az_facts':
         module.deprecate("The 'aws_az_facts' module has been renamed to 'aws_az_info'", version='2.14')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
     connection = boto3_conn(

--- a/lib/ansible/modules/cloud/amazon/aws_az_info.py
+++ b/lib/ansible/modules/cloud/amazon/aws_az_info.py
@@ -70,10 +70,10 @@ availability_zones:
     ]"
 '''
 
+from ansible.module_utils.aws.core import AnsibleAWSModule
 
 import traceback
 from ansible.module_utils._text import to_native
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec, boto3_conn
 from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list, camel_dict_to_snake_dict, HAS_BOTO3
 
@@ -91,7 +91,7 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec)
     if module._name == 'aws_az_facts':
         module.deprecate("The 'aws_az_facts' module has been renamed to 'aws_az_info'", version='2.14')
 

--- a/lib/ansible/modules/cloud/amazon/aws_batch_compute_environment.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_compute_environment.py
@@ -233,7 +233,7 @@ output:
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.aws.batch import AWSConnection
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import ec2_argument_spec, HAS_BOTO3
 from ansible.module_utils.ec2 import snake_dict_to_camel_dict, camel_dict_to_snake_dict
 import re
@@ -486,7 +486,7 @@ def main():
         )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
         supports_check_mode=True
     )

--- a/lib/ansible/modules/cloud/amazon/aws_batch_compute_environment.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_compute_environment.py
@@ -242,7 +242,7 @@ import traceback
 try:
     from botocore.exceptions import ClientError, ParamValidationError, MissingParametersError
 except ImportError:
-    pass  # Handled by HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 
 # ---------------------------------------------------------------------------------------------------
@@ -491,9 +491,6 @@ def main():
         supports_check_mode=True
     )
 
-    # validate dependencies
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 is required for this module.')
 
     aws = AWSConnection(module, ['batch'])
 

--- a/lib/ansible/modules/cloud/amazon/aws_batch_compute_environment.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_compute_environment.py
@@ -240,7 +240,7 @@ import re
 import traceback
 
 try:
-    from botocore.exceptions import ClientError, ParamValidationError, MissingParametersError
+    from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
@@ -344,9 +344,8 @@ def create_compute_environment(module, aws):
         if not module.check_mode:
             client.create_compute_environment(**api_params)
         changed = True
-    except (ClientError, ParamValidationError, MissingParametersError) as e:
-        module.fail_json(msg='Error creating compute environment: {0}'.format(to_native(e)),
-                         exception=traceback.format_exc())
+    except (ClientError, BotoCoreError) as e:
+        module.fail_json_aws(e, msg='Error creating compute environment')
 
     return changed
 
@@ -370,9 +369,8 @@ def remove_compute_environment(module, aws):
         if not module.check_mode:
             client.delete_compute_environment(**api_params)
         changed = True
-    except (ClientError, ParamValidationError, MissingParametersError) as e:
-        module.fail_json(msg='Error removing compute environment: {0}'.format(to_native(e)),
-                         exception=traceback.format_exc())
+    except (ClientError, BotoCoreError) as e:
+        module.fail_json_aws(e, msg='Error removing compute environment')
     return changed
 
 
@@ -428,9 +426,8 @@ def manage_state(module, aws):
                         module.fail_json(msg='Unable to get compute environment information after creating')
                     changed = True
                     action_taken = "updated"
-                except (ParamValidationError, ClientError) as e:
-                    module.fail_json(msg="Unable to update environment: {0}".format(to_native(e)),
-                                     exception=traceback.format_exc())
+                except (BotoCoreError, ClientError) as e:
+                    module.fail_json_aws(e, msg="Unable to update environment.")
 
         else:
             # Create Batch Compute Environment

--- a/lib/ansible/modules/cloud/amazon/aws_batch_compute_environment.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_compute_environment.py
@@ -231,13 +231,9 @@ output:
   type: dict
 '''
 
-from ansible.module_utils._text import to_native
-from ansible.module_utils.aws.batch import AWSConnection
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import ec2_argument_spec, HAS_BOTO3
 from ansible.module_utils.ec2 import snake_dict_to_camel_dict, camel_dict_to_snake_dict
 import re
-import traceback
 
 try:
     from botocore.exceptions import ClientError, BotoCoreError

--- a/lib/ansible/modules/cloud/amazon/aws_batch_compute_environment.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_compute_environment.py
@@ -461,29 +461,25 @@ def main():
     :return dict: changed, batch_compute_environment_action, response
     """
 
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            state=dict(default='present', choices=['present', 'absent']),
-            compute_environment_name=dict(required=True),
-            type=dict(required=True, choices=['MANAGED', 'UNMANAGED']),
-            compute_environment_state=dict(required=False, default='ENABLED', choices=['ENABLED', 'DISABLED']),
-            service_role=dict(required=True),
-            compute_resource_type=dict(required=True, choices=['EC2', 'SPOT']),
-            minv_cpus=dict(type='int', required=True),
-            maxv_cpus=dict(type='int', required=True),
-            desiredv_cpus=dict(type='int'),
-            instance_types=dict(type='list', required=True),
-            image_id=dict(),
-            subnets=dict(type='list', required=True),
-            security_group_ids=dict(type='list', required=True),
-            ec2_key_pair=dict(),
-            instance_role=dict(required=True),
-            tags=dict(type='dict'),
-            bid_percentage=dict(type='int'),
-            spot_iam_fleet_role=dict(),
-            region=dict(aliases=['aws_region', 'ec2_region'])
-        )
+    argument_spec = dict(
+        state=dict(default='present', choices=['present', 'absent']),
+        compute_environment_name=dict(required=True),
+        type=dict(required=True, choices=['MANAGED', 'UNMANAGED']),
+        compute_environment_state=dict(required=False, default='ENABLED', choices=['ENABLED', 'DISABLED']),
+        service_role=dict(required=True),
+        compute_resource_type=dict(required=True, choices=['EC2', 'SPOT']),
+        minv_cpus=dict(type='int', required=True),
+        maxv_cpus=dict(type='int', required=True),
+        desiredv_cpus=dict(type='int'),
+        instance_types=dict(type='list', required=True),
+        image_id=dict(),
+        subnets=dict(type='list', required=True),
+        security_group_ids=dict(type='list', required=True),
+        ec2_key_pair=dict(),
+        instance_role=dict(required=True),
+        tags=dict(type='dict'),
+        bid_percentage=dict(type='int'),
+        spot_iam_fleet_role=dict(),
     )
 
     module = AnsibleAWSModule(

--- a/lib/ansible/modules/cloud/amazon/aws_batch_job_definition.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_job_definition.py
@@ -235,7 +235,7 @@ from ansible.module_utils.ec2 import camel_dict_to_snake_dict
 import traceback
 
 try:
-    from botocore.exceptions import ClientError, ParamValidationError, MissingParametersError
+    from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
@@ -307,9 +307,8 @@ def create_job_definition(module, aws):
         if not module.check_mode:
             client.register_job_definition(**api_params)
         changed = True
-    except (ClientError, ParamValidationError, MissingParametersError) as e:
-        module.fail_json(msg='Error registering job definition: {0}'.format(to_native(e)),
-                         exception=traceback.format_exc())
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg='Error registering job definition')
 
     return changed
 
@@ -350,9 +349,8 @@ def remove_job_definition(module, aws):
         if not module.check_mode:
             client.deregister_job_definition(jobDefinition=module.params['job_definition_arn'])
         changed = True
-    except (ClientError, ParamValidationError, MissingParametersError) as e:
-        module.fail_json(msg='Error removing job definition: {0}'.format(to_native(e)),
-                         exception=traceback.format_exc())
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg='Error removing job definition')
     return changed
 
 

--- a/lib/ansible/modules/cloud/amazon/aws_batch_job_definition.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_job_definition.py
@@ -226,13 +226,9 @@ output:
   type: dict
 '''
 
-from ansible.module_utils._text import to_native
-from ansible.module_utils.aws.batch import AWSConnection, cc, set_api_params
-from ansible.module_utils.ec2 import ec2_argument_spec, HAS_BOTO3
+from ansible.module_utils.aws.batch import cc, set_api_params
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict
-
-import traceback
 
 try:
     from botocore.exceptions import ClientError, BotoCoreError

--- a/lib/ansible/modules/cloud/amazon/aws_batch_job_definition.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_job_definition.py
@@ -428,29 +428,25 @@ def main():
     :return dict: ansible facts
     """
 
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            state=dict(required=False, default='present', choices=['present', 'absent']),
-            job_definition_name=dict(required=True),
-            job_definition_arn=dict(),
-            type=dict(required=True),
-            parameters=dict(type='dict'),
-            image=dict(required=True),
-            vcpus=dict(type='int', required=True),
-            memory=dict(type='int', required=True),
-            command=dict(type='list', default=[]),
-            job_role_arn=dict(),
-            volumes=dict(type='list', default=[]),
-            environment=dict(type='list', default=[]),
-            mount_points=dict(type='list', default=[]),
-            readonly_root_filesystem=dict(),
-            privileged=dict(),
-            ulimits=dict(type='list', default=[]),
-            user=dict(),
-            attempts=dict(type='int'),
-            region=dict(aliases=['aws_region', 'ec2_region'])
-        )
+    argument_spec = dict(
+        state=dict(required=False, default='present', choices=['present', 'absent']),
+        job_definition_name=dict(required=True),
+        job_definition_arn=dict(),
+        type=dict(required=True),
+        parameters=dict(type='dict'),
+        image=dict(required=True),
+        vcpus=dict(type='int', required=True),
+        memory=dict(type='int', required=True),
+        command=dict(type='list', default=[]),
+        job_role_arn=dict(),
+        volumes=dict(type='list', default=[]),
+        environment=dict(type='list', default=[]),
+        mount_points=dict(type='list', default=[]),
+        readonly_root_filesystem=dict(),
+        privileged=dict(),
+        ulimits=dict(type='list', default=[]),
+        user=dict(),
+        attempts=dict(type='int')
     )
 
     module = AnsibleAWSModule(

--- a/lib/ansible/modules/cloud/amazon/aws_batch_job_definition.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_job_definition.py
@@ -228,8 +228,8 @@ output:
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.aws.batch import AWSConnection, cc, set_api_params
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import ec2_argument_spec, HAS_BOTO3
+from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict
 
 import traceback
@@ -453,7 +453,7 @@ def main():
         )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
         supports_check_mode=True
     )

--- a/lib/ansible/modules/cloud/amazon/aws_batch_job_definition.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_job_definition.py
@@ -237,7 +237,7 @@ import traceback
 try:
     from botocore.exceptions import ClientError, ParamValidationError, MissingParametersError
 except ImportError:
-    pass  # Handled by HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 
 # ---------------------------------------------------------------------------------------------------
@@ -457,10 +457,6 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True
     )
-
-    # validate dependencies
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 is required for this module.')
 
     aws = AWSConnection(module, ['batch'])
 

--- a/lib/ansible/modules/cloud/amazon/aws_batch_job_queue.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_job_queue.py
@@ -124,7 +124,7 @@ import re
 import traceback
 
 try:
-    from botocore.exceptions import ClientError, ParamValidationError, MissingParametersError
+    from botocore.exceptions import BotoCoreError, ClientError
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
@@ -187,9 +187,8 @@ def create_job_queue(module, aws):
         if not module.check_mode:
             client.create_job_queue(**api_params)
         changed = True
-    except (ClientError, ParamValidationError, MissingParametersError) as e:
-        module.fail_json(msg='Error creating compute environment: {0}'.format(to_native(e)),
-                         exception=traceback.format_exc())
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg='Error creating compute environment')
 
     return changed
 
@@ -220,9 +219,8 @@ def remove_job_queue(module, aws):
         if not module.check_mode:
             client.delete_job_queue(**api_params)
         changed = True
-    except (ClientError, ParamValidationError, MissingParametersError) as e:
-        module.fail_json(msg='Error removing job queue: {0}'.format(to_native(e)),
-                         exception=traceback.format_exc())
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg='Error removing job queue')
     return changed
 
 
@@ -268,9 +266,8 @@ def manage_state(module, aws):
                         aws.client().update_job_queue(**job_kwargs)
                     changed = True
                     action_taken = "updated"
-                except (ParamValidationError, ClientError) as e:
-                    module.fail_json(msg="Unable to update job queue: {0}".format(to_native(e)),
-                                     exception=traceback.format_exc())
+                except (BotoCoreError, ClientError) as e:
+                    module.fail_json_aws(e, msg="Unable to update job queue")
 
         else:
             # Create Job Queue

--- a/lib/ansible/modules/cloud/amazon/aws_batch_job_queue.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_job_queue.py
@@ -116,8 +116,8 @@ output:
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.aws.batch import AWSConnection, cc, set_api_params
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info, boto3_conn, HAS_BOTO3
+from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict
 
 import re
@@ -314,7 +314,7 @@ def main():
         )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
         supports_check_mode=True
     )

--- a/lib/ansible/modules/cloud/amazon/aws_batch_job_queue.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_job_queue.py
@@ -302,16 +302,12 @@ def main():
     :return dict: changed, batch_job_queue_action, response
     """
 
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            state=dict(required=False, default='present', choices=['present', 'absent']),
-            job_queue_name=dict(required=True),
-            job_queue_state=dict(required=False, default='ENABLED', choices=['ENABLED', 'DISABLED']),
-            priority=dict(type='int', required=True),
-            compute_environment_order=dict(type='list', required=True),
-            region=dict(aliases=['aws_region', 'ec2_region'])
-        )
+    argument_spec = dict(
+        state=dict(required=False, default='present', choices=['present', 'absent']),
+        job_queue_name=dict(required=True),
+        job_queue_state=dict(required=False, default='ENABLED', choices=['ENABLED', 'DISABLED']),
+        priority=dict(type='int', required=True),
+        compute_environment_order=dict(type='list', required=True),
     )
 
     module = AnsibleAWSModule(

--- a/lib/ansible/modules/cloud/amazon/aws_batch_job_queue.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_job_queue.py
@@ -126,7 +126,7 @@ import traceback
 try:
     from botocore.exceptions import ClientError, ParamValidationError, MissingParametersError
 except ImportError:
-    pass  # Handled by HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 # ---------------------------------------------------------------------------------------------------
 #
@@ -318,10 +318,6 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True
     )
-
-    # validate dependencies
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 is required for this module.')
 
     aws = AWSConnection(module, ['batch'])
 

--- a/lib/ansible/modules/cloud/amazon/aws_batch_job_queue.py
+++ b/lib/ansible/modules/cloud/amazon/aws_batch_job_queue.py
@@ -114,14 +114,9 @@ output:
   type: dict
 '''
 
-from ansible.module_utils._text import to_native
-from ansible.module_utils.aws.batch import AWSConnection, cc, set_api_params
-from ansible.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info, boto3_conn, HAS_BOTO3
+from ansible.module_utils.aws.batch import set_api_params
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict
-
-import re
-import traceback
 
 try:
     from botocore.exceptions import BotoCoreError, ClientError

--- a/lib/ansible/modules/cloud/amazon/aws_region_info.py
+++ b/lib/ansible/modules/cloud/amazon/aws_region_info.py
@@ -73,11 +73,8 @@ except ImportError:
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            filters=dict(default={}, type='dict')
-        )
+    argument_spec = dict(
+        filters=dict(default={}, type='dict')
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec)

--- a/lib/ansible/modules/cloud/amazon/aws_region_info.py
+++ b/lib/ansible/modules/cloud/amazon/aws_region_info.py
@@ -98,13 +98,8 @@ def main():
         regions = connection.describe_regions(
             Filters=ansible_dict_to_boto3_filter_list(sanitized_filters)
         )
-    except ClientError as e:
-        module.fail_json(msg="Unable to describe regions: {0}".format(to_native(e)),
-                         exception=traceback.format_exc(),
-                         **camel_dict_to_snake_dict(e.response))
-    except BotoCoreError as e:
-        module.fail_json(msg="Unable to describe regions: {0}".format(to_native(e)),
-                         exception=traceback.format_exc())
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg="Unable to describe regions.")
 
     module.exit_json(regions=[camel_dict_to_snake_dict(r) for r in regions['Regions']])
 

--- a/lib/ansible/modules/cloud/amazon/aws_region_info.py
+++ b/lib/ansible/modules/cloud/amazon/aws_region_info.py
@@ -59,10 +59,10 @@ regions:
     }]"
 '''
 
+from ansible.module_utils.aws.core import AnsibleAWSModule
 
 import traceback
 from ansible.module_utils._text import to_native
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec, boto3_conn
 from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list, camel_dict_to_snake_dict, HAS_BOTO3
 
@@ -80,7 +80,7 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec)
     if module._name == 'aws_region_facts':
         module.deprecate("The 'aws_region_facts' module has been renamed to 'aws_region_info'", version='2.13')
 

--- a/lib/ansible/modules/cloud/amazon/aws_region_info.py
+++ b/lib/ansible/modules/cloud/amazon/aws_region_info.py
@@ -64,7 +64,7 @@ from ansible.module_utils.aws.core import AnsibleAWSModule
 import traceback
 from ansible.module_utils._text import to_native
 from ansible.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec, boto3_conn
-from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list, camel_dict_to_snake_dict, HAS_BOTO3
+from ansible.module_utils.ec2 import AWSRetry, ansible_dict_to_boto3_filter_list, camel_dict_to_snake_dict, HAS_BOTO3
 
 try:
     from botocore.exceptions import ClientError, BotoCoreError
@@ -81,15 +81,7 @@ def main():
     if module._name == 'aws_region_facts':
         module.deprecate("The 'aws_region_facts' module has been renamed to 'aws_region_info'", version='2.13')
 
-    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
-    connection = boto3_conn(
-        module,
-        conn_type='client',
-        resource='ec2',
-        region=region,
-        endpoint=ec2_url,
-        **aws_connect_params
-    )
+    connection = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())
 
     # Replace filter key underscores with dashes, for compatibility
     sanitized_filters = dict((k.replace('_', '-'), v) for k, v in module.params.get('filters').items())

--- a/lib/ansible/modules/cloud/amazon/aws_region_info.py
+++ b/lib/ansible/modules/cloud/amazon/aws_region_info.py
@@ -60,11 +60,7 @@ regions:
 '''
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-
-import traceback
-from ansible.module_utils._text import to_native
-from ansible.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec, boto3_conn
-from ansible.module_utils.ec2 import AWSRetry, ansible_dict_to_boto3_filter_list, camel_dict_to_snake_dict, HAS_BOTO3
+from ansible.module_utils.ec2 import AWSRetry, ansible_dict_to_boto3_filter_list, camel_dict_to_snake_dict
 
 try:
     from botocore.exceptions import ClientError, BotoCoreError

--- a/lib/ansible/modules/cloud/amazon/aws_region_info.py
+++ b/lib/ansible/modules/cloud/amazon/aws_region_info.py
@@ -69,7 +69,7 @@ from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list, camel_di
 try:
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
-    pass  # will be detected by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 
 def main():
@@ -83,9 +83,6 @@ def main():
     module = AnsibleAWSModule(argument_spec=argument_spec)
     if module._name == 'aws_region_facts':
         module.deprecate("The 'aws_region_facts' module has been renamed to 'aws_region_info'", version='2.13')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
     connection = boto3_conn(

--- a/lib/ansible/modules/cloud/amazon/aws_s3_cors.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3_cors.py
@@ -102,11 +102,7 @@ except Exception:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-import traceback
-
-from ansible.module_utils._text import to_native
-from ansible.module_utils.ec2 import (HAS_BOTO3, boto3_conn, ec2_argument_spec, get_aws_connection_info,
-                                      camel_dict_to_snake_dict, snake_dict_to_camel_dict, compare_policies)
+from ansible.module_utils.ec2 import snake_dict_to_camel_dict, compare_policies
 
 
 def create_or_update_bucket_cors(connection, module):

--- a/lib/ansible/modules/cloud/amazon/aws_s3_cors.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3_cors.py
@@ -102,10 +102,10 @@ except Exception:
     # handled by HAS_BOTO3 check in main
     pass
 
+from ansible.module_utils.aws.core import AnsibleAWSModule
 import traceback
 
 from ansible.module_utils._text import to_native
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import (HAS_BOTO3, boto3_conn, ec2_argument_spec, get_aws_connection_info,
                                       camel_dict_to_snake_dict, snake_dict_to_camel_dict, compare_policies)
 
@@ -178,7 +178,7 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec)
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 is required.')

--- a/lib/ansible/modules/cloud/amazon/aws_s3_cors.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3_cors.py
@@ -128,17 +128,8 @@ def create_or_update_bucket_cors(connection, module):
     if changed:
         try:
             cors = connection.put_bucket_cors(Bucket=name, CORSConfiguration={'CORSRules': new_camel_rules})
-        except ClientError as e:
-            module.fail_json(
-                msg="Unable to update CORS for bucket {0}: {1}".format(name, to_native(e)),
-                exception=traceback.format_exc(),
-                **camel_dict_to_snake_dict(e.response)
-            )
-        except BotoCoreError as e:
-            module.fail_json(
-                msg=to_native(e),
-                exception=traceback.format_exc()
-            )
+        except (BotoCoreError, ClientError) as e:
+            module.fail_json_aws(e, msg="Unable to update CORS for bucket {0}".format(name))
 
     module.exit_json(changed=changed, name=name, rules=rules)
 
@@ -151,17 +142,8 @@ def destroy_bucket_cors(connection, module):
     try:
         cors = connection.delete_bucket_cors(Bucket=name)
         changed = True
-    except ClientError as e:
-        module.fail_json(
-            msg="Unable to delete CORS for bucket {0}: {1}".format(name, to_native(e)),
-            exception=traceback.format_exc(),
-            **camel_dict_to_snake_dict(e.response)
-        )
-    except BotoCoreError as e:
-        module.fail_json(
-            msg=to_native(e),
-            exception=traceback.format_exc()
-        )
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg="Unable to delete CORS for bucket {0}".format(name))
 
     module.exit_json(changed=changed)
 

--- a/lib/ansible/modules/cloud/amazon/aws_s3_cors.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3_cors.py
@@ -99,8 +99,7 @@ rules:
 try:
     from botocore.exceptions import ClientError, BotoCoreError
 except Exception:
-    # handled by HAS_BOTO3 check in main
-    pass
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
 import traceback
@@ -179,9 +178,6 @@ def main():
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec)
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 is required.')
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
     client = boto3_conn(module, conn_type='client', resource='s3',

--- a/lib/ansible/modules/cloud/amazon/aws_s3_cors.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3_cors.py
@@ -168,20 +168,15 @@ def destroy_bucket_cors(connection, module):
 
 def main():
 
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            name=dict(required=True, type='str'),
-            rules=dict(type='list'),
-            state=dict(type='str', choices=['present', 'absent'], required=True)
-        )
+    argument_spec = dict(
+        name=dict(required=True, type='str'),
+        rules=dict(type='list'),
+        state=dict(type='str', choices=['present', 'absent'], required=True)
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec)
 
-    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-    client = boto3_conn(module, conn_type='client', resource='s3',
-                        region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    client = module.client('s3')
 
     state = module.params.get("state")
 

--- a/lib/ansible/modules/cloud/amazon/cloudtrail.py
+++ b/lib/ansible/modules/cloud/amazon/cloudtrail.py
@@ -270,7 +270,7 @@ except ImportError:
     # Handled in main() by imported HAS_BOTO3
     pass
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import (boto3_conn, ec2_argument_spec, get_aws_connection_info,
                                       HAS_BOTO3, ansible_dict_to_boto3_tag_list,
                                       boto3_tag_list_to_ansible_dict, camel_dict_to_snake_dict)
@@ -468,7 +468,7 @@ def main():
     required_if = [('state', 'present', ['s3_bucket_name']), ('state', 'enabled', ['s3_bucket_name'])]
     required_together = [('cloudwatch_logs_role_arn', 'cloudwatch_logs_log_group_arn')]
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_together=required_together, required_if=required_if)
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True, required_together=required_together, required_if=required_if)
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 is required for this module')

--- a/lib/ansible/modules/cloud/amazon/cloudtrail.py
+++ b/lib/ansible/modules/cloud/amazon/cloudtrail.py
@@ -279,7 +279,7 @@ def create_trail(module, client, ct_params):
     """
     Creates a CloudTrail
 
-    module : AnsibleModule object
+    module : AnsibleAWSModule object
     client : boto3 client connection object
     ct_params : The parameters for the Trail to create
     """
@@ -296,7 +296,7 @@ def tag_trail(module, client, tags, trail_arn, curr_tags=None, dry_run=False):
     """
     Creates, updates, removes tags on a CloudTrail resource
 
-    module : AnsibleModule object
+    module : AnsibleAWSModule object
     client : boto3 client connection object
     tags : Dict of tags converted from ansible_dict to boto3 list of dicts
     trail_arn : The ARN of the CloudTrail to operate on
@@ -361,7 +361,7 @@ def set_logging(module, client, name, action):
     """
     Starts or stops logging based on given state
 
-    module : AnsibleModule object
+    module : AnsibleAWSModule object
     client : boto3 client connection object
     name : The name or ARN of the CloudTrail to operate on
     action : start or stop
@@ -386,7 +386,7 @@ def get_trail_facts(module, client, name):
     """
     Describes existing trail in an account
 
-    module : AnsibleModule object
+    module : AnsibleAWSModule object
     client : boto3 client connection object
     name : Name of the trail
     """
@@ -422,7 +422,7 @@ def delete_trail(module, client, trail_arn):
     """
     Delete a CloudTrail
 
-    module : AnsibleModule object
+    module : AnsibleAWSModule object
     client : boto3 client connection object
     trail_arn : Full CloudTrail ARN
     """
@@ -436,7 +436,7 @@ def update_trail(module, client, ct_params):
     """
     Delete a CloudTrail
 
-    module : AnsibleModule object
+    module : AnsibleAWSModule object
     client : boto3 client connection object
     ct_params : The parameters for the Trail to update
     """

--- a/lib/ansible/modules/cloud/amazon/cloudtrail.py
+++ b/lib/ansible/modules/cloud/amazon/cloudtrail.py
@@ -268,7 +268,7 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import (get_aws_connection_info, camel_dict_to_snake_dict,
+from ansible.module_utils.ec2 import (camel_dict_to_snake_dict,
                                       ansible_dict_to_boto3_tag_list, boto3_tag_list_to_ansible_dict)
 
 
@@ -498,7 +498,7 @@ def main():
         ct_params['KmsKeyId'] = module.params['kms_key_id']
 
     client = module.client('cloudtrail')
-    region = get_aws_connection_info(module, boto3=True)[0]
+    region = module.region
 
     results = dict(
         changed=False,

--- a/lib/ansible/modules/cloud/amazon/cloudtrail.py
+++ b/lib/ansible/modules/cloud/amazon/cloudtrail.py
@@ -267,8 +267,7 @@ import traceback
 try:
     from botocore.exceptions import ClientError
 except ImportError:
-    # Handled in main() by imported HAS_BOTO3
-    pass
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import (boto3_conn, ec2_argument_spec, get_aws_connection_info,
@@ -469,9 +468,6 @@ def main():
     required_together = [('cloudwatch_logs_role_arn', 'cloudwatch_logs_log_group_arn')]
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True, required_together=required_together, required_if=required_if)
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 is required for this module')
 
     # collect parameters
     if module.params['state'] in ('present', 'enabled'):

--- a/lib/ansible/modules/cloud/amazon/cloudtrail.py
+++ b/lib/ansible/modules/cloud/amazon/cloudtrail.py
@@ -447,8 +447,7 @@ def update_trail(module, client, ct_params):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state=dict(default='present', choices=['present', 'absent', 'enabled', 'disabled']),
         name=dict(default='default'),
         enable_logging=dict(default=True, type='bool'),
@@ -462,7 +461,7 @@ def main():
         cloudwatch_logs_log_group_arn=dict(),
         kms_key_id=dict(),
         tags=dict(default={}, type='dict'),
-    ))
+    )
 
     required_if = [('state', 'present', ['s3_bucket_name']), ('state', 'enabled', ['s3_bucket_name'])]
     required_together = [('cloudwatch_logs_role_arn', 'cloudwatch_logs_log_group_arn')]

--- a/lib/ansible/modules/cloud/amazon/cloudtrail.py
+++ b/lib/ansible/modules/cloud/amazon/cloudtrail.py
@@ -262,17 +262,14 @@ trail:
             sample: {'environment': 'dev', 'Name': 'default'}
 '''
 
-import traceback
-
 try:
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import (boto3_conn, ec2_argument_spec, get_aws_connection_info,
-                                      HAS_BOTO3, ansible_dict_to_boto3_tag_list,
-                                      boto3_tag_list_to_ansible_dict, camel_dict_to_snake_dict)
+from ansible.module_utils.ec2 import (get_aws_connection_info, camel_dict_to_snake_dict,
+                                      ansible_dict_to_boto3_tag_list, boto3_tag_list_to_ansible_dict)
 
 
 def create_trail(module, client, ct_params):

--- a/lib/ansible/modules/cloud/amazon/cloudtrail.py
+++ b/lib/ansible/modules/cloud/amazon/cloudtrail.py
@@ -500,11 +500,8 @@ def main():
     if module.params['kms_key_id']:
         ct_params['KmsKeyId'] = module.params['kms_key_id']
 
-    try:
-        region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
-        client = boto3_conn(module, conn_type='client', resource='cloudtrail', region=region, endpoint=ec2_url, **aws_connect_params)
-    except ClientError as err:
-        module.fail_json(msg=err.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(err.response))
+    client = module.client('cloudtrail')
+    region = get_aws_connection_info(module, boto3=True)[0]
 
     results = dict(
         changed=False,
@@ -598,7 +595,7 @@ def main():
         if module.check_mode:
             acct_id = '123456789012'
             try:
-                sts_client = boto3_conn(module, conn_type='client', resource='sts', region=region, endpoint=ec2_url, **aws_connect_params)
+                sts_client = module.client('sts')
                 acct_id = sts_client.get_caller_identity()['Account']
             except (BotoCoreError, ClientError):
                 pass

--- a/lib/ansible/modules/cloud/amazon/ec2_asg_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg_info.py
@@ -225,7 +225,7 @@ import re
 try:
     from botocore.exceptions import ClientError
 except ImportError:
-    pass  # caught by imported HAS_BOTO3
+    pass  # caught by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import (get_aws_connection_info, boto3_conn, ec2_argument_spec,
@@ -400,9 +400,6 @@ def main():
     module = AnsibleAWSModule(argument_spec=argument_spec)
     if module._name == 'ec2_asg_facts':
         module.deprecate("The 'ec2_asg_facts' module has been renamed to 'ec2_asg_info'", version='2.13')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     asg_name = module.params.get('name')
     asg_tags = module.params.get('tags')

--- a/lib/ansible/modules/cloud/amazon/ec2_asg_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg_info.py
@@ -227,7 +227,7 @@ try:
 except ImportError:
     pass  # caught by imported HAS_BOTO3
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import (get_aws_connection_info, boto3_conn, ec2_argument_spec,
                                       camel_dict_to_snake_dict, HAS_BOTO3)
 
@@ -397,7 +397,7 @@ def main():
             tags=dict(type='dict'),
         )
     )
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec)
     if module._name == 'ec2_asg_facts':
         module.deprecate("The 'ec2_asg_facts' module has been renamed to 'ec2_asg_info'", version='2.13')
 

--- a/lib/ansible/modules/cloud/amazon/ec2_asg_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg_info.py
@@ -228,8 +228,7 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import (get_aws_connection_info, boto3_conn, ec2_argument_spec,
-                                      camel_dict_to_snake_dict, HAS_BOTO3)
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def match_asg_tags(tags_to_match, asg):

--- a/lib/ansible/modules/cloud/amazon/ec2_asg_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg_info.py
@@ -390,12 +390,9 @@ def find_asgs(conn, module, name=None, tags=None):
 
 def main():
 
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            name=dict(type='str'),
-            tags=dict(type='dict'),
-        )
+    argument_spec = dict(
+        name=dict(type='str'),
+        tags=dict(type='dict'),
     )
     module = AnsibleAWSModule(argument_spec=argument_spec)
     if module._name == 'ec2_asg_facts':

--- a/lib/ansible/modules/cloud/amazon/ec2_asg_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg_info.py
@@ -340,9 +340,9 @@ def find_asgs(conn, module, name=None, tags=None):
 
     if not asgs:
         return asgs
+
     try:
-        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-        elbv2 = boto3_conn(module, conn_type='client', resource='elbv2', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+        elbv2 = module.client('elbv2')
     except ClientError as e:
         # This is nice to have, not essential
         elbv2 = None
@@ -405,11 +405,7 @@ def main():
     asg_name = module.params.get('name')
     asg_tags = module.params.get('tags')
 
-    try:
-        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-        autoscaling = boto3_conn(module, conn_type='client', resource='autoscaling', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-    except ClientError as e:
-        module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+    autoscaling = module.client('autoscaling')
 
     results = find_asgs(autoscaling, module, name=asg_name, tags=asg_tags)
     module.exit_json(results=results)

--- a/lib/ansible/modules/cloud/amazon/ec2_group_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group_info.py
@@ -109,11 +109,8 @@ from ansible.module_utils.ec2 import (ec2_argument_spec, boto3_conn, HAS_BOTO3, 
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            filters=dict(default={}, type='dict')
-        )
+    argument_spec = dict(
+        filters=dict(default={}, type='dict')
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)

--- a/lib/ansible/modules/cloud/amazon/ec2_group_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group_info.py
@@ -98,7 +98,7 @@ security_groups:
 import traceback
 
 try:
-    from botocore.exceptions import ClientError
+    from botocore.exceptions import BotoCoreError, ClientError
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
@@ -141,8 +141,8 @@ def main():
         security_groups = connection.describe_security_groups(
             Filters=ansible_dict_to_boto3_filter_list(sanitized_filters)
         )
-    except ClientError as e:
-        module.fail_json(msg=e.message, exception=traceback.format_exc())
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg='Failed to describe security groups')
 
     snaked_security_groups = []
     for security_group in security_groups['SecurityGroups']:

--- a/lib/ansible/modules/cloud/amazon/ec2_group_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group_info.py
@@ -102,7 +102,7 @@ try:
 except ImportError:
     pass  # caught by imported HAS_BOTO3
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import (ec2_argument_spec, boto3_conn, HAS_BOTO3, get_aws_connection_info,
                                       boto3_tag_list_to_ansible_dict, ansible_dict_to_boto3_filter_list,
                                       camel_dict_to_snake_dict)
@@ -116,8 +116,7 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           supports_check_mode=True)
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'ec2_group_facts':
         module.deprecate("The 'ec2_group_facts' module has been renamed to 'ec2_group_info'", version='2.13')
 

--- a/lib/ansible/modules/cloud/amazon/ec2_group_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group_info.py
@@ -100,7 +100,7 @@ import traceback
 try:
     from botocore.exceptions import ClientError
 except ImportError:
-    pass  # caught by imported HAS_BOTO3
+    pass  # caught by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import (ec2_argument_spec, boto3_conn, HAS_BOTO3, get_aws_connection_info,
@@ -119,9 +119,6 @@ def main():
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'ec2_group_facts':
         module.deprecate("The 'ec2_group_facts' module has been renamed to 'ec2_group_info'", version='2.13')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
 

--- a/lib/ansible/modules/cloud/amazon/ec2_group_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group_info.py
@@ -95,17 +95,13 @@ security_groups:
     sample:
 '''
 
-import traceback
-
 try:
     from botocore.exceptions import BotoCoreError, ClientError
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import (ec2_argument_spec, boto3_conn, HAS_BOTO3, get_aws_connection_info,
-                                      boto3_tag_list_to_ansible_dict, ansible_dict_to_boto3_filter_list,
-                                      camel_dict_to_snake_dict)
+from ansible.module_utils.ec2 import (boto3_tag_list_to_ansible_dict, ansible_dict_to_boto3_filter_list, camel_dict_to_snake_dict)
 
 
 def main():

--- a/lib/ansible/modules/cloud/amazon/ec2_group_info.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group_info.py
@@ -117,19 +117,7 @@ def main():
     if module._name == 'ec2_group_facts':
         module.deprecate("The 'ec2_group_facts' module has been renamed to 'ec2_group_info'", version='2.13')
 
-    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
-
-    if region:
-        connection = boto3_conn(
-            module,
-            conn_type='client',
-            resource='ec2',
-            region=region,
-            endpoint=ec2_url,
-            **aws_connect_params
-        )
-    else:
-        module.fail_json(msg="region must be specified")
+    connection = module.client('ec2')
 
     # Replace filter key underscores with dashes, for compatibility, except if we're dealing with tags
     sanitized_filters = module.params.get("filters")

--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -205,15 +205,8 @@ def build_kwargs(registry_id):
 
 class EcsEcr:
     def __init__(self, module):
-        region, ec2_url, aws_connect_kwargs = \
-            get_aws_connection_info(module, boto3=True)
-
-        self.ecr = boto3_conn(module, conn_type='client',
-                              resource='ecr', region=region,
-                              endpoint=ec2_url, **aws_connect_kwargs)
-        self.sts = boto3_conn(module, conn_type='client',
-                              resource='sts', region=region,
-                              endpoint=ec2_url, **aws_connect_kwargs)
+        self.ecr = module.client('ecr')
+        self.sts = module.client('sts')
         self.check_mode = module.check_mode
         self.changed = False
         self.skipped = False

--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -183,7 +183,7 @@ try:
 except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO3
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import (HAS_BOTO3, boto3_conn, boto_exception, ec2_argument_spec,
                                       get_aws_connection_info, compare_policies,
                                       sort_json_policy_dict)
@@ -520,12 +520,11 @@ def main():
         purge_policy=dict(required=False, type='bool', aliases=['delete_policy']),
         lifecycle_policy=dict(required=False, type='json'),
         purge_lifecycle_policy=dict(required=False, type='bool')))
+    mutually_exclusive = [
+        ['policy', 'purge_policy'],
+        ['lifecycle_policy', 'purge_lifecycle_policy']]
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           supports_check_mode=True,
-                           mutually_exclusive=[
-                               ['policy', 'purge_policy'],
-                               ['lifecycle_policy', 'purge_lifecycle_policy']])
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True, mutually_exclusive=mutually_exclusive)
     if module.params.get('delete_policy'):
         module.deprecate(
             'The alias "delete_policy" has been deprecated and will be removed, '

--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -184,9 +184,7 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import (HAS_BOTO3, boto3_conn, boto_exception, ec2_argument_spec,
-                                      get_aws_connection_info, compare_policies,
-                                      sort_json_policy_dict)
+from ansible.module_utils.ec2 import boto_exception, compare_policies, sort_json_policy_dict
 from ansible.module_utils.six import string_types
 
 

--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -181,7 +181,7 @@ import traceback
 try:
     from botocore.exceptions import ClientError
 except ImportError:
-    pass  # Taken care of by ec2.HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import (HAS_BOTO3, boto3_conn, boto_exception, ec2_argument_spec,
@@ -530,9 +530,6 @@ def main():
             'The alias "delete_policy" has been deprecated and will be removed, '
             'use "purge_policy" instead',
             version='2.14')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     ecr = EcsEcr(module)
     passed, result = run(ecr, module.params)

--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -507,8 +507,7 @@ def run(ecr, params):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         name=dict(required=True),
         registry_id=dict(required=False),
         state=dict(required=False, choices=['present', 'absent'],

--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -509,19 +509,16 @@ def main():
         policy=dict(required=False, type='json'),
         image_tag_mutability=dict(required=False, choices=['mutable', 'immutable'],
                                   default='mutable'),
-        purge_policy=dict(required=False, type='bool', aliases=['delete_policy']),
+        purge_policy=dict(required=False, type='bool', aliases=['delete_policy'],
+                          deprecated_aliases=[dict(name='delete_policy', version='2.14')]),
         lifecycle_policy=dict(required=False, type='json'),
-        purge_lifecycle_policy=dict(required=False, type='bool')))
+        purge_lifecycle_policy=dict(required=False, type='bool')
+    )
     mutually_exclusive = [
         ['policy', 'purge_policy'],
         ['lifecycle_policy', 'purge_lifecycle_policy']]
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True, mutually_exclusive=mutually_exclusive)
-    if module.params.get('delete_policy'):
-        module.deprecate(
-            'The alias "delete_policy" has been deprecated and will be removed, '
-            'use "purge_policy" instead',
-            version='2.14')
 
     ecr = EcsEcr(module)
     passed, result = run(ecr, module.params)

--- a/lib/ansible/modules/cloud/amazon/efs.py
+++ b/lib/ansible/modules/cloud/amazon/efs.py
@@ -441,12 +441,8 @@ class EFSConnection(object):
             try:
                 self.connection.create_file_system(**params)
                 changed = True
-            except ClientError as e:
-                self.module.fail_json(msg="Unable to create file system: {0}".format(to_native(e)),
-                                      exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
-            except BotoCoreError as e:
-                self.module.fail_json(msg="Unable to create file system: {0}".format(to_native(e)),
-                                      exception=traceback.format_exc())
+            except (ClientError, BotoCoreError) as e:
+                self.module.fail_json_aws(e, msg="Unable to create file system.")
 
         # we always wait for the state to be available when creating.
         # if we try to take any actions on the file system before it's available
@@ -483,12 +479,8 @@ class EFSConnection(object):
                 try:
                     self.connection.update_file_system(FileSystemId=fs_id, **params)
                     changed = True
-                except ClientError as e:
-                    self.module.fail_json(msg="Unable to update file system: {0}".format(to_native(e)),
-                                          exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
-                except BotoCoreError as e:
-                    self.module.fail_json(msg="Unable to update file system: {0}".format(to_native(e)),
-                                          exception=traceback.format_exc())
+                except (ClientError, BotoCoreError) as e:
+                    self.module.fail_json_aws(e, msg="Unable to update file system.")
         return changed
 
     def converge_file_system(self, name, tags, purge_tags, targets, throughput_mode, provisioned_throughput_in_mibps):
@@ -507,12 +499,8 @@ class EFSConnection(object):
                         FileSystemId=fs_id,
                         TagKeys=tags_to_delete
                     )
-                except ClientError as e:
-                    self.module.fail_json(msg="Unable to delete tags: {0}".format(to_native(e)),
-                                          exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
-                except BotoCoreError as e:
-                    self.module.fail_json(msg="Unable to delete tags: {0}".format(to_native(e)),
-                                          exception=traceback.format_exc())
+                except (ClientError, BotoCoreError) as e:
+                    self.module.fail_json_aws(e, msg="Unable to delete tags.")
 
                 result = True
 
@@ -522,12 +510,8 @@ class EFSConnection(object):
                         FileSystemId=fs_id,
                         Tags=ansible_dict_to_boto3_tag_list(tags_need_modify)
                     )
-                except ClientError as e:
-                    self.module.fail_json(msg="Unable to create tags: {0}".format(to_native(e)),
-                                          exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
-                except BotoCoreError as e:
-                    self.module.fail_json(msg="Unable to create tags: {0}".format(to_native(e)),
-                                          exception=traceback.format_exc())
+                except (ClientError, BotoCoreError) as e:
+                    self.module.fail_json_aws(e, msg="Unable to create tags.")
 
                 result = True
 

--- a/lib/ansible/modules/cloud/amazon/efs.py
+++ b/lib/ansible/modules/cloud/amazon/efs.py
@@ -244,8 +244,8 @@ try:
 except ImportError as e:
     pass  # Taken care of by ec2.HAS_BOTO3
 
+from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils._text import to_native
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import (HAS_BOTO3, boto3_conn, camel_dict_to_snake_dict,
                                       ec2_argument_spec, get_aws_connection_info, ansible_dict_to_boto3_tag_list,
                                       compare_aws_tags, boto3_tag_list_to_ansible_dict)
@@ -727,7 +727,7 @@ def main():
         wait_timeout=dict(required=False, type="int", default=0)
     ))
 
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec)
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 required for this module')
 

--- a/lib/ansible/modules/cloud/amazon/efs.py
+++ b/lib/ansible/modules/cloud/amazon/efs.py
@@ -242,7 +242,7 @@ import traceback
 try:
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError as e:
-    pass  # Taken care of by ec2.HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils._text import to_native
@@ -728,8 +728,6 @@ def main():
     ))
 
     module = AnsibleAWSModule(argument_spec=argument_spec)
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
     connection = EFSConnection(module, region, **aws_connect_params)

--- a/lib/ansible/modules/cloud/amazon/efs.py
+++ b/lib/ansible/modules/cloud/amazon/efs.py
@@ -244,7 +244,7 @@ except ImportError as e:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import (get_aws_connection_info, compare_aws_tags, camel_dict_to_snake_dict,
+from ansible.module_utils.ec2 import (compare_aws_tags, camel_dict_to_snake_dict,
                                       ansible_dict_to_boto3_tag_list, boto3_tag_list_to_ansible_dict)
 
 
@@ -263,7 +263,7 @@ class EFSConnection(object):
 
     def __init__(self, module):
         self.connection = module.client('efs')
-        region = get_aws_connection_info(module, boto3=True)[0]
+        region = module.region
 
         self.module = module
         self.region = region

--- a/lib/ansible/modules/cloud/amazon/efs.py
+++ b/lib/ansible/modules/cloud/amazon/efs.py
@@ -237,7 +237,6 @@ tags:
 
 from time import sleep
 from time import time as timestamp
-import traceback
 
 try:
     from botocore.exceptions import ClientError, BotoCoreError
@@ -245,10 +244,8 @@ except ImportError as e:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils._text import to_native
-from ansible.module_utils.ec2 import (HAS_BOTO3, boto3_conn, camel_dict_to_snake_dict,
-                                      ec2_argument_spec, get_aws_connection_info, ansible_dict_to_boto3_tag_list,
-                                      compare_aws_tags, boto3_tag_list_to_ansible_dict)
+from ansible.module_utils.ec2 import (get_aws_connection_info, compare_aws_tags, camel_dict_to_snake_dict,
+                                      ansible_dict_to_boto3_tag_list, boto3_tag_list_to_ansible_dict)
 
 
 def _index_by_key(key, items):

--- a/lib/ansible/modules/cloud/amazon/efs.py
+++ b/lib/ansible/modules/cloud/amazon/efs.py
@@ -710,8 +710,7 @@ def main():
     """
      Module action handler
     """
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         encrypt=dict(required=False, type="bool", default=False),
         state=dict(required=False, type='str', choices=["present", "absent"], default="present"),
         kms_key_id=dict(required=False, type='str', default=None),
@@ -725,7 +724,7 @@ def main():
         provisioned_throughput_in_mibps=dict(required=False, type='float'),
         wait=dict(required=False, type="bool", default=False),
         wait_timeout=dict(required=False, type="int", default=0)
-    ))
+    )
 
     module = AnsibleAWSModule(argument_spec=argument_spec)
 

--- a/lib/ansible/modules/cloud/amazon/efs.py
+++ b/lib/ansible/modules/cloud/amazon/efs.py
@@ -264,10 +264,9 @@ class EFSConnection(object):
     STATE_DELETING = 'deleting'
     STATE_DELETED = 'deleted'
 
-    def __init__(self, module, region, **aws_connect_params):
-        self.connection = boto3_conn(module, conn_type='client',
-                                     resource='efs', region=region,
-                                     **aws_connect_params)
+    def __init__(self, module):
+        self.connection = module.client('efs')
+        region = get_aws_connection_info(module, boto3=True)[0]
 
         self.module = module
         self.region = region
@@ -712,8 +711,7 @@ def main():
 
     module = AnsibleAWSModule(argument_spec=argument_spec)
 
-    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
-    connection = EFSConnection(module, region, **aws_connect_params)
+    connection = EFSConnection(module)
 
     name = module.params.get('name')
     fs_id = module.params.get('id')

--- a/lib/ansible/modules/cloud/amazon/redshift_info.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_info.py
@@ -346,11 +346,7 @@ def main():
     cluster_identifier = module.params.get('cluster_identifier')
     cluster_tags = module.params.get('tags')
 
-    try:
-        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-        redshift = boto3_conn(module, conn_type='client', resource='redshift', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-    except ClientError as e:
-        module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+    redshift = module.client('redshift')
 
     results = find_clusters(redshift, module, identifier=cluster_identifier, tags=cluster_tags)
     module.exit_json(results=results)

--- a/lib/ansible/modules/cloud/amazon/redshift_info.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_info.py
@@ -283,7 +283,7 @@ import re
 import traceback
 
 try:
-    from botocore.exception import ClientError
+    from botocore.exception import BotoCoreError, ClientError
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
@@ -306,8 +306,8 @@ def find_clusters(conn, module, identifier=None, tags=None):
     try:
         cluster_paginator = conn.get_paginator('describe_clusters')
         clusters = cluster_paginator.paginate().build_full_result()
-    except ClientError as e:
-        module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e, msg='Failed to fetch clusters.')
 
     matched_clusters = []
 

--- a/lib/ansible/modules/cloud/amazon/redshift_info.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_info.py
@@ -332,12 +332,9 @@ def find_clusters(conn, module, identifier=None, tags=None):
 
 def main():
 
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            cluster_identifier=dict(type='str', aliases=['identifier', 'name']),
-            tags=dict(type='dict')
-        )
+    argument_spec = dict(
+        cluster_identifier=dict(type='str', aliases=['identifier', 'name']),
+        tags=dict(type='dict')
     )
     module = AnsibleAWSModule(
         argument_spec=argument_spec,

--- a/lib/ansible/modules/cloud/amazon/redshift_info.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_info.py
@@ -280,7 +280,6 @@ iam_roles:
 '''
 
 import re
-import traceback
 
 try:
     from botocore.exception import BotoCoreError, ClientError
@@ -288,8 +287,7 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import ec2_argument_spec, boto3_conn, get_aws_connection_info
-from ansible.module_utils.ec2 import HAS_BOTO3, camel_dict_to_snake_dict
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def match_tags(tags_to_match, cluster):

--- a/lib/ansible/modules/cloud/amazon/redshift_info.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_info.py
@@ -285,7 +285,7 @@ import traceback
 try:
     from botocore.exception import ClientError
 except ImportError:
-    pass  # will be picked up from imported HAS_BOTO3
+    pass  # caught by AnsibleAWSModule
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import ec2_argument_spec, boto3_conn, get_aws_connection_info
@@ -348,9 +348,6 @@ def main():
 
     cluster_identifier = module.params.get('cluster_identifier')
     cluster_tags = module.params.get('tags')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     try:
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)

--- a/lib/ansible/modules/cloud/amazon/redshift_info.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_info.py
@@ -287,7 +287,7 @@ try:
 except ImportError:
     pass  # will be picked up from imported HAS_BOTO3
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import ec2_argument_spec, boto3_conn, get_aws_connection_info
 from ansible.module_utils.ec2 import HAS_BOTO3, camel_dict_to_snake_dict
 
@@ -339,7 +339,7 @@ def main():
             tags=dict(type='dict')
         )
     )
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
         supports_check_mode=True
     )


### PR DESCRIPTION
##### SUMMARY

Migrate various AWS modules over to AnsibleAWSModule and its helpers.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

lib/ansible/modules/cloud/amazon/aws_az_info.py
lib/ansible/modules/cloud/amazon/aws_batch_compute_environment.py
lib/ansible/modules/cloud/amazon/aws_batch_job_definition.py
lib/ansible/modules/cloud/amazon/aws_batch_job_queue.py
lib/ansible/modules/cloud/amazon/aws_region_info.py
lib/ansible/modules/cloud/amazon/aws_s3_cors.py
lib/ansible/modules/cloud/amazon/cloudtrail.py
lib/ansible/modules/cloud/amazon/ec2_asg_info.py
lib/ansible/modules/cloud/amazon/ec2_group_info.py
lib/ansible/modules/cloud/amazon/ecs_ecr.py
lib/ansible/modules/cloud/amazon/efs.py
lib/ansible/modules/cloud/amazon/redshift_info.py

##### ADDITIONAL INFORMATION

**Note:** Review might be simplest by commit