### PR TITLE
[stable-2.8] openssl_* modules: prevent crash on fingerprint determination in FIPS mode (#67515)

### DIFF
--- a/changelogs/fragments/67515-openssl-fingerprint-fips.yml
+++ b/changelogs/fragments/67515-openssl-fingerprint-fips.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "openssl_* modules - prevent crash on fingerprint determination in FIPS mode (https://github.com/ansible/ansible/issues/67213)."

--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -151,7 +151,12 @@ def get_fingerprint_of_bytes(source):
 
     for algo in algorithms:
         f = getattr(hashlib, algo)
-        h = f(source)
+        try:
+            h = f(source)
+        except ValueError:
+            # This can happen for hash algorithms not supported in FIPS mode
+            # (https://github.com/ansible/ansible/issues/67213)
+            continue
         try:
             # Certain hash functions have a hexdigest() which expects a length parameter
             pubkey_digest = h.hexdigest()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #67515 for Ansible 2.8
(cherry picked from commit ca57871954)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/crypto.py`
##### ADDITIONAL INFORMATION
This could be considered a critical bug fix since it breaks Tower on RHEL 7 running in FIPS mode. https://github.com/ansible/tower/issues/4003#issuecomment-593575408