### PR TITLE
Split handler tasks for setup_remote_tmp_dir.

### DIFF
--- a/test/integration/targets/setup_remote_tmp_dir/handlers/main.yml
+++ b/test/integration/targets/setup_remote_tmp_dir/handlers/main.yml
@@ -1,10 +1,5 @@
 - name: delete temporary directory
-  file:
-    path: "{{ remote_tmp_dir }}"
-    state: absent
-  no_log: yes
+  include_tasks: default-cleanup.yml
 
 - name: delete temporary directory (windows)
-  win_file:
-    path: "{{ remote_tmp_dir }}"
-    state: absent
+  include_tasks: windows-cleanup.yml

--- a/test/integration/targets/setup_remote_tmp_dir/tasks/default-cleanup.yml
+++ b/test/integration/targets/setup_remote_tmp_dir/tasks/default-cleanup.yml
@@ -1,0 +1,5 @@
+- name: delete temporary directory
+  file:
+    path: "{{ remote_tmp_dir }}"
+    state: absent
+  no_log: yes

--- a/test/integration/targets/setup_remote_tmp_dir/tasks/windows-cleanup.yml
+++ b/test/integration/targets/setup_remote_tmp_dir/tasks/windows-cleanup.yml
@@ -1,0 +1,4 @@
+- name: delete temporary directory (windows)
+  win_file:
+    path: "{{ remote_tmp_dir }}"
+    state: absent


### PR DESCRIPTION
##### SUMMARY

This allows a platform handler to run even when the module required for the other platform is not present.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

setup_remote_tmp_dir
