### PR TITLE
vmware_guest_tools_wait: disable the function test

### DIFF
--- a/test/integration/targets/vmware_guest_tools_wait/aliases
+++ b/test/integration/targets/vmware_guest_tools_wait/aliases
@@ -2,3 +2,5 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+# the test fails randomly in the CI
+disabled


### PR DESCRIPTION
##### SUMMARY

The test fails randomly in the CI with a timeout.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_guest_tools_wait
<!--- Write the short name of the module, plugin, task or feature below -->