### PR TITLE
[2.9] openssl_* modules: prevent crash on fingerprint determination in FIPS mode

### DIFF
--- a/changelogs/fragments/67515-openssl-fingerprint-fips.yml
+++ b/changelogs/fragments/67515-openssl-fingerprint-fips.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "openssl_* modules - prevent crash on fingerprint determination in FIPS mode (https://github.com/ansible/ansible/issues/67213)."

--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -154,7 +154,12 @@ def get_fingerprint_of_bytes(source):
 
     for algo in algorithms:
         f = getattr(hashlib, algo)
-        h = f(source)
+        try:
+            h = f(source)
+        except ValueError:
+            # This can happen for hash algorithms not supported in FIPS mode
+            # (https://github.com/ansible/ansible/issues/67213)
+            continue
         try:
             # Certain hash functions have a hexdigest() which expects a length parameter
             pubkey_digest = h.hexdigest()


### PR DESCRIPTION
##### SUMMARY
Backport of #67515 to stable-2.9.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_certificate_info
openssl_csr_info
openssl_privatekey
openssl_privatekey_info
openssl_publickey
