### PR TITLE
Set global skipped result flag for looped tasks

### DIFF
--- a/changelogs/fragments/16949-global-skipped-result-flag-looped-tasks.yml
+++ b/changelogs/fragments/16949-global-skipped-result-flag-looped-tasks.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Allow for the skipped filter to be used on a registered looped task results. (https://github.com/ansible/ansible/issues/16949)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -122,10 +122,13 @@ class TaskExecutor:
                     # create the overall result item
                     res = dict(results=item_results)
 
-                    # loop through the item results, and set the global changed/failed result flags based on any item.
+                    # loop through the item results and set the global changed/failed/skipped result flags based on any item.
+                    res['skipped'] = True
                     for item in item_results:
                         if 'changed' in item and item['changed'] and not res.get('changed'):
                             res['changed'] = True
+                        if res['skipped'] and ('skipped' not in item or ('skipped' in item and not item['skipped'])):
+                            res['skipped'] = False
                         if 'failed' in item and item['failed']:
                             item_ignore = item.pop('_ansible_ignore_errors')
                             if not res.get('failed'):
@@ -147,6 +150,8 @@ class TaskExecutor:
 
                     if not res.get('Failed', False):
                         res['msg'] = 'All items completed'
+                    if res['skipped']:
+                        res['msg'] = 'All items skipped'
                 else:
                     res = dict(changed=False, skipped=True, skipped_reason='No items in the list', results=[])
             else:

--- a/test/integration/targets/lookup_subelements/tasks/main.yml
+++ b/test/integration/targets/lookup_subelements/tasks/main.yml
@@ -39,7 +39,7 @@
 - name: verify with_subelements in subkeys results
   assert:
     that:
-        - _subelements_missing_subkeys.skipped is not defined
+        - _subelements_missing_subkeys is not skipped
         - _subelements_missing_subkeys.results|length == 2
         - "_xk == 'k'"
         - "_xl == 'l'"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This allows for the skipped filter to be used on a registered looped
task results.

Fixes #16949
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`lib/ansible/executor/task_executor.py`