### PR TITLE
Fix inline vaults for plugins in ensure_type

### DIFF
--- a/changelogs/fragments/67492-fix-decrypting-str-types-for-plugins.yaml
+++ b/changelogs/fragments/67492-fix-decrypting-str-types-for-plugins.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - plugins - If the option's type was not defined in the plugin documentation the type is assumed to be a string
+    and is decrypted if it's a vault. This fixes decrypting values for options that define the type to be a string.

--- a/changelogs/fragments/67492-fix-decrypting-str-types-for-plugins.yaml
+++ b/changelogs/fragments/67492-fix-decrypting-str-types-for-plugins.yaml
@@ -1,3 +1,2 @@
 bugfixes:
-  - plugins - If the option's type was not defined in the plugin documentation the type is assumed to be a string
-    and is decrypted if it's a vault. This fixes decrypting values for options that define the type to be a string.
+  - plugins - Allow ensure_type to decrypt the value for string types (and implicit string types) when value is an inline vault.

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -151,7 +151,7 @@ def ensure_type(value, value_type, origin=None):
                 errmsg = 'string'
 
         # defaults to string type
-        elif isinstance(value, string_types):
+        elif isinstance(value, (string_types, AnsibleVaultEncryptedUnicode)):
             value = unquote(to_text(value, errors='surrogate_or_strict'))
 
         if errmsg:

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -145,7 +145,7 @@ def ensure_type(value, value_type, origin=None):
                 errmsg = 'pathlist'
 
         elif value_type in ('str', 'string'):
-            if isinstance(value, string_types):
+            if isinstance(value, (string_types, AnsibleVaultEncryptedUnicode)):
                 value = unquote(to_text(value, errors='surrogate_or_strict'))
             else:
                 errmsg = 'string'

--- a/test/units/config/test_manager.py
+++ b/test/units/config/test_manager.py
@@ -131,3 +131,15 @@ class TestConfigManager:
         actual_value, actual_origin = self.manager._loop_entries({'name': vault_var}, [{'name': 'name'}])
         assert actual_value == "vault text"
         assert actual_origin == "name"
+
+    @pytest.mark.parametrize("value_type", ("str", "string", None))
+    def test_ensure_type_with_vaulted_str(self, value_type):
+        class MockVault:
+            def decrypt(self, value):
+                return value
+
+        vault_var = AnsibleVaultEncryptedUnicode(b"vault text")
+        vault_var.vault = MockVault()
+
+        actual_value = ensure_type(vault_var, value_type)
+        assert actual_value == "vault text"


### PR DESCRIPTION
##### SUMMARY
~Inline vaults work for plugins if the type isn't defined by the documentation (added in #65023). Most plugins do define the type, so this allows defined string types to also decrypt the value rather than just implicit strings.~ Actually, that PR's change to ensure_type doesn't really seem related to vaults. Fixed both code paths and added tests for them.

Would allow #55385 to have a work-around
Addresses https://github.com/ansible/ansible/pull/60715#issuecomment-580409757

##### ISSUE TYPE
- Bugfix Pull Request
