### PR TITLE
Backport PR to fix the bug where IOS vlans module throws traceback

### DIFF
--- a/changelogs/fragments/64633-fix-ios-vlans-traceback-error.yaml
+++ b/changelogs/fragments/64633-fix-ios-vlans-traceback-error.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "fix the bug where IOS vlans module throws traceback. (ref: https://github.com/ansible/ansible/pull/64633)"

--- a/lib/ansible/module_utils/network/ios/facts/vlans/vlans.py
+++ b/lib/ansible/module_utils/network/ios/facts/vlans/vlans.py
@@ -111,7 +111,7 @@ class VlansFacts(object):
         config = deepcopy(spec)
 
         if vlan_info == 'Name' and 'Name' not in conf:
-            conf = filter(None, conf.split(' '))
+            conf = list(filter(None, conf.split(' ')))
             config['vlan_id'] = int(conf[0])
             config['name'] = conf[1]
             if len(conf[2].split('/')) > 1:
@@ -127,7 +127,7 @@ class VlansFacts(object):
                     config['state'] = 'active'
                 config['shutdown'] = 'disabled'
         elif vlan_info == 'Type' and 'Type' not in conf:
-            conf = filter(None, conf.split(' '))
+            conf = list(filter(None, conf.split(' ')))
             config['mtu'] = int(conf[3])
         elif vlan_info == 'Remote':
             if len(conf.split(',')) > 1 or conf.isdigit():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
cherry-pick from: c5a2ba5217dbb75998f61d86b83700b912f29054
Backport PR to fix the bug where IOS vlans module throws traceback PR #64633

Backport of https://github.com/ansible/ansible/pull/64633

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_vlans
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
