### PR TITLE
Fix AWS hacking policy (states)

### DIFF
--- a/hacking/aws_config/testing_policies/compute-policy.json
+++ b/hacking/aws_config/testing_policies/compute-policy.json
@@ -248,7 +248,7 @@
               "states:UpdateStateMachine"
             ],
             "Resource": [
-              "arn:aws:states:*"
+              "arn:aws:states:*:*:*"
             ]
         },
         {


### PR DESCRIPTION
##### SUMMARY
The hacking policy currently includes the resource "arn:aws:states:*" which isn't valid.

If you put it through the policy simulator you get ``This policy is invalid! : Loading one or more policies failed!``

##### ISSUE TYPE

- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME

hacking/aws_config/testing_policies/compute-policy.json

##### ADDITIONAL INFORMATION