### PR TITLE
Automatically enable test plugins after migration.

### DIFF
--- a/test/utils/shippable/linux.sh
+++ b/test/utils/shippable/linux.sh
@@ -13,6 +13,13 @@ else
     target="shippable/posix/"
 fi
 
+# detect the post migration ansible/ansible repo and enable test support plugins
+if [ -f lib/ansible/config/routing.yml ]; then
+    # this option is only useful for ansible/ansible (not collections) and should not be used prior to migration (except for incidental tests)
+    enable_test_support=--enable-test-support
+fi
+
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
+    ${enable_test_support:+"$enable_test_support"} \
     --docker "${image}"

--- a/test/utils/shippable/remote.sh
+++ b/test/utils/shippable/remote.sh
@@ -17,6 +17,13 @@ fi
 stage="${S:-prod}"
 provider="${P:-default}"
 
+# detect the post migration ansible/ansible repo and enable test support plugins
+if [ -f lib/ansible/config/routing.yml ]; then
+    # this option is only useful for ansible/ansible (not collections) and should not be used prior to migration (except for incidental tests)
+    enable_test_support=--enable-test-support
+fi
+
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
+    ${enable_test_support:+"$enable_test_support"} \
     --remote "${platform}/${version}" --remote-terminate always --remote-stage "${stage}" --remote-provider "${provider}"

--- a/test/utils/shippable/windows.sh
+++ b/test/utils/shippable/windows.sh
@@ -13,6 +13,12 @@ target="shippable/windows/group${group}/"
 stage="${S:-prod}"
 provider="${P:-default}"
 
+# detect the post migration ansible/ansible repo and enable test support plugins
+if [ -f lib/ansible/config/routing.yml ]; then
+    # this option is only useful for ansible/ansible (not collections) and should not be used prior to migration (except for incidental tests)
+    enable_test_support=--enable-test-support
+fi
+
 # python versions to test in order
 # python 2.7 runs full tests while other versions run minimal tests
 python_versions=(
@@ -93,5 +99,6 @@ for version in "${python_versions[@]}"; do
     ansible-test windows-integration --color -v --retry-on-error "${ci}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
         "${platforms[@]}" --changed-all-target "${changed_all_target}" --changed-all-mode "${changed_all_mode}" \
         --docker default --python "${version}" \
+        ${enable_test_support:+"$enable_test_support"} \
         --remote-terminate "${terminate}" --remote-stage "${stage}" --remote-provider "${provider}"
 done


### PR DESCRIPTION
##### SUMMARY

Automatically enable test plugins after migration.

This should allow most integration tests to pass after migration is run, which will ease testing of revised versions of the temp-2.10-devel branch prior to the final version being created.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

test/utils/shippable/
