### PR TITLE
fetch - normalize and validate paths

### DIFF
--- a/changelogs/fragments/fetch-path-traversal.yml
+++ b/changelogs/fragments/fetch-path-traversal.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >
+    **security issue** fetch - normalize and compare paths used by fetch
+    module to prevent path traversal (CVE-2020-1735)

--- a/test/units/plugins/action/test_fetch.py
+++ b/test/units/plugins/action/test_fetch.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
@@ -20,6 +19,8 @@ from ansible.playbook.task import Task
     '../../../foo',
     '/../../../foo',
     '/../foo',
+    '//..//foo',
+    '..//..//foo',
 ]
 )
 def test_fetch_path_traversal(mocker, source):

--- a/test/units/plugins/action/test_fetch.py
+++ b/test/units/plugins/action/test_fetch.py
@@ -1,0 +1,49 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible.errors import AnsibleError
+from ansible.plugins.action.fetch import ActionModule
+from ansible.playbook.task import Task
+
+
+# CVE-2020-1735
+@pytest.mark.parametrize('source', [
+    '../foo',
+    '../../foo',
+    '../../../foo',
+    '/../../../foo',
+    '/../foo',
+]
+)
+def test_fetch_path_traversal(mocker, source):
+    task = mocker.MagicMock(Task)
+    task.args = {
+        'src': '/tmp/foo',
+        'dest': 'bar',
+        'fail_on_missing': True,
+    }
+    task.async_val = False
+
+    connection = mocker.MagicMock()
+    mocker.patch.object(connection._shell, 'join_path', return_value='a/')
+
+    play_context = mocker.MagicMock()
+    play_context.check_mode = False
+    play_context.remote_addr = 'testhost'
+
+    loader = mocker.MagicMock()
+    mocker.patch.object(loader, 'path_dwim', return_value='bar')
+
+    plugin = ActionModule(task, connection, play_context, loader, templar=None, shared_loader_obj=None)
+    mocker.patch.object(plugin, '_remote_expand_user', return_value='/tmp/foo')
+    mocker.patch.object(plugin, '_execute_module', return_value={'source': source, 'encoding': 'notbase64'})
+
+    with pytest.raises(AnsibleError, match=r'Source path would result in incorrect destination'):
+        plugin.run()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #67793

If the source path returned from the remote contains relative paths, the file could be created in the incorrect location.

Normalize and validate the paths returned from the remote host in order to ensure the file is put in the expected location on the controller.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/action/fetch.py`