### PR TITLE
Link the testing documentation to the module documenting page - backport of #67248

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -280,7 +280,7 @@ You can link from your module documentation to other module docs, other resource
 
 .. note::
 
-	For modules in a collection, you can only use ``L()`` and ``M()`` for content within that collection. Use ``U()`` to refer to content in a different collection.
+  For modules in a collection, you can only use ``L()`` and ``M()`` for content within that collection. Use ``U()`` to refer to content in a different collection.
 
 .. note::
 
@@ -452,3 +452,10 @@ After the shebang, the UTF-8 coding, the copyright line, the license, and the se
    from module_utils.basic import AnsibleModule
 
 The use of "wildcard" imports such as ``from module_utils.basic import *`` is no longer allowed.
+
+.. _dev_testing_module_documentation:
+
+Testing module documentation
+============================
+
+To test Ansible documentation locally please :ref:`follow instruction<testing_module_documentation>`.


### PR DESCRIPTION
##### SUMMARY
Link to the related documentation page added.

That is a backport of #67248.

##### ISSUE TYPE
- Docs Pull Request