### PR TITLE
module manifest - tidy up become parameters

### DIFF
--- a/changelogs/fragments/become-pc.yaml
+++ b/changelogs/fragments/become-pc.yaml
@@ -1,0 +1,3 @@
+deprecated_features:
+- Deprecated the ``become``, ``become_method``, ``become_user``, ``become_password``, and ``become_flags`` kwargs for ``modify_module()`` called by action plugins. There were effectively a no-op argument except for Windows and should not be used going forward.
+- Added deprecation notice for the play context fallback if a become plugin does not implement ``become_user``, ``become_pass``, ``become_flags``, or ``become_exe``. 3rd party become plugins should implement these 4 options if they are used by an Ansible plugin.

--- a/lib/ansible/executor/powershell/module_manifest.py
+++ b/lib/ansible/executor/powershell/module_manifest.py
@@ -296,7 +296,7 @@ def _create_powershell_wrapper(b_module_data, module_path, module_args,
         exec_manifest["async_timeout_sec"] = async_timeout
         exec_manifest["async_startup_timeout"] = C.config.get_config_value("WIN_ASYNC_STARTUP_TIMEOUT", variables=task_vars)
 
-    if become and become.name.endswith('runas'):  # runas and namespace.collection.runas
+    if become and become.name.split('.')[-1] == 'runas':  # runas and namespace.collection.runas
         finder.scan_exec_script('exec_wrapper')
         finder.scan_exec_script('become_wrapper')
 

--- a/lib/ansible/executor/powershell/module_manifest.py
+++ b/lib/ansible/executor/powershell/module_manifest.py
@@ -259,8 +259,7 @@ def _strip_comments(source):
 
 def _create_powershell_wrapper(b_module_data, module_path, module_args,
                                environment, async_timeout, become,
-                               become_method, become_user, become_password,
-                               become_flags, substyle, task_vars):
+                               substyle, task_vars):
     # creates the manifest/wrapper used in PowerShell/C# modules to enable
     # things like become and async - this is also called in action/script.py
 
@@ -297,14 +296,14 @@ def _create_powershell_wrapper(b_module_data, module_path, module_args,
         exec_manifest["async_timeout_sec"] = async_timeout
         exec_manifest["async_startup_timeout"] = C.config.get_config_value("WIN_ASYNC_STARTUP_TIMEOUT", variables=task_vars)
 
-    if become and become_method.split('.')[-1] == 'runas':  # runas and namespace.collection.runas
+    if become and become.name.endswith('runas'):  # runas and namespace.collection.runas
         finder.scan_exec_script('exec_wrapper')
         finder.scan_exec_script('become_wrapper')
 
         exec_manifest["actions"].insert(0, 'become_wrapper')
-        exec_manifest["become_user"] = become_user
-        exec_manifest["become_password"] = become_password
-        exec_manifest['become_flags'] = become_flags
+        exec_manifest["become_user"] = become.get_option('become_user')
+        exec_manifest["become_password"] = become.get_option('become_pass')
+        exec_manifest['become_flags'] = become.get_option('become_flags')
 
     exec_manifest['min_ps_version'] = finder.ps_version
     exec_manifest['min_os_version'] = finder.os_version

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -187,17 +187,6 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         final_environment = dict()
         self._compute_environment_string(final_environment)
 
-        become_kwargs = {}
-        if self._connection.become:
-            become_kwargs['become'] = True
-            become_kwargs['become_method'] = self._connection.become.name
-            become_kwargs['become_user'] = self._connection.become.get_option('become_user',
-                                                                              playcontext=self._play_context)
-            become_kwargs['become_password'] = self._connection.become.get_option('become_pass',
-                                                                                  playcontext=self._play_context)
-            become_kwargs['become_flags'] = self._connection.become.get_option('become_flags',
-                                                                               playcontext=self._play_context)
-
         # modify_module will exit early if interpreter discovery is required; re-run after if necessary
         for dummy in (1, 2):
             try:
@@ -206,7 +195,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                                                                             module_compression=self._play_context.module_compression,
                                                                             async_timeout=self._task.async_val,
                                                                             environment=final_environment,
-                                                                            **become_kwargs)
+                                                                            become_plugin=self._connection.become)
                 break
             except InterpreterDiscoveryRequiredError as idre:
                 self._discovered_interpreter = AnsibleUnsafeText(discover_interpreter(

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -128,11 +128,9 @@ class ActionModule(ActionBase):
             # like become and environment args
             if getattr(self._connection._shell, "_IS_WINDOWS", False):
                 # FUTURE: use a more public method to get the exec payload
-                pc = self._play_context
                 exec_data = ps_manifest._create_powershell_wrapper(
                     to_bytes(script_cmd), source, {}, env_dict, self._task.async_val,
-                    pc.become, pc.become_method, pc.become_user,
-                    pc.become_pass, pc.become_flags, "script", task_vars
+                    self._connection.become, 'script', task_vars
                 )
                 # build the necessary exec wrapper command
                 # FUTURE: this still doesn't let script work on Windows with non-pipelined connections or


### PR DESCRIPTION
##### SUMMARY
* Simplifies `modify_module` to pass in the actual become plugin and not each individual options required for Windows become
* Add deprecation notices for the play context fallback in case a become plugin does not implement some known base options.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
become
runas