### PR TITLE
Fix tracebacks with search_obj_in_list

### DIFF
--- a/lib/ansible/module_utils/network/common/utils.py
+++ b/lib/ansible/module_utils/network/common/utils.py
@@ -596,10 +596,12 @@ def validate_config(spec, data):
 
 
 def search_obj_in_list(name, lst, key='name'):
-    for item in lst:
-        if item.get(key) == name:
-            return item
-    return None
+    if not lst:
+        return None
+    else:
+        for item in lst:
+            if item.get(key) == name:
+                return item
 
 
 class Template:


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- search_obj_in_list() ~may~ will traceback with `TypeError: 'NoneType' object is not iterable` if the passed item is None.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
network/common/utils.py
