### PR TITLE
Skip mongodb tests on all centos versions.

### DIFF
--- a/test/integration/targets/incidental_setup_mongodb/tasks/main.yml
+++ b/test/integration/targets/incidental_setup_mongodb/tasks/main.yml
@@ -25,7 +25,7 @@
     or (ansible_os_family == "RedHat" and ansible_distribution_major_version == '6')
     or ansible_os_family == "Suse"
     or ansible_distribution == 'Fedora'
-    or (ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == '7')
+    or (ansible_facts['distribution'] == "CentOS")
 
 # Ubuntu
 - name: Import MongoDB public GPG Key

--- a/test/integration/targets/setup_mongodb/tasks/main.yml
+++ b/test/integration/targets/setup_mongodb/tasks/main.yml
@@ -25,7 +25,7 @@
     or (ansible_os_family == "RedHat" and ansible_distribution_major_version == '6')
     or ansible_os_family == "Suse"
     or ansible_distribution == 'Fedora'
-    or (ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_major_version'] == '7')
+    or (ansible_facts['distribution'] == "CentOS")
 
 # Ubuntu
 - name: Import MongoDB public GPG Key


### PR DESCRIPTION
##### SUMMARY

Skip mongodb tests on all centos versions.

The tests were already skipped for versions 6 and 7, and are not passing on version 8.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

integration tests
