### PR TITLE
CloudRetry/AWSRetry : Disable catching of NotFound exceptions

### DIFF
--- a/changelogs/fragments/67281-AWSRetry-disable-NotFound.yaml
+++ b/changelogs/fragments/67281-AWSRetry-disable-NotFound.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-- "The AWSRetry decorator no longer catches NotFound exceptions unless they're explicitly added via catch_extra_error_codes."
+- "The ``AWSRetry`` decorator no longer catches ``NotFound`` exceptions unless they're explicitly added via ``catch_extra_error_codes``."

--- a/changelogs/fragments/67281-AWSRetry-disable-NotFound.yaml
+++ b/changelogs/fragments/67281-AWSRetry-disable-NotFound.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- "The AWSRetry decorator no longer catches NotFound exceptions unless they're explicitly added via catch_extra_error_codes."

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -99,6 +99,7 @@ Noteworthy module changes
 * The ``datacenter`` option has been removed from :ref:`vmware_guest_find <vmware_guest_find_module>`
 * The options ``ip_address`` and ``subnet_mask`` have been removed from :ref:`vmware_vmkernel <vmware_vmkernel_module>`; use the suboptions ``ip_address`` and ``subnet_mask`` of the ``network`` option instead.
 * Ansible modules created with ``add_file_common_args=True`` added a number of undocumented arguments which were mostly there to ease implementing certain action plugins. The undocumented arguments ``src``, ``follow``, ``force``, ``content``, ``backup``, ``remote_src``, ``regexp``, ``delimiter``, and ``directory_mode`` are now no longer added. Modules relying on these options to be added need to specify them by themselves.
+* The AWSRetry decorator no longer catches NotFound exceptions by default, NotFound exceptions need to be explicitly added using ``catch_extra_error_codes``.  Some AWS modules may see an increase in transient failures due to AWS's eventual consistency model.
 * :ref:`vmware_datastore_maintenancemode <vmware_datastore_maintenancemode_module>` now returns ``datastore_status`` instead of Ansible internal key ``results``.
 * :ref:`vmware_host_kernel_manager <vmware_host_kernel_manager_module>` now returns ``host_kernel_status`` instead of Ansible internal key ``results``.
 * :ref:`vmware_host_ntp <vmware_host_ntp_module>` now returns ``host_ntp_status`` instead of Ansible internal key ``results``.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -99,7 +99,7 @@ Noteworthy module changes
 * The ``datacenter`` option has been removed from :ref:`vmware_guest_find <vmware_guest_find_module>`
 * The options ``ip_address`` and ``subnet_mask`` have been removed from :ref:`vmware_vmkernel <vmware_vmkernel_module>`; use the suboptions ``ip_address`` and ``subnet_mask`` of the ``network`` option instead.
 * Ansible modules created with ``add_file_common_args=True`` added a number of undocumented arguments which were mostly there to ease implementing certain action plugins. The undocumented arguments ``src``, ``follow``, ``force``, ``content``, ``backup``, ``remote_src``, ``regexp``, ``delimiter``, and ``directory_mode`` are now no longer added. Modules relying on these options to be added need to specify them by themselves.
-* The AWSRetry decorator no longer catches NotFound exceptions by default, NotFound exceptions need to be explicitly added using ``catch_extra_error_codes``.  Some AWS modules may see an increase in transient failures due to AWS's eventual consistency model.
+* The ``AWSRetry`` decorator no longer catches ``NotFound`` exceptions by default.  ``NotFound`` exceptions need to be explicitly added using ``catch_extra_error_codes``.  Some AWS modules may see an increase in transient failures due to AWS's eventual consistency model.
 * :ref:`vmware_datastore_maintenancemode <vmware_datastore_maintenancemode_module>` now returns ``datastore_status`` instead of Ansible internal key ``results``.
 * :ref:`vmware_host_kernel_manager <vmware_host_kernel_manager_module>` now returns ``host_kernel_status`` instead of Ansible internal key ``results``.
 * :ref:`vmware_host_ntp <vmware_host_ntp_module>` now returns ``host_ntp_status`` instead of Ansible internal key ``results``.

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -111,8 +111,7 @@ class AWSRetry(CloudRetry):
         if catch_extra_error_codes:
             retry_on.extend(catch_extra_error_codes)
 
-        not_found = re.compile(r'^\w+.NotFound')
-        return response_code in retry_on or not_found.search(response_code)
+        return response_code in retry_on
 
 
 def boto3_conn(module, conn_type=None, resource=None, region=None, endpoint=None, **params):

--- a/test/units/module_utils/ec2/test_aws.py
+++ b/test/units/module_utils/ec2/test_aws.py
@@ -43,7 +43,7 @@ class RetryTestCase(unittest.TestCase):
         def extend_failures():
             self.counter += 1
             if self.counter < 2:
-                raise botocore.exceptions.ClientError(err_msg, 'Could not find you')
+                raise botocore.exceptions.ClientError(err_msg, 'You did something wrong.')
             else:
                 return 'success'
 
@@ -53,13 +53,13 @@ class RetryTestCase(unittest.TestCase):
 
     def test_retry_once(self):
         self.counter = 0
-        err_msg = {'Error': {'Code': 'InstanceId.NotFound'}}
+        err_msg = {'Error': {'Code': 'InternalFailure'}}
 
         @AWSRetry.backoff(tries=2, delay=0.1)
         def retry_once():
             self.counter += 1
             if self.counter < 2:
-                raise botocore.exceptions.ClientError(err_msg, 'Could not find you')
+                raise botocore.exceptions.ClientError(err_msg, 'Something went wrong!')
             else:
                 return 'success'
 


### PR DESCRIPTION
##### SUMMARY

AWSRetry auto-catches a wide variety of NotFound exceptions, which we don't always want to catch.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

lib/ansible/module_utils/cloud.py
lib/ansible/module_utils/ec2.py

##### ADDITIONAL INFORMATION

see also #67204

There will be a number of followup PRs explicitly adding the various NotFound error codes to modules where we believe this behavior was expected.