### PR TITLE
read enabled_key_rotation status also in aws_kms_info

### DIFF
--- a/changelogs/fragments/67770-aws-kms-info-key-rotation.yml
+++ b/changelogs/fragments/67770-aws-kms-info-key-rotation.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - aws_kms_info - Adds the ``enable_key_rotation`` info to the return value.

--- a/lib/ansible/modules/cloud/amazon/aws_kms_info.py
+++ b/lib/ansible/modules/cloud/amazon/aws_kms_info.py
@@ -288,10 +288,12 @@ def list_key_policies_with_backoff(connection, key_id):
 def get_key_policy_with_backoff(connection, key_id, policy_name):
     return connection.get_key_policy(KeyId=key_id, PolicyName=policy_name)
 
+
 @AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
 def get_enable_key_rotation_with_backoff(connection, key_id):
     current_rotation_status = connection.get_key_rotation_status(KeyId=key_id)
     return current_rotation_status.get('KeyRotationEnabled')
+
 
 def get_kms_tags(connection, module, key_id):
     # Handle pagination here as list_resource_tags does not have

--- a/lib/ansible/modules/cloud/amazon/aws_kms_info.py
+++ b/lib/ansible/modules/cloud/amazon/aws_kms_info.py
@@ -107,6 +107,11 @@ keys:
       type: str
       returned: always
       sample: false
+    enable_key_rotation:
+      description: Whether the automatically key rotation every year is enabled.
+      type: bool
+      returned: always
+      sample: false
     aliases:
       description: list of aliases associated with the key
       type: list
@@ -360,6 +365,8 @@ def get_key_details(connection, module, key_id, tokens=None):
                          exception=traceback.format_exc(),
                          **camel_dict_to_snake_dict(e.response))
     result['aliases'] = aliases.get(result['KeyId'], [])
+    current_rotation_status = connection.get_key_rotation_status(KeyId=key_id)
+    result['enable_key_rotation'] = current_rotation_status.get('KeyRotationEnabled')
 
     if module.params.get('pending_deletion'):
         return camel_dict_to_snake_dict(result)

--- a/test/integration/targets/aws_kms/tasks/main.yml
+++ b/test/integration/targets/aws_kms/tasks/main.yml
@@ -72,6 +72,7 @@
       assert:
         that:
           - new_key["keys"]|length == 1
+          - new_key["keys"][0]["enable_key_rotation"] == true
 
     - name: Update Policy on key to match AWS Console generate policy
       aws_kms:


### PR DESCRIPTION
##### SUMMARY

Along with https://github.com/ansible/ansible/pull/67651
read `enable_key_rotation` status also in aws_kms_info

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

aws_kms_info

##### ADDITIONAL INFORMATION

`enable_key_rotation` should also be returned by `aws_kms_info` since `aws_kms` supports it in devel now.
