### PR TITLE
Added support for private vlan config in VMware distributed port group

### DIFF
--- a/changelogs/fragments/67205-pvlan-config-vmware-dvs-portgroup.yml
+++ b/changelogs/fragments/67205-pvlan-config-vmware-dvs-portgroup.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- vmware_dvs_portgroup - Added support for dpg with private VLAN.
+- vmware_dvs_portgroup - Added support for distributed port group with private VLAN.

--- a/changelogs/fragments/67205-pvlan-config-vmware-dvs-portgroup.yml
+++ b/changelogs/fragments/67205-pvlan-config-vmware-dvs-portgroup.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- vmware_dvs_portgroup - Added support for dpg with private VLAN.

--- a/test/integration/targets/vmware_dvs_portgroup/tasks/main.yml
+++ b/test/integration/targets/vmware_dvs_portgroup/tasks/main.yml
@@ -408,113 +408,103 @@
         - not dvs_pg_result_0018.changed
         - "'No private vlan with id 10 in distributed vSwitch {{ dvswitch1 }}' == '{{ dvs_pg_result_0018.msg }}'"
 
-- name: add distributed vSwitch
-  vmware_dvswitch:
-    validate_certs: False
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    datacenter_name: "{{ dc1 }}"
-    state: present
-    switch_name: dvswitch_0001
-    mtu: 9000
-    uplink_quantity: 2
-    discovery_proto: lldp
-    discovery_operation: both
-  register: dvs_result_0001
+- when: vcsim is not defined
+  block:
+    - name: add distributed vSwitch
+      vmware_dvswitch:
+        validate_certs: False
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter_name: "{{ dc1 }}"
+        state: present
+        switch_name: dvswitch_0001
+        mtu: 9000
+        uplink_quantity: 2
+        discovery_proto: lldp
+        discovery_operation: both
+      register: dvs_result_0001
 
-- name: ensure distributed vswitch is present
-  assert:
-    that:
-        - dvs_result_0001 is changed
+    - name: ensure distributed vswitch is present
+      assert:
+        that:
+            - dvs_result_0001 is changed
 
-- name: Configure PVLANs to test PVLAN dpg
-  vmware_dvswitch_pvlans:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    switch: dvswitch_0001
-    primary_pvlans:
-      - primary_pvlan_id: 1
-    secondary_pvlans:
-      - primary_pvlan_id: 1
-        secondary_pvlan_id: 2
-        pvlan_type: isolated
-    validate_certs: false
-  register: pvlans_result
+    - name: Configure PVLANs to test PVLAN dpg
+      vmware_dvswitch_pvlans:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        switch: dvswitch_0001
+        primary_pvlans:
+          - primary_pvlan_id: 1
+        secondary_pvlans:
+          - primary_pvlan_id: 1
+            secondary_pvlan_id: 2
+            pvlan_type: isolated
+        validate_certs: false
+      register: pvlans_result
 
-- name: ensure pvlans were configured
-  assert:
-    that:
-      - pvlans_result is not failed
+    - name: ensure pvlans were configured
+      assert:
+        that:
+          - pvlans_result is not failed
 
-- name: Get facts about DVPG
-  vmware_dvs_portgroup_facts:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    dvswitch: dvswitch_0001
-    show_vlan_info: yes
-    validate_certs: no
-    datacenter: "{{ dc1 }}"
-  register: dvpg_facts
+    - name: Create private vlan portgroup
+      vmware_dvs_portgroup:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        portgroup_name: private-vlan-portgroup
+        switch_name: dvswitch_0001
+        vlan_id: 1
+        vlan_private: True
+        num_ports: 12
+        portgroup_type: earlyBinding
+        state: present
+        validate_certs: false
+      register: dvs_pg_result_0019
 
+    - name: ensure dvs portgroup with pvlan is present
+      assert:
+        that:
+            - dvs_pg_result_0019.changed
 
-- name: Create private vlan portgroup
-  vmware_dvs_portgroup:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
-    portgroup_name: private-vlan-portgroup
-    switch_name: dvswitch_0001
-    vlan_id: 1
-    vlan_private: True
-    num_ports: 12
-    portgroup_type: earlyBinding
-    state: present
-    validate_certs: false
-  register: dvs_pg_result_0019
+    - name: Change private vlan id
+      vmware_dvs_portgroup:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        portgroup_name: private-vlan-portgroup
+        switch_name: dvswitch_0001
+        vlan_id: 2
+        vlan_private: True
+        num_ports: 12
+        portgroup_type: earlyBinding
+        state: present
+        validate_certs: false
+      register: dvs_pg_result_0020
 
-- name: ensure dvs portgroup with pvlan is present
-  assert:
-    that:
-        - dvs_pg_result_0019.changed
+    - name: ensure dvs portgroup pvlan id is changed
+      assert:
+        that:
+            - dvs_pg_result_0020.changed
 
-- name: Change private vlan id
-  vmware_dvs_portgroup:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
-    portgroup_name: private-vlan-portgroup
-    switch_name: dvswitch_0001
-    vlan_id: 2
-    vlan_private: True
-    num_ports: 12
-    portgroup_type: earlyBinding
-    state: present
-    validate_certs: false
-  register: dvs_pg_result_0020
+    - name: Change private vlan to basic vlan portgroup
+      vmware_dvs_portgroup:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        portgroup_name: private-vlan-portgroup
+        switch_name: dvswitch_0001
+        vlan_id: 5
+        num_ports: 12
+        portgroup_type: earlyBinding
+        state: present
+        validate_certs: false
+      register: dvs_pg_result_0021
 
-- name: ensure dvs portgroup pvlan id is changed
-  assert:
-    that:
-        - dvs_pg_result_0020.changed
-
-- name: Change private vlan to basic vlan portgroup
-  vmware_dvs_portgroup:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
-    portgroup_name: private-vlan-portgroup
-    switch_name: dvswitch_0001
-    vlan_id: 5
-    num_ports: 12
-    portgroup_type: earlyBinding
-    state: present
-    validate_certs: false
-  register: dvs_pg_result_0021
-
-- name: ensure dvs portgroup type changed
-  assert:
-    that:
-        - dvs_pg_result_0021.changed
+    - name: ensure dvs portgroup type changed
+      assert:
+        that:
+            - dvs_pg_result_0021.changed

--- a/test/integration/targets/vmware_dvs_portgroup/tasks/main.yml
+++ b/test/integration/targets/vmware_dvs_portgroup/tasks/main.yml
@@ -408,12 +408,32 @@
         - not dvs_pg_result_0018.changed
         - "'No private vlan with id 10 in distributed vSwitch {{ dvswitch1 }}' == '{{ dvs_pg_result_0018.msg }}'"
 
+- name: add distributed vSwitch
+  vmware_dvswitch:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    state: present
+    switch_name: dvswitch_0001
+    mtu: 9000
+    uplink_quantity: 2
+    discovery_proto: lldp
+    discovery_operation: both
+  register: dvs_result_0001
+
+- name: ensure distributed vswitch is present
+  assert:
+    that:
+        - dvs_result_0001 is changed
+
 - name: Configure PVLANs to test PVLAN dpg
   vmware_dvswitch_pvlans:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    switch: "{{ dvswitch1 }}"
+    switch: dvswitch_0001
     primary_pvlans:
       - primary_pvlan_id: 1
     secondary_pvlans:
@@ -428,13 +448,25 @@
     that:
       - pvlans_result is not failed
 
+- name: Get facts about DVPG
+  vmware_dvs_portgroup_facts:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    dvswitch: dvswitch_0001
+    show_vlan_info: yes
+    validate_certs: no
+    datacenter: "{{ dc1 }}"
+  register: dvpg_facts
+
+
 - name: Create private vlan portgroup
   vmware_dvs_portgroup:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     portgroup_name: private-vlan-portgroup
-    switch_name: "{{ dvswitch1 }}"
+    switch_name: dvswitch_0001
     vlan_id: 1
     vlan_private: True
     num_ports: 12
@@ -454,7 +486,7 @@
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     portgroup_name: private-vlan-portgroup
-    switch_name: "{{ dvswitch1 }}"
+    switch_name: dvswitch_0001
     vlan_id: 2
     vlan_private: True
     num_ports: 12
@@ -468,41 +500,21 @@
     that:
         - dvs_pg_result_0020.changed
 
-- name: Change basic VLAN portgroup to PVLAN
-  vmware_dvs_portgroup:
-    validate_certs: False
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    switch_name: "{{ dvswitch1 }}"
-    portgroup_name: "basic-vlan10"
-    vlan_private: True
-    vlan_id: 2
-    num_ports: 32
-    portgroup_type: earlyBinding
-    state: present
-  register: dvs_pg_result_0021
-
-- name: ensure basic VLAN portgroup is changed
-  assert:
-    that:
-        - dvs_pg_result_0021.changed
-
-- name: Return from private vlan to basic vlan portgroup
+- name: Change private vlan to basic vlan portgroup
   vmware_dvs_portgroup:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
-    portgroup_name: "basic-vlan10"
-    switch_name: "{{ dvswitch1 }}"
-    vlan_id: 20
-    num_ports: 32
+    portgroup_name: private-vlan-portgroup
+    switch_name: dvswitch_0001
+    vlan_id: 5
+    num_ports: 12
     portgroup_type: earlyBinding
     state: present
     validate_certs: false
-  register: dvs_pg_result_0022
+  register: dvs_pg_result_0021
 
 - name: ensure dvs portgroup type changed
   assert:
     that:
-        - dvs_pg_result_0022.changed
+        - dvs_pg_result_0021.changed

--- a/test/integration/targets/vmware_dvs_portgroup/tasks/main.yml
+++ b/test/integration/targets/vmware_dvs_portgroup/tasks/main.yml
@@ -385,3 +385,124 @@
   assert:
     that:
         - dvs_pg_result_0017.changed
+
+- name: Check fail for missing PVLAN in dvs
+  vmware_dvs_portgroup:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    portgroup_name: private-vlan-portgroup
+    switch_name: "{{ dvswitch1 }}"
+    vlan_id: 10
+    vlan_private: True
+    num_ports: 12
+    portgroup_type: earlyBinding
+    state: present
+    validate_certs: false
+  register: dvs_pg_result_0018
+  ignore_errors: True
+
+- name: Ensure module fails for missing private VLAN in dvs
+  assert:
+    that:
+        - not dvs_pg_result_0018.changed
+        - "'No private vlan with id 10 in distributed vSwitch {{ dvswitch1 }}' == '{{ dvs_pg_result_0018.msg }}'"
+
+- name: Configure PVLANs to test PVLAN dpg
+  vmware_dvswitch_pvlans:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    switch: "{{ dvswitch1 }}"
+    primary_pvlans:
+      - primary_pvlan_id: 1
+    secondary_pvlans:
+      - primary_pvlan_id: 1
+        secondary_pvlan_id: 2
+        pvlan_type: isolated
+    validate_certs: false
+  register: pvlans_result
+
+- name: ensure pvlans were configured
+  assert:
+    that:
+      - pvlans_result is not failed
+
+- name: Create private vlan portgroup
+  vmware_dvs_portgroup:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    portgroup_name: private-vlan-portgroup
+    switch_name: "{{ dvswitch1 }}"
+    vlan_id: 1
+    vlan_private: True
+    num_ports: 12
+    portgroup_type: earlyBinding
+    state: present
+    validate_certs: false
+  register: dvs_pg_result_0019
+
+- name: ensure dvs portgroup with pvlan is present
+  assert:
+    that:
+        - dvs_pg_result_0019.changed
+
+- name: Change private vlan id
+  vmware_dvs_portgroup:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    portgroup_name: private-vlan-portgroup
+    switch_name: "{{ dvswitch1 }}"
+    vlan_id: 2
+    vlan_private: True
+    num_ports: 12
+    portgroup_type: earlyBinding
+    state: present
+    validate_certs: false
+  register: dvs_pg_result_0020
+
+- name: ensure dvs portgroup pvlan id is changed
+  assert:
+    that:
+        - dvs_pg_result_0020.changed
+
+- name: Change basic VLAN portgroup to PVLAN
+  vmware_dvs_portgroup:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    switch_name: "{{ dvswitch1 }}"
+    portgroup_name: "basic-vlan10"
+    vlan_private: True
+    vlan_id: 2
+    num_ports: 32
+    portgroup_type: earlyBinding
+    state: present
+  register: dvs_pg_result_0021
+
+- name: ensure basic VLAN portgroup is changed
+  assert:
+    that:
+        - dvs_pg_result_0021.changed
+
+- name: Return from private vlan to basic vlan portgroup
+  vmware_dvs_portgroup:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    portgroup_name: "basic-vlan10"
+    switch_name: "{{ dvswitch1 }}"
+    vlan_id: 20
+    num_ports: 32
+    portgroup_type: earlyBinding
+    state: present
+    validate_certs: false
+  register: dvs_pg_result_0022
+
+- name: ensure dvs portgroup type changed
+  assert:
+    that:
+        - dvs_pg_result_0022.changed


### PR DESCRIPTION

##### SUMMARY
Added support for creating a distributed port group with a private VLAN.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py

##### ADDITIONAL INFORMATION
Tested on vSphere 6.7
