### PR TITLE
SOCKS5 proxy support for uri module

### DIFF
--- a/changelogs/fragments/67715-socks5_proxy_support_uri.yml
+++ b/changelogs/fragments/67715-socks5_proxy_support_uri.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - uri - add support for SOCKS5 proxy (https://github.com/ansible/ansible/issues/44338)

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -176,6 +176,7 @@ options:
     description:
       - "SOCKS5 configuration in the following format: ip_address:port."
     type: str
+    version_added: "2.10"
 notes:
   - The dependency on httplib2 was removed in Ansible 2.1.
   - The module returns all the HTTP headers in lower-case.

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -172,6 +172,10 @@ options:
       - Header to identify as, generally appears in web server logs.
     type: str
     default: ansible-httpget
+  socks5_proxy:
+    description:
+      - "SOCKS5 configuration in the following format: ip_address:port."
+    type: str
 notes:
   - The dependency on httplib2 was removed in Ansible 2.1.
   - The module returns all the HTTP headers in lower-case.
@@ -365,8 +369,15 @@ import re
 import shutil
 import sys
 import tempfile
+import socket
 
-from ansible.module_utils.basic import AnsibleModule
+try:
+    import socks
+    HAVE_PYSOCKS = True
+except ImportError:
+    HAVE_PYSOCKS = False
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.six import PY2, iteritems, string_types
 from ansible.module_utils.six.moves.urllib.parse import urlencode, urlsplit
 from ansible.module_utils._text import to_native, to_text
@@ -585,6 +596,7 @@ def main():
         headers=dict(type='dict', default={}),
         unix_socket=dict(type='path'),
         remote_src=dict(type='bool', default=False),
+        socks5_proxy=dict(type='str')
     )
 
     module = AnsibleModule(
@@ -606,11 +618,20 @@ def main():
     removes = module.params['removes']
     status_code = [int(x) for x in list(module.params['status_code'])]
     socket_timeout = module.params['timeout']
+    socks5_proxy = module.params['socks5_proxy']
 
     dict_headers = module.params['headers']
 
+    if not HAVE_PYSOCKS and socks5_proxy:
+        module.fail_json(msg=missing_required_lib('PySocks'))
+
     if not re.match('^[A-Z]+$', method):
         module.fail_json(msg="Parameter 'method' needs to be a single word in uppercase, like GET or POST.")
+
+    if socks5_proxy:
+        host, port = socks5_proxy.split(':')
+        socks.set_default_proxy(socks.SOCKS5, host, port=int(port))
+        socket.socket = socks.socksocket
 
     if body_format == 'json':
         # Encode the body unless its a string, then assume it is pre-formatted JSON


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Because SOCKS proxies are not currently supported by the urllib on which Ansible is dependent, this patch provides a simple workaround to enable SOCKS5 support for the uri module.
For the same reason there is no option to give that support more generally - through handler to the urllib's opener.

Fixes #44338 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
uri
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Patch introduces a new module argument which is the location of a SOCKS5 proxy in the format of ip_address:port_number.
```
