### PR TITLE
Rebalance Windows groups for devel run

### DIFF
--- a/test/integration/targets/win_hosts/aliases
+++ b/test/integration/targets/win_hosts/aliases
@@ -1,1 +1,1 @@
-shippable/windows/group3
+shippable/windows/group7

--- a/test/integration/targets/win_package/aliases
+++ b/test/integration/targets/win_package/aliases
@@ -1,1 +1,1 @@
-shippable/windows/group7
+shippable/windows/group3


### PR DESCRIPTION
##### SUMMARY
The recent win_package changes added a lot more tests for Server 2019 which is reaching the time limit on the nightly run in Shippable. This swaps the win_package and win_hosts test groups as group 3 had a lot more time available.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test