### PR TITLE
Handle NoneType error in vmware_host_service_info

### DIFF
--- a/changelogs/fragments/67615-vmware_host_service_info_fix.yml
+++ b/changelogs/fragments/67615-vmware_host_service_info_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Handle NoneType error when accessing service system info in vmware_host_service_info module (https://github.com/ansible/ansible/issues/67615).

--- a/lib/ansible/modules/cloud/vmware/vmware_host_service_info.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_service_info.py
@@ -112,7 +112,7 @@ class VmwareServiceManager(PyVmomi):
         for host in self.hosts:
             host_service_info = []
             host_service_system = host.configManager.serviceSystem
-            if host_service_system:
+            if host_service_system and host_service_system.serviceInfo:
                 services = host_service_system.serviceInfo.service
                 for service in services:
                     host_service_info.append(


### PR DESCRIPTION
##### SUMMARY

Handle NoneType error occured due to accessing host system service info
in vmware_host_service_info module.

Fixes: #67615

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
changelogs/fragments/67615-vmware_host_service_info_fix.yml
lib/ansible/modules/cloud/vmware/vmware_host_service_info.py
