### PR TITLE
fix hashi_vault lookup generates warning at LDAP authenticate #52131

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -247,7 +247,7 @@ class HashiVault:
         if mount_point is None:
             mount_point = 'ldap'
 
-        self.client.auth_ldap(username, password, mount_point=mount_point)
+        self.client.auth.ldap.login(username, password, mount_point=mount_point)
 
     def boolean_or_cacert(self, validate_certs, cacert):
         validate_certs = boolean(validate_certs, strict=False)


### PR DESCRIPTION
##### SUMMARY
Fix #52131
 
```
DeprecationWarning: Call to deprecated function 'auth_ldap'. This method will be removed in version '0.8.0' Please use the 'login' method on the 'hvac.api.auth_methods.ldap' class moving forward. 
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/lookup/hashi_vault.py

##### ADDITIONAL INFORMATION
The Python hvac module deprecated the function 'auth_ldap' and generates the warning
