### PR TITLE
vmware_guest_disk storage DRS bugfix for get_recommended_datastore

### DIFF
--- a/changelogs/fragments/67221-vmware-guest-disk-storage-drs-fix.yml
+++ b/changelogs/fragments/67221-vmware-guest-disk-storage-drs-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- return correct datastore cluster placement recommendations during when adding disk using the vmware_guest_disk module

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
@@ -191,6 +191,7 @@ EXAMPLES = '''
       - filename: "[datastore1] path/to/existing/disk.vmdk"
   delegate_to: localhost
   register: disk_facts
+  
 - name: Add disks with specified shares to the virtual machine
   vmware_guest_disk:
     hostname: "{{ vcenter_hostname }}"
@@ -211,6 +212,7 @@ EXAMPLES = '''
           level_value: 1300
   delegate_to: localhost
   register: test_custom_shares
+  
 - name: create new disk with custom IO limits and shares in IO Limits
   vmware_guest_disk:
     hostname: "{{ vcenter_hostname }}"
@@ -233,6 +235,7 @@ EXAMPLES = '''
               level_value: 1305
   delegate_to: localhost
   register: test_custom_IoLimit_shares
+  
 - name: Remove disks from virtual machine using name
   vmware_guest_disk:
     hostname: "{{ vcenter_hostname }}"
@@ -247,6 +250,7 @@ EXAMPLES = '''
         unit_number: 1
   delegate_to: localhost
   register: disk_facts
+  
 - name: Remove disk from virtual machine using moid
   vmware_guest_disk:
     hostname: "{{ vcenter_hostname }}"
@@ -261,6 +265,7 @@ EXAMPLES = '''
         unit_number: 1
   delegate_to: localhost
   register: disk_facts
+  
 - name: Remove disk from virtual machine but keep the VMDK file on the datastore
   vmware_guest_disk:
     hostname: "{{ vcenter_hostname }}"
@@ -331,7 +336,9 @@ class PyVmomiHelper(PyVmomi):
         Args:
             scsi_type: Type of SCSI
             scsi_bus_number: SCSI Bus number to be assigned
+
         Returns: Virtual device spec for SCSI Controller
+
         """
         scsi_ctl = vim.vm.device.VirtualDeviceSpec()
         scsi_ctl.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
@@ -353,7 +360,9 @@ class PyVmomiHelper(PyVmomi):
             disk_index: Disk unit number at which disk needs to be attached
             disk_mode: Disk mode
             disk_filename: Path to the disk file on the datastore
+
         Returns: Virtual Device Spec for virtual disk
+
         """
         disk_spec = vim.vm.device.VirtualDeviceSpec()
         disk_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
@@ -376,7 +385,9 @@ class PyVmomiHelper(PyVmomi):
         Args:
             config_spec: Config Spec
             device_type: Type of device being modified
+
         Returns: Boolean status 'changed' and actual task result
+
         """
         changed, results = (False, '')
         try:
@@ -418,6 +429,7 @@ class PyVmomiHelper(PyVmomi):
         Manage internal state of virtual machine disks
         Args:
             vm_obj: Managed object of virtual machine
+
         """
         # Set vm object
         self.vm = vm_obj
@@ -537,6 +549,7 @@ class PyVmomiHelper(PyVmomi):
         """
         Check correctness of disk input provided by user
         Returns: A list of dictionary containing disk information
+
         """
         disks_data = list()
         if not self.desired_disks:
@@ -738,8 +751,10 @@ class PyVmomiHelper(PyVmomi):
         Return Storage DRS recommended datastore from datastore cluster
         Args:
             datastore_cluster_obj: datastore cluster managed object
+
         Returns: Name of recommended datastore from the given datastore cluster,
                  Returns None if no datastore recommendation found.
+
         """
         # Check if Datastore Cluster provided by user is SDRS ready
         sdrs_status = datastore_cluster_obj.podStorageDrsEntry.storageDrsConfig.podConfig.enabled
@@ -783,7 +798,9 @@ class PyVmomiHelper(PyVmomi):
         Gather facts about VM's disks
         Args:
             vm_obj: Managed object of virtual machine
+
         Returns: A list of dict containing disks information
+
         """
         disks_facts = dict()
         if vm_obj is None:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
@@ -483,7 +483,7 @@ class PyVmomiHelper(PyVmomi):
                 elif disk['disk_type'] == 'eagerzeroedthick':
                     disk_spec.device.backing.eagerlyScrub = True
                 # get Storage DRS recommended datastore from the datastore cluster
-                if disk['datastore_cluster']:
+                if disk['datastore_cluster'] is not None:
                     datastore_name = self.get_recommended_datastore(datastore_cluster_obj=disk['datastore_cluster'], disk_spec_obj=disk_spec)
                     disk['datastore'] = find_obj(self.content, [vim.Datastore], datastore_name)
                 if disk['filename'] is None:
@@ -562,6 +562,7 @@ class PyVmomiHelper(PyVmomi):
                                 state='present',
                                 destroy=True,
                                 filename=None,
+                                datastore_cluster=None,
                                 datastore=None,
                                 autoselect_datastore=True,
                                 disk_unit_number=0,

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
@@ -191,7 +191,7 @@ EXAMPLES = '''
       - filename: "[datastore1] path/to/existing/disk.vmdk"
   delegate_to: localhost
   register: disk_facts
-  
+
 - name: Add disks with specified shares to the virtual machine
   vmware_guest_disk:
     hostname: "{{ vcenter_hostname }}"
@@ -212,7 +212,7 @@ EXAMPLES = '''
           level_value: 1300
   delegate_to: localhost
   register: test_custom_shares
-  
+
 - name: create new disk with custom IO limits and shares in IO Limits
   vmware_guest_disk:
     hostname: "{{ vcenter_hostname }}"
@@ -235,7 +235,7 @@ EXAMPLES = '''
               level_value: 1305
   delegate_to: localhost
   register: test_custom_IoLimit_shares
-  
+
 - name: Remove disks from virtual machine using name
   vmware_guest_disk:
     hostname: "{{ vcenter_hostname }}"
@@ -250,7 +250,7 @@ EXAMPLES = '''
         unit_number: 1
   delegate_to: localhost
   register: disk_facts
-  
+
 - name: Remove disk from virtual machine using moid
   vmware_guest_disk:
     hostname: "{{ vcenter_hostname }}"
@@ -265,7 +265,7 @@ EXAMPLES = '''
         unit_number: 1
   delegate_to: localhost
   register: disk_facts
-  
+
 - name: Remove disk from virtual machine but keep the VMDK file on the datastore
   vmware_guest_disk:
     hostname: "{{ vcenter_hostname }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change introduces the correct `storage_spec` parameters when calling `RecommendDatastores()` method from the pyvmomi plugin. This fixes incorrect datastore cluster placement recommendations during an "add disk" scenario for the `vmware_guest_disk` module.

Fixes #67100
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
See related issue for full conversation.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest_disk

