### PR TITLE
Fix ansible-galaxy role list regression

### DIFF
--- a/changelogs/fragments/galaxy-role-list-fix.yml
+++ b/changelogs/fragments/galaxy-role-list-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - fix regression that prenented roles from being listed

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -176,7 +176,7 @@ class GalaxyCLI(CLI):
         self.add_init_options(role_parser, parents=[common, force, offline])
         self.add_remove_options(role_parser, parents=[common, roles_path])
         self.add_delete_options(role_parser, parents=[common, github])
-        self.add_list_options(role_parser, parents=[common])
+        self.add_list_options(role_parser, parents=[common, roles_path])
         self.add_search_options(role_parser, parents=[common])
         self.add_import_options(role_parser, parents=[common, github])
         self.add_setup_options(role_parser, parents=[common, roles_path])

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -107,6 +107,20 @@ EOF
 popd # ${galaxy_testdir}
 rm -fr "${galaxy_testdir}"
 
+
+# Galaxy role list test case
+#
+# Basic tests to ensure listing roles works
+
+f_ansible_galaxy_status \
+    "role list"
+
+    ansible-galaxy role list | tee out.txt
+    ansible-galaxy role list test-role | tee -a out.txt
+
+    [[ $(grep -c '^- test-role' out.txt ) -eq 2 ]]
+
+
 #################################
 # ansible-galaxy collection tests
 #################################


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I forgot to add the `roles_path` parent to the `role_parser` object, so no paths were being passed to the list function. Oops.

Add basic role list tests to prevent future regressions.

This was introduced in #65022, so no need to backport this fix.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/cli/galaxy.py`