### PR TITLE
bugfix #66983

### DIFF
--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -449,6 +449,7 @@ class ActionModule(ActionBase):
         # look up the files and use the first one we find as src
         elif remote_src:
             result.update(self._execute_module(module_name='copy', task_vars=task_vars))
+            result['diff'] = self._get_diff_data(dest, source, task_vars)
             return self._ensure_invocation(result)
         else:
             # find_needle returns a path that may not have a trailing slash on


### PR DESCRIPTION
##### SUMMARY
Fixes bug where -diff flag didn't work when using remote_src=true

#66983

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Copy Plugin

##### STEPS TO REPRODUCE

Create two different files on remote host:
```sh
echo 'Original file with text' > test_file1; echo 'Modified file with text' > test_file2
```
Run ad-hoc command from Ansible server:
```sh
ansible server -m copy -a 'src=test_file2 dest=test_file1 remote_src=yes' --check --diff
```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
###### OUTPUT
Before:
```sh
192.168.122.109 | CHANGED => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python3"
    },
    "changed": true,
    "checksum": "cb848e4f836c58438bb1956059cd36cd568ea8b7",
    "dest": "./test_file1",
    "gid": 1000,
    "group": "group",
    "md5sum": "7050a9b4092fabad858a03a401768e0c",
    "mode": "0664",
    "owner": "owner",
    "size": 24,
    "src": "test_file2",
    "state": "file",
    "uid": 1000
}
```
After: 
```sh
--- before: test_file1
+++ after: test_file2
@@ -1 +1 @@
-Original file with text
+Modified file with text

192.168.122.109 | CHANGED => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python3"
    },
    "changed": true,
    "checksum": "cb848e4f836c58438bb1956059cd36cd568ea8b7",
    "dest": "./test_file1",
    "gid": 1000,
    "group": "group",
    "md5sum": "7050a9b4092fabad858a03a401768e0c",
    "mode": "0664",
    "owner": "owner",
    "size": 24,
    "src": "test_file2",
    "state": "file",
    "uid": 1000
}

```



<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
