### PR TITLE
Specify display width and no color in test_execute_list_collection_no_valid_paths

### DIFF
--- a/test/units/cli/galaxy/test_execute_list_collection.py
+++ b/test/units/cli/galaxy/test_execute_list_collection.py
@@ -240,6 +240,8 @@ def test_execute_list_collection_no_valid_paths(mocker, capsys):
 
     mocker.patch('os.path.exists', return_value=True)
     mocker.patch('os.path.isdir', return_value=False)
+    mocker.patch('ansible.utils.color.ANSIBLE_COLOR', False)
+    mocker.patch('ansible.cli.galaxy.display.columns', 79)
     gc = GalaxyCLI(['ansible-galaxy', 'collection', 'list'])
 
     with pytest.raises(AnsibleOptionsError, match=r'None of the provided paths were usable.'):
@@ -248,7 +250,7 @@ def test_execute_list_collection_no_valid_paths(mocker, capsys):
     out, err = capsys.readouterr()
 
     assert '[WARNING]: - the configured path' in err
-    assert 'exists, but it is not a directory.' in err
+    assert 'exists, but it\nis not a directory.' in err
 
 
 def test_execute_list_collection_one_invalid_path(mocker, capsys, mock_collection_objects):


### PR DESCRIPTION
##### SUMMARY

This ensures the test passes regardless of the test environment.
Previously, it would pass in some environments but fail locally
in other environments, due to the width being calculated as
different or support for color not being consistently detected.

Signed-off-by: Rick Elrod <rick@elrod.me>


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

`test/units/cli/galaxy/test_execute_list_collection.py`
