### PR TITLE
Zabbix: Fix to remove unnecessary duplicate line

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host_events_info.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host_events_info.py
@@ -234,7 +234,6 @@ class Host(object):
     def get_triggers_by_host_id_in_problem_state(self, host_id, trigger_severity):
         """ Get triggers in problem state from a hostid"""
         # https://www.zabbix.com/documentation/3.4/manual/api/reference/trigger/get
-        output = ['triggerids', 'description', 'priority']
         output = 'extend'
         triggers_list = self._zapi.trigger.get({'output': output, 'hostids': host_id,
                                                 'min_severity': trigger_severity})


### PR DESCRIPTION
##### SUMMARY
Remove `outline` variable because it was duplicated.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_host_events_info

##### ADDITIONAL INFORMATION
tested on zabbix 3.0/4.0/4.2/4.4
