### PR TITLE
UCS Emulator link to Doc Fragment use cs.co domain

### DIFF
--- a/lib/ansible/modules/remote_management/ucs/ucs_disk_group_policy.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_disk_group_policy.py
@@ -17,7 +17,6 @@ module: ucs_disk_group_policy
 short_description: Configures disk group policies on Cisco UCS Manager
 description:
 - Configures disk group policies on Cisco UCS Manager.
-- Examples can be used with the L(UCS Platform Emulator,https://bit.ly/38w8JCk).
 extends_documentation_fragment: ucs
 options:
   state:

--- a/lib/ansible/modules/remote_management/ucs/ucs_dns_server.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_dns_server.py
@@ -21,7 +21,6 @@ extends_documentation_fragment:
 
 description:
 - Configure DNS servers on Cisco UCS Manager.
-- Examples can be used with the L(UCS Platform Emulator,https://bit.ly/38w8JCk).
 
 options:
   state:

--- a/lib/ansible/modules/remote_management/ucs/ucs_ip_pool.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_ip_pool.py
@@ -16,7 +16,6 @@ module: ucs_ip_pool
 short_description: Configures IP address pools on Cisco UCS Manager
 description:
 - Configures IP address pools and blocks of IP addresses on Cisco UCS Manager.
-- Examples can be used with the L(UCS Platform Emulator,https://bit.ly/38w8JCk).
 extends_documentation_fragment: ucs
 options:
   state:

--- a/lib/ansible/modules/remote_management/ucs/ucs_lan_connectivity.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_lan_connectivity.py
@@ -16,7 +16,6 @@ module: ucs_lan_connectivity
 short_description: Configures LAN Connectivity Policies on Cisco UCS Manager
 description:
 - Configures LAN Connectivity Policies on Cisco UCS Manager.
-- Examples can be used with the L(UCS Platform Emulator,https://bit.ly/38w8JCk).
 extends_documentation_fragment: ucs
 options:
   state:

--- a/lib/ansible/modules/remote_management/ucs/ucs_mac_pool.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_mac_pool.py
@@ -16,7 +16,6 @@ module: ucs_mac_pool
 short_description: Configures MAC address pools on Cisco UCS Manager
 description:
 - Configures MAC address pools and MAC address blocks on Cisco UCS Manager.
-- Examples can be used with the L(UCS Platform Emulator,https://bit.ly/38w8JCk).
 extends_documentation_fragment: ucs
 options:
   state:

--- a/lib/ansible/modules/remote_management/ucs/ucs_managed_objects.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_managed_objects.py
@@ -18,7 +18,6 @@ description:
 - Configures Managed Objects on Cisco UCS Manager.
 - The Python SDK module, Python class within the module (UCSM Class), and all properties must be directly specified.
 - More information on the UCSM Python SDK and how to directly configure Managed Objects is available at L(UCSM Python SDK,http://ucsmsdk.readthedocs.io/).
-- Examples can be used with the L(UCS Platform Emulator,https://bit.ly/38w8JCk).
 extends_documentation_fragment: ucs
 options:
   state:

--- a/lib/ansible/modules/remote_management/ucs/ucs_ntp_server.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_ntp_server.py
@@ -18,7 +18,6 @@ extends_documentation_fragment:
 - ucs
 description:
 - Configures NTP server on Cisco UCS Manager.
-- Examples can be used with the L(UCS Platform Emulator,https://bit.ly/38w8JCk).
 options:
   state:
     description:

--- a/lib/ansible/modules/remote_management/ucs/ucs_org.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_org.py
@@ -18,7 +18,6 @@ short_description: Manages UCS Organizations for UCS Manager
 
 description:
   - Manages UCS Organizations for UCS Manager.
-  - Examples can be used with the L(UCS Platform Emulator,https://bit.ly/38w8JCk).
 
 extends_documentation_fragment: ucs
 

--- a/lib/ansible/modules/remote_management/ucs/ucs_query.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_query.py
@@ -18,7 +18,6 @@ short_description: Queries UCS Manager objects by class or distinguished name
 
 description:
   -Queries UCS Manager objects by class or distinguished name.
-  - Examples can be used with the L(UCS Platform Emulator,https://bit.ly/38w8JCk).
 
 extends_documentation_fragment: ucs
 

--- a/lib/ansible/modules/remote_management/ucs/ucs_san_connectivity.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_san_connectivity.py
@@ -16,7 +16,6 @@ module: ucs_san_connectivity
 short_description: Configures SAN Connectivity Policies on Cisco UCS Manager
 description:
 - Configures SAN Connectivity Policies on Cisco UCS Manager.
-- Examples can be used with the L(UCS Platform Emulator,https://bit.ly/38w8JCk).
 extends_documentation_fragment: ucs
 options:
   state:

--- a/lib/ansible/modules/remote_management/ucs/ucs_service_profile_template.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_service_profile_template.py
@@ -16,7 +16,6 @@ module: ucs_service_profile_template
 short_description: Configures Service Profile Templates on Cisco UCS Manager
 description:
 - Configures Service Profile Templates on Cisco UCS Manager.
-- Examples can be used with the L(UCS Platform Emulator,https://bit.ly/38w8JCk).
 extends_documentation_fragment: ucs
 options:
   state:

--- a/lib/ansible/modules/remote_management/ucs/ucs_storage_profile.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_storage_profile.py
@@ -16,7 +16,6 @@ module: ucs_storage_profile
 short_description: Configures storage profiles on Cisco UCS Manager
 description:
 - Configures storage profiles on Cisco UCS Manager.
-- Examples can be used with the L(UCS Platform Emulator,https://bit.ly/38w8JCk).
 extends_documentation_fragment: ucs
 options:
   state:

--- a/lib/ansible/modules/remote_management/ucs/ucs_timezone.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_timezone.py
@@ -16,7 +16,6 @@ module: ucs_timezone
 short_description: Configures timezone on Cisco UCS Manager
 description:
 - Configures timezone on Cisco UCS Manager.
-- Examples can be used with the L(UCS Platform Emulator,https://bit.ly/38w8JCk).
 extends_documentation_fragment: ucs
 options:
   state:

--- a/lib/ansible/modules/remote_management/ucs/ucs_uuid_pool.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_uuid_pool.py
@@ -16,7 +16,6 @@ module: ucs_uuid_pool
 short_description: Configures server UUID pools on Cisco UCS Manager
 description:
 - Configures server UUID pools and UUID blocks on Cisco UCS Manager.
-- Examples can be used with the L(UCS Platform Emulator,https://bit.ly/38w8JCk).
 extends_documentation_fragment: ucs
 options:
   state:

--- a/lib/ansible/modules/remote_management/ucs/ucs_vhba_template.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_vhba_template.py
@@ -16,7 +16,6 @@ module: ucs_vhba_template
 short_description: Configures vHBA templates on Cisco UCS Manager
 description:
 - Configures vHBA templates on Cisco UCS Manager.
-- Examples can be used with the L(UCS Platform Emulator,https://bit.ly/38w8JCk).
 extends_documentation_fragment: ucs
 options:
   state:

--- a/lib/ansible/modules/remote_management/ucs/ucs_vlans.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_vlans.py
@@ -16,7 +16,6 @@ module: ucs_vlans
 short_description: Configures VLANs on Cisco UCS Manager
 description:
 - Configures VLANs on Cisco UCS Manager.
-- Examples can be used with the L(UCS Platform Emulator,https://bit.ly/38w8JCk).
 extends_documentation_fragment: ucs
 options:
   state:

--- a/lib/ansible/modules/remote_management/ucs/ucs_vnic_template.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_vnic_template.py
@@ -16,7 +16,6 @@ module: ucs_vnic_template
 short_description: Configures vNIC templates on Cisco UCS Manager
 description:
 - Configures vNIC templates on Cisco UCS Manager.
-- Examples can be used with the L(UCS Platform Emulator,https://bit.ly/38w8JCk).
 extends_documentation_fragment: ucs
 options:
   state:

--- a/lib/ansible/modules/remote_management/ucs/ucs_vsans.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_vsans.py
@@ -16,7 +16,6 @@ module: ucs_vsans
 short_description: Configures VSANs on Cisco UCS Manager
 description:
 - Configures VSANs on Cisco UCS Manager.
-- Examples can be used with the L(UCS Platform Emulator,https://bit.ly/38w8JCk).
 extends_documentation_fragment: ucs
 options:
   state:

--- a/lib/ansible/modules/remote_management/ucs/ucs_wwn_pool.py
+++ b/lib/ansible/modules/remote_management/ucs/ucs_wwn_pool.py
@@ -16,7 +16,6 @@ module: ucs_wwn_pool
 short_description: Configures WWNN or WWPN pools on Cisco UCS Manager
 description:
 - Configures WWNNs or WWPN pools on Cisco UCS Manager.
-- Examples can be used with the L(UCS Platform Emulator,https://bit.ly/38w8JCk).
 extends_documentation_fragment: ucs
 options:
   state:

--- a/lib/ansible/plugins/doc_fragments/ucs.py
+++ b/lib/ansible/plugins/doc_fragments/ucs.py
@@ -7,7 +7,7 @@
 # to the complete work.
 #
 # (c) 2016 Red Hat Inc.
-# (c) 2017 Cisco Systems Inc.
+# (c) 2020 Cisco Systems Inc.
 #
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:
@@ -33,6 +33,8 @@
 class ModuleDocFragment(object):
     # Cisco UCS doc fragment
     DOCUMENTATION = '''
+notes:
+  - Examples can be used with the L(UCS Platform Emulator, https://cs.co/ucspe).
 options:
   hostname:
     description:


### PR DESCRIPTION
##### SUMMARY

Moved UCS Emulator Link to doc_fragment notes: section

lib/ansible/plugins/doc_fragments/ucs.py

The previous link was a https://bit.ly/38w8JCk move to Cisco domain cs.co/ucspe

Removed from modules

lib/ansible/modules/remote_management/ucs/ucs_disk_group_policy.py
lib/ansible/modules/remote_management/ucs/ucs_dns_server.py
lib/ansible/modules/remote_management/ucs/ucs_ip_pool.py
lib/ansible/modules/remote_management/ucs/ucs_lan_connectivity.py
lib/ansible/modules/remote_management/ucs/ucs_mac_pool.py
lib/ansible/modules/remote_management/ucs/ucs_managed_objects.py
lib/ansible/modules/remote_management/ucs/ucs_ntp_server.py
lib/ansible/modules/remote_management/ucs/ucs_org.py
lib/ansible/modules/remote_management/ucs/ucs_query.py
lib/ansible/modules/remote_management/ucs/ucs_san_connectivity.py
lib/ansible/modules/remote_management/ucs/ucs_service_profile_template.py
lib/ansible/modules/remote_management/ucs/ucs_storage_profile.py
lib/ansible/modules/remote_management/ucs/ucs_timezone.py
lib/ansible/modules/remote_management/ucs/ucs_uuid_pool.py
lib/ansible/modules/remote_management/ucs/ucs_vhba_template.py
lib/ansible/modules/remote_management/ucs/ucs_vlan_find.py
lib/ansible/modules/remote_management/ucs/ucs_vlans.py
lib/ansible/modules/remote_management/ucs/ucs_vnic_template.py
lib/ansible/modules/remote_management/ucs/ucs_vsans.py
lib/ansible/modules/remote_management/ucs/ucs_wwn_pool.py

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
ucs_disk_group_policy.py
ucs_dns_server.py
ucs_ip_pool.py
ucs_lan_connectivity.py
ucs_mac_pool.py
ucs_managed_objects.py
ucs_ntp_server.py
ucs_org.py
ucs_query.py
ucs_san_connectivity.py
ucs_service_profile_template.py
ucs_storage_profile.py
ucs_timezone.py
ucs_uuid_pool.py
ucs_vhba_template.py
ucs_vlan_find.py
ucs_vlans.py
ucs_vnic_template.py
ucs_vsans.py
ucs_wwn_pool.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
