### PR TITLE
Fix proxmox_template upload exceptions

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox_template.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_template.py
@@ -137,7 +137,7 @@ def get_template(proxmox, node, storage, content_type, template):
 def upload_template(module, proxmox, api_host, node, storage, content_type, realpath, timeout):
     taskid = proxmox.nodes(node).storage(storage).upload.post(content=content_type, filename=open(realpath, 'rb'))
     while timeout:
-        task_status = proxmox.nodes(api_host.split('.')[0]).tasks(taskid).status.get()
+        task_status = proxmox.nodes(node).tasks(taskid).status.get()
         if task_status['status'] == 'stopped' and task_status['exitstatus'] == 'OK':
             return True
         timeout = timeout - 1

--- a/lib/ansible/modules/cloud/misc/proxmox_template.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_template.py
@@ -32,7 +32,7 @@ options:
   api_password:
     description:
       - the password to authenticate with
-      - you can use PROXMOX_PASSWORD environment variable
+      - if omitted, PROXMOX_PASSWORD environment variable is used instead
   validate_certs:
     description:
       - enable / disable https certificate verification
@@ -40,17 +40,16 @@ options:
     type: bool
   node:
     description:
-      - Proxmox VE node, when you will operate with template
+      - Proxmox VE node to operate on with template
     required: true
   src:
     description:
-      - path to uploaded file
+      - path to file to be uploaded
       - required only for C(state=present)
-    aliases: ['path']
   template:
     description:
       - the template name
-      - required only for states C(absent), C(info)
+      - required only for state C(absent)
   content_type:
     description:
       - content type
@@ -67,7 +66,7 @@ options:
     default: 30
   force:
     description:
-      - can be used only with C(state=present), exists template will be overwritten
+      - can be used only with C(state=present), existing template will be overwritten
     type: bool
     default: 'no'
   state:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -1505,7 +1505,6 @@ lib/ansible/modules/cloud/misc/proxmox_kvm.py validate-modules:parameter-type-no
 lib/ansible/modules/cloud/misc/proxmox_kvm.py validate-modules:undocumented-parameter
 lib/ansible/modules/cloud/misc/proxmox_template.py validate-modules:doc-missing-type
 lib/ansible/modules/cloud/misc/proxmox_template.py validate-modules:doc-required-mismatch
-lib/ansible/modules/cloud/misc/proxmox_template.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/cloud/misc/proxmox_template.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/cloud/misc/rhevm.py validate-modules:doc-required-mismatch
 lib/ansible/modules/cloud/misc/rhevm.py validate-modules:parameter-list-no-elements


### PR DESCRIPTION
##### SUMMARY
This PR updates some documentation within proxmox_template module. Especially, references to an alias for the 'src' parameter, which was actually not an alias, was removed, as well as a reference to state 'info', which was also not available. The main intention was to fix bug #58944, however.

Fixes #58944

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
proxmox_template module

##### ADDITIONAL INFORMATION
Before the bug fix, the first component of the FQDN or IP address of the Proxmox Cluster API host was sent as the node argument to the REST API when uploading a template/iso to the cluster, instead of the actual target node name. This caused lookup errors on the Proxmox API host and in turn a failure code from the API, although the template itself was uploaded correctly.
