### PR TITLE
gem - added the --build-flags keyword

### DIFF
--- a/changelogs/fragments/67973-gem-build-flags-format.yaml
+++ b/changelogs/fragments/67973-gem-build-flags-format.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - gem - fixed issue when compiling gems with custom build_flags (https://github.com/ansible/ansible/issues/67973)

--- a/lib/ansible/modules/packaging/language/gem.py
+++ b/lib/ansible/modules/packaging/language/gem.py
@@ -212,6 +212,7 @@ def uninstall(module):
     cmd.append(module.params['name'])
     module.run_command(cmd, environ_update=environ, check_rc=True)
 
+import shlex
 
 def install(module):
 
@@ -253,7 +254,8 @@ def install(module):
         cmd.append('--env-shebang')
     cmd.append(module.params['gem_source'])
     if module.params['build_flags']:
-        cmd.extend(['--', module.params['build_flags']])
+        cmd.extend([ '--', '--build-flags'])
+        cmd.extend( shlex.split(module.params['build_flags']) )
     if module.params['force']:
         cmd.append('--force')
     module.run_command(cmd, check_rc=True)

--- a/lib/ansible/modules/packaging/language/gem.py
+++ b/lib/ansible/modules/packaging/language/gem.py
@@ -212,7 +212,9 @@ def uninstall(module):
     cmd.append(module.params['name'])
     module.run_command(cmd, environ_update=environ, check_rc=True)
 
+
 import shlex
+
 
 def install(module):
 
@@ -254,8 +256,8 @@ def install(module):
         cmd.append('--env-shebang')
     cmd.append(module.params['gem_source'])
     if module.params['build_flags']:
-        cmd.extend([ '--', '--build-flags'])
-        cmd.extend( shlex.split(module.params['build_flags']) )
+        cmd.extend(['--', '--build-flags'])
+        cmd.extend(shlex.split(module.params['build_flags']))
     if module.params['force']:
         cmd.append('--force')
     module.run_command(cmd, check_rc=True)

--- a/test/units/modules/packaging/language/test_gem.py
+++ b/test/units/modules/packaging/language/test_gem.py
@@ -137,3 +137,24 @@ class TestGem(ModuleTestCase):
         assert run_command.called
 
         assert '--force' in get_command(run_command)
+
+    def test_build_flags(self):
+        set_module_args({
+            'name': 'dummy',
+            'user_install': True,
+            'build_flags': '  --pkg-include-path=/usr/local/include/foo   --pkg-lib-path=/usr/local/lib/foo   ',
+        })
+
+        self.patch_rubygems_version()
+        self.patch_installed_versions([])
+        run_command = self.patch_run_command()
+
+        with pytest.raises(AnsibleExitJson) as exc:
+            gem.main()
+
+        result = exc.value.args[0]
+        assert result['changed']
+        assert run_command.called
+
+        cmd = get_command(run_command)
+        assert cmd.endswith('-- --build-flags --pkg-include-path=/usr/local/include/foo --pkg-lib-path=/usr/local/lib/foo')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Added the --build-flags keyword since it would seem redundant to require this of the user.
- Split the build_flags parameter into a list that can be "extended" into the command.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #67973 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gem

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before
```paste below
/opt/ruby/ruby-2.7.0-1/bin/gem install --user-install --no-document pg -- '--with-pg-include=/opt/postgres/postgres-12.2/include --with-pg-lib=/opt/postgres/postgres-12.2/lib'
```
after
```paste below
/opt/ruby/ruby-2.7.0-1/bin/gem install --user-install --no-document pg -- --build-flags --with-pg-include=/opt/postgres/postgres-12.2/include --with-pg-lib=/opt/postgres/postgres-12.2/lib
```