### PR TITLE
Create a dedicated windows-minimal test target.

### DIFF
--- a/test/integration/targets/windows-minimal/aliases
+++ b/test/integration/targets/windows-minimal/aliases
@@ -1,2 +1,4 @@
 shippable/windows/group1
+shippable/windows/minimal
 shippable/windows/smoketest
+windows

--- a/test/integration/targets/windows-minimal/library/win_ping.ps1
+++ b/test/integration/targets/windows-minimal/library/win_ping.ps1
@@ -1,0 +1,21 @@
+#!powershell
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$spec = @{
+    options = @{
+        data = @{ type = "str"; default = "pong" }
+    }
+    supports_check_mode = $true
+}
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+$data = $module.Params.data
+
+if ($data -eq "crash") {
+    throw "boom"
+}
+
+$module.Result.ping = $data
+$module.ExitJson()

--- a/test/integration/targets/windows-minimal/library/win_ping.py
+++ b/test/integration/targets/windows-minimal/library/win_ping.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>, and others
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['stableinterface'],
+                    'supported_by': 'core'}
+
+DOCUMENTATION = r'''
+---
+module: win_ping
+version_added: "1.7"
+short_description: A windows version of the classic ping module
+description:
+  - Checks management connectivity of a windows host.
+  - This is NOT ICMP ping, this is just a trivial test module.
+  - For non-Windows targets, use the M(ping) module instead.
+  - For Network targets, use the M(net_ping) module instead.
+options:
+  data:
+    description:
+      - Alternate data to return instead of 'pong'.
+      - If this parameter is set to C(crash), the module will cause an exception.
+    type: str
+    default: pong
+seealso:
+- module: ping
+author:
+- Chris Church (@cchurch)
+'''
+
+EXAMPLES = r'''
+# Test connectivity to a windows host
+# ansible winserver -m win_ping
+
+- name: Example from an Ansible Playbook
+  win_ping:
+
+- name: Induce an exception to see what happens
+  win_ping:
+    data: crash
+'''
+
+RETURN = r'''
+ping:
+    description: Value provided with the data parameter.
+    returned: success
+    type: str
+    sample: pong
+'''

--- a/test/integration/targets/windows-minimal/library/win_ping_set_attr.ps1
+++ b/test/integration/targets/windows-minimal/library/win_ping_set_attr.ps1
@@ -1,0 +1,31 @@
+#!powershell
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# POWERSHELL_COMMON
+
+$params = Parse-Args $args $true;
+
+$data = Get-Attr $params "data" "pong";
+
+$result = @{
+    changed = $false
+    ping = "pong"
+};
+
+# Test that Set-Attr will replace an existing attribute.
+Set-Attr $result "ping" $data
+
+Exit-Json $result;

--- a/test/integration/targets/windows-minimal/library/win_ping_strict_mode_error.ps1
+++ b/test/integration/targets/windows-minimal/library/win_ping_strict_mode_error.ps1
@@ -1,0 +1,30 @@
+#!powershell
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# POWERSHELL_COMMON
+
+$params = Parse-Args $args $true;
+
+$params.thisPropertyDoesNotExist
+
+$data = Get-Attr $params "data" "pong";
+
+$result = @{
+    changed = $false
+    ping = $data
+};
+
+Exit-Json $result;

--- a/test/integration/targets/windows-minimal/library/win_ping_syntax_error.ps1
+++ b/test/integration/targets/windows-minimal/library/win_ping_syntax_error.ps1
@@ -1,0 +1,30 @@
+#!powershell
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# POWERSHELL_COMMON
+
+$blah = 'I can't quote my strings correctly.'
+
+$params = Parse-Args $args $true;
+
+$data = Get-Attr $params "data" "pong";
+
+$result = @{
+    changed = $false
+    ping = $data
+};
+
+Exit-Json $result;

--- a/test/integration/targets/windows-minimal/library/win_ping_throw.ps1
+++ b/test/integration/targets/windows-minimal/library/win_ping_throw.ps1
@@ -1,0 +1,30 @@
+#!powershell
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# POWERSHELL_COMMON
+
+throw
+
+$params = Parse-Args $args $true;
+
+$data = Get-Attr $params "data" "pong";
+
+$result = @{
+    changed = $false
+    ping = $data
+};
+
+Exit-Json $result;

--- a/test/integration/targets/windows-minimal/library/win_ping_throw_string.ps1
+++ b/test/integration/targets/windows-minimal/library/win_ping_throw_string.ps1
@@ -1,0 +1,30 @@
+#!powershell
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# POWERSHELL_COMMON
+
+throw "no ping for you"
+
+$params = Parse-Args $args $true;
+
+$data = Get-Attr $params "data" "pong";
+
+$result = @{
+    changed = $false
+    ping = $data
+};
+
+Exit-Json $result;

--- a/test/integration/targets/windows-minimal/tasks/main.yml
+++ b/test/integration/targets/windows-minimal/tasks/main.yml
@@ -1,0 +1,67 @@
+# test code for the win_ping module
+# (c) 2014, Chris Church <chris@ninemoreminutes.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: test win_ping
+  action: win_ping
+  register: win_ping_result
+
+- name: check win_ping result
+  assert:
+    that:
+      - win_ping_result is not failed
+      - win_ping_result is not changed
+      - win_ping_result.ping == 'pong'
+
+- name: test win_ping with data
+  win_ping:
+    data: ☠
+  register: win_ping_with_data_result
+
+- name: check win_ping result with data
+  assert:
+    that:
+      - win_ping_with_data_result is not failed
+      - win_ping_with_data_result is not changed
+      - win_ping_with_data_result.ping == '☠'
+
+- name: test win_ping.ps1 with data as complex args
+  # win_ping.ps1: # TODO: do we want to actually support this? no other tests that I can see...
+  win_ping:
+    data: bleep
+  register: win_ping_ps1_result
+
+- name: check win_ping.ps1 result with data
+  assert:
+    that:
+      - win_ping_ps1_result is not failed
+      - win_ping_ps1_result is not changed
+      - win_ping_ps1_result.ping == 'bleep'
+
+- name: test win_ping using data=crash so that it throws an exception
+  win_ping:
+    data: crash
+  register: win_ping_crash_result
+  ignore_errors: yes
+
+- name: check win_ping_crash result
+  assert:
+    that:
+      - win_ping_crash_result is failed
+      - win_ping_crash_result is not changed
+      - 'win_ping_crash_result.msg == "Unhandled exception while executing module: boom"'
+      - '"throw \"boom\"" in win_ping_crash_result.exception'

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -8198,6 +8198,7 @@ test/integration/targets/win_script/files/test_script_with_splatting.ps1 pslint:
 test/integration/targets/win_stat/library/test_symlink_file.ps1 pslint:PSCustomUseLiteralPath
 test/integration/targets/win_template/files/foo.dos.txt line-endings
 test/integration/targets/win_user_right/library/test_get_right.ps1 pslint:PSCustomUseLiteralPath
+test/integration/targets/windows-minimal/library/win_ping_syntax_error.ps1 pslint!skip
 test/lib/ansible_test/_data/requirements/constraints.txt test-constraints
 test/lib/ansible_test/_data/requirements/integration.cloud.azure.txt test-constraints
 test/lib/ansible_test/_data/sanity/pylint/plugins/string_format.py use-compat-six


### PR DESCRIPTION
##### SUMMARY

Create a dedicated windows-minimal test target.

The windows-minimal target is a copy of the win_ping test, taking the place of that test as the windows minimal test run on multiple python versions.

It includes a private copy of the win_ping module so it will work after migration.

This will keep tests passing during the migration prep process.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

integration tests
