### PR TITLE
postgresql_info: add subscription info

### DIFF
--- a/changelogs/fragments/67464-postgresql_info_add_collecting_subscription_info.yml
+++ b/changelogs/fragments/67464-postgresql_info_add_collecting_subscription_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_info - add collection info about replication subscriptions (https://github.com/ansible/ansible/pull/67464).

--- a/test/integration/targets/postgresql_info/aliases
+++ b/test/integration/targets/postgresql_info/aliases
@@ -1,4 +1,9 @@
 destructive
-shippable/posix/group4
+shippable/posix/group1
 skip/aix
 skip/osx
+skip/centos
+skip/freebsd
+skip/rhel
+skip/opensuse
+skip/fedora

--- a/test/integration/targets/postgresql_info/defaults/main.yml
+++ b/test/integration/targets/postgresql_info/defaults/main.yml
@@ -1,2 +1,15 @@
 ---
+pg_user: postgres
 db_default: postgres
+master_port: 5433
+replica_port: 5434
+
+test_table1: acme1
+test_pub: first_publication
+test_pub2: second_publication
+replication_role: logical_replication
+replication_pass: alsdjfKJKDf1#
+test_db: acme_db
+test_subscription: test
+test_subscription2: test2
+conn_timeout: 100

--- a/test/integration/targets/postgresql_info/meta/main.yml
+++ b/test/integration/targets/postgresql_info/meta/main.yml
@@ -1,2 +1,2 @@
 dependencies:
-  - setup_postgresql_db
+  - setup_postgresql_replication

--- a/test/integration/targets/postgresql_info/tasks/main.yml
+++ b/test/integration/targets/postgresql_info/tasks/main.yml
@@ -1,2 +1,7 @@
+# For testing getting publication and subscription info
+- import_tasks: setup_publication.yml
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version >= '18'
+
 # Initial CI tests of postgresql_info module
 - import_tasks: postgresql_info_initial.yml
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version >= '18'

--- a/test/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
+++ b/test/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
@@ -1,28 +1,67 @@
-# Test code for the postgresql_info module
-# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# Copyright: (c) 2020, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: postgresql_info - create role to check session_role
-  become_user: "{{ pg_user }}"
-  become: yes
-  postgresql_user:
-    db: "{{ db_default }}"
-    login_user: "{{ pg_user }}"
-    name: session_superuser
-    role_attr_flags: SUPERUSER
+- vars:
+    task_parameters: &task_parameters
+      become_user: '{{ pg_user }}'
+      become: yes
+      register: result
+    pg_parameters: &pg_parameters
+      login_user: '{{ pg_user }}'
+      login_db: '{{ db_default }}'
 
-- name: postgresql_info - test return values and session_role param
-  become_user: "{{ pg_user }}"
-  become: yes
-  postgresql_info:
-    db: "{{ db_default }}"
-    login_user: "{{ pg_user }}"
-    session_role: session_superuser
-  register: result
-  ignore_errors: yes
+  block:
 
-- assert:
-    that:
+  - name: Create test subscription
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription }}'
+      login_db: '{{ test_db }}'
+      state: present
+      publications: '{{ test_pub }}'
+      connparams:
+        host: 127.0.0.1
+        port: '{{ master_port }}'
+        user: '{{ replication_role }}'
+        password: '{{ replication_pass }}'
+        dbname: '{{ test_db }}'
+
+  - name: Create test subscription
+    <<: *task_parameters
+    postgresql_subscription:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      name: '{{ test_subscription2 }}'
+      login_db: '{{ test_db }}'
+      state: present
+      publications: '{{ test_pub2 }}'
+      connparams:
+        host: 127.0.0.1
+        port: '{{ master_port }}'
+        user: '{{ replication_role }}'
+        password: '{{ replication_pass }}'
+        dbname: '{{ test_db }}'
+
+  - name: postgresql_info - create role to check session_role
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      login_user: "{{ pg_user }}"
+      name: session_superuser
+      role_attr_flags: SUPERUSER
+
+  - name: postgresql_info - test return values and session_role param
+    <<: *task_parameters
+    postgresql_info:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      session_role: session_superuser
+
+  - assert:
+      that:
       - result.version != {}
       - result.databases.{{ db_default }}.collate
       - result.databases.{{ db_default }}.languages
@@ -31,21 +70,39 @@
       - result.settings
       - result.tablespaces
       - result.roles
+      - result.subscriptions.{{ test_db }}.{{ test_subscription }}
+      - result.subscriptions.{{ test_db }}.{{ test_subscription2 }}
 
-- name: postgresql_info - check filter param passed by list
-  become_user: "{{ pg_user }}"
-  become: yes
-  postgresql_info:
-    db: "{{ db_default }}"
-    login_user: "{{ pg_user }}"
-    filter:
-      - ver*
-      - rol*
-  register: result
-  ignore_errors: yes
+  - name: postgresql_info - check filter param passed by list
+    <<: *task_parameters
+    postgresql_info:
+      <<: *pg_parameters
+      login_port: '{{ replica_port }}'
+      filter:
+        - ver*
+        - rol*
+        - subscr*
 
-- assert:
-    that:
+  - assert:
+      that:
+      - result.version != {}
+      - result.roles
+      - result.subscriptions.{{ test_db }}.{{ test_subscription }} != {}
+      - result.subscriptions.{{ test_db }}.{{ test_subscription2 }} != {}
+      - result.databases == {}
+      - result.repl_slots == {}
+      - result.replications == {}
+      - result.settings == {}
+      - result.tablespaces == {}
+
+  - name: postgresql_info - check filter param passed by string
+    <<: *task_parameters
+    postgresql_info:
+      <<: *pg_parameters
+      filter: ver*,role*
+
+  - assert:
+      that:
       - result.version != {}
       - result.roles
       - result.databases == {}
@@ -54,55 +111,27 @@
       - result.settings == {}
       - result.tablespaces == {}
 
-- name: postgresql_info - check filter param passed by string
-  become_user: "{{ pg_user }}"
-  become: yes
-  postgresql_info:
-    db: "{{ db_default }}"
-    filter: ver*,role*
-    login_user: "{{ pg_user }}"
-  register: result
-  ignore_errors: yes
+  - name: postgresql_info - check filter param passed by string
+    <<: *task_parameters
+    postgresql_info:
+      <<: *pg_parameters
+      filter: ver*
 
-- assert:
-    that:
-      - result.version != {}
-      - result.roles
-      - result.databases == {}
-      - result.repl_slots == {}
-      - result.replications == {}
-      - result.settings == {}
-      - result.tablespaces == {}
-
-- name: postgresql_info - check filter param passed by string
-  become_user: "{{ pg_user }}"
-  become: yes
-  postgresql_info:
-    db: "{{ db_default }}"
-    filter: ver*
-    login_user: "{{ pg_user }}"
-  register: result
-  ignore_errors: yes
-
-- assert:
-    that:
+  - assert:
+      that:
       - result.version
       - result.roles == {}
 
-- name: postgresql_info - check excluding filter param passed by list
-  become_user: "{{ pg_user }}"
-  become: yes
-  postgresql_info:
-    db: "{{ db_default }}"
-    filter:
+  - name: postgresql_info - check excluding filter param passed by list
+    <<: *task_parameters
+    postgresql_info:
+      <<: *pg_parameters
+      filter:
       - "!ver*"
       - "!rol*"
-    login_user: "{{ pg_user }}"
-  register: result
-  ignore_errors: yes
 
-- assert:
-    that:
+  - assert:
+      that:
       - result.version == {}
       - result.roles == {}
       - result.databases

--- a/test/integration/targets/postgresql_info/tasks/setup_publication.yml
+++ b/test/integration/targets/postgresql_info/tasks/setup_publication.yml
@@ -1,0 +1,61 @@
+# Copyright: (c) 2019, Andrew Klychkov (@Andersson007) <aaklychkov@mail.ru>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Preparation for further tests of postgresql_subscription module.
+
+- vars:
+    task_parameters: &task_parameters
+      become_user: '{{ pg_user }}'
+      become: yes
+      register: result
+    pg_parameters: &pg_parameters
+      login_user: '{{ pg_user }}'
+      login_db: '{{ test_db }}'
+
+  block:
+  - name: Create test db
+    <<: *task_parameters
+    postgresql_db:
+      login_user: '{{ pg_user }}'
+      login_port: '{{ master_port }}'
+      maintenance_db: '{{ db_default }}'
+      name: '{{ test_db }}'
+
+  - name: Create test role
+    <<: *task_parameters
+    postgresql_user:
+      <<: *pg_parameters
+      login_port: '{{ master_port }}'
+      name: '{{ replication_role }}'
+      password: '{{ replication_pass }}'
+      role_attr_flags: LOGIN,REPLICATION
+
+  - name: Create test table
+    <<: *task_parameters
+    postgresql_table:
+      <<: *pg_parameters
+      login_port: '{{ master_port }}'
+      name: '{{ test_table1 }}'
+      columns:
+      - id int
+
+  - name: Master - dump schema
+    <<: *task_parameters
+    shell: pg_dumpall -p '{{ master_port }}' -s > /tmp/schema.sql
+
+  - name: Replicat restore schema
+    <<: *task_parameters
+    shell: psql -p '{{ replica_port }}' -f /tmp/schema.sql
+
+  - name: Create publication
+    <<: *task_parameters
+    postgresql_publication: 
+      <<: *pg_parameters
+      login_port: '{{ master_port }}'
+      name: '{{ test_pub }}'
+
+  - name: Create publication
+    <<: *task_parameters
+    postgresql_publication: 
+      <<: *pg_parameters
+      login_port: '{{ master_port }}'
+      name: '{{ test_pub2 }}'


### PR DESCRIPTION
##### SUMMARY
postgresql_info: add subscription info

```
    "subscriptions": {
        "acme_db": {
            "test": {
                "ownername": "postgres",
                "subconninfo": "host=127.0.0.1 port=5433 user=logical_replication password=alsdjfKJKDf1# dbname=acme_db",
                "subdbid": 16385,
                "subenabled": true,
                "subowner": 10,
                "subpublications": [
                    "first_publication"
                ],
                "subslotname": "test",
                "subsynccommit": "off"
            },
            "test2": {
                "ownername": "postgres",
                "subconninfo": "host=127.0.0.1 port=5433 user=logical_replication password=alsdjfKJKDf1# dbname=acme_db",
                "subdbid": 16385,
                "subenabled": true,
                "subowner": 10,
                "subpublications": [
                    "second_publication"
                ],
                "subslotname": "test2",
                "subsynccommit": "off"
            }
        }
    },
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/postgresql/postgresql_info.py```