### PR TITLE
To fix nxos_l2_interfaces integration tests failure

### DIFF
--- a/test/integration/targets/nxos_l2_interfaces/tests/cli/deleted.yaml
+++ b/test/integration/targets/nxos_l2_interfaces/tests/cli/deleted.yaml
@@ -46,7 +46,7 @@
         - "'interface {{ test_int2 }}' in result.commands"
         - "'no switchport mode' in result.commands"
         - "'no switchport trunk allowed vlan' in result.commands"
-        - "result.commands|length == 4"
+        - "result.commands|length == 5"
 
   - name: Idempotence - deleted
     nxos_l2_interfaces: *deleted

--- a/test/integration/targets/nxos_l2_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/nxos_l2_interfaces/tests/cli/merged.yaml
@@ -72,7 +72,7 @@
         - "'interface {{ test_int1 }}' in result.commands"
         - "'switchport mode trunk' in result.commands"
         - "'switchport trunk allowed vlan add 10,11,12' in result.commands"
-        - "result.commands|length == 2"
+        - "result.commands|length == 3"
 
   - name: Gather l2_interfaces facts
     nxos_facts:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To fix nxos_l2_interfaces integration tests failure
ref: https://object-storage-ca-ymq-1.vexxhost.net/v1/a0b4156a37f9453eb4ec7db5422272df/ansible_56/67456/8ce17377d733864db43ce6db3c09d69f5bb2f0a8/third-party-check/ansible-test-network-integration-nxos-cli-python36/8ccd9d7/controller/ara-report/reports/0529628a-211f-4049-9fbc-093369d099a5.html
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
nxos_l2_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
