### PR TITLE
[2.8] postgresql_info module: fix broken link

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_info.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_info.py
@@ -248,7 +248,7 @@ databases:
 repl_slots:
   description:
   - Replication slots (available in 9.4 and later)
-    U(https://www.postgresql.org/docs/current/catalog-pg-replication-slots.html).
+    U(https://www.postgresql.org/docs/current/view-pg-replication-slots.html).
   returned: if existent
   type: dict
   sample: { "slot0": { "active": false, "database": null, "plugin": null, "slot_type": "physical" } }


### PR DESCRIPTION
(cherry picked from commit 5a7c58b2be903988175773a4ddcf76010027b47b)

##### SUMMARY
Backport of postgresql_info module: fix broken link (#67517)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/postgresql/postgresql_info.py```
