### PR TITLE
"Fix" test_get_bin_path by changing mock order

### DIFF
--- a/test/units/module_utils/common/process/test_get_bin_path.py
+++ b/test/units/module_utils/common/process/test_get_bin_path.py
@@ -15,9 +15,15 @@ def test_get_bin_path(mocker):
     mocker.patch.dict('os.environ', {'PATH': path})
     mocker.patch('os.pathsep', ':')
 
-    mocker.patch('os.path.exists', side_effect=[False, True])
     mocker.patch('os.path.isdir', return_value=False)
     mocker.patch('ansible.module_utils.common.process.is_executable', return_value=True)
+
+    # pytest-mock 2.0.0 will throw when os.path.exists is messed with
+    # and then another method is patched afterwards. Likely
+    # something in the pytest-mock chain uses os.path.exists internally, and
+    # since pytest-mock prohibits context-specific patching, there's not a
+    # good solution. For now, just patch os.path.exists last.
+    mocker.patch('os.path.exists', side_effect=[False, True])
 
     assert '/usr/local/bin/notacommand' == get_bin_path('notacommand')
 


### PR DESCRIPTION
##### SUMMARY

pytest-mock 2.0.0, when run locally, gets grumpy when os.path.exists is
messed with and then another method is patched afterwards. Likely
something in the pytest-mock chain uses os.path.exists internally, and
since pytest-mock prohibits context-specific patching, there's not a
good solution. For now, just patch os.path.exists last.

Signed-off-by: Rick Elrod <rick@elrod.me>


For the record, this is reproducible, running this with `pytest`:

```python
def test_foo(mocker):
    mocker.patch('os.path.exists', side_effect=[False, True])
    mocker.patch('os.path.isdir', return_value=False)
    assert True
```

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

`test/units/module_utils/common/process/test_get_bin_path.py`