### PR TITLE
postgresql_info: move subscription info to corresponding database dict

### DIFF
--- a/test/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
+++ b/test/integration/targets/postgresql_info/tasks/postgresql_info_initial.yml
@@ -67,11 +67,11 @@
       - result.databases.{{ db_default }}.languages
       - result.databases.{{ db_default }}.namespaces
       - result.databases.{{ db_default }}.extensions
+      - result.databases.{{ test_db }}.subscriptions.{{ test_subscription }}
+      - result.databases.{{ test_db }}.subscriptions.{{ test_subscription2 }}
       - result.settings
       - result.tablespaces
       - result.roles
-      - result.subscriptions.{{ test_db }}.{{ test_subscription }}
-      - result.subscriptions.{{ test_db }}.{{ test_subscription2 }}
 
   - name: postgresql_info - check filter param passed by list
     <<: *task_parameters
@@ -81,14 +81,11 @@
       filter:
         - ver*
         - rol*
-        - subscr*
 
   - assert:
       that:
       - result.version != {}
       - result.roles
-      - result.subscriptions.{{ test_db }}.{{ test_subscription }} != {}
-      - result.subscriptions.{{ test_db }}.{{ test_subscription2 }} != {}
       - result.databases == {}
       - result.repl_slots == {}
       - result.replications == {}


### PR DESCRIPTION
##### SUMMARY
postgresql_info: move subscription info to corresponding database dict

this implementation is more logical than initial there https://github.com/ansible/ansible/pull/67464
because subscriptions relate to particular databases, they are not global objects

i realized this working on getting publication info

the feature hasn't been released so, i think, it doesn't need a changelog fragment

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/postgresql/postgresql_info.py```
