### PR TITLE
Allow list of filters for the setup module

### DIFF
--- a/changelogs/fragments/67263_allow_list_of_filters_for_the_setup_module.yml
+++ b/changelogs/fragments/67263_allow_list_of_filters_for_the_setup_module.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - setup - allow list of filters (https://github.com/ansible/ansible/pull/67263).

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -128,6 +128,7 @@ Noteworthy module changes
 * The parameter ``message`` in :ref:`grafana_dashboard <grafana_dashboard_module>` module is renamed to ``commit_message`` since ``message`` is used by Ansible Core engine internally.
 * The parameter ``message`` in :ref:`datadog_monitor <datadog_monitor_module>` module is renamed to ``notification_message`` since ``message`` is used by Ansible Core engine internally.
 * The parameter ``message`` in :ref:`bigpanda <bigpanda_module>` module is renamed to ``deployment_message`` since ``message`` is used by Ansible Core engine internally.
+* The parameter ``filter`` type is changed from ``string`` to ``list`` in the :ref:`setup <setup_module>` module in order to use more than one filter. Previous behaviour (using a ``string``) still remains and works as a single filter.
 
 
 Plugins

--- a/lib/ansible/module_utils/facts/ansible_collector.py
+++ b/lib/ansible/module_utils/facts/ansible_collector.py
@@ -34,6 +34,7 @@ import sys
 
 from ansible.module_utils.facts import timeout
 from ansible.module_utils.facts import collector
+from ansible.module_utils.common.collections import is_string
 
 
 class AnsibleFactCollector(collector.BaseFactCollector):
@@ -53,11 +54,14 @@ class AnsibleFactCollector(collector.BaseFactCollector):
         self.filter_spec = filter_spec
 
     def _filter(self, facts_dict, filter_spec):
-        # assume a filter_spec='' is equilv to filter_spec='*'
+        # assume a filter_spec='' or [] is equilv to filter_spec='*'
         if not filter_spec or filter_spec == '*':
             return facts_dict
 
-        return [(x, y) for x, y in facts_dict.items() if fnmatch.fnmatch(x, filter_spec)]
+        if is_string(filter_spec):
+            filter_spec = [filter_spec]
+
+        return [(x, y) for x, y in facts_dict.items() for f in filter_spec if not f or fnmatch.fnmatch(x, f)]
 
     def collect(self, module=None, collected_facts=None):
         collected_facts = collected_facts or {}
@@ -111,7 +115,7 @@ def get_ansible_collector(all_collector_classes,
                           gather_timeout=None,
                           minimal_gather_subset=None):
 
-    filter_spec = filter_spec or '*'
+    filter_spec = filter_spec or []
     gather_subset = gather_subset or ['all']
     gather_timeout = gather_timeout or timeout.DEFAULT_GATHER_TIMEOUT
     minimal_gather_subset = minimal_gather_subset or frozenset()

--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -44,9 +44,16 @@ options:
     filter:
         version_added: "1.1"
         description:
-            - If supplied, only return facts that match this shell-style (fnmatch) wildcard.
+            - If supplied, only return facts that match one of the shell-style
+              (fnmatch) pattern. An empty list basically means 'no filter'.
+              As of Ansible 2.10, the type has changed from string to list
+              and the default has became an empty list. A simple string is
+              still accepted and works as a single pattern. The behaviour
+              prior to Ansible 2.10 remains.
         required: false
-        default: "*"
+        type: list
+        elements: str
+        default: []
     fact_path:
         version_added: "1.3"
         description:
@@ -110,6 +117,13 @@ EXAMPLES = """
       - '!any'
       - facter
 
+- name: Collect only selected facts
+  setup:
+    filter:
+      - 'ansible_distribution'
+      - 'ansible_machine_id'
+      - 'ansible_*_mb'
+
 # Display only facts about certain interfaces.
 # ansible all -m setup -a 'filter=ansible_eth[0-2]'
 
@@ -146,7 +160,7 @@ def main():
         argument_spec=dict(
             gather_subset=dict(default=["all"], required=False, type='list'),
             gather_timeout=dict(default=10, required=False, type='int'),
-            filter=dict(default="*", required=False),
+            filter=dict(default=[], required=False, type='list', elements='str'),
             fact_path=dict(default='/etc/ansible/facts.d', required=False, type='path'),
         ),
         supports_check_mode=True,

--- a/test/integration/targets/gathering_facts/test_gathering_facts.yml
+++ b/test/integration/targets/gathering_facts/test_gathering_facts.yml
@@ -122,6 +122,24 @@
           - 'ansible_virtualization_role|default("UNDEF_VIRT") == "UNDEF_VIRT"'
           - 'ansible_env|default("UNDEF_ENV") != "UNDEF_ENV"'
 
+- hosts: facthost24
+  tags: [ 'fact_min' ]
+  connection: local
+  gather_facts: no
+  tasks:
+    - setup:
+        filter:
+            - "*env*"
+            - "*virt*"
+
+    - name: Test that retrieving all facts filtered to env and virt works
+      assert:
+        that:
+          - 'ansible_interfaces|default("UNDEF_NET") == "UNDEF_NET"'
+          - 'ansible_mounts|default("UNDEF_MOUNT") == "UNDEF_MOUNT"'
+          - 'ansible_virtualization_role|default("UNDEF_VIRT") != "UNDEF_VIRT"'
+          - 'ansible_env|default("UNDEF_ENV") != "UNDEF_ENV"'
+
 - hosts: facthost13
   tags: [ 'fact_min' ]
   connection: local

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -7601,7 +7601,6 @@ lib/ansible/modules/system/selogin.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/system/seport.py validate-modules:parameter-list-no-elements
 lib/ansible/modules/system/service.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/system/service.py validate-modules:use-run-command-not-popen
-lib/ansible/modules/system/setup.py validate-modules:doc-missing-type
 lib/ansible/modules/system/setup.py validate-modules:parameter-list-no-elements
 lib/ansible/modules/system/setup.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/system/solaris_zone.py validate-modules:doc-required-mismatch


### PR DESCRIPTION
##### SUMMARY
The setup module can now filter out multiple pattern by providing a list to the filter parameter instead of just a string. The default behavior and single string filtering still work as before. But instead of calling the setup module multiple times to filter out multiple facts, it can now be called only once with multiple filtering with an important speed improvement. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- modules/system/setup
- module_utils/facts/ansible_collector

##### ADDITIONAL INFORMATION
In a task, when only some facts must be gathered (and cached) the only solution was to use the `setup` module with the `filter` parameter  called multiple times (with a `loop`) like below:
```
tasks:
  - setup:
      filter: "{{ item }}"
    loop:
      - 'ansible_machine_id'
      - 'ansible_distribution'
```

It implies that the setup modules is called several times doing the same work and only filtering out the one element that needs to be selected. This is a waste of time and can quickly get painfull with a large number of hosts and of filters.

This patch allow to pass a list of filters to the setup module. This way, the setup module is called only once and the filtering is done once also for each filters. See below:
```
tasks:
  - setup:
      filter: 
        - 'ansible_machine_id'
        - 'ansible_distribution'
```