### PR TITLE
Explicitly chose an AZ for cloudformation and ec2_vol tests

### DIFF
--- a/test/integration/targets/cloudformation/tasks/main.yml
+++ b/test/integration/targets/cloudformation/tasks/main.yml
@@ -10,6 +10,13 @@
   block:
 
     # ==== Env setup ==========================================================
+    - name: list available AZs
+      aws_az_info:
+      register: region_azs
+
+    - name: pick an AZ for testing
+      set_fact:
+        availability_zone: "{{ region_azs.availability_zones[0].zone_name }}"
 
     - name: Create a test VPC
       ec2_vpc_net:
@@ -23,6 +30,7 @@
       ec2_vpc_subnet:
         vpc_id: "{{ testing_vpc.vpc.id }}"
         cidr: "{{ subnet_cidr }}"
+        az: "{{ availability_zone }}"
       register: testing_subnet
 
     - name: Find AMI to use

--- a/test/integration/targets/ec2_vol/tasks/main.yml
+++ b/test/integration/targets/ec2_vol/tasks/main.yml
@@ -10,6 +10,13 @@
   block:
 
     # ==== Env setup ==========================================================
+    - name: list available AZs
+      aws_az_info:
+      register: region_azs
+
+    - name: pick an AZ for testing
+      set_fact:
+        availability_zone: "{{ region_azs.availability_zones[0].zone_name }}"
 
     - name: Create a test VPC
       ec2_vpc_net:
@@ -27,6 +34,7 @@
         tags:
           Name: ec2_vol testing
           ResourcePrefix: "{{ resource_prefix }}"
+        az: '{{ availability_zone }}'
       register: testing_subnet
 
     - name: Find AMI to use
@@ -47,7 +55,7 @@
     - name: create a volume (validate module defaults)
       ec2_vol:
         volume_size: 1
-        zone: "{{ testing_subnet.subnet.availability_zone }}"
+        zone: "{{ availability_zone }}"
         tags:
           ResourcePrefix: "{{ resource_prefix }}"
       register: volume1
@@ -76,7 +84,7 @@
         name: "{{ resource_prefix }}"
         tags:
           ResourcePrefix: "{{ resource_prefix }}"
-        zone: "{{ testing_subnet.subnet.availability_zone }}"
+        zone: "{{ availability_zone }}"
       register: volume2
 
     - name: check task return attributes
@@ -102,7 +110,7 @@
         name: "{{ resource_prefix }}"
         tags:
           ResourcePrefix: "{{ resource_prefix }}"
-        zone: "{{ testing_subnet.subnet.availability_zone }}"
+        zone: "{{ availability_zone }}"
       register: volume2_idem
 
     - name: check task return attributes
@@ -129,7 +137,7 @@
         encrypted: yes
         volume_type: gp2
         volume_size: 1
-        zone: "{{ testing_subnet.subnet.availability_zone }}"
+        zone: "{{ availability_zone }}"
         tags:
           ResourcePrefix: "{{ resource_prefix }}"
       register: volume3


### PR DESCRIPTION
##### SUMMARY

In the CI account we use us-east-1.  When we don't define an AZ us-east-1e is sometimes picked at random, and has no support for t3/m5 instance types, which breaks these tests.

> ClientError: An error occurred (Unsupported) when calling the RunInstances operation: Your requested instance type (t3.nano) is not supported in your requested Availability Zone (us-east-1e). Please retry your request by not specifying an Availability Zone or choosing us-east-1a, us-east-1b, us-east-1c, us-east-1d, us-east-1f.

Because availability_zones is returned in a consistent (sorted) order, we should at least get either consistent success or consistent failure.


##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_vol
cloudformation

##### ADDITIONAL INFORMATION
See for example: 
https://app.shippable.com/github/ansible/ansible/runs/159353/121/tests

https://www.reddit.com/r/aws/comments/9oy2iy/your_requested_instance_type_m5large_is_not/e7xips2/

In theory we could use something even more robust:
- explicitly filtering out known 'bad' AZs
- using describe-reserved-instances-offerings to find AZs with capacity

However there's limited additional value given that these are only integration tests.