### PR TITLE
Run Powershell modules on windows container via docker connection

### DIFF
--- a/changelogs/fragments/67832-run_powershell_modules_on_windows_containers.yml
+++ b/changelogs/fragments/67832-run_powershell_modules_on_windows_containers.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - docker connection plugin - run Powershell modules on Windows containers.

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -75,11 +75,11 @@ class Connection(ConnectionBase):
         # error it probably means that docker on their system is only
         # configured to be connected to by root and they are not running as
         # root.
-        
+
         # Windows uses Powershell modules
         if getattr(self._shell, "_IS_WINDOWS", False):
             self.module_implementation_preferences = ('.ps1', '.exe', '')
-            
+
         if 'docker_command' in kwargs:
             self.docker_cmd = kwargs['docker_command']
         else:

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -75,7 +75,11 @@ class Connection(ConnectionBase):
         # error it probably means that docker on their system is only
         # configured to be connected to by root and they are not running as
         # root.
-
+        
+        # Windows uses Powershell modules
+        if getattr(self._shell, "_IS_WINDOWS", False):
+            self.module_implementation_preferences = ('.ps1', '.exe', '')
+            
         if 'docker_command' in kwargs:
             self.docker_cmd = kwargs['docker_command']
         else:


### PR DESCRIPTION
##### SUMMARY
Currently, while executing an Ansible role against windows containers via docker connection plugin, Ansible runs the python modules instead of Powershell modules. We found this limitation, especially while executing `win_copy` task.
Hence, adding a commit that enables ansible to run Powershell modules on windows container via docker connection. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
Docker connection plugin (lib/ansible/plugins/connection/docker.py)

##### ADDITIONAL INFORMATION
Please comment if you require more details about my use case. 
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
