### PR TITLE
[stable-2.9] Fix eos_vlans docs

### DIFF
--- a/changelogs/fragments/66131_backport_eos_vlans_doc_fix.yaml
+++ b/changelogs/fragments/66131_backport_eos_vlans_doc_fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix examples in eos_vlans (https://github.com/ansible/ansible/pull/66131).

--- a/lib/ansible/modules/network/eos/eos_vlans.py
+++ b/lib/ansible/modules/network/eos/eos_vlans.py
@@ -93,7 +93,7 @@ EXAMPLES = """
 #    name twenty
 
 - name: Delete attributes of the given VLANs.
-  ios_vlans:
+  eos_vlans:
     config:
       - vlan_id: 20
     state: deleted
@@ -119,7 +119,7 @@ EXAMPLES = """
 #    name twenty
 
 - name: Merge given VLAN attributes with device configuration
-  ios_vlans:
+  eos_vlans:
     config:
       - vlan_id: 20
         state: suspend
@@ -150,7 +150,7 @@ EXAMPLES = """
 #    name twenty
 
 - name: Override device configuration of all VLANs with provided configuration
-  ios_vlans:
+  eos_vlans:
     config:
       - vlan_id: 20
         state: suspend
@@ -177,7 +177,7 @@ EXAMPLES = """
 #    name twenty
 
 - name: Replace all attributes of specified VLANs with provided configuration
-  ios_vlans:
+  eos_vlans:
     config:
       - vlan_id: 20
         state: suspend


### PR DESCRIPTION
wording in examples changed ios to eos (#66131)

wrong module was used in examples: should be eos_vlans not ios_vlans

(cherry picked from commit 506e2da0ff0088aa5287850a238289b82a98b0f7)

Add changelog for eos_vlans docs fix

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/66131

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
eos_vlans.py