### PR TITLE
Fix galaxy-install role and collection consistency

### DIFF
--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -154,7 +154,7 @@ class CollectionRequirement:
 
     def install(self, path, b_temp_path):
         if self.skip:
-            display.display("Skipping '%s' as it is already installed" % to_text(self))
+            display.display("%s is already installed, skipping" % to_text(self))
             return
 
         # Install if it is not


### PR DESCRIPTION
##### SUMMARY

Currently the output for role and collection install differs when a dependency is skipped:

Role:

    - geerlingguy.java (1.9.7) is already installed, skipping.

Collection:

    Skipping 'geerlingguy.php_roles' as it is already installed

It would be less jarring if these two types of output were the same (especially if something like #67843 is merged, and someone were to run `ansible-galaxy install -r requirements.yml` multiple times and see all the different messages/formats).

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ansible-galaxy

##### ADDITIONAL INFORMATION

N/A