### PR TITLE
Fixes wrong return value docs in cloudscale_server

### DIFF
--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
@@ -211,13 +211,13 @@ state:
 flavor:
   description: The flavor that has been used for this server
   returned: success when not state == absent
-  type: str
-  sample: flex-8
+  type: dict
+  sample: { "slug": "flex-4", "name": "Flex-4", "vcpu_count": 2, "memory_gb": 4 }
 image:
   description: The image used for booting this server
   returned: success when not state == absent
-  type: str
-  sample: debian-8
+  type: dict
+  sample: { "default_username": "ubuntu", "name": "Ubuntu 18.04 LTS", "operating_system": "Ubuntu", "slug": "ubuntu-18.04" }
 volumes:
   description: List of volumes attached to the server
   returned: success when not state == absent


### PR DESCRIPTION
##### SUMMARY
Fixes two documentation errors in `cloudscale_server`.

The following return values had the wrong type and sample data:

* `flavor`
* `image`

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`cloudscale_server`

##### ADDITIONAL INFORMATION
As requested in the review of #67165
