### PR TITLE
rabbitmq_users: add -s flag to remove header line 

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
@@ -194,8 +194,7 @@ class RabbitMqUser(object):
 
     def _get_permissions(self):
         """Get permissions of the user from RabbitMQ."""
-        perms_out = [perm for perm in self._exec(
-            ['list_user_permissions', self.username], True) if perm.strip()]
+        perms_out = [perm for perm in self._exec(['list_user_permissions', self.username], True) if perm.strip()]
 
         perms_list = list()
         for perm in perms_out:
@@ -234,10 +233,8 @@ class RabbitMqUser(object):
         self._exec(['set_user_tags', self.username] + self.tags)
 
     def set_permissions(self):
-        permissions_to_clear = [
-            permission for permission in self._permissions if permission not in self.permissions]
-        permissions_to_add = [
-            permission for permission in self.permissions if permission not in self._permissions]
+        permissions_to_clear = [permission for permission in self._permissions if permission not in self.permissions]
+        permissions_to_add = [permission for permission in self.permissions if permission not in self._permissions]
         for permission in permissions_to_clear:
             cmd = 'clear_permissions -p {vhost} {username}'.format(username=self.username,
                                                                    vhost=permission['vhost'])
@@ -273,8 +270,7 @@ def main():
         force=dict(default='no', type='bool'),
         state=dict(default='present', choices=['present', 'absent']),
         node=dict(default='rabbit'),
-        update_password=dict(default='on_create', choices=[
-                             'on_create', 'always'])
+        update_password=dict(default='on_create', choices=['on_create', 'always'])
     )
     module = AnsibleModule(
         argument_spec=arg_spec,
@@ -298,8 +294,7 @@ def main():
         vhosts = map(lambda permission: permission.get(
             'vhost', '/'), permissions)
         if any(map(lambda count: count > 1, count(vhosts).values())):
-            module.fail_json(
-                msg="Error parsing permissions: You can't have two permission dicts for the same vhost")
+            module.fail_json(msg="Error parsing permissions: You can't have two permission dicts for the same vhost")
         bulk_permissions = True
     else:
         perm = {

--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
@@ -143,7 +143,7 @@ class RabbitMqUser(object):
         self._version = self._rabbit_version()
 
     def _rabbit_version(self):
-        status = self.module.run_command(
+        rc,status,err = self.module.run_command(
                 [self._rabbitmqctl, '-q', 'status'], check_rc=True)
 
         # 3.7.x erlang style output

--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
@@ -165,8 +165,7 @@ class RabbitMqUser(object):
                 cmd.extend(['-n', self.node])
             if self._version >= Version('3.8'):
                 cmd.extend(['-s'])
-            rc, out, err = self.module.run_command(
-                cmd + args, check_rc=check_rc)
+            rc, out, err = self.module.run_command(cmd + args, check_rc=check_rc)
             return out.splitlines()
         return list()
 
@@ -291,8 +290,7 @@ def main():
     update_password = module.params['update_password']
 
     if permissions:
-        vhosts = map(lambda permission: permission.get(
-            'vhost', '/'), permissions)
+        vhosts = map(lambda permission: permission.get('vhost', '/'), permissions)
         if any(map(lambda count: count > 1, count(vhosts).values())):
             module.fail_json(msg="Error parsing permissions: You can't have two permission dicts for the same vhost")
         bulk_permissions = True

--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
@@ -5,11 +5,8 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-from ansible.module_utils.common.collections import count
-from ansible.module_utils.basic import AnsibleModule
-from distutils.version import LooseVersion as Version
 __metaclass__ = type
-import re
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -121,6 +118,11 @@ EXAMPLES = '''
     state: present
 '''
 
+from ansible.module_utils.common.collections import count
+from ansible.module_utils.basic import AnsibleModule
+from distutils.version import LooseVersion as Version
+import re
+
 
 class RabbitMqUser(object):
     def __init__(self, module, username, password, tags, permissions,
@@ -143,8 +145,7 @@ class RabbitMqUser(object):
         self._version = self._rabbit_version()
 
     def _rabbit_version(self):
-        rc, status, err = self.module.run_command(
-                [self._rabbitmqctl, '-q', 'status'], check_rc=True)
+        rc, status, err = self.module.run_command([self._rabbitmqctl, '-q', 'status'], check_rc=True)
 
         # 3.7.x erlang style output
         version_match = re.search('{rabbit,".*","(?P<version>.*)"}', status)

--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_user.py
@@ -143,7 +143,7 @@ class RabbitMqUser(object):
         self._version = self._rabbit_version()
 
     def _rabbit_version(self):
-        rc,status,err = self.module.run_command(
+        rc, status, err = self.module.run_command(
                 [self._rabbitmqctl, '-q', 'status'], check_rc=True)
 
         # 3.7.x erlang style output


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Rabbitmq 3.8 needs -s flag for removing the headers line. I did version check same as rabbitmq_policy.py, but didn't use exec function to get version (as I added -s flag only if version is newer to exec function).

Example that lear permissions fails as it takes the header line as user:
Example for rabbitmqctl output:
# rabbitmqctl list_user_permissions  -q admin
vhost	configure	write	read
/	.*	.*	.*

# rabbitmqctl list_user_permissions -q -s admin
/	.*	.*	.*

--- 
example playbook:
- hosts: all
  become: yes
  gather_facts: false
  tasks:
  - name: Add rabbitmq users
    rabbitmq_user:
        user: "{{ user.username }}"
        password: "{{ user.password }}"
        tags: "{{ user.tags }}"
        permissions: "{{ user.permissions }}"
        vhost: "/"
    loop:
    - name: "admin"
      username: "admin"
      password: admin
      tags: administrator
      permissions:
        - vhost: /
          configure_priv: .*
          write_priv: .*
          read_priv: .*

    loop_control:
      loop_var: "user"
      label: "{{ user.username }}"


for a rabbitmq installation that the user already exists ansible fails:
{"ansible_loop_var": "user", "changed": false, "cmd": "/sbin/rabbitmqctl -q -n rabbit clear_permissions -p vhost VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "msg": "Virtual host 'vhost' does not exist", "rc": 65, "stderr": "Virtual host 'vhost' does not exist\n", "stderr_lines": ["Virtual host 'vhost' does not exist"], "stdout": "", "stdout_lines": [], "user": {"name": "admin", "password": "admin", "permissions": [{"configure_priv": ".*", "read_priv": ".*", "vhost": "/", "write_priv": ".*"}], "tags": "administrator", "username": "admin"}}


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
rabbitmq_user
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
