### PR TITLE
nxos_ntp: Fix behavior when vrf_name is None

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_ntp.py
+++ b/lib/ansible/modules/network/nxos/nxos_ntp.py
@@ -250,7 +250,7 @@ def set_ntp_server_peer(peer_type, address, prefer, key_id, vrf_name):
 
 
 def config_ntp(delta, existing):
-    if (delta.get('address') or delta.get('peer_type') or delta.get('vrf_name') or
+    if (delta.get('address') or delta.get('peer_type') or 'vrf_name' in delta or
             delta.get('key_id') or delta.get('prefer')):
         address = delta.get('address', existing.get('address'))
         peer_type = delta.get('peer_type', existing.get('peer_type'))
@@ -359,6 +359,9 @@ def main():
                 source=source)
 
     proposed = dict((k, v) for k, v in args.items() if v is not None)
+
+    if "address" in proposed:
+        proposed.setdefault('vrf_name', None)
 
     existing, peer_server_list = get_ntp_existing(address, peer_type, module)
 


### PR DESCRIPTION
##### SUMMARY
Fix behavior when `vrf_name` of the `nxos_ntp` module is set to None: we should take it into account when comparing with existing servers.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nxos_ntp

##### ADDITIONAL INFORMATION
This fixes the case where there is a NTP server *already configured* using `vrf_name` and we wish to configure the same server **without VRF information** (essentially move the server from one VRF to no VRF)
In this case, the vrf_name is None and *will be ignored*. The module will consider existing NTP and proposed NTP identical, thus making no changes.

After this fix, **vrf_name is consider even when set to None** and will be part of the delta between existing and proposed, allowing change of NTP VRF to default instance.

<!--- Paste verbatim command output below, e.g. before and after your change -->
For existing configuration: 
```
ntp server 10.44.23.12 use-vrf management
```

Apply following task:
```
    - name: Ensure NTP server is configured
      nxos_ntp:
        server: "10.44.23.12"
        vrf_name: null
        state: present
```

Before (no change)
```
ok: [192.168.98.103] => {
    "changed": false,
    "end_state": {
        "address": "10.44.23.12",
        "key_id": null,
        "peer_type": "server",
        "prefer": "disabled",
        "vrf_name": "management"
    },
    "existing": {
        "address": "10.44.23.12",
        "key_id": null,
        "peer_type": "server",
        "prefer": "disabled",
        "vrf_name": "management"
    },
    "invocation": {
        "module_args": {
            "auth_pass": null,
            "authorize": null,
            "host": null,
            "key_id": null,
            "password": null,
            "peer": null,
            "port": null,
            "prefer": null,
            "provider": null,
            "server": "10.44.23.12",
            "source_addr": null,
            "source_int": null,
            "ssh_keyfile": null,
            "state": "present",
            "timeout": null,
            "transport": null,
            "use_ssl": null,
            "username": null,
            "validate_certs": null,
            "vrf_name": null
        }
    },
    "peer_server_list": [],
    "proposed": {
        "address": "10.44.23.12",
        "peer_type": "server"
    },
    "updates": []
}

```

After (change)

```
changed: [192.168.98.103] => {
    "changed": true,
    "end_state": {
        "address": "10.44.23.12",
        "key_id": null,
        "peer_type": "server",
        "prefer": "disabled",
        "vrf_name": null
    },
    "existing": {
        "address": "10.44.23.12",
        "key_id": null,
        "peer_type": "server",
        "prefer": "disabled",
        "vrf_name": "management"
    },
    "invocation": {
        "module_args": {
            "auth_pass": null,
            "authorize": null,
            "host": null,
            "key_id": null,
            "password": null,
            "peer": null,
            "port": null,
            "prefer": null,
            "provider": null,
            "server": "10.44.23.12",
            "source_addr": null,
            "source_int": null,
            "ssh_keyfile": null,
            "state": "present",
            "timeout": null,
            "transport": null,
            "use_ssl": null,
            "username": null,
            "validate_certs": null,
            "vrf_name": null
        }
    },
    "peer_server_list": [],
    "proposed": {
        "address": "10.44.23.12",
        "peer_type": "server",
        "vrf_name": null
    },
    "updates": [
        "no ntp server 10.44.23.12",
        "ntp server 10.44.23.12"
    ]
}
```

End result
```
ntp server 10.44.23.12
```