### PR TITLE
nsupdate: Improve TTL change detection for NS records

### DIFF
--- a/changelogs/fragments/67894-nsupdate-improved-NS-record-ttl-change-detection.yaml
+++ b/changelogs/fragments/67894-nsupdate-improved-NS-record-ttl-change-detection.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - nsupdate - Improve TTL change detection for NS records (https://github.com/ansible/ansible/issues/66845)

--- a/lib/ansible/modules/net_tools/nsupdate.py
+++ b/lib/ansible/modules/net_tools/nsupdate.py
@@ -420,6 +420,13 @@ class RecordManager(object):
         if lookup.rcode() != dns.rcode.NOERROR:
             self.module.fail_json(msg='Failed to lookup TTL of existing matching record.')
 
+        if self.module.params['type'].lower() == 'ns' and self.fqdn.lower() != self.zone.lower():
+            try:
+                current_ttl = lookup.authority[0].ttl
+                return current_ttl != self.module.params['ttl']
+            except IndexError:
+                pass
+
         current_ttl = lookup.answer[0].ttl
         return current_ttl != self.module.params['ttl']
 


### PR DESCRIPTION
When querying a parent zone about child zone NS records there is, by
design, no regular Answer. In that scenario we need to instead look in
the Authority section of the query response.

There is still the case where the same server is authoritative both
for the parent zone and the child zone. Then a query will always
return a Answer based on the child zone, potentially resulting in a
misleading NS record TTL change detection. Since I don't see any
reliable way around that, short of requring AXFR queries, I'm opting
to leave that behavior as is, to fix the bug we can fix.

Note that TTL change detection is a relatively recent addition to this
module (3ddec4d), making this a relatively new issue.

Resolves #66845

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nsupdate