### PR TITLE
Add warning when running devel

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -88,7 +88,7 @@ Which Ansible version to install is based on your particular needs. You can choo
 
 .. note::
 
-	You should only run Ansible from ``devel`` if you are actively developing content for Ansible. This is a rapidly changing source of code and can become unstable at any point.
+	You should only run Ansible from ``devel`` if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
 
 
 Ansible creates new releases two to three times a year. Due to this short release cycle,
@@ -363,7 +363,7 @@ Running Ansible from source (devel)
 
 .. note::
 
-	You should only run Ansible from ``devel`` if you are actively developing content for Ansible. This is a rapidly changing source of code and can become unstable at any point.
+	You should only run Ansible from ``devel`` if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
 
 Ansible is easy to run from source. You do not need ``root`` permissions
 to use it and there is no software to actually install. No daemons

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -70,6 +70,13 @@ class CLI(with_metaclass(ABCMeta, object)):
         self.parser = None
         self.callback = callback
 
+        if __version__.endswith('dev0'):
+            display.warning(
+                'You are running the development version of Ansible. You should only run Ansible from "devel" if '
+                'you are actively developing content for Ansible. This is a rapidly changing source of code and can '
+                'become unstable at any point.'
+            )
+
     @abstractmethod
     def run(self):
         """Run the ansible command

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -70,7 +70,7 @@ class CLI(with_metaclass(ABCMeta, object)):
         self.parser = None
         self.callback = callback
 
-        if __version__.endswith('dev0'):
+        if C.DEVEL_WARNING and __version__.endswith('dev0'):
             display.warning(
                 'You are running the development version of Ansible. You should only run Ansible from "devel" if '
                 'you are actively developing content for Ansible. This is a rapidly changing source of code and can '

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -73,8 +73,8 @@ class CLI(with_metaclass(ABCMeta, object)):
         if C.DEVEL_WARNING and __version__.endswith('dev0'):
             display.warning(
                 'You are running the development version of Ansible. You should only run Ansible from "devel" if '
-                'you are actively developing content for Ansible. This is a rapidly changing source of code and can '
-                'become unstable at any point.'
+                'you are modifying the Ansible engine, or trying out features under development. This is a rapidly '
+                'changing source of code and can become unstable at any point.'
             )
 
     @abstractmethod

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1227,6 +1227,14 @@ DEPRECATION_WARNINGS:
   ini:
   - {key: deprecation_warnings, section: defaults}
   type: boolean
+DEVEL_WARNING:
+  nane: Running devel warning
+  default: True
+  description: Toggle to control showing warnings related to running devel
+  env: [{name: ANSIBLE_DEVEL_WARNING}]
+  ini:
+  - {key: devel_warning, section: defaults}
+  type: boolean
 DIFF_ALWAYS:
   name: Show differences
   default: False

--- a/test/lib/ansible_test/_internal/ansible_util.py
+++ b/test/lib/ansible_test/_internal/ansible_util.py
@@ -71,6 +71,7 @@ def ansible_environment(args, color=True, ansible_config=None):
         ANSIBLE_RETRY_FILES_ENABLED='false',
         ANSIBLE_CONFIG=ansible_config,
         ANSIBLE_LIBRARY='/dev/null',
+        ANSIBLE_DEVEL_WARNING='false',  # Don't show warnings that CI is running devel
         PYTHONPATH=get_ansible_python_path(),
         PAGER='/bin/cat',
         PATH=path,


### PR DESCRIPTION
##### SUMMARY
Add warning when running devel

Copy taken from https://github.com/ansible/ansible/pull/67483

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
```
lib/ansible/cli/__init__.py
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
