### PR TITLE
vmware_guest_tools_upgrade docs: added example for how to get vm uuid

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_tools_upgrade.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_tools_upgrade.py
@@ -76,13 +76,24 @@ author:
 '''
 
 EXAMPLES = '''
+- name: Get VM UUID
+  vmware_guest_facts:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ datacenter }}"
+    folder: "/{{datacenter}}/vm"
+    name: "{{ vm_name }}"
+  delegate_to: localhost
+  register: vm_facts
+  
 - name: Upgrade VMware Tools using uuid
   vmware_guest_tools_upgrade:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter_name }}"
-    uuid: 421e4592-c069-924d-ce20-7e7533fab926
+    uuid: "{{ vm_facts.instance.hw_product_uuid }}"
   delegate_to: localhost
 
 - name: Upgrade VMware Tools using MoID


### PR DESCRIPTION
##### SUMMARY
According to https://docs.ansible.com/ansible/latest/modules/vmware_guest_move_module.html#examples added an example how to get VM uuid


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
According to https://docs.ansible.com/ansible/latest/modules/vmware_guest_move_module.html#examples added an example how to get VM uuid
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest_tools_upgrade

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
