### PR TITLE
Zabbix: Reflect changed JSON structure than zabbix version 4.4 or more to zab…

### DIFF
--- a/changelogs/fragments/zabbix_user-mediatype-error.yml
+++ b/changelogs/fragments/zabbix_user-mediatype-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_user - Fixed an issue where module failed with zabbix 4.4 or above (see https://github.com/ansible/ansible/pull/67475)

--- a/test/integration/targets/zabbix_user/aliases
+++ b/test/integration/targets/zabbix_user/aliases
@@ -4,4 +4,3 @@ skip/osx
 skip/freebsd
 skip/rhel
 skip/aix
-disabled


### PR DESCRIPTION
##### SUMMARY
It changed structure(JSON) for mediatype from since version 4.4
Up until now value of `description key` was `mediatype['name']`, but since version 4.4 changed to `name key` from `description key`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_user

##### ADDITIONAL INFORMATION
tested on 3.0/3.2/3.4/4.0/4.2/4.4
