### PR TITLE
Ensure Ansible's unique filter preserves order

### DIFF
--- a/changelogs/fragments/63417-unique-filter-preserve-order.yml
+++ b/changelogs/fragments/63417-unique-filter-preserve-order.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Ensure Ansible's unique filter preserves order (https://github.com/ansible/ansible/issues/63417)

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -56,11 +56,7 @@ def unique(environment, a, case_sensitive=False, attribute=None):
     error = e = None
     try:
         if HAS_UNIQUE:
-            c = do_unique(environment, a, case_sensitive=case_sensitive, attribute=attribute)
-            if isinstance(a, Hashable):
-                c = set(c)
-            else:
-                c = list(c)
+            c = list(do_unique(environment, a, case_sensitive=case_sensitive, attribute=attribute))
     except TypeError as e:
         error = e
         _do_fail(e)
@@ -76,13 +72,11 @@ def unique(environment, a, case_sensitive=False, attribute=None):
             raise AnsibleFilterError("Ansible's unique filter does not support case_sensitive nor attribute parameters, "
                                      "you need a newer version of Jinja2 that provides their version of the filter.")
 
-        if isinstance(a, Hashable):
-            c = set(a)
-        else:
-            c = []
-            for x in a:
-                if x not in c:
-                    c.append(x)
+        c = []
+        for x in a:
+            if x not in c:
+                c.append(x)
+
     return c
 
 

--- a/test/units/plugins/filter/test_mathstuff.py
+++ b/test/units/plugins/filter/test_mathstuff.py
@@ -12,10 +12,10 @@ import ansible.plugins.filter.mathstuff as ms
 from ansible.errors import AnsibleFilterError
 
 
-UNIQUE_DATA = (([1, 3, 4, 2], sorted([1, 2, 3, 4])),
-               ([1, 3, 2, 4, 2, 3], sorted([1, 2, 3, 4])),
-               (['a', 'b', 'c', 'd'], sorted(['a', 'b', 'c', 'd'])),
-               (['a', 'a', 'd', 'b', 'a', 'd', 'c', 'b'], sorted(['a', 'b', 'c', 'd'])),
+UNIQUE_DATA = (([1, 3, 4, 2], [1, 3, 4, 2]),
+               ([1, 3, 2, 4, 2, 3], [1, 3, 2, 4]),
+               (['a', 'b', 'c', 'd'], ['a', 'b', 'c', 'd']),
+               (['a', 'a', 'd', 'b', 'a', 'd', 'c', 'b'], ['a', 'd', 'b', 'c']),
                )
 
 TWO_SETS_DATA = (([1, 2], [3, 4], ([], sorted([1, 2]), sorted([1, 2, 3, 4]), sorted([1, 2, 3, 4]))),
@@ -29,10 +29,10 @@ env = Environment()
 @pytest.mark.parametrize('data, expected', UNIQUE_DATA)
 class TestUnique:
     def test_unhashable(self, data, expected):
-        assert sorted(ms.unique(env, list(data))) == expected
+        assert ms.unique(env, list(data)) == expected
 
     def test_hashable(self, data, expected):
-        assert sorted(ms.unique(env, tuple(data))) == expected
+        assert ms.unique(env, tuple(data)) == expected
 
 
 @pytest.mark.parametrize('dataset1, dataset2, expected', TWO_SETS_DATA)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

As Jinja2's version does (https://jinja.palletsprojects.com/en/2.11.x/templates/#unique):
> The unique items are yielded in the same order as their first occurrence in the iterable passed to the filter.

Fixes #63417
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/plugins/filter/mathstuff.py