### PR TITLE
mysql_db: add dump_extra_args parameter

### DIFF
--- a/changelogs/fragments/67747-mysql_db_add_dump_extra_args_param.yml
+++ b/changelogs/fragments/67747-mysql_db_add_dump_extra_args_param.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mysql_db - add the ``dump_extra_args`` parameter (https://github.com/ansible/ansible/pull/67747).

--- a/test/integration/targets/mysql_db/tasks/state_dump_import.yml
+++ b/test/integration/targets/mysql_db/tasks/state_dump_import.yml
@@ -67,13 +67,14 @@
     force: yes
     master_data: 1
     skip_lock_tables: yes
+    dump_extra_args: --skip-triggers
   register: result
 
 - name: assert successful completion of dump operation
   assert:
     that:
     - result is changed
-    - result.executed_commands[0] is search("mysqldump --force --socket={{ mysql_socket }} --databases {{ db_name }} --skip-lock-tables --quick --ignore-table={{ db_name }}.department --master-data=1")
+    - result.executed_commands[0] is search("mysqldump --force --socket={{ mysql_socket }} --databases {{ db_name }} --skip-lock-tables --quick --ignore-table={{ db_name }}.department --master-data=1 --skip-triggers")
 
 - name: state dump/import - file name should exist
   file: name={{ db_file_name }} state=file


### PR DESCRIPTION
##### SUMMARY
mysql_db: add dump_extra_args parameter
Fixes: https://github.com/ansible/ansible/pull/66238

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/mysql/mysql_db.py```
