### PR TITLE
ovirt: update botmeta deprecated

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -436,6 +436,10 @@ files:
     keywords: [ ovirt, RHEV, RHV ]
     labels: [ cloud, ovirt ]
     maintainers: $team_ovirt
+    deprecated:
+      removed_in: "2.10"
+      why: Compatible only with deprecated version of ovirt. Was not migrated to ovirt.ovirt_collection.
+      alternative: Use M(ovirt_vm) instead
   $modules/cloud/misc/proxmox.py: &virt
     ignored: skvidal
     keywords: [ kvm, libvirt, proxmox, qemu ]
@@ -569,19 +573,31 @@ files:
   $modules/cloud/ovirt/ovirt_job.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/_ovirt_affinity_label_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_affinity_label_info) instead
   $modules/cloud/ovirt/ovirt_host.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/_ovirt_quota_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_quota_info) instead
   $modules/cloud/ovirt/_ovirt_tag_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_tag_info) instead
   $modules/cloud/ovirt/ovirt_network.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/__init__.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/_ovirt_vmpool_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_vmpool_info) instead
   $modules/cloud/ovirt/ovirt_event.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_storage_domain_info.py:
@@ -589,13 +605,22 @@ files:
   $modules/cloud/ovirt/ovirt_affinity_label_info.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/_ovirt_network_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_network_info) instead
   $modules/cloud/ovirt/ovirt_external_provider.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/_ovirt_scheduling_policy_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_scheduling_policy_info) instead
   $modules/cloud/ovirt/_ovirt_datacenter_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_datacenter_info) instead
   $modules/cloud/ovirt/ovirt_cluster.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_datacenter.py:
@@ -609,21 +634,36 @@ files:
   $modules/cloud/ovirt/ovirt_disk_info.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/_ovirt_group_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_group_info) instead
   $modules/cloud/ovirt/_ovirt_snapshot_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_snapshot_info) instead
   $modules/cloud/ovirt/ovirt_quota.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/_ovirt_storage_domain_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_storage_domain_info) instead
   $modules/cloud/ovirt/ovirt_host_pm.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/_ovirt_template_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_template_info) instead
   $modules/cloud/ovirt/ovirt_cluster_info.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/_ovirt_host_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_host_info) instead
   $modules/cloud/ovirt/ovirt_host_storage_info.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_snapshot.py:
@@ -631,7 +671,10 @@ files:
   $modules/cloud/ovirt/ovirt_storage_template_info.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/_ovirt_disk_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_disk_info) instead
   $modules/cloud/ovirt/ovirt_vmpool.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_datacenter_info.py:
@@ -647,9 +690,15 @@ files:
   $modules/cloud/ovirt/ovirt_vm.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/_ovirt_cluster_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_cluster_info) instead
   $modules/cloud/ovirt/_ovirt_user_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_user_info) instead
   $modules/cloud/ovirt/ovirt_quota_info.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_snapshot_info.py:
@@ -667,7 +716,10 @@ files:
   $modules/cloud/ovirt/ovirt_vmpool_info.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/_ovirt_nic_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_nic_info) instead
   $modules/cloud/ovirt/ovirt_host_network.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_group.py:
@@ -675,11 +727,20 @@ files:
   $modules/cloud/ovirt/ovirt_role.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/_ovirt_permission_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_permission_info) instead
   $modules/cloud/ovirt/_ovirt_external_provider_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_external_provider_info) instead
   $modules/cloud/ovirt/_ovirt_event_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_event_info) instead
   $modules/cloud/ovirt/ovirt_auth.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_vnic_profile.py:
@@ -689,7 +750,10 @@ files:
   $modules/cloud/ovirt/ovirt_template_info.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/_ovirt_storage_vm_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_storage_vm_info) instead
   $modules/cloud/ovirt/ovirt_storage_connection.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_nic_info.py:
@@ -697,11 +761,20 @@ files:
   $modules/cloud/ovirt/ovirt_nic.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/_ovirt_api_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_api_info) instead
   $modules/cloud/ovirt/_ovirt_host_storage_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_host_storage_info) instead
   $modules/cloud/ovirt/_ovirt_storage_template_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_storage_template_info) instead
   $modules/cloud/ovirt/ovirt_template.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_external_provider_info.py:
@@ -717,7 +790,10 @@ files:
   $modules/cloud/ovirt/ovirt_network_info.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/_ovirt_vm_facts.py:
-    migrated_to: ovirt.ovirt_collection
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_vm_info) instead
   $modules/cloud/ovirt/ovirt_instance_type.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_affinity_label.py:
@@ -3697,6 +3773,11 @@ files:
     migrated_to: ovirt.ovirt_collection
   $plugins/doc_fragments/ovirt_info.py:
     migrated_to: ovirt.ovirt_collection
+  $plugins/doc_fragments/ovirt_facts.py:
+    deprecated:
+      removed_in: "2.10"
+      why: When migrating to collection we decided to use only _info modules.
+      alternative: Use M(ovirt_info) instead
   $plugins/doc_fragments/xenserver.py:
     maintainers: bvitnik
   $plugins/doc_fragments/hpe3par.py: *hpe3par

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -436,10 +436,6 @@ files:
     keywords: [ ovirt, RHEV, RHV ]
     labels: [ cloud, ovirt ]
     maintainers: $team_ovirt
-    deprecated:
-      removed_in: "2.10"
-      why: Compatible only with deprecated version of ovirt. Was not migrated to ovirt.ovirt_collection.
-      alternative: Use M(ovirt_vm) instead
   $modules/cloud/misc/proxmox.py: &virt
     ignored: skvidal
     keywords: [ kvm, libvirt, proxmox, qemu ]
@@ -572,55 +568,20 @@ files:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_job.py:
     migrated_to: ovirt.ovirt_collection
-  $modules/cloud/ovirt/_ovirt_affinity_label_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_affinity_label_info) instead
   $modules/cloud/ovirt/ovirt_host.py:
     migrated_to: ovirt.ovirt_collection
-  $modules/cloud/ovirt/_ovirt_quota_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_quota_info) instead
-  $modules/cloud/ovirt/_ovirt_tag_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_tag_info) instead
   $modules/cloud/ovirt/ovirt_network.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/__init__.py:
     migrated_to: ovirt.ovirt_collection
-  $modules/cloud/ovirt/_ovirt_vmpool_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_vmpool_info) instead
   $modules/cloud/ovirt/ovirt_event.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_storage_domain_info.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_affinity_label_info.py:
     migrated_to: ovirt.ovirt_collection
-  $modules/cloud/ovirt/_ovirt_network_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_network_info) instead
   $modules/cloud/ovirt/ovirt_external_provider.py:
     migrated_to: ovirt.ovirt_collection
-  $modules/cloud/ovirt/_ovirt_scheduling_policy_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_scheduling_policy_info) instead
-  $modules/cloud/ovirt/_ovirt_datacenter_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_datacenter_info) instead
   $modules/cloud/ovirt/ovirt_cluster.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_datacenter.py:
@@ -633,48 +594,18 @@ files:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_disk_info.py:
     migrated_to: ovirt.ovirt_collection
-  $modules/cloud/ovirt/_ovirt_group_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_group_info) instead
-  $modules/cloud/ovirt/_ovirt_snapshot_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_snapshot_info) instead
   $modules/cloud/ovirt/ovirt_quota.py:
     migrated_to: ovirt.ovirt_collection
-  $modules/cloud/ovirt/_ovirt_storage_domain_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_storage_domain_info) instead
   $modules/cloud/ovirt/ovirt_host_pm.py:
     migrated_to: ovirt.ovirt_collection
-  $modules/cloud/ovirt/_ovirt_template_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_template_info) instead
   $modules/cloud/ovirt/ovirt_cluster_info.py:
     migrated_to: ovirt.ovirt_collection
-  $modules/cloud/ovirt/_ovirt_host_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_host_info) instead
   $modules/cloud/ovirt/ovirt_host_storage_info.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_snapshot.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_storage_template_info.py:
     migrated_to: ovirt.ovirt_collection
-  $modules/cloud/ovirt/_ovirt_disk_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_disk_info) instead
   $modules/cloud/ovirt/ovirt_vmpool.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_datacenter_info.py:
@@ -689,16 +620,6 @@ files:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_vm.py:
     migrated_to: ovirt.ovirt_collection
-  $modules/cloud/ovirt/_ovirt_cluster_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_cluster_info) instead
-  $modules/cloud/ovirt/_ovirt_user_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_user_info) instead
   $modules/cloud/ovirt/ovirt_quota_info.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_snapshot_info.py:
@@ -715,32 +636,12 @@ files:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_vmpool_info.py:
     migrated_to: ovirt.ovirt_collection
-  $modules/cloud/ovirt/_ovirt_nic_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_nic_info) instead
   $modules/cloud/ovirt/ovirt_host_network.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_group.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_role.py:
     migrated_to: ovirt.ovirt_collection
-  $modules/cloud/ovirt/_ovirt_permission_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_permission_info) instead
-  $modules/cloud/ovirt/_ovirt_external_provider_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_external_provider_info) instead
-  $modules/cloud/ovirt/_ovirt_event_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_event_info) instead
   $modules/cloud/ovirt/ovirt_auth.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_vnic_profile.py:
@@ -749,32 +650,12 @@ files:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_template_info.py:
     migrated_to: ovirt.ovirt_collection
-  $modules/cloud/ovirt/_ovirt_storage_vm_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_storage_vm_info) instead
   $modules/cloud/ovirt/ovirt_storage_connection.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_nic_info.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_nic.py:
     migrated_to: ovirt.ovirt_collection
-  $modules/cloud/ovirt/_ovirt_api_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_api_info) instead
-  $modules/cloud/ovirt/_ovirt_host_storage_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_host_storage_info) instead
-  $modules/cloud/ovirt/_ovirt_storage_template_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_storage_template_info) instead
   $modules/cloud/ovirt/ovirt_template.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_external_provider_info.py:
@@ -789,11 +670,6 @@ files:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_network_info.py:
     migrated_to: ovirt.ovirt_collection
-  $modules/cloud/ovirt/_ovirt_vm_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_vm_info) instead
   $modules/cloud/ovirt/ovirt_instance_type.py:
     migrated_to: ovirt.ovirt_collection
   $modules/cloud/ovirt/ovirt_affinity_label.py:

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -3649,11 +3649,6 @@ files:
     migrated_to: ovirt.ovirt_collection
   $plugins/doc_fragments/ovirt_info.py:
     migrated_to: ovirt.ovirt_collection
-  $plugins/doc_fragments/ovirt_facts.py:
-    deprecated:
-      removed_in: "2.10"
-      why: When migrating to collection we decided to use only _info modules.
-      alternative: Use M(ovirt_info) instead
   $plugins/doc_fragments/xenserver.py:
     maintainers: bvitnik
   $plugins/doc_fragments/hpe3par.py: *hpe3par

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -431,7 +431,7 @@ files:
   $modules/cloud/linode/: $team_linode
   $modules/cloud/lxd/: hnakamur
   $modules/cloud/memset/: glitchcrab
-  $modules/cloud/misc/ovirt.py: &ovirt
+  $modules/cloud/misc/_ovirt.py: &ovirt
     ignored: vincentvdk
     keywords: [ ovirt, RHEV, RHV ]
     labels: [ cloud, ovirt ]

--- a/lib/ansible/modules/cloud/misc/_ovirt.py
+++ b/lib/ansible/modules/cloud/misc/_ovirt.py
@@ -15,10 +15,6 @@ DOCUMENTATION = '''
 module: ovirt
 author:
 - Vincent Van der Kussen (@vincentvdk)
-deprecated:
-    removed_in: "2.10"
-    why: Compatible only with deprecated version of ovirt. Was not migrated to ovirt.ovirt_collection.
-    alternative: Use M(ovirt_vm) instead
 short_description: oVirt/RHEV platform management
 description:
     - This module only supports oVirt/RHEV version 3. A newer module M(ovirt_vm) supports oVirt/RHV version 4.
@@ -224,6 +220,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.removed import removed_module
+
 
 # ------------------------------------------------------------------- #
 # create connection with API

--- a/lib/ansible/modules/cloud/misc/_ovirt.py
+++ b/lib/ansible/modules/cloud/misc/_ovirt.py
@@ -16,6 +16,10 @@ module: ovirt
 author:
 - Vincent Van der Kussen (@vincentvdk)
 short_description: oVirt/RHEV platform management
+deprecated:
+    removed_in: "2.10"
+    why: This module is for deprecated version of ovirt.
+    alternative: Use M(ovirt_vm) instead
 description:
     - This module only supports oVirt/RHEV version 3. A newer module M(ovirt_vm) supports oVirt/RHV version 4.
     - Allows you to create new instances, either from scratch or an image, in addition to deleting or stopping instances on the oVirt/RHEV platform.

--- a/lib/ansible/modules/cloud/misc/ovirt.py
+++ b/lib/ansible/modules/cloud/misc/ovirt.py
@@ -15,11 +15,11 @@ DOCUMENTATION = '''
 module: ovirt
 author:
 - Vincent Van der Kussen (@vincentvdk)
-short_description: oVirt/RHEV platform management
 deprecated:
     removed_in: "2.10"
     why: Compatible only with deprecated version of ovirt. Was not migrated to ovirt.ovirt_collection.
     alternative: Use M(ovirt_vm) instead
+short_description: oVirt/RHEV platform management
 description:
     - This module only supports oVirt/RHEV version 3. A newer module M(ovirt_vm) supports oVirt/RHV version 4.
     - Allows you to create new instances, either from scratch or an image, in addition to deleting or stopping instances on the oVirt/RHEV platform.

--- a/lib/ansible/modules/cloud/misc/ovirt.py
+++ b/lib/ansible/modules/cloud/misc/ovirt.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = '''
@@ -16,6 +16,10 @@ module: ovirt
 author:
 - Vincent Van der Kussen (@vincentvdk)
 short_description: oVirt/RHEV platform management
+deprecated:
+    removed_in: "2.10"
+    why: Compatible only with deprecated version of ovirt. Was not migrated to ovirt.ovirt_collection.
+    alternative: Use M(ovirt_vm) instead
 description:
     - This module only supports oVirt/RHEV version 3. A newer module M(ovirt_vm) supports oVirt/RHV version 4.
     - Allows you to create new instances, either from scratch or an image, in addition to deleting or stopping instances on the oVirt/RHEV platform.

--- a/lib/ansible/modules/cloud/misc/ovirt.py
+++ b/lib/ansible/modules/cloud/misc/ovirt.py
@@ -223,7 +223,7 @@ except ImportError:
     HAS_OVIRTSDK = False
 
 from ansible.module_utils.basic import AnsibleModule
-
+from ansible.module_utils.common.removed import removed_module
 
 # ------------------------------------------------------------------- #
 # create connection with API
@@ -479,4 +479,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_affinity_label_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_affinity_label_facts.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_affinity_label_info
+module: ovirt_affinity_label_facts
 short_description: Retrieve information about one or more oVirt/RHV affinity labels
 author: "Ondra Machacek (@machacekondra)"
 deprecated:
@@ -103,6 +103,7 @@ ovirt_affinity_labels:
 import fnmatch
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -183,4 +184,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_affinity_label_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_affinity_label_facts.py
@@ -1,1 +1,186 @@
-ovirt_affinity_label_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_affinity_label_info
+short_description: Retrieve information about one or more oVirt/RHV affinity labels
+author: "Ondra Machacek (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_affinity_label_info) instead
+version_added: "2.3"
+description:
+    - "Retrieve information about one or more oVirt/RHV affinity labels."
+    - This module was called C(ovirt_affinity_label_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_affinity_label_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_affinity_labels), which
+       contains a list of affinity labels. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    name:
+      description:
+        - "Name of the affinity labels which should be listed."
+    vm:
+      description:
+        - "Name of the VM, which affinity labels should be listed."
+    host:
+      description:
+        - "Name of the host, which affinity labels should be listed."
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about all affinity labels, which names start with C(label):
+- ovirt_affinity_label_info:
+    name: label*
+  register: result
+- debug:
+    msg: "{{ result.ovirt_affinity_labels }}"
+
+# Gather information about all affinity labels, which are assigned to VMs
+# which names start with C(postgres):
+- ovirt_affinity_label_info:
+    vm: postgres*
+  register: result
+- debug:
+    msg: "{{ result.ovirt_affinity_labels }}"
+
+# Gather information about all affinity labels, which are assigned to hosts
+# which names start with C(west):
+- ovirt_affinity_label_info:
+    host: west*
+  register: result
+- debug:
+    msg: "{{ result.ovirt_affinity_labels }}"
+
+# Gather information about all affinity labels, which are assigned to hosts
+# which names start with C(west) or VMs which names start with C(postgres):
+- ovirt_affinity_label_info:
+    host: west*
+    vm: postgres*
+  register: result
+- debug:
+    msg: "{{ result.ovirt_affinity_labels }}"
+'''
+
+RETURN = '''
+ovirt_affinity_labels:
+    description: "List of dictionaries describing the affinity labels. Affinity labels attributes are mapped to dictionary keys,
+                  all affinity labels attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/affinity_label."
+    returned: On success.
+    type: list
+'''
+
+import fnmatch
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+    search_by_name,
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        name=dict(default=None),
+        host=dict(default=None),
+        vm=dict(default=None),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_affinity_label_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_affinity_label_facts' module has been renamed to 'ovirt_affinity_label_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        affinity_labels_service = connection.system_service().affinity_labels_service()
+        labels = []
+        all_labels = affinity_labels_service.list()
+        if module.params['name']:
+            labels.extend([
+                l for l in all_labels
+                if fnmatch.fnmatch(l.name, module.params['name'])
+            ])
+        if module.params['host']:
+            hosts_service = connection.system_service().hosts_service()
+            if search_by_name(hosts_service, module.params['host']) is None:
+                raise Exception("Host '%s' was not found." % module.params['host'])
+            labels.extend([
+                label
+                for label in all_labels
+                for host in connection.follow_link(label.hosts)
+                if fnmatch.fnmatch(hosts_service.service(host.id).get().name, module.params['host'])
+            ])
+        if module.params['vm']:
+            vms_service = connection.system_service().vms_service()
+            if search_by_name(vms_service, module.params['vm']) is None:
+                raise Exception("Vm '%s' was not found." % module.params['vm'])
+            labels.extend([
+                label
+                for label in all_labels
+                for vm in connection.follow_link(label.vms)
+                if fnmatch.fnmatch(vms_service.service(vm.id).get().name, module.params['vm'])
+            ])
+
+        if not (module.params['vm'] or module.params['host'] or module.params['name']):
+            labels = all_labels
+
+        result = dict(
+            ovirt_affinity_labels=[
+                get_dict_of_struct(
+                    struct=l,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for l in labels
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_affinity_label_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_affinity_label_facts.py
@@ -19,6 +19,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_api_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_api_facts.py
@@ -1,1 +1,102 @@
-ovirt_api_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['deprecated'],
+    'supported_by': 'community'
+}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_api_info
+short_description: Retrieve information about the oVirt/RHV API
+author: "Ondra Machacek (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_api_info) instead
+version_added: "2.5"
+description:
+    - "Retrieve information about the oVirt/RHV API."
+    - This module was called C(ovirt_api_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_api_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_api),
+       which contains a information about oVirt/RHV API. You need to register the result with
+       the I(register) keyword to use it."
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information oVirt API:
+- ovirt_api_info:
+  register: result
+- debug:
+    msg: "{{ result.ovirt_api }}"
+'''
+
+RETURN = '''
+ovirt_api:
+    description: "Dictionary describing the oVirt API information.
+                  Api attributes are mapped to dictionary keys,
+                  all API attributes can be found at following
+                  url: https://ovirt.example.com/ovirt-engine/api/model#types/api."
+    returned: On success.
+    type: dict
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec()
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_api_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_api_facts' module has been renamed to 'ovirt_api_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        api = connection.system_service().get()
+        result = dict(
+            ovirt_api=get_dict_of_struct(
+                struct=api,
+                connection=connection,
+                fetch_nested=module.params.get('fetch_nested'),
+                attributes=module.params.get('nested_attributes'),
+            )
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_api_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_api_facts.py
@@ -16,7 +16,7 @@ ANSIBLE_METADATA = {
 
 DOCUMENTATION = '''
 ---
-module: ovirt_api_info
+module: ovirt_api_facts
 short_description: Retrieve information about the oVirt/RHV API
 author: "Ondra Machacek (@machacekondra)"
 deprecated:
@@ -58,6 +58,7 @@ ovirt_api:
 
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -99,4 +100,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_cluster_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_cluster_facts.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_cluster_info
+module: ovirt_cluster_facts
 short_description: Retrieve information about one or more oVirt/RHV clusters
 author: "Ondra Machacek (@machacekondra)"
 deprecated:
@@ -74,6 +74,7 @@ ovirt_clusters:
 
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -121,4 +122,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_cluster_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_cluster_facts.py
@@ -1,1 +1,124 @@
-ovirt_cluster_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_cluster_info
+short_description: Retrieve information about one or more oVirt/RHV clusters
+author: "Ondra Machacek (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_cluster_info) instead
+version_added: "2.3"
+description:
+    - "Retrieve information about one or more oVirt/RHV clusters."
+    - This module was called C(ovirt_cluster_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_cluster_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_clusters), which
+       contains a list of clusters. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    pattern:
+      description:
+        - "Search term which is accepted by oVirt/RHV search backend."
+        - "For example to search cluster X from datacenter Y use following pattern:
+           name=X and datacenter=Y"
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about all clusters which names start with C<production>:
+- ovirt_cluster_info:
+    pattern:
+      name: 'production*'
+  register: result
+- debug:
+    msg: "{{ result.ovirt_clusters }}"
+'''
+
+RETURN = '''
+ovirt_clusters:
+    description: "List of dictionaries describing the clusters. Cluster attributes are mapped to dictionary keys,
+                  all clusters attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/cluster."
+    returned: On success.
+    type: list
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        pattern=dict(default='', required=False),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_cluster_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_cluster_facts' module has been renamed to 'ovirt_cluster_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        clusters_service = connection.system_service().clusters_service()
+        clusters = clusters_service.list(search=module.params['pattern'])
+        result = dict(
+            ovirt_clusters=[
+                get_dict_of_struct(
+                    struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for c in clusters
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_cluster_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_cluster_facts.py
@@ -19,6 +19,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_datacenter_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_datacenter_facts.py
@@ -19,10 +19,6 @@ deprecated:
     why: When migrating to collection we decided to use only _info modules.
     alternative: Use M(ovirt_datacenter_info) instead
 version_added: "2.3"
-deprecated:
-    removed_in: "2.10"
-    why: When migrating to collection we decided to use only _info modules.
-    alternative: Use M(ovirt_datacenter_info) instead
 description:
     - "Retrieve information about one or more oVirt/RHV datacenters."
     - This module was called C(ovirt_datacenter_facts) before Ansible 2.9, returning C(ansible_facts).

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_datacenter_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_datacenter_facts.py
@@ -11,7 +11,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_datacenter_info
+module: ovirt_datacenter_facts
 short_description: Retrieve information about one or more oVirt/RHV datacenters
 author: "Ondra Machacek (@machacekondra)"
 deprecated:
@@ -57,6 +57,7 @@ ovirt_datacenters:
 
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -104,4 +105,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_datacenter_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_datacenter_facts.py
@@ -4,6 +4,9 @@
 # Copyright (c) 2016 Red Hat, Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_datacenter_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_datacenter_facts.py
@@ -1,1 +1,111 @@
-ovirt_datacenter_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_datacenter_info
+short_description: Retrieve information about one or more oVirt/RHV datacenters
+author: "Ondra Machacek (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_datacenter_info) instead
+version_added: "2.3"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_datacenter_info) instead
+description:
+    - "Retrieve information about one or more oVirt/RHV datacenters."
+    - This module was called C(ovirt_datacenter_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_datacenter_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_datacenters), which
+       contains a list of datacenters. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    pattern:
+      description:
+        - "Search term which is accepted by oVirt/RHV search backend."
+        - "For example to search datacenter I(X) use following pattern: I(name=X)"
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about all data centers which names start with C(production):
+- ovirt_datacenter_info:
+    pattern: name=production*
+  register: result
+- debug:
+    msg: "{{ result.ovirt_datacenters }}"
+'''
+
+RETURN = '''
+ovirt_datacenters:
+    description: "List of dictionaries describing the datacenters. Datacenter attributes are mapped to dictionary keys,
+                  all datacenters attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/data_center."
+    returned: On success.
+    type: list
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        pattern=dict(default='', required=False),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_datacenter_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_datacenter_facts' module has been renamed to 'ovirt_datacenter_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        datacenters_service = connection.system_service().data_centers_service()
+        datacenters = datacenters_service.list(search=module.params['pattern'])
+        result = dict(
+            ovirt_datacenters=[
+                get_dict_of_struct(
+                    struct=d,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for d in datacenters
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_disk_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_disk_facts.py
@@ -1,1 +1,124 @@
-ovirt_disk_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2017 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_disk_info
+short_description: Retrieve information about one or more oVirt/RHV disks
+author: "Katerina Koukiou (@KKoukiou)"
+version_added: "2.5"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_disk_info) instead
+description:
+    - "Retrieve information about one or more oVirt/RHV disks."
+    - This module was called C(ovirt_disk_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_disk_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_disks), which
+       contains a list of disks. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    pattern:
+      description:
+        - "Search term which is accepted by oVirt/RHV search backend."
+        - "For example to search Disk X from storage Y use following pattern:
+           name=X and storage.name=Y"
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about all Disks which names start with C(centos)
+- ovirt_disk_info:
+    pattern: name=centos*
+  register: result
+- debug:
+    msg: "{{ result.ovirt_disks }}"
+'''
+
+RETURN = '''
+ovirt_disks:
+    description: "List of dictionaries describing the Disks. Disk attributes are mapped to dictionary keys,
+                  all Disks attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/disk."
+    returned: On success.
+    type: list
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        pattern=dict(default='', required=False),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_disk_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_disk_facts' module has been renamed to 'ovirt_disk_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        disks_service = connection.system_service().disks_service()
+        disks = disks_service.list(
+            search=module.params['pattern'],
+        )
+        result = dict(
+            ovirt_disks=[
+                get_dict_of_struct(
+                    struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for c in disks
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_disk_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_disk_facts.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_disk_info
+module: ovirt_disk_facts
 short_description: Retrieve information about one or more oVirt/RHV disks
 author: "Katerina Koukiou (@KKoukiou)"
 version_added: "2.5"
@@ -73,6 +73,7 @@ ovirt_disks:
 
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -121,4 +122,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_disk_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_disk_facts.py
@@ -19,6 +19,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_event_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_event_facts.py
@@ -13,7 +13,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_event_info
+module: ovirt_event_facts
 short_description: This module can be used to retrieve information about one or more oVirt/RHV events
 author: "Chris Keller (@nasx)"
 deprecated:
@@ -109,6 +109,7 @@ ovirt_events:
 
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -171,4 +172,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_event_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_event_facts.py
@@ -1,1 +1,174 @@
-ovirt_event_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright: (c) 2019, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_event_info
+short_description: This module can be used to retrieve information about one or more oVirt/RHV events
+author: "Chris Keller (@nasx)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_event_info) instead
+version_added: "2.8"
+description:
+    - "Retrieve information about one or more oVirt/RHV events."
+    - This module was called C(ovirt_event_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_event_info) module no longer returns C(ansible_facts)!
+options:
+    case_sensitive:
+        description:
+            - "Indicates if the search performed using the search parameter should be performed taking case
+               into account. The default value is true, which means that case is taken into account. If you
+               want to search ignoring case set it to false."
+        required: false
+        default: true
+        type: bool
+
+    from_:
+        description:
+            - "Indicates the event index after which events should be returned. The indexes of events are
+               strictly increasing, so when this parameter is used only the events with greater indexes
+               will be returned."
+        required: false
+        type: int
+
+    max:
+        description:
+            - "Sets the maximum number of events to return. If not specified all the events are returned."
+        required: false
+        type: int
+
+    search:
+        description:
+            - "Search term which is accepted by the oVirt/RHV API."
+            - "For example to search for events of severity alert use the following pattern: severity=alert"
+        required: false
+        type: str
+
+    headers:
+        description:
+            - "Additional HTTP headers."
+        required: false
+        type: str
+
+    query:
+        description:
+            - "Additional URL query parameters."
+        required: false
+        type: str
+
+    wait:
+        description:
+            - "If True wait for the response."
+        required: false
+        default: true
+        type: bool
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain the auth parameter for simplicity,
+# look at the ovirt_auth module to see how to reuse authentication.
+
+- name: Return all events
+  ovirt_event_info:
+  register: result
+
+- name: Return the last 10 events
+  ovirt_event_info:
+    max: 10
+  register: result
+
+- name: Return all events of type alert
+  ovirt_event_info:
+    search: "severity=alert"
+  register: result
+- debug:
+    msg: "{{ result.ovirt_events }}"
+'''
+
+RETURN = '''
+ovirt_events:
+    description: "List of dictionaries describing the events. Event attributes are mapped to dictionary keys.
+                  All event attributes can be found at the following url:
+                  http://ovirt.github.io/ovirt-engine-api-model/master/#types/event"
+    returned: On success."
+    type: list
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        case_sensitive=dict(default=True, type='bool', required=False),
+        from_=dict(default=None, type='int', required=False),
+        max=dict(default=None, type='int', required=False),
+        search=dict(default='', required=False),
+        headers=dict(default='', required=False),
+        query=dict(default='', required=False),
+        wait=dict(default=True, type='bool', required=False)
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_event_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_event_facts' module has been renamed to 'ovirt_event_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        events_service = connection.system_service().events_service()
+        events = events_service.list(
+            case_sensitive=module.params['case_sensitive'],
+            from_=module.params['from_'],
+            max=module.params['max'],
+            search=module.params['search'],
+            headers=module.params['headers'],
+            query=module.params['query'],
+            wait=module.params['wait']
+        )
+
+        result = dict(
+            ovirt_events=[
+                get_dict_of_struct(
+                    struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for c in events
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_external_provider_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_external_provider_facts.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_external_provider_info
+module: ovirt_external_provider_facts
 short_description: Retrieve information about one or more oVirt/RHV external providers
 author: "Ondra Machacek (@machacekondra)"
 deprecated:
@@ -162,4 +162,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_external_provider_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_external_provider_facts.py
@@ -1,1 +1,165 @@
-ovirt_external_provider_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_external_provider_info
+short_description: Retrieve information about one or more oVirt/RHV external providers
+author: "Ondra Machacek (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_external_provider_info) instead
+version_added: "2.3"
+description:
+    - "Retrieve information about one or more oVirt/RHV external providers."
+    - This module was called C(ovirt_external_provider_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_external_provider_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_external_providers), which
+       contains a list of external_providers. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    type:
+        description:
+            - "Type of the external provider."
+        choices: ['os_image', 'os_network', 'os_volume', 'foreman']
+        required: true
+    name:
+        description:
+            - "Name of the external provider, can be used as glob expression."
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about all image external providers named C<glance>:
+- ovirt_external_provider_info:
+    type: os_image
+    name: glance
+  register: result
+- debug:
+    msg: "{{ result.ovirt_external_providers }}"
+'''
+
+RETURN = '''
+ovirt_external_providers:
+    description:
+        - "List of dictionaries. Content depends on I(type)."
+        - "For type C(foreman), attributes appearing in the dictionary can be found on your oVirt/RHV instance
+           at the following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/external_host_provider."
+        - "For type C(os_image), attributes appearing in the dictionary can be found on your oVirt/RHV instance
+           at the following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/openstack_image_provider."
+        - "For type C(os_volume), attributes appearing in the dictionary can be found on your oVirt/RHV instance
+           at the following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/openstack_volume_provider."
+        - "For type C(os_network), attributes appearing in the dictionary can be found on your oVirt/RHV instance
+           at the following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/openstack_network_provider."
+    returned: On success
+    type: list
+'''
+
+import fnmatch
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+)
+
+
+def _external_provider_service(provider_type, system_service):
+    if provider_type == 'os_image':
+        return system_service.openstack_image_providers_service()
+    elif provider_type == 'os_network':
+        return system_service.openstack_network_providers_service()
+    elif provider_type == 'os_volume':
+        return system_service.openstack_volume_providers_service()
+    elif provider_type == 'foreman':
+        return system_service.external_host_providers_service()
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        name=dict(default=None, required=False),
+        type=dict(
+            default=None,
+            required=True,
+            choices=[
+                'os_image', 'os_network', 'os_volume', 'foreman',
+            ],
+            aliases=['provider'],
+        ),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_external_provider_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_external_provider_facts' module has been renamed to 'ovirt_external_provider_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        external_providers_service = _external_provider_service(
+            provider_type=module.params.pop('type'),
+            system_service=connection.system_service(),
+        )
+        if module.params['name']:
+            external_providers = [
+                e for e in external_providers_service.list()
+                if fnmatch.fnmatch(e.name, module.params['name'])
+            ]
+        else:
+            external_providers = external_providers_service.list()
+
+        result = dict(
+            ovirt_external_providers=[
+                get_dict_of_struct(
+                    struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for c in external_providers
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_external_provider_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_external_provider_facts.py
@@ -86,6 +86,7 @@ ovirt_external_providers:
 import fnmatch
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_external_provider_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_external_provider_facts.py
@@ -19,6 +19,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_group_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_group_facts.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_group_info
+module: ovirt_group_facts
 short_description: Retrieve information about one or more oVirt/RHV groups
 author: "Ondra Machacek (@machacekondra)"
 deprecated:
@@ -72,6 +72,7 @@ ovirt_groups:
 
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -119,4 +120,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_group_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_group_facts.py
@@ -19,6 +19,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_group_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_group_facts.py
@@ -1,1 +1,122 @@
-ovirt_group_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_group_info
+short_description: Retrieve information about one or more oVirt/RHV groups
+author: "Ondra Machacek (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_group_info) instead
+version_added: "2.3"
+description:
+    - "Retrieve information about one or more oVirt/RHV groups."
+    - This module was called C(ovirt_group_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_group_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_groups), which
+       contains a list of groups. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    pattern:
+      description:
+        - "Search term which is accepted by oVirt/RHV search backend."
+        - "For example to search group X use following pattern: name=X"
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about all groups which names start with C(admin):
+- ovirt_group_info:
+    pattern: name=admin*
+  register: result
+- debug:
+    msg: "{{ result.ovirt_groups }}"
+'''
+
+RETURN = '''
+ovirt_groups:
+    description: "List of dictionaries describing the groups. Group attributes are mapped to dictionary keys,
+                  all groups attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/group."
+    returned: On success.
+    type: list
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        pattern=dict(default='', required=False),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_group_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_group_facts' module has been renamed to 'ovirt_group_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        groups_service = connection.system_service().groups_service()
+        groups = groups_service.list(search=module.params['pattern'])
+        result = dict(
+            ovirt_groups=[
+                get_dict_of_struct(
+                    struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for c in groups
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_host_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_host_facts.py
@@ -11,7 +11,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_host_info
+module: ovirt_host_facts
 short_description: Retrieve information about one or more oVirt/RHV hosts
 author: "Ondra Machacek (@machacekondra)"
 deprecated:
@@ -79,6 +79,7 @@ ovirt_hosts:
 
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -145,4 +146,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_host_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_host_facts.py
@@ -4,6 +4,9 @@
 # Copyright (c) 2016 Red Hat, Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_host_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_host_facts.py
@@ -1,1 +1,148 @@
-ovirt_host_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_host_info
+short_description: Retrieve information about one or more oVirt/RHV hosts
+author: "Ondra Machacek (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_host_info) instead
+version_added: "2.3"
+description:
+    - "Retrieve information about one or more oVirt/RHV hosts."
+    - This module was called C(ovirt_host_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_host_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_hosts), which
+       contains a list of hosts. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    pattern:
+      description:
+        - "Search term which is accepted by oVirt/RHV search backend."
+        - "For example to search host X from datacenter Y use following pattern:
+           name=X and datacenter=Y"
+    all_content:
+      description:
+        - "If I(true) all the attributes of the hosts should be
+           included in the response."
+      default: False
+      version_added: "2.7"
+      type: bool
+    cluster_version:
+      description:
+        - "Filter the hosts based on the cluster version."
+      type: str
+      version_added: "2.8"
+
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about all hosts which names start with C(host) and
+# belong to data center C(west):
+- ovirt_host_info:
+    pattern: name=host* and datacenter=west
+  register: result
+- debug:
+    msg: "{{ result.ovirt_hosts }}"
+# All hosts with cluster version 4.2:
+- ovirt_host_info:
+    pattern: name=host*
+    cluster_version: "4.2"
+  register: result
+- debug:
+    msg: "{{ result.ovirt_hosts }}"
+'''
+
+RETURN = '''
+ovirt_hosts:
+    description: "List of dictionaries describing the hosts. Host attributes are mapped to dictionary keys,
+                  all hosts attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/host."
+    returned: On success.
+    type: list
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+)
+
+
+def get_filtered_hosts(cluster_version, hosts, connection):
+    # Filtering by cluster version returns only those which have same cluster version as input
+    filtered_hosts = []
+    for host in hosts:
+        cluster = connection.follow_link(host.cluster)
+        cluster_version_host = str(cluster.version.major) + '.' + str(cluster.version.minor)
+        if cluster_version_host == cluster_version:
+            filtered_hosts.append(host)
+    return filtered_hosts
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        pattern=dict(default='', required=False),
+        all_content=dict(default=False, type='bool'),
+        cluster_version=dict(default=None, type='str'),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_host_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_host_facts' module has been renamed to 'ovirt_host_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        hosts_service = connection.system_service().hosts_service()
+        hosts = hosts_service.list(
+            search=module.params['pattern'],
+            all_content=module.params['all_content']
+        )
+        cluster_version = module.params.get('cluster_version')
+        if cluster_version is not None:
+            hosts = get_filtered_hosts(cluster_version, hosts, connection)
+        result = dict(
+            ovirt_hosts=[
+                get_dict_of_struct(
+                    struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for c in hosts
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_host_storage_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_host_storage_facts.py
@@ -1,1 +1,186 @@
-ovirt_host_storage_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2017 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: ovirt_host_storage_info
+short_description: Retrieve information about one or more oVirt/RHV HostStorages (applicable only for block storage)
+author: "Daniel Erez (@derez)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_host_storage_info) instead
+version_added: "2.4"
+description:
+    - "Retrieve information about one or more oVirt/RHV HostStorages (applicable only for block storage)."
+    - This module was called C(ovirt_host_storage_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_host_storage_info) module no longer returns C(ansible_facts)!
+options:
+    host:
+        description:
+            - "Host to get device list from."
+        required: true
+    iscsi:
+        description:
+            - "Dictionary with values for iSCSI storage type:"
+        suboptions:
+            address:
+                description:
+                  - "Address of the iSCSI storage server."
+            target:
+                description:
+                  - "The target IQN for the storage device."
+            username:
+                description:
+                  - "A CHAP user name for logging into a target."
+            password:
+                description:
+                  - "A CHAP password for logging into a target."
+            portal:
+                description:
+                  - "The portal being used to connect with iscsi."
+                version_added: 2.10
+    fcp:
+        description:
+            - "Dictionary with values for fibre channel storage type:"
+        suboptions:
+            address:
+                description:
+                  - "Address of the fibre channel storage server."
+            port:
+                description:
+                  - "Port of the fibre channel storage server."
+            lun_id:
+                description:
+                  - "LUN id."
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about HostStorages with specified target and address:
+- ovirt_host_storage_info:
+    host: myhost
+    iscsi:
+      target: iqn.2016-08-09.domain-01:nickname
+      address: 10.34.63.204
+  register: result
+- debug:
+    msg: "{{ result.ovirt_host_storages }}"
+'''
+
+RETURN = '''
+ovirt_host_storages:
+    description: "List of dictionaries describing the HostStorage. HostStorage attributes are mapped to dictionary keys,
+                  all HostStorage attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/host_storage."
+    returned: On success.
+    type: list
+'''
+
+import traceback
+
+try:
+    import ovirtsdk4.types as otypes
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+    get_id_by_name,
+)
+
+
+def _login(host_service, iscsi):
+    host_service.iscsi_login(
+        iscsi=otypes.IscsiDetails(
+            username=iscsi.get('username'),
+            password=iscsi.get('password'),
+            address=iscsi.get('address'),
+            target=iscsi.get('target'),
+            portal=iscsi.get('portal')
+        ),
+    )
+
+
+def _get_storage_type(params):
+    for sd_type in ['iscsi', 'fcp']:
+        if params.get(sd_type) is not None:
+            return sd_type
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        host=dict(required=True),
+        iscsi=dict(default=None, type='dict'),
+        fcp=dict(default=None, type='dict'),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_host_storage_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_host_storage_facts' module has been renamed to 'ovirt_host_storage_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+
+        # Get Host
+        hosts_service = connection.system_service().hosts_service()
+        host_id = get_id_by_name(hosts_service, module.params['host'])
+        storage_type = _get_storage_type(module.params)
+        host_service = hosts_service.host_service(host_id)
+
+        if storage_type == 'iscsi':
+            # Login
+            iscsi = module.params.get('iscsi')
+            _login(host_service, iscsi)
+
+        # Get LUNs exposed from the specified target
+        host_storages = host_service.storage_service().list()
+
+        if storage_type == 'iscsi':
+            filterred_host_storages = [host_storage for host_storage in host_storages
+                                       if host_storage.type == otypes.StorageType.ISCSI]
+            if 'target' in iscsi:
+                filterred_host_storages = [host_storage for host_storage in filterred_host_storages
+                                           if iscsi.get('target') == host_storage.logical_units[0].target]
+        elif storage_type == 'fcp':
+            filterred_host_storages = [host_storage for host_storage in host_storages
+                                       if host_storage.type == otypes.StorageType.FCP]
+
+        result = dict(
+            ovirt_host_storages=[
+                get_dict_of_struct(
+                    struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for c in filterred_host_storages
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_host_storage_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_host_storage_facts.py
@@ -4,6 +4,9 @@
 # Copyright (c) 2017 Red Hat, Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_host_storage_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_host_storage_facts.py
@@ -10,7 +10,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_host_storage_info
+module: ovirt_host_storage_facts
 short_description: Retrieve information about one or more oVirt/RHV HostStorages (applicable only for block storage)
 author: "Daniel Erez (@derez)"
 deprecated:
@@ -93,6 +93,7 @@ try:
 except ImportError:
     pass
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -183,4 +184,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_network_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_network_facts.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_network_info
+module: ovirt_network_facts
 short_description: Retrieve information about one or more oVirt/RHV networks
 author: "Ondra Machacek (@machacekondra)"
 deprecated:
@@ -74,6 +74,7 @@ ovirt_networks:
 
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -121,4 +122,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_network_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_network_facts.py
@@ -19,6 +19,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_network_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_network_facts.py
@@ -1,1 +1,124 @@
-ovirt_network_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_network_info
+short_description: Retrieve information about one or more oVirt/RHV networks
+author: "Ondra Machacek (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_network_info) instead
+version_added: "2.3"
+description:
+    - "Retrieve information about one or more oVirt/RHV networks."
+    - This module was called C(ovirt_network_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_network_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_networks), which
+       contains a list of networks. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    pattern:
+      description:
+        - "Search term which is accepted by oVirt/RHV search backend."
+        - "For example to search network starting with string vlan1 use: name=vlan1*"
+extends_documentation_fragment: ovirt_info
+'''
+
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about all networks which names start with C(vlan1):
+- ovirt_network_info:
+    pattern: name=vlan1*
+  register: result
+- debug:
+    msg: "{{ result.ovirt_networks }}"
+'''
+
+
+RETURN = '''
+ovirt_networks:
+    description: "List of dictionaries describing the networks. Network attributes are mapped to dictionary keys,
+                  all networks attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/network."
+    returned: On success.
+    type: list
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        pattern=dict(default='', required=False),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_network_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_network_facts' module has been renamed to 'ovirt_network_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        networks_service = connection.system_service().networks_service()
+        networks = networks_service.list(search=module.params['pattern'])
+        result = dict(
+            ovirt_networks=[
+                get_dict_of_struct(
+                    struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for c in networks
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_nic_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_nic_facts.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_nic_info
+module: ovirt_nic_facts
 short_description: Retrieve information about one or more oVirt/RHV virtual machine network interfaces
 author: "Ondra Machacek (@machacekondra)"
 deprecated:
@@ -77,6 +77,7 @@ ovirt_nics:
 import fnmatch
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -139,4 +140,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_nic_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_nic_facts.py
@@ -19,6 +19,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_nic_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_nic_facts.py
@@ -1,1 +1,142 @@
-ovirt_nic_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_nic_info
+short_description: Retrieve information about one or more oVirt/RHV virtual machine network interfaces
+author: "Ondra Machacek (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_nic_info) instead
+version_added: "2.3"
+description:
+    - "Retrieve information about one or more oVirt/RHV virtual machine network interfaces."
+    - This module was called C(ovirt_nic_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_nic_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_nics), which
+       contains a list of NICs. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    vm:
+        description:
+            - "Name of the VM where NIC is attached."
+        required: true
+    name:
+        description:
+            - "Name of the NIC, can be used as glob expression."
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about all NICs which names start with C(eth) for VM named C(centos7):
+- ovirt_nic_info:
+    vm: centos7
+    name: eth*
+  register: result
+- debug:
+    msg: "{{ result.ovirt_nics }}"
+'''
+
+RETURN = '''
+ovirt_nics:
+    description: "List of dictionaries describing the network interfaces. NIC attributes are mapped to dictionary keys,
+                  all NICs attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/nic."
+    returned: On success.
+    type: list
+'''
+
+import fnmatch
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+    search_by_name,
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        vm=dict(required=True),
+        name=dict(default=None),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_nic_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_nic_facts' module has been renamed to 'ovirt_nic_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        vms_service = connection.system_service().vms_service()
+        vm_name = module.params['vm']
+        vm = search_by_name(vms_service, vm_name)
+        if vm is None:
+            raise Exception("VM '%s' was not found." % vm_name)
+
+        nics_service = vms_service.service(vm.id).nics_service()
+        if module.params['name']:
+            nics = [
+                e for e in nics_service.list()
+                if fnmatch.fnmatch(e.name, module.params['name'])
+            ]
+        else:
+            nics = nics_service.list()
+
+        result = dict(
+            ovirt_nics=[
+                get_dict_of_struct(
+                    struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for c in nics
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_permission_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_permission_facts.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_permission_info
+module: ovirt_permission_facts
 short_description: Retrieve information about one or more oVirt/RHV permissions
 author: "Ondra Machacek (@machacekondra)"
 deprecated:
@@ -89,6 +89,7 @@ try:
 except ImportError:
     pass
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -162,4 +163,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_permission_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_permission_facts.py
@@ -19,6 +19,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_permission_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_permission_facts.py
@@ -1,1 +1,165 @@
-ovirt_permission_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_permission_info
+short_description: Retrieve information about one or more oVirt/RHV permissions
+author: "Ondra Machacek (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_permission_info) instead
+version_added: "2.3"
+description:
+    - "Retrieve information about one or more oVirt/RHV permissions."
+    - This module was called C(ovirt_permission_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_permission_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_permissions), which
+       contains a list of permissions. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    user_name:
+        description:
+            - "Username of the user to manage. In most LDAPs it's I(uid) of the user, but in Active Directory you must specify I(UPN) of the user."
+    group_name:
+        description:
+            - "Name of the group to manage."
+    authz_name:
+        description:
+            - "Authorization provider of the user/group. In previous versions of oVirt/RHV known as domain."
+        required: true
+        aliases: ['domain']
+    namespace:
+        description:
+            - "Namespace of the authorization provider, where user/group resides."
+        required: false
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about all permissions of user with username C(john):
+- ovirt_permission_info:
+    user_name: john
+    authz_name: example.com-authz
+  register: result
+- debug:
+    msg: "{{ result.ovirt_permissions }}"
+'''
+
+RETURN = '''
+ovirt_permissions:
+    description: "List of dictionaries describing the permissions. Permission attributes are mapped to dictionary keys,
+                  all permissions attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/permission."
+    returned: On success.
+    type: list
+'''
+
+import traceback
+
+try:
+    import ovirtsdk4 as sdk
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_link_name,
+    ovirt_info_full_argument_spec,
+    search_by_name,
+)
+
+
+def _permissions_service(connection, module):
+    if module.params['user_name']:
+        service = connection.system_service().users_service()
+        entity = next(
+            iter(
+                service.list(
+                    search='usrname={0}'.format(
+                        '{0}@{1}'.format(module.params['user_name'], module.params['authz_name'])
+                    )
+                )
+            ),
+            None
+        )
+    else:
+        service = connection.system_service().groups_service()
+        entity = search_by_name(service, module.params['group_name'])
+
+    if entity is None:
+        raise Exception("User/Group wasn't found.")
+
+    return service.service(entity.id).permissions_service()
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        authz_name=dict(required=True, aliases=['domain']),
+        user_name=dict(default=None),
+        group_name=dict(default=None),
+        namespace=dict(default=None),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_permission_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_permission_facts' module has been renamed to 'ovirt_permission_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        permissions_service = _permissions_service(connection, module)
+        permissions = []
+        for p in permissions_service.list():
+            newperm = dict()
+            for key, value in p.__dict__.items():
+                if value and isinstance(value, sdk.Struct):
+                    newperm[key[1:]] = get_link_name(connection, value)
+                    newperm['%s_id' % key[1:]] = value.id
+            permissions.append(newperm)
+
+        result = dict(ovirt_permissions=permissions)
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_quota_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_quota_facts.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_quota_info
+module: ovirt_quota_facts
 short_description: Retrieve information about one or more oVirt/RHV quotas
 version_added: "2.3"
 author: "Maor Lipchuk (@machacekondra)"
@@ -77,6 +77,7 @@ ovirt_quotas:
 import fnmatch
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -139,4 +140,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_quota_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_quota_facts.py
@@ -19,6 +19,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_quota_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_quota_facts.py
@@ -1,1 +1,142 @@
-ovirt_quota_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_quota_info
+short_description: Retrieve information about one or more oVirt/RHV quotas
+version_added: "2.3"
+author: "Maor Lipchuk (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_quota_info) instead
+description:
+    - "Retrieve information about one or more oVirt/RHV quotas."
+    - This module was called C(ovirt_quota_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_quota_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_quotas), which
+       contains a list of quotas. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    data_center:
+        description:
+            - "Name of the datacenter where quota resides."
+        required: true
+    name:
+        description:
+            - "Name of the quota, can be used as glob expression."
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about quota named C<myquota> in Default datacenter:
+- ovirt_quota_info:
+    data_center: Default
+    name: myquota
+  register: result
+- debug:
+    msg: "{{ result.ovirt_quotas }}"
+'''
+
+RETURN = '''
+ovirt_quotas:
+    description: "List of dictionaries describing the quotas. Quota attributes are mapped to dictionary keys,
+                  all quotas attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/quota."
+    returned: On success.
+    type: list
+'''
+
+import fnmatch
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+    search_by_name,
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        data_center=dict(required=True),
+        name=dict(default=None),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_quota_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_quota_facts' module has been renamed to 'ovirt_quota_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        datacenters_service = connection.system_service().data_centers_service()
+        dc_name = module.params['data_center']
+        dc = search_by_name(datacenters_service, dc_name)
+        if dc is None:
+            raise Exception("Datacenter '%s' was not found." % dc_name)
+
+        quotas_service = datacenters_service.service(dc.id).quotas_service()
+        if module.params['name']:
+            quotas = [
+                e for e in quotas_service.list()
+                if fnmatch.fnmatch(e.name, module.params['name'])
+            ]
+        else:
+            quotas = quotas_service.list()
+
+        result = dict(
+            ovirt_quotas=[
+                get_dict_of_struct(
+                    struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for c in quotas
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_scheduling_policy_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_scheduling_policy_facts.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_scheduling_policy_info
+module: ovirt_scheduling_policy_facts
 short_description: Retrieve information about one or more oVirt scheduling policies
 author: "Ondra Machacek (@machacekondra)"
 deprecated:
@@ -78,6 +78,7 @@ ovirt_scheduling_policies:
 import fnmatch
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -138,4 +139,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_scheduling_policy_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_scheduling_policy_facts.py
@@ -19,6 +19,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_scheduling_policy_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_scheduling_policy_facts.py
@@ -1,1 +1,141 @@
-ovirt_scheduling_policy_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2017 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_scheduling_policy_info
+short_description: Retrieve information about one or more oVirt scheduling policies
+author: "Ondra Machacek (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_scheduling_policy_info) instead
+version_added: "2.4"
+description:
+    - "Retrieve information about one or more oVirt scheduling policies."
+    - This module was called C(ovirt_scheduling_policy_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_scheduling_policy_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_scheduling_policies),
+       which contains a list of scheduling policies. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    id:
+        description:
+            - "ID of the scheduling policy."
+        required: true
+    name:
+        description:
+            - "Name of the scheduling policy, can be used as glob expression."
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about all scheduling policies with name InClusterUpgrade:
+- ovirt_scheduling_policy_info:
+    name: InClusterUpgrade
+  register: result
+- debug:
+    msg: "{{ result.ovirt_scheduling_policies }}"
+'''
+
+RETURN = '''
+ovirt_scheduling_policies:
+    description: "List of dictionaries describing the scheduling policies.
+                  Scheduling policies attributes are mapped to dictionary keys,
+                  all scheduling policies attributes can be found at following
+                  url: https://ovirt.example.com/ovirt-engine/api/model#types/scheduling_policy."
+    returned: On success.
+    type: list
+'''
+
+import fnmatch
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        id=dict(default=None),
+        name=dict(default=None),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_scheduling_policy_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_scheduling_policy_facts' module has been renamed to 'ovirt_scheduling_policy_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        system_service = connection.system_service()
+        sched_policies_service = system_service.scheduling_policies_service()
+        if module.params['name']:
+            sched_policies = [
+                e for e in sched_policies_service.list()
+                if fnmatch.fnmatch(e.name, module.params['name'])
+            ]
+        elif module.params['id']:
+            sched_policies = [
+                sched_policies_service.service(module.params['id']).get()
+            ]
+        else:
+            sched_policies = sched_policies_service.list()
+
+        result = dict(
+            ovirt_scheduling_policies=[
+                get_dict_of_struct(
+                    struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for c in sched_policies
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_snapshot_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_snapshot_facts.py
@@ -1,1 +1,137 @@
-ovirt_snapshot_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_snapshot_info
+short_description: Retrieve information about one or more oVirt/RHV virtual machine snapshots
+author: "Ondra Machacek (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_snapshot_info) instead
+version_added: "2.3"
+description:
+    - "Retrieve information about one or more oVirt/RHV virtual machine snapshots."
+    - This module was called C(ovirt_snapshot_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_snapshot_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_snapshots), which
+       contains a list of snapshots. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    vm:
+        description:
+            - "Name of the VM with snapshot."
+        required: true
+    description:
+        description:
+            - "Description of the snapshot, can be used as glob expression."
+    snapshot_id:
+        description:
+            - "Id of the snapshot we want to retrieve information about."
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about all snapshots which description start with C(update) for VM named C(centos7):
+- ovirt_snapshot_info:
+    vm: centos7
+    description: update*
+  register: result
+- debug:
+    msg: "{{ result.ovirt_snapshots }}"
+'''
+
+RETURN = '''
+ovirt_snapshots:
+    description: "List of dictionaries describing the snapshot. Snapshot attributes are mapped to dictionary keys,
+                  all snapshot attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/snapshot."
+    returned: On success.
+    type: list
+'''
+
+
+import fnmatch
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+    search_by_name,
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        vm=dict(required=True),
+        description=dict(default=None),
+        snapshot_id=dict(default=None),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_snapshot_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_snapshot_facts' module has been renamed to 'ovirt_snapshot_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        vms_service = connection.system_service().vms_service()
+        vm_name = module.params['vm']
+        vm = search_by_name(vms_service, vm_name)
+        if vm is None:
+            raise Exception("VM '%s' was not found." % vm_name)
+
+        snapshots_service = vms_service.service(vm.id).snapshots_service()
+        if module.params['description']:
+            snapshots = [
+                e for e in snapshots_service.list()
+                if fnmatch.fnmatch(e.description, module.params['description'])
+            ]
+        elif module.params['snapshot_id']:
+            snapshots = [
+                snapshots_service.snapshot_service(module.params['snapshot_id']).get()
+            ]
+        else:
+            snapshots = snapshots_service.list()
+
+        result = dict(
+            ovirt_snapshots=[
+                get_dict_of_struct(
+                    struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for c in snapshots
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_snapshot_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_snapshot_facts.py
@@ -4,6 +4,8 @@
 # Copyright (c) 2016 Red Hat, Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_snapshot_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_snapshot_facts.py
@@ -12,7 +12,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_snapshot_info
+module: ovirt_snapshot_facts
 short_description: Retrieve information about one or more oVirt/RHV virtual machine snapshots
 author: "Ondra Machacek (@machacekondra)"
 deprecated:
@@ -67,6 +67,7 @@ ovirt_snapshots:
 import fnmatch
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -134,4 +135,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_storage_domain_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_storage_domain_facts.py
@@ -1,1 +1,124 @@
-ovirt_storage_domain_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_storage_domain_info
+short_description: Retrieve information about one or more oVirt/RHV storage domains
+author: "Ondra Machacek (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_storage_domain_info) instead
+version_added: "2.3"
+description:
+    - "Retrieve information about one or more oVirt/RHV storage domains."
+    - This module was called C(ovirt_storage_domain_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_storage_domain_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_storage_domains), which
+       contains a list of storage domains. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    pattern:
+      description:
+        - "Search term which is accepted by oVirt/RHV search backend."
+        - "For example to search storage domain X from datacenter Y use following pattern:
+           name=X and datacenter=Y"
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about all storage domains which names start with C(data) and
+# belong to data center C(west):
+- ovirt_storage_domain_info:
+    pattern: name=data* and datacenter=west
+  register: result
+- debug:
+    msg: "{{ result.ovirt_storage_domains }}"
+'''
+
+RETURN = '''
+ovirt_storage_domains:
+    description: "List of dictionaries describing the storage domains. Storage_domain attributes are mapped to dictionary keys,
+                  all storage domains attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/storage_domain."
+    returned: On success.
+    type: list
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        pattern=dict(default='', required=False),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_storage_domain_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_storage_domain_facts' module has been renamed to 'ovirt_storage_domain_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        storage_domains_service = connection.system_service().storage_domains_service()
+        storage_domains = storage_domains_service.list(search=module.params['pattern'])
+        result = dict(
+            ovirt_storage_domains=[
+                get_dict_of_struct(
+                    struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for c in storage_domains
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_storage_domain_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_storage_domain_facts.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_storage_domain_info
+module: ovirt_storage_domain_facts
 short_description: Retrieve information about one or more oVirt/RHV storage domains
 author: "Ondra Machacek (@machacekondra)"
 deprecated:
@@ -74,6 +74,7 @@ ovirt_storage_domains:
 
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -121,4 +122,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_storage_domain_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_storage_domain_facts.py
@@ -19,6 +19,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_storage_template_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_storage_template_facts.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_storage_template_info
+module: ovirt_storage_template_facts
 short_description: Retrieve information about one or more oVirt/RHV templates relate to a storage domain.
 author: "Maor Lipchuk (@machacekondra)"
 deprecated:
@@ -81,6 +81,7 @@ ovirt_storage_templates:
 
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -139,4 +140,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_storage_template_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_storage_template_facts.py
@@ -1,1 +1,142 @@
-ovirt_storage_template_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2017 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_storage_template_info
+short_description: Retrieve information about one or more oVirt/RHV templates relate to a storage domain.
+author: "Maor Lipchuk (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_storage_template_info) instead
+version_added: "2.4"
+description:
+    - "Retrieve information about one or more oVirt/RHV templates relate to a storage domain."
+    - This module was called C(ovirt_storage_template_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_storage_template_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_storage_templates), which
+       contains a list of templates. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    unregistered:
+        description:
+            - "Flag which indicates whether to get unregistered templates which contain one or more
+               disks which reside on a storage domain or diskless templates."
+        type: bool
+        default: false
+    max:
+        description:
+            - "Sets the maximum number of templates to return. If not specified all the templates are returned."
+    storage_domain:
+        description:
+            - "The storage domain name where the templates should be listed."
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about all Templates which relate to a storage domain and
+# are unregistered:
+- ovirt_storage_template_info:
+    unregistered=True
+  register: result
+- debug:
+    msg: "{{ result.ovirt_storage_templates }}"
+'''
+
+RETURN = '''
+ovirt_storage_templates:
+    description: "List of dictionaries describing the Templates. Template attributes are mapped to dictionary keys,
+                  all Templates attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/template."
+    returned: On success.
+    type: list
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+    get_id_by_name
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        storage_domain=dict(default=None),
+        max=dict(default=None, type='int'),
+        unregistered=dict(default=False, type='bool'),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_storage_template_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_storage_template_facts' module has been renamed to 'ovirt_storage_template_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        storage_domains_service = connection.system_service().storage_domains_service()
+        sd_id = get_id_by_name(storage_domains_service, module.params['storage_domain'])
+        storage_domain_service = storage_domains_service.storage_domain_service(sd_id)
+        templates_service = storage_domain_service.templates_service()
+
+        # Find the unregistered Template we want to register:
+        if module.params.get('unregistered'):
+            templates = templates_service.list(unregistered=True)
+        else:
+            templates = templates_service.list(max=module.params['max'])
+        result = dict(
+            ovirt_storage_templates=[
+                get_dict_of_struct(
+                    struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for c in templates
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_storage_template_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_storage_template_facts.py
@@ -19,6 +19,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_storage_vm_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_storage_vm_facts.py
@@ -1,1 +1,142 @@
-ovirt_storage_vm_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2017 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_storage_vm_info
+short_description: Retrieve information about one or more oVirt/RHV virtual machines relate to a storage domain.
+author: "Maor Lipchuk (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_storage_vm_info) instead
+version_added: "2.4"
+description:
+    - "Retrieve information about one or more oVirt/RHV virtual machines relate to a storage domain."
+    - This module was called C(ovirt_storage_vm_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_storage_vm_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_storage_vms), which
+       contains a list of virtual machines. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    unregistered:
+        description:
+            - "Flag which indicates whether to get unregistered virtual machines which contain one or more
+               disks which reside on a storage domain or diskless virtual machines."
+        type: bool
+        default: false
+    max:
+        description:
+            - "Sets the maximum number of virtual machines to return. If not specified all the virtual machines are returned."
+    storage_domain:
+        description:
+            - "The storage domain name where the virtual machines should be listed."
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about all VMs which relate to a storage domain and
+# are unregistered:
+- ovirt_vms_info:
+    unregistered=True
+  register: result
+- debug:
+    msg: "{{ result.ovirt_storage_vms }}"
+'''
+
+RETURN = '''
+ovirt_storage_vms:
+    description: "List of dictionaries describing the VMs. VM attributes are mapped to dictionary keys,
+                  all VMs attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/vm."
+    returned: On success.
+    type: list
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+    get_id_by_name
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        storage_domain=dict(default=None),
+        max=dict(default=None, type='int'),
+        unregistered=dict(default=False, type='bool'),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_storage_vm_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_storage_vm_facts' module has been renamed to 'ovirt_storage_vm_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        storage_domains_service = connection.system_service().storage_domains_service()
+        sd_id = get_id_by_name(storage_domains_service, module.params['storage_domain'])
+        storage_domain_service = storage_domains_service.storage_domain_service(sd_id)
+        vms_service = storage_domain_service.vms_service()
+
+        # Find the unregistered VM we want to register:
+        if module.params.get('unregistered'):
+            vms = vms_service.list(unregistered=True)
+        else:
+            vms = vms_service.list()
+        result = dict(
+            ovirt_storage_vms=[
+                get_dict_of_struct(
+                    struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for c in vms
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_storage_vm_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_storage_vm_facts.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_storage_vm_info
+module: ovirt_storage_vm_facts
 short_description: Retrieve information about one or more oVirt/RHV virtual machines relate to a storage domain.
 author: "Maor Lipchuk (@machacekondra)"
 deprecated:
@@ -81,6 +81,7 @@ ovirt_storage_vms:
 
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -139,4 +140,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_storage_vm_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_storage_vm_facts.py
@@ -19,6 +19,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_tag_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_tag_facts.py
@@ -1,1 +1,171 @@
-ovirt_tag_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_tag_info
+short_description: Retrieve information about one or more oVirt/RHV tags
+author: "Ondra Machacek (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_tag_info) instead
+version_added: "2.3"
+description:
+    - "Retrieve information about one or more oVirt/RHV tags."
+    - This module was called C(ovirt_tag_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_tag_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_tags), which
+       contains a list of tags. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    name:
+      description:
+        - "Name of the tag which should be listed."
+    vm:
+      description:
+        - "Name of the VM, which tags should be listed."
+    host:
+      description:
+        - "Name of the host, which tags should be listed."
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about all tags, which names start with C(tag):
+- ovirt_tag_info:
+    name: tag*
+  register: result
+- debug:
+    msg: "{{ result.ovirt_tags }}"
+
+# Gather information about all tags, which are assigned to VM C(postgres):
+- ovirt_tag_info:
+    vm: postgres
+  register: result
+- debug:
+    msg: "{{ result.ovirt_tags }}"
+
+# Gather information about all tags, which are assigned to host C(west):
+- ovirt_tag_info:
+    host: west
+  register: result
+- debug:
+    msg: "{{ result.ovirt_tags }}"
+'''
+
+RETURN = '''
+ovirt_tags:
+    description: "List of dictionaries describing the tags. Tags attributes are mapped to dictionary keys,
+                  all tags attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/tag."
+    returned: On success.
+    type: list
+'''
+
+import fnmatch
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+    search_by_name,
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        name=dict(default=None),
+        host=dict(default=None),
+        vm=dict(default=None),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_tag_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_tag_facts' module has been renamed to 'ovirt_tag_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        tags_service = connection.system_service().tags_service()
+        tags = []
+        all_tags = tags_service.list()
+        if module.params['name']:
+            tags.extend([
+                t for t in all_tags
+                if fnmatch.fnmatch(t.name, module.params['name'])
+            ])
+        if module.params['host']:
+            hosts_service = connection.system_service().hosts_service()
+            host = search_by_name(hosts_service, module.params['host'])
+            if host is None:
+                raise Exception("Host '%s' was not found." % module.params['host'])
+            tags.extend([
+                tag for tag in hosts_service.host_service(host.id).tags_service().list()
+            ])
+        if module.params['vm']:
+            vms_service = connection.system_service().vms_service()
+            vm = search_by_name(vms_service, module.params['vm'])
+            if vm is None:
+                raise Exception("Vm '%s' was not found." % module.params['vm'])
+            tags.extend([
+                tag for tag in vms_service.vm_service(vm.id).tags_service().list()
+            ])
+
+        if not (module.params['vm'] or module.params['host'] or module.params['name']):
+            tags = all_tags
+
+        result = dict(
+            ovirt_tags=[
+                get_dict_of_struct(
+                    struct=t,
+                    connection=connection,
+                    fetch_nested=module.params['fetch_nested'],
+                    attributes=module.params['nested_attributes'],
+                ) for t in tags
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_tag_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_tag_facts.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_tag_info
+module: ovirt_tag_facts
 short_description: Retrieve information about one or more oVirt/RHV tags
 author: "Ondra Machacek (@machacekondra)"
 deprecated:
@@ -92,6 +92,7 @@ ovirt_tags:
 import fnmatch
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -168,4 +169,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_tag_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_tag_facts.py
@@ -19,6 +19,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_template_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_template_facts.py
@@ -1,1 +1,124 @@
-ovirt_template_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_template_info
+short_description: Retrieve information about one or more oVirt/RHV templates
+author: "Ondra Machacek (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_template_info) instead
+version_added: "2.3"
+description:
+    - "Retrieve information about one or more oVirt/RHV templates."
+    - This module was called C(ovirt_template_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_template_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_templates), which
+       contains a list of templates. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    pattern:
+      description:
+        - "Search term which is accepted by oVirt/RHV search backend."
+        - "For example to search template X from datacenter Y use following pattern:
+           name=X and datacenter=Y"
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about all templates which names start with C(centos) and
+# belongs to data center C(west):
+- ovirt_template_info:
+    pattern: name=centos* and datacenter=west
+  register: result
+- debug:
+    msg: "{{ result.ovirt_templates }}"
+'''
+
+RETURN = '''
+ovirt_templates:
+    description: "List of dictionaries describing the templates. Template attributes are mapped to dictionary keys,
+                  all templates attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/template."
+    returned: On success.
+    type: list
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        pattern=dict(default='', required=False),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_template_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_template_facts' module has been renamed to 'ovirt_template_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        templates_service = connection.system_service().templates_service()
+        templates = templates_service.list(search=module.params['pattern'])
+        result = dict(
+            ovirt_templates=[
+                get_dict_of_struct(
+                    struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for c in templates
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_template_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_template_facts.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_template_info
+module: ovirt_template_facts
 short_description: Retrieve information about one or more oVirt/RHV templates
 author: "Ondra Machacek (@machacekondra)"
 deprecated:
@@ -74,6 +74,7 @@ ovirt_templates:
 
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -121,4 +122,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_template_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_template_facts.py
@@ -19,6 +19,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_user_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_user_facts.py
@@ -1,1 +1,122 @@
-ovirt_user_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_user_info
+short_description: Retrieve information about one or more oVirt/RHV users
+author: "Ondra Machacek (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_user_info) instead
+version_added: "2.3"
+description:
+    - "Retrieve information about one or more oVirt/RHV users."
+    - This module was called C(ovirt_user_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_user_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_users), which
+       contains a list of users. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    pattern:
+      description:
+        - "Search term which is accepted by oVirt/RHV search backend."
+        - "For example to search user X use following pattern: name=X"
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about all users which first names start with C(john):
+- ovirt_user_info:
+    pattern: name=john*
+  register: result
+- debug:
+    msg: "{{ result.ovirt_users }}"
+'''
+
+RETURN = '''
+ovirt_users:
+    description: "List of dictionaries describing the users. User attributes are mapped to dictionary keys,
+                  all users attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/user."
+    returned: On success.
+    type: list
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        pattern=dict(default='', required=False),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_user_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_user_facts' module has been renamed to 'ovirt_user_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        users_service = connection.system_service().users_service()
+        users = users_service.list(search=module.params['pattern'])
+        result = dict(
+            ovirt_users=[
+                get_dict_of_struct(
+                    struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for c in users
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_user_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_user_facts.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_user_info
+module: ovirt_user_facts
 short_description: Retrieve information about one or more oVirt/RHV users
 author: "Ondra Machacek (@machacekondra)"
 deprecated:
@@ -72,6 +72,7 @@ ovirt_users:
 
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -119,4 +120,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_user_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_user_facts.py
@@ -19,6 +19,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_vm_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_vm_facts.py
@@ -1,1 +1,164 @@
-ovirt_vm_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_vm_info
+short_description: Retrieve information about one or more oVirt/RHV virtual machines
+author: "Ondra Machacek (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_vm_info) instead
+version_added: "2.3"
+description:
+    - "Retrieve information about one or more oVirt/RHV virtual machines."
+    - This module was called C(ovirt_vm_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_vm_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_vms), which
+       contains a list of virtual machines. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    pattern:
+      description:
+        - "Search term which is accepted by oVirt/RHV search backend."
+        - "For example to search VM X from cluster Y use following pattern:
+           name=X and cluster=Y"
+    all_content:
+      description:
+        - "If I(true) all the attributes of the virtual machines should be
+           included in the response."
+      type: bool
+    case_sensitive:
+      description:
+        - "If I(true) performed search will take case into account."
+      type: bool
+      default: true
+    max:
+      description:
+        - "The maximum number of results to return."
+    next_run:
+      description:
+        - "Indicates if the returned result describes the virtual machine as it is currently running or if describes
+           the virtual machine with the modifications that have already been performed but that will only come into
+           effect when the virtual machine is restarted. By default the value is set by engine."
+      type: bool
+      version_added: "2.8"
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about all VMs which names start with C(centos) and
+# belong to cluster C(west):
+- ovirt_vm_info:
+    pattern: name=centos* and cluster=west
+  register: result
+- debug:
+    msg: "{{ result.ovirt_vms }}"
+
+# Gather info about next run configuration of virtual machine named myvm
+- ovirt_vm_info:
+    pattern: name=myvm
+    next_run: true
+  register: result
+- debug:
+    msg: "{{ result.ovirt_vms[0] }}"
+'''
+
+RETURN = '''
+ovirt_vms:
+    description: "List of dictionaries describing the VMs. VM attributes are mapped to dictionary keys,
+                  all VMs attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/vm."
+    returned: On success.
+    type: list
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        pattern=dict(default='', required=False),
+        all_content=dict(default=False, type='bool'),
+        next_run=dict(default=None, type='bool'),
+        case_sensitive=dict(default=True, type='bool'),
+        max=dict(default=None, type='int'),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_vm_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_vm_facts' module has been renamed to 'ovirt_vm_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        vms_service = connection.system_service().vms_service()
+        vms = vms_service.list(
+            search=module.params['pattern'],
+            all_content=module.params['all_content'],
+            case_sensitive=module.params['case_sensitive'],
+            max=module.params['max'],
+        )
+        if module.params['next_run']:
+            vms = [vms_service.vm_service(vm.id).get(next_run=True) for vm in vms]
+
+        result = dict(
+            ovirt_vms=[
+                get_dict_of_struct(
+                    struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for c in vms
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_vm_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_vm_facts.py
@@ -19,6 +19,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_vm_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_vm_facts.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_vm_info
+module: ovirt_vm_facts
 short_description: Retrieve information about one or more oVirt/RHV virtual machines
 author: "Ondra Machacek (@machacekondra)"
 deprecated:
@@ -102,6 +102,7 @@ ovirt_vms:
 
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,
@@ -161,4 +162,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_vmpool_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_vmpool_facts.py
@@ -72,6 +72,7 @@ ovirt_vm_pools:
 
 import traceback
 
+from ansible.module_utils.common.removed import removed_module
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ovirt import (
     check_sdk,

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_vmpool_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_vmpool_facts.py
@@ -1,1 +1,122 @@
-ovirt_vmpool_info.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ovirt_vmpool_info
+short_description: Retrieve information about one or more oVirt/RHV vmpools
+author: "Ondra Machacek (@machacekondra)"
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_vmpool_info) instead
+version_added: "2.3"
+description:
+    - "Retrieve information about one or more oVirt/RHV vmpools."
+    - This module was called C(ovirt_vmpool_facts) before Ansible 2.9, returning C(ansible_facts).
+      Note that the M(ovirt_vmpool_info) module no longer returns C(ansible_facts)!
+notes:
+    - "This module returns a variable C(ovirt_vmpools), which
+       contains a list of vmpools. You need to register the result with
+       the I(register) keyword to use it."
+options:
+    pattern:
+      description:
+        - "Search term which is accepted by oVirt/RHV search backend."
+        - "For example to search vmpool X: name=X"
+extends_documentation_fragment: ovirt_info
+'''
+
+EXAMPLES = '''
+# Examples don't contain auth parameter for simplicity,
+# look at ovirt_auth module to see how to reuse authentication:
+
+# Gather information about all vm pools which names start with C(centos):
+- ovirt_vmpool_info:
+    pattern: name=centos*
+  register: result
+- debug:
+    msg: "{{ result.ovirt_vm_pools }}"
+'''
+
+RETURN = '''
+ovirt_vm_pools:
+    description: "List of dictionaries describing the vmpools. Vm pool attributes are mapped to dictionary keys,
+                  all vmpools attributes can be found at following url: http://ovirt.github.io/ovirt-engine-api-model/master/#types/vm_pool."
+    returned: On success.
+    type: list
+'''
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ovirt import (
+    check_sdk,
+    create_connection,
+    get_dict_of_struct,
+    ovirt_info_full_argument_spec,
+)
+
+
+def main():
+    argument_spec = ovirt_info_full_argument_spec(
+        pattern=dict(default='', required=False),
+    )
+    module = AnsibleModule(argument_spec)
+    is_old_facts = module._name == 'ovirt_vmpool_facts'
+    if is_old_facts:
+        module.deprecate("The 'ovirt_vmpool_facts' module has been renamed to 'ovirt_vmpool_info', "
+                         "and the renamed one no longer returns ansible_facts", version='2.13')
+
+    check_sdk(module)
+
+    try:
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
+        vmpools_service = connection.system_service().vm_pools_service()
+        vmpools = vmpools_service.list(search=module.params['pattern'])
+        result = dict(
+            ovirt_vm_pools=[
+                get_dict_of_struct(
+                    struct=c,
+                    connection=connection,
+                    fetch_nested=module.params.get('fetch_nested'),
+                    attributes=module.params.get('nested_attributes'),
+                ) for c in vmpools
+            ],
+        )
+        if is_old_facts:
+            module.exit_json(changed=False, ansible_facts=result)
+        else:
+            module.exit_json(changed=False, **result)
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
+    finally:
+        connection.close(logout=auth.get('token') is None)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_vmpool_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_vmpool_facts.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: ovirt_vmpool_info
+module: ovirt_vmpool_facts
 short_description: Retrieve information about one or more oVirt/RHV vmpools
 author: "Ondra Machacek (@machacekondra)"
 deprecated:
@@ -119,4 +119,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    removed_module("2.10")

--- a/lib/ansible/modules/cloud/ovirt/_ovirt_vmpool_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/_ovirt_vmpool_facts.py
@@ -19,6 +19,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
                     'supported_by': 'community'}

--- a/lib/ansible/plugins/doc_fragments/ovirt_facts.py
+++ b/lib/ansible/plugins/doc_fragments/ovirt_facts.py
@@ -6,6 +6,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+
 class ModuleDocFragment(object):
 
     # info standard oVirt documentation fragment

--- a/lib/ansible/plugins/doc_fragments/ovirt_facts.py
+++ b/lib/ansible/plugins/doc_fragments/ovirt_facts.py
@@ -3,6 +3,8 @@
 # Copyright: (c) 2016, Red Hat, Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
 
 class ModuleDocFragment(object):
 

--- a/lib/ansible/plugins/doc_fragments/ovirt_facts.py
+++ b/lib/ansible/plugins/doc_fragments/ovirt_facts.py
@@ -1,1 +1,61 @@
-ovirt_info.py
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2016, Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+class ModuleDocFragment(object):
+
+    # info standard oVirt documentation fragment
+    DOCUMENTATION = r'''
+deprecated:
+    removed_in: "2.10"
+    why: When migrating to collection we decided to use only _info modules.
+    alternative: Use M(ovirt_info) instead
+options:
+    fetch_nested:
+        description:
+            - If I(yes) the module will fetch additional data from the API.
+            - It will fetch only IDs of nested entity. It doesn't fetch multiple levels of nested attributes.
+              Only the attributes of the current entity. User can configure to fetch other
+              attributes of the nested entities by specifying C(nested_attributes).
+        type: bool
+        version_added: "2.3"
+    nested_attributes:
+        description:
+            - Specifies list of the attributes which should be fetched from the API.
+            - This parameter apply only when C(fetch_nested) is I(true).
+        type: list
+        version_added: "2.3"
+    auth:
+        description:
+            - "Dictionary with values needed to create HTTP/HTTPS connection to oVirt:"
+            - C(username)[I(required)] - The name of the user, something like I(admin@internal).
+              Default value is set by I(OVIRT_USERNAME) environment variable.
+            - "C(password)[I(required)] - The password of the user. Default value is set by I(OVIRT_PASSWORD) environment variable."
+            - "C(url)- A string containing the API URL of the server, usually
+            something like `I(https://server.example.com/ovirt-engine/api)`. Default value is set by I(OVIRT_URL) environment variable.
+            Either C(url) or C(hostname) is required."
+            - "C(hostname) - A string containing the hostname of the server, usually
+            something like `I(server.example.com)`. Default value is set by I(OVIRT_HOSTNAME) environment variable.
+            Either C(url) or C(hostname) is required."
+            - "C(token) - Token to be used instead of login with username/password. Default value is set by I(OVIRT_TOKEN) environment variable."
+            - "C(insecure) - A boolean flag that indicates if the server TLS
+            certificate and host name should be checked."
+            - "C(ca_file) - A PEM file containing the trusted CA certificates. The
+            certificate presented by the server will be verified using these CA
+            certificates. If `C(ca_file)` parameter is not set, system wide
+            CA certificate store is used. Default value is set by I(OVIRT_CAFILE) environment variable."
+            - "C(kerberos) - A boolean flag indicating if Kerberos authentication
+            should be used instead of the default basic authentication."
+            - "C(headers) - Dictionary of HTTP headers to be added to each API call."
+        type: dict
+        required: true
+requirements:
+  - python >= 2.7
+  - ovirt-engine-sdk-python >= 4.3.0
+notes:
+  - "In order to use this module you have to install oVirt Python SDK.
+     To ensure it's installed with correct version you can create the following task:
+     pip: name=ovirt-engine-sdk-python version=4.3.0"
+'''

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -1839,9 +1839,9 @@ lib/ansible/modules/cloud/memset/memset_zone_record.py validate-modules:paramete
 lib/ansible/modules/cloud/misc/cloud_init_data_facts.py validate-modules:doc-missing-type
 lib/ansible/modules/cloud/misc/helm.py validate-modules:doc-missing-type
 lib/ansible/modules/cloud/misc/helm.py validate-modules:parameter-type-not-in-doc
-lib/ansible/modules/cloud/misc/ovirt.py validate-modules:doc-choices-do-not-match-spec
-lib/ansible/modules/cloud/misc/ovirt.py validate-modules:parameter-type-not-in-doc
-lib/ansible/modules/cloud/misc/ovirt.py validate-modules:undocumented-parameter
+lib/ansible/modules/cloud/misc/_ovirt.py validate-modules:doc-choices-do-not-match-spec
+lib/ansible/modules/cloud/misc/_ovirt.py validate-modules:parameter-type-not-in-doc
+lib/ansible/modules/cloud/misc/_ovirt.py validate-modules:undocumented-parameter
 lib/ansible/modules/cloud/misc/proxmox.py validate-modules:doc-missing-type
 lib/ansible/modules/cloud/misc/proxmox.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/cloud/misc/proxmox_kvm.py validate-modules:doc-default-does-not-match-spec

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -1839,9 +1839,6 @@ lib/ansible/modules/cloud/memset/memset_zone_record.py validate-modules:paramete
 lib/ansible/modules/cloud/misc/cloud_init_data_facts.py validate-modules:doc-missing-type
 lib/ansible/modules/cloud/misc/helm.py validate-modules:doc-missing-type
 lib/ansible/modules/cloud/misc/helm.py validate-modules:parameter-type-not-in-doc
-lib/ansible/modules/cloud/misc/_ovirt.py validate-modules:doc-choices-do-not-match-spec
-lib/ansible/modules/cloud/misc/_ovirt.py validate-modules:parameter-type-not-in-doc
-lib/ansible/modules/cloud/misc/_ovirt.py validate-modules:undocumented-parameter
 lib/ansible/modules/cloud/misc/proxmox.py validate-modules:doc-missing-type
 lib/ansible/modules/cloud/misc/proxmox.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/cloud/misc/proxmox_kvm.py validate-modules:doc-default-does-not-match-spec


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
@thedoubl3j @gundalow 
I have added 
- `from ansible.module_utils.common.removed import removed_module`
- `from __future__ import absolute_import, division, print_function`
- `removed_module("2.10")`
- `__metaclass__ = type`
- ```yaml
    deprecated:
        removed_in: "2.10"
        why: When migrating to collection we decided to use only _info modules.
        alternative: Use M(ovirt_NAME_info) instead```
- removed links from _facts modules 
- removed _fatcs from BOTMETA
- removed unnecessary sanity ignore for ovirt misc
- updated status in ANSIBLE_METADATA to deprecated in all _facts modules

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
