### PR TITLE
Clarify b64encode with Python 2 (#67488) - 2.9

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1270,12 +1270,15 @@ To get the root and extension of a path or filename (new in version 2.0)::
 To work with Base64 encoded strings::
 
     {{ encoded | b64decode }}
-    {{ decoded | b64encode }}
+    {{ decoded | string | b64encode }}
 
 As of version 2.6, you can define the type of encoding to use, the default is ``utf-8``::
 
     {{ encoded | b64decode(encoding='utf-16-le') }}
-    {{ decoded | b64encode(encoding='utf-16-le') }}
+    {{ decoded | string | b64encode(encoding='utf-16-le') }}
+
+.. note:: The ``string`` filter is only required for Python 2 and ensures that text to encode is a unicode string.
+    Without that filter before b64encode the wrong value will be encoded.
 
 .. versionadded:: 2.6
 


### PR DESCRIPTION
(cherry picked from commit 423a900791d2cd2494a3407e4cfba62623e758cf)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/67488

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
playbooks_filters.rst