### PR TITLE
Update BOTMETA.yml migrated_to for Netbox components

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -695,6 +695,7 @@ files:
       - networking
       - infoblox
   $modules/net_tools/netbox/: FragmentedPacket
+    migrated_to: netbox_community.ansible_modules
   $modules/network/a10/: ericchou1 mischapeters
   $modules/network/aci/: &aci
     keywords: [ aci, cisco msc, cisco mso, multisite, multi-site ]
@@ -3549,6 +3550,7 @@ files:
   $plugins/inventory/netbox.py:
     support: community
     maintainers: $team_netbox
+    migrated_to: netbox_community.ansible_modules
   $plugins/inventory/openshift.py:
     support: community
     maintainers: chouseknecht maxamillion fabianvf flaper87

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -697,15 +697,15 @@ files:
   $modules/net_tools/netbox:
     maintainers: FragmentedPacket
   $modules/net_tools/netbox/netbox_device.py:
-    migrated_to: netbox_community.ansible_modules
+    migrated_to: netbox.netbox
   $modules/net_tools/netbox/netbox_interface.py:
-    migrated_to: netbox_community.ansible_modules
+    migrated_to: netbox.netbox
   $modules/net_tools/netbox/netbox_ip_address.py:
-    migrated_to: netbox_community.ansible_modules
+    migrated_to: netbox.netbox
   $modules/net_tools/netbox/netbox_prefix.py:
-    migrated_to: netbox_community.ansible_modules
+    migrated_to: netbox.netbox
   $modules/net_tools/netbox/netbox_site.py:
-    migrated_to: netbox_community.ansible_modules
+    migrated_to: netbox.netbox
   $modules/network/a10/: ericchou1 mischapeters
   $modules/network/aci/: &aci
     keywords: [ aci, cisco msc, cisco mso, multisite, multi-site ]
@@ -3560,7 +3560,7 @@ files:
   $plugins/inventory/netbox.py:
     support: community
     maintainers: $team_netbox
-    migrated_to: netbox_community.ansible_modules
+    migrated_to: netbox.netbox
   $plugins/inventory/openshift.py:
     support: community
     maintainers: chouseknecht maxamillion fabianvf flaper87

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -694,7 +694,19 @@ files:
     labels:
       - networking
       - infoblox
-  $modules/net_tools/netbox/:
+  $modules/net_tools/netbox/netbox_device.py
+    maintainers: FragmentedPacket
+    migrated_to: netbox_community.ansible_modules
+  $modules/net_tools/netbox/netbox_interface.py
+    maintainers: FragmentedPacket
+    migrated_to: netbox_community.ansible_modules
+  $modules/net_tools/netbox/netbox_ip_address.py
+    maintainers: FragmentedPacket
+    migrated_to: netbox_community.ansible_modules
+  $modules/net_tools/netbox/netbox_prefix.py
+    maintainers: FragmentedPacket
+    migrated_to: netbox_community.ansible_modules
+  $modules/net_tools/netbox/netbox_site.py
     maintainers: FragmentedPacket
     migrated_to: netbox_community.ansible_modules
   $modules/network/a10/: ericchou1 mischapeters

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -694,20 +694,17 @@ files:
     labels:
       - networking
       - infoblox
-  $modules/net_tools/netbox/netbox_device.py
+  $modules/net_tools/netbox:
     maintainers: FragmentedPacket
+  $modules/net_tools/netbox/netbox_device.py:
     migrated_to: netbox_community.ansible_modules
-  $modules/net_tools/netbox/netbox_interface.py
-    maintainers: FragmentedPacket
+  $modules/net_tools/netbox/netbox_interface.py:
     migrated_to: netbox_community.ansible_modules
-  $modules/net_tools/netbox/netbox_ip_address.py
-    maintainers: FragmentedPacket
+  $modules/net_tools/netbox/netbox_ip_address.py:
     migrated_to: netbox_community.ansible_modules
-  $modules/net_tools/netbox/netbox_prefix.py
-    maintainers: FragmentedPacket
+  $modules/net_tools/netbox/netbox_prefix.py:
     migrated_to: netbox_community.ansible_modules
-  $modules/net_tools/netbox/netbox_site.py
-    maintainers: FragmentedPacket
+  $modules/net_tools/netbox/netbox_site.py:
     migrated_to: netbox_community.ansible_modules
   $modules/network/a10/: ericchou1 mischapeters
   $modules/network/aci/: &aci

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -694,7 +694,8 @@ files:
     labels:
       - networking
       - infoblox
-  $modules/net_tools/netbox/: FragmentedPacket
+  $modules/net_tools/netbox/:
+    maintainers: FragmentedPacket
     migrated_to: netbox_community.ansible_modules
   $modules/network/a10/: ericchou1 mischapeters
   $modules/network/aci/: &aci


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Updated BOTMETA.yml to show that the Netbox modules have been moved to Ansible Collections.

Is there anything else I need to do before all the migrations start to occur?

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task r feature below -->
netbox.py
netbox_device.py
netbox_interface.by
netbox_site.py
netbox_ip_address.py
netbox_prefix.py
