### PR TITLE
Setup documentation - windows custom fact variable name

### DIFF
--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -56,7 +56,7 @@ options:
               File/results format can be JSON or INI-format. The default C(fact_path) can be
               specified in C(ansible.cfg) for when setup is automatically called as part of
               C(gather_facts).
-              NOTE: For windows clients, the results will be added to a variable named after the 
+              NOTE - For windows clients, the results will be added to a variable named after the 
               local file (without extension suffix), rather than C(ansible_local).
         required: false
         default: /etc/ansible/facts.d

--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -56,7 +56,7 @@ options:
               File/results format can be JSON or INI-format. The default C(fact_path) can be
               specified in C(ansible.cfg) for when setup is automatically called as part of
               C(gather_facts).
-              NOTE - For windows clients, the results will be added to a variable named after the 
+              NOTE - For windows clients, the results will be added to a variable named after the
               local file (without extension suffix), rather than C(ansible_local).
         required: false
         default: /etc/ansible/facts.d

--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -51,11 +51,13 @@ options:
         version_added: "1.3"
         description:
             - Path used for local ansible facts (C(*.fact)) - files in this dir
-              will be run (if executable) and their results be added to C(ansible_local) facts
-              if a file is not executable it is read. Check notes for Windows options. (from 2.1 on)
+              will be run (if executable) and their results be added to C(ansible_local) facts.
+              If a file is not executable it is read instead. Check notes for Windows options. (from 2.1 on)
               File/results format can be JSON or INI-format. The default C(fact_path) can be
               specified in C(ansible.cfg) for when setup is automatically called as part of
               C(gather_facts).
+              NOTE: For windows clients, the results will be added to a variable named after the 
+              local file (without extension suffix), rather than C(ansible_local).
         required: false
         default: /etc/ansible/facts.d
 description:


### PR DESCRIPTION
##### SUMMARY
<!--- Your description here -->
Add clarification for the windows implementation setup.ps1. Unlike for *nix, custom facts on windows are added to ansible_facts under the name of the executable file, rather than ansible_local as on *nix.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
