### PR TITLE
Fix powershell coverage path rewriting.

### DIFF
--- a/changelogs/fragments/ansible-test-powershell-coverage-paths.yml
+++ b/changelogs/fragments/ansible-test-powershell-coverage-paths.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now correctly rewrites coverage paths for PowerShell files when testing collections

--- a/test/lib/ansible_test/_internal/coverage/__init__.py
+++ b/test/lib/ansible_test/_internal/coverage/__init__.py
@@ -153,7 +153,11 @@ def enumerate_python_arcs(
         yield filename, set(arcs)
 
 
-def enumerate_powershell_lines(path):  # type: (str) -> t.Generator[t.Tuple[str, t.Dict[int, int]]]
+def enumerate_powershell_lines(
+        path,  # type: str
+        collection_search_re,  # type: t.Optional[t.Pattern]
+        collection_sub_re,  # type: t.Optional[t.Pattern]
+):  # type: (...) -> t.Generator[t.Tuple[str, t.Dict[int, int]]]
     """Enumerate PowerShell code coverage lines in the given file."""
     if os.path.getsize(path) == 0:
         display.warning('Empty coverage file: %s' % path, verbosity=2)
@@ -166,7 +170,7 @@ def enumerate_powershell_lines(path):  # type: (str) -> t.Generator[t.Tuple[str,
         return
 
     for filename, hits in coverage_run.items():
-        filename = sanitize_filename(filename)
+        filename = sanitize_filename(filename, collection_search_re=collection_search_re, collection_sub_re=collection_sub_re)
 
         if not filename:
             continue

--- a/test/lib/ansible_test/_internal/coverage/analyze/targets/generate.py
+++ b/test/lib/ansible_test/_internal/coverage/analyze/targets/generate.py
@@ -90,6 +90,7 @@ def analyze_powershell_coverage(
 ):  # type: (...) -> Lines
     """Analyze PowerShell code coverage"""
     results = {}  # type: Lines
+    collection_search_re, collection_sub_re = get_collection_path_regexes()
     powershell_files = get_powershell_coverage_files()
 
     for powershell_file in powershell_files:
@@ -99,7 +100,7 @@ def analyze_powershell_coverage(
         target_name = get_target_name(powershell_file)
         target_index = get_target_index(target_name, target_indexes)
 
-        for filename, hits in enumerate_powershell_lines(powershell_file):
+        for filename, hits in enumerate_powershell_lines(powershell_file, collection_search_re, collection_sub_re):
             lines = results.setdefault(filename, {})
 
             for covered_line in hits:

--- a/test/lib/ansible_test/_internal/coverage/combine.py
+++ b/test/lib/ansible_test/_internal/coverage/combine.py
@@ -135,6 +135,8 @@ def _command_coverage_combine_powershell(args):
     sources = _get_coverage_targets(args, walk_powershell_targets)
     groups = _build_stub_groups(args, sources, _default_stub_value)
 
+    collection_search_re, collection_sub_re = get_collection_path_regexes()
+
     for coverage_file in coverage_files:
         counter += 1
         display.info('[%4d/%4d] %s' % (counter, len(coverage_files), coverage_file), verbosity=2)
@@ -145,7 +147,7 @@ def _command_coverage_combine_powershell(args):
             display.warning('Unexpected name for coverage file: %s' % coverage_file)
             continue
 
-        for filename, hits in enumerate_powershell_lines(coverage_file):
+        for filename, hits in enumerate_powershell_lines(coverage_file, collection_search_re, collection_sub_re):
             if group not in groups:
                 groups[group] = {}
 


### PR DESCRIPTION
##### SUMMARY

Fix powershell coverage path rewriting.

This applies the same rewrite logic to PowerShell coverage as is used for Python coverage.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

Alternative to https://github.com/ansible/ansible/pull/67954