### PR TITLE
Fix unmerged merge conflict in footer of documentation for 2.7

### DIFF
--- a/docs/docsite/_themes/sphinx_rtd_theme/footer.html
+++ b/docs/docsite/_themes/sphinx_rtd_theme/footer.html
@@ -22,12 +22,6 @@
   _st('install','yABGvz2N8PwcwBxyfzUc','2.0.0');
 </script>
 
-<<<<<<< HEAD
-  <p>
-  {%- if last_updated %}{% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}<br/>{% endif %}
-  Copyright © 2018 Red Hat, Inc. <br/>
-  </p>
-=======
   <div role="contentinfo">
     <p>
     {%- if show_copyright %}
@@ -65,5 +59,4 @@
   {%- endif %}
 
   {%- block extrafooter %} {% endblock %}
->>>>>>> 912c493... Backport/2.8/theme (#62611)
 </footer>


### PR DESCRIPTION
##### SUMMARY
Fix unmerged merge conflict in footer of documentation by removing part of the old footer that should have been updated.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Footer of the documentation for 2.7.