### PR TITLE
Update 'server' doc in nsupdate module

### DIFF
--- a/lib/ansible/modules/net_tools/nsupdate.py
+++ b/lib/ansible/modules/net_tools/nsupdate.py
@@ -36,7 +36,7 @@ options:
         default: 'present'
     server:
         description:
-            - Apply DNS modification on this server.
+            - Apply DNS modification on this server, specified by IPv4 or IPv6 address.
         required: true
     port:
         description:


### PR DESCRIPTION
##### SUMMARY
The 'server' option to the nsupdate module only accepts IP addresses (IPv4 or IPv6), it does not accept DNS names. Document that so that users will not be tempted to use DNS names and find that the nsupdate operation fails.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr
