### PR TITLE
open_iscsi: Set default port as string

### DIFF
--- a/lib/ansible/modules/system/open_iscsi.py
+++ b/lib/ansible/modules/system/open_iscsi.py
@@ -252,7 +252,7 @@ def main():
 
             # target
             portal=dict(type='str', aliases=['ip']),
-            port=dict(type='str', default=3260),
+            port=dict(type='str', default='3260'),
             target=dict(type='str', aliases=['name', 'targetname']),
             node_auth=dict(type='str', default='CHAP'),
             node_user=dict(type='str'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix https://github.com/ansible/ansible/issues/67267
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
* open_iscsi

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
[WARNING]: The value 3260 (type int) in a string field was converted to '3260' (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.
```
