### PR TITLE
fix docker_login doc example

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_login.py
+++ b/lib/ansible/modules/cloud/docker/docker_login.py
@@ -98,7 +98,7 @@ EXAMPLES = '''
 
 - name: Log into private registry and force re-authorization
   docker_login:
-    registry: your.private.registry.io
+    registry_url: your.private.registry.io
     username: yourself
     password: secrets3
     reauthorize: yes


### PR DESCRIPTION
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
docker_login example do not match parameters (`registry` should be `registry_url`)

##### COMPONENT NAME
docker_login
