### PR TITLE
Backport/2.9/57737 ec2_asg unhandled exception

### DIFF
--- a/changelogs/fragments/57737-fix-asg-with-no-lc-anymore.yml
+++ b/changelogs/fragments/57737-fix-asg-with-no-lc-anymore.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2_asg - regression bug, when an existing autoscaling group was updated and but the launch config of existing instances was deleted.

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -1382,7 +1382,7 @@ def get_instances_by_launch_config(props, lc_check, initial_instances):
             # Check if migrating from launch_template to launch_config first
             if 'launch_template' in props['instance_facts'][i]:
                 old_instances.append(i)
-            elif props['instance_facts'][i]['launch_config_name'] == props['launch_config_name']:
+            elif props['instance_facts'][i].get('launch_config_name') == props['launch_config_name']:
                 new_instances.append(i)
             else:
                 old_instances.append(i)
@@ -1409,7 +1409,7 @@ def get_instances_by_launch_template(props, lt_check, initial_instances):
             # Check if migrating from launch_config_name to launch_template_name first
             if 'launch_config_name' in props['instance_facts'][i]:
                 old_instances.append(i)
-            elif props['instance_facts'][i]['launch_template'] == props['launch_template']:
+            elif props['instance_facts'][i].get('launch_template') == props['launch_template']:
                 new_instances.append(i)
             else:
                 old_instances.append(i)


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/57737

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
ec2_asg


##### ADDITIONAL INFORMATION

After launch template was introduced in 2.8, `ec2_asg` can run into an unhandled exception, when the ASG has still active instances but the launch config was already deleted.
