### PR TITLE
BOTMETA: ignore authors ethanculler and woz5999 for logicmonitor* modules

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -371,6 +371,8 @@ files:
       migrated_to: community.grafana
   $modules/monitoring/logentries.py:
     ignored: ivanvanderbyl
+  $modules/monitoring/logicmonitor:
+    ignored: ethanculler woz5999
   $modules/monitoring/monit.py: brian-brazil
   $modules/monitoring/pagerduty.py:
     ignored: bpennypacker


### PR DESCRIPTION
##### SUMMARY
@woz5999 requested in #60536 to be removed as a maintainer for `logicmonitor` and `logicmonitor_facts`, and mentioned that @ethanculler also no longer works for LogicMonitor (both of them are the authors of these modules). This PR puts both of them on the ignore list for these modules so they won't get pinged for new issues and PRs.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml
logicmonitor
logicmonitor_facts
