### PR TITLE
ec2_instance: Fix spurious error message when we lose a race

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_instance.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance.py
@@ -1557,7 +1557,9 @@ def change_instance_state(filters, desired_state, ec2=None):
         await_instances(ids=list(changed) + list(unchanged), state=desired_state)
 
     change_failed = list(to_change - changed)
-    instances = find_instances(ec2, ids=list(i['InstanceId'] for i in instances))
+
+    if instances:
+        instances = find_instances(ec2, ids=list(i['InstanceId'] for i in instances))
     return changed, change_failed, instances, failure_reason
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It is possible for all instances to stop matching the filters between the initial check for existing instances and the first call to `find_instances()` in `change_instance_state()`.

If this happened, `find_instances()` would previously be called a second time with an empty list of instance IDs and no filters, which should not happen and immediately ends module execution with the error "No filters provided when they were required".

A more comprehensive fix (probably including propagating the initial list of existing instances instead of wastefully calling `find_instances()` again) might be possible, but I don't feel like digging that deep into the logic at the moment.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_instance