### PR TITLE
Use `package` for `pkgng` and `zypper` in tests.

### DIFF
--- a/test/integration/targets/apache2_module/tasks/actualtest.yml
+++ b/test/integration/targets/apache2_module/tasks/actualtest.yml
@@ -23,7 +23,7 @@
     - libapache2-mod-evasive
 
 - name: install apache via zypper
-  zypper:
+  package:
     name: apache2
     state: present
   when: "ansible_os_family == 'Suse'"

--- a/test/integration/targets/hg/tasks/install.yml
+++ b/test/integration/targets/hg/tasks/install.yml
@@ -32,7 +32,7 @@
   when: ansible_pkg_mgr == 'yum'
 
 - name: install mercurial (pkgng)
-  pkgng:
+  package:
     name: mercurial
   when: ansible_pkg_mgr == 'pkgng'
 

--- a/test/integration/targets/hg/tasks/uninstall.yml
+++ b/test/integration/targets/hg/tasks/uninstall.yml
@@ -29,7 +29,7 @@
   when: ansible_pkg_mgr == 'yum'
 
 - name: uninstall packages which were not originally installed (pkgng)
-  pkgng:
+  package:
     name: mercurial
     state: absent
     autoremove: yes

--- a/test/integration/targets/lookup_passwordstore/tasks/package.yml
+++ b/test/integration/targets/lookup_passwordstore/tasks/package.yml
@@ -24,7 +24,7 @@
       dest: /etc/zypp/repos.d/security:privacy.repo
 
   - name: SUSE | Install package
-    zypper:
+    package:
       name: password-store
       state: present
       update_cache: yes

--- a/test/integration/targets/pull/cleanup.yml
+++ b/test/integration/targets/pull/cleanup.yml
@@ -9,7 +9,7 @@
       when: git_install.changed
 
     - name: remove auto-installed packages from FreeBSD
-      pkgng:
+      package:
         name: git
         state: absent
         autoremove: yes

--- a/test/integration/targets/setup_mysql_db/tasks/main.yml
+++ b/test/integration/targets/setup_mysql_db/tasks/main.yml
@@ -64,7 +64,7 @@
   notify: cleanup mysql
 
 - name: install mysqldb_test FreeBSD dependencies
-  pkgng:
+  package:
     name: "{{ mysql_packages }}"
     state: present
   when: ansible_os_family == "FreeBSD"

--- a/test/integration/targets/xml/tasks/main.yml
+++ b/test/integration/targets/xml/tasks/main.yml
@@ -2,7 +2,7 @@
   setup:
 
 - name: Install lxml (FreeBSD)
-  pkgng:
+  package:
     name: '{{ "py27-lxml" if ansible_python.version.major == 2 else "py36-lxml" }}'
     state: present
   when: ansible_os_family == "FreeBSD"


### PR DESCRIPTION
##### SUMMARY

Use `package` for `pkgng` and `zypper` in tests.

This allows tests to run on other platforms when `pkgng` or `zypper` are not present.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

integration tests
