### PR TITLE
Use Ansible to load ps module utils in arg spec checker

### DIFF
--- a/changelogs/fragments/valdate-modules-ps-arg-util.yaml
+++ b/changelogs/fragments/valdate-modules-ps-arg-util.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-test validate-modules - Fix arg spec collector for PowerShell to find utils in both a collection and base.

--- a/lib/ansible/executor/powershell/module_manifest.py
+++ b/lib/ansible/executor/powershell/module_manifest.py
@@ -29,6 +29,7 @@ from ansible.plugins.loader import ps_module_utils_loader
 class PSModuleDepFinder(object):
 
     def __init__(self):
+        # This is also used by validate-modules to get a module's required utils in base and a collection.
         self.ps_modules = dict()
         self.exec_scripts = dict()
 

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/module_args.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/module_args.py
@@ -26,8 +26,10 @@ import sys
 
 from contextlib import contextmanager
 
+from ansible.executor.powershell.module_manifest import PSModuleDepFinder
 from ansible.module_utils.basic import FILE_COMMON_ARGUMENTS
 from ansible.module_utils.six import reraise
+from ansible.module_utils._text import to_bytes, to_text
 
 from .utils import CaptureStd, find_executable, get_module_name_from_filename
 
@@ -94,8 +96,22 @@ def get_ps_argument_spec(filename):
     if not pwsh:
         raise FileNotFoundError('Required program for PowerShell arg spec inspection "pwsh" not found.')
 
+    module_path = os.path.join(os.getcwd(), filename)
+    b_module_path = to_bytes(module_path, errors='surrogate_or_strict')
+    with open(b_module_path, mode='rb') as module_fd:
+        b_module_data = module_fd.read()
+
+    ps_dep_finder = PSModuleDepFinder()
+    ps_dep_finder.scan_module(b_module_data)
+
+    util_manifest = json.dumps({
+        'module_path': to_text(module_path, errors='surrogiate_or_strict'),
+        'ps_utils': dict([(name, info['path']) for name, info in ps_dep_finder.ps_modules.items()])
+    })
+
     script_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'ps_argspec.ps1')
-    proc = subprocess.Popen([script_path, filename], stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=False)
+    proc = subprocess.Popen([script_path, util_manifest], stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                            shell=False)
     stdout, stderr = proc.communicate()
 
     if proc.returncode != 0:


### PR DESCRIPTION
##### SUMMARY
Instead of manually trying to find the PowerShell module utils in the validate-modules arg spec this instead relies on the same module loader code that we use when executing code. This allows the arg spec collector to work if a collection module relies on a util to build it's arg spec.

Fixes https://github.com/ansible/ansible/issues/67591

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test validate-modules