### PR TITLE
vmware_guest_register_operation/test: no deprecated mod

### DIFF
--- a/test/integration/targets/vmware_guest_register_operation/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_register_operation/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - block:
   - name: gather facts of vm
-    vmware_guest_facts:
+    vmware_guest_info:
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
@@ -218,7 +218,7 @@
         | length == 1
 
 - name: Gather facts of vm
-  vmware_guest_facts:
+  vmware_guest_info:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"


### PR DESCRIPTION
##### SUMMARY

Don't use `vmware_guest_facts` to collect the Guest information. The
module is deprecated and replaced by `vmware_guest_info`.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

vmware_guest_register_operation