### PR TITLE
openssl_* / x509_* modules: refactoring

### DIFF
--- a/lib/ansible/modules/crypto/openssl_certificate_info.py
+++ b/lib/ansible/modules/crypto/openssl_certificate_info.py
@@ -348,31 +348,6 @@ else:
 TIMESTAMP_FORMAT = "%Y%m%d%H%M%SZ"
 
 
-def get_relative_time_option(input_string, input_name):
-    """Return an ASN1 formatted string if a relative timespec
-       or an ASN1 formatted string is provided."""
-    result = input_string
-    if result.startswith("+") or result.startswith("-"):
-        return crypto_utils.convert_relative_to_datetime(result)
-    if result is None:
-        raise crypto_utils.OpenSSLObjectError(
-            'The timespec "%s" for %s is not valid' %
-            input_string, input_name)
-    for date_fmt in ['%Y%m%d%H%M%SZ', '%Y%m%d%H%MZ', '%Y%m%d%H%M%S%z', '%Y%m%d%H%M%z']:
-        try:
-            result = datetime.datetime.strptime(input_string, date_fmt)
-            break
-        except ValueError:
-            pass
-
-    if not isinstance(result, datetime.datetime):
-        raise crypto_utils.OpenSSLObjectError(
-            'The time spec "%s" for %s is invalid' %
-            (input_string, input_name)
-        )
-    return result
-
-
 class CertificateInfo(crypto_utils.OpenSSLObject):
     def __init__(self, module, backend):
         super(CertificateInfo, self).__init__(
@@ -394,7 +369,7 @@ class CertificateInfo(crypto_utils.OpenSSLObject):
                     self.module.fail_json(
                         msg='The value for valid_at.{0} must be of type string (got {1})'.format(k, type(v))
                     )
-                self.valid_at[k] = get_relative_time_option(v, 'valid_at.{0}'.format(k))
+                self.valid_at[k] = crypto_utils.get_relative_time_option(v, 'valid_at.{0}'.format(k))
 
     def generate(self):
         # Empty method because crypto_utils.OpenSSLObject wants this

--- a/lib/ansible/modules/crypto/x509_crl.py
+++ b/lib/ansible/modules/crypto/x509_crl.py
@@ -369,25 +369,8 @@ try:
         RevokedCertificateBuilder,
         NameAttribute,
         Name,
-        ReasonFlags,
     )
     CRYPTOGRAPHY_VERSION = LooseVersion(cryptography.__version__)
-
-    REASON_MAP = {
-        'unspecified': ReasonFlags.unspecified,
-        'key_compromise': ReasonFlags.key_compromise,
-        'ca_compromise': ReasonFlags.ca_compromise,
-        'affiliation_changed': ReasonFlags.affiliation_changed,
-        'superseded': ReasonFlags.superseded,
-        'cessation_of_operation': ReasonFlags.cessation_of_operation,
-        'certificate_hold': ReasonFlags.certificate_hold,
-        'privilege_withdrawn': ReasonFlags.privilege_withdrawn,
-        'aa_compromise': ReasonFlags.aa_compromise,
-        'remove_from_crl': ReasonFlags.remove_from_crl,
-    }
-    REASON_MAP_INVERSE = dict()
-    for k, v in REASON_MAP.items():
-        REASON_MAP_INVERSE[v] = k
 except ImportError:
     CRYPTOGRAPHY_IMP_ERR = traceback.format_exc()
     CRYPTOGRAPHY_FOUND = False
@@ -499,7 +482,7 @@ class CRL(crypto_utils.OpenSSLObject):
                 path_prefix + 'revocation_date'
             )
             if rc['reason']:
-                result['reason'] = REASON_MAP[rc['reason']]
+                result['reason'] = crypto_utils.REVOCATION_REASON_MAP[rc['reason']]
                 result['reason_critical'] = rc['reason_critical']
             if rc['invalidity_date']:
                 result['invalidity_date'] = self.get_relative_time_option(
@@ -563,37 +546,6 @@ class CRL(crypto_utils.OpenSSLObject):
                 entry['invalidity_date_critical'],
             )
 
-    def _decode_revoked(self, cert):
-        result = {
-            'serial_number': cert.serial_number,
-            'revocation_date': cert.revocation_date,
-            'issuer': None,
-            'issuer_critical': False,
-            'reason': None,
-            'reason_critical': False,
-            'invalidity_date': None,
-            'invalidity_date_critical': False,
-        }
-        try:
-            ext = cert.extensions.get_extension_for_class(x509.CertificateIssuer)
-            result['issuer'] = list(ext.value)
-            result['issuer_critical'] = ext.critical
-        except x509.ExtensionNotFound:
-            pass
-        try:
-            ext = cert.extensions.get_extension_for_class(x509.CRLReason)
-            result['reason'] = ext.value.reason
-            result['reason_critical'] = ext.critical
-        except x509.ExtensionNotFound:
-            pass
-        try:
-            ext = cert.extensions.get_extension_for_class(x509.InvalidityDate)
-            result['invalidity_date'] = ext.value.invalidity_date
-            result['invalidity_date_critical'] = ext.critical
-        except x509.ExtensionNotFound:
-            pass
-        return result
-
     def check(self, perms_required=True):
         """Ensure the resource is in its desired state."""
 
@@ -616,7 +568,7 @@ class CRL(crypto_utils.OpenSSLObject):
         if want_issuer != [(sub.oid, sub.value) for sub in self.crl.issuer]:
             return False
 
-        old_entries = [self._compress_entry(self._decode_revoked(cert)) for cert in self.crl]
+        old_entries = [self._compress_entry(crypto_utils.cryptography_decode_revoked_certificate(cert)) for cert in self.crl]
         new_entries = [self._compress_entry(cert) for cert in self.revoked_certificates]
         if self.update:
             # We don't simply use a set so that duplicate entries are treated correctly
@@ -649,7 +601,7 @@ class CRL(crypto_utils.OpenSSLObject):
         if self.update and self.crl:
             new_entries = set([self._compress_entry(entry) for entry in self.revoked_certificates])
             for entry in self.crl:
-                decoded_entry = self._compress_entry(self._decode_revoked(entry))
+                decoded_entry = self._compress_entry(crypto_utils.cryptography_decode_revoked_certificate(entry))
                 if decoded_entry not in new_entries:
                     crl = crl.add_revoked_certificate(entry)
         for entry in self.revoked_certificates:
@@ -700,7 +652,7 @@ class CRL(crypto_utils.OpenSSLObject):
                 [crypto_utils.cryptography_decode_name(issuer) for issuer in entry['issuer']]
                 if entry['issuer'] is not None else None,
             'issuer_critical': entry['issuer_critical'],
-            'reason': REASON_MAP_INVERSE.get(entry['reason']) if entry['reason'] is not None else None,
+            'reason': crypto_utils.REVOCATION_REASON_MAP_INVERSE.get(entry['reason']) if entry['reason'] is not None else None,
             'reason_critical': entry['reason_critical'],
             'invalidity_date':
                 entry['invalidity_date'].strftime(TIMESTAMP_FORMAT)
@@ -758,7 +710,7 @@ class CRL(crypto_utils.OpenSSLObject):
                 result['issuer'][k] = v
             result['revoked_certificates'] = []
             for cert in self.crl:
-                entry = self._decode_revoked(cert)
+                entry = crypto_utils.cryptography_decode_revoked_certificate(cert)
                 result['revoked_certificates'].append(self._dump_revoked(entry))
 
         if self.return_content:


### PR DESCRIPTION
##### SUMMARY
Moves some common code `openssl_certificate`, `openssl_certificate_info` and `x509_crl` to `module_utils/crypto.py`.

This is a subset of #67539, i.e. essentially that PR without the new module. I think it's better to get that merged first before adding the new module.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
openssl_certificate
openssl_certificate_info
x509_crl
lib/ansible/module_utils/crypto.py
