### PR TITLE
fixes link, makes intrapage TOC local

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_running_locally.rst
+++ b/docs/docsite/rst/dev_guide/testing_running_locally.rst
@@ -6,12 +6,13 @@
 Testing Ansible
 ***************
 
-.. contents:: Topics
-
 This document describes how to:
 
 * Run tests locally using ``ansible-test``
 * Extend
+
+.. contents::
+   :local:
 
 Requirements
 ============
@@ -35,7 +36,7 @@ An API key is required to use this feature.
 
     Recommended for integration tests.
 
-See the `list of supported platforms and versions <https://github.com/ansible/ansible/blob/devel/test/runner/completion/remote.txt>`_ for additional details.
+See the `list of supported platforms and versions <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/remote.txt>`_ for additional details.
 
 Environment Variables
 ---------------------


### PR DESCRIPTION
##### SUMMARY
Fixes link from testing page to the list of supported local testing environments. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
testing
