### PR TITLE
Edgeos config module add unmanaged config output

### DIFF
--- a/test/units/modules/network/edgeos/edgeos_module.py
+++ b/test/units/modules/network/edgeos/edgeos_module.py
@@ -48,7 +48,7 @@ def load_fixture(name):
 
 class TestEdgeosModule(ModuleTestCase):
 
-    def execute_module(self, failed=False, changed=False, commands=None, sort=True, defaults=False):
+    def execute_module(self, failed=False, changed=False, commands=None, filtered=None, sort=True, defaults=False):
         self.load_fixtures(commands)
 
         if failed:
@@ -63,6 +63,9 @@ class TestEdgeosModule(ModuleTestCase):
                 self.assertEqual(sorted(commands), sorted(result['commands']), result['commands'])
             else:
                 self.assertEqual(commands, result['commands'], result['commands'])
+
+        if filtered is not None:
+            self.assertEqual(sorted(filtered), sorted(result['filtered']), result['filtered'])
 
         return result
 

--- a/test/units/modules/network/edgeos/edgeos_module.py
+++ b/test/units/modules/network/edgeos/edgeos_module.py
@@ -48,7 +48,7 @@ def load_fixture(name):
 
 class TestEdgeosModule(ModuleTestCase):
 
-    def execute_module(self, failed=False, changed=False, commands=None, filtered=None, sort=True, defaults=False):
+    def execute_module(self, failed=False, changed=False, commands=None, unmanaged=None, invalid=None, sort=True, defaults=False):
         self.load_fixtures(commands)
 
         if failed:
@@ -64,8 +64,11 @@ class TestEdgeosModule(ModuleTestCase):
             else:
                 self.assertEqual(commands, result['commands'], result['commands'])
 
-        if filtered is not None:
-            self.assertEqual(sorted(filtered), sorted(result['filtered']), result['filtered'])
+        if unmanaged is not None:
+            self.assertEqual(sorted(unmanaged), sorted(result['unmanaged']), result['unmanaged'])
+
+        if invalid is not None:
+            self.assertEqual(sorted(invalid), sorted(result['invalid']), result['invalid'])
 
         return result
 

--- a/test/units/modules/network/edgeos/fixtures/edgeos_config_filtered_src_brackets.cfg
+++ b/test/units/modules/network/edgeos/fixtures/edgeos_config_filtered_src_brackets.cfg
@@ -1,0 +1,9 @@
+system {
+    login {
+        user test {
+            authentication {
+                encrypted-password test1
+            }
+        }
+    }
+}

--- a/test/units/modules/network/edgeos/fixtures/edgeos_config_unmanaged_src_brackets.cfg
+++ b/test/units/modules/network/edgeos/fixtures/edgeos_config_unmanaged_src_brackets.cfg
@@ -1,0 +1,3 @@
+system {
+    host-name 'router'
+}

--- a/test/units/modules/network/edgeos/test_edgeos_config.py
+++ b/test/units/modules/network/edgeos/test_edgeos_config.py
@@ -141,3 +141,50 @@ class TestEdgeosConfigModule(TestEdgeosModule):
         lines = ["set system interfaces ethernet eth0 description 'test's single quotes'"]
         set_module_args(dict(lines=lines))
         self.execute_module(failed=True)
+
+    def test_edgeos_config_unmanaged_lines(self):
+        candidate_config = ["set system host-name 'router'"]
+        set_module_args(dict(lines=candidate_config))
+        result_unmanaged = [
+            "set system domain-name 'acme.com'",
+            "set system domain-search domain 'acme.com'",
+            "set system name-server 208.67.220.220",
+            "set system name-server 208.67.222.222",
+            "set interfaces ethernet eth0 address 1.2.3.4/24",
+            "set interfaces ethernet eth0 description 'Outside'",
+            "set interfaces ethernet eth1 address 10.77.88.1/24",
+            "set interfaces ethernet eth1 description 'Inside'",
+            "set interfaces ethernet eth1 disable"
+        ]
+        self.execute_module(changed=False, unmanaged=result_unmanaged)
+
+    def test_edgeos_config_unmanaged_src(self):
+        candidate_config = load_fixture('edgeos_config_unmanaged_src_brackets.cfg')
+        set_module_args(dict(src=candidate_config))
+        result_unmanaged = [
+            "set system domain-name 'acme.com'",
+            "set system domain-search domain 'acme.com'",
+            "set system name-server 208.67.220.220",
+            "set system name-server 208.67.222.222",
+            "set interfaces ethernet eth0 address 1.2.3.4/24",
+            "set interfaces ethernet eth0 description 'Outside'",
+            "set interfaces ethernet eth1 address 10.77.88.1/24",
+            "set interfaces ethernet eth1 description 'Inside'",
+            "set interfaces ethernet eth1 disable"
+        ]
+        self.execute_module(changed=False, unmanaged=result_unmanaged)
+
+    def test_edgeos_config_invalid(self):
+        candidate_config = [
+            "set system host-name 'router'",
+            "setsystem host-name 'router'",
+            "deletesystem host-name 'router'",
+            "invalid"
+        ]
+        set_module_args(dict(lines=candidate_config))
+        result_invalid = [
+            "invalid",
+            "setsystem host-name 'router'",
+            "deletesystem host-name 'router'"
+        ]
+        self.execute_module(changed=False, invalid=result_invalid)


### PR DESCRIPTION
##### SUMMARY
Added the ability for the edgeos_config module to return a list of unmanaged and invalid config. The unmanaged config has been added to allow for a ansible workflow to delete unmanaged config on the remote device.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
edgeos_config

##### ADDITIONAL INFORMATION
- Have also included some general updates to variable names and test formatting to improve readability 
