### PR TITLE
line indentation issue in postgresql_set

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_set.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_set.py
@@ -98,7 +98,7 @@ EXAMPLES = r'''
   postgresql_set:
     name: work_mem
     value: 32mb
-    register: set
+  register: set
 
 - debug:
     msg: "{{ set.name }} {{ set.prev_val_pretty }} >> {{ set.value_pretty }} restart_req: {{ set.restart_required }}"


### PR DESCRIPTION
##### SUMMARY
There is an indentation issue with the `register` for this example task.

```
- name: Set work mem parameter
  postgresql_set:
    name: work_mem
    value: 32mb
  register: set
```


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr
