### PR TITLE
Remove options from some vmware modules that aren't used in the code

### DIFF
--- a/changelogs/fragments/67282-remove_options_from_some_vmware_modules_that_aren't_used_in_the_code.yml
+++ b/changelogs/fragments/67282-remove_options_from_some_vmware_modules_that_aren't_used_in_the_code.yml
@@ -1,0 +1,4 @@
+removed_features:
+  - vmware_guest_find - Removed deprecated ``datacenter`` option
+  - vmware_vmkernel - Removed deprecated ``ip_address`` option; use sub-option ip_address in the network option instead
+  - vmware_vmkernel - Removed deprecated ``subnet_mask`` option; use sub-option subnet_mask in the network option instead

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -96,6 +96,8 @@ The following modules will be removed in Ansible 2.14. Please update your playbo
 Noteworthy module changes
 -------------------------
 
+* The ``datacenter`` option has been removed from :ref:`vmware_guest_find <vmware_guest_find_module>`
+* The options ``ip_address`` and ``subnet_mask`` have been removed from :ref:`vmware_vmkernel <vmware_vmkernel_module>`; use the suboptions ``ip_address`` and ``subnet_mask`` of the ``network`` option instead.
 * Ansible modules created with ``add_file_common_args=True`` added a number of undocumented arguments which were mostly there to ease implementing certain action plugins. The undocumented arguments ``src``, ``follow``, ``force``, ``content``, ``backup``, ``remote_src``, ``regexp``, ``delimiter``, and ``directory_mode`` are now no longer added. Modules relying on these options to be added need to specify them by themselves.
 * :ref:`vmware_datastore_maintenancemode <vmware_datastore_maintenancemode_module>` now returns ``datastore_status`` instead of Ansible internal key ``results``.
 * :ref:`vmware_host_kernel_manager <vmware_host_kernel_manager_module>` now returns ``host_kernel_status`` instead of Ansible internal key ``results``.

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_find.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_find.py
@@ -44,11 +44,6 @@ options:
      default: no
      type: bool
      version_added: '2.8'
-   datacenter:
-     description:
-     - Destination datacenter for the find operation.
-     - Deprecated in 2.5, will be removed in 2.9 release.
-     type: str
 extends_documentation_fragment: vmware.documentation
 '''
 
@@ -133,7 +128,6 @@ def main():
         name=dict(type='str'),
         uuid=dict(type='str'),
         use_instance_uuid=dict(type='bool', default=False),
-        datacenter=dict(removed_in_version=2.9, type='str')
     )
 
     module = AnsibleModule(argument_spec=argument_spec,

--- a/lib/ansible/modules/cloud/vmware/vmware_vmkernel.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmkernel.py
@@ -79,18 +79,6 @@ options:
           tcpip_stack: 'default',
       }
       version_added: 2.5
-    ip_address:
-      description:
-      - The IP Address for the VMKernel interface.
-      - Use C(network) parameter with C(ip_address) instead.
-      - Deprecated option, will be removed in version 2.9.
-      type: str
-    subnet_mask:
-      description:
-      - The Subnet Mask for the VMKernel interface.
-      - Use C(network) parameter with C(subnet_mask) instead.
-      - Deprecated option, will be removed in version 2.9.
-      type: str
     mtu:
       description:
       - The MTU for the VMKernel interface.
@@ -1057,8 +1045,6 @@ def main():
     argument_spec.update(dict(
         esxi_hostname=dict(required=True, type='str'),
         portgroup_name=dict(required=True, type='str', aliases=['portgroup']),
-        ip_address=dict(removed_in_version=2.9, type='str'),
-        subnet_mask=dict(removed_in_version=2.9, type='str'),
         mtu=dict(required=False, type='int', default=1500),
         device=dict(type='str'),
         enable_vsan=dict(required=False, type='bool', default=False),

--- a/test/integration/targets/vmware_guest_find/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_find/tasks/main.yml
@@ -15,7 +15,6 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     name: "{{ item.name }}"
-    datacenter: "{{ dc1 }}"
   with_items: "{{ virtual_machines }}"
   register: folders
 


### PR DESCRIPTION
##### SUMMARY
It looks like `vmware_guest_find` and `vmware_vmkernel` mention options in the documentation section and the argument_spec that aren't used in the code.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_guest_find.py
lib/ansible/modules/cloud/vmware/vmware_vmkernel.py

##### ADDITIONAL INFORMATION
Fixes #67016 
