### PR TITLE
async_status - Make sure async_dir is not seen as a private option

### DIFF
--- a/changelogs/fragments/async_status-dir.yaml
+++ b/changelogs/fragments/async_status-dir.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- async_status - Rename ``_async_dir`` to ``async_dir`` to ensure the option is seen as a stable name in a post collection world

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -127,7 +127,7 @@ Noteworthy module changes
 * The parameter ``message`` in :ref:`grafana_dashboard <grafana_dashboard_module>` module is renamed to ``commit_message`` since ``message`` is used by Ansible Core engine internally.
 * The parameter ``message`` in :ref:`datadog_monitor <datadog_monitor_module>` module is renamed to ``notification_message`` since ``message`` is used by Ansible Core engine internally.
 * The parameter ``message`` in :ref:`bigpanda <bigpanda_module>` module is renamed to ``deployment_message`` since ``message`` is used by Ansible Core engine internally.
-* :ref:`async_status <async_status_mode>` renamed the option ``_async_dir`` to ``async_dir`` to ensure it is seen as a stable interface and not to be changed in case a collection in the future overrides the existing async_status module.
+* :ref:`async_status <async_status_module>` renamed the option ``_async_dir`` to ``async_dir`` to ensure it is seen as a stable interface and not to be changed in case a collection in the future overrides the existing async_status module.
 
 
 Plugins

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -127,6 +127,7 @@ Noteworthy module changes
 * The parameter ``message`` in :ref:`grafana_dashboard <grafana_dashboard_module>` module is renamed to ``commit_message`` since ``message`` is used by Ansible Core engine internally.
 * The parameter ``message`` in :ref:`datadog_monitor <datadog_monitor_module>` module is renamed to ``notification_message`` since ``message`` is used by Ansible Core engine internally.
 * The parameter ``message`` in :ref:`bigpanda <bigpanda_module>` module is renamed to ``deployment_message`` since ``message`` is used by Ansible Core engine internally.
+* :ref:`async_status <async_status_mode>` renamed the option ``_async_dir`` to ``async_dir`` to ensure it is seen as a stable interface and not to be changed in case a collection in the future overrides the existing async_status module.
 
 
 Plugins

--- a/lib/ansible/modules/utilities/logic/async_status.py
+++ b/lib/ansible/modules/utilities/logic/async_status.py
@@ -92,12 +92,12 @@ def main():
         jid=dict(type='str', required=True),
         mode=dict(type='str', default='status', choices=['cleanup', 'status']),
         # passed in from the async_status action plugin
-        _async_dir=dict(type='path', required=True),
+        async_dir=dict(type='path', required=True),
     ))
 
     mode = module.params['mode']
     jid = module.params['jid']
-    async_dir = module.params['_async_dir']
+    async_dir = module.params['async_dir']
 
     # setup logging directory
     logdir = os.path.expanduser(async_dir)

--- a/lib/ansible/modules/utilities/logic/async_status.py
+++ b/lib/ansible/modules/utilities/logic/async_status.py
@@ -92,7 +92,7 @@ def main():
         jid=dict(type='str', required=True),
         mode=dict(type='str', default='status', choices=['cleanup', 'status']),
         # passed in from the async_status action plugin
-        async_dir=dict(type='path', required=True),
+        async_dir=dict(type='path', required=True, aliases=['_async_dir']),
     ))
 
     mode = module.params['mode']

--- a/lib/ansible/modules/windows/async_status.ps1
+++ b/lib/ansible/modules/windows/async_status.ps1
@@ -11,7 +11,7 @@ $jid = Get-AnsibleParam $parsed_args "jid" -failifempty $true -resultobj $result
 $mode = Get-AnsibleParam $parsed_args "mode" -Default "status" -ValidateSet "status","cleanup"
 
 # parsed in from the async_status action plugin
-$async_dir = Get-AnsibleParam $parsed_args "_async_dir" -type "path" -failifempty $true
+$async_dir = Get-AnsibleParam $parsed_args "async_dir" -type "path" -failifempty $true
 
 $log_path = [System.IO.Path]::Combine($async_dir, $jid)
 

--- a/lib/ansible/plugins/action/async_status.py
+++ b/lib/ansible/plugins/action/async_status.py
@@ -39,7 +39,7 @@ class ActionModule(ActionBase):
             # module args
             async_dir = self.get_shell_option('async_dir', default="~/.ansible_async")
 
-        module_args = dict(jid=jid, mode=mode, _async_dir=async_dir)
+        module_args = dict(jid=jid, mode=mode, async_dir=async_dir)
         status = self._execute_module(task_vars=task_vars,
                                       module_args=module_args)
         results = merge_hash(results, status)

--- a/lib/ansible/plugins/action/async_status.py
+++ b/lib/ansible/plugins/action/async_status.py
@@ -39,6 +39,7 @@ class ActionModule(ActionBase):
             # module args
             async_dir = self.get_shell_option('async_dir', default="~/.ansible_async")
 
+        # async_dir should not change as it is relied on by the Windows collection async_status.ps1.
         module_args = dict(jid=jid, mode=mode, async_dir=async_dir)
         status = self._execute_module(task_vars=task_vars,
                                       module_args=module_args)

--- a/lib/ansible/plugins/action/gather_facts.py
+++ b/lib/ansible/plugins/action/gather_facts.py
@@ -96,7 +96,7 @@ class ActionModule(ActionBase):
 
             while jobs:
                 for module in jobs:
-                    poll_args = {'jid': jobs[module]['ansible_job_id'], '_async_dir': os.path.dirname(jobs[module]['results_file'])}
+                    poll_args = {'jid': jobs[module]['ansible_job_id'], 'async_dir': os.path.dirname(jobs[module]['results_file'])}
                     res = self._execute_module(module_name='async_status', module_args=poll_args, task_vars=task_vars, wrap_async=False)
                     if res.get('finished', 0) == 1:
                         if res.get('failed', False):

--- a/test/integration/targets/async_status_dir/aliases
+++ b/test/integration/targets/async_status_dir/aliases
@@ -1,0 +1,3 @@
+async_status
+shippable/posix/group2
+skip/aix

--- a/test/integration/targets/async_status_dir/library/async_status.py
+++ b/test/integration/targets/async_status_dir/library/async_status.py
@@ -28,4 +28,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/test/integration/targets/async_status_dir/library/async_status.py
+++ b/test/integration/targets/async_status_dir/library/async_status.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import json
+import os
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
+
+def main():
+
+    module = AnsibleModule(argument_spec=dict(
+        jid=dict(type='str', required=True),
+        mode=dict(type='str', default='status', choices=['cleanup', 'status']),
+        # Tests that async_dir is always set, this shouldn't change in case a collection's async_status relies on this.
+        async_dir=dict(type='path', required=True),
+    ))
+
+    module.exit_json(async_dir=module.params['async_dir'])
+
+
+if __name__ == '__main__':
+    main()
+

--- a/test/integration/targets/async_status_dir/tasks/main.yml
+++ b/test/integration/targets/async_status_dir/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: test setting async dir through env var (deprecated)
+  async_status:
+    jid: jid
+  register: async_status_env
+  environment:
+    ANSIBLE_ASYNC_DIR: env var
+
+- name: assert test setting async dir through env var (deprecated)
+  assert:
+    that:
+    - async_status_env.async_dir == 'env var'
+
+- name: test setting async dir from shell option var
+  async_status:
+    jid: jid
+  register: async_status_shell
+  vars:
+    ansible_async_dir: shell var
+
+- name: assert test setting async dir from shell option var
+  assert:
+    that:
+    - async_status_shell.async_dir == 'shell var'


### PR DESCRIPTION
##### SUMMARY
Changes the module option to define the async dir from `_async_dir` to `async_dir` so we at least pretend the the option shouldn't be changed in the future.

This is mostly a way to try and make sure people don't change this option name in the future and don't inadvertently break the Windows `async_status.ps1` module that will exist in another collection.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
async_status