### PR TITLE
docs: Add an example of specifying a specific commit hash to user_guide.rst

### DIFF
--- a/docs/docsite/rst/galaxy/user_guide.rst
+++ b/docs/docsite/rst/galaxy/user_guide.rst
@@ -273,6 +273,10 @@ Use the following example as a guide for specifying roles in *requirements.yml*:
       src: https://github.com/bennojoy/nginx
       version: master
 
+    # from GitHub, specifying a specific commit hash
+    - src: https://github.com/bennojoy/nginx
+      version: "ee8aa41"
+
     # from a webserver, where the role is packaged in a tar.gz
     - name: http-role-gz
       src: https://some.webserver.example.com/files/master.tar.gz


### PR DESCRIPTION
##### SUMMARY
Add an example of specifying a specific commit hash to `user_guide.rst`. The modified page is here: [Installing content — Ansible Documentation](https://galaxy.ansible.com/docs/using/installing.html#installing-multiple-roles-from-a-file).

Since there is no example using commit hash in the documentation, I have to search the web to find the concrete example.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr
