### PR TITLE
Handle EndpointSpec in docker_swarm_info

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_swarm_info.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm_info.py
@@ -327,7 +327,7 @@ class DockerSwarmManager(DockerBaseClass):
             # Number of replicas have to be updated in calling method or may be left as None
             object_essentials['Replicas'] = None
         object_essentials['Image'] = item['Spec']['TaskTemplate']['ContainerSpec']['Image']
-        if 'Ports' in item['Spec']['EndpointSpec']:
+        if 'EndpointSpec' in item['Spec'] and 'Ports' in item['Spec']['EndpointSpec']:
             object_essentials['Ports'] = item['Spec']['EndpointSpec']['Ports']
         else:
             object_essentials['Ports'] = []


### PR DESCRIPTION
According to bug https://github.com/ansible/ansible/issues/67956 reported by me.

Currently function `get_essential_facts_services` assumes that 'EndpointSpec' property is always defined in item['Spec'], but apparently it's not.
