### PR TITLE
67534 - synchronize module uses sshpass when local

### DIFF
--- a/changelogs/fragments/67534-synchronize-uses-sshpass-when-local.yaml
+++ b/changelogs/fragments/67534-synchronize-uses-sshpass-when-local.yaml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - synchronize - ansible_password or ansible_ssh_pass trigger an SSH connection for rsync even when both source and dest are local paths and the connection is local
+  - synchronize - ansible_password or ansible_ssh_pass trigger the use of sshpass for rsync even when both source and dest are local paths and the connection is local
 ...

--- a/changelogs/fragments/67534-synchronize-uses-sshpass-when-local.yaml
+++ b/changelogs/fragments/67534-synchronize-uses-sshpass-when-local.yaml
@@ -1,4 +1,2 @@
----
 bugfixes:
   - synchronize - ansible_password or ansible_ssh_pass trigger the use of sshpass for rsync even when both source and dest are local paths and the connection is local
-...

--- a/changelogs/fragments/67534-synchronize-uses-sshpass-when-local.yaml
+++ b/changelogs/fragments/67534-synchronize-uses-sshpass-when-local.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - synchronize - ansible_password or ansible_ssh_pass trigger an SSH connection for rsync even when both source and dest are local paths and the connection is local
+...

--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -448,6 +448,8 @@ def main():
     verify_host = module.params['verify_host']
     link_dest = module.params['link_dest']
 
+    if ':' not in source + dest:
+        rsync_password = None
     if '/' not in rsync:
         rsync = module.get_bin_path(rsync, required=True)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #67534 

Adding a simple check for the presence of a colon and resetting `rsync_password` when one is detected.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`synchronize`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
