### PR TITLE
msg.exe always includes session id 1 when using *, this session doesn…

### DIFF
--- a/lib/ansible/modules/windows/win_msg.ps1
+++ b/lib/ansible/modules/windows/win_msg.ps1
@@ -26,6 +26,18 @@ if ($msg.Length -gt 255) {
     Fail-Json -obj $result -message "msg length must be less than 256 characters, current length: $($msg.Length)"
 }
 
+if ($to -eq "*") {
+    $tempfile = "$env:TEMP\sessionids.txt"
+    (((quser) -replace '^>', '') -replace '\s{2,}', ',').Trim() | ForEach-Object {
+        if ($_.Split(',').Count -eq 5) {
+            Write-Output ($_ -replace '(^[^,]+)', '$1,')
+        } else {
+            Write-Output $_
+        }
+    } | ConvertFrom-Csv | Select-Object -ExpandProperty ID | Out-File -FilePath $tempfile -Encoding ascii -Force
+    $to = "@$tempfile"
+}
+
 $msg_args = @($to, "/TIME:$display_seconds")
 
 if ($wait) {


### PR DESCRIPTION
…'t always exists, though - e.g. headless RDSH servers.

##### SUMMARY
msg.exe always includes session id 1 when using *, this session doesn't always exists, though - e.g. headless RDSH servers.

This code gets all current sessions and feeds the sessions ID's to msg.exe via a text file - the only other supported method to message more than one user in call to msg.exe. I did this instead of having to loop through and pass session ID's to msg.exe one at a time.

The bug is ultimately in msg.exe, but also in how win_msg.ps1 doesn't know how to handle the error when session 1 doesn't exist.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_msg.ps1

##### ADDITIONAL INFORMATION
The error can be reproduced easily on via a remote session to Windows (Server 2016 in my case), where session 1 doesn't exist - run "msg.exe * test"
