### PR TITLE
[stable-2.8] ansible-test - add constraint for virtualenv (#67289)

### DIFF
--- a/changelogs/fragments/ansible-test-constraints-virtualenv.yml
+++ b/changelogs/fragments/ansible-test-constraints-virtualenv.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Use ``virtualenv`` versions before 20 on provisioned macOS instances to remain compatible with an older pip install.

--- a/test/runner/setup/remote.sh
+++ b/test/runner/setup/remote.sh
@@ -73,7 +73,7 @@ elif [ "${platform}" = "rhel" ]; then
 elif [ "${platform}" = "osx" ]; then
     while true; do
         pip install --disable-pip-version-check --quiet \
-            virtualenv \
+            'virtualenv<20' \
         && break
         echo "Failed to install packages. Sleeping before trying again..."
         sleep 10


### PR DESCRIPTION
##### SUMMARY

[stable-2.8] ansible-test - add constraint for virtualenv (#67289)

Co-authored-by: Matt Clay <matt@mystile.com>

(cherry picked from commit 8f296a6533dd8c10e80b04de8495be3140a94c66)

Co-authored-by: Sam Doran <sdoran@redhat.com>

Backport of https://github.com/ansible/ansible/pull/67289

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
