### PR TITLE
MongoDB: different test setups collide

### DIFF
--- a/test/integration/targets/mongodb_info/aliases
+++ b/test/integration/targets/mongodb_info/aliases
@@ -1,5 +1,5 @@
 destructive
-shippable/posix/group1
+shippable/posix/group4
 skip/aix
 skip/osx
 skip/freebsd


### PR DESCRIPTION
##### SUMMARY
There are two different `setup_mongodb`s for integration tests (`setup_mongodb` and `setup_mongodb_v4`) and they seem to collide. This is a result of #67846.

For now I'm moving the test using `setup_mongodb_v4` to another POSIX group. @Andersson007 promised to clean this up once things have been moved to collections :)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mongodb_info
