### PR TITLE
Updated description of apt module examples to avoid confusion

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -203,12 +203,12 @@ EXAMPLES = '''
     state: latest
     install_recommends: no
 
-- name: Upgrade all packages to the latest version
+- name: Update all packages to their latest version
   apt:
     name: "*"
     state: latest
 
-- name: Update all packages to the latest version
+- name: Upgrade the OS (apt-get dist-upgrade)
   apt:
     upgrade: dist
 


### PR DESCRIPTION
##### SUMMARY

I find some of he documented examples to be confusing and possible incorrect, so I proposed some changes.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- apt module

##### ADDITIONAL INFORMATION

I propose these changes because:

 - The **update** example uses the word **upgrade**, which is misleading
 - When updating all packages, they do not all share the same version number, so using **their** latest version is less ambiguous
 - The upgrade example should use the verb **upgrade** and is arguably rather misleading. Given that a `dist-upgrade` is not a trivial task that could potentially break a bunch of things, I think this should be made more clear

+label: docsite_pr

