### PR TITLE
ansible-test coverage - fix delegation when in collection

### DIFF
--- a/changelogs/fragments/ansible-test-coverage.yaml
+++ b/changelogs/fragments/ansible-test-coverage.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-test - Fix coverage path rewriter when reading coverage in a delegation scenario from a collection

--- a/test/lib/ansible_test/_internal/coverage/__init__.py
+++ b/test/lib/ansible_test/_internal/coverage/__init__.py
@@ -229,9 +229,9 @@ def sanitize_filename(
         new_name = os.path.abspath(modules[module_name])
         display.info('%s -> %s' % (filename, new_name), verbosity=3)
         filename = new_name
-    elif re.search('^(/.*?)?/root/ansible/', filename):
+    elif re.search('^(/.*?)?%s/' % data_context().content.delegation_install_root, filename):
         # Rewrite the path of code running on a remote host or in a docker container as root.
-        new_name = re.sub('^(/.*?)?/root/ansible/', root_path, filename)
+        new_name = re.sub('^(/.*?)?%s/' % data_context().content.delegation_content_root, root_path, filename)
         display.info('%s -> %s' % (filename, new_name), verbosity=3)
         filename = new_name
     elif integration_temp_path in filename:

--- a/test/lib/ansible_test/_internal/delegation.py
+++ b/test/lib/ansible_test/_internal/delegation.py
@@ -239,7 +239,6 @@ def delegate_docker(args, exclude, require, integration_targets):
 
     python_interpreter = get_python_interpreter(args, get_docker_completion(), args.docker_raw)
 
-
     install_root = data_context().content.delegation_install_root
     content_root = data_context().content.delegation_content_root
     remote_results_root = os.path.join(content_root, data_context().content.results_path)

--- a/test/lib/ansible_test/_internal/delegation.py
+++ b/test/lib/ansible_test/_internal/delegation.py
@@ -239,13 +239,9 @@ def delegate_docker(args, exclude, require, integration_targets):
 
     python_interpreter = get_python_interpreter(args, get_docker_completion(), args.docker_raw)
 
-    install_root = '/root/ansible'
 
-    if data_context().content.collection:
-        content_root = os.path.join(install_root, data_context().content.collection.directory)
-    else:
-        content_root = install_root
-
+    install_root = data_context().content.delegation_install_root
+    content_root = data_context().content.delegation_content_root
     remote_results_root = os.path.join(content_root, data_context().content.results_path)
 
     cmd = generate_command(args, python_interpreter, os.path.join(install_root, 'bin'), content_root, options, exclude, require)
@@ -314,11 +310,12 @@ def delegate_docker(args, exclude, require, integration_targets):
                 test_id = test_id.strip()
 
             # write temporary files to /root since /tmp isn't ready immediately on container start
+            install_root = data_context().content.delegation_install_root
             docker_put(args, test_id, os.path.join(ANSIBLE_TEST_DATA_ROOT, 'setup', 'docker.sh'), '/root/docker.sh')
             docker_exec(args, test_id, ['/bin/bash', '/root/docker.sh'])
             docker_put(args, test_id, local_source_fd.name, '/root/ansible.tgz')
-            docker_exec(args, test_id, ['mkdir', '/root/ansible'])
-            docker_exec(args, test_id, ['tar', 'oxzf', '/root/ansible.tgz', '-C', '/root/ansible'])
+            docker_exec(args, test_id, ['mkdir', install_root])
+            docker_exec(args, test_id, ['tar', 'oxzf', '/root/ansible.tgz', '-C', install_root])
 
             # docker images are only expected to have a single python version available
             if isinstance(args, UnitsConfig) and not args.python:

--- a/test/lib/ansible_test/_internal/provider/layout/__init__.py
+++ b/test/lib/ansible_test/_internal/provider/layout/__init__.py
@@ -114,6 +114,18 @@ class ContentLayout(Layout):
         self.is_ansible = root == ANSIBLE_SOURCE_ROOT
 
     @property
+    def delegation_install_root(self):
+        return '/root/ansible'
+
+    @property
+    def delegation_content_root(self):
+        content_root = self.delegation_install_root
+        if self.collection:
+            content_root += '/%s' % self.collection.directory
+
+        return content_root
+
+    @property
     def prefix(self):  # type: () -> str
         """Return the collection prefix or an empty string if not a collection."""
         if self.collection:

--- a/test/lib/ansible_test/_internal/provider/layout/__init__.py
+++ b/test/lib/ansible_test/_internal/provider/layout/__init__.py
@@ -115,10 +115,12 @@ class ContentLayout(Layout):
 
     @property
     def delegation_install_root(self):
+        """Return the install root path when running through a delegated context."""
         return '/root/ansible'
 
     @property
     def delegation_content_root(self):
+        """Return the content root path when running through a delegated context."""
         content_root = self.delegation_install_root
         if self.collection:
             content_root += '/%s' % self.collection.directory


### PR DESCRIPTION
##### SUMMARY
When reporting on coverage that was generated in a delegated scenario (--docker, --windows, --remote) the paths were not being fixed up properly. The code was changing `/root/ansible/` to the root path but this should have been `/root/ansible/ansible_collections/{namespace}/{name}/`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test coverage