### PR TITLE
Add whitelisting for package and service module

### DIFF
--- a/changelogs/fragments/67796-package-service-fact_fix.yml
+++ b/changelogs/fragments/67796-package-service-fact_fix.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >
+    **security issue** Add a whitelist of modules for package and service module
+    when 'use' is not used and engine relies on pkg_mgr and service_mgr facts (CVE-2020-1738).

--- a/lib/ansible/plugins/action/package.py
+++ b/lib/ansible/plugins/action/package.py
@@ -56,6 +56,14 @@ class ActionModule(ActionBase):
                 module = facts.get('ansible_facts', {}).get('ansible_pkg_mgr', 'auto')
 
             if module != 'auto':
+                if module not in ['apk', 'apt_rpm', 'apt', 'dnf', 'homebrew_cask',
+                                  'homebrew_tap', 'homebrew', 'installp', 'macports', 'mas',
+                                  'openbsd_pkg', 'opkg', 'pacman', 'pkg5', 'pkgin',
+                                  'pkgng', 'pkgutil', 'portage', 'portinstall', 'slackpkg',
+                                  'snap', 'sorcery', 'svr4pkg', 'swdepot', 'swupd',
+                                  'urpmi', 'xbps', 'yum', 'zypper']:
+                    raise AnsibleActionFail('Could not find a module for package manager %s.'
+                                            'Try setting the "use" option.' % module)
 
                 if module not in self._shared_loader_obj.module_loader:
                     raise AnsibleActionFail('Could not find a module for %s.' % module)

--- a/lib/ansible/plugins/action/service.py
+++ b/lib/ansible/plugins/action/service.py
@@ -61,6 +61,11 @@ class ActionModule(ActionBase):
                 module = 'service'
 
             if module != 'auto':
+                # Check if auto detected module is valid module name or not
+                if module not in ['nosh', 'openwrt_init', 'runit',
+                                  'svc', 'systemd', 'sysvinit', 'service']:
+                    raise AnsibleActionFail('Could not find module for "%s" service manager. '
+                                            'Try setting the "use" option.' % module)
                 # run the 'service' module
                 new_module_args = self._task.args.copy()
                 if 'use' in new_module_args:

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -368,6 +368,12 @@
   async: 90
   poll: 0
 
+- name: Wait for SimpleHTTPServer to come up online
+  wait_for:
+    host: 'localhost'
+    port: '{{ http_port }}'
+    state: started
+
 - name: download src with sha1 checksum url
   get_url:
     url: 'http://localhost:{{ http_port }}/27617.txt'


### PR DESCRIPTION
##### SUMMARY

**security issue** (CVE-2020-1738)
When 'use' parameter is not used in package and service module,
ansible relies on ansible facts such as 'pkg_mgr' and 'service_mgr'.

This would allow arbitrary code execution on the managed node.

Fix is added by adding a whitelist of allowed package manager modules and
service manager modules to avoid arbitrary code execution on the managed node.

Fixes: #67796

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/67796-package-service-fact_fix.yml
lib/ansible/plugins/action/package.py
