### PR TITLE
Remove unnecessary indent

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_user_obj_stat_info.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user_obj_stat_info.py
@@ -275,7 +275,7 @@ class PgUserObjStatInfo():
                                           query_params=(relname,),
                                           add_to_executed=False)
 
-                        self.info[info_key][elem[schema_key]][elem[name_key]]['total_size'] = result[0][0]
+                    self.info[info_key][elem[schema_key]][elem[name_key]]['total_size'] = result[0][0]
 
     def set_schema(self, schema):
         """If schema exists, sets self.schema, otherwise fails."""


### PR DESCRIPTION
##### SUMMARY

total_size fact is populated if schema is not specified in
postgresql_user_obj_stat_info module.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE 
- Bugfix Pull Request





##### COMPONENT NAME
lib/ansible/modules/database/postgresql/postgresql_user_obj_stat_info.py
