### PR TITLE
Skip lookup tests on Python 2.6.

### DIFF
--- a/test/integration/targets/lookup_cartesian/aliases
+++ b/test/integration/targets/lookup_cartesian/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group1
 skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_dict/aliases
+++ b/test/integration/targets/lookup_dict/aliases
@@ -1,3 +1,3 @@
 shippable/posix/group1
 skip/aix
-skip/python2.6
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_env/aliases
+++ b/test/integration/targets/lookup_env/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group1
 skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_file/aliases
+++ b/test/integration/targets/lookup_file/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group1
 skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_first_found/aliases
+++ b/test/integration/targets/lookup_first_found/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group2
 skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_flattened/aliases
+++ b/test/integration/targets/lookup_flattened/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group2
 skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_hashi_vault/aliases
+++ b/test/integration/targets/lookup_hashi_vault/aliases
@@ -3,4 +3,4 @@ destructive
 needs/target/setup_openssl
 needs/file/test/lib/ansible_test/_data/requirements/constraints.txt
 skip/aix
-skip/python2.6
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_indexed_items/aliases
+++ b/test/integration/targets/lookup_indexed_items/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group2
 skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_ini/aliases
+++ b/test/integration/targets/lookup_ini/aliases
@@ -1,1 +1,2 @@
 shippable/posix/group3
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_inventory_hostnames/aliases
+++ b/test/integration/targets/lookup_inventory_hostnames/aliases
@@ -1,1 +1,2 @@
 shippable/posix/group2
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_items/aliases
+++ b/test/integration/targets/lookup_items/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group2
 skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_lines/aliases
+++ b/test/integration/targets/lookup_lines/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group2
 skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_lmdb_kv/aliases
+++ b/test/integration/targets/lookup_lmdb_kv/aliases
@@ -1,3 +1,4 @@
 shippable/posix/group2
 destructive
 skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_nested/aliases
+++ b/test/integration/targets/lookup_nested/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group2
 skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_password/aliases
+++ b/test/integration/targets/lookup_password/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group1
 skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_passwordstore/aliases
+++ b/test/integration/targets/lookup_passwordstore/aliases
@@ -2,3 +2,4 @@ shippable/posix/group4
 destructive
 skip/aix
 skip/rhel
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_pipe/aliases
+++ b/test/integration/targets/lookup_pipe/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group1
 skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_rabbitmq/aliases
+++ b/test/integration/targets/lookup_rabbitmq/aliases
@@ -4,3 +4,4 @@ skip/aix
 skip/osx
 skip/freebsd
 skip/rhel
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_random_choice/aliases
+++ b/test/integration/targets/lookup_random_choice/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group2
 skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_sequence/aliases
+++ b/test/integration/targets/lookup_sequence/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group2
 skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_subelements/aliases
+++ b/test/integration/targets/lookup_subelements/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group2
 skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_template/aliases
+++ b/test/integration/targets/lookup_template/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group1
 skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_together/aliases
+++ b/test/integration/targets/lookup_together/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group2
 skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_url/aliases
+++ b/test/integration/targets/lookup_url/aliases
@@ -1,3 +1,4 @@
 shippable/posix/group1
 needs/httptester
 skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_vars/aliases
+++ b/test/integration/targets/lookup_vars/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group1
 skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller


### PR DESCRIPTION
##### SUMMARY

Skip lookup tests on Python 2.6.

Lookups are only executed on the controller and Python 2.6 is no longer supported on the controller.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

lookup integration tests
