### PR TITLE
[stable-2.9] Clean up CONDITIONAL_BARE_VARS warning

### DIFF
--- a/changelogs/fragments/67735-warning-cleanup.yml
+++ b/changelogs/fragments/67735-warning-cleanup.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- Update the warning message for ``CONDITIONAL_BARE_VARS`` to list the original conditional
+  not the value of the original conditional (https://github.com/ansible/ansible/issues/67735)

--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -133,8 +133,8 @@ class Conditional:
             disable_lookups = hasattr(conditional, '__UNSAFE__')
             conditional = templar.template(conditional, disable_lookups=disable_lookups)
             if bare_vars_warning and not isinstance(conditional, bool):
-                display.deprecated('evaluating %s as a bare variable, this behaviour will go away and you might need to add |bool'
-                                   ' to the expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle.' % conditional, "2.12")
+                display.deprecated('evaluating %r as a bare variable, this behaviour will go away and you might need to add |bool'
+                                   ' to the expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle' % original, "2.12")
             if not isinstance(conditional, text_type) or conditional == "":
                 return conditional
 


### PR DESCRIPTION
[stable-2.9] Clean up CONDITIONAL_BARE_VARS warning. Fixes #67735 (#67751).
(cherry picked from commit 6e1a59174aba6bfe00c7b03a4287e784f802b2e8)

Backport of https://github.com/ansible/ansible/pull/67751

Co-authored-by: Matt Martz <matt@sivel.net>