### PR TITLE
Fix ec2.py cache when running via python3

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -470,7 +470,10 @@ class Ec2Inventory(object):
         cache_id = self.boto_profile or os.environ.get('AWS_ACCESS_KEY_ID', self.credentials.get('aws_access_key_id'))
         if cache_id:
             cache_name = '%s-%s' % (cache_name, cache_id)
-        cache_name += '-' + hashlib.md5(__file__.encode('utf-8')).hexdigest()[:6]
+        if sys.version_info.major == 2:
+            cache_name += '-' + hashlib.md5(__file__).hexdigest()[:6]
+        else:
+            cache_name += '-' + hashlib.md5(__file__.encode('utf-8')).hexdigest()[:6]
         self.cache_path_cache = os.path.join(cache_dir, "%s.cache" % cache_name)
         self.cache_path_index = os.path.join(cache_dir, "%s.index" % cache_name)
         self.cache_max_age = config.getint('ec2', 'cache_max_age')

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -470,7 +470,7 @@ class Ec2Inventory(object):
         cache_id = self.boto_profile or os.environ.get('AWS_ACCESS_KEY_ID', self.credentials.get('aws_access_key_id'))
         if cache_id:
             cache_name = '%s-%s' % (cache_name, cache_id)
-        if sys.version_info.major == 2:
+        if sys.version_info[0] == 2:
             cache_name += '-' + hashlib.md5(__file__).hexdigest()[:6]
         else:
             cache_name += '-' + hashlib.md5(__file__.encode('utf-8')).hexdigest()[:6]

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -158,6 +158,7 @@ import sys
 import os
 import argparse
 import re
+import hashlib
 from time import time
 from copy import deepcopy
 from datetime import date, datetime
@@ -469,7 +470,7 @@ class Ec2Inventory(object):
         cache_id = self.boto_profile or os.environ.get('AWS_ACCESS_KEY_ID', self.credentials.get('aws_access_key_id'))
         if cache_id:
             cache_name = '%s-%s' % (cache_name, cache_id)
-        cache_name += '-' + str(abs(hash(__file__)))[1:7]
+        cache_name += '-' + hashlib.md5(__file__.encode('utf-8')).hexdigest()[:6]
         self.cache_path_cache = os.path.join(cache_dir, "%s.cache" % cache_name)
         self.cache_path_index = os.path.join(cache_dir, "%s.index" % cache_name)
         self.cache_max_age = config.getint('ec2', 'cache_max_age')


### PR DESCRIPTION
##### SUMMARY
In python3 hash() returns different results between script executions.
Therefore ec2.py refers to different cache files and effectively works
without cache.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2.py