### PR TITLE
azure_rm_rg_info: fix KeyError: 'ansible_facts' (#66729)

### DIFF
--- a/changelogs/fragments/67479-fix-azure_rm_resourcegroup_facts.yaml
+++ b/changelogs/fragments/67479-fix-azure_rm_resourcegroup_facts.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- azure_rm_resourcegroup_facts - adds the ansible_facts as a sub map to fix the KeyError (https://github.com/ansible/ansible/issues/66727).

--- a/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup_info.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup_info.py
@@ -183,7 +183,9 @@ class AzureRMResourceGroupInfo(AzureRMModuleBase):
                 item['resources'] = self.list_by_rg(item['name'])
 
         if is_old_facts:
-            self.results['ansible_facts']['azure_resourcegroups'] = result
+            self.results['ansible_facts'] = dict(
+                azure_resourcegroups=result
+            )
         self.results['resourcegroups'] = result
 
         return self.results


### PR DESCRIPTION
Fix facts for using old azure_rm_resourcegroup_facts,

SUMMARY
Backport of #66729 to stable-2.9

Fixes #66727

Adds the ansible_facts as a sub map to fix the KeyError

ISSUE TYPE
Bugfix Pull Request
COMPONENT NAME
azure / azure_rm_resourcegroup_info

ADDITIONAL INFORMATION
None
