### PR TITLE
ios_user: Incorrectly handling state: absent for users that have ssh public keys configured

### DIFF
--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -294,8 +294,7 @@ def map_obj_to_commands(updates, module):
         if want['state'] == 'absent':
             if have['sshkey']:
                 add_ssh(commands, want)
-            else:
-                commands.append(user_del_cmd(want['name']))
+            commands.append(user_del_cmd(want['name']))
 
         if needs_update(want, have, 'view'):
             add(commands, want, 'view %s' % want['view'])


### PR DESCRIPTION
##### SUMMARY
There is a problem with the logic, if the user has an ssh key configured only the commands for removing the key are executed, nothing further, like the removal the base user:


    "commands": [
        "ip ssh pubkey-chain",
        "no username ansible",
        "exit"
    ],

The patch corrects the logic and causes it to execute the rest of the commands:

    "commands": [
        "ip ssh pubkey-chain",
        "no username ansible",
        "exit",
        {
            "answer": "y",
            "command": "no username ansible",
            "newline": false,
            "prompt": "This operation will remove all username related configurations with same name"
        }
    ],

##### ISSUE TYPE

- Bugfix Pull Request


