### PR TITLE
scaleway_compute: check image on get instead of list

### DIFF
--- a/changelogs/fragments/67655-scaleway_compute-get-image-instead-loop-on-list.yml
+++ b/changelogs/fragments/67655-scaleway_compute-get-image-instead-loop-on-list.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- 'scaleway_compute(check_image_id): use get image instead loop on first page of images results'

--- a/lib/ansible/modules/cloud/scaleway/scaleway_compute.py
+++ b/lib/ansible/modules/cloud/scaleway/scaleway_compute.py
@@ -178,14 +178,11 @@ SCALEWAY_TRANSITIONS_STATES = (
 
 
 def check_image_id(compute_api, image_id):
-    response = compute_api.get(path="images")
+    response = compute_api.get(path="images/%s" % image_id)
 
-    if response.ok and response.json:
-        image_ids = [image["id"] for image in response.json["images"]]
-        if image_id not in image_ids:
-            compute_api.module.fail_json(msg='Error in getting image %s on %s' % (image_id, compute_api.module.params.get('api_url')))
-    else:
-        compute_api.module.fail_json(msg="Error in getting images from: %s" % compute_api.module.params.get('api_url'))
+    if not response.ok:
+        msg = 'Error in getting image %s on %s : %s' % (image_id, compute_api.module.params.get('api_url'), response.json)
+        compute_api.module.fail_json(msg=msg)
 
 
 def fetch_state(compute_api, server):


### PR DESCRIPTION
Signed-off-by: Alexis Camilleri <acamilleri@scaleway.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The image is checked by it's id (`GET /images/{id}`) and not from the first results of `GET /images` endpoint.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/cloud/scaleway/scaleway_compute.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I'm using the [scaleway_compute](https://docs.ansible.com/ansible/latest/modules/scaleway_compute_module.html) module, but i get an error with `Ubuntu Bionic Beaver (f974feac-abae-4365-b988-8ec7d1cec10d)` image because it's on the second page, but image exist!

<!--- Paste verbatim command output below, e.g. before and after your change -->
##### UNEXPECTED RESULT
```paste below
TASK [create_instance : Ensure instance is created] ************************************************
[WARNING]: https://cp-par1.scaleway.com/images?

fatal: [localhost]: FAILED! => {"changed": false, "msg": "Error in getting image f974feac-abae-4365-b988-8ec7d1cec10d on https://cp-par1.scaleway.com"}
```

##### EXPECTED RESULT WITH CHANGES
```
TASK [create_instance : Ensure instance is created] ***************************************************************
[WARNING]: https://cp-par1.scaleway.com/images/f974feac-abae-4365-b988-8ec7d1cec10d?

[WARNING]: https://cp-par1.scaleway.com/servers?name=node-cp-p14&per_page=1

ok: [localhost]
```
