### PR TITLE
[2.9] Allow nxos_l2_interfaces to append the allowed vlans list

### DIFF
--- a/changelogs/fragments/66517-nxos-append-allowed-vlans.yaml
+++ b/changelogs/fragments/66517-nxos-append-allowed-vlans.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "nxos_vlans -  Allow nxos_l2_interfaces to append the allowed vlans list"

--- a/lib/ansible/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/config/l2_interfaces/l2_interfaces.py
@@ -151,12 +151,12 @@ class L2_interfaces(ConfigBase):
             diff = dict_diff(w, obj_in_have)
         else:
             diff = w
-        merged_commands = self.set_commands(w, have)
+        merged_commands = self.set_commands(w, have, True)
         if 'name' not in diff:
             diff['name'] = w['name']
         wkeys = w.keys()
         dkeys = diff.keys()
-        for k in wkeys:
+        for k in w.copy():
             if k in self.exclude_params and k in dkeys:
                 del diff[k]
         replaced_commands = self.del_attribs(diff)
@@ -192,7 +192,7 @@ class L2_interfaces(ConfigBase):
                             del h[k]
             commands.extend(self.del_attribs(h))
         for w in want:
-            commands.extend(self.set_commands(flatten_dict(w), have))
+            commands.extend(self.set_commands(flatten_dict(w), have, True))
         return commands
 
     def _state_merged(self, w, have):
@@ -246,7 +246,7 @@ class L2_interfaces(ConfigBase):
             diff.update({'name': w['name']})
         return diff
 
-    def add_commands(self, d):
+    def add_commands(self, d, vlan_exists=False):
         commands = []
         if not d:
             return commands
@@ -255,19 +255,35 @@ class L2_interfaces(ConfigBase):
         if 'vlan' in d:
             commands.append(cmd + 'access vlan ' + str(d['vlan']))
         if 'allowed_vlans' in d:
-            commands.append(cmd + 'trunk allowed vlan ' + str(d['allowed_vlans']))
+            if vlan_exists:
+                commands.append(cmd + 'trunk allowed vlan add ' + str(d['allowed_vlans']))
+            else:
+                commands.append(cmd + 'trunk allowed vlan ' + str(d['allowed_vlans']))
         if 'native_vlan' in d:
             commands.append(cmd + 'trunk native vlan ' + str(d['native_vlan']))
         if commands:
             commands.insert(0, 'interface ' + d['name'])
         return commands
 
-    def set_commands(self, w, have):
+    def set_commands(self, w, have, replace=False):
         commands = []
+        vlan_tobe_added = []
         obj_in_have = flatten_dict(search_obj_in_list(w['name'], have, 'name'))
         if not obj_in_have:
             commands = self.add_commands(w)
         else:
             diff = self.diff_of_dicts(w, obj_in_have)
+            if diff and not replace:
+                if "allowed_vlans" in diff.keys() and diff["allowed_vlans"]:
+                    vlan_tobe_added = diff["allowed_vlans"].split(',')
+                    vlan_list = vlan_tobe_added[:]
+                    have_vlans = obj_in_have["allowed_vlans"].split(',')
+                    for w_vlans in vlan_list:
+                        if w_vlans in have_vlans:
+                            vlan_tobe_added.pop(vlan_tobe_added.index(w_vlans))
+                    if vlan_tobe_added:
+                        diff.update({"allowed_vlans": ','.join(vlan_tobe_added)})
+                        commands = self.add_commands(diff, True)
+                    return commands
             commands = self.add_commands(diff)
         return commands

--- a/test/integration/targets/nxos_l2_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/nxos_l2_interfaces/tests/cli/merged.yaml
@@ -23,6 +23,8 @@
         - name: "{{ test_int1 }}"
           access:
             vlan: 6
+          trunk:
+            allowed_vlans: 200
       state:  merged
     register: result
 
@@ -32,7 +34,7 @@
         - "result.before|length == 0"
         - "'interface {{ test_int1 }}' in result.commands"
         - "'switchport access vlan 6' in result.commands"
-        - "result.commands|length == 2"
+        - "result.commands|length == 3"
 
   - name: Gather l2_interfaces facts
     nxos_facts:
@@ -53,6 +55,43 @@
       that:
         - "result.changed == false"
         - "result.commands|length == 0"
+
+  - name: Merge with existing vlans
+    nxos_l2_interfaces: &vlanadd
+      config:
+        - name: "{{ test_int1 }}"
+          trunk:
+            allowed_vlans: "10-12"
+      state:  merged
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == true"
+        - "'interface {{ test_int1 }}' in result.commands"
+        - "'switchport trunk allowed vlan add 10,11,12' in result.commands"
+        - "result.commands|length == 2"
+
+  - name: Gather l2_interfaces facts
+    nxos_facts:
+      gather_subset:
+        - '!all'
+        - '!min'
+      gather_network_resources: l2_interfaces
+
+  - assert:
+      that:
+        - "ansible_facts.network_resources.l2_interfaces|symmetric_difference(result.after)|length == 0"
+
+  - name: Idempotence - with newly added vlans
+    nxos_l2_interfaces: *vlanadd
+    register: result
+
+  - assert:
+      that:
+        - "result.changed == false"
+        - "result.commands|length == 0"
+
 
   always:
   - name: teardown

--- a/test/integration/targets/nxos_l2_interfaces/tests/cli/overridden.yaml
+++ b/test/integration/targets/nxos_l2_interfaces/tests/cli/overridden.yaml
@@ -35,6 +35,8 @@
         - name: "{{ test_int2 }}"
           access:
             vlan: 6
+          trunk:
+            allowed_vlans: "10-12"
       state: overridden
     register: result
 
@@ -46,6 +48,7 @@
         - "'no switchport trunk allowed vlan' in result.commands"
         - "'interface {{ test_int2 }}' in result.commands"
         - "'switchport access vlan 6' in result.commands"
+        - "'switchport trunk allowed vlan 10,11,12' in result.commands"
 
   - name: Gather l2_interfaces post facts
     nxos_facts: *facts

--- a/test/integration/targets/nxos_l2_interfaces/tests/cli/replaced.yaml
+++ b/test/integration/targets/nxos_l2_interfaces/tests/cli/replaced.yaml
@@ -22,6 +22,7 @@
         interface {{ test_int2 }}
           switchport
           switchport trunk native vlan 15
+          switchport trunk allowed vlan 25-27
 
   - name: Gather l2_interfaces facts
     nxos_facts: &facts
@@ -36,16 +37,18 @@
         - name: "{{ test_int1 }}"
           access:
             vlan: 8
+          trunk:
+            allowed_vlans: "10-12"
       state: replaced
     register: result
 
   - assert:
       that:
-        - "ansible_facts.network_resources.l2_interfaces|symmetric_difference(result.before)|length == 0"
         - "result.changed == true"
         - "'interface {{ test_int1 }}' in result.commands"
         - "'switchport access vlan 8' in result.commands"
-        - "result.commands|length == 2"
+        - "'switchport trunk allowed vlan 10,11,12' in result.commands"
+        - "result.commands|length == 3"
 
   - name: Gather l2_interfaces post facts
     nxos_facts: *facts


### PR DESCRIPTION
##### SUMMARY

Backport of #66517

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
nxos_vlans.py



```
