### PR TITLE
strip spaces for each value in host list lists (#67701)

### DIFF
--- a/changelogs/fragments/pathlist_strip.yml
+++ b/changelogs/fragments/pathlist_strip.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - also strip spaces around config values in pathlist as we do in list types

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -137,7 +137,7 @@ def ensure_type(value, value_type, origin=None):
 
         elif value_type == 'pathlist':
             if isinstance(value, string_types):
-                value = value.split(',')
+                value = [x.strip() for x in value.split(',')]
 
             if isinstance(value, Sequence):
                 value = [resolve_path(x, basedir=basedir) for x in value]


### PR DESCRIPTION
fix pathlist to work like lists

now `hosts.ini, hosts.yml` would be the same as `hosts.ini,hosts.yml`

(cherry picked from commit 9ea5bb336400e20178cc6fb3816aef30dbdc8b60)

Backport of https://github.com/ansible/ansible/pull/67701

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
config