### PR TITLE
better error for "ansible-galaxy collection verify" if there's no MANIFEST.json

### DIFF
--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -578,6 +578,10 @@ def verify_collections(collections, search_paths, apis, validate_certs, ignore_e
                             break
                     if local_collection is None:
                         raise AnsibleError(message='Collection %s is not installed in any of the collection paths.' % collection_name)
+                    if local_collection.latest_version == '*':
+                        msg = 'Collection %s does not appear to have the MANIFEST.json. ' % collection_name
+                        msg += 'A MANIFEST.json is expected if the collection has been built and installed via ansible-galaxy.'
+                        raise AnsibleError(message=msg)
 
                     # Download collection on a galaxy server for comparison
                     try:

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -574,14 +574,15 @@ def verify_collections(collections, search_paths, apis, validate_certs, ignore_e
                     for search_path in search_paths:
                         b_search_path = to_bytes(os.path.join(search_path, namespace, name), errors='surrogate_or_strict')
                         if os.path.isdir(b_search_path):
+                            if not os.path.isfile(os.path.join(to_text(b_search_path), 'MANIFEST.json')):
+                                raise AnsibleError(
+                                    message="Collection %s does not appear to have a MANIFEST.json. " % collection_name +
+                                            "A MANIFEST.json is expected if the collection has been built and installed via ansible-galaxy."
+                                )
                             local_collection = CollectionRequirement.from_path(b_search_path, False)
                             break
                     if local_collection is None:
                         raise AnsibleError(message='Collection %s is not installed in any of the collection paths.' % collection_name)
-                    if local_collection.latest_version == '*':
-                        msg = 'Collection %s does not appear to have the MANIFEST.json. ' % collection_name
-                        msg += 'A MANIFEST.json is expected if the collection has been built and installed via ansible-galaxy.'
-                        raise AnsibleError(message=msg)
 
                     # Download collection on a galaxy server for comparison
                     try:

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -574,7 +574,7 @@ def verify_collections(collections, search_paths, apis, validate_certs, ignore_e
                     for search_path in search_paths:
                         b_search_path = to_bytes(os.path.join(search_path, namespace, name), errors='surrogate_or_strict')
                         if os.path.isdir(b_search_path):
-                            if not os.path.isfile(os.path.join(to_text(b_search_path), 'MANIFEST.json')):
+                            if not os.path.isfile(os.path.join(to_text(b_search_path, errors='surrogate_or_strict'), 'MANIFEST.json')):
                                 raise AnsibleError(
                                     message="Collection %s does not appear to have a MANIFEST.json. " % collection_name +
                                             "A MANIFEST.json is expected if the collection has been built and installed via ansible-galaxy."

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -1146,7 +1146,7 @@ def test_verify_collections_no_version(mock_isdir, mock_collection, monkeypatch)
     with pytest.raises(AnsibleError) as err:
         collection.verify_collections(collections, './', local_collection.api, False, False)
 
-    err_msg = 'Collection %s.%s does not appear to have the MANIFEST.json. ' % (namespace, name)
+    err_msg = 'Collection %s.%s does not appear to have a MANIFEST.json. ' % (namespace, name)
     err_msg += 'A MANIFEST.json is expected if the collection has been built and installed via ansible-galaxy.'
     assert err.value.message == err_msg
 
@@ -1210,6 +1210,7 @@ def test_verify_collections_no_remote(mock_verify, mock_isdir, mock_collection, 
     name = 'collection'
     version = '1.0.0'
 
+    monkeypatch.setattr(os.path, 'isfile', MagicMock(side_effect=[False, True]))
     monkeypatch.setattr(collection.CollectionRequirement, 'from_path', MagicMock(return_value=mock_collection()))
 
     collections = [('%s.%s' % (namespace, name), version, None)]
@@ -1231,6 +1232,7 @@ def test_verify_collections_no_remote_ignore_errors(mock_verify, mock_isdir, moc
     name = 'collection'
     version = '1.0.0'
 
+    monkeypatch.setattr(os.path, 'isfile', MagicMock(side_effect=[False, True]))
     monkeypatch.setattr(collection.CollectionRequirement, 'from_path', MagicMock(return_value=mock_collection()))
 
     collections = [('%s.%s' % (namespace, name), version, None)]
@@ -1291,12 +1293,13 @@ def test_verify_collections_url(monkeypatch):
     assert err.value.message == msg
 
 
-@patch.object(os.path, 'isfile', return_value=False)
 @patch.object(os.path, 'isdir', return_value=True)
 @patch.object(collection.CollectionRequirement, 'verify')
-def test_verify_collections_name(mock_verify, mock_isdir, mock_isfile, mock_collection, monkeypatch):
+def test_verify_collections_name(mock_verify, mock_isdir, mock_collection, monkeypatch):
     local_collection = mock_collection()
     monkeypatch.setattr(collection.CollectionRequirement, 'from_path', MagicMock(return_value=local_collection))
+
+    monkeypatch.setattr(os.path, 'isfile', MagicMock(side_effect=[False, True, False]))
 
     located_remote_from_name = MagicMock(return_value=mock_collection(local=False))
     monkeypatch.setattr(collection.CollectionRequirement, 'from_name', located_remote_from_name)

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -1186,10 +1186,12 @@ def test_verify_collections_not_installed_ignore_errors(mock_verify, mock_collec
 
 @patch.object(os.path, 'isdir', return_value=True)
 @patch.object(collection.CollectionRequirement, 'verify')
-def test_verify_collections_no_remote(mock_verify, mock_isdir, mock_collection):
+def test_verify_collections_no_remote(mock_verify, mock_isdir, mock_collection, monkeypatch):
     namespace = 'ansible_namespace'
     name = 'collection'
     version = '1.0.0'
+
+    monkeypatch.setattr(collection.CollectionRequirement, 'from_path', MagicMock(return_value=mock_collection()))
 
     collections = [('%s.%s' % (namespace, name), version, None)]
     search_path = './'
@@ -1205,12 +1207,12 @@ def test_verify_collections_no_remote(mock_verify, mock_isdir, mock_collection):
 
 @patch.object(os.path, 'isdir', return_value=True)
 @patch.object(collection.CollectionRequirement, 'verify')
-def test_verify_collections_no_remote_ignore_errors(mock_verify, mock_isdir, mock_collection):
+def test_verify_collections_no_remote_ignore_errors(mock_verify, mock_isdir, mock_collection, monkeypatch):
     namespace = 'ansible_namespace'
     name = 'collection'
     version = '1.0.0'
 
-    local_collection = mock_collection(local_installed=False)
+    monkeypatch.setattr(collection.CollectionRequirement, 'from_path', MagicMock(return_value=mock_collection()))
 
     collections = [('%s.%s' % (namespace, name), version, None)]
     search_path = './'


### PR DESCRIPTION
##### SUMMARY
The MANIFEST.json may have been deleted from the installed collection or the collection may not have been installed via normal means

The error message is misleading right now (e.g. `openstack.cloud has the version '*' but is being compared to '1.0.0'`) since an installed collection could never have an undefined version. Built collections do not have a galaxy.yml for finding the version and only built collections should be install-able for verification against a server.

##### ISSUE TYPE
- Bugfix Pull Request
