### PR TITLE
Add tests for check_required_by and fix default return value

### DIFF
--- a/lib/ansible/module_utils/common/validation.py
+++ b/lib/ansible/module_utils/common/validation.py
@@ -139,7 +139,7 @@ def check_required_by(requirements, module_parameters):
     :arg requirements: Dictionary of requirements
     :arg module_parameters: Dictionary of module parameters
 
-    :returns: Empty dictionary or raises TypeError if the
+    :returns: Empty dictionary or raises TypeError if the check fails.
     """
 
     result = {}
@@ -149,16 +149,17 @@ def check_required_by(requirements, module_parameters):
     for (key, value) in requirements.items():
         if key not in module_parameters or module_parameters[key] is None:
             continue
-        result[key] = []
         # Support strings (single-item lists)
         if isinstance(value, string_types):
             value = [value]
         for required in value:
             if required not in module_parameters or module_parameters[required] is None:
+                if key not in result:
+                    result[key] = []
                 result[key].append(required)
 
     if result:
-        for key, missing in result.items():
+        for key, missing in sorted(result.items()):
             if len(missing) > 0:
                 msg = "missing parameter(s) required by '%s': %s" % (key, ', '.join(missing))
                 raise TypeError(to_native(msg))

--- a/test/units/module_utils/common/validation/test_check_required_by.py
+++ b/test/units/module_utils/common/validation/test_check_required_by.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible.module_utils._text import to_native
+from ansible.module_utils.common.validation import check_required_by
+
+
+@pytest.fixture
+def required_by_terms():
+    return {
+        'fruit': ['name', 'flavor'],
+        'car': ['color', 'doors'],
+    }
+
+
+def test_check_required_by(required_by_terms):
+    params = {
+        'fruit': 'hello',
+        'flavor': 'sweet',
+        'name': 'banana',
+    }
+
+    assert check_required_by(required_by_terms, params) == {}
+
+
+def test_check_required_by_missing(required_by_terms):
+    params = {
+        'fruit': 'hello',
+        'flavor': 'sweet',
+    }
+
+    expected = "missing parameter(s) required by 'fruit': name"
+
+    with pytest.raises(TypeError) as e:
+        check_required_by(required_by_terms, params)
+
+    assert to_native(e.value) == expected
+
+
+def test_check_required_by_multiple_same_missing(required_by_terms):
+    params = {
+        'fruit': 'hello',
+    }
+
+    expected = "missing parameter(s) required by 'fruit': name, flavor"
+
+    with pytest.raises(TypeError) as e:
+        check_required_by(required_by_terms, params)
+
+    assert to_native(e.value) == expected
+
+
+def test_check_required_by_multiple_different_missing(required_by_terms):
+    params = {
+        'fruit': 'hello',
+        'car': 'goodbye',
+    }
+
+    expected = "missing parameter(s) required by 'car': color, doors"
+
+    with pytest.raises(TypeError) as e:
+        check_required_by(required_by_terms, params)
+
+    assert to_native(e.value) == expected
+
+
+def test_check_required_by_multiple_different_second_missing(required_by_terms):
+    params = {
+        'fruit': 'hello',
+        'flavor': 'sour',
+        'name': 'apple',
+        'car': 'goodbye',
+    }
+
+    expected = "missing parameter(s) required by 'car': color, doors"
+
+    with pytest.raises(TypeError) as e:
+        check_required_by(required_by_terms, params)
+
+    assert to_native(e.value) == expected
+
+
+def test_check_required_required_by_missing_none():
+    terms = None
+    params = {
+        'foo': 'bar',
+        'baz': 'buzz',
+    }
+    assert check_required_by(terms, params) == {}
+
+
+def test_check_required_by_no_params(required_by_terms):
+    with pytest.raises(TypeError) as te:
+        check_required_by(required_by_terms, None)
+    assert "'NoneType' is not iterable" in to_native(te.value)


### PR DESCRIPTION
##### SUMMARY

- Return an empty dict by default (for consistency with the other
  validators).
- Sort the dictionary's .items() when we iterate to see if we need
  to throw. This is for consistency between python 2 and python 3 which
  sort .items() differently by default and could result in the user
  seeing a different error message based on python version.
- Add some tests for check_required_by.

Signed-off-by: Rick Elrod <rick@elrod.me>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
- `lib/ansible/module_utils/common/validation.py`
- tests
