### PR TITLE
Fix inline vaults for plugins in ensure_type (#67492)

### DIFF
--- a/changelogs/fragments/67492-fix-decrypting-str-types-for-plugins.yaml
+++ b/changelogs/fragments/67492-fix-decrypting-str-types-for-plugins.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - plugins - Allow ensure_type to decrypt the value for string types (and implicit string types) when value is an inline vault.

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -145,13 +145,13 @@ def ensure_type(value, value_type, origin=None):
                 errmsg = 'pathlist'
 
         elif value_type in ('str', 'string'):
-            if isinstance(value, string_types):
+            if isinstance(value, (string_types, AnsibleVaultEncryptedUnicode)):
                 value = unquote(to_text(value, errors='surrogate_or_strict'))
             else:
                 errmsg = 'string'
 
         # defaults to string type
-        elif isinstance(value, string_types):
+        elif isinstance(value, (string_types, AnsibleVaultEncryptedUnicode)):
             value = unquote(to_text(value, errors='surrogate_or_strict'))
 
         if errmsg:

--- a/test/units/config/test_manager.py
+++ b/test/units/config/test_manager.py
@@ -131,3 +131,15 @@ class TestConfigManager:
         actual_value, actual_origin = self.manager._loop_entries({'name': vault_var}, [{'name': 'name'}])
         assert actual_value == "vault text"
         assert actual_origin == "name"
+
+    @pytest.mark.parametrize("value_type", ("str", "string", None))
+    def test_ensure_type_with_vaulted_str(self, value_type):
+        class MockVault:
+            def decrypt(self, value):
+                return value
+
+        vault_var = AnsibleVaultEncryptedUnicode(b"vault text")
+        vault_var.vault = MockVault()
+
+        actual_value = ensure_type(vault_var, value_type)
+        assert actual_value == "vault text"


### PR DESCRIPTION
##### SUMMARY
Backport of #67492

Connection plugins have been able to use inline vaults due to using vars (rather than direct), because it was fixed in _loop_entries. This fixes it universally for plugins in ensure_type for string options.

* Fix inline vaults for plugins in ensure_type
* Add tests for strings and implicit strings

(cherry picked from commit 8eb00dd14cc9cc896a7cfd8719ffa325f2f98f23)

##### ISSUE TYPE
- Bugfix Pull Request
