### PR TITLE
win - Allow FQCN for win_command and win_shell

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -64,7 +64,7 @@ class AdHocCLI(CLI):
         return options
 
     def _play_ds(self, pattern, async_val, poll):
-        check_raw = context.CLIARGS['module_name'] in ('command', 'win_command', 'shell', 'win_shell', 'script', 'raw')
+        check_raw = context.CLIARGS['module_name'] in C.MODULE_REQUIRE_ARGS
 
         mytask = {'action': {'module': context.CLIARGS['module_name'], 'args': parse_kv(context.CLIARGS['module_args'], check_raw=check_raw)}}
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -108,8 +108,10 @@ DOCUMENTABLE_PLUGINS = CONFIGURABLE_PLUGINS + ('module', 'strategy')
 IGNORE_FILES = ("COPYING", "CONTRIBUTING", "LICENSE", "README", "VERSION", "GUIDELINES")  # ignore during module search
 INTERNAL_RESULT_KEYS = ('add_host', 'add_group')
 LOCALHOST = ('127.0.0.1', 'localhost', '::1')
-MODULE_REQUIRE_ARGS = ('command', 'win_command', 'shell', 'win_shell', 'raw', 'script')
-MODULE_NO_JSON = ('command', 'win_command', 'shell', 'win_shell', 'raw')
+MODULE_REQUIRE_ARGS = ('command', 'win_command', 'ansible.windows.win_command', 'shell', 'win_shell',
+                       'ansible.windows.win_shell', 'raw', 'script')
+MODULE_NO_JSON = ('command', 'win_command', 'ansible.windows.win_command', 'shell', 'win_shell',
+                  'ansible.windows.win_shell', 'raw')
 RESTRICTED_RESULT_KEYS = ('ansible_rsync_path', 'ansible_playbook_python')
 TREE_DIR = None
 VAULT_VERSION_MIN = 1.0

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -19,6 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import ansible.constants as C
 from ansible.errors import AnsibleParserError, AnsibleError, AnsibleAssertionError
 from ansible.module_utils.six import iteritems, string_types
 from ansible.module_utils._text import to_text
@@ -29,14 +30,7 @@ from ansible.utils.sentinel import Sentinel
 
 
 # For filtering out modules correctly below
-FREEFORM_ACTIONS = frozenset((
-    'command',
-    'win_command',
-    'shell',
-    'win_shell',
-    'script',
-    'raw'
-))
+FREEFORM_ACTIONS = frozenset(C.MODULE_REQUIRE_ARGS)
 
 RAW_PARAM_MODULES = FREEFORM_ACTIONS.union((
     'include',


### PR DESCRIPTION
##### SUMMARY
Add the FQCN for `win_command` and `win_shell` so people can call them with the FQCN in their playbooks. I was debating just checking the module name at the end but this way people can't implement their own `command` in their own collection with _raw_params.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_command
win_shell