### PR TITLE
ansible-vault - create temp file with strict permissions

### DIFF
--- a/changelogs/fragments/vault-temp-file-race-condition.yml
+++ b/changelogs/fragments/vault-temp-file-race-condition.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >
+    **security_issue** - create temporary vault file with strict permissions
+    when editing and prevent race condition (CVE-2020-1740)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
CVE-2020-1740
Fixes #67798

Explicitly set permissions on temporary file so that it is only accessible by the current user. Also check to ensure that we create the file.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/parsing/vault/__init__.py`