### PR TITLE
[stable-2.9] Remove Tower module tests from CI. (#67368)

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -163,9 +163,6 @@ matrix:
     - env: T=cs/2.7/1
     - env: T=cs/3.6/1
 
-    - env: T=tower/2.7/1
-    - env: T=tower/3.6/1
-
     - env: T=cloud/2.7/1
     - env: T=cloud/3.6/1
 

--- a/test/integration/targets/tower_common/aliases
+++ b/test/integration/targets/tower_common/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_credential/aliases
+++ b/test/integration/targets/tower_credential/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_credential_type/aliases
+++ b/test/integration/targets/tower_credential_type/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_group/aliases
+++ b/test/integration/targets/tower_group/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_host/aliases
+++ b/test/integration/targets/tower_host/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_inventory/aliases
+++ b/test/integration/targets/tower_inventory/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_inventory_source/aliases
+++ b/test/integration/targets/tower_inventory_source/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_job_cancel/aliases
+++ b/test/integration/targets/tower_job_cancel/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_job_launch/aliases
+++ b/test/integration/targets/tower_job_launch/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_job_list/aliases
+++ b/test/integration/targets/tower_job_list/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_job_template/aliases
+++ b/test/integration/targets/tower_job_template/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_job_wait/aliases
+++ b/test/integration/targets/tower_job_wait/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_label/aliases
+++ b/test/integration/targets/tower_label/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_notification/aliases
+++ b/test/integration/targets/tower_notification/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_organization/aliases
+++ b/test/integration/targets/tower_organization/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_project/aliases
+++ b/test/integration/targets/tower_project/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_receive/aliases
+++ b/test/integration/targets/tower_receive/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_role/aliases
+++ b/test/integration/targets/tower_role/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_send/aliases
+++ b/test/integration/targets/tower_send/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_settings/aliases
+++ b/test/integration/targets/tower_settings/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_team/aliases
+++ b/test/integration/targets/tower_team/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_user/aliases
+++ b/test/integration/targets/tower_user/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_workflow_launch/aliases
+++ b/test/integration/targets/tower_workflow_launch/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported

--- a/test/integration/targets/tower_workflow_template/aliases
+++ b/test/integration/targets/tower_workflow_template/aliases
@@ -1,2 +1,2 @@
 cloud/tower
-shippable/tower/group1
+unsupported


### PR DESCRIPTION
##### SUMMARY

* Remove Tower module tests from CI.

The required AMIs are no longer available.

* Mark Tower tests as unsupported..

(cherry picked from commit b041d9676246f2aa8258c078d673cb9bb39044b8)

Backport of https://github.com/ansible/ansible/pull/67368

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

shippable.yml
