### PR TITLE
Fixing typo in regex escape.

### DIFF
--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -188,7 +188,7 @@ EXAMPLES = r'''
 - name: Ensure the JBoss memory settings are exactly as needed
   lineinfile:
     path: /opt/jboss-as/bin/standalone.conf
-    regexp: '^(.*)Xms(\\d+)m(.*)$'
+    regexp: '^(.*)Xms(\d+)m(.*)$'
     line: '\1Xms${xms}m\3'
     backrefs: yes
 


### PR DESCRIPTION
##### SUMMARY
Fixing typo in regex example. `\\d` should read `\d`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lineinfile

##### ADDITIONAL INFORMATION
