### PR TITLE
Add 'OperationAborted' to the list of S3 error codes where we'll retry

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -389,22 +389,22 @@ def create_bucket(s3_client, bucket_name, location):
             raise e
 
 
-@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket'])
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def put_bucket_tagging(s3_client, bucket_name, tags):
     s3_client.put_bucket_tagging(Bucket=bucket_name, Tagging={'TagSet': ansible_dict_to_boto3_tag_list(tags)})
 
 
-@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket'])
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def put_bucket_policy(s3_client, bucket_name, policy):
     s3_client.put_bucket_policy(Bucket=bucket_name, Policy=json.dumps(policy))
 
 
-@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket'])
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def delete_bucket_policy(s3_client, bucket_name):
     s3_client.delete_bucket_policy(Bucket=bucket_name)
 
 
-@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket'])
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def get_bucket_policy(s3_client, bucket_name):
     try:
         current_policy = json.loads(s3_client.get_bucket_policy(Bucket=bucket_name).get('Policy'))
@@ -416,27 +416,27 @@ def get_bucket_policy(s3_client, bucket_name):
     return current_policy
 
 
-@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket'])
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def put_bucket_request_payment(s3_client, bucket_name, payer):
     s3_client.put_bucket_request_payment(Bucket=bucket_name, RequestPaymentConfiguration={'Payer': payer})
 
 
-@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket'])
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def get_bucket_request_payment(s3_client, bucket_name):
     return s3_client.get_bucket_request_payment(Bucket=bucket_name).get('Payer')
 
 
-@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket'])
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def get_bucket_versioning(s3_client, bucket_name):
     return s3_client.get_bucket_versioning(Bucket=bucket_name)
 
 
-@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket'])
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def put_bucket_versioning(s3_client, bucket_name, required_versioning):
     s3_client.put_bucket_versioning(Bucket=bucket_name, VersioningConfiguration={'Status': required_versioning})
 
 
-@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket'])
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def get_bucket_encryption(s3_client, bucket_name):
     if not hasattr(s3_client, "get_bucket_encryption"):
         return None
@@ -472,18 +472,18 @@ def put_bucket_encryption_with_retry(module, s3_client, name, expected_encryptio
                      current=current_encryption, expected=expected_encryption, retries=retries)
 
 
-@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket'])
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def put_bucket_encryption(s3_client, bucket_name, encryption):
     server_side_encryption_configuration = {'Rules': [{'ApplyServerSideEncryptionByDefault': encryption}]}
     s3_client.put_bucket_encryption(Bucket=bucket_name, ServerSideEncryptionConfiguration=server_side_encryption_configuration)
 
 
-@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket'])
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def delete_bucket_tagging(s3_client, bucket_name):
     s3_client.delete_bucket_tagging(Bucket=bucket_name)
 
 
-@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket'])
+@AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def delete_bucket_encryption(s3_client, bucket_name):
     s3_client.delete_bucket_encryption(Bucket=bucket_name)
 


### PR DESCRIPTION
##### SUMMARY

Follow up to #66778, catch 'OperationAborted ("A conflicting conditional operation is currently in progress against this resource")

This is primarily a follow up to #66778 so I don't think it needs its own changelog fragment.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

s3_bucket

##### ADDITIONAL INFORMATION


```
TASK [s3_bucket : Update attributes for s3_bucket] *****************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: botocore.exceptions.ClientError: An error occurred (OperationAborted) when calli
ng the PutBucketPolicy operation: A conflicting conditional operation is currently in progress against this resource. Please try again.
fatal: [complex]: FAILED! => {"boto3_version": "1.9.249", "botocore_version": "1.12.249", "changed": false, "error": {"code": "OperationAborted", "message": "A conflicting condi
tional operation is currently in progress against this resource. Please try again."}, "msg": "Failed to update bucket policy: An error occurred (OperationAborted) when calling t
he PutBucketPolicy operation: A conflicting conditional operation is currently in progress against this resource. Please try again.", "resource_actions": ["s3:GetBucketRequestPa
yment", "s3:PutBucketVersioning", "s3:ListBuckets", "s3:PutBucketPolicy", "s3:GetBucketVersioning", "s3:GetBucketPolicy"], "response_metadata": {"host_id": "z6rbs1Hjn6S0Z/flKet1
Mtqj7VyyPVpXaJwknNmRhq5O8GPoh69exMno2Qt3vvBIovZceHr8pNc=", "http_headers": {"content-type": "application/xml", "date": "Wed, 26 Feb 2020 18:25:21 GMT", "server": "AmazonS3", "transfer-encoding": "chunked", "x-amz-id-2": "z6rbs1Hjn6S0Z/flKet1Mtqj7VyyPVpXaJwknNmRhq5O8GPoh69exMno2Qt3vvBIovZceHr8pNc=", "x-amz-request-id": "A8A29AF7C124FA6C"}, "http_status_code": 409, "request_id": "A8A29AF7C124FA6C", "retry_attempts": 0}}
```