### PR TITLE
Bugfix of 65525: proxysql in check_config TypeError: tuple indices must be integers, not str (#66850)

### DIFF
--- a/lib/ansible/modules/database/proxysql/proxysql_backend_servers.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_backend_servers.py
@@ -259,6 +259,10 @@ class ProxySQLServer(object):
 
         cursor.execute(query_string, query_data)
         check_count = cursor.fetchone()
+
+        if isinstance(check_count, tuple):
+            return int(check_count[0]) > 0
+
         return (int(check_count['host_count']) > 0)
 
     def get_server_config(self, cursor):

--- a/lib/ansible/modules/database/proxysql/proxysql_global_variables.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_global_variables.py
@@ -119,6 +119,10 @@ def check_config(variable, value, cursor):
 
     cursor.execute(query_string, query_data)
     check_count = cursor.fetchone()
+
+    if isinstance(check_count, tuple):
+        return int(check_count[0]) > 0
+
     return (int(check_count['variable_count']) > 0)
 
 


### PR DESCRIPTION
(cherry picked from commit a86524b2bb84a254f92a7351d95af8c3d83605a8)

##### SUMMARY
Bugfix of #65525 : proxysql in check_config TypeError: tuple indices must be integers, not str (#66850)

Backport of https://github.com/ansible/ansible/pull/66850

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/proxysql/proxysql_backend_servers.py```
