### PR TITLE
[backport][2.9] add info on creating doc fragments in a collection (#67171)

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -212,6 +212,29 @@ Then you can populate the directories with the content you want inside the colle
 https://github.com/bcoca/collection to get a better idea of what you can place inside a collection.
 
 
+.. _docfragments_collections:
+
+Using documentation fragments in collections
+--------------------------------------------
+
+To include documentation fragments in your collection:
+
+#. Create the documentation fragment: ``plugins/doc_fragments/fragment_name``.
+
+#. Refer to the documentation fragment with its FQCN.
+
+.. code-block:: yaml
+
+   extends_documentation_fragment:
+     - community.kubernetes.k8s_name_options
+     - community.kubernetes.k8s_auth_options
+     - community.kubernetes.k8s_resource_options
+     - community.kubernetes.k8s_scale_options
+
+:ref:`module_docs_fragments` covers the basics for documentation fragments. The `kubernetes <https://github.com/ansible-collections/kubernetes>`_ collection includes a complete example.
+
+You can also share documentation fragments across collections with the FQCN.
+
 .. _building_collections:
 
 Building collections

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -345,6 +345,7 @@ For example, all AWS modules should include:
     - aws
     - ec2
 
+:ref:`docfragments_collections` describes how to incorporate documentation fragments in a collection.
 
 .. _examples_block:
 


### PR DESCRIPTION
* add info on creating doc fragments in a collection
Co-authored-by: Alicia Cozine <879121+acozine@users.noreply.github.com>

(cherry picked from commit 4dd2513371800c649eeb45ea0bd819ac3ebd153b)

Backport of #67171 

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
