### PR TITLE
lib/ansible/plugins/inventory: added space between lines for ini error

### DIFF
--- a/lib/ansible/plugins/inventory/ini.py
+++ b/lib/ansible/plugins/inventory/ini.py
@@ -203,7 +203,7 @@ class InventoryModule(BaseFileInventoryPlugin):
 
                 continue
             elif line.startswith('[') and line.endswith(']'):
-                self._raise_error("Invalid section entry: '%s'. Please make sure that there are no spaces" % line +
+                self._raise_error("Invalid section entry: '%s'. Please make sure that there are no spaces" % line + " " +
                                   "in the section entry, and that there are no other invalid characters")
 
             # It's not a section, so the current state tells us what kind of


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added space between lines for error output.

BEFORE:
~~~
[WARNING]:  * Failed to parse /opt/bogus_inv with ini plugin: /opt/bogus_inv:1: Invalid section entry: '[Bogus Copy]'. Please make sure that there are no spacesin the section entry, and that there are no
other invalid characters
~~~

AFTER:
~~~
[WARNING]:  * Failed to parse /opt/bogus_inv with ini plugin: /opt/bogus_inv:1: Invalid section entry: '%s'. Please make sure that there are no spaces in the section entry, and that there are no other
invalid characters
~~~ 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/plugins/inventory/ini.py