### PR TITLE
Remove conflicting integration test aliases.

### DIFF
--- a/test/integration/targets/acme_certificate/aliases
+++ b/test/integration/targets/acme_certificate/aliases
@@ -1,3 +1,2 @@
 shippable/cloud/group1
 cloud/acme
-acme_account_info

--- a/test/integration/targets/apt_repository/aliases
+++ b/test/integration/targets/apt_repository/aliases
@@ -1,4 +1,3 @@
-apt_key
 destructive
 shippable/posix/group1
 skip/freebsd

--- a/test/integration/targets/ec2_vol/aliases
+++ b/test/integration/targets/ec2_vol/aliases
@@ -1,3 +1,2 @@
 cloud/aws
 shippable/aws/group3
-ec2_vol_info

--- a/test/integration/targets/postgresql_privs/aliases
+++ b/test/integration/targets/postgresql_privs/aliases
@@ -1,5 +1,4 @@
 destructive
 shippable/posix/group4
-postgresql_user
 skip/aix
 skip/osx

--- a/test/integration/targets/service/aliases
+++ b/test/integration/targets/service/aliases
@@ -3,4 +3,3 @@ shippable/posix/group1
 skip/aix
 skip/freebsd
 skip/osx
-systemd

--- a/test/integration/targets/timezone/aliases
+++ b/test/integration/targets/timezone/aliases
@@ -2,4 +2,3 @@ destructive
 shippable/posix/group1
 skip/aix
 skip/osx
-systemd


### PR DESCRIPTION
##### SUMMARY

Modules and plugins can only have one integration test target associated with them.

When there is a conflict between alias(es) and/or the target name, only one target will trigger on changes to the module or plugin.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

integration tests
