### PR TITLE
VMware: Fix creating IP specific firewall rules with Python 2

### DIFF
--- a/changelogs/fragments/67303-vmware_host_firewall_manager-fix_ip_specific_firewall_rules_for_python2.yml
+++ b/changelogs/fragments/67303-vmware_host_firewall_manager-fix_ip_specific_firewall_rules_for_python2.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_host_firewall_manager - Fixed creating IP specific firewall rules with Python 2 (https://github.com/ansible/ansible/issues/67303)

--- a/lib/ansible/modules/cloud/vmware/vmware_host_firewall_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_firewall_manager.py
@@ -173,7 +173,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware import vmware_argument_spec, PyVmomi
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.compat import ipaddress
 
 
@@ -229,7 +229,7 @@ class VmwareFirewallManager(PyVmomi):
             ip_networks = allowed_hosts.get('ip_network', [])
             for ip_address in ip_addresses:
                 try:
-                    ipaddress.ip_address(ip_address)
+                    ipaddress.ip_address(to_text(ip_address))
                 except ValueError:
                     self.module.fail_json(msg="The provided IP address %s is not a valid IP"
                                               " for the rule %s" % (ip_address, rule_name))


### PR DESCRIPTION
##### SUMMARY
IP specific firewall rules don't work with Python 2.

Fixes #67303 for devel, I will open a backport PR as soon as this one is merged.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_host_firewall_manager.py

##### ADDITIONAL INFORMATION
I've had a look at some other modules that use `ipaddress.ip_address()` and just stole their solution.