### PR TITLE
Support private plugins for tests in ansible-test.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -26,6 +26,7 @@ recursive-include test/lib/ansible_test/_data *.cfg *.ini *.json *.ps1 *.psd1 *.
 recursive-include test/lib/ansible_test/_data/injector ansible ansible-config ansible-connection ansible-console ansible-doc ansible-galaxy ansible-playbook ansible-pull ansible-test ansible-vault pytest
 recursive-include test/lib/ansible_test/_data/sanity/validate-modules validate-modules
 recursive-include test/sanity *.json *.py *.txt
+recursive-include test/support/plugins *.py
 exclude test/sanity/code-smell/botmeta.*
 recursive-include test/units *
 include Makefile

--- a/test/lib/ansible_test/_data/sanity/code-smell/shebang.py
+++ b/test/lib/ansible_test/_data/sanity/code-smell/shebang.py
@@ -64,6 +64,8 @@ def main():
 
             if path.startswith('lib/ansible/modules/'):
                 is_module = True
+            elif path.startswith('test/support/plugins/modules/'):
+                is_module = True
             elif path.startswith('test/lib/ansible_test/_data/'):
                 pass
             elif path.startswith('lib/') or path.startswith('test/lib/'):

--- a/test/lib/ansible_test/_internal/ansible_util.py
+++ b/test/lib/ansible_test/_internal/ansible_util.py
@@ -102,6 +102,20 @@ def ansible_environment(args, color=True, ansible_config=None):
             ANSIBLE_COLLECTIONS_PATHS=data_context().content.collection.root,
         ))
 
+    if data_context().content.is_ansible:
+        # provide private copies of plugins for integration tests
+        # this provides a temporary means of running integration tests until the modules can be sourced from collections
+        plugin_root = os.path.join(ANSIBLE_SOURCE_ROOT, 'test', 'support', 'plugins')
+
+        plugin_map = dict(
+            library='modules',
+        )
+
+        plugin_env = dict(('ANSIBLE_%s' % key.upper(), os.path.join(plugin_root, value)) for key, value in plugin_map.items())
+        plugin_env = dict((key, value) for key, value in plugin_env.items() if os.path.exists(value))
+
+        env.update(plugin_env)
+
     return env
 
 

--- a/test/lib/ansible_test/_internal/classification.py
+++ b/test/lib/ansible_test/_internal/classification.py
@@ -728,6 +728,9 @@ class PathMapper:
         if path.startswith('test/ansible_test/'):
             return minimal  # these tests are not invoked from ansible-test
 
+        if path.startswith('test/support/plugins/'):
+            return minimal
+
         if path.startswith('test/legacy/'):
             return minimal
 


### PR DESCRIPTION
##### SUMMARY

Support private plugins for tests in ansible-test.

This feature is only available for tests in ansible/ansible and not collections.

It is a temporary feature to support the ansible-base migration.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
