### PR TITLE
postgresql_info: add getting publication statistics

### DIFF
--- a/changelogs/fragments/67614-postgresql_info_add_collecting_publication_info.yml
+++ b/changelogs/fragments/67614-postgresql_info_add_collecting_publication_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- postgresql_info - add collecting info about logical replication publications in databases (https://github.com/ansible/ansible/pull/67614).

--- a/lib/ansible/modules/database/postgresql/postgresql_info.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_info.py
@@ -638,7 +638,7 @@ class PgClusterInfo(object):
 
     def get_subscr_info(self):
         """Get subscription statistics and fill out self.pg_info dictionary."""
-        if self.cursor.connection.server_version < 10000:
+        if self.cursor.connection.server_version < 100000:
             return
 
         query = ("SELECT s.*, r.rolname AS ownername, d.datname AS dbname "
@@ -956,7 +956,7 @@ class PgClusterInfo(object):
             db_dict[datname]['namespaces'] = self.get_namespaces()
             db_dict[datname]['extensions'] = self.get_ext_info()
             db_dict[datname]['languages'] = self.get_lang_info()
-            if self.cursor.connection.server_version >= 10000:
+            if self.cursor.connection.server_version >= 100000:
                 db_dict[datname]['publications'] = self.get_pub_info()
 
         self.pg_info["databases"] = db_dict

--- a/lib/ansible/modules/database/postgresql/postgresql_info.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_info.py
@@ -612,9 +612,6 @@ class PgClusterInfo(object):
 
     def get_pub_info(self):
         """Get publication statistics."""
-        if self.cursor.connection.server_version < 10000:
-            return
-
         query = ("SELECT p.*, r.rolname AS ownername "
                  "FROM pg_catalog.pg_publication AS p "
                  "JOIN pg_catalog.pg_roles AS r "
@@ -959,7 +956,8 @@ class PgClusterInfo(object):
             db_dict[datname]['namespaces'] = self.get_namespaces()
             db_dict[datname]['extensions'] = self.get_ext_info()
             db_dict[datname]['languages'] = self.get_lang_info()
-            db_dict[datname]['publications'] = self.get_pub_info()
+            if self.cursor.connection.server_version >= 10000:
+                db_dict[datname]['publications'] = self.get_pub_info()
 
         self.pg_info["databases"] = db_dict
 

--- a/lib/ansible/modules/database/postgresql/postgresql_info.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_info.py
@@ -235,6 +235,15 @@ databases:
               returned: always
               type: str
               sample: postgres
+        publications:
+          description:
+          - Information about logical replication publications (available for PostgreSQL 10 and higher)
+            U(https://www.postgresql.org/docs/current/logical-replication-publication.html).
+          - Content depends on PostgreSQL server version.
+          returned: if configured
+          type: dict
+          version_added: "2.10"
+          sample: { "mydb": { "pub1": { "ownername": "postgres", "puballtables": true, "pubinsert": true, "pubupdate": true } } }
 repl_slots:
   description:
   - Replication slots (available in 9.4 and later)
@@ -460,6 +469,7 @@ subscriptions:
   - Content depends on PostgreSQL server version.
   returned: if configured
   type: dict
+  version_added: "2.10"
   sample:
   - {"acme_db": {"my_subscription": {"ownername": "postgres", "subenabled": true, "subpublications": ["first_publication"]}}}
 '''
@@ -599,6 +609,35 @@ class PgClusterInfo(object):
                 subset_map[s]()
 
         return self.pg_info
+
+    def get_pub_info(self):
+        """Get publication statistics."""
+        if self.cursor.connection.server_version < 10000:
+            return
+
+        query = ("SELECT p.*, r.rolname AS ownername "
+                 "FROM pg_catalog.pg_publication AS p "
+                 "JOIN pg_catalog.pg_roles AS r "
+                 "ON p.pubowner = r.oid")
+
+        result = self.__exec_sql(query)
+
+        if result:
+            result = [dict(row) for row in result]
+        else:
+            return {}
+
+        publications = {}
+
+        for elem in result:
+            if not publications.get(elem['pubname']):
+                publications[elem['pubname']] = {}
+
+            for key, val in iteritems(elem):
+                if key != 'pubname':
+                    publications[elem['pubname']][key] = val
+
+        return publications
 
     def get_subscr_info(self):
         """Get subscription statistics and fill out self.pg_info dictionary."""
@@ -920,6 +959,7 @@ class PgClusterInfo(object):
             db_dict[datname]['namespaces'] = self.get_namespaces()
             db_dict[datname]['extensions'] = self.get_ext_info()
             db_dict[datname]['languages'] = self.get_lang_info()
+            db_dict[datname]['publications'] = self.get_pub_info()
 
         self.pg_info["databases"] = db_dict
 

--- a/test/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
+++ b/test/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
@@ -135,3 +135,23 @@
       - result.version == {}
       - result.roles == {}
       - result.databases
+
+  - name: postgresql_info - test return publication info
+    <<: *task_parameters
+    postgresql_info:
+      <<: *pg_parameters
+      login_db: '{{ test_db }}'
+      login_port: '{{ master_port }}'
+
+  - assert:
+      that:
+      - result.version != {}
+      - result.databases.{{ db_default }}.collate
+      - result.databases.{{ db_default }}.languages
+      - result.databases.{{ db_default }}.namespaces
+      - result.databases.{{ db_default }}.extensions
+      - result.databases.{{ test_db }}.publications.{{ test_pub }}.ownername == '{{ pg_user }}'
+      - result.databases.{{ test_db }}.publications.{{ test_pub2 }}.puballtables == true
+      - result.settings
+      - result.tablespaces
+      - result.roles


### PR DESCRIPTION
##### SUMMARY
postgresql_info: add getting publication statistics for databases

i also added ```version_added: "2.10"``` to ```subscriptions:``` in RETURN section because it was merged today earlier and i forgot to add this https://github.com/ansible/ansible/pull/67464

also fixed the server_version check for the subscription and publication related parts

```
      "acme_db": {
            ...
            "publications": {
                "first_publication": {
                    "ownername": "postgres",
                    "puballtables": true,
                    "pubdelete": true,
                    "pubinsert": true,
                    "pubowner": 10,
                    "pubupdate": true
                },
                "second_publication": {
                    "ownername": "postgres",
                    "puballtables": true,
                    "pubdelete": true,
                    "pubinsert": true,
                    "pubowner": 10,
                    "pubupdate": true
                }
            },
        }
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/postgresql/postgresql_info.py```
