### PR TITLE
Win tests - prepare for collection migration in tests

### DIFF
--- a/test/integration/targets/win_package/tasks/msix_tests.yml
+++ b/test/integration/targets/win_package/tasks/msix_tests.yml
@@ -14,9 +14,7 @@
     dest: '{{ test_path }}\makeappx.zip'
 
 - name: extract makeappx binaries
-  win_unzip:
-    src: '{{ test_path }}\makeappx.zip'
-    dest: '{{ test_path }}\makeappx'
+  win_shell: Expand-Archive -LiteralPath '{{ test_path }}\makeappx.zip' -DestinationPath '{{ test_path }}\makeappx'
 
 - name: setup MSIX packages
   win_make_appx:

--- a/test/integration/targets/win_reg_stat/tasks/main.yml
+++ b/test/integration/targets/win_reg_stat/tasks/main.yml
@@ -9,8 +9,7 @@
     dest: '{{ win_output_dir }}\test_reg.reg'
 
 - name: import test registry structure
-  win_regmerge:
-    path: '{{ win_output_dir }}\test_reg.reg'
+  win_command: reg.exe import "{{ win_output_dir }}\test_reg.reg"
 
 - block:
   - name: run tests


### PR DESCRIPTION
##### SUMMARY
The `win_package` test relied on `win_unzip` and `win_reg_stat` relied on `win_regmerge`. This PR removes that reliance so the "core" windows collection will not rely on the "community" collection when it is migrated out.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test