### PR TITLE
Specify lowercase only for Galaxy namespaces

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -339,7 +339,7 @@ Next, try using the local collection inside a playbook. For examples and more de
 Publishing collections
 ----------------------
 
-You can publish collections to Galaxy using the ``ansible-galaxy collection publish`` command or the Galaxy UI itself.
+You can publish collections to Galaxy using the ``ansible-galaxy collection publish`` command or the Galaxy UI itself. You need a namespace on Galaxy to upload your collection. See `Galaxy namespaces <https://galaxy.ansible.com/docs/contributing/namespaces.html#galaxy-namespaces>`_ on the Galaxy docsite for details.
 
 .. note:: Once you upload a version of a collection, you cannot delete or modify that version. Ensure that everything looks okay before you upload it.
 

--- a/lib/ansible/galaxy/data/collections_galaxy_meta.yml
+++ b/lib/ansible/galaxy/data/collections_galaxy_meta.yml
@@ -10,7 +10,7 @@
   description:
   - The namespace of the collection.
   - This can be a company/brand/organization or product namespace under which all content lives.
-  - May only contain alphanumeric characters and underscores. Additionally namespaces cannot start with underscores or
+  - May only contain alphanumeric lowercase characters and underscores. Namespaces cannot start with underscores or
     numbers and cannot contain consecutive underscores.
   required: yes
   type: str


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ansible docs need to specify that only  lowercase is allowed in Galaxy namespaces
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs.ansible.com
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
