### PR TITLE
Remove return status not specific to shell module

### DIFF
--- a/lib/ansible/modules/commands/shell.py
+++ b/lib/ansible/modules/commands/shell.py
@@ -160,11 +160,11 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-msg:
-    description: changed
+cmd:
+    description: The command executed by the task
     returned: always
-    type: bool
-    sample: True
+    type: str
+    sample: 'rabbitmqctl join_cluster rabbit@master'
 start:
     description: The command execution start time
     returned: always
@@ -180,29 +180,4 @@ delta:
     returned: always
     type: str
     sample: '0:00:00.325771'
-stdout:
-    description: The command standard output
-    returned: always
-    type: str
-    sample: 'Clustering node rabbit@slave1 with rabbit@master ...'
-stderr:
-    description: The command standard error
-    returned: always
-    type: str
-    sample: 'ls: cannot access foo: No such file or directory'
-cmd:
-    description: The command executed by the task
-    returned: always
-    type: str
-    sample: 'rabbitmqctl join_cluster rabbit@master'
-rc:
-    description: The command return code (0 means success)
-    returned: always
-    type: int
-    sample: 0
-stdout_lines:
-    description: The command standard output split in lines
-    returned: always
-    type: list
-    sample: [u'Clustering node rabbit@slave1 with rabbit@master ...']
 '''


### PR DESCRIPTION
Only specific return status should be documented as the standard ones are
already given in a separate page.

##### SUMMARY
Remove return codes that are already documented in the common return codes.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- shell module

##### ADDITIONAL INFORMATION

```
ansible 2.9.4
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/baptistemm/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.6 (default, Jan 30 2020, 09:44:41) [GCC 9.2.1 20190827 (Red Hat 9.2.1-1)]

```
