### PR TITLE
[2.9] Templating: make sure only one variable results are cached

### DIFF
--- a/changelogs/fragments/67429-jinja2-caching.yml
+++ b/changelogs/fragments/67429-jinja2-caching.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "Templating - Ansible was caching results of Jinja2 expressions in some cases where these expressions could have dynamic results, like password generation (https://github.com/ansible/ansible/issues/34144)."

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -596,7 +596,7 @@ class Templar:
                         # we only cache in the case where we have a single variable
                         # name, to make sure we're not putting things which may otherwise
                         # be dynamic in the cache (filters, lookups, etc.)
-                        if cache:
+                        if cache and only_one:
                             self._cached_result[sha1_hash] = result
 
                 return result


### PR DESCRIPTION
##### SUMMARY
Backport of #67429 to stable-2.9.

Doesn't contain the tests since the tests this was added to don't seem to exist in stable-2.9.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/template/__init__.py
