### PR TITLE
authorized_key: delete trailing spaces

### DIFF
--- a/lib/ansible/modules/system/authorized_key.py
+++ b/lib/ansible/modules/system/authorized_key.py
@@ -464,7 +464,7 @@ def readfile(filename):
 
 def parsekeys(module, lines):
     keys = {}
-    for rank_index, line in enumerate(lines.splitlines(True)):
+    for rank_index, line in enumerate(lines.splitlines()):
         key_data = parsekey(module, line, rank=rank_index)
         if key_data:
             # use key as identifier
@@ -517,11 +517,13 @@ def serialize(keys):
             if key_type == 'skipped':
                 key_line = key[0]
             else:
-                key_line = "%s%s %s %s\n" % (option_str, key_type, keyhash, comment)
+                key_line = (
+                    "%s%s %s %s" % (option_str, key_type, keyhash, comment)
+                ).rstrip()
         except Exception:
             key_line = key
         lines.append(key_line)
-    return ''.join(lines)
+    return "%s\n" % '\n'.join(lines)
 
 
 def enforce_state(module, params):


### PR DESCRIPTION
##### SUMMARY
authorized_key adds trailing white space to keys 

Fixes #67170

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
authorized_key module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```bash
$cat -A /tmp/authorized_keys
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCvXbDjLXmYKySDg1By8ZD3a3cZ97bmqVpSZ9VSh/MgKlWVrd+1+Vg8fiNI5gXKJjKxZTvPAmF/M+SPmL9JylPqK9c4ujqVQmdytpYatLCZJXMqgxc9MdLNDUusFMZ3lB1uVvA55oU6MB1msv3gsqLnl4/WuaA2DPFRWOWXHUy4wNgcqIHwd5vgfNJKMgOOGWcBCV/NTDx55dbgrEdanLZ7/bK9FLeA11MIc64ogC1JSc9pUb/Ws+uRBxi+1R8ZaLBWOkAOvNKAwJ/dtFpy/0Y5O4oBDHD3MjuMnwr/4NlGtFeclqLDEIJA6rh2fhsRdSa66OoUR1GTWCzTPeK1cMSb $
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwJBq7EwYOF2H+bnUnj1CSeiEgHPae9wkgBP24KI+PJc7RSCDiwg4lTPyzM2bR0PF28nVTPMJZbxU7jHAyF4UI73Yqh4H4LvJZpwT8HOUMiCnIYiccklswWg4KkCdL7mcsxxdD6hxRm7tmoszM2aSnb8Fn2Oyvq+o3M+O72L72xzqWQ/aKRei1x8ZG50l3Mx38m6E/RTy3rY+ey01uLi2g42WePbULVS5+p3rUdfEFKliOTePl21FSbxAcJFGGzmPM6ATRdWf8J5SZT+7chEO9TG6jGKQbW13UG+N96Tn75nbMbCeHzNcDnPPTyRcSs3m9NyIjYcjC6gX9IWPeFoRD $

```
After:
```bash
$ cat -A /tmp/authorized_keys_fixed
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCvXbDjLXmYKySDg1By8ZD3a3cZ97bmqVpSZ9VSh/MgKlWVrd+1+Vg8fiNI5gXKJjKxZTvPAmF/M+SPmL9JylPqK9c4ujqVQmdytpYatLCZJXMqgxc9MdLNDUusFMZ3lB1uVvA55oU6MB1msv3gsqLnl4/WuaA2DPFRWOWXHUy4wNgcqIHwd5vgfNJKMgOOGWcBCV/NTDx55dbgrEdanLZ7/bK9FLeA11MIc64ogC1JSc9pUb/Ws+uRBxi+1R8ZaLBWOkAOvNKAwJ/dtFpy/0Y5O4oBDHD3MjuMnwr/4NlGtFeclqLDEIJA6rh2fhsRdSa66OoUR1GTWCzTPeK1cMSb$
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwJBq7EwYOF2H+bnUnj1CSeiEgHPae9wkgBP24KI+PJc7RSCDiwg4lTPyzM2bR0PF28nVTPMJZbxU7jHAyF4UI73Yqh4H4LvJZpwT8HOUMiCnIYiccklswWg4KkCdL7mcsxxdD6hxRm7tmoszM2aSnb8Fn2Oyvq+o3M+O72L72xzqWQ/aKRei1x8ZG50l3Mx38m6E/RTy3rY+ey01uLi2g42WePbULVS5+p3rUdfEFKliOTePl21FSbxAcJFGGzmPM6ATRdWf8J5SZT+7chEO9TG6jGKQbW13UG+N96Tn75nbMbCeHzNcDnPPTyRcSs3m9NyIjYcjC6gX9IWPeFoRD$
```