### PR TITLE
[2.9] Bugfix of 65351: mysql_db create dump with CREATE DATABASE and USE instruction

### DIFF
--- a/changelogs/fragments/67767-mysql_db_fix_bug_introduced_by_56721.yml
+++ b/changelogs/fragments/67767-mysql_db_fix_bug_introduced_by_56721.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_db - fix bug in the ``db_import`` function introduced by https://github.com/ansible/ansible/pull/56721 (https://github.com/ansible/ansible/issues/65351).

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -203,10 +203,14 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port, 
         cmd += " --socket=%s" % shlex_quote(socket)
     else:
         cmd += " --host=%s --port=%i" % (shlex_quote(host), port)
+
     if all_databases:
         cmd += " --all-databases"
-    else:
+    elif len(db_name) > 1:
         cmd += " --databases {0} --skip-lock-tables".format(' '.join(db_name))
+    else:
+        cmd += " %s" % shlex_quote(' '.join(db_name))
+
     if single_transaction:
         cmd += " --single-transaction=true"
     if quick:


### PR DESCRIPTION
##### SUMMARY 
Bugfix of #65351: mysql_db create dump with CREATE DATABASE and USE instruction

Backport of https://github.com/ansible/ansible/pull/67767

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/mysql/mysql_db.py```
