### PR TITLE
Add integration tests for the mas module

### DIFF
--- a/test/integration/targets/mas/aliases
+++ b/test/integration/targets/mas/aliases
@@ -1,0 +1,2 @@
+needs/root
+unsupported

--- a/test/integration/targets/mas/tasks/main.yml
+++ b/test/integration/targets/mas/tasks/main.yml
@@ -34,7 +34,7 @@
 - name: Ensure that the status would have changed
   assert:
     that:
-    - install_check.changed == true
+    - install_check is changed
     - install_check.msg == "Installed 1 app(s)"
 
 - name: Determine whether the app is installed
@@ -56,7 +56,7 @@
 - name: Ensure that the status changed
   assert:
     that:
-    - install.changed == true
+    - install is changed
     - install.msg == "Installed 1 app(s)"
 
 - name: Determine whether the app is installed
@@ -82,7 +82,7 @@
 - name: Ensure that the status is unchanged (already installed)
   assert:
     that:
-    - install_again.changed == false
+    - install_again is not changed
     - "'msg' not in install_again"
 
 # Uninstallation
@@ -97,7 +97,7 @@
 - name: Ensure that the status would have changed
   assert:
     that:
-    - uninstall_check.changed == true
+    - uninstall_check is changed
     - uninstall_check.msg == "Uninstalled 1 app(s)"
 
 - name: Determine whether the app is installed
@@ -120,7 +120,7 @@
 - name: Ensure that the status changed
   assert:
     that:
-    - uninstall.changed == true
+    - uninstall is changed
     - uninstall.msg == "Uninstalled 1 app(s)"
 
 - name: Determine whether the app is installed
@@ -147,5 +147,5 @@
 - name: Ensure that the status is unchanged (already uninstalled)
   assert:
     that:
-    - uninstall_again.changed == false
+    - uninstall_again is not changed
     - "'msg' not in uninstall_again"

--- a/test/integration/targets/mas/tasks/main.yml
+++ b/test/integration/targets/mas/tasks/main.yml
@@ -1,0 +1,151 @@
+# Test code for the mas module.
+# Copyright: (c) 2020, Lukas Bestle <project-ansible@lukasbestle.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+# Test preparation
+- name: Uninstall Rested to ensure consistent starting point
+  mas:
+    id: 421879749
+    state: absent
+  become: yes
+
+- name: Determine whether the app is installed
+  stat:
+    path: /Applications/Rested.app
+  register: install_status
+
+- name: Ensure the app is uninstalled
+  assert:
+    that:
+    - install_status.stat.exists == false
+
+- name: Wait until the OS-internal cache was updated
+  pause:
+    seconds: 5
+
+# Installation
+- name: Check if Rested needs to be installed
+  mas:
+    id: 421879749
+    state: present
+  register: install_check
+  check_mode: yes
+
+- name: Ensure that the status would have changed
+  assert:
+    that:
+    - install_check.changed == true
+    - install_check.msg == "Installed 1 app(s)"
+
+- name: Determine whether the app is installed
+  stat:
+    path: /Applications/Rested.app
+  register: install_status
+
+- name: Ensure the app is not yet installed
+  assert:
+    that:
+    - install_status.stat.exists == false
+
+- name: Install Rested
+  mas:
+    id: 421879749
+    state: present
+  register: install
+
+- name: Ensure that the status changed
+  assert:
+    that:
+    - install.changed == true
+    - install.msg == "Installed 1 app(s)"
+
+- name: Determine whether the app is installed
+  stat:
+    path: /Applications/Rested.app
+  register: install_status
+
+- name: Ensure the app is installed
+  assert:
+    that:
+    - install_status.stat.exists == true
+
+- name: Wait until the OS-internal cache was updated
+  pause:
+    seconds: 5
+
+- name: Install Rested again
+  mas:
+    id: 421879749
+    state: present
+  register: install_again
+
+- name: Ensure that the status is unchanged (already installed)
+  assert:
+    that:
+    - install_again.changed == false
+    - "'msg' not in install_again"
+
+# Uninstallation
+- name: Check if Rested needs to be uninstalled
+  mas:
+    id: 421879749
+    state: absent
+  register: uninstall_check
+  become: yes
+  check_mode: yes
+
+- name: Ensure that the status would have changed
+  assert:
+    that:
+    - uninstall_check.changed == true
+    - uninstall_check.msg == "Uninstalled 1 app(s)"
+
+- name: Determine whether the app is installed
+  stat:
+    path: /Applications/Rested.app
+  register: install_status
+
+- name: Ensure the app is not yet uninstalled
+  assert:
+    that:
+    - install_status.stat.exists == true
+
+- name: Unistall Rested
+  mas:
+    id: 421879749
+    state: absent
+  register: uninstall
+  become: yes
+
+- name: Ensure that the status changed
+  assert:
+    that:
+    - uninstall.changed == true
+    - uninstall.msg == "Uninstalled 1 app(s)"
+
+- name: Determine whether the app is installed
+  stat:
+    path: /Applications/Rested.app
+  register: uninstall_status
+
+- name: Ensure the app is uninstalled
+  assert:
+    that:
+    - uninstall_status.stat.exists == false
+
+- name: Wait until the OS-internal cache was updated
+  pause:
+    seconds: 5
+
+- name: Uninstall Rested again
+  mas:
+    id: 421879749
+    state: absent
+  register: uninstall_again
+  become: yes
+
+- name: Ensure that the status is unchanged (already uninstalled)
+  assert:
+    that:
+    - uninstall_again.changed == false
+    - "'msg' not in uninstall_again"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

See https://github.com/ansible/ansible/pull/19768.
Pinging @felixfontein.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

mas

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

I have verified that the tests run through on my local machine.

Testing the `latest` state and the `upgrade_all` command is unfortunately not possible as I can't "fake" the outdated state without mocking the underlying `mas` utility.