### PR TITLE
Fix missing space in puppet command (#60576)

### DIFF
--- a/changelogs/fragments/67742-puppet-noop-space.yaml
+++ b/changelogs/fragments/67742-puppet-noop-space.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - puppet - add a missing space between the `--noop` option and the manifest file (https://github.com/ansible/ansible/pull/67742)

--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -300,7 +300,7 @@ def main():
         if p['execute']:
             cmd += " --execute '%s'" % p['execute']
         else:
-            cmd += shlex_quote(p['manifest'])
+            cmd += " " + shlex_quote(p['manifest'])
         if p['summarize']:
             cmd += " --summarize"
         if p['debug']:


### PR DESCRIPTION
##### SUMMARY
This commit adds a missing space in the `puppet` command between the options and the parameters.

Fixes #60576

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
puppet

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
How to reproduce:
```
# cat playbook.yml
---
- name: hello world playbook
  hosts: all
  tasks:
    - name: puppet apply
      puppet:
        manifest: /tmp/hello_world.pp
```
```
# cat /tmp/hello_world.pp
notify {'Hello world':}
```
```
# ansible-playbook --verbose  -i localhost, -- playbook.yml
Using /home/sam/.ansible.cfg as config file

PLAY [hello world playbook] 
****************************************************************************************************

TASK [Gathering Facts] ****************************************************************************************************
ok: [localhost]

TASK [puppet apply] ****************************************************************************************************
fatal: [localhost]: FAILED! => changed=false
  disabled: false
  error: true
  msg: puppet did not run
  rc: 1
  stderr: |-
    [1;31mError: Could not parse application options: invalid option: --no-noop/tmp/hello_world.pp[0m
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>

PLAY RECAP ****************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```
