### PR TITLE
openssl_* modules: improve test robustness

### DIFF
--- a/test/integration/targets/openssl_certificate/tasks/ownca.yml
+++ b/test/integration/targets/openssl_certificate/tasks/ownca.yml
@@ -449,122 +449,129 @@
       loop:
         - Ed25519
         - Ed448
-
-    - name: (OwnCA, {{select_crypto_backend}}) Generate CSR
-      openssl_csr:
-        path: '{{ output_dir }}/csr_{{ item }}.csr'
-        privatekey_path: '{{ output_dir }}/privatekey_{{ item }}.pem'
-        subject:
-          commonName: www.ansible.com
-        select_crypto_backend: '{{ select_crypto_backend }}'
-      loop:
-        - Ed25519
-        - Ed448
+      register: ownca_certificate_ed25519_ed448_privatekey
       ignore_errors: yes
 
-    - name: (OwnCA, {{select_crypto_backend}}) Generate ownca certificate
-      openssl_certificate:
-        path: '{{ output_dir }}/ownca_cert_{{ item }}.pem'
-        csr_path: '{{ output_dir }}/csr_{{ item }}.csr'
-        ownca_path: '{{ output_dir }}/ca_cert.pem'
-        ownca_privatekey_path: '{{ output_dir }}/ca_privatekey.pem'
-        provider: ownca
-        ownca_digest: sha256
-        select_crypto_backend: '{{ select_crypto_backend }}'
-      loop:
-        - Ed25519
-        - Ed448
-      register: ownca_certificate_ed25519_ed448
-      ignore_errors: yes
+    - name: (OwnCA, {{select_crypto_backend}}) Generate CSR etc. if private key generation succeeded
+      when: ownca_certificate_ed25519_ed448_privatekey is not failed
+      block:
 
-    - name: (OwnCA, {{select_crypto_backend}}) Generate ownca certificate (idempotent)
-      openssl_certificate:
-        path: '{{ output_dir }}/ownca_cert_{{ item }}.pem'
-        csr_path: '{{ output_dir }}/csr_{{ item }}.csr'
-        ownca_path: '{{ output_dir }}/ca_cert.pem'
-        ownca_privatekey_path: '{{ output_dir }}/ca_privatekey.pem'
-        provider: ownca
-        ownca_digest: sha256
-        select_crypto_backend: '{{ select_crypto_backend }}'
-      loop:
-        - Ed25519
-        - Ed448
-      register: ownca_certificate_ed25519_ed448_idempotence
-      ignore_errors: yes
+        - name: (OwnCA, {{select_crypto_backend}}) Generate CSR
+          openssl_csr:
+            path: '{{ output_dir }}/csr_{{ item }}.csr'
+            privatekey_path: '{{ output_dir }}/privatekey_{{ item }}.pem'
+            subject:
+              commonName: www.ansible.com
+            select_crypto_backend: '{{ select_crypto_backend }}'
+          loop:
+            - Ed25519
+            - Ed448
+          ignore_errors: yes
 
-    - name: (OwnCA, {{select_crypto_backend}}) Generate CA privatekey
-      openssl_privatekey:
-        path: '{{ output_dir }}/ca_privatekey_{{ item }}.pem'
-        type: '{{ item }}'
-        cipher: auto
-        passphrase: Test123
-      loop:
-        - Ed25519
-        - Ed448
+        - name: (OwnCA, {{select_crypto_backend}}) Generate ownca certificate
+          openssl_certificate:
+            path: '{{ output_dir }}/ownca_cert_{{ item }}.pem'
+            csr_path: '{{ output_dir }}/csr_{{ item }}.csr'
+            ownca_path: '{{ output_dir }}/ca_cert.pem'
+            ownca_privatekey_path: '{{ output_dir }}/ca_privatekey.pem'
+            provider: ownca
+            ownca_digest: sha256
+            select_crypto_backend: '{{ select_crypto_backend }}'
+          loop:
+            - Ed25519
+            - Ed448
+          register: ownca_certificate_ed25519_ed448
+          ignore_errors: yes
 
-    - name: (OwnCA, {{select_crypto_backend}}) Generate CA CSR
-      openssl_csr:
-        path: '{{ output_dir }}/ca_csr_{{ item }}.csr'
-        privatekey_path: '{{ output_dir }}/ca_privatekey_{{ item }}.pem'
-        privatekey_passphrase: Test123
-        subject:
-          commonName: Example CA
-        useCommonNameForSAN: no
-        basic_constraints:
-        - 'CA:TRUE'
-        basic_constraints_critical: yes
-        key_usage:
-        - cRLSign
-        - keyCertSign
-      loop:
-        - Ed25519
-        - Ed448
-      ignore_errors: yes
+        - name: (OwnCA, {{select_crypto_backend}}) Generate ownca certificate (idempotent)
+          openssl_certificate:
+            path: '{{ output_dir }}/ownca_cert_{{ item }}.pem'
+            csr_path: '{{ output_dir }}/csr_{{ item }}.csr'
+            ownca_path: '{{ output_dir }}/ca_cert.pem'
+            ownca_privatekey_path: '{{ output_dir }}/ca_privatekey.pem'
+            provider: ownca
+            ownca_digest: sha256
+            select_crypto_backend: '{{ select_crypto_backend }}'
+          loop:
+            - Ed25519
+            - Ed448
+          register: ownca_certificate_ed25519_ed448_idempotence
+          ignore_errors: yes
 
-    - name: (OwnCA, {{select_crypto_backend}}) Generate selfsigned CA certificate
-      openssl_certificate:
-        path: '{{ output_dir }}/ca_cert_{{ item }}.pem'
-        csr_path: '{{ output_dir }}/ca_csr_{{ item }}.csr'
-        privatekey_path: '{{ output_dir }}/ca_privatekey_{{ item }}.pem'
-        privatekey_passphrase: Test123
-        provider: selfsigned
-        select_crypto_backend: '{{ select_crypto_backend }}'
-      loop:
-        - Ed25519
-        - Ed448
-      ignore_errors: yes
+        - name: (OwnCA, {{select_crypto_backend}}) Generate CA privatekey
+          openssl_privatekey:
+            path: '{{ output_dir }}/ca_privatekey_{{ item }}.pem'
+            type: '{{ item }}'
+            cipher: auto
+            passphrase: Test123
+          ignore_errors: yes
+          loop:
+            - Ed25519
+            - Ed448
 
-    - name: (OwnCA, {{select_crypto_backend}}) Generate ownca certificate
-      openssl_certificate:
-        path: '{{ output_dir }}/ownca_cert_{{ item }}_2.pem'
-        csr_path: '{{ output_dir }}/csr.csr'
-        ownca_path: '{{ output_dir }}/ca_cert_{{ item }}.pem'
-        ownca_privatekey_path: '{{ output_dir }}/ca_privatekey_{{ item }}.pem'
-        ownca_privatekey_passphrase: Test123
-        provider: ownca
-        ownca_digest: sha256
-        select_crypto_backend: '{{ select_crypto_backend }}'
-      loop:
-        - Ed25519
-        - Ed448
-      register: ownca_certificate_ed25519_ed448_2
-      ignore_errors: yes
+        - name: (OwnCA, {{select_crypto_backend}}) Generate CA CSR
+          openssl_csr:
+            path: '{{ output_dir }}/ca_csr_{{ item }}.csr'
+            privatekey_path: '{{ output_dir }}/ca_privatekey_{{ item }}.pem'
+            privatekey_passphrase: Test123
+            subject:
+              commonName: Example CA
+            useCommonNameForSAN: no
+            basic_constraints:
+            - 'CA:TRUE'
+            basic_constraints_critical: yes
+            key_usage:
+            - cRLSign
+            - keyCertSign
+          loop:
+            - Ed25519
+            - Ed448
+          ignore_errors: yes
 
-    - name: (OwnCA, {{select_crypto_backend}}) Generate ownca certificate (idempotent)
-      openssl_certificate:
-        path: '{{ output_dir }}/ownca_cert_{{ item }}_2.pem'
-        csr_path: '{{ output_dir }}/csr.csr'
-        ownca_path: '{{ output_dir }}/ca_cert_{{ item }}.pem'
-        ownca_privatekey_path: '{{ output_dir }}/ca_privatekey_{{ item }}.pem'
-        ownca_privatekey_passphrase: Test123
-        provider: ownca
-        ownca_digest: sha256
-        select_crypto_backend: '{{ select_crypto_backend }}'
-      loop:
-        - Ed25519
-        - Ed448
-      register: ownca_certificate_ed25519_ed448_2_idempotence
-      ignore_errors: yes
+        - name: (OwnCA, {{select_crypto_backend}}) Generate selfsigned CA certificate
+          openssl_certificate:
+            path: '{{ output_dir }}/ca_cert_{{ item }}.pem'
+            csr_path: '{{ output_dir }}/ca_csr_{{ item }}.csr'
+            privatekey_path: '{{ output_dir }}/ca_privatekey_{{ item }}.pem'
+            privatekey_passphrase: Test123
+            provider: selfsigned
+            select_crypto_backend: '{{ select_crypto_backend }}'
+          loop:
+            - Ed25519
+            - Ed448
+          ignore_errors: yes
+
+        - name: (OwnCA, {{select_crypto_backend}}) Generate ownca certificate
+          openssl_certificate:
+            path: '{{ output_dir }}/ownca_cert_{{ item }}_2.pem'
+            csr_path: '{{ output_dir }}/csr.csr'
+            ownca_path: '{{ output_dir }}/ca_cert_{{ item }}.pem'
+            ownca_privatekey_path: '{{ output_dir }}/ca_privatekey_{{ item }}.pem'
+            ownca_privatekey_passphrase: Test123
+            provider: ownca
+            ownca_digest: sha256
+            select_crypto_backend: '{{ select_crypto_backend }}'
+          loop:
+            - Ed25519
+            - Ed448
+          register: ownca_certificate_ed25519_ed448_2
+          ignore_errors: yes
+
+        - name: (OwnCA, {{select_crypto_backend}}) Generate ownca certificate (idempotent)
+          openssl_certificate:
+            path: '{{ output_dir }}/ownca_cert_{{ item }}_2.pem'
+            csr_path: '{{ output_dir }}/csr.csr'
+            ownca_path: '{{ output_dir }}/ca_cert_{{ item }}.pem'
+            ownca_privatekey_path: '{{ output_dir }}/ca_privatekey_{{ item }}.pem'
+            ownca_privatekey_passphrase: Test123
+            provider: ownca
+            ownca_digest: sha256
+            select_crypto_backend: '{{ select_crypto_backend }}'
+          loop:
+            - Ed25519
+            - Ed448
+          register: ownca_certificate_ed25519_ed448_2_idempotence
+          ignore_errors: yes
 
   when: select_crypto_backend == 'cryptography' and cryptography_version.stdout is version('2.6', '>=')
 

--- a/test/integration/targets/openssl_certificate/tasks/selfsigned.yml
+++ b/test/integration/targets/openssl_certificate/tasks/selfsigned.yml
@@ -379,46 +379,52 @@
       loop:
         - Ed25519
         - Ed448
-
-    - name: (Selfsigned, {{select_crypto_backend}}) Generate CSR
-      openssl_csr:
-        path: '{{ output_dir }}/csr_{{ item }}.csr'
-        privatekey_path: '{{ output_dir }}/privatekey_{{ item }}.pem'
-        subject:
-          commonName: www.ansible.com
-        select_crypto_backend: '{{ select_crypto_backend }}'
-      loop:
-        - Ed25519
-        - Ed448
+      register: selfsigned_certificate_ed25519_ed448_privatekey
       ignore_errors: yes
 
-    - name: (Selfsigned, {{select_crypto_backend}}) Generate selfsigned certificate
-      openssl_certificate:
-        path: '{{ output_dir }}/cert_{{ item }}.pem'
-        csr_path: '{{ output_dir }}/csr_{{ item }}.csr'
-        privatekey_path: '{{ output_dir }}/privatekey_{{ item }}.pem'
-        provider: selfsigned
-        selfsigned_digest: sha256
-        select_crypto_backend: '{{ select_crypto_backend }}'
-      loop:
-        - Ed25519
-        - Ed448
-      register: selfsigned_certificate_ed25519_ed448
-      ignore_errors: yes
+    - name: (Selfsigned, {{select_crypto_backend}}) Generate CSR etc. if private key generation succeeded
+      when: selfsigned_certificate_ed25519_ed448_privatekey is not failed
+      block:
 
-    - name: (Selfsigned, {{select_crypto_backend}}) Generate selfsigned certificate - idempotency
-      openssl_certificate:
-        path: '{{ output_dir }}/cert_{{ item }}.pem'
-        csr_path: '{{ output_dir }}/csr_{{ item }}.csr'
-        privatekey_path: '{{ output_dir }}/privatekey_{{ item }}.pem'
-        provider: selfsigned
-        selfsigned_digest: sha256
-        select_crypto_backend: '{{ select_crypto_backend }}'
-      loop:
-        - Ed25519
-        - Ed448
-      register: selfsigned_certificate_ed25519_ed448_idempotence
-      ignore_errors: yes
+        - name: (Selfsigned, {{select_crypto_backend}}) Generate CSR
+          openssl_csr:
+            path: '{{ output_dir }}/csr_{{ item }}.csr'
+            privatekey_path: '{{ output_dir }}/privatekey_{{ item }}.pem'
+            subject:
+              commonName: www.ansible.com
+            select_crypto_backend: '{{ select_crypto_backend }}'
+          loop:
+            - Ed25519
+            - Ed448
+          ignore_errors: yes
+
+        - name: (Selfsigned, {{select_crypto_backend}}) Generate selfsigned certificate
+          openssl_certificate:
+            path: '{{ output_dir }}/cert_{{ item }}.pem'
+            csr_path: '{{ output_dir }}/csr_{{ item }}.csr'
+            privatekey_path: '{{ output_dir }}/privatekey_{{ item }}.pem'
+            provider: selfsigned
+            selfsigned_digest: sha256
+            select_crypto_backend: '{{ select_crypto_backend }}'
+          loop:
+            - Ed25519
+            - Ed448
+          register: selfsigned_certificate_ed25519_ed448
+          ignore_errors: yes
+
+        - name: (Selfsigned, {{select_crypto_backend}}) Generate selfsigned certificate - idempotency
+          openssl_certificate:
+            path: '{{ output_dir }}/cert_{{ item }}.pem'
+            csr_path: '{{ output_dir }}/csr_{{ item }}.csr'
+            privatekey_path: '{{ output_dir }}/privatekey_{{ item }}.pem'
+            provider: selfsigned
+            selfsigned_digest: sha256
+            select_crypto_backend: '{{ select_crypto_backend }}'
+          loop:
+            - Ed25519
+            - Ed448
+          register: selfsigned_certificate_ed25519_ed448_idempotence
+          ignore_errors: yes
 
   when: select_crypto_backend == 'cryptography' and cryptography_version.stdout is version('2.6', '>=')
 

--- a/test/integration/targets/openssl_certificate/tests/validate_ownca.yml
+++ b/test/integration/targets/openssl_certificate/tests/validate_ownca.yml
@@ -158,7 +158,7 @@
       - ownca_certificate_ed25519_ed448_2.results[1] is failed
       - ownca_certificate_ed25519_ed448_2_idempotence.results[0] is failed
       - ownca_certificate_ed25519_ed448_2_idempotence.results[1] is failed
-  when: select_crypto_backend == 'cryptography' and cryptography_version.stdout is version('2.6', '>=') and cryptography_version.stdout is version('2.8', '<')
+  when: select_crypto_backend == 'cryptography' and cryptography_version.stdout is version('2.6', '>=') and cryptography_version.stdout is version('2.8', '<') and ownca_certificate_ed25519_ed448_privatekey is not failed
 
 - name: (OwnCA validation, {{select_crypto_backend}}) Verify Ed25519 and Ed448 tests (for cryptography >= 2.8)
   assert:
@@ -175,4 +175,4 @@
       - ownca_certificate_ed25519_ed448_2_idempotence is succeeded
       - ownca_certificate_ed25519_ed448_2_idempotence.results[0] is not changed
       - ownca_certificate_ed25519_ed448_2_idempotence.results[1] is not changed
-  when: select_crypto_backend == 'cryptography' and cryptography_version.stdout is version('2.8', '>=')
+  when: select_crypto_backend == 'cryptography' and cryptography_version.stdout is version('2.8', '>=') and ownca_certificate_ed25519_ed448_privatekey is not failed

--- a/test/integration/targets/openssl_certificate/tests/validate_selfsigned.yml
+++ b/test/integration/targets/openssl_certificate/tests/validate_selfsigned.yml
@@ -150,7 +150,7 @@
       - selfsigned_certificate_ed25519_ed448.results[1] is failed
       - selfsigned_certificate_ed25519_ed448_idempotence.results[0] is failed
       - selfsigned_certificate_ed25519_ed448_idempotence.results[1] is failed
-  when: select_crypto_backend == 'cryptography' and cryptography_version.stdout is version('2.6', '>=') and cryptography_version.stdout is version('2.8', '<')
+  when: select_crypto_backend == 'cryptography' and cryptography_version.stdout is version('2.6', '>=') and cryptography_version.stdout is version('2.8', '<') and selfsigned_certificate_ed25519_ed448_privatekey is not failed
 
 - name: (Selfsigned validation, {{select_crypto_backend}}) Verify Ed25519 and Ed448 tests (for cryptography >= 2.8)
   assert:
@@ -161,4 +161,4 @@
       - selfsigned_certificate_ed25519_ed448_idempotence is succeeded
       - selfsigned_certificate_ed25519_ed448_idempotence.results[0] is not changed
       - selfsigned_certificate_ed25519_ed448_idempotence.results[1] is not changed
-  when: select_crypto_backend == 'cryptography' and cryptography_version.stdout is version('2.8', '>=')
+  when: select_crypto_backend == 'cryptography' and cryptography_version.stdout is version('2.8', '>=') and selfsigned_certificate_ed25519_ed448_privatekey is not failed

--- a/test/integration/targets/openssl_csr/tasks/impl.yml
+++ b/test/integration/targets/openssl_csr/tasks/impl.yml
@@ -731,31 +731,37 @@
       loop:
         - Ed25519
         - Ed448
-
-    - name: Generate CSR
-      openssl_csr:
-        path: '{{ output_dir }}/csr_{{ item }}.csr'
-        privatekey_path: '{{ output_dir }}/privatekey_{{ item }}.pem'
-        subject:
-          commonName: www.ansible.com
-        select_crypto_backend: '{{ select_crypto_backend }}'
-      loop:
-        - Ed25519
-        - Ed448
-      register: generate_csr_ed25519_ed448
+      register: generate_csr_ed25519_ed448_privatekey
       ignore_errors: yes
 
-    - name: Generate CSR (idempotent)
-      openssl_csr:
-        path: '{{ output_dir }}/csr_{{ item }}.csr'
-        privatekey_path: '{{ output_dir }}/privatekey_{{ item }}.pem'
-        subject:
-          commonName: www.ansible.com
-        select_crypto_backend: '{{ select_crypto_backend }}'
-      loop:
-        - Ed25519
-        - Ed448
-      register: generate_csr_ed25519_ed448_idempotent
-      ignore_errors: yes
+    - name: Generate CSR if private key generation succeeded
+      when: ownca_certificate_ed25519_ed448_privatekey is not failed
+      block:
+
+        - name: Generate CSR
+          openssl_csr:
+            path: '{{ output_dir }}/csr_{{ item }}.csr'
+            privatekey_path: '{{ output_dir }}/privatekey_{{ item }}.pem'
+            subject:
+              commonName: www.ansible.com
+            select_crypto_backend: '{{ select_crypto_backend }}'
+          loop:
+            - Ed25519
+            - Ed448
+          register: generate_csr_ed25519_ed448
+          ignore_errors: yes
+
+        - name: Generate CSR (idempotent)
+          openssl_csr:
+            path: '{{ output_dir }}/csr_{{ item }}.csr'
+            privatekey_path: '{{ output_dir }}/privatekey_{{ item }}.pem'
+            subject:
+              commonName: www.ansible.com
+            select_crypto_backend: '{{ select_crypto_backend }}'
+          loop:
+            - Ed25519
+            - Ed448
+          register: generate_csr_ed25519_ed448_idempotent
+          ignore_errors: yes
 
   when: select_crypto_backend == 'cryptography' and cryptography_version.stdout is version('2.6', '>=')

--- a/test/integration/targets/openssl_csr/tasks/impl.yml
+++ b/test/integration/targets/openssl_csr/tasks/impl.yml
@@ -735,7 +735,7 @@
       ignore_errors: yes
 
     - name: Generate CSR if private key generation succeeded
-      when: ownca_certificate_ed25519_ed448_privatekey is not failed
+      when: generate_csr_ed25519_ed448_privatekey is not failed
       block:
 
         - name: Generate CSR

--- a/test/integration/targets/openssl_csr/tests/validate.yml
+++ b/test/integration/targets/openssl_csr/tests/validate.yml
@@ -194,7 +194,7 @@
       - generate_csr_ed25519_ed448.results[1].msg == 'Signing with Ed25519 and Ed448 keys requires cryptography 2.8 or newer.'
       - generate_csr_ed25519_ed448_idempotent.results[0] is failed
       - generate_csr_ed25519_ed448_idempotent.results[1] is failed
-  when: select_crypto_backend == 'cryptography' and cryptography_version.stdout is version('2.6', '>=') and cryptography_version.stdout is version('2.8', '<')
+  when: select_crypto_backend == 'cryptography' and cryptography_version.stdout is version('2.6', '>=') and cryptography_version.stdout is version('2.8', '<') and generate_csr_ed25519_ed448_privatekey is not failed
 
 - name: Verify Ed25519 and Ed448 tests (for cryptography >= 2.8)
   assert:
@@ -205,4 +205,4 @@
       - generate_csr_ed25519_ed448_idempotent is succeeded
       - generate_csr_ed25519_ed448_idempotent.results[0] is not changed
       - generate_csr_ed25519_ed448_idempotent.results[1] is not changed
-  when: select_crypto_backend == 'cryptography' and cryptography_version.stdout is version('2.8', '>=')
+  when: select_crypto_backend == 'cryptography' and cryptography_version.stdout is version('2.8', '>=') and generate_csr_ed25519_ed448_privatekey is not failed

--- a/test/integration/targets/openssl_privatekey/tasks/impl.yml
+++ b/test/integration/targets/openssl_privatekey/tasks/impl.yml
@@ -170,6 +170,7 @@
     loop: "{{ types }}"
     loop_control:
       label: "{{ item.type }}"
+    ignore_errors: yes
     register: privatekey_t1_generate
 
   - name: Test other type generation (idempotency)
@@ -181,6 +182,7 @@
     loop: "{{ types }}"
     loop_control:
       label: "{{ item.type }}"
+    ignore_errors: yes
     register: privatekey_t1_idempotency
 
   when: select_crypto_backend == 'cryptography'

--- a/test/integration/targets/openssl_privatekey/tasks/impl.yml
+++ b/test/integration/targets/openssl_privatekey/tasks/impl.yml
@@ -385,6 +385,7 @@
       type: X448
       format: pkcs8
       select_crypto_backend: '{{ select_crypto_backend }}'
+    ignore_errors: yes
     register: privatekey_fmt_2_step_1
 
   - name: Generate privatekey_fmt_2 - PKCS8 format (idempotent)
@@ -393,6 +394,7 @@
       type: X448
       format: pkcs8
       select_crypto_backend: '{{ select_crypto_backend }}'
+    ignore_errors: yes
     register: privatekey_fmt_2_step_2
 
   - name: Generate privatekey_fmt_2 - raw format
@@ -402,17 +404,20 @@
       format: raw
       select_crypto_backend: '{{ select_crypto_backend }}'
       return_content: yes
+    ignore_errors: yes
     register: privatekey_fmt_2_step_3
 
   - name: Read privatekey_fmt_2.pem
     slurp:
       src: "{{ output_dir }}/privatekey_fmt_2.pem"
+    ignore_errors: yes
     register: content
 
   - name: Generate privatekey_fmt_2 - verify that returned content is base64 encoded
     assert:
       that:
         - privatekey_fmt_2_step_3.privatekey == content.content
+    when: privatekey_fmt_2_step_1 is not failed
 
   - name: Generate privatekey_fmt_2 - raw format (idempotent)
     openssl_privatekey:
@@ -421,17 +426,20 @@
       format: raw
       select_crypto_backend: '{{ select_crypto_backend }}'
       return_content: yes
+    ignore_errors: yes
     register: privatekey_fmt_2_step_4
 
   - name: Read privatekey_fmt_2.pem
     slurp:
       src: "{{ output_dir }}/privatekey_fmt_2.pem"
+    ignore_errors: yes
     register: content
 
   - name: Generate privatekey_fmt_2 - verify that returned content is base64 encoded
     assert:
       that:
         - privatekey_fmt_2_step_4.privatekey == content.content
+    when: privatekey_fmt_2_step_1 is not failed
 
   - name: Generate privatekey_fmt_2 - auto format (ignore)
     openssl_privatekey:
@@ -440,17 +448,20 @@
       format: auto_ignore
       select_crypto_backend: '{{ select_crypto_backend }}'
       return_content: yes
+    ignore_errors: yes
     register: privatekey_fmt_2_step_5
 
   - name: Read privatekey_fmt_2.pem
     slurp:
       src: "{{ output_dir }}/privatekey_fmt_2.pem"
+    ignore_errors: yes
     register: content
 
   - name: Generate privatekey_fmt_2 - verify that returned content is base64 encoded
     assert:
       that:
         - privatekey_fmt_2_step_5.privatekey == content.content
+    when: privatekey_fmt_2_step_1 is not failed
 
   - name: Generate privatekey_fmt_2 - auto format (no ignore)
     openssl_privatekey:
@@ -459,12 +470,14 @@
       format: auto
       select_crypto_backend: '{{ select_crypto_backend }}'
       return_content: yes
+    ignore_errors: yes
     register: privatekey_fmt_2_step_6
 
   - name: Generate privatekey_fmt_2 - verify that returned content is not base64 encoded
     assert:
       that:
         - privatekey_fmt_2_step_6.privatekey == lookup('file', output_dir ~ '/privatekey_fmt_2.pem', rstrip=False)
+    when: privatekey_fmt_2_step_1 is not failed
 
   when: 'select_crypto_backend == "cryptography" and cryptography_version.stdout is version("2.6", ">=")'
 

--- a/test/integration/targets/openssl_privatekey/tests/validate.yml
+++ b/test/integration/targets/openssl_privatekey/tests/validate.yml
@@ -1,4 +1,7 @@
 ---
+- set_fact:
+    system_potentially_has_no_algorithm_support: "{{ ansible_os_family == 'FreeBSD' }}"
+
 - name: Validate privatekey1 idempotency and content returned
   assert:
     that:
@@ -120,9 +123,6 @@
   loop_control:
     label: "{{ item.item.curve }}"
 
-- set_fact:
-    system_potentially_has_no_algorithm_support: "{{ ansible_os_family == 'FreeBSD' }}"
-
 - name: Validate other type generation (just check changed)
   assert:
     that:
@@ -195,13 +195,21 @@
       - privatekey_fmt_1_step_9_before.public_key == privatekey_fmt_1_step_9_after.public_key
   when: 'select_crypto_backend == "cryptography"'
 
+- name: Validate format 2 (failed)
+  assert:
+    that:
+      - system_potentially_has_no_algorithm_support
+      - privatekey_fmt_2_step_1 is failed
+      - "'Cryptography backend does not support the algorithm required for ' in privatekey_fmt_2_step_1.msg"
+  when: 'select_crypto_backend == "cryptography" and cryptography_version.stdout is version("2.6", ">=") and privatekey_fmt_2_step_1 is failed'
+
 - name: Validate format 2
   assert:
     that:
-      - privatekey_fmt_2_step_1 is changed
-      - privatekey_fmt_2_step_2 is not changed
-      - privatekey_fmt_2_step_3 is changed
-      - privatekey_fmt_2_step_4 is not changed
-      - privatekey_fmt_2_step_5 is not changed
-      - privatekey_fmt_2_step_6 is changed
-  when: 'select_crypto_backend == "cryptography" and cryptography_version.stdout is version("2.6", ">=")'
+      - privatekey_fmt_2_step_1 is succeeded and privatekey_fmt_2_step_1 is changed
+      - privatekey_fmt_2_step_2 is succeeded and privatekey_fmt_2_step_2 is not changed
+      - privatekey_fmt_2_step_3 is succeeded and privatekey_fmt_2_step_3 is changed
+      - privatekey_fmt_2_step_4 is succeeded and privatekey_fmt_2_step_4 is not changed
+      - privatekey_fmt_2_step_5 is succeeded and privatekey_fmt_2_step_5 is not changed
+      - privatekey_fmt_2_step_6 is succeeded and privatekey_fmt_2_step_6 is changed
+  when: 'select_crypto_backend == "cryptography" and cryptography_version.stdout is version("2.6", ">=") and privatekey_fmt_2_step_1 is not failed'

--- a/test/integration/targets/openssl_privatekey/tests/validate.yml
+++ b/test/integration/targets/openssl_privatekey/tests/validate.yml
@@ -120,20 +120,24 @@
   loop_control:
     label: "{{ item.item.curve }}"
 
+- set_fact:
+    system_potentially_has_no_algorithm_support: "{{ ansible_os_family == 'FreeBSD' }}"
+
 - name: Validate other type generation (just check changed)
   assert:
     that:
-    - item is changed
+    - (item is succeeded and item is changed) or
+      (item is failed and 'Cryptography backend does not support the algorithm required for ' in item.msg and system_potentially_has_no_algorithm_support)
   loop: "{{ privatekey_t1_generate.results }}"
   when: "'skip_reason' not in item"
   loop_control:
     label: "{{ item.item.type }}"
 
-
 - name: Validate other type generation idempotency
   assert:
     that:
-    - item is not changed
+    - (item is succeeded and item is not changed) or
+      (item is failed and 'Cryptography backend does not support the algorithm required for ' in item.msg and system_potentially_has_no_algorithm_support)
   loop: "{{ privatekey_t1_idempotency.results }}"
   when: "'skip_reason' not in item"
   loop_control:


### PR DESCRIPTION
##### SUMMARY
This are the changes to the openssl_* tests from #67565 which are required to make tests work under newer FreeBSD versions (11.3 and 12.1).

The problem is that they have cryptography 2.6.1, which in theory supports Ed25519, Ed448, X25519 and X448, but the libssl it's using doesn't support these. This PR skips the tests for openssl_csr and openssl_certificate when generating these keys fails, and allows them to fail during the openssl_privsatekey tests when the distribution is FreeBSD and the correct message (`Cryptography backend does not support the algorithm required for XXX`) is returned.

This way we know that the tests will run on Linux and macOS assuming a new enough cryptography is installed, so these features work in general, but we also don't fail on FreeBSD.

CC @samdoran

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
openssl_certificate
openssl_csr
openssl_privatekey
