### PR TITLE
Templating: make sure only one variable results are cached

### DIFF
--- a/changelogs/fragments/67429-jinja2-caching.yml
+++ b/changelogs/fragments/67429-jinja2-caching.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "Templating - Ansible was caching results of Jinja2 expressions in some cases where these expressions could have dynamic results, like password generation (https://github.com/ansible/ansible/issues/34144)."

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -628,7 +628,7 @@ class Templar:
                         # we only cache in the case where we have a single variable
                         # name, to make sure we're not putting things which may otherwise
                         # be dynamic in the cache (filters, lookups, etc.)
-                        if cache:
+                        if cache and only_one:
                             self._cached_result[sha1_hash] = result
 
                 return result

--- a/test/integration/targets/templating_lookups/template_lookups/tasks/main.yml
+++ b/test/integration/targets/templating_lookups/template_lookups/tasks/main.yml
@@ -71,3 +71,17 @@
 - name: set with_dict
   shell: echo "{{ item.key + '=' + item.value  }}"
   with_dict: "{{ mydict }}"
+
+# BUG #34144 bad template caching
+
+- name: generate two random passwords
+    password1: "{{ lookup('password', '/dev/null length=20') }}"
+    password2: "{{ lookup('password', '/dev/null length=20') }}"
+    # If the passwords are generated randomly, the chance that they
+    # coincide is neglectable (< 1e-18 assuming 120 bits of randomness
+    # per password).
+
+- name: make sure passwords are not the same
+  assert:
+    that:
+      - password1 != password2

--- a/test/integration/targets/templating_lookups/template_lookups/tasks/main.yml
+++ b/test/integration/targets/templating_lookups/template_lookups/tasks/main.yml
@@ -75,6 +75,7 @@
 # BUG #34144 bad template caching
 
 - name: generate two random passwords
+  set_fact:
     password1: "{{ lookup('password', '/dev/null length=20') }}"
     password2: "{{ lookup('password', '/dev/null length=20') }}"
     # If the passwords are generated randomly, the chance that they


### PR DESCRIPTION
##### SUMMARY
Currently, it looks like all jinja2 templating results are cached, even though a comment says `# we only cache in the case where we have a single variable name, to make sure we're not putting things which may otherwise be dynamic in the cache (filters, lookups, etc.)`. This causes dynamic lookup results to be cached, which can be seen in #34144 and @resmo's example from IRC.

Fixes #34144

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/template/__init__.py
