### PR TITLE
[2.9] Fix broken links in crypto, docker and hetzner modules

### DIFF
--- a/lib/ansible/modules/crypto/acme/acme_certificate_revoke.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate_revoke.py
@@ -98,7 +98,7 @@ options:
   revoke_reason:
     description:
       - "One of the revocation reasonCodes defined in
-         L(https://tools.ietf.org/html/rfc5280#section-5.3.1, Section 5.3.1 of RFC5280)."
+         L(Section 5.3.1 of RFC5280,https://tools.ietf.org/html/rfc5280#section-5.3.1)."
       - "Possible values are C(0) (unspecified), C(1) (keyCompromise),
          C(2) (cACompromise), C(3) (affiliationChanged), C(4) (superseded),
          C(5) (cessationOfOperation), C(6) (certificateHold),

--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -18,7 +18,7 @@ version_added: "2.3"
 short_description: Generate OpenSSL private keys
 description:
     - This module allows one to (re)generate OpenSSL private keys.
-    - One can generate L(RSA,https://en.wikipedia.org/wiki/RSA_(cryptosystem)),
+    - One can generate L(RSA,https://en.wikipedia.org/wiki/RSA_%28cryptosystem%29),
       L(DSA,https://en.wikipedia.org/wiki/Digital_Signature_Algorithm),
       L(ECC,https://en.wikipedia.org/wiki/Elliptic-curve_cryptography) or
       L(EdDSA,https://en.wikipedia.org/wiki/EdDSA) private keys.

--- a/lib/ansible/plugins/doc_fragments/docker.py
+++ b/lib/ansible/plugins/doc_fragments/docker.py
@@ -99,7 +99,7 @@ notes:
     You can define C(DOCKER_HOST), C(DOCKER_TLS_HOSTNAME), C(DOCKER_API_VERSION), C(DOCKER_CERT_PATH), C(DOCKER_SSL_VERSION),
     C(DOCKER_TLS), C(DOCKER_TLS_VERIFY) and C(DOCKER_TIMEOUT). If you are using docker machine, run the script shipped
     with the product that sets up the environment. It will set these variables for you. See
-    U(https://docker-py.readthedocs.io/en/stable/machine/) for more details.
+    U(https://docs.docker.com/machine/reference/env/) for more details.
   - When connecting to Docker daemon with TLS, you might need to install additional Python packages.
     For the Docker SDK for Python, version 2.4 or newer, this can be done by installing C(docker[tls]) with M(pip).
   - Note that the Docker SDK for Python only allows to specify the path to the Docker configuration for very few functions.


### PR DESCRIPTION
##### SUMMARY
Backport of #67360 to stable-2.9.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
acme_certificate_revoke
openssl_privatekey
lib/ansible/plugins/doc_fragments/docker.py
