### PR TITLE
foreman: ansible_ssh_host should consider ip, ipv4, ipv6

### DIFF
--- a/lib/ansible/plugins/inventory/foreman.py
+++ b/lib/ansible/plugins/inventory/foreman.py
@@ -263,12 +263,14 @@ class InventoryModule(BaseInventoryPlugin, Cacheable, Constructable):
 
                 # put ansible_ssh_host as hostvar
                 if self.get_option('want_ansible_ssh_host'):
-                    if host.get('ip'):
-                        try:
-                            self.inventory.set_variable(host_name, 'ansible_ssh_host', host['ip'])
-                        except ValueError as e:
-                            self.display.warning("Could not set hostvar ansible_ssh_host to '%s' for the '%s' host, skipping: %s" %
-                                                 (host['ip'], host_name, to_text(e)))
+                    for key in ('ip', 'ipv4', 'ipv6'):
+                        if host.get(key):
+                            try:
+                                self.inventory.set_variable(host_name, 'ansible_ssh_host', host[key])
+                                break
+                            except ValueError as e:
+                                self.display.warning("Could not set hostvar ansible_ssh_host to '%s' for the '%s' host, skipping: %s" %
+                                                     (host[key], host_name, to_text(e)))
 
                 strict = self.get_option('strict')
 


### PR DESCRIPTION
##### SUMMARY
When setting `ansible_ssh_host`, foreman plugin should look for `ip`, `ipv4`, and `ipv6` hostvars (not just `ip`).

Fixes https://github.com/ansible/awx/issues/2916

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
foreman plugin

##### ADDITIONAL INFORMATION
Confirmed fix with:

`foreman.yml`
```
plugin: foreman
user: admin
password: ***
url: https://insights-sat66.usersys.redhat.com
want_ansible_ssh_host: True
```

`ansible-inventory -i foreman.yml --list`

.. which returned:

![image](https://user-images.githubusercontent.com/4440360/74472558-fef75f00-4e56-11ea-9620-675f23c31013.png)
