### PR TITLE
galaxy - Fix collection install dep resolver for bad versions

### DIFF
--- a/changelogs/fragments/galaxy-collection-install-version.yaml
+++ b/changelogs/fragments/galaxy-collection-install-version.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-galaxy - Fix issue when compared installed dependencies with a collection having no ``MANIFEST.json`` or an empty version string in the json

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -289,7 +289,7 @@ class CollectionRequirement:
             manifest = info['manifest_file']['collection_info']
             namespace = manifest['namespace']
             name = manifest['name']
-            version = manifest['version']
+            version = to_text(manifest['version'], errors='surrogate_or_strict')
 
             if not hasattr(LooseVersion(version), 'version'):
                 display.warning("Collection at '%s' does not have a valid version set, falling back to '*'. Found "

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -219,12 +219,15 @@ class CollectionRequirement:
                 requirement = req
                 op = operator.eq
 
-                # In the case we are checking a new requirement on a base requirement (parent != None) we can't accept
-                # version as '*' (unknown version) unless the requirement is also '*'.
-                if parent and version == '*' and requirement != '*':
-                    break
-                elif requirement == '*' or version == '*':
-                    continue
+            # In the case we are checking a new requirement on a base requirement (parent != None) we can't accept
+            # version as '*' (unknown version) unless the requirement is also '*'.
+            if parent and version == '*' and requirement != '*':
+                display.warning("Failed to validate the collection requirement '%s:%s' for %s when the existing "
+                                "install does not have a version set, the collection may not work."
+                                % (to_text(self), req, parent))
+                continue
+            elif requirement == '*' or version == '*':
+                continue
 
             if not op(LooseVersion(version), LooseVersion(requirement)):
                 break
@@ -287,6 +290,12 @@ class CollectionRequirement:
             namespace = manifest['namespace']
             name = manifest['name']
             version = manifest['version']
+
+            if not hasattr(LooseVersion(version), 'version'):
+                display.warning("Collection at '%s' does not have a valid version set, falling back to '*'. Found "
+                                "version: '%s'" % (to_text(b_path), version))
+                version = '*'
+
             dependencies = manifest['dependencies']
         else:
             display.warning("Collection at '%s' does not have a MANIFEST.json file, cannot detect version."
@@ -877,7 +886,7 @@ def _get_collection_info(dep_map, existing_collections, collection, requirement,
     existing = [c for c in existing_collections if to_text(c) == to_text(collection_info)]
     if existing and not collection_info.force:
         # Test that the installed collection fits the requirement
-        existing[0].add_requirement(to_text(collection_info), requirement)
+        existing[0].add_requirement(parent, requirement)
         collection_info = existing[0]
 
     dep_map[to_text(collection_info)] = collection_info

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -165,13 +165,14 @@ def test_build_requirement_from_path(collection_artifact):
     assert actual.dependencies == {}
 
 
-def test_build_requirement_from_path_with_manifest(collection_artifact):
+@pytest.mark.parametrize('version', ['1.1.1', 1.1, 1])
+def test_build_requirement_from_path_with_manifest(version, collection_artifact):
     manifest_path = os.path.join(collection_artifact[0], b'MANIFEST.json')
     manifest_value = json.dumps({
         'collection_info': {
             'namespace': 'namespace',
             'name': 'name',
-            'version': '1.1.1',
+            'version': version,
             'dependencies': {
                 'ansible_namespace.collection': '*'
             }
@@ -188,8 +189,8 @@ def test_build_requirement_from_path_with_manifest(collection_artifact):
     assert actual.b_path == collection_artifact[0]
     assert actual.api is None
     assert actual.skip is True
-    assert actual.versions == set([u'1.1.1'])
-    assert actual.latest_version == u'1.1.1'
+    assert actual.versions == set([to_text(version)])
+    assert actual.latest_version == to_text(version)
     assert actual.dependencies == {'ansible_namespace.collection': '*'}
 
 

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -203,6 +203,42 @@ def test_build_requirement_from_path_invalid_manifest(collection_artifact):
         collection.CollectionRequirement.from_path(collection_artifact[0], True)
 
 
+def test_build_requirement_from_path_no_version(collection_artifact, monkeypatch):
+    manifest_path = os.path.join(collection_artifact[0], b'MANIFEST.json')
+    manifest_value = json.dumps({
+        'collection_info': {
+            'namespace': 'namespace',
+            'name': 'name',
+            'version': '',
+            'dependencies': {}
+        }
+    })
+    with open(manifest_path, 'wb') as manifest_obj:
+        manifest_obj.write(to_bytes(manifest_value))
+
+    mock_display = MagicMock()
+    monkeypatch.setattr(Display, 'display', mock_display)
+
+    actual = collection.CollectionRequirement.from_path(collection_artifact[0], True)
+
+    # While the folder name suggests a different collection, we treat MANIFEST.json as the source of truth.
+    assert actual.namespace == u'namespace'
+    assert actual.name == u'name'
+    assert actual.b_path == collection_artifact[0]
+    assert actual.api is None
+    assert actual.skip is True
+    assert actual.versions == set(['*'])
+    assert actual.latest_version == u'*'
+    assert actual.dependencies == {}
+
+    assert mock_display.call_count == 1
+
+    actual_warn = ' '.join(mock_display.mock_calls[0][1][0].split('\n'))
+    expected_warn = "Collection at '%s' does not have a valid version set, falling back to '*'. Found version: ''" \
+        % to_text(collection_artifact[0])
+    assert expected_warn in actual_warn
+
+
 def test_build_requirement_from_tar(collection_artifact):
     actual = collection.CollectionRequirement.from_tar(collection_artifact[1], True, True)
 
@@ -497,13 +533,20 @@ def test_add_collection_requirements(versions, requirement, expected_filter, exp
     assert req.latest_version == expected_latest
 
 
-def test_add_collection_requirement_to_unknown_installed_version():
+def test_add_collection_requirement_to_unknown_installed_version(monkeypatch):
+    mock_display = MagicMock()
+    monkeypatch.setattr(Display, 'display', mock_display)
+
     req = collection.CollectionRequirement('namespace', 'name', None, 'https://galaxy.com', ['*'], '*', False,
                                            skip=True)
 
-    expected = "Cannot meet requirement namespace.name:1.0.0 as it is already installed at version 'unknown'."
-    with pytest.raises(AnsibleError, match=expected):
-        req.add_requirement(str(req), '1.0.0')
+    req.add_requirement('parent.collection', '1.0.0')
+    assert req.latest_version == '*'
+
+    assert mock_display.call_count == 1
+
+    actual_warn = ' '.join(mock_display.mock_calls[0][1][0].split('\n'))
+    assert "Failed to validate the collection requirement 'namespace.name:1.0.0' for parent.collection" in actual_warn
 
 
 def test_add_collection_wildcard_requirement_to_unknown_installed_version():


### PR DESCRIPTION
##### SUMMARY
When installing a collection it scans existing collections at the path specified and if a collection has a `MANIFEST.json` file with a version set to an empty string it will fail with

```
ERROR! Unexpected Exception, this is probably a bug: 'LooseVersion' object has no attribute 'version'
the full traceback was:                                                                                  
                                                                                                         
Traceback (most recent call last):                                                                       
  File "/home/jborean/dev/ansible/bin/ansible-galaxy", line 123, in <module>                 
    exit_code = cli.run()                                                                                
  File "/home/jborean/dev/ansible/lib/ansible/cli/galaxy.py", line 387, in run       
    context.CLIARGS['func']()                    
  File "/home/jborean/dev/ansible/lib/ansible/cli/galaxy.py", line 848, in execute_install                                                                                                                         
    no_deps, force, force_deps)                                                                          
  File "/home/jborean/dev/ansible/lib/ansible/galaxy/collection.py", line 435, in install_collections    
    existing_collections = find_existing_collections(output_path)                    
  File "/home/jborean/dev/ansible/lib/ansible/galaxy/collection.py", line 792, in find_existing_collections
    req = CollectionRequirement.from_path(b_collection_path, False)                                                                                                                                                
  File "/home/jborean/dev/ansible/lib/ansible/galaxy/collection.py", line 309, in from_path
    metadata=meta, files=files, skip=True)                                                               
  File "/home/jborean/dev/ansible/lib/ansible/galaxy/collection.py", line 88, in __init__                
    self.add_requirement(parent, requirement)                                                            
  File "/home/jborean/dev/ansible/lib/ansible/galaxy/collection.py", line 120, in add_requirement
    new_versions = set(v for v in self.versions if self._meets_requirements(v, requirement, parent))
  File "/home/jborean/dev/ansible/lib/ansible/galaxy/collection.py", line 120, in <genexpr> 
    new_versions = set(v for v in self.versions if self._meets_requirements(v, requirement, parent))
  File "/home/jborean/dev/ansible/lib/ansible/galaxy/collection.py", line 233, in _meets_requirements    
    if not op(LooseVersion(version), LooseVersion(requirement)):                             
  File "/usr/local/lib/python3.7/distutils/version.py", line 46, in __eq__                                                                                                                                         
    c = self._cmp(other)                  
  File "/usr/local/lib/python3.7/distutils/version.py", line 335, in _cmp            
    if self.version == other.version:                                                                                                                                                                              
AttributeError: 'LooseVersion' object has no attribute 'version'  
```

The first part of this PR fixes up this bug by treating invalid `LooseVersion` objects as having a version of `*` which is treated as matching all versions.

The 2nd bug this PR fixes is when a version for a pre-installed collection is `*` (no MANIFEST.json and now the above scenario) and the parent collection that requires that pre-installed one has an explicit version requirement. It fails with the following traceback

```
ERROR! Unexpected Exception, this is probably a bug: '<' not supported between instances of 'str' and 'int'
the full traceback was:
Traceback (most recent call last):
  File "/usr/local/bin/ansible-galaxy", line 123, in <module>
    exit_code = cli.run()
  File "/usr/local/lib/python3.7/site-packages/ansible/cli/galaxy.py", line 375, in run
    context.CLIARGS['func']()
  File "/usr/local/lib/python3.7/site-packages/ansible/cli/galaxy.py", line 837, in execute_install
    no_deps, force, force_deps)
  File "/usr/local/lib/python3.7/site-packages/ansible/galaxy/collection.py", line 430, in install_collections
    validate_certs, force, force_deps, no_deps)
  File "/usr/local/lib/python3.7/site-packages/ansible/galaxy/collection.py", line 790, in _build_dependency_map
    parent=parent)
  File "/usr/local/lib/python3.7/site-packages/ansible/galaxy/collection.py", line 851, in _get_collection_info
    existing[0].add_requirement(to_text(collection_info), requirement)
  File "/usr/local/lib/python3.7/site-packages/ansible/galaxy/collection.py", line 114, in add_requirement
    new_versions = set(v for v in self.versions if self._meets_requirements(v, requirement, parent))
  File "/usr/local/lib/python3.7/site-packages/ansible/galaxy/collection.py", line 114, in <genexpr>
    new_versions = set(v for v in self.versions if self._meets_requirements(v, requirement, parent))
  File "/usr/local/lib/python3.7/site-packages/ansible/galaxy/collection.py", line 223, in _meets_requirements
    if not op(LooseVersion(version), LooseVersion(requirement)):
  File "/usr/local/Cellar/python/3.7.6_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/distutils/version.py", line 70, in __ge__
    c = self._cmp(other)
  File "/usr/local/Cellar/python/3.7.6_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/distutils/version.py", line 337, in _cmp
    if self.version < other.version:
TypeError: '<' not supported between instances of 'str' and 'int'
```

This fixes that traceback and changes the behaviour to warn the user in this case but still continue ahead and not fail.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy