### PR TITLE
jenkins_plugin should use POST method when uninstalling plugins

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -640,7 +640,7 @@ class JenkinsPlugin(object):
         # Perform the action
         if self.is_installed:
             if not self.module.check_mode:
-                self._pm_query('doUninstall', 'Uninstallation')
+                self._pm_query('doUninstall', 'Uninstallation', 'POST')
 
             changed = True
 
@@ -692,7 +692,7 @@ class JenkinsPlugin(object):
 
         return changed
 
-    def _pm_query(self, action, msg):
+    def _pm_query(self, action, msg, http_method='GET'):
         url = "%s/pluginManager/plugin/%s/%s" % (
             self.params['url'], self.params['name'], action)
 
@@ -700,7 +700,8 @@ class JenkinsPlugin(object):
         self._get_url_data(
             url,
             msg_status="Plugin not found. %s" % url,
-            msg_exception="%s has failed." % msg)
+            msg_exception="%s has failed." % msg,
+            method=http_method)
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY
On recent versions of Jenkins to uninstall a plugin programmatically you need to use a POST method to the endpoint. The current implementation of jenkins_plugin uses a GET method and so fails when trying to set a plugin to `absent`. This change tries to amend that.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/web_infrastructure/jenkins_plugin.py

##### ADDITIONAL INFORMATION
An example of using the module:
```
- name: Manage Jenkins plugins using password
  jenkins_plugin:
    name: "ansible"
    state: "absent"
    url: "http://localhost:8080/"
  notify: restart jenkins
```
And the output error produced during the ansible run:
```
TASK [jenkins-master : manage jenkins plugins] 
failed: [127.0.0.1] (item={u'state': u'absent', u'version': u'1.0', u'name': u'ansible'}) => {"changed": false, "details": "HTTP Error 405: Method Not Allowed", "item": {"name": "ansible", "state": "absent", "version": "1.0"}, "msg": "Plugin not found. http://localhost:8080/pluginManager/plugin/ansible/doUninstall"}
```

I realise my implementation might be a basic/need cleaning up, so happy to take on board any feedback required to get this merged.

Cheers