### PR TITLE
ansible-test - add constraint for virtualenv

### DIFF
--- a/changelogs/fragments/ansible-test-constraints-virtualenv.yml
+++ b/changelogs/fragments/ansible-test-constraints-virtualenv.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ansible-test - add additional constraint for virtualenv on Python 2.7
+  - ansible-test - Use ``virtualenv`` versions before 20 on provisioned macOS instances to remain compatible with an older pip install.

--- a/changelogs/fragments/ansible-test-constraints-virtualenv.yml
+++ b/changelogs/fragments/ansible-test-constraints-virtualenv.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - add additional constraint for virtualenv on Python 2.7

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -25,8 +25,7 @@ requests-ntlm >= 1.1.0 # message encryption support
 requests-credssp >= 0.1.0 # message encryption support
 voluptuous >= 0.11.0 # Schema recursion via Self
 openshift >= 0.6.2, < 0.9.0 # merge_type support
-virtualenv < 16.0.0 ; python_version < '2.7'   # virtualenv 16.0.0 and later require python 2.7 or later
-virtualenv < 20.0.0 ; python_version == '2.7'  # virtualenv 20.0.0 breaks on macOS due to the older pip we have there not installing the zipp dependency
+virtualenv < 16.0.0 ; python_version < '2.7' # virtualenv 16.0.0 and later require python 2.7 or later
 pathspec < 0.6.0 ; python_version < '2.7' # pathspec 0.6.0 and later require python 2.7 or later
 pyopenssl < 18.0.0 ; python_version < '2.7' # pyOpenSSL 18.0.0 and later require python 2.7 or later
 pyfmg == 0.6.1 # newer versions do not pass current unit tests

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -25,7 +25,8 @@ requests-ntlm >= 1.1.0 # message encryption support
 requests-credssp >= 0.1.0 # message encryption support
 voluptuous >= 0.11.0 # Schema recursion via Self
 openshift >= 0.6.2, < 0.9.0 # merge_type support
-virtualenv < 16.0.0 ; python_version < '2.7' # virtualenv 16.0.0 and later require python 2.7 or later
+virtualenv < 16.0.0 ; python_version < '2.7'   # virtualenv 16.0.0 and later require python 2.7 or later
+virtualenv < 20.0.0 ; python_version == '2.7'  # virtualenv 20.0.0 breaks on macOS due to the older pip we have there not installing the zipp dependency
 pathspec < 0.6.0 ; python_version < '2.7' # pathspec 0.6.0 and later require python 2.7 or later
 pyopenssl < 18.0.0 ; python_version < '2.7' # pyOpenSSL 18.0.0 and later require python 2.7 or later
 pyfmg == 0.6.1 # newer versions do not pass current unit tests

--- a/test/lib/ansible_test/_data/setup/remote.sh
+++ b/test/lib/ansible_test/_data/setup/remote.sh
@@ -73,7 +73,7 @@ elif [ "${platform}" = "rhel" ]; then
 elif [ "${platform}" = "osx" ]; then
     while true; do
         pip install --disable-pip-version-check --quiet \
-            virtualenv \
+            'virtualenv<20' \
         && break
         echo "Failed to install packages. Sleeping before trying again..."
         sleep 10


### PR DESCRIPTION
##### SUMMARY

The new version of `virtualenv` has a dependency on `zipp`, which does not get installed by the older version of `pip` on our macOS image in CI.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/lib/ansible_test/_data/requirements/constraints.txt`