### PR TITLE
vmware_host_firewall_manager: avoid ansible.netcommon dep

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_host_firewall_manager.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_firewall_manager.py
@@ -173,8 +173,19 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vmware import vmware_argument_spec, PyVmomi
-from ansible.module_utils._text import to_native, to_text
-from ansible.module_utils.compat import ipaddress
+from ansible.module_utils._text import to_native
+import socket
+
+
+def is_ipaddress(value):
+    try:
+        socket.inet_aton(value)
+    except socket.error:
+        try:
+            socket.inet_pton(socket.AF_INET6, value)
+        except socket.error:
+            return False
+    return True
 
 
 class VmwareFirewallManager(PyVmomi):
@@ -229,14 +240,14 @@ class VmwareFirewallManager(PyVmomi):
             ip_networks = allowed_hosts.get('ip_network', [])
             for ip_address in ip_addresses:
                 try:
-                    ipaddress.ip_address(to_text(ip_address))
+                    is_ipaddress(ip_address)
                 except ValueError:
                     self.module.fail_json(msg="The provided IP address %s is not a valid IP"
                                               " for the rule %s" % (ip_address, rule_name))
 
             for ip_network in ip_networks:
                 try:
-                    ipaddress.ip_network(ip_network)
+                    is_ipaddress(ip_network)
                 except ValueError:
                     self.module.fail_json(msg="The provided IP network %s is not a valid network"
                                               " for the rule %s" % (ip_network, rule_name))


### PR DESCRIPTION
##### SUMMARY

We use `ansible.module_utils.compat.ipaddress()` just for trivial IP
validations that are not critical. This module will be ship in the
`ansible.netcommon` collection. If we continue this way, it means
the futur `community.vmware` will carry this extra dependency for
limited benefit.

This commit introduce a new `is_ipaddress()` that provide similar
feature.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_host_firewall_manager
<!--- Write the short name of the module, plugin, task or feature below -->