### PR TITLE
[2.9] vultr: Fix retry max delay param ignored (#67437)

### DIFF
--- a/changelogs/fragments/67437-vultr-fix-retry-max-delay-param.yml
+++ b/changelogs/fragments/67437-vultr-fix-retry-max-delay-param.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vultr - Fixed the issue retry max delay param was ignored.

--- a/lib/ansible/module_utils/vultr.py
+++ b/lib/ansible/module_utils/vultr.py
@@ -61,7 +61,7 @@ class Vultr:
                 'api_key': self.module.params.get('api_key') or config.get('key'),
                 'api_timeout': self.module.params.get('api_timeout') or int(config.get('timeout') or 60),
                 'api_retries': self.module.params.get('api_retries') or int(config.get('retries') or 5),
-                'api_retry_max_delay': self.module.params.get('api_retries') or int(config.get('retry_max_delay') or 12),
+                'api_retry_max_delay': self.module.params.get('api_retry_max_delay') or int(config.get('retry_max_delay') or 12),
                 'api_endpoint': self.module.params.get('api_endpoint') or config.get('endpoint') or VULTR_API_ENDPOINT,
             }
         except ValueError as e:


### PR DESCRIPTION
##### SUMMARY
* vultr: Fix retry max delay param not taken

* add changelog

Backport of https://github.com/ansible/ansible/pull/67437

(cherry picked from commit bcd145c111095e7fce620676921fbc796765ff4e)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
vultr

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
