### PR TITLE
fixing issue #3505: capabilities: show "changes" all the time

### DIFF
--- a/lib/ansible/modules/system/capabilities.py
+++ b/lib/ansible/modules/system/capabilities.py
@@ -155,6 +155,7 @@ class CapabilitiesModule(object):
                 return (cap, None, None)
         op = cap[opind]
         cap, flags = cap.split(op)
+        flags = ''.join(sorted(flags))
         return (cap, op, flags)
 
 


### PR DESCRIPTION
the order of the capability flags doesn't matter, the 'cap_net_raw+ep'
and 'cap_net_raw+pe' is the same, the _parse_cap function modified
accordingly

##### SUMMARY
fixing issue #3505 (ansible-modules-extras)
https://github.com/ansible/ansible-modules-extras/issues/3505

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
capabilities module 


