### PR TITLE
[2.9] VMware: vmware_export_ovf module fix Python3 compatibility issue

### DIFF
--- a/changelogs/fragments/60265-vmware_export_ovf-py3fix.yml
+++ b/changelogs/fragments/60265-vmware_export_ovf-py3fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix Python3 compatibility for vmware_export_ovf module.

--- a/test/integration/targets/vmware_export_ovf/aliases
+++ b/test/integration/targets/vmware_export_ovf/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+shippable/vcenter/group1
+needs/target/prepare_vmware_tests

--- a/test/integration/targets/vmware_export_ovf/tasks/main.yml
+++ b/test/integration/targets/vmware_export_ovf/tasks/main.yml
@@ -1,0 +1,69 @@
+# Test code for the vmware_export_ovf module
+# Copyright: (c) 2019, Diane Wang (Tomorrow9) <dianew@vmware.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- when: vcsim is not defined
+  block:
+  - name: create temporary build directory
+    tempfile:
+      state: directory
+      suffix: build
+    register: temp_dir
+  - debug: var=temp_dir
+
+  - import_role:
+      name: prepare_vmware_tests
+    vars:
+      setup_attach_host: true
+      setup_datastore: true
+      setup_virtualmachines: true
+
+  - name: set state to poweroff on the tested VM
+    vmware_guest:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      name: "{{ virtual_machines_in_cluster[0].name }}"
+      state: poweredoff
+
+  - name: export VM to ovf template
+    vmware_export_ovf:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      name: "{{ virtual_machines_in_cluster[0].name }}"
+      datacenter: "{{ dc1 }}"
+      export_dir: "{{ temp_dir.path }}"
+    register: ovf_template
+  - debug: var=ovf_template
+  - name: assert the ovf template exported
+    assert:
+      that:
+        - "ovf_template.changed == true"
+        - "ovf_template.instance.device_files | length >= 1"
+
+  - name: export VM to ovf template with timeout set
+    vmware_export_ovf:
+      validate_certs: False
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      name: "{{ virtual_machines_in_cluster[0].name }}"
+      datacenter: "{{ dc1 }}"
+      export_dir: "{{ temp_dir.path }}"
+      download_timeout: 30
+    register: ovf_template
+  - debug: var=ovf_template
+  - name: assert the ovf template exported
+    assert:
+      that:
+        - "ovf_template.changed == true"
+        - "ovf_template.instance.device_files | length >= 1"
+  rescue:
+  - name: Clean up the temporary dir
+    file:
+      path: "{{ temp_dir.path }}"
+      state: absent
+    when: temp_dir.path is defined


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/60265

(cherry picked from commit 023a9b31661febdff3fb7650b27ba65278971549)


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/60265-vmware_export_ovf-py3fix.yml
lib/ansible/modules/cloud/vmware/vmware_export_ovf.py
test/integration/targets/vmware_export_ovf/aliases
test/integration/targets/vmware_export_ovf/tasks/main.yml
