### PR TITLE
Mark `mariadb_replication` tests unsupported.

### DIFF
--- a/test/integration/targets/mariadb_replication/aliases
+++ b/test/integration/targets/mariadb_replication/aliases
@@ -1,7 +1,5 @@
 destructive
-shippable/posix/group2
-# Make sure that this test runs in a different group than mysql_replication!
-mysql_replication
+unsupported  # these tests conflict with mysql_replication tests and do not run on changes to the mysql_replication module
 skip/aix
 skip/osx
 skip/freebsd


### PR DESCRIPTION
##### SUMMARY

Only one integration test target is supported per module. Since there is already a `mysql_replication` integration test, the `mariadb_replication` tests will not execute for the same module.

To avoid issues with tests not running on changes to the `mysql_replication` module and then failing after changes are made and all tests are executed, the test has been marked `unsupported` to prevent it from running in CI.

To re-enable this test for CI it will need to be merged into the `mysql_replication` tests, which will require working around conflicts between the packages required by the two sets of tests.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

mariadb_replication integration tests
