### PR TITLE
Fix typo in nxos_banner docs

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_banner.py
+++ b/lib/ansible/modules/network/nxos/nxos_banner.py
@@ -31,7 +31,7 @@ author: "Trishna Guha (@trishnaguha)"
 short_description: Manage multiline banners on Cisco NXOS devices
 description:
   - This will configure both exec and motd banners on remote devices
-    running Cisco NXOS. It allows playbooks to add or remote
+    running Cisco NXOS. It allows playbooks to add or remove
     banner text from the active running configuration.
 options:
   banner:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is only a docs bugfix and changes a word from "remote" to "remove".
No functionality is added or changed.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Updates the doc section of `ansible/lib/ansible/modules/network/nxos/nxos_banner.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
  - This will configure both exec and motd banners on remote devices
    running Cisco NXOS. It allows playbooks to add or remote
    banner text from the active running configuration.
```

After:
```  - This will configure both exec and motd banners on remote devices
    running Cisco NXOS. It allows playbooks to add or remove
    banner text from the active running configuration.
```
