### PR TITLE
win_domain_controller: Added domain_log_path

### DIFF
--- a/changelogs/fragments/win_domain_controller-log.yaml
+++ b/changelogs/fragments/win_domain_controller-log.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_domain_controller - Added the ``domain_log_path`` to control the directory for the new AD log files location - https://github.com/ansible/ansible/issues/59348

--- a/lib/ansible/modules/windows/win_domain_controller.ps1
+++ b/lib/ansible/modules/windows/win_domain_controller.ps1
@@ -103,6 +103,7 @@ $domain_admin_password= Get-AnsibleParam -obj $params -name "domain_admin_passwo
 $local_admin_password= Get-AnsibleParam -obj $params -name "local_admin_password"
 $database_path = Get-AnsibleParam -obj $params -name "database_path" -type "path"
 $sysvol_path = Get-AnsibleParam -obj $params -name "sysvol_path" -type "path"
+$domain_log_path = Get-AnsibleParam -obj $params -name "domain_log_path" -type "path"  # TODO: Use log_path and alias domain_log_path once the log_path for debug logging option has been removed.
 $read_only = Get-AnsibleParam -obj $params -name "read_only" -type "bool" -default $false
 $site_name = Get-AnsibleParam -obj $params -name "site_name" -type "str" -failifempty $read_only
 $install_dns = Get-AnsibleParam -obj $params -name "install_dns" -type "bool"
@@ -205,6 +206,9 @@ Try {
                 }
                 if ($database_path) {
                     $install_params.DatabasePath = $database_path
+                }
+                if ($domain_log_path) {
+                    $install_params.LogPath = $domain_log_path
                 }
                 if ($sysvol_path) {
                     $install_params.SysvolPath = $sysvol_path

--- a/lib/ansible/modules/windows/win_domain_controller.py
+++ b/lib/ansible/modules/windows/win_domain_controller.py
@@ -63,6 +63,12 @@ options:
     - If not set then the default path is C(%SYSTEMROOT%\NTDS).
     type: path
     version_added: '2.5'
+  domain_log_path:
+    description:
+    - Specified the fully qualified, non-UNC path to a directory on a fixed disk of the local computer that will
+      contain the domain log files.
+    type: path
+    version_added: '2.10'
   sysvol_path:
     description:
     - The path to a directory on a fixed disk of the Windows host where the
@@ -131,4 +137,20 @@ EXAMPLES = r'''
     state: domain_controller
     read_only: yes
     site_name: London
+
+- name: Promote server with custom paths
+  win_domain_controller:
+    dns_domain_name: ansible.vagrant
+    domain_admin_user: testguy@ansible.vagrant
+    domain_admin_password: password123!
+    safe_mode_password: password123!
+    state: domain_controller
+    sysvol_path: D:\SYSVOL
+    database_path: D:\NTDS
+    domain_log_path: D:\NTDS
+  register: dc_promotion
+
+- name: Reboot after promotion
+  win_reboot:
+  when: dc_promotion.reboot_required
 '''


### PR DESCRIPTION
##### SUMMARY
Adds the `domain_log_path` module option to `win_domain_controller` to control where the log paths are placed on a new domain controller. We unfortunately cannot use `log_path` right now as it is in use with module debug logging but once that feature has been removed we can add an alias for consistency with `win_domain`.

Fixes https://github.com/ansible/ansible/issues/59348

Supersedes https://github.com/ansible/ansible/pull/59468

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_domain_controller

##### OTHER INFO
I've manually tested this change with the following playbook

```
---
- hosts: dc1
  gather_facts: no
  tasks:
  - win_domain:
      dns_domain_name: ansible.log
      safe_mode_password: Password01
      sysvol_path: C:\JordanSysVol
      database_path: C:\Jordan
      log_path: C:\Jordan
    register: domain

  - win_reboot:
    when: domain.reboot_required

  - win_domain_user:
      name: ansible-test
      upn: ansible-test@ANSIBLE.LOG
      password: Password01
      password_never_expires: yes
      groups:
      - Domain Admins
      state: present
    register: create_user
    # On the first reboot the AD services aren't fully ready, just retry until it works
    retries: 30
    delay: 15
    until: create_user is successful

- hosts: dc2
  gather_facts: no
  tasks:
  - win_dns_client:
      adapter_names: Ethernet 2
      ipv4_addresses:
      - 192.168.57.10

  - win_domain_controller:
      dns_domain_name: ansible.log
      domain_admin_user: ansible-test@ANSIBLE.LOG
      domain_admin_password: Password01
      safe_mode_password: Password01
      state: domain_controller
      database_path: C:\Jordan
      sysvol_path: C:\JordanSysVol
      domain_log_path: C:\Jordan
    register: domain

  - win_reboot:
    when: domain.reboot_required
```

This was tested against 2 Windows Server 2019 hosts set up by Vagrant.