### PR TITLE
[stable-2.9] Do not error if collection specified null dependencies (#67575)

### DIFF
--- a/changelogs/fragments/67574-null_collection_dependency_list.yml
+++ b/changelogs/fragments/67574-null_collection_dependency_list.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix collection install error that happened if a dependency specified dependencies to be null (https://github.com/ansible/ansible/issues/67574).

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -101,13 +101,17 @@ class CollectionRequirement:
 
     @property
     def dependencies(self):
-        if self._metadata:
-            return self._metadata.dependencies
-        elif len(self.versions) > 1:
-            return None
+        if not self._metadata:
+            if len(self.versions) > 1:
+                return {}
+            self._get_metadata()
 
-        self._get_metadata()
-        return self._metadata.dependencies
+        dependencies = self._metadata.dependencies
+
+        if dependencies is None:
+            return {}
+
+        return dependencies
 
     def add_requirement(self, parent, requirement):
         self.required_by.append((parent, requirement))

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -304,7 +304,7 @@ def test_build_requirement_from_name(galaxy_server, monkeypatch):
     assert actual.skip is False
     assert actual.versions == set([u'2.1.9', u'2.1.10'])
     assert actual.latest_version == u'2.1.10'
-    assert actual.dependencies is None
+    assert actual.dependencies == {}
 
     assert mock_get_versions.call_count == 1
     assert mock_get_versions.mock_calls[0][1] == ('namespace', 'collection')
@@ -324,7 +324,7 @@ def test_build_requirement_from_name_with_prerelease(galaxy_server, monkeypatch)
     assert actual.skip is False
     assert actual.versions == set([u'1.0.1', u'2.0.1'])
     assert actual.latest_version == u'2.0.1'
-    assert actual.dependencies is None
+    assert actual.dependencies == {}
 
     assert mock_get_versions.call_count == 1
     assert mock_get_versions.mock_calls[0][1] == ('namespace', 'collection')
@@ -374,7 +374,7 @@ def test_build_requirement_from_name_second_server(galaxy_server, monkeypatch):
     assert actual.skip is False
     assert actual.versions == set([u'1.0.2', u'1.0.3'])
     assert actual.latest_version == u'1.0.3'
-    assert actual.dependencies is None
+    assert actual.dependencies == {}
 
     assert mock_404.call_count == 1
     assert mock_404.mock_calls[0][1] == ('namespace', 'collection')
@@ -474,7 +474,7 @@ def test_build_requirement_from_name_multiple_version_results(galaxy_server, mon
     assert actual.skip is False
     assert actual.versions == set([u'2.0.0', u'2.0.1', u'2.0.3', u'2.0.4', u'2.0.5'])
     assert actual.latest_version == u'2.0.5'
-    assert actual.dependencies is None
+    assert actual.dependencies == {}
 
     assert mock_get_versions.call_count == 1
     assert mock_get_versions.mock_calls[0][1] == ('namespace', 'collection')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #67575 for Ansible 2.9.
(cherry picked from commit cffead4631)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/galaxy/collection.py`