### PR TITLE
Use a custom test module for module_defaults test.

### DIFF
--- a/lib/ansible/config/module_defaults.yml
+++ b/lib/ansible/config/module_defaults.yml
@@ -1281,6 +1281,8 @@ groupings:
   - ovirt
   ovirt_vnic_profile:
   - ovirt
+  test_module_defaults:
+  - test
   vcenter_extension:
   - vmware
   vcenter_extension_info:

--- a/test/integration/targets/module_defaults/library/test_module_defaults.py
+++ b/test/integration/targets/module_defaults/library/test_module_defaults.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            arg1=dict(type='str', default='default1'),
+            arg2=dict(type='str', default='default2'),
+            arg3=dict(type='str', default='default3'),
+        ),
+        supports_check_mode=True
+    )
+
+    result = dict(
+        test_module_defaults=dict(
+            arg1=module.params['arg1'],
+            arg2=module.params['arg2'],
+            arg3=module.params['arg3'],
+        ),
+    )
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/module_defaults/tasks/main.yml
+++ b/test/integration/targets/module_defaults/tasks/main.yml
@@ -89,26 +89,28 @@
             foo.msg == "Hello world!"
 - name: Module group defaults block
   module_defaults:
-    group/aws:
-      region: us-east-1
-      aws_secret_key: foobar
+    group/test:
+      arg1: "test1"
+      arg2: "test2"
   block:
-    - aws_s3_bucket_info:
-      ignore_errors: true
-      register: s3
+    - test_module_defaults:
+      register: result
     - assert:
         that:
-          - "'Partial credentials' in s3.msg or 'boto3 required' in s3.msg"
+          - "result.test_module_defaults.arg1 == 'test1'"
+          - "result.test_module_defaults.arg2 == 'test2'"
+          - "result.test_module_defaults.arg3 == 'default3'"
 - name: Module group defaults block
   module_defaults:
-    group/aws:
-      region: us-east-1
-      aws_secret_key: foobar
-      aws_access_key: foobar
+    group/test:
+      arg1: "test1"
+      arg2: "test2"
+      arg3: "test3"
   block:
-    - aws_s3_bucket_info:
-      ignore_errors: true
-      register: s3
+    - test_module_defaults:
+      register: result
     - assert:
         that:
-          - "'InvalidAccessKeyId' in s3.msg or 'boto3 required' in s3.msg"
+          - "result.test_module_defaults.arg1 == 'test1'"
+          - "result.test_module_defaults.arg2 == 'test2'"
+          - "result.test_module_defaults.arg3 == 'test3'"


### PR DESCRIPTION
##### SUMMARY

Use a custom test module for module_defaults test.

This avoids a dependency on a module which will not remain in the repo after migration.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

module_defaults integration test
