### PR TITLE
WIP: Enable 'extra' options for role installation

### DIFF
--- a/changelogs/fragments/67569-requirement-file-options.yml
+++ b/changelogs/fragments/67569-requirement-file-options.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- "requirements file now supports extra options for downloads, for example client certificate and basic auth. See Ansible Galaxy user guide for details."
+- "ansible-galaxy - requirements file now supports extra options for downloads, for example client certificate and basic auth. See Ansible Galaxy user guide for details."

--- a/changelogs/fragments/67569-requirement-file-options.yml
+++ b/changelogs/fragments/67569-requirement-file-options.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "requirements file now supports extra options for downloads, for example client certificate and basic auth. See Ansible Galaxy user guide for details."

--- a/docs/docsite/rst/galaxy/user_guide.rst
+++ b/docs/docsite/rst/galaxy/user_guide.rst
@@ -246,11 +246,13 @@ Each role in the file will have one or more of the following attributes:
      to a repository within a git based SCM. See the examples below. This is a required attribute.
    scm
      Specify the SCM. As of this writing only *git* or *hg* are allowed. See the examples below. Defaults to *git*.
-   version:
+   version
      The version of the role to download. Provide a release tag value, commit hash, or branch name. Defaults to the branch set as a default in the repository, otherwise defaults to the *master*.
-   name:
+   name
      Download the role to a specific name. Defaults to the Galaxy name when downloading from Galaxy, otherwise it defaults
      to the name of the repository.
+   extra_opts
+     Advanced options for specific use-cases, see examples below.
 
 Use the following example as a guide for specifying roles in *requirements.yml*:
 
@@ -291,6 +293,28 @@ Use the following example as a guide for specifying roles in *requirements.yml*:
     - src: git@gitlab.company.com:mygroup/ansible-base.git
       scm: git
       version: "0.1"  # quoted, so YAML doesn't parse this as a floating-point value
+
+Advanced options for downloading roles in requirements.yml
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Keys are as-supported by the ``open_url`` method in :file:`lib/ansible/module_utils/urls.py:`. The most likely options you could use are:
+
+- ``ca_path``: path to a CA cert bundle for ad-hoc trust of specific roots.
+- ``client_cert``: path to a public client certificate, or combined certificate + key.
+- ``client_key``: path to a private key for the above public client certificate (not required if it's in the same file as the public cert)
+- ``url_username``: username for basic auth
+- ``url_password``: password for basic auth
+- ``force_basic_auth``: force enable basic auth
+
+For example:
+
+.. code-block:: yaml
+
+    - src: https://some.webserver.example.com/files/master.tar.xz
+      name: http-role-xz
+      extra_opts:
+        client_cert: /path/to/client.crt
+        client_key: /path/to/client.key
 
 Installing roles and collections from the same requirements.yml file
 ---------------------------------------------------------------------

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -49,7 +49,7 @@ class GalaxyRole(object):
     META_INSTALL = os.path.join('meta', '.galaxy_install_info')
     ROLE_DIRS = ('defaults', 'files', 'handlers', 'meta', 'tasks', 'templates', 'vars', 'tests')
 
-    def __init__(self, galaxy, api, name, src=None, version=None, scm=None, path=None):
+    def __init__(self, galaxy, api, name, src=None, version=None, scm=None, path=None, extra_opts=None):
 
         self._metadata = None
         self._install_info = None
@@ -64,6 +64,7 @@ class GalaxyRole(object):
         self.version = version
         self.src = src or name
         self.scm = scm
+        self.extra_opts = extra_opts
 
         if path is not None:
             if not path.endswith(os.path.join(os.path.sep, self.name)):
@@ -190,7 +191,7 @@ class GalaxyRole(object):
             display.display("- downloading role from %s" % archive_url)
 
             try:
-                url_file = open_url(archive_url, validate_certs=self._validate_certs, http_agent=user_agent())
+                url_file = open_url(archive_url, validate_certs=self._validate_certs, http_agent=user_agent(), **self.extra_opts)
                 temp_file = tempfile.NamedTemporaryFile(delete=False)
                 data = url_file.read()
                 while data:

--- a/lib/ansible/playbook/role/requirement.py
+++ b/lib/ansible/playbook/role/requirement.py
@@ -42,6 +42,7 @@ VALID_SPEC_KEYS = [
     'scm',
     'src',
     'version',
+    'extra_opts',
 ]
 
 display = Display()


### PR DESCRIPTION
##### SUMMARY
I have a use-case where I need to provide some additional options for role download/installation, specifically a client certificate. This PR allows users to supply arguments compatible with `open_url` to the role definition and they'll be passed down verbatim (see example below)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
core

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
# requirements.yml
---

- name: example-role
  src: https://example.com/my_role.tgz
  extra_opts:
    client_key: /path/to/client.key
    client_cert: /path/to/client.crt

```

I've done a quick test locally and it seemed fine, but would appreciate any advice/guidance on what else I should be looking at.

`requirement.py` defines valid keys for a role requirement and has had `extra_opts` added here.

`role.py` handles the actual downloading of roles, and passes `extra_opts` through to `open_url` in `lib/ansible/module_utils/urls.py`

There is currently no validation done on the keys passed down, happy to add this in (in the same vein as the VALID_SPEC_KEYS logic) but wanted to get some feedback on the change itself first.