### PR TITLE
Docs: improve anchors vs. header bar

### DIFF
--- a/docs/docsite/_static/ansible.css
+++ b/docs/docsite/_static/ansible.css
@@ -53,3 +53,16 @@ tr .ansibleOptionLink {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+
+@media screen and (min-width:767px){
+  /* Move anchors a bit up so that they aren't hidden by the header bar */
+  section [id] {
+    padding-top: 45px;
+    margin-top: -45px;
+  }
+  /* Without this, for example most links in the page's TOC aren't usable anymore */
+  section a[id] {
+    padding-top: 0;
+    margin-top: 0;
+  }
+}

--- a/docs/docsite/_static/ansible.css
+++ b/docs/docsite/_static/ansible.css
@@ -36,15 +36,6 @@ tr .ansibleOptionLink::after {
   content: "";
   font-family: FontAwesome;
 }
-tr .ansibleOptionLink::before {
-  font-family: "FontAwesome";
-  display: inline-block;
-  font-style: normal;
-  font-weight: normal;
-  line-height: 1;
-  text-decoration: inherit;
-  -webkit-font-smoothing: antialiased;
-}
 tr .ansibleOptionLink {
   visibility: hidden;
   display: inline-block;

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -115,7 +115,7 @@ Parameters
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
                     <div class="ansibleOptionAnchor" id="parameter-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
                     <b>@{ key }@</b>
-                    <a class="ansibleOptionLink" href="#parameter-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this option">¶</a>
+                    <a class="ansibleOptionLink" href="#parameter-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">@{ value.type | documented_type }@</span>
                         {% if value.get('elements') %} / <span style="color: purple">elements=@{ value.elements | documented_type }@</span>{% endif %}
@@ -291,7 +291,7 @@ Facts returned by this module are added/updated in the ``hostvars`` host facts a
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@" colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
                     <div class="ansibleOptionAnchor" id="return-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
                     <b>@{ key }@</b>
-                    <a class="ansibleOptionLink" href="#return-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this fact">¶</a>
+                    <a class="ansibleOptionLink" href="#return-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this fact"></a>
                     <div style="font-size: small">
                       <span style="color: purple">@{ value.type | documented_type }@</span>
                       {% if value.elements %} / <span style="color: purple">elements=@{ value.elements | documented_type }@</span>{% endif %}
@@ -368,7 +368,7 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
                     <div class="ansibleOptionAnchor" id="return-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
                     <b>@{ key }@</b>
-                    <a class="ansibleOptionLink" href="#return-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this return value">¶</a>
+                    <a class="ansibleOptionLink" href="#return-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this return value"></a>
                     <div style="font-size: small">
                       <span style="color: purple">@{ value.type | documented_type }@</span>
                       {% if value.elements %} / <span style="color: purple">elements=@{ value.elements | documented_type }@</span>{% endif %}

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -106,13 +106,14 @@ Parameters
             <th width="100%">Comments</th>
         </tr>
         {% for key, value in options|dictsort recursive %}
-            <tr id="parameter-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}">
+            <tr>
                 {# indentation based on nesting level #}
                 {% for i in range(1, loop.depth) %}
                     <td class="elbow-placeholder"></td>
                 {% endfor %}
                 {# parameter name with required and/or introduced label #}
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
+                    <div class="ansibleOptionAnchor" id="parameter-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
                     <b>@{ key }@</b>
                     <a class="ansibleOptionLink" href="#parameter-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this option">¶</a>
                     <div style="font-size: small">
@@ -283,11 +284,12 @@ Facts returned by this module are added/updated in the ``hostvars`` host facts a
             <th width="100%">Description</th>
         </tr>
         {% for key, value in returnfacts|dictsort recursive %}
-            <tr id="return-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}">
+            <tr>
                 {% for i in range(1, loop.depth) %}
                     <td class="elbow-placeholder"></td>
                 {% endfor %}
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@" colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
+                    <div class="ansibleOptionAnchor" id="return-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
                     <b>@{ key }@</b>
                     <a class="ansibleOptionLink" href="#return-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this fact">¶</a>
                     <div style="font-size: small">
@@ -359,11 +361,12 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
             <th width="100%">Description</th>
         </tr>
         {% for key, value in returndocs|dictsort recursive %}
-            <tr id="return-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}">
+            <tr>
                 {% for i in range(1, loop.depth) %}
                     <td class="elbow-placeholder">&nbsp;</td>
                 {% endfor %}
                 <td colspan="@{ from_kludge_ns('maxdepth') - loop.depth0 }@">
+                    <div class="ansibleOptionAnchor" id="return-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}"></div>
                     <b>@{ key }@</b>
                     <a class="ansibleOptionLink" href="#return-{% for part in value.full_key %}@{ part }@{% if not loop.last %}/{% endif %}{% endfor %}" title="Permalink to this return value">¶</a>
                     <div style="font-size: small">


### PR DESCRIPTION
##### SUMMARY
Currently, when the header bar is shown (min-width is 767px), anchors of sections or options are hidden behind the header bar when they are used (on a device with a larger width see https://docs.ansible.com/ansible/devel/modules/docker_container_module.html#parameters: the `Parameters` section header is not visible; and https://docs.ansible.com/ansible/devel/modules/docker_container_module.html#parameter-capabilities: the option `capabilities` is not visible).

This PR does two things to prevent this:
 1) For regular sections, uses a negative margin-top and a corresponding padding-top to move the anchor itself up by 45 pixels (height of the header bar). This is only done for elements with `id=` in `section`, and not for `<a id=` elements (like the page's TOC).
 2) For option anchors, it turns out that adding the `id` to a `<div>` inside the `<td>` is enough (instead of using `<tr id=`). I'm not really sure why that is, but it works both in Firefox and Chromium for me.

I don't have Safari to test this, and haven't tried it with mobile devices.

I also improved the option / return value links a bit (remove the always invisible paragraph sign, which just eats up space, and remove some unnecessary CSS).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/_static/ansible.css
docs/templates/plugin.rst.j2
