### PR TITLE
[cloud/vmware/vmware_guest_disk]: Reset disk['destroy'] to False when user set not remove disk file explicitly

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
@@ -572,8 +572,9 @@ class PyVmomiHelper(PyVmomi):
                 else:
                     current_disk['state'] = disk['state']
 
+            # By default destroy file from datastore if 'destroy' parameter is not provided
             if current_disk['state'] == 'absent':
-                current_disk['destroy'] = disk['destroy']
+                current_disk['destroy'] = disk.get('destroy', True)
             elif current_disk['state'] == 'present':
                 # Select datastore or datastore cluster
                 if 'datastore' in disk:

--- a/test/integration/targets/vmware_guest_disk/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_disk/tasks/main.yml
@@ -230,3 +230,52 @@
   assert:
      that:
          - test_shares_IoLimits is changed
+
+- name: remove disk without destroy file
+  vmware_guest_disk:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    validate_certs: no
+    name: "{{ virtual_machines[0].name }}"
+    disk:
+        - state: "absent"
+          scsi_controller: 0
+          unit_number: 2
+          destroy: false
+  register: test_remove_without_destroy
+
+- debug:
+    msg: "{{ test_remove_without_destroy }}"
+
+- name: assert that changes were made
+  assert:
+    that:
+        - test_remove_without_destroy is changed
+
+- name: remove disks with destroy file
+  vmware_guest_disk:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    validate_certs: no
+    name: "{{ virtual_machines[0].name }}"
+    disk:
+        - state: "absent"
+          scsi_controller: 0
+          unit_number: 3
+          destroy: true
+        - state: "absent"
+          scsi_controller: 0
+          unit_number: 4
+  register: test_remove_with_destroy
+
+- debug:
+    msg: "{{ test_remove_with_destroy }}"
+
+- name: assert that changes were made
+  assert:
+    that:
+        - test_remove_with_destroy is changed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #67329 

Reset disk['destroy'] to False when user set not remove disk file explicitly
Fix of assigning value with nonexisting dict attribute.

The following commit introduce a new parameter `destroy`. If  `destroy` doesn't give, disk dict would have no attribute `destroy`, so line 576 of `lib/ansible/modules/cloud/vmware/vmware_guest_disk.py` would fail.

```
diff --git a/lib/ansible/modules/cloud/vmware/vmware_guest_disk.py b/lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
index a22809fca1..bc070fbb1b 100644
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
@@ -104,6 +104,10 @@ options:
      - '   This value is ignored, if SCSI Controller is already present or C(state) is C(absent).'
      - '   Valid values are C(buslogic), C(lsilogic), C(lsilogicsas) and C(paravirtual).'
      - '   C(paravirtual) is default value for this parameter.'
+     - ' - C(destroy) (bool): If C(state) is C(absent), make sure the disk file is deleted from the datastore (default C(yes)).'
```

```yaml
- name: "Disks to virtual machine {{ vm_name }}: {{ state }}"
  vmware_guest_disk:
    hostname: "{{ vsphere_host_name }}"
    username: "{{ vsphere_host_user }}"
    password: "{{ vsphere_host_user_password }}"
    validate_certs: "{{ valid_cert | default(False) }}"
    datacenter: "{{ vsphere_host_datacenter }}"
    folder: "{{ vm_folder | default('/') }}"
    name: "{{ vm_name }}"
    disk:
      - state: "absent"
        scsi_controller: "{{ ctrl_no }}"
        unit_number: "{{ unit_no }}"
```

Error Line 576 of lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
```
575 if current_disk['state'] == 'absent': 
576     current_disk['destroy'] = disk['destroy'] 
```
So add this fix, Reset currrent_disk['destroy'] to False only disk object has attribute `destroy`  and `False` value (means that given `destroy: False` in yml explicitly), otherwise use default True.

```
            # Reset current_disk['destroy'] to False only when user set not remove disk file explicitly
            if current_disk['state'] == 'absent' and 'destroy' in disk and not disk['destroy']:
                current_disk['destroy'] = False
```

Test PASS on following scenario:
1.   `destroy: False` in playbook
```
- name: "Disks to virtual machine {{ vm_name }}: {{ state }}"
  vmware_guest_disk:
    hostname: "{{ vsphere_host_name }}"
    username: "{{ vsphere_host_user }}"
    password: "{{ vsphere_host_user_password }}"
    validate_certs: "{{ valid_cert | default(False) }}"
    datacenter: "{{ vsphere_host_datacenter }}"
    folder: "{{ vm_folder | default('/') }}"
    name: "{{ vm_name }}"
    disk:
      - state: "absent"
        scsi_controller: "{{ ctrl_no }}"
        unit_number: "{{ unit_no }}"
        destroy: False
  delegate_to: localhost

```

2.   `destroy: True` in playbook
```
- name: "Disks to virtual machine {{ vm_name }}: {{ state }}"
  vmware_guest_disk:
    hostname: "{{ vsphere_host_name }}"
    username: "{{ vsphere_host_user }}"
    password: "{{ vsphere_host_user_password }}"
    validate_certs: "{{ valid_cert | default(False) }}"
    datacenter: "{{ vsphere_host_datacenter }}"
    folder: "{{ vm_folder | default('/') }}"
    name: "{{ vm_name }}"
    disk:
      - state: "absent"
        scsi_controller: "{{ ctrl_no }}"
        unit_number: "{{ unit_no }}"
        destroy: True

```
3.   `destroy`  not given in playbook
```
- name: "Disks to virtual machine {{ vm_name }}: {{ state }}"
  vmware_guest_disk:
    hostname: "{{ vsphere_host_name }}"
    username: "{{ vsphere_host_user }}"
    password: "{{ vsphere_host_user_password }}"
    validate_certs: "{{ valid_cert | default(False) }}"
    datacenter: "{{ vsphere_host_datacenter }}"
    folder: "{{ vm_folder | default('/') }}"
    name: "{{ vm_name }}"
    disk:
      - state: "absent"
        scsi_controller: "{{ ctrl_no }}"
        unit_number: "{{ unit_no }}"
        #        destroy: True
  delegate_to: localhost

```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #67329 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
##### ADDITIONAL INFORMATION

