### PR TITLE
[2.8] line indentation issue in postgresql_set (#67859)

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_set.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_set.py
@@ -98,7 +98,7 @@ EXAMPLES = r'''
   postgresql_set:
     name: work_mem
     value: 32mb
-    register: set
+  register: set
 
 - debug:
     msg: "{{ set.name }} {{ set.prev_val_pretty }} >> {{ set.value_pretty }} restart_req: {{ set.restart_required }}"


### PR DESCRIPTION
Fixed indentation issue with the `register` for the example task in postgresql_set module.

Backport of https://github.com/ansible/ansible/pull/67859

(cherry picked from commit b43716767173bfc22821239b372ae2f6866854c9)

##### SUMMARY
[2.8] line indentation issue in postgresql_set (#67859)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/postgresql/postgresql_set.py```
