### PR TITLE
Fixes nxos_l2_interfaces module traceback if allowed vlans are not preconfigured

### DIFF
--- a/lib/ansible/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
@@ -277,7 +277,10 @@ class L2_interfaces(ConfigBase):
                 if "allowed_vlans" in diff.keys() and diff["allowed_vlans"]:
                     vlan_tobe_added = diff["allowed_vlans"].split(',')
                     vlan_list = vlan_tobe_added[:]
-                    have_vlans = obj_in_have["allowed_vlans"].split(',')
+                    if obj_in_have.get("allowed_vlans"):
+                        have_vlans = obj_in_have["allowed_vlans"].split(',')
+                    else:
+                        have_vlans = []
                     for w_vlans in vlan_list:
                         if w_vlans in have_vlans:
                             vlan_tobe_added.pop(vlan_tobe_added.index(w_vlans))

--- a/lib/ansible/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
@@ -267,7 +267,7 @@ class L2_interfaces(ConfigBase):
 
     def set_commands(self, w, have, replace=False):
         commands = []
-        vlan_tobe_added = []
+
         obj_in_have = flatten_dict(search_obj_in_list(w['name'], have, 'name'))
         if not obj_in_have:
             commands = self.add_commands(w)
@@ -286,7 +286,10 @@ class L2_interfaces(ConfigBase):
                             vlan_tobe_added.pop(vlan_tobe_added.index(w_vlans))
                     if vlan_tobe_added:
                         diff.update({"allowed_vlans": ','.join(vlan_tobe_added)})
-                        commands = self.add_commands(diff, True)
+                        if have_vlans:
+                            commands = self.add_commands(diff, True)
+                        else:
+                            commands = self.add_commands(diff)
                     return commands
             commands = self.add_commands(diff)
         return commands


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes nxos_l2_interfaces module traceback if allowed vlans are not preconfigured, bug fix for #67455
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_l2_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
