### PR TITLE
O365 connector_card import from dict_transformations

### DIFF
--- a/lib/ansible/modules/notification/office_365_connector_card.py
+++ b/lib/ansible/modules/notification/office_365_connector_card.py
@@ -134,7 +134,7 @@ RETURN = """
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
-from ansible.module_utils.ec2 import snake_dict_to_camel_dict
+from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
 
 OFFICE_365_CARD_CONTEXT = "http://schema.org/extensions"
 OFFICE_365_CARD_TYPE = "MessageCard"


### PR DESCRIPTION
##### SUMMARY

Update `office_365_connector_card.py` to import `snake_dict_to_camel_dict`
from `common.dict_transformations` instead of `ec2`, to eliminate `community.general` collection
dependency on AWS collection.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
office_365_connector_card
