### PR TITLE
Skip lookup_hashi_vault test for Python 2.6

### DIFF
--- a/test/integration/targets/lookup_hashi_vault/aliases
+++ b/test/integration/targets/lookup_hashi_vault/aliases
@@ -3,3 +3,4 @@ destructive
 needs/target/setup_openssl
 needs/file/test/lib/ansible_test/_data/requirements/constraints.txt
 skip/aix
+skip/python2.6

--- a/test/integration/targets/lookup_hashi_vault/playbooks/install_dependencies.yml
+++ b/test/integration/targets/lookup_hashi_vault/playbooks/install_dependencies.yml
@@ -17,4 +17,3 @@
     - name: 'Install hvac Python package'
       pip:
         name: "{{ hvac_package|default('hvac') }}"
-        extra_args: "-c {{ playbook_dir }}/../../../../lib/ansible_test/_data/requirements/constraints.txt"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes the test to work on FreeBSD 11.3 and 12.1.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/lookup_hashi_vault`