### PR TITLE
implement support for hidden/protected variables gitlab_project_variable

### DIFF
--- a/changelogs/fragments/67461-gitlab-project-variable-masked-protected.yml
+++ b/changelogs/fragments/67461-gitlab-project-variable-masked-protected.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - implement masked and protected attributes for gitlab project variable

--- a/changelogs/fragments/67461-gitlab-project-variable-masked-protected.yml
+++ b/changelogs/fragments/67461-gitlab-project-variable-masked-protected.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - implement masked and protected attributes for gitlab project variable
+  - gitlab_project_variable - implement masked and protected attributes

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -205,7 +205,7 @@ def native_python_main(this_gitlab, purge, var_list, state, module):
             masked = var_list[key].get('masked', False)
             protected = var_list[key].get('protected', False)
         else:
-            module.fail_json(msg="value must be of type string or dict")
+            module.fail_json(msg="value must be of type string, integer or dict")
 
         if key in existing_variables:
             index = existing_variables.index(key)

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -132,6 +132,7 @@ from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_native
 from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.six import string_types
+from ansible.module_utils.six import integer_types
 
 
 GITLAB_IMP_ERR = None
@@ -196,7 +197,7 @@ def native_python_main(this_gitlab, purge, var_list, state, module):
 
     for key in var_list:
 
-        if isinstance(var_list[key], string_types):
+        if isinstance(var_list[key], string_types) or isinstance(var_list[key], integer_types):
             value = var_list[key]
             masked = False
             protected = False

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -167,7 +167,7 @@ class GitlabProjectVariables(object):
         if self._module.check_mode:
             return True
 
-        if var.protected == protected and vaar.masked == masked:
+        if var.protected == protected and var.masked == masked:
             var.value = value
             var.save()
             return True

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -53,7 +53,7 @@ options:
   vars:
     description:
       - When the list element is a simple key-value pair, masked and protected will be set to false.
-      - Wnen provided a dict with the keys "value", "masked" and "protected", you have full control about if a value should be masked, protected or both.
+      - When the list element is a dict with the keys "value", "masked" and "protected", user can have full control about if a value should be masked, protected or both.
       - Wehn you masked a value, the value must be base64 compliant and has at least a length of 8 characters.
     default: {}
     type: dict

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -52,7 +52,7 @@ options:
     type: bool
   vars:
     description:
-      - When it's a simple key value pair, masked and protected will be set to false.
+      - When the list element is a simple key-value pair, masked and protected will be set to false.
       - Wnen provided a dict with the keys "value", "masked" and "protected", you have full control about if a value should be masked, protected or both.
       - Wehn you masked a value, the value must be base64 compliant and has at least a length of 8 characters.
     default: {}

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -53,7 +53,7 @@ options:
   vars:
     description:
       - When the list element is a simple key-value pair, masked and protected will be set to false.
-      - When the list element is a dict with the keys "value", "masked" and "protected", user can
+      - When the list element is a dict with the keys I(value), I(masked) and I(protected), the user can
         have full control about if a value should be masked, protected or both.
       - When you masked a value, the value must be base64 compliant and has at least a length of 8 characters.
     default: {}

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -201,7 +201,7 @@ def native_python_main(this_gitlab, purge, var_list, state):
             masked = var_list[key].get('masked', False)
             protected = var_list[key].get('protected', False)
         else:
-          self._module.fail_json(msg="value must be from type string or dict")
+            self._module.fail_json(msg="value must be of type string or dict")
 
         if key in existing_variables:
             index = existing_variables.index(key)

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -55,6 +55,9 @@ options:
       - When the list element is a simple key-value pair, masked and protected will be set to false.
       - When the list element is a dict with the keys I(value), I(masked) and I(protected), the user can
         have full control about whether a value should be masked, protected or both.
+      - When a I(value) must be I(protected), GitLab >= 9.3 is required.
+      - When a I(value) must be I(masked), GitLab >= 11.10 is required.
+      - A I(value) must be a string or a number.
       - When a value is masked, it must be in Base64 and have a length of at least 8 characters.
     default: {}
     type: dict

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -53,7 +53,8 @@ options:
   vars:
     description:
       - When the list element is a simple key-value pair, masked and protected will be set to false.
-      - When the list element is a dict with the keys "value", "masked" and "protected", user can have full control about if a value should be masked, protected or both.
+      - When the list element is a dict with the keys "value", "masked" and "protected", user can 
+      have full control about if a value should be masked, protected or both.
       - When you masked a value, the value must be base64 compliant and has at least a length of 8 characters.
     default: {}
     type: dict

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -82,7 +82,7 @@ EXAMPLES = '''
       ACCESS_KEY_ID: abc123
       SECRET_ACCESS_KEY:
         value: 3214cbad
-        masked: True
+        masked: true
         protected: True
 
 - name: Delete one variable

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -54,7 +54,7 @@ options:
     description:
       - When the list element is a simple key-value pair, masked and protected will be set to false.
       - When the list element is a dict with the keys "value", "masked" and "protected", user can have full control about if a value should be masked, protected or both.
-      - Wehn you masked a value, the value must be base64 compliant and has at least a length of 8 characters.
+      - When you masked a value, the value must be base64 compliant and has at least a length of 8 characters.
     default: {}
     type: dict
 '''

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -190,7 +190,7 @@ def native_python_main(this_gitlab, purge, var_list, state):
             protected = False
         else:
             value = var_list[key].get('value')
-            masked = var_list[key].get('masked') or False
+            masked = var_list[key].get('masked', False)
             protected = var_list[key].get('protected') or False
 
         if key in existing_variables:

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -55,7 +55,7 @@ options:
       - When the list element is a simple key-value pair, masked and protected will be set to false.
       - When the list element is a dict with the keys I(value), I(masked) and I(protected), the user can
         have full control about whether a value should be masked, protected or both.
-      - When you masked a value, the value must be base64 compliant and has at least a length of 8 characters.
+      - When a value is masked, it must be in Base64 and have a length of at least 8 characters.
     default: {}
     type: dict
 '''

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -59,6 +59,7 @@ options:
       - Support for masked values requires GitLab >= 11.10.
       - A I(value) must be a string or a number.
       - When a value is masked, it must be in Base64 and have a length of at least 8 characters.
+        See gitlab documentation on acceptable values for a masked variable (https://docs.gitlab.com/ce/ci/variables/#masked-variables).
     default: {}
     type: dict
 '''

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -54,7 +54,7 @@ options:
     description:
       - When the list element is a simple key-value pair, masked and protected will be set to false.
       - When the list element is a dict with the keys I(value), I(masked) and I(protected), the user can
-        have full control about if a value should be masked, protected or both.
+        have full control about whether a value should be masked, protected or both.
       - When you masked a value, the value must be base64 compliant and has at least a length of 8 characters.
     default: {}
     type: dict

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -83,7 +83,7 @@ EXAMPLES = '''
       SECRET_ACCESS_KEY:
         value: 3214cbad
         masked: true
-        protected: True
+        protected: true
 
 - name: Delete one variable
   gitlab_project_variable:

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -191,7 +191,7 @@ def native_python_main(this_gitlab, purge, var_list, state):
         else:
             value = var_list[key].get('value')
             masked = var_list[key].get('masked', False)
-            protected = var_list[key].get('protected') or False
+            protected = var_list[key].get('protected', False)
 
         if key in existing_variables:
             index = existing_variables.index(key)

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -197,7 +197,7 @@ def native_python_main(this_gitlab, purge, var_list, state, module):
 
     for key in var_list:
 
-        if isinstance(var_list[key], string_types) or isinstance(var_list[key], integer_types):
+        if isinstance(var_list[key], string_types) or isinstance(var_list[key], (integer_types, float)):
             value = var_list[key]
             masked = False
             protected = False

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -56,7 +56,7 @@ options:
       - When the list element is a dict with the keys I(value), I(masked) and I(protected), the user can
         have full control about whether a value should be masked, protected or both.
       - Support for protected values requires GitLab >= 9.3.
-      - When a I(value) must be I(masked), GitLab >= 11.10 is required.
+      - Support for masked values requires GitLab >= 11.10.
       - A I(value) must be a string or a number.
       - When a value is masked, it must be in Base64 and have a length of at least 8 characters.
     default: {}

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -59,7 +59,7 @@ options:
       - Support for masked values requires GitLab >= 11.10.
       - A I(value) must be a string or a number.
       - When a value is masked, it must be in Base64 and have a length of at least 8 characters.
-        See gitlab documentation on acceptable values for a masked variable (https://docs.gitlab.com/ce/ci/variables/#masked-variables).
+        See GitLab documentation on acceptable values for a masked variable (https://docs.gitlab.com/ce/ci/variables/#masked-variables).
     default: {}
     type: dict
 '''

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -80,7 +80,7 @@ EXAMPLES = '''
     vars:
       ACCESS_KEY_ID: abc123
       SECRET_ACCESS_KEY:
-        value: 321cba
+        value: 3214cbad
         masked: True
         protected: True
 

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -128,6 +128,7 @@ import traceback
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_native
 from ansible.module_utils.api import basic_auth_argument_spec
+from ansible.module_utils.six import string_types
 
 
 GITLAB_IMP_ERR = None

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -53,7 +53,7 @@ options:
   vars:
     description:
       - When the list element is a simple key-value pair, masked and protected will be set to false.
-      - When the list element is a dict with the keys "value", "masked" and "protected", user can 
+      - When the list element is a dict with the keys "value", "masked" and "protected", user can
         have full control about if a value should be masked, protected or both.
       - When you masked a value, the value must be base64 compliant and has at least a length of 8 characters.
     default: {}

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -55,7 +55,7 @@ options:
       - When the list element is a simple key-value pair, masked and protected will be set to false.
       - When the list element is a dict with the keys I(value), I(masked) and I(protected), the user can
         have full control about whether a value should be masked, protected or both.
-      - When a I(value) must be I(protected), GitLab >= 9.3 is required.
+      - Support for protected values requires GitLab >= 9.3.
       - When a I(value) must be I(masked), GitLab >= 11.10 is required.
       - A I(value) must be a string or a number.
       - When a value is masked, it must be in Base64 and have a length of at least 8 characters.

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -182,7 +182,7 @@ class GitlabProjectVariables(object):
         return self.project.variables.delete(key)
 
 
-def native_python_main(this_gitlab, purge, var_list, state):
+def native_python_main(this_gitlab, purge, var_list, state, module):
 
     change = False
     return_value = dict(added=list(), updated=list(), removed=list(), untouched=list())
@@ -201,7 +201,7 @@ def native_python_main(this_gitlab, purge, var_list, state):
             masked = var_list[key].get('masked', False)
             protected = var_list[key].get('protected', False)
         else:
-            self._module.fail_json(msg="value must be of type string or dict")
+            module.fail_json(msg="value must be of type string or dict")
 
         if key in existing_variables:
             index = existing_variables.index(key)
@@ -276,7 +276,7 @@ def main():
 
     this_gitlab = GitlabProjectVariables(module=module, gitlab_instance=gitlab_instance)
 
-    change, return_value = native_python_main(this_gitlab, purge, var_list, state)
+    change, return_value = native_python_main(this_gitlab, purge, var_list, state, module)
 
     module.exit_json(changed=change, project_variable=return_value)
 

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -54,7 +54,7 @@ options:
     description:
       - When the list element is a simple key-value pair, masked and protected will be set to false.
       - When the list element is a dict with the keys "value", "masked" and "protected", user can 
-      have full control about if a value should be masked, protected or both.
+        have full control about if a value should be masked, protected or both.
       - When you masked a value, the value must be base64 compliant and has at least a length of 8 characters.
     default: {}
     type: dict

--- a/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
+++ b/lib/ansible/modules/source_control/gitlab/gitlab_project_variable.py
@@ -163,8 +163,15 @@ class GitlabProjectVariables(object):
     def update_variable(self, key, var, value, masked, protected):
         if var.value == value and var.protected == protected and var.masked == masked:
             return False
+
         if self._module.check_mode:
             return True
+
+        if var.protected == protected and vaar.masked == masked:
+            var.value = value
+            var.save()
+            return True
+
         self.delete_variable(key)
         self.create_variable(key, value, masked, protected)
         return True
@@ -185,14 +192,16 @@ def native_python_main(this_gitlab, purge, var_list, state):
 
     for key in var_list:
 
-        if isinstance(var_list[key], str):
+        if isinstance(var_list[key], string_types):
             value = var_list[key]
             masked = False
             protected = False
-        else:
+        elif isinstance(var_list[key], dict):
             value = var_list[key].get('value')
             masked = var_list[key].get('masked', False)
             protected = var_list[key].get('protected', False)
+        else:
+          self._module.fail_json(msg="value must be from type string or dict")
 
         if key in existing_variables:
             index = existing_variables.index(key)

--- a/test/integration/targets/gitlab_project_variable/tasks/main.yml
+++ b/test/integration/targets/gitlab_project_variable/tasks/main.yml
@@ -49,7 +49,7 @@
         value: checkmode
   register: gitlab_project_variable_state
 
-- name: state must be changed
+- name: state must be not changed
   assert:
     that:
       - gitlab_project_variable_state is not changed

--- a/test/integration/targets/gitlab_project_variable/tasks/main.yml
+++ b/test/integration/targets/gitlab_project_variable/tasks/main.yml
@@ -149,6 +149,23 @@
     that:
       - gitlab_project_variable_state is changed
 
+- name: set again both (masked and protected) attribute (idempotent)
+  gitlab_project_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    project: "{{ gitlab_project_name }}"
+    vars:
+      ACCESS_KEY_ID:
+        value: checkmode
+        masked: True
+        protected: True
+  register: gitlab_project_variable_state
+
+- name: state must not be changed
+  assert:
+    that:
+      - gitlab_project_variable_state is not changed
+
 - name: revert both (masked and protected) attribute
   gitlab_project_variable:
     api_url: "{{ gitlab_host }}"

--- a/test/integration/targets/gitlab_project_variable/tasks/main.yml
+++ b/test/integration/targets/gitlab_project_variable/tasks/main.yml
@@ -355,6 +355,44 @@
       - gitlab_project_variable_state.project_variable.updated|length == 0
       - gitlab_project_variable_state.project_variable.untouched[0] == "some"
 
+- name: test integer values
+  gitlab_project_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    project: "{{ gitlab_project_name }}"
+    vars:
+      some: 42
+    purge: False
+  register: gitlab_project_variable_state
+
+- name: only one variable is left state must be changed
+  assert:
+    that:
+      - gitlab_project_variable_state.changed
+      - gitlab_project_variable_state.project_variable.added|length == 0
+      - gitlab_project_variable_state.project_variable.untouched|length == 0
+      - gitlab_project_variable_state.project_variable.removed|length == 0
+      - gitlab_project_variable_state.project_variable.updated|length == 1
+
+- name: test float values
+  gitlab_project_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    project: "{{ gitlab_project_name }}"
+    vars:
+      some: 42.23
+    purge: False
+  register: gitlab_project_variable_state
+
+- name: only one variable is left state must be changed
+  assert:
+    that:
+      - gitlab_project_variable_state.changed
+      - gitlab_project_variable_state.project_variable.added|length == 0
+      - gitlab_project_variable_state.project_variable.untouched|length == 0
+      - gitlab_project_variable_state.project_variable.removed|length == 0
+      - gitlab_project_variable_state.project_variable.updated|length == 1
+
 - name: delete the last left variable
   gitlab_project_variable:
     api_url: "{{ gitlab_host }}"

--- a/test/integration/targets/gitlab_project_variable/tasks/main.yml
+++ b/test/integration/targets/gitlab_project_variable/tasks/main.yml
@@ -117,7 +117,7 @@
     that:
       - gitlab_project_variable_state is changed
 
-- name: revert again masked attribute by not mention it
+- name: revert again masked attribute by not mention it (idempotent)
   gitlab_project_variable:
     api_url: "{{ gitlab_host }}"
     api_token: "{{ gitlab_login_token }}"

--- a/test/integration/targets/gitlab_project_variable/tasks/main.yml
+++ b/test/integration/targets/gitlab_project_variable/tasks/main.yml
@@ -117,6 +117,21 @@
     that:
       - gitlab_project_variable_state is changed
 
+- name: revert again masked attribute by not mention it
+  gitlab_project_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    project: "{{ gitlab_project_name }}"
+    vars:
+      ACCESS_KEY_ID:
+        value: checkmode
+  register: gitlab_project_variable_state
+
+- name: state must be not changed
+  assert:
+    that:
+      - gitlab_project_variable_state is not changed
+
 - name: set both (masked and protected) attribute
   gitlab_project_variable:
     api_url: "{{ gitlab_host }}"

--- a/test/integration/targets/gitlab_project_variable/tasks/main.yml
+++ b/test/integration/targets/gitlab_project_variable/tasks/main.yml
@@ -39,6 +39,117 @@
     that:
       - gitlab_project_variable_state is changed
 
+- name: test new format
+  gitlab_project_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    project: "{{ gitlab_project_name }}"
+    vars:
+      ACCESS_KEY_ID:
+        value: checkmode
+  register: gitlab_project_variable_state
+
+- name: state must be changed
+  assert:
+    that:
+      - gitlab_project_variable_state is not changed
+
+- name: change protected attribute
+  gitlab_project_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    project: "{{ gitlab_project_name }}"
+    vars:
+      ACCESS_KEY_ID:
+        value: checkmode
+        protected: True
+  register: gitlab_project_variable_state
+
+- name: state must be changed
+  assert:
+    that:
+      - gitlab_project_variable_state is changed
+
+- name: revert protected attribute
+  gitlab_project_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    project: "{{ gitlab_project_name }}"
+    vars:
+      ACCESS_KEY_ID:
+        value: checkmode
+        protected: False
+  register: gitlab_project_variable_state
+
+- name: state must be changed
+  assert:
+    that:
+      - gitlab_project_variable_state is changed
+
+- name: change masked attribute
+  gitlab_project_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    project: "{{ gitlab_project_name }}"
+    vars:
+      ACCESS_KEY_ID:
+        value: checkmode
+        masked: True
+  register: gitlab_project_variable_state
+
+- name: state must be changed
+  assert:
+    that:
+      - gitlab_project_variable_state is changed
+
+- name: revert masked attribute by not mention it
+  gitlab_project_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    project: "{{ gitlab_project_name }}"
+    vars:
+      ACCESS_KEY_ID:
+        value: checkmode
+  register: gitlab_project_variable_state
+
+- name: state must be changed
+  assert:
+    that:
+      - gitlab_project_variable_state is changed
+
+- name: set both (masked and protected) attribute
+  gitlab_project_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    project: "{{ gitlab_project_name }}"
+    vars:
+      ACCESS_KEY_ID:
+        value: checkmode
+        masked: True
+        protected: True
+  register: gitlab_project_variable_state
+
+- name: state must be changed
+  assert:
+    that:
+      - gitlab_project_variable_state is changed
+
+- name: revert both (masked and protected) attribute
+  gitlab_project_variable:
+    api_url: "{{ gitlab_host }}"
+    api_token: "{{ gitlab_login_token }}"
+    project: "{{ gitlab_project_name }}"
+    vars:
+      ACCESS_KEY_ID:
+        value: checkmode
+        protected: False
+  register: gitlab_project_variable_state
+
+- name: state must be changed
+  assert:
+    that:
+      - gitlab_project_variable_state is changed
+
 - name: change a variable value in check_mode again
   gitlab_project_variable:
     api_url: "{{ gitlab_host }}"


### PR DESCRIPTION
##### SUMMARY

fix issue #66135 

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

gitlab_project_variable

##### ADDITIONAL INFORMATION

The gitlab python sdk doesn't support update the attribute of values itself.  
Therefore, the `update_variable()` method will compare, next to the value itself, also the attributes.  
When any change is detected, it deletes the value and recreates it with the requested attributes.

Integrationtest is also appended and passes.  
To break not backwards compatibility, the vars can be a string (as before) or a dictionary (with the keys value, masked and protected).

```yml
- name: Set or update some CI/CD variables
  gitlab_project_variable:
    api_url: https://gitlab.com
    api_token: secret_access_token
    project: markuman/dotfiles
    purge: false
    vars:
      ACCESS_KEY_ID: abc123
      SECRET_ACCESS_KEY:
        value: 321cba
        masked: true
        protected: false
```
