### PR TITLE
VMware: Fix to be set default parameter for runtime_settings to runtime_settings

### DIFF
--- a/changelogs/fragments/67670-vmware_vcenter_settings.yml
+++ b/changelogs/fragments/67670-vmware_vcenter_settings.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_vcenter_settings - Fixed when runtime_settings parameters not defined occur error(https://github.com/ansible/ansible/issues/66713)

--- a/test/integration/targets/vmware_vcenter_settings/aliases
+++ b/test/integration/targets/vmware_vcenter_settings/aliases
@@ -1,4 +1,3 @@
-shippable/vcenter/group2
 cloud/vcenter
-needs/target/prepare_vmware_tests
+unsupported
 zuul/vmware/vcenter_only


### PR DESCRIPTION
##### SUMMARY
When runtime_settings parameter not defined or some parameters not set in runtime_settings, fix to be set default parameters for runtime_settings to runtime_settings parameters.

fixes: https://github.com/ansible/ansible/issues/66713

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
vmware_vcenter_settings

##### ADDITIONAL INFORMATION
tested on vCenter 6.7
