### PR TITLE
ansible-galaxy - fix role list bug

### DIFF
--- a/changelogs/fragments/67365-role-list-role-name-in-path.yml
+++ b/changelogs/fragments/67365-role-list-role-name-in-path.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - properly list roles when the role name also happens to be in the role path (https://github.com/ansible/ansible/issues/67365)

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -66,8 +66,18 @@ class GalaxyRole(object):
         self.scm = scm
 
         if path is not None:
-            if self.name not in path:
+            if not path.endswith(os.path.join(os.path.sep, self.name)):
                 path = os.path.join(path, self.name)
+            else:
+                # Look for a meta/main.ya?ml inside the potential role dir in case
+                #  the role name is the same as parent directory of the role.
+                #
+                # Example:
+                #   ./roles/testing/testing/meta/main.yml
+                for meta_main in self.META_MAIN:
+                    if os.path.exists(os.path.join(path, name, meta_main)):
+                        path = os.path.join(path, self.name)
+                        break
             self.path = path
         else:
             # use the first path by default


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Properly list roles even when the role name is the same or a substring of the path to the role.

When the role name is a subset of the role path, the full path to the role would be improperly constructed. This resulted in a failure to find the `meta/main.yml` file for the role, resulting in the role not being listed.

Fixes #67365

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/galaxy/role.py`