### PR TITLE
[WIP] ansible-galaxy - use galaxy.yml when listing collections

### DIFF
--- a/changelogs/fragments/galaxy-collection-list-use-galaxy-yml.yml
+++ b/changelogs/fragments/galaxy-collection-list-use-galaxy-yml.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - read information from ``galaxy.yml`` when listing collections if no ``MANIFEST.JSON`` exists (https://github.com/ansible/ansible/issues/67490)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If no `MANIFEST.json` is present, use galaxy.ya?ml for getting collection information.

Fixes #67490
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/galaxy/collection.py`