### PR TITLE
Split hcloud tests into two CI groups.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -211,6 +211,9 @@ matrix:
 
     - env: T=hcloud/2.7/1
     - env: T=hcloud/3.6/1
+
+    - env: T=hcloud/2.7/2
+    - env: T=hcloud/3.6/2
 branches:
   except:
     - "*-patch-*"

--- a/test/integration/targets/hcloud_datacenter_info/aliases
+++ b/test/integration/targets/hcloud_datacenter_info/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-shippable/hcloud/group1
+shippable/hcloud/group2

--- a/test/integration/targets/hcloud_floating_ip/aliases
+++ b/test/integration/targets/hcloud_floating_ip/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-shippable/hcloud/group1
+shippable/hcloud/group2

--- a/test/integration/targets/hcloud_floating_ip_info/aliases
+++ b/test/integration/targets/hcloud_floating_ip_info/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-shippable/hcloud/group1
+shippable/hcloud/group2

--- a/test/integration/targets/hcloud_image_info/aliases
+++ b/test/integration/targets/hcloud_image_info/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-shippable/hcloud/group1
+shippable/hcloud/group2

--- a/test/integration/targets/hcloud_location_info/aliases
+++ b/test/integration/targets/hcloud_location_info/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-shippable/hcloud/group1
+shippable/hcloud/group2

--- a/test/integration/targets/hcloud_server_info/aliases
+++ b/test/integration/targets/hcloud_server_info/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-shippable/hcloud/group1
+shippable/hcloud/group2

--- a/test/integration/targets/hcloud_server_network/aliases
+++ b/test/integration/targets/hcloud_server_network/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-shippable/hcloud/group1
+shippable/hcloud/group2

--- a/test/integration/targets/hcloud_server_type_info/aliases
+++ b/test/integration/targets/hcloud_server_type_info/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-shippable/hcloud/group1
+shippable/hcloud/group2

--- a/test/integration/targets/hcloud_ssh_key/aliases
+++ b/test/integration/targets/hcloud_ssh_key/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-shippable/hcloud/group1
+shippable/hcloud/group2

--- a/test/integration/targets/hcloud_ssh_key_info/aliases
+++ b/test/integration/targets/hcloud_ssh_key_info/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-shippable/hcloud/group1
+shippable/hcloud/group2

--- a/test/integration/targets/hcloud_subnetwork/aliases
+++ b/test/integration/targets/hcloud_subnetwork/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-shippable/hcloud/group1
+shippable/hcloud/group2

--- a/test/integration/targets/hcloud_volume/aliases
+++ b/test/integration/targets/hcloud_volume/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-shippable/hcloud/group1
+shippable/hcloud/group2

--- a/test/integration/targets/hcloud_volume_info/aliases
+++ b/test/integration/targets/hcloud_volume_info/aliases
@@ -1,2 +1,2 @@
 cloud/hcloud
-shippable/hcloud/group1
+shippable/hcloud/group2

--- a/test/utils/shippable/cloud.sh
+++ b/test/utils/shippable/cloud.sh
@@ -15,14 +15,14 @@ stage="${S:-prod}"
 
 changed_all_target="shippable/${cloud}/smoketest/"
 
+if ! ansible-test integration "${changed_all_target}" --list-targets > /dev/null 2>&1; then
+    # no smoketest tests are available for this cloud
+    changed_all_target="none"
+fi
+
 if [ "${group}" == "1" ]; then
     # only run smoketest tests for group1
     changed_all_mode="include"
-
-    if ! ansible-test integration "${changed_all_target}" --list-targets > /dev/null 2>&1; then
-        # no smoketest tests are available for this cloud
-        changed_all_target="none"
-    fi
 else
     # smoketest tests already covered by group1
     changed_all_mode="exclude"


### PR DESCRIPTION
##### SUMMARY

Split hcloud tests into two CI groups.

This will hopefully resolve CI failures when running with code coverage.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

shippable.yml
