### PR TITLE
Update clarity on which cloudflare token to use

### DIFF
--- a/lib/ansible/modules/net_tools/cloudflare_dns.py
+++ b/lib/ansible/modules/net_tools/cloudflare_dns.py
@@ -27,7 +27,7 @@ options:
     description:
     - API token.
     - Required for api token authentication.
-    - "You can obtain your API token from the bottom of the Cloudflare 'My Account' page, found here: U(https://dash.cloudflare.com/)"
+    - "You can obtain your API token from the bottom of the Cloudflare 'My Account' page, found here: U(https://dash.cloudflare.com/)". IMPORTANT: Use the "Global API Key", NOT a custom API token.
     type: str
     required: false
     version_added: '2.10'


### PR DESCRIPTION
##### SUMMARY
The module documentation is ambiguous. Standard practice is to typically create scoped tokens with minimal required permissions. However, using an API Token rather than the Global API Key gives an error: `API bad request; Status: 400; Method: GET: Call: /zones?name=example.com; Error details: code: 6003, error: Invalid request headers; code: 6103, error: Invalid format for X-Auth-Key header;`

This PR updates the doc string to make it clear which API key to use.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
cloudflare_dns
