### PR TITLE
Update AWS modules that retry on NotFound errors

### DIFF
--- a/lib/ansible/module_utils/aws/acm.py
+++ b/lib/ansible/module_utils/aws/acm.py
@@ -71,18 +71,18 @@ class ACMServiceManager(object):
             kwargs['CertificateStatuses'] = statuses
         return paginator.paginate(**kwargs).build_full_result()['CertificateSummaryList']
 
-    @AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+    @AWSRetry.backoff(tries=5, delay=5, backoff=2.0, catch_extra_error_codes=['ResourceNotFoundException'])
     def get_certificate_with_backoff(self, client, certificate_arn):
         response = client.get_certificate(CertificateArn=certificate_arn)
         # strip out response metadata
         return {'Certificate': response['Certificate'],
                 'CertificateChain': response['CertificateChain']}
 
-    @AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+    @AWSRetry.backoff(tries=5, delay=5, backoff=2.0, catch_extra_error_codes=['ResourceNotFoundException'])
     def describe_certificate_with_backoff(self, client, certificate_arn):
         return client.describe_certificate(CertificateArn=certificate_arn)['Certificate']
 
-    @AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+    @AWSRetry.backoff(tries=5, delay=5, backoff=2.0, catch_extra_error_codes=['ResourceNotFoundException'])
     def list_certificate_tags_with_backoff(self, client, certificate_arn):
         return client.list_tags_for_certificate(CertificateArn=certificate_arn)['Tags']
 

--- a/lib/ansible/module_utils/aws/waiters.py
+++ b/lib/ansible/module_utils/aws/waiters.py
@@ -13,6 +13,24 @@ except ImportError:
 ec2_data = {
     "version": 2,
     "waiters": {
+        "InternetGatewayExists": {
+            "delay": 5,
+            "maxAttempts": 40,
+            "operation": "DescribeInternetGateways",
+            "acceptors": [
+                {
+                    "matcher": "path",
+                    "expected": True,
+                    "argument": "length(InternetGateways) > `0`",
+                    "state": "success"
+                },
+                {
+                    "matcher": "error",
+                    "expected": "InvalidInternetGatewayID.NotFound",
+                    "state": "retry"
+                },
+            ]
+        },
         "RouteTableExists": {
             "delay": 5,
             "maxAttempts": 40,
@@ -280,6 +298,12 @@ def rds_model(name):
 
 
 waiters_by_name = {
+    ('EC2', 'internet_gateway_exists'): lambda ec2: core_waiter.Waiter(
+        'internet_gateway_exists',
+        ec2_model('InternetGatewayExists'),
+        core_waiter.NormalizedOperationMethod(
+            ec2.describe_internet_gateways
+        )),
     ('EC2', 'route_table_exists'): lambda ec2: core_waiter.Waiter(
         'route_table_exists',
         ec2_model('RouteTableExists'),

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -545,7 +545,7 @@ def rule_from_group_permission(perm):
             )
 
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+@AWSRetry.backoff(tries=5, delay=5, backoff=2.0, catch_extra_error_codes=['InvalidGroup.NotFound'])
 def get_security_groups_with_backoff(connection, **kwargs):
     return connection.describe_security_groups(**kwargs)
 

--- a/lib/ansible/modules/cloud/amazon/ec2_launch_template.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_launch_template.py
@@ -479,7 +479,7 @@ def delete_template(module):
 
 
 def create_or_update(module, template_options):
-    ec2 = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())
+    ec2 = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff(catch_extra_error_codes=['InvalidLaunchTemplateId.NotFound']))
     template, template_versions = existing_templates(module)
     out = {}
     lt_data = params_to_launch_data(module, dict((k, v) for k, v in module.params.items() if k in template_options))

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option.py
@@ -219,7 +219,7 @@ def retry_not_found(to_call, *args, **kwargs):
         try:
             return to_call(*args, **kwargs)
         except EC2ResponseError as e:
-            if e.error_code == 'InvalidDhcpOptionID.NotFound':
+            if e.error_code in ['InvalidDhcpOptionID.NotFound', 'InvalidDhcpOptionsID.NotFound']:
                 sleep(3)
                 continue
             raise e

--- a/lib/ansible/modules/cloud/amazon/elb_target.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target.py
@@ -126,7 +126,7 @@ except ImportError:
     HAS_BOTO3 = False
 
 
-@AWSRetry.jittered_backoff(retries=10, delay=10)
+@AWSRetry.jittered_backoff(retries=10, delay=10, catch_extra_error_codes=['TargetGroupNotFound'])
 def describe_target_groups_with_backoff(connection, tg_name):
     return connection.describe_target_groups(Names=[tg_name])
 
@@ -147,7 +147,7 @@ def convert_tg_name_to_arn(connection, module, tg_name):
     return tg_arn
 
 
-@AWSRetry.jittered_backoff(retries=10, delay=10)
+@AWSRetry.jittered_backoff(retries=10, delay=10, catch_extra_error_codes=['TargetGroupNotFound'])
 def describe_targets_with_backoff(connection, tg_arn, target):
     if target is None:
         tg = []

--- a/lib/ansible/modules/cloud/amazon/rds_snapshot.py
+++ b/lib/ansible/modules/cloud/amazon/rds_snapshot.py
@@ -338,7 +338,7 @@ def main():
         required_if=[['state', 'present', ['db_instance_identifier']]]
     )
 
-    client = module.client('rds', retry_decorator=AWSRetry.jittered_backoff(retries=10))
+    client = module.client('rds', retry_decorator=AWSRetry.jittered_backoff(retries=10, catch_extra_error_codes=['DBSnapshotNotFound']))
 
     if module.params['state'] == 'absent':
         ret_dict = ensure_snapshot_absent(client, module)


### PR DESCRIPTION
##### SUMMARY
Updating modules affected by #67281

Modules should intentionally define any extra error codes to catch and retry.

_info modules should not retry on NotFound errors. It's possible we may have tests that create a resource without waiting and promptly attempt to retrieve it with an _info module. `wait: True` should be used instead if possible. Hopefully ci_complete will help catch any of those when the PR above is merged.

I've looked through each module using AWSRetry and added back exception codes where needed. I may have missed something, but the breakage appears quite minimal.

List of possibly-affected modules I've checked:
aws_api_gateway
aws_config_aggregation_authorization
aws_config_aggregator
aws_config_delivery_channel
aws_config_recorder
aws_config_rule
aws_direct_connect_connection
aws_direct_connect_link_aggregation_group
aws_direct_connect_virtual_interface
aws_inspector_target
aws_kms
aws_kms_info
aws_ses_identity
aws_ses_identity_policy
aws_ses_rule_set
aws_step_functions_state_machine
aws_waf_condition
cloudformation
cloudformation_info
cloudformation_stack_set
dms_endpoint
dms_replication_subnet_group
ec2_asg
ec2_customer_gateway
ec2_eip
ec2_elb_info
ec2_group
ec2_instance
ec2_launch_template
ec2_placement_group
ec2_transit_gateway
ec2_transit_gateway_info
ec2_vol_info
ec2_vpc_endpoint_info
ec2_vpc_igw
ec2_vpc_net
ec2_vpc_net_info
ec2_vpc_route_table
ec2_vpc_subnet
ec2_vpc_subnet_info
ec2_vpc_vgw
ecs_service_info
efs_info
elasticache_info
elb_classic_lb_info
elb_target
elb_target_info
iam_group
iam_managed_policy
iam_role
iam_role_info
iam_saml_federation
iam_user_info
rds
rds_instance
rds_instance_info
rds_snapshot
rds_snapshot_info
s3_bucket
sns_topic


##### ISSUE TYPE
- Bugfix Pull Request

