### PR TITLE
Zabbix: Fix to be support for zabbix 4.4 or more and python3

### DIFF
--- a/changelogs/fragments/67693-zabbix_mediatype.yml
+++ b/changelogs/fragments/67693-zabbix_mediatype.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_mediatype - Fixed to support zabbix 4.4 or more and python3 (https://github.com/ansible/ansible/pull/67693)

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_mediatype.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_mediatype.py
@@ -44,6 +44,7 @@ options:
         type: 'str'
         description:
             - Type of the media type.
+            - Media types I(jabber) and I(ez_texting) workable only with Zabbix 4.2 or less.
         choices:
             - email
             - script
@@ -223,7 +224,7 @@ import traceback
 
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils.common.text.converters import container_to_bytes
+from distutils.version import LooseVersion
 
 
 try:
@@ -350,7 +351,7 @@ def construct_parameters(**kwargs):
             attempt_interval=str(kwargs['attempt_interval']),
             gsm_modem=kwargs['gsm_modem']
         )
-    elif kwargs['transport_type'] == 'jabber':
+    elif kwargs['transport_type'] == 'jabber' and LooseVersion(kwargs['zbx_api_version']) <= LooseVersion('4.2'):
         return dict(
             description=kwargs['name'],
             status=to_numeric_value(kwargs['status'],
@@ -368,7 +369,7 @@ def construct_parameters(**kwargs):
             username=kwargs['username'],
             passwd=kwargs['password']
         )
-    elif kwargs['transport_type'] == 'ez_texting':
+    elif kwargs['transport_type'] == 'ez_texting' and LooseVersion(kwargs['zbx_api_version']) <= LooseVersion('4.2'):
         return dict(
             description=kwargs['name'],
             status=to_numeric_value(kwargs['status'],
@@ -390,8 +391,10 @@ def construct_parameters(**kwargs):
                                         'Canada': '1'}),
         )
 
+    return {'unsupported_parameter': kwargs['transport_type'], 'zbx_api_version': kwargs['zbx_api_version']}
 
-def check_if_mediatype_exists(module, zbx, name):
+
+def check_if_mediatype_exists(module, zbx, name, zbx_api_version):
     """Checks if mediatype exists.
 
     Args:
@@ -402,10 +405,15 @@ def check_if_mediatype_exists(module, zbx, name):
     Returns:
         Tuple of (True, `id of the mediatype`) if mediatype exists, (False, None) otherwise
     """
+    filter_key_name = 'description'
+    if LooseVersion(zbx_api_version) >= LooseVersion('4.4'):
+        # description key changed to name key from zabbix 4.4
+        filter_key_name = 'name'
+
     try:
         mediatype_list = zbx.mediatype.get({
             'output': 'extend',
-            'filter': {'description': [name]}
+            'filter': {filter_key_name: [name]}
         })
         if len(mediatype_list) < 1:
             return False, None
@@ -452,10 +460,10 @@ def get_update_params(module, zbx, mediatype_id, **kwargs):
         returned by diff() function with
         existing mediatype data and new params passed to it.
     """
-    existing_mediatype = container_to_bytes(zbx.mediatype.get({
+    existing_mediatype = zbx.mediatype.get({
         'output': 'extend',
         'mediatypeids': [mediatype_id]
-    })[0])
+    })[0]
 
     if existing_mediatype['type'] != kwargs['type']:
         return kwargs, diff(existing_mediatype, kwargs)
@@ -589,7 +597,8 @@ def main():
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 
-    mediatype_exists, mediatype_id = check_if_mediatype_exists(module, zbx, name)
+    zbx_api_version = zbx.api_version()[:3]
+    mediatype_exists, mediatype_id = check_if_mediatype_exists(module, zbx, name, zbx_api_version)
 
     parameters = construct_parameters(
         name=name,
@@ -611,8 +620,16 @@ def main():
         smtp_authentication=smtp_authentication,
         smtp_verify_host=smtp_verify_host,
         smtp_verify_peer=smtp_verify_peer,
-        message_text_limit=message_text_limit
+        message_text_limit=message_text_limit,
+        zbx_api_version=zbx_api_version
     )
+
+    if 'unsupported_parameter' in parameters:
+        module.fail_json(msg="%s is unsupported for Zabbix version %s" % (parameters['unsupported_parameter'], parameters['zbx_api_version']))
+
+    if LooseVersion(zbx_api_version) >= LooseVersion('4.4'):
+        # description key changed to name key from zabbix 4.4
+        parameters['name'] = parameters.pop('description')
 
     if mediatype_exists:
         if state == 'absent':


### PR DESCRIPTION
##### SUMMARY
This PR will reflect following.

**remove container_to_bytes**

The container_to_bytes was implementing in code but use python3 to run was following error occurs.

```
The full traceback is:
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1582538352.0711439-27533304798404/AnsiballZ_zabbix_mediatype.py", line 102, in <module>
    _ansiballz_main()
  File "/root/.ansible/tmp/ansible-tmp-1582538352.0711439-27533304798404/AnsiballZ_zabbix_mediatype.py", line 94, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/root/.ansible/tmp/ansible-tmp-1582538352.0711439-27533304798404/AnsiballZ_zabbix_mediatype.py", line 40, in invoke_module
    runpy.run_module(mod_name='ansible.modules.monitoring.zabbix.zabbix_mediatype', init_globals=None, run_name='__main__', alter_sys=True)
  File "/usr/lib64/python3.6/runpy.py", line 205, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib64/python3.6/runpy.py", line 96, in _run_module_code
    mod_name, mod_spec, pkg_name, script_name)
  File "/usr/lib64/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_zabbix_mediatype_payload_mzongyua/ansible_zabbix_mediatype_payload.zip/ansible/modules/monitoring/zabbix/zabbix_mediatype.py", line 688, in <module>
  File "/tmp/ansible_zabbix_mediatype_payload_mzongyua/ansible_zabbix_mediatype_payload.zip/ansible/modules/monitoring/zabbix/zabbix_mediatype.py", line 636, in main
  File "/tmp/ansible_zabbix_mediatype_payload_mzongyua/ansible_zabbix_mediatype_payload.zip/ansible/modules/monitoring/zabbix/zabbix_mediatype.py", line 460, in get_update_params
KeyError: 'type'
failed: [localhost] (item=54280) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": 54280,
    "module_stderr": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1582538352.0711439-27533304798404/AnsiballZ_zabbix_mediatype.py\", line 102, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1582538352.0711439-27533304798404/AnsiballZ_zabbix_mediatype.py\", line 94, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1582538352.0711439-27533304798404/AnsiballZ_zabbix_mediatype.py\", line 40, in invoke_module\n    runpy.run_module(mod_name='ansible.modules.monitoring.zabbix.zabbix_mediatype', init_globals=None, run_name='__main__', alter_sys=True)\n  File \"/usr/lib64/python3.6/runpy.py\", line 205, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.6/runpy.py\", line 96, in _run_module_code\n    mod_name, mod_spec, pkg_name, script_name)\n  File \"/usr/lib64/python3.6/runpy.py\", line 85, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_zabbix_mediatype_payload_mzongyua/ansible_zabbix_mediatype_payload.zip/ansible/modules/monitoring/zabbix/zabbix_mediatype.py\", line 688, in <module>\n  File \"/tmp/ansible_zabbix_mediatype_payload_mzongyua/ansible_zabbix_mediatype_payload.zip/ansible/modules/monitoring/zabbix/zabbix_mediatype.py\", line 636, in main\n  File \"/tmp/ansible_zabbix_mediatype_payload_mzongyua/ansible_zabbix_mediatype_payload.zip/ansible/modules/monitoring/zabbix/zabbix_mediatype.py\", line 460, in get_update_params\nKeyError: 'type'\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
```

So, remove container_to_bytes from code.

**about jabber and ez_texting**

Media types jabber and ez_texting workable only with Zabbix 4.2 or less.  
So add displayed an error message to code with when Zabbix 4.4 or more runs.

**change description key to name key for mediatype object**

description key changed to name key from zabbix version 4.4

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
zabbix_mediatype

##### ADDITIONAL INFORMATION
tested on zabbix 4.0/4.2/4.4 with python2.7 and 3.6

