### PR TITLE
ansible-galaxy - fix listing specific role and role description

### DIFF
--- a/changelogs/fragments/ansible-galaxy-role-list-specific-fix.yml
+++ b/changelogs/fragments/ansible-galaxy-role-list-specific-fix.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - >
+    ansible-galaxy - fix a bug where listing a specific role if it was not in the first
+    path failed to find the role
+
+  - ansible-galaxy - properly show the role description when running offline (https://github.com/ansible/ansible/issues/60167)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -858,6 +858,9 @@ class GalaxyCLI(CLI):
 
             role_info = {'path': roles_path}
             gr = GalaxyRole(self.galaxy, self.api, role)
+            if not gr._exists:
+                data = u"- the role %s was not found" % role
+                break
 
             install_info = gr.install_info
             if install_info:
@@ -882,10 +885,6 @@ class GalaxyCLI(CLI):
                 role_info.update(role_spec)
 
             data = self._display_role_info(role_info)
-            # FIXME: This is broken in both 1.9 and 2.0 as
-            # _display_role_info() always returns something
-            if not data:
-                data = u"\n- the role %s was not found" % role
 
         self.pager(data)
 

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -583,7 +583,7 @@ class GalaxyCLI(CLI):
 
         # Get description from galaxy_info['galaxy_info']['description'] first, falling back to top-level 'description'.
         galaxy_info = role_info.get('galaxy_info', {})
-        description = galaxy_info.get('description', role_info.get('description', ''))
+        description = role_info.get('description', galaxy_info.get('description', ''))
         text.append(u"\tdescription: %s" % description)
 
         for k in sorted(role_info.keys()):

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -580,7 +580,11 @@ class GalaxyCLI(CLI):
     def _display_role_info(role_info):
 
         text = [u"", u"Role: %s" % to_text(role_info['name'])]
-        text.append(u"\tdescription: %s" % role_info.get('description', ''))
+
+        # Get description from galaxy_info['galaxy_info']['description'] first, falling back to top-level 'description'.
+        galaxy_info = role_info.get('galaxy_info', {})
+        description = galaxy_info.get('description', role_info.get('description', ''))
+        text.append(u"\tdescription: %s" % description)
 
         for k in sorted(role_info.keys()):
 

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -581,7 +581,7 @@ class GalaxyCLI(CLI):
 
         text = [u"", u"Role: %s" % to_text(role_info['name'])]
 
-        # Get description from galaxy_info['galaxy_info']['description'] first, falling back to top-level 'description'.
+        # Get the top-level 'description' first, falling back to galaxy_info['galaxy_info']['description'].
         galaxy_info = role_info.get('galaxy_info', {})
         description = role_info.get('description', galaxy_info.get('description', ''))
         text.append(u"\tdescription: %s" % description)

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -64,6 +64,7 @@ class GalaxyRole(object):
         self.version = version
         self.src = src or name
         self.scm = scm
+        self.paths = [os.path.join(x, self.name) for x in galaxy.roles_paths]
 
         if path is not None:
             if not path.endswith(os.path.join(os.path.sep, self.name)):
@@ -82,9 +83,6 @@ class GalaxyRole(object):
         else:
             # use the first path by default
             self.path = os.path.join(galaxy.roles_paths[0], self.name)
-            # create list of possible paths
-            self.paths = [x for x in galaxy.roles_paths]
-            self.paths = [os.path.join(x, self.name) for x in self.paths]
 
     def __repr__(self):
         """
@@ -105,17 +103,19 @@ class GalaxyRole(object):
         Returns role metadata
         """
         if self._metadata is None:
-            for meta_main in self.META_MAIN:
-                meta_path = os.path.join(self.path, meta_main)
-                if os.path.isfile(meta_path):
-                    try:
-                        f = open(meta_path, 'r')
-                        self._metadata = yaml.safe_load(f)
-                    except Exception:
-                        display.vvvvv("Unable to load metadata for %s" % self.name)
-                        return False
-                    finally:
-                        f.close()
+            for path in self.paths:
+                for meta_main in self.META_MAIN:
+                    meta_path = os.path.join(path, meta_main)
+                    if os.path.isfile(meta_path):
+                        try:
+                            f = open(meta_path, 'r')
+                            self._metadata = yaml.safe_load(f)
+                        except Exception:
+                            display.vvvvv("Unable to load metadata for %s" % self.name)
+                            return False
+                        finally:
+                            f.close()
+                        break
 
         return self._metadata
 

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -108,13 +108,11 @@ class GalaxyRole(object):
                     meta_path = os.path.join(path, meta_main)
                     if os.path.isfile(meta_path):
                         try:
-                            f = open(meta_path, 'r')
-                            self._metadata = yaml.safe_load(f)
+                            with open(meta_path, 'r') as f:
+                                self._metadata = yaml.safe_load(f)
                         except Exception:
                             display.vvvvv("Unable to load metadata for %s" % self.name)
                             return False
-                        finally:
-                            f.close()
                         break
 
         return self._metadata

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -138,6 +138,14 @@ class GalaxyRole(object):
                     f.close()
         return self._install_info
 
+    @property
+    def _exists(self):
+        for path in self.paths:
+            if os.path.isdir(path):
+                return True
+
+        return False
+
     def _write_galaxy_install_info(self):
         """
         Writes a YAML-formatted file to the role's meta/ directory

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -120,6 +120,31 @@ f_ansible_galaxy_status \
 
     [[ $(grep -c '^- test-role' out.txt ) -eq 2 ]]
 
+# Galaxy role test case
+#
+# Test listing a specific role that is not in the first path in ANSIBLE_ROLES_PATH.
+# https://github.com/ansible/ansible/issues/60167#issuecomment-585460706
+
+f_ansible_galaxy_status \
+    "list specific role not in the first path in ANSIBLE_ROLES_PATHS"
+
+role_testdir=$(mktemp -d)
+pushd "${role_testdir}"
+
+    mkdir testroles
+    ansible-galaxy role init --init-path ./local-roles quark
+    ANSIBLE_ROLES_PATH=./local-roles:${HOME}/.ansible/roles ansible-galaxy role list quark | tee out.txt
+
+    [[ $(grep -c 'not found' out.txt) -eq 0 ]]
+
+    ANSIBLE_ROLES_PATH=${HOME}/.ansible/roles:./local-roles ansible-galaxy role list quark | tee out.txt
+
+    [[ $(grep -c 'not found' out.txt) -eq 0 ]]
+
+popd # ${galaxy_testdir}
+rm -fr "${galaxy_testdir}"
+
+
 
 # Properly list roles when the role name is a subset of the path, or the role
 # name is the same name as the parent directory of the role. Issue #67365

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -175,10 +175,10 @@ f_ansible_galaxy_status \
         cat - ./testroles/testdesc/meta/main.yml > tmp.yml && \
         mv tmp.yml ./testroles/testdesc/meta/main.yml
     ansible-galaxy role info -p ./testroles --offline testdesc | tee out.txt
-    grep 'description: Description in galaxy_info' out.txt
+    grep 'description: Top level' out.txt
 
-    # Only top level 'description'exists in file
-    sed -i -e '/^[[:space:]]\+description: Description in galaxy_info/d' ./testroles/testdesc/meta/main.yml
+    # Only top level 'description' exists in file
+    sed -i.bak '/^[[:space:]]\{1,\}description: Description in galaxy_info/d' ./testroles/testdesc/meta/main.yml
     ansible-galaxy role info -p ./testroles --offline testdesc | tee out.txt
     grep 'description: Top level' out.txt
 

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -169,7 +169,11 @@ f_ansible_galaxy_status \
     grep 'description: Description in galaxy_info' out.txt
 
     # Both top level 'description' and galaxy_info['description'] exist in file
-    sed -i -e '1i description: Top level' ./testroles/testdesc/meta/main.yml
+    # Use shell-fu instead of sed to prepend a line to a file because BSD
+    # and macOS sed don't work the same as GNU sed.
+    echo 'description: Top level' | \
+        cat - ./testroles/testdesc/meta/main.yml > tmp.yml && \
+        mv tmp.yml ./testroles/testdesc/meta/main.yml
     ansible-galaxy role info -p ./testroles --offline testdesc | tee out.txt
     grep 'description: Description in galaxy_info' out.txt
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If the role was not in the first search path, it was reported as not found.

Get the role description from within `galaxy_info` and fall back to a top level `description` key.

Fix logic around reporting whether or not a role exists when displaying info.

Add integration tests.

Fixes #60167
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/galaxy/role.py`