### PR TITLE
[2.9] acme_* modules: adjust documentation to reference RFCs 8737 and 8738 instead of the drafts

### DIFF
--- a/lib/ansible/modules/crypto/acme/acme_certificate.py
+++ b/lib/ansible/modules/crypto/acme/acme_certificate.py
@@ -37,10 +37,10 @@ description:
       It is I(not) the responsibility of this module to perform these steps."
    - "For details on how to fulfill these challenges, you might have to read through
       L(the main ACME specification,https://tools.ietf.org/html/rfc8555#section-8)
-      and the L(TLS-ALPN-01 specification,https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-05#section-3).
+      and the L(TLS-ALPN-01 specification,https://www.rfc-editor.org/rfc/rfc8737.html#section-3).
       Also, consider the examples provided for this module."
    - "The module includes experimental support for IP identifiers according to
-      the L(current ACME IP draft,https://tools.ietf.org/html/draft-ietf-acme-ip-05)."
+      the L(RFC 8738,https://www.rfc-editor.org/rfc/rfc8738.html)."
 notes:
    - "At least one of C(dest) and C(fullchain_dest) must be specified."
    - "This module includes basic account management functionality.
@@ -62,8 +62,8 @@ seealso:
     description: The specification of the ACME protocol (RFC 8555).
     link: https://tools.ietf.org/html/rfc8555
   - name: ACME TLS ALPN Challenge Extension
-    description: The current draft specification of the C(tls-alpn-01) challenge.
-    link: https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-05
+    description: The specification of the C(tls-alpn-01) challenge (RFC 8737).
+    link: https://www.rfc-editor.org/rfc/rfc8737.html-05
   - module: acme_challenge_cert_helper
     description: Helps preparing C(tls-alpn-01) challenges.
   - module: openssl_privatekey
@@ -347,7 +347,7 @@ challenge_data:
         - "For C(tls-alpn-01) challenges, note that this return value contains a
            Base64 encoded version of the correct binary blob which has to be put
            into the acmeValidation x509 extension; see
-           U(https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-05#section-3)
+           U(https://www.rfc-editor.org/rfc/rfc8737.html#section-3)
            for details. To do this, you might need the C(b64decode) Jinja filter
            to extract the binary blob from this return value."
       returned: changed
@@ -591,7 +591,7 @@ class ACMEClient(object):
                 record = (resource + identifier[1:]) if identifier.startswith('*.') else (resource + '.' + identifier)
                 data[challenge_type] = {'resource': resource, 'resource_value': value, 'record': record}
             elif challenge_type == 'tls-alpn-01':
-                # https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-05#section-3
+                # https://www.rfc-editor.org/rfc/rfc8737.html#section-3
                 if identifier_type == 'ip':
                     # IPv4/IPv6 address: use reverse mapping (RFC1034, RFC3596)
                     resource = compat_ipaddress.ip_address(identifier).reverse_pointer

--- a/lib/ansible/modules/crypto/acme/acme_challenge_cert_helper.py
+++ b/lib/ansible/modules/crypto/acme/acme_challenge_cert_helper.py
@@ -24,15 +24,13 @@ description:
    - "The raw data is provided by the M(acme_certificate) module, and needs to be
       converted to a certificate to be used for challenge validation. This module
       provides a simple way to generate the required certificates."
-   - "The C(tls-alpn-01) implementation is based on
-      L(the draft-05 version of the specification,https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-05)."
 seealso:
   - name: Automatic Certificate Management Environment (ACME)
     description: The specification of the ACME protocol (RFC 8555).
     link: https://tools.ietf.org/html/rfc8555
   - name: ACME TLS ALPN Challenge Extension
-    description: The current draft specification of the C(tls-alpn-01) challenge.
-    link: https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-05
+    description: The specification of the C(tls-alpn-01) challenge (RFC 8737).
+    link: https://www.rfc-editor.org/rfc/rfc8737.html
 requirements:
    - "cryptography >= 1.3"
 options:

--- a/lib/ansible/modules/crypto/acme/acme_inspect.py
+++ b/lib/ansible/modules/crypto/acme/acme_inspect.py
@@ -44,8 +44,8 @@ seealso:
     description: The specification of the ACME protocol (RFC 8555).
     link: https://tools.ietf.org/html/rfc8555
   - name: ACME TLS ALPN Challenge Extension
-    description: The current draft specification of the C(tls-alpn-01) challenge.
-    link: https://tools.ietf.org/html/draft-ietf-acme-tls-alpn-05
+    description: The specification of the C(tls-alpn-01) challenge (RFC 8737).
+    link: https://www.rfc-editor.org/rfc/rfc8737.html
 extends_documentation_fragment:
   - acme
 options:

--- a/test/integration/targets/acme_inspect/tasks/impl.yml
+++ b/test/integration/targets/acme_inspect/tasks/impl.yml
@@ -53,7 +53,7 @@
   vars:
     account_info:
       # For valid values, see
-      # https://tools.ietf.org/html/draft-ietf-acme-acme-16#section-7.3
+      # https://www.rfc-editor.org/rfc/rfc8555.html#section-7.3
       contact:
       - mailto:me@example.com
   register: account_update
@@ -72,7 +72,8 @@
   vars:
     create_order:
       # For valid values, see
-      # https://tools.ietf.org/html/draft-ietf-acme-acme-16#section-7.4
+      # https://www.rfc-editor.org/rfc/rfc8555.html#section-7.4 and
+      # https://www.rfc-editor.org/rfc/rfc8738.html
       identifiers:
       - type: dns
         value: example.com


### PR DESCRIPTION
##### SUMMARY
Backport of #67881 to stable-2.9.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
acme_certificate
acme_challenge_cert_helper
acme_inspect
