### PR TITLE
win_credential - fix wildcard name

### DIFF
--- a/changelogs/fragments/win_credential-wildcard.yaml
+++ b/changelogs/fragments/win_credential-wildcard.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_credential - Fix issue that errors when trying to add a ``name`` with wildcards.

--- a/lib/ansible/modules/windows/win_credential.ps1
+++ b/lib/ansible/modules/windows/win_credential.ps1
@@ -378,8 +378,10 @@ namespace Ansible.CredentialManager
                     using (SafeMemoryBuffer attributes = new SafeMemoryBuffer(attributeBytes.Length))
                     {
                         if (attributeBytes.Length != 0)
+                        {
                             Marshal.Copy(attributeBytes, 0, attributes.DangerousGetHandle(), attributeBytes.Length);
-                        credential.Attributes = attributes.DangerousGetHandle();
+                            credential.Attributes = attributes.DangerousGetHandle();
+                        }
 
                         NativeHelpers.CredentialCreateFlags createFlags = 0;
                         if (preserveExisting)
@@ -588,10 +590,10 @@ if ($state -eq "absent") {
         $new_credential = New-Object -TypeName Ansible.CredentialManager.Credential
         $new_credential.Type = $type
         $new_credential.TargetName = $name
-        $new_credential.Comment = $comment
+        $new_credential.Comment = if ($comment) { $comment } else { [NullString]::Value }
         $new_credential.Secret = $secret
         $new_credential.Persist = $persistence
-        $new_credential.TargetAlias = $alias
+        $new_credential.TargetAlias = if ($alias) { $alias } else { [NullString]::Value }
         $new_credential.UserName = $username
 
         if ($null -ne $attributes) {

--- a/test/integration/targets/win_credential/tasks/tests.yml
+++ b/test/integration/targets/win_credential/tasks/tests.yml
@@ -366,6 +366,52 @@
     that:
     - not remove_cred_again is changed
 
+# https://github.com/ansible/ansible/issues/67278
+- name: create credential with wildcard
+  win_credential:
+    name: '*.{{ test_hostname }}'
+    type: domain_password
+    username: DOMAIN\username
+    secret: password
+    state: present
+    persistence: enterprise
+  register: wildcard_cred
+  vars: *become_vars
+
+- name: get result of create credential with wildcard
+  test_cred_facts:
+    name: '*.{{ test_hostname }}'
+    type: domain_password
+  register: wildcard_cred_actual
+  vars: *become_vars
+
+- name: assert create credential with wildcard
+  assert:
+    that:
+    - wildcard_cred is changed
+    - wildcard_cred_actual.name == '*.' ~ test_hostname
+
+- name: remove credential with wildcard
+  win_credential:
+    name: '*.{{ test_hostname }}'
+    type: domain_password
+    state: absent
+  register: wildcard_remove
+  vars: *become_vars
+
+- name: get result of remove credential with wildcard
+  test_cred_facts:
+    name: '*.{{ test_hostname }}'
+    type: domain_password
+  register: wildcard_remove_actual
+  vars: *become_vars
+
+- name: assert remove credential with wildcard
+  assert:
+    that:
+    - wildcard_remove is changed
+    - not wildcard_remove_actual.exists
+
 - name: create generic password (check mode)
   win_credential:
     name: '{{ test_hostname }}'


### PR DESCRIPTION
##### SUMMARY
Due to PowerShell changing `$null` to be `""` when calling a .NET function the call to `CredWriteW` was trying to write an empty string for Comment and TargetAlias. This was problematic as it doesn't seem like you can set an alias when using a wildcard server and `""` is not considered `NULL`.

This PR ensures we set those attributes to `[NullString]::Value` which preserves `$null` when crossing that boundary. This ensures that when we set a wildcard name there is no actual alias being set at the same time.

Fixes https://github.com/ansible/ansible/issues/67278

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_credential