### PR TITLE
adds missing alias to win_regedit documentation

### DIFF
--- a/lib/ansible/modules/windows/win_regedit.py
+++ b/lib/ansible/modules/windows/win_regedit.py
@@ -37,7 +37,7 @@ options:
     - If not provided, or empty then the '(Default)' property for the key will
       be used.
     type: str
-    aliases: [ entry ]
+    aliases: [ entry, value ]
   data:
     description:
     - Value of the registry entry C(name) in C(path).


### PR DESCRIPTION
##### SUMMARY
The win_regedit module has supported the "entry" and "value" aliases to the "name" parameter since inception, but it looks like the "value" alias never got added to the documentation. This PR fixes that. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
win_regedit.py

##### ADDITIONAL INFORMATION
None relevant
+label: docsite_pr