### PR TITLE
ldap_attr: fix small bug (using wrong variable)

### DIFF
--- a/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
@@ -250,7 +250,7 @@ class LdapAttrs(LdapGeneric):
                 results = self.connection.search_s(
                     self.dn, ldap.SCOPE_BASE, attrlist=[name])
             except ldap.LDAPError as e:
-                self.fail("Cannot search for attribute %s" % self.name, e)
+                self.fail("Cannot search for attribute %s" % name, e)
 
             current = results[0][1].get(name, [])
 


### PR DESCRIPTION
##### SUMMARY
I found a small bug in `ldap_attrs`, which happens when searching for an attribute fails. Instead of dying with `AttributeError: 'LdapAttrs' object has no attribute 'name'`, the module now fails (as expected).

No changelog fragment since the module is new for Ansible 2.10.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ldap_attrs
