### PR TITLE
Fix become for network_cli in collections.

### DIFF
--- a/changelogs/fragments/network-cli-become-collections.yml
+++ b/changelogs/fragments/network-cli-become-collections.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Skipping of become for ``network_cli`` connections now works when ``network_cli`` is sourced from a collection.

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1048,7 +1048,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         ruser = self._get_remote_user()
         buser = self.get_become_option('become_user')
         if (sudoable and self._connection.become and  # if sudoable and have become
-                self._connection.transport != 'network_cli' and  # if not using network_cli
+                self._connection.transport.split('.')[-1] != 'network_cli' and  # if not using network_cli
                 (C.BECOME_ALLOW_SAME_USER or (buser != ruser or not any((ruser, buser))))):  # if we allow same user PE or users are different and either is set
             display.debug("_low_level_execute_command(): using become for this command")
             cmd = self._connection.become.build_become_command(cmd, self._connection._shell)


### PR DESCRIPTION
##### SUMMARY

Skipping of become for `network_cli` connections now works when `network_cli` is sourced from a collection.

This logic for handling `network_cli` in collections matches other occurrences in the code, where there are many occurrences of:

```python
 persistent_connection = self._play_context.connection.split('.')[-1]
```

As well as:

```python
if self._play_context.connection.split('.')[-1] != 'network_cli'
```

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible
