### PR TITLE
[2.9] docker_login: fix permissions for ~/.docker/config.json

### DIFF
--- a/changelogs/fragments/67353-docker_login-permissions.yml
+++ b/changelogs/fragments/67353-docker_login-permissions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_login - make sure that ``~/.docker/config.json`` is created with permissions ``0600``."

--- a/lib/ansible/modules/cloud/docker/docker_login.py
+++ b/lib/ansible/modules/cloud/docker/docker_login.py
@@ -257,8 +257,13 @@ class LoginManager(DockerBaseClass):
 
     def write_config(self, path, config):
         try:
-            with open(path, "w") as file:
-                json.dump(config, file, indent=5, sort_keys=True)
+            # Write config; make sure it has permissions 0x600
+            content = json.dumps(config, indent=5, sort_keys=True).encode('utf-8')
+            f = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            try:
+                os.write(f, content)
+            finally:
+                os.close(f)
         except Exception as exc:
             self.fail("Error: failed to write config to %s - %s" % (path, str(exc)))
 


### PR DESCRIPTION
##### SUMMARY
Backport of #67353 to stable-2.9.

Since the module has been rewritten completely since 2.9, this PR is adding the code in a similar way. (Also there are no tests, since the module has no tests in 2.9.) The code is simple enough that this should be fine though.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_login
