### PR TITLE
[backport 2.9] Bump min openstacksdk version for os_network

### DIFF
--- a/changelogs/fragments/62062-os_network-openstacksdk-min.yml
+++ b/changelogs/fragments/62062-os_network-openstacksdk-min.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Bump the minimum openstacksdk version to 0.18.0 when os_network
+    uses the port_security_enabled or mtu arguments.

--- a/changelogs/fragments/64495-os_network-openstacksdk-min.yml
+++ b/changelogs/fragments/64495-os_network-openstacksdk-min.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - bump the minimum openstacksdk version when os_network
+  - Bump the minimum openstacksdk version to 0.29.0 when os_network
     uses the dns_domain argument

--- a/lib/ansible/modules/cloud/openstack/os_network.py
+++ b/lib/ansible/modules/cloud/openstack/os_network.py
@@ -73,14 +73,14 @@ options:
      description:
         -  Whether port security is enabled on the network or not.
            Network will use OpenStack defaults if this option is
-           not utilised.
+           not utilised. Requires openstacksdk>=0.18.
      type: bool
      version_added: "2.8"
    mtu:
      description:
        -  The maximum transmission unit (MTU) value to address fragmentation.
           Network will use OpenStack defaults if this option is
-          not provided.
+          not provided. Requires openstacksdk>=0.18.
      type: int
      version_added: "2.9"
    dns_domain:
@@ -199,16 +199,22 @@ def main():
     provider_segmentation_id = module.params['provider_segmentation_id']
     project = module.params['project']
 
-    net_create_kwargs = {
-        'port_security_enabled': module.params['port_security_enabled'],
-        'mtu_size': module.params['mtu']
-    }
+    net_create_kwargs = {}
+    min_version = None
+
+    if module.params['mtu'] is not None:
+        min_version = '0.18.0'
+        net_create_kwargs['mtu_size'] = module.params['mtu']
+
+    if module.params['port_security_enabled'] is not None:
+        min_version = '0.18.0'
+        net_create_kwargs['port_security_enabled'] = module.params['port_security_enabled']
 
     if module.params['dns_domain'] is not None:
-        sdk, cloud = openstack_cloud_from_module(module, min_version='0.29.0')
+        min_version = '0.29.0'
         net_create_kwargs['dns_domain'] = module.params['dns_domain']
-    else:
-        sdk, cloud = openstack_cloud_from_module(module)
+
+    sdk, cloud = openstack_cloud_from_module(module, min_version)
     try:
         if project is not None:
             proj = cloud.get_project(project)


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To make use of the port_security_enabled [a] and mtu [b] parameters,
[c] and [d] need to be present in the openstacksdk or the os_network
module with return an error like:

TypeError: create_network() got an unexpected keyword argument 'port_security_enabled'

or:

TypeError: create_network() got an unexpected keyword argument 'mtu'

To handle this, we fail the module if one of the arguments are used
and the minimum openstacksdk version for that argument is not met.

[a] https://github.com/ansible/ansible/commit/eaf238b033a0504c48440cf85982a2b89851059d
[b] https://github.com/ansible/ansible/commit/c6a8e99d34eeacd84b097bb0bd2ba9a0d7fb230d
[c] https://github.com/openstack/openstacksdk/commit/8eb788af07ed88166db7b8a58ce1fecacd7a29b1
[d] https://github.com/openstack/openstacksdk/commit/a1fc820a2f3669f64d222506c17be99c4d6be7b7

Backport-of: https://review.opendev.org/708119
Fixes #62062
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
