### PR TITLE
openssl_* modules, cryptography backend: parse dirName, RID and otherName names

### DIFF
--- a/changelogs/fragments/67669-cryptography-names.yml
+++ b/changelogs/fragments/67669-cryptography-names.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "openssl_* modules - the cryptography backend now properly supports ``dirName``, ``otherName`` and ``RID`` (Registered ID) names."

--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -1945,7 +1945,7 @@ def cryptography_decode_name(name):
         return 'URI:{0}'.format(name.value)
     if isinstance(name, x509.DirectoryName):
         return 'dirName:' + ''.join([
-            '/{0}={1}'.format(cryptography_oid_to_name(attribute.oid), _dn_escape_value(attribute.value))
+            '/{0}={1}'.format(cryptography_oid_to_name(attribute.oid, short=True), _dn_escape_value(attribute.value))
             for attribute in name.value
         ])
     if isinstance(name, x509.RegisteredID):

--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -1824,6 +1824,22 @@ def cryptography_oid_to_name(oid, short=False):
         return _NORMALIZE_NAMES.get(name, name)
 
 
+def _get_hex(bytesstr):
+    if bytesstr is None:
+        return bytesstr
+    data = binascii.hexlify(bytesstr)
+    data = to_text(b':'.join(data[i:i + 2] for i in range(0, len(data), 2)))
+    return data
+
+
+def _parse_hex(bytesstr):
+    if bytesstr is None:
+        return bytesstr
+    data = ''.join([('0' * (2 - len(p)) + p) if len(p) < 2 else p for p in to_text(bytesstr).split(':')])
+    data = binascii.unhexlify(data)
+    return data
+
+
 def cryptography_get_name(name):
     '''
     Given a name string, returns a cryptography x509.Name object.
@@ -1838,19 +1854,21 @@ def cryptography_get_name(name):
             return x509.RFC822Name(to_text(name[6:]))
         if name.startswith('URI:'):
             return x509.UniformResourceIdentifier(to_text(name[4:]))
+        if name.startswith('RID:'):
+            m = re.match(r'^([0-9]+(?:\.[0-9]+)*)$', to_text(name[4:]))
+            if not m:
+                raise OpenSSLObjectError('Cannot parse Subject Alternative Name "{0}"'.format(name))
+            return x509.RegisteredID(x509.oid.ObjectIdentifier(m.group(1)))
+        if name.startswith('otherName:'):
+            m = re.match(r'^([0-9]+(?:\.[0-9]+)*);([0-9a-fA-F]{1,2}(?::[0-9a-fA-F]{1,2})*)$', to_text(name[10:]))
+            if not m:
+                raise OpenSSLObjectError('Cannot parse Subject Alternative Name "{0}"'.format(name))
+            return x509.OtherName(x509.oid.ObjectIdentifier(m.group(1)), _parse_hex(m.group(2)))
     except Exception as e:
         raise OpenSSLObjectError('Cannot parse Subject Alternative Name "{0}": {1}'.format(name, e))
     if ':' not in name:
         raise OpenSSLObjectError('Cannot parse Subject Alternative Name "{0}" (forgot "DNS:" prefix?)'.format(name))
     raise OpenSSLObjectError('Cannot parse Subject Alternative Name "{0}" (potentially unsupported by cryptography backend)'.format(name))
-
-
-def _get_hex(bytesstr):
-    if bytesstr is None:
-        return bytesstr
-    data = binascii.hexlify(bytesstr)
-    data = to_text(b':'.join(data[i:i + 2] for i in range(0, len(data), 2)))
-    return data
 
 
 def cryptography_decode_name(name):
@@ -1868,13 +1886,11 @@ def cryptography_decode_name(name):
         return 'URI:{0}'.format(name.value)
     if isinstance(name, x509.DirectoryName):
         # FIXME: test
-        return 'DirName:' + ''.join(['/{0}:{1}'.format(attribute.oid._name, attribute.value) for attribute in name.value])
+        return 'dirName:' + ''.join(['/{0}:{1}'.format(attribute.oid._name, attribute.value) for attribute in name.value])
     if isinstance(name, x509.RegisteredID):
-        # FIXME: test
-        return 'RegisteredID:{0}'.format(name.value)
+        return 'RID:{0}'.format(name.value.dotted_string)
     if isinstance(name, x509.OtherName):
-        # FIXME: test
-        return '{0}:{1}'.format(name.type_id.dotted_string, _get_hex(name.value))
+        return 'otherName:{0};{1}'.format(name.type_id.dotted_string, _get_hex(name.value))
     raise OpenSSLObjectError('Cannot decode name "{0}"'.format(name))
 
 

--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -2210,6 +2210,10 @@ def pyopenssl_normalize_name_attribute(san):
     if san.startswith('IP:'):
         ip = compat_ipaddress.ip_address(san[3:])
         san = 'IP:{0}'.format(ip.compressed)
+
     if san.startswith('Registered ID:'):
         san = 'RID:' + san[len('Registered ID:'):]
+    # Some versions of OpenSSL apparently forgot the colon. Happens in CI with Ubuntu 16.04 and FreeBSD 11.1
+    if san.startswith('Registered ID'):
+        san = 'RID:' + san[len('Registered ID'):]
     return san

--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -1909,7 +1909,7 @@ def cryptography_get_name(name):
                 raise OpenSSLObjectError('Cannot parse Subject Alternative Name "{0}"'.format(name))
             return x509.OtherName(x509.oid.ObjectIdentifier(m.group(1)), _parse_hex(m.group(2)))
         if name.startswith('dirName:'):
-            return x509.DirectoryName(x509.Name(_parse_dn(name[8:])))
+            return x509.DirectoryName(x509.Name(_parse_dn(to_text(name[8:]))))
     except Exception as e:
         raise OpenSSLObjectError('Cannot parse Subject Alternative Name "{0}": {1}'.format(name, e))
     if ':' not in name:

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -2232,6 +2232,8 @@ class AssertOnlyCertificate(AssertOnlyCertificateBase):
         if san.startswith('IP:'):
             ip = compat_ipaddress.ip_address(san[3:])
             san = 'IP:{0}'.format(ip.compressed)
+        if san.startswith('Registered ID:'):
+            san = 'RID:' + san[len('Registered ID:'):]
         return san
 
     def _validate_subject_alt_name(self):

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -707,6 +707,8 @@ class CertificateSigningRequestPyOpenSSL(CertificateSigningRequestBase):
         if san.startswith('IP:'):
             ip = compat_ipaddress.ip_address(san[3:])
             san = 'IP:{0}'.format(ip.compressed)
+        if san.startswith('Registered ID:'):
+            san = 'RID:' + san[len('Registered ID:'):]
         return san
 
     def _check_csr(self):

--- a/test/integration/targets/openssl_csr/tasks/impl.yml
+++ b/test/integration/targets/openssl_csr/tasks/impl.yml
@@ -586,6 +586,8 @@
       - "URI:https://example.org/test/index.html"
       - "RID:1.2.3.4"
       - '{{ "otherName:1.2.3.4;0c:07:63:65:72:74:72:65:71" if select_crypto_backend != "pyopenssl" else "" }}'
+      - '{{ "dirName:O = Example Net, CN = example.net" if select_crypto_backend != "pyopenssl" else "" }}'
+      - '{{ "dirName:/O=Example Com/CN=example.com" if select_crypto_backend != "pyopenssl" else "" }}'
   register: everything_1
 
 - name: Generate CSR with everything (idempotent, check mode)
@@ -657,6 +659,8 @@
       - "URI:https://example.org/test/index.html"
       - "RID:1.2.3.4"
       - '{{ "otherName:1.2.3.4;0c:07:63:65:72:74:72:65:71" if select_crypto_backend != "pyopenssl" else "" }}'
+      - '{{ "dirName:O=Example Net,CN=example.net" if select_crypto_backend != "pyopenssl" else "" }}'
+      - '{{ "dirName:/O = Example Com/CN = example.com" if select_crypto_backend != "pyopenssl" else "" }}'
   check_mode: yes
   register: everything_2
 
@@ -729,6 +733,8 @@
       - "URI:https://example.org/test/index.html"
       - "RID:1.2.3.4"
       - '{{ "otherName:1.2.3.4;0c:07:63:65:72:74:72:65:71" if select_crypto_backend != "pyopenssl" else "" }}'
+      - '{{ "dirName:O  =Example Net,    CN= example.net" if select_crypto_backend != "pyopenssl" else "" }}'
+      - '{{ "dirName:/O  =Example Com/CN=  example.com" if select_crypto_backend != "pyopenssl" else "" }}'
   register: everything_3
 
 - name: Ed25519 and Ed448 tests (for cryptography >= 2.6)

--- a/test/integration/targets/openssl_csr/tasks/impl.yml
+++ b/test/integration/targets/openssl_csr/tasks/impl.yml
@@ -563,7 +563,7 @@
       - DVCS
       - IPSec User
       - biometricInfo
-    subject_alt_name: '{{ value_for_san | reject("equalto", "") | list }}'
+    subject_alt_name: '{{ value_for_san if select_crypto_backend != "pyopenssl" else value_for_san_pyopenssl }}'
     basic_constraints:
       - "CA:TRUE"
       - "pathlen:23"
@@ -578,6 +578,13 @@
     value_for_authority_cert_issuer:
       - "DNS:ca.example.org"
       - "IP:1.2.3.4"
+    value_for_san_pyopenssl:
+      - "DNS:www.ansible.com"
+      - "IP:1.2.3.4"
+      - "IP:::1"
+      - "email:test@example.org"
+      - "URI:https://example.org/test/index.html"
+      - "RID:1.2.3.4"
     value_for_san:
       - "DNS:www.ansible.com"
       - "IP:1.2.3.4"
@@ -585,9 +592,9 @@
       - "email:test@example.org"
       - "URI:https://example.org/test/index.html"
       - "RID:1.2.3.4"
-      - '{{ "otherName:1.2.3.4;0c:07:63:65:72:74:72:65:71" if select_crypto_backend != "pyopenssl" else "" }}'
-      - '{{ "dirName:O = Example Net, CN = example.net" if select_crypto_backend != "pyopenssl" else "" }}'
-      - '{{ "dirName:/O=Example Com/CN=example.com" if select_crypto_backend != "pyopenssl" else "" }}'
+      - "otherName:1.2.3.4;0c:07:63:65:72:74:72:65:71"
+      - "dirName:O = Example Net, CN = example.net"
+      - "dirName:/O=Example Com/CN=example.com"
   register: everything_1
 
 - name: Generate CSR with everything (idempotent, check mode)
@@ -636,7 +643,7 @@
       - DVCS
       - IPSec User
       - biometricInfo
-    subject_alt_name: '{{ value_for_san | reject("equalto", "") | list }}'
+    subject_alt_name: '{{ value_for_san if select_crypto_backend != "pyopenssl" else value_for_san_pyopenssl }}'
     basic_constraints:
       - "CA:TRUE"
       - "pathlen:23"
@@ -651,6 +658,13 @@
     value_for_authority_cert_issuer:
       - "DNS:ca.example.org"
       - "IP:1.2.3.4"
+    value_for_san_pyopenssl:
+      - "DNS:www.ansible.com"
+      - "IP:1.2.3.4"
+      - "IP:::1"
+      - "email:test@example.org"
+      - "URI:https://example.org/test/index.html"
+      - "RID:1.2.3.4"
     value_for_san:
       - "DNS:www.ansible.com"
       - "IP:1.2.3.4"
@@ -658,9 +672,9 @@
       - "email:test@example.org"
       - "URI:https://example.org/test/index.html"
       - "RID:1.2.3.4"
-      - '{{ "otherName:1.2.3.4;0c:07:63:65:72:74:72:65:71" if select_crypto_backend != "pyopenssl" else "" }}'
-      - '{{ "dirName:O=Example Net,CN=example.net" if select_crypto_backend != "pyopenssl" else "" }}'
-      - '{{ "dirName:/O = Example Com/CN = example.com" if select_crypto_backend != "pyopenssl" else "" }}'
+      - "otherName:1.2.3.4;0c:07:63:65:72:74:72:65:71"
+      - "dirName:O=Example Net,CN=example.net"
+      - "dirName:/O = Example Com/CN = example.com"
   check_mode: yes
   register: everything_2
 
@@ -710,7 +724,7 @@
       - DVCS
       - IPSec User
       - biometricInfo
-    subject_alt_name: '{{ value_for_san | reject("equalto", "") | list }}'
+    subject_alt_name: '{{ value_for_san if select_crypto_backend != "pyopenssl" else value_for_san_pyopenssl }}'
     basic_constraints:
       - "CA:TRUE"
       - "pathlen:23"
@@ -725,6 +739,13 @@
     value_for_authority_cert_issuer:
       - "DNS:ca.example.org"
       - "IP:1.2.3.4"
+    value_for_san_pyopenssl:
+      - "DNS:www.ansible.com"
+      - "IP:1.2.3.4"
+      - "IP:::1"
+      - "email:test@example.org"
+      - "URI:https://example.org/test/index.html"
+      - "RID:1.2.3.4"
     value_for_san:
       - "DNS:www.ansible.com"
       - "IP:1.2.3.4"
@@ -732,9 +753,9 @@
       - "email:test@example.org"
       - "URI:https://example.org/test/index.html"
       - "RID:1.2.3.4"
-      - '{{ "otherName:1.2.3.4;0c:07:63:65:72:74:72:65:71" if select_crypto_backend != "pyopenssl" else "" }}'
-      - '{{ "dirName:O  =Example Net,    CN= example.net" if select_crypto_backend != "pyopenssl" else "" }}'
-      - '{{ "dirName:/O  =Example Com/CN=  example.com" if select_crypto_backend != "pyopenssl" else "" }}'
+      - "otherName:1.2.3.4;0c:07:63:65:72:74:72:65:71"
+      - "dirName:O  =Example Net,    CN= example.net"
+      - "dirName:/O  =Example Com/CN=  example.com"
   register: everything_3
 
 - name: Ed25519 and Ed448 tests (for cryptography >= 2.6)

--- a/test/integration/targets/openssl_csr/tasks/impl.yml
+++ b/test/integration/targets/openssl_csr/tasks/impl.yml
@@ -563,12 +563,7 @@
       - DVCS
       - IPSec User
       - biometricInfo
-    subject_alt_name:
-      - "DNS:www.ansible.com"
-      - "IP:1.2.3.4"
-      - "IP:::1"
-      - "email:test@example.org"
-      - "URI:https://example.org/test/index.html"
+    subject_alt_name: '{{ value_for_san | reject("equalto", "") | list }}'
     basic_constraints:
       - "CA:TRUE"
       - "pathlen:23"
@@ -583,6 +578,14 @@
     value_for_authority_cert_issuer:
       - "DNS:ca.example.org"
       - "IP:1.2.3.4"
+    value_for_san:
+      - "DNS:www.ansible.com"
+      - "IP:1.2.3.4"
+      - "IP:::1"
+      - "email:test@example.org"
+      - "URI:https://example.org/test/index.html"
+      - "RID:1.2.3.4"
+      - '{{ "otherName:1.2.3.4;0c:07:63:65:72:74:72:65:71" if select_crypto_backend != "pyopenssl" else "" }}'
   register: everything_1
 
 - name: Generate CSR with everything (idempotent, check mode)
@@ -631,12 +634,7 @@
       - DVCS
       - IPSec User
       - biometricInfo
-    subject_alt_name:
-      - "DNS:www.ansible.com"
-      - "IP:1.2.3.4"
-      - "IP:::1"
-      - "email:test@example.org"
-      - "URI:https://example.org/test/index.html"
+    subject_alt_name: '{{ value_for_san | reject("equalto", "") | list }}'
     basic_constraints:
       - "CA:TRUE"
       - "pathlen:23"
@@ -651,6 +649,14 @@
     value_for_authority_cert_issuer:
       - "DNS:ca.example.org"
       - "IP:1.2.3.4"
+    value_for_san:
+      - "DNS:www.ansible.com"
+      - "IP:1.2.3.4"
+      - "IP:::1"
+      - "email:test@example.org"
+      - "URI:https://example.org/test/index.html"
+      - "RID:1.2.3.4"
+      - '{{ "otherName:1.2.3.4;0c:07:63:65:72:74:72:65:71" if select_crypto_backend != "pyopenssl" else "" }}'
   check_mode: yes
   register: everything_2
 
@@ -700,12 +706,7 @@
       - DVCS
       - IPSec User
       - biometricInfo
-    subject_alt_name:
-      - "DNS:www.ansible.com"
-      - "IP:1.2.3.4"
-      - "IP:::1"
-      - "email:test@example.org"
-      - "URI:https://example.org/test/index.html"
+    subject_alt_name: '{{ value_for_san | reject("equalto", "") | list }}'
     basic_constraints:
       - "CA:TRUE"
       - "pathlen:23"
@@ -720,6 +721,14 @@
     value_for_authority_cert_issuer:
       - "DNS:ca.example.org"
       - "IP:1.2.3.4"
+    value_for_san:
+      - "DNS:www.ansible.com"
+      - "IP:1.2.3.4"
+      - "IP:::1"
+      - "email:test@example.org"
+      - "URI:https://example.org/test/index.html"
+      - "RID:1.2.3.4"
+      - '{{ "otherName:1.2.3.4;0c:07:63:65:72:74:72:65:71" if select_crypto_backend != "pyopenssl" else "" }}'
   register: everything_3
 
 - name: Ed25519 and Ed448 tests (for cryptography >= 2.6)

--- a/test/integration/targets/openssl_csr/tasks/impl.yml
+++ b/test/integration/targets/openssl_csr/tasks/impl.yml
@@ -758,6 +758,12 @@
       - "dirName:/O  =Example Com/CN=  example.com"
   register: everything_3
 
+- name: Get info from CSR with everything
+  openssl_csr_info:
+    path: '{{ output_dir }}/csr_everything.csr'
+    select_crypto_backend: '{{ select_crypto_backend }}'
+  register: everything_info
+
 - name: Ed25519 and Ed448 tests (for cryptography >= 2.6)
   block:
     - name: Generate privatekeys

--- a/test/integration/targets/openssl_csr/tests/validate.yml
+++ b/test/integration/targets/openssl_csr/tests/validate.yml
@@ -184,6 +184,95 @@
       - everything_1 is changed
       - everything_2 is not changed
       - everything_3 is not changed
+      - everything_info.basic_constraints == [
+          "CA:TRUE",
+          "pathlen:23",
+        ]
+      - everything_info.basic_constraints_critical == true
+      - everything_info.extended_key_usage == [
+            "Any Extended Key Usage",
+            "Biometric Info",
+            "Code Signing",
+            "E-mail Protection",
+            "IPSec User",
+            "OCSP Signing",
+            "TLS Web Client Authentication",
+            "TLS Web Server Authentication",
+            "TLS Web Server Authentication",
+            "Time Stamping",
+            "dvcs",
+            "qcStatements",
+        ]
+      - everything_info.extended_key_usage_critical == false
+      - everything_info.key_usage == [
+            "CRL Sign",
+            "Certificate Sign",
+            "Data Encipherment",
+            "Decipher Only",
+            "Digital Signature",
+            "Encipher Only",
+            "Key Agreement",
+            "Key Encipherment",
+            "Non Repudiation"
+        ],
+      - everything_info.key_usage_critical == true
+      - everything_info.ocsp_must_staple == true
+      - everything_info.ocsp_must_staple_critical == false
+      - everything_info.signature_valid == true
+      - everything_info.subject.commonName == "www.example.com"
+      - everything_info.subject.countryName == "de"
+      - everything_info.subject.emailAddress == "test@example.com"
+      - everything_info.subject.givenName == "First Name"
+      - everything_info.subject.localityName == "Somewhere"
+      - everything_info.subject.organizationName == "Ansible"
+      - everything_info.subject.organizationalUnitName == "Crypto Department"
+      - everything_info.subject.postalAddress == "1234 Somewhere"
+      - everything_info.subject.postalCode == "1234"
+      - everything_info.subject.pseudonym == "test"
+      - everything_info.subject.serialNumber == "1234"
+      - everything_info.subject.stateOrProvinceName == "Zurich"
+      - everything_info.subject.streetAddress == "Welcome Street"
+      - everything_info.subject.surname == "Last Name"
+      - everything_info.subject.title == "Chief"
+      - everything_info.subject.userId == "asdf"
+      - everything_info.subject | length == 16
+      - everything_info.subject_alt_name_critical == false
+
+- name: Check CSR with everything (pyOpenSSL specific)
+  assert:
+    that:
+      - everything_info.subject_alt_name == [
+            "DNS:www.ansible.com",
+            "IP:1.2.3.4",
+            "IP:::1",
+            "email:test@example.org",
+            "URI:https://example.org/test/index.html",
+            "RID:1.2.3.4",
+        ]
+  when: select_crypto_backend == 'pyopenssl'
+
+- name: Check CSR with everything (non-pyOpenSSL specific)
+  assert:
+    that:
+      - everything_info.authority_cert_issuer == [
+            "DNS:ca.example.org",
+            "IP:1.2.3.4"
+        ]
+      - everything_info.authority_cert_serial_number == 12345
+      - everything_info.authority_key_identifier == "44:55:66:77"
+      - everything_info.subject_alt_name == [
+            "DNS:www.ansible.com",
+            "IP:1.2.3.4",
+            "IP:::1",
+            "email:test@example.org",
+            "URI:https://example.org/test/index.html",
+            "RID:1.2.3.4",
+            "otherName:1.2.3.4;0c:07:63:65:72:74:72:65:71",
+            "dirName:/O=Example Net/CN=example.net",
+            "dirName:/O=Example Com/CN=example.com"
+        ]
+      - everything_info.subject_key_identifier == "00:11:22:33"
+  when: select_crypto_backend != 'pyopenssl'
 
 - name: Verify Ed25519 and Ed448 tests (for cryptography >= 2.6, < 2.8)
   assert:


### PR DESCRIPTION
##### SUMMARY
These weren't supported so far. Prompted by a [question on the ansible-project mailing list](https://groups.google.com/d/msgid/ansible-project/273386b0-ef64-4bca-902e-593b88a7f9ff%40googlegroups.com).

While adding tests, I noticed that it is pretty much impossible to use `dirName` with the pyOpenSSL backend, since the functions are designed to work with a OpenSSL config file (the syntax is `dirName:sectionName`, and `sectionName` is supposed to be a section name in that config file - not very helpful); and support for `otherName` is only partial: while it supports more complex ways of specifying it (you can specify the ASN.1 type and the value in a readable form), it can't parse the result: it will always be printed as `<unsupported>`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/crypto.py
openssl_csr
openssl_csr_info
openssl_certificate
openssl_certificate_info
x509_crl
