### PR TITLE
[backport 2.8] Bump min openstacksdk version for os_network

### DIFF
--- a/changelogs/fragments/62062-os_network-openstacksdk-min.yml
+++ b/changelogs/fragments/62062-os_network-openstacksdk-min.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Bump the minimum openstacksdk version to 0.18.0 when os_network
+    uses the port_security_enabled argument.

--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -118,6 +118,11 @@ def openstack_cloud_from_module(module, min_version='0.12.0'):
         module.fail_json(msg='openstacksdk is required for this module')
 
     if min_version:
+        min_version = max(StrictVersion('0.12.0'), StrictVersion(min_version))
+    else:
+        min_version = StrictVersion('0.12.0')
+
+    if min_version:
         if StrictVersion(sdk.version.__version__) < StrictVersion(min_version):
             module.fail_json(
                 msg="To utilize this module, the installed version of"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To make use of the port_security_enabled [a] parameter, [b] needs
to be present in the openstacksdk or the os_network module will
return an error like:

TypeError: create_network() got an unexpected keyword argument 'port_security_enabled'

To handle this, we fail the module if one of the arguments are used
and the minimum openstacksdk version for that argument is not met.

[a] https://github.com/ansible/ansible/commit/eaf238b033a0504c48440cf85982a2b89851059d
[b] https://github.com/openstack/openstacksdk/commit/8eb788af07ed88166db7b8a58ce1fecacd7a29b1

Backport-of: https://review.opendev.org/708119
Fixes: #62062

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
