### PR TITLE
Fix KeyError for iSCSI parameters

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vm.py
@@ -2207,13 +2207,13 @@ def _get_lun_mappings(module):
                             ['iscsi', 'fcp']) else None,
                         logical_units=[
                             otypes.LogicalUnit(
-                                id=lunMapping['dest_logical_unit_id'],
-                                port=lunMapping['dest_logical_unit_port'],
-                                portal=lunMapping['dest_logical_unit_portal'],
-                                address=lunMapping['dest_logical_unit_address'],
-                                target=lunMapping['dest_logical_unit_target'],
-                                password=lunMapping['dest_logical_unit_password'],
-                                username=lunMapping['dest_logical_unit_username'],
+                                id=lunMapping.get('dest_logical_unit_id'),
+                                port=lunMapping.get('dest_logical_unit_port'),
+                                portal=lunMapping.get('dest_logical_unit_portal'),
+                                address=lunMapping.get('dest_logical_unit_address'),
+                                target=lunMapping.get('dest_logical_unit_target'),
+                                password=lunMapping.get('dest_logical_unit_password'),
+                                username=lunMapping.get('dest_logical_unit_username'),
                             )
                         ],
                     ),


### PR DESCRIPTION
#### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The required parameters for the LUN mapping for destination LUN is
address, port and iqn. However if the user doesn't pass parameters
like  CHAP authentication parameters, we will get KeyError. The patch
fixes the same.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ovirt_vm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
