### PR TITLE
vmware_host: fix doc syntax error

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_host.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host.py
@@ -59,9 +59,7 @@ options:
     - "Here 'host' is an invisible folder under VMware Web Client."
     - "Another example, if there is a nested folder structure like '/myhosts/india/pune' under
        datacenter 'dc2', then C(folder) value will be '/dc2/host/myhosts/india/pune'."
-    - "Other Examples: "
-    - "  - '/Site2/dc2/Asia-Cluster/host'"
-    - "  - '/dc3/Asia-Cluster/host'"
+    - "Other Examples: '/Site2/dc2/Asia-Cluster/host' or '/dc3/Asia-Cluster/host'"
     version_added: "2.6"
     aliases: ['folder_name']
     type: str


### PR DESCRIPTION
##### SUMMARY

Adjust the `DOCUMENTATION` section to get a proper rendering of the
`folder` example.

This is actually breaking the black code formatter.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_host