### PR TITLE
updated single quote handling to not strip and error on odd number

### DIFF
--- a/changelogs/fragments/67500-fix-edgeos-config-single-quote-stripping.yaml
+++ b/changelogs/fragments/67500-fix-edgeos-config-single-quote-stripping.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - edgeos_config - fixed issue of handling single quotation marks. Now fails when unmatched (odd numbers)

--- a/test/units/modules/network/edgeos/fixtures/edgeos_config_config.cfg
+++ b/test/units/modules/network/edgeos/fixtures/edgeos_config_config.cfg
@@ -1,10 +1,10 @@
 set system host-name 'router'
 set system domain-name 'acme.com'
 set system domain-search domain 'acme.com'
-set system name-server '208.67.220.220'
-set system name-server '208.67.222.222'
-set interfaces ethernet eth0 address '1.2.3.4/24'
+set system name-server 208.67.220.220
+set system name-server 208.67.222.222
+set interfaces ethernet eth0 address 1.2.3.4/24
 set interfaces ethernet eth0 description 'Outside'
-set interfaces ethernet eth1 address '10.77.88.1/24'
+set interfaces ethernet eth1 address 10.77.88.1/24
 set interfaces ethernet eth1 description 'Inside'
 set interfaces ethernet eth1 disable

--- a/test/units/modules/network/edgeos/fixtures/edgeos_config_src.cfg
+++ b/test/units/modules/network/edgeos/fixtures/edgeos_config_src.cfg
@@ -1,5 +1,5 @@
 set system host-name er01
 delete interfaces ethernet eth0 address
-set interfaces ethernet eth1 address '10.77.88.1/24'
+set interfaces ethernet eth1 address 10.77.88.1/24
 set interfaces ethernet eth1 description 'Inside'
 set interfaces ethernet eth1 disable

--- a/test/units/modules/network/edgeos/fixtures/edgeos_config_src_brackets.cfg
+++ b/test/units/modules/network/edgeos/fixtures/edgeos_config_src_brackets.cfg
@@ -4,7 +4,7 @@ interfaces {
     }
     ethernet eth1 {
         address 10.77.88.1/24
-        description Inside
+        description 'Inside'
         disable
     }
 }

--- a/test/units/modules/network/edgeos/test_edgeos_config.py
+++ b/test/units/modules/network/edgeos/test_edgeos_config.py
@@ -92,3 +92,14 @@ class TestEdgeosConfigModule(TestEdgeosModule):
                  'set system interfaces ethernet eth0 description Outside']
         set_module_args(dict(lines=lines, match='none'))
         self.execute_module(changed=True, commands=lines, sort=False)
+
+    def test_edgeos_config_single_quote_wrapped_values(self):
+        lines = ["set system interfaces ethernet eth0 description 'tests single quotes'"]
+        set_module_args(dict(lines=lines))
+        commands = ["set system interfaces ethernet eth0 description 'tests single quotes'"]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_edgeos_config_single_quote_wrapped_values_failure(self):
+        lines = ["set system interfaces ethernet eth0 description 'test's single quotes'"]
+        set_module_args(dict(lines=lines))
+        self.execute_module(failed=True)


### PR DESCRIPTION
##### SUMMARY
Fixes #67274

Updated the edgeos_config module to no longer strip single quote marks. Now errors on odd numbers of them which has the potential to hang Ansible operation waiting on input. Otherwise can now validly use to wrap values. If using an even number of single quotes it will pass onto the Edgerouter device which will error device side with `The specified configuration node is not valid`.  

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
edgeos_config