### PR TITLE
Remove redundant check for pyopenssl

### DIFF
--- a/changelogs/fragments/67901-get_certificate-fix-cryptography.yml
+++ b/changelogs/fragments/67901-get_certificate-fix-cryptography.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- get_certificate - Fix cryptography backend when pyopenssl is unavailable (https://github.com/ansible/ansible/issues/67900)

--- a/lib/ansible/modules/crypto/get_certificate.py
+++ b/lib/ansible/modules/crypto/get_certificate.py
@@ -258,9 +258,6 @@ def main():
         changed=False,
     )
 
-    if not PYOPENSSL_FOUND:
-        module.fail_json(msg=missing_required_lib('pyOpenSSL >= 0.15'), exception=PYOPENSSL_IMP_ERR)
-
     if timeout:
         setdefaulttimeout(timeout)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Removes second check for pyOpenssl presence which breaks `cryptography` support in `get_certificate`. This fixes #67900
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
get_certificate

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before:
```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_get_certificate_payload_pwc38k3u/ansible_get_certificate_payload.zip/ansible/modules/crypto/get_certificate.py", line 185, in <module>
ModuleNotFoundError: No module named 'OpenSSL'
failed: [localhost] (item={'host': 'example.org'}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "invocation": {
        "module_args": {
            "ca_cert": null,
            "host": "example.org",
            "port": 443,
            "proxy_host": null,
            "proxy_port": 8080,
            "select_crypto_backend": "cryptography",
            "timeout": 10
        }
    },
    "item": {
        "host": "example.org"
    },
    "msg": "Failed to import the required Python library (pyOpenSSL >= 0.15) on platinum's Python /home/gp/.local/share/virtualenvs/ansible-site-jT6p0Ljs/bin/python3.7m. Please read module documentation and install in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"
}
```

After
```paste below
PLAY [localhost] ****************************************************************************************************************************************************************************************************************************

TASK [Test HTTPS download] ******************************************************************************************************************************************************************************************************************
ok: [localhost] => (item={'host': 'example.net'})
ok: [localhost] => (item={'host': 'example.org'})

PLAY RECAP **********************************************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
