### PR TITLE
vmware_guest_network/test: renable the test

### DIFF
--- a/test/integration/targets/vmware_guest_network/aliases
+++ b/test/integration/targets/vmware_guest_network/aliases
@@ -2,5 +2,3 @@ cloud/vcenter
 shippable/vcenter/group1
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
-# until we figure out why vmware_guest_tools_wait fails in the CI
-disabled

--- a/test/integration/targets/vmware_guest_network/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_network/tasks/main.yml
@@ -42,7 +42,7 @@
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
-      timeout: 600
+      timeout: 800
       validate_certs: no
       name: test_vm1
 


### PR DESCRIPTION
##### SUMMARY

Increase the timeout to be able to pass the `vmware_guest_tool_wait`
task.

See: https://github.com/ansible/ansible/pull/66990
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_guest_network