### PR TITLE
reclassify fact_path to avoid local relative path

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -592,7 +592,7 @@ DEFAULT_FACT_PATH:
   env: [{name: ANSIBLE_FACT_PATH}]
   ini:
   - {key: fact_path, section: defaults}
-  type: path
+  type: string
   yaml: {key: facts.gathering.fact_path}
 DEFAULT_FILTER_PLUGIN_PATH:
   name: Jinja2 Filter Plugins Path


### PR DESCRIPTION
should fix following when setting fact_path to a windows path in ansible.cfg:

```
  {"ansible_facts": {}, "changed": false, "failed_modules": {"setup": {"changed": false, "failed": true, "msg": "Get-AnsibleParam: Parameter 'fact_path' has an invalid path '/home/myname/ansible/test/C:\\users\\vagrant\\facts.d\\' specified."}}, "msg": "The following modules failed to execute: setup\n"}
```
As reported in irc.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
config