### PR TITLE
parse_cli fix

### DIFF
--- a/lib/ansible/plugins/filter/network.py
+++ b/lib/ansible/plugins/filter/network.py
@@ -120,7 +120,7 @@ def parse_cli(output, tmpl):
                     block_started = True
 
                 elif match_end:
-                    if lines:
+                    if block_started:
                         lines.append(line)
                         blocks.append('\n'.join(lines))
                     block_started = False


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

It will end a block only if it has been started, avoiding multiple blocks creation.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
parse_cli

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
When using the `start_block` and `end_block` directives of parse_cli filter, if we have:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
  start
    value
  end
  end
```
the filter was reporting 2 blocks instead of only 1. With this fix it will report only the first one
