### PR TITLE
Update yum.py

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -188,7 +188,7 @@ options:
     description:
       - Amount of time to wait for the yum lockfile to be freed.
     required: false
-    default: 30
+    default: 0
     type: int
     version_added: "2.8"
   install_weak_deps:


### PR DESCRIPTION
##### SUMMARY
After upgrading ansible from 2.7 to 2.8, i got this error message frequently .  "msg": "yum lockfile is held by another process".
and also found this in the logs /var/log/messages : ansible-yum Invoked with lock_timeout=0 .

Seems the default is 0 and not 30. Please verify and update.
using positive number resolved the issue.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
