### PR TITLE
Fix galaxy publish sha256 value format.

### DIFF
--- a/changelogs/fragments/67942-fix-galaxy-multipart.yml
+++ b/changelogs/fragments/67942-fix-galaxy-multipart.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- ansible-galaxy - Fix ``multipart/form-data`` body to include extra CRLF
+  (https://github.com/ansible/ansible/pull/67942)

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -435,6 +435,7 @@ class GalaxyAPI:
         form = [
             part_boundary,
             b"Content-Disposition: form-data; name=\"sha256\"",
+            b"",
             to_bytes(secure_hash_s(data, hash_func=hashlib.sha256), errors='surrogate_or_strict'),
             part_boundary,
             b"Content-Disposition: file; name=\"file\"; filename=\"%s\"" % b_file_name,


### PR DESCRIPTION
##### SUMMARY

The multipart/form content used for the body
of the POST to /api/automation-hub/v3/collections
was missing a newline before the line with the value
of the sha256.

automation-hub/galaxy/django skips the field entirely in
that case and automation-hub code will use None for default
to indicate that no sha256 is provided (an available option).

Fixes ansible/galaxy-dev#246

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
ansible-galaxy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

An example of the POST body before the pr as captured with a mitmproxy setup:
(Note also that mitmproxy can parse the body as being multipart/form content-type and
this is the 'raw' display)


```
----------------------------fed11896469248549f8ad141dc999cdb
Content-Disposition: form-data; name="sha256"
542d750a6cf9a327e5c26608c10c3fba21b8f3f19e4e5527b5a1c0b189ccb664
----------------------------fed11896469248549f8ad141dc999cdb
Content-Disposition: file; name="file"; filename="alikins-collection_inspect-0.0.148.tar.gz"
Content-Type: application/octet-stream
\x1f\x8b\x08\x08\xa7W]^\x02\xffalikins-collection_inspect-0.0.148.tar\x00\xed}\xdbv\xdbH\x92
# LOTS OF BINARY BLOB OF A TARBALL REDACTED FOR BREVITY
```


With the pr applied:
```
----------------------------04faf152ce91404bacb7e9cd9449111c
Content-Disposition: form-data; name="sha256"
e2915802d529294930d00467b86b48294f04544d0e9660169db0101b100497b8
----------------------------04faf152ce91404bacb7e9cd9449111c
Content-Disposition: file; name="file"; filename="alikins-collection_inspect-0.0.147.tar.gz"
Content-Type: application/octet-stream
\x1f\x8b\x08\x08
W]^\x02\xffalikins-collection_inspect-0.0.147.tar\x00\xed}
#  OF BINARY BLOB OF A TARBALL REDACTED FOR BREVITY
```

Another way to compare to to munge galaxy api.py to do the publish POST to 'https://httpbin/port'.

Before PR:

``` python
{'args': {},
 'data': '',
 'files': {},
 'form': {'sha256': '\x1f'
                    '�\x08\x08�W]^\x02�alikins-collection_inspect-0.0.148.tar\x00�}
               # LOTS OF BINARY REMOVED'},
 'headers': {'Accept-Encoding': 'identity',
             'Content-Length': '13901',
             'Content-Type': 'multipart/form-data; '
                             'boundary=--------------------------0c671c58518441cf9887b4d05f24a699',
             'Host': 'httpbin.org',
             'User-Agent': 'ansible-galaxy/2.10.0.dev0 (Linux; python:3.7.6)',},
 'json': None,
 'origin': '75.177.176.215',
 'url': 'https://httpbin.org/post'}
```

After PR:

``` python
{'args': {},
 'data': '',
 'files': {'file': 'data:application/octet-stream;base64,H4sICKdXXV4C/2FsaWtpbnMtY29sbGVjdGlvbl9pbnNwZWN0LTAuMC4xNDgudGFy
# LOTS OF BASE64'ed binary of a taball redacted'}.
 'form': {'sha256': '542d750a6cf9a327e5c26608c10c3fba21b8f3f19e4e5527b5a1c0b189ccb664'},
 'headers': {'Accept-Encoding': 'identity',
             'Content-Length': '13903',
             'Content-Type': 'multipart/form-data; '
                             'boundary=--------------------------93c1c2046d51415595edd936b1b6cf4d',
             'Host': 'httpbin.org',
             'User-Agent': 'ansible-galaxy/2.10.0.dev0 (Linux; python:3.7.6)',},
 'json': None,
 'origin': '75.177.176.215',
 'url': 'https://httpbin.org/post'}
```