### PR TITLE
Support multiple events in snmp_community setup module

### DIFF
--- a/lib/ansible/modules/network/fortios/fortios_system_snmp_community.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_snmp_community.py
@@ -425,17 +425,17 @@ def fortios_system_snmp(data, fos):
 def validate_events(data):
 
     events_set = set(["cpu-high", "mem-low", "log-full", "intf-ip",
-                  "vpn-tun-up", "vpn-tun-down", "ha-switch",
-                  "ha-hb-failure", "ips-signature", "ips-anomaly",
-                  "av-virus", "av-oversize", "av-pattern",
-                  "av-fragmented", "fm-if-change", "fm-conf-change",
-                  "bgp-established", "bgp-backward-transition",
-                  "ha-member-up", "ha-member-down", "ent-conf-change",
-                  "av-conserve", "av-bypass", "av-oversize-passed",
-                  "av-oversize-blocked", "ips-pkg-update", "ips-fail-open",
-                  "faz-disconnect", "wc-ap-up", "wc-ap-down",
-                  "fswctl-session-up", "fswctl-session-down", "load-balance-real-server-down",
-                  "device-new", "per-cpu-high"])
+                      "vpn-tun-up", "vpn-tun-down", "ha-switch",
+                      "ha-hb-failure", "ips-signature", "ips-anomaly",
+                      "av-virus", "av-oversize", "av-pattern",
+                      "av-fragmented", "fm-if-change", "fm-conf-change",
+                      "bgp-established", "bgp-backward-transition",
+                      "ha-member-up", "ha-member-down", "ent-conf-change",
+                      "av-conserve", "av-bypass", "av-oversize-passed",
+                      "av-oversize-blocked", "ips-pkg-update", "ips-fail-open",
+                      "faz-disconnect", "wc-ap-up", "wc-ap-down",
+                      "fswctl-session-up", "fswctl-session-down", "load-balance-real-server-down",
+                      "device-new", "per-cpu-high"])
     # check if the current events is a subset of the events_set
     curr_events_str = data['system_snmp_community']['events']
     if curr_events_str is None:

--- a/lib/ansible/modules/network/fortios/fortios_system_snmp_community.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_snmp_community.py
@@ -424,7 +424,7 @@ def fortios_system_snmp(data, fos):
 
 def validate_events(data):
 
-    events_set = {"cpu-high", "mem-low", "log-full", "intf-ip",
+    events_set = set(["cpu-high", "mem-low", "log-full", "intf-ip",
                   "vpn-tun-up", "vpn-tun-down", "ha-switch",
                   "ha-hb-failure", "ips-signature", "ips-anomaly",
                   "av-virus", "av-oversize", "av-pattern",
@@ -435,7 +435,7 @@ def validate_events(data):
                   "av-oversize-blocked", "ips-pkg-update", "ips-fail-open",
                   "faz-disconnect", "wc-ap-up", "wc-ap-down",
                   "fswctl-session-up", "fswctl-session-down", "load-balance-real-server-down",
-                  "device-new", "per-cpu-high"}
+                  "device-new", "per-cpu-high"])
     # check if the current events is a subset of the events_set
     curr_events_str = data['system_snmp_community']['events']
     if curr_events_str is None:

--- a/lib/ansible/modules/network/fortios/fortios_system_snmp_community.py
+++ b/lib/ansible/modules/network/fortios/fortios_system_snmp_community.py
@@ -88,42 +88,12 @@ options:
         suboptions:
             events:
                 description:
-                    - SNMP trap events. Accepted events are as below:
-                    - cpu-high
-                    - mem-low
-                    - log-full
-                    - intf-ip
-                    - vpn-tun-up
-                    - vpn-tun-down
-                    - ha-switch
-                    - ha-hb-failure
-                    - ips-signature
-                    - ips-anomaly
-                    - av-virus
-                    - av-oversize
-                    - av-pattern
-                    - av-fragmented
-                    - fm-if-change
-                    - fm-conf-change
-                    - bgp-established
-                    - bgp-backward-transition
-                    - ha-member-up
-                    - ha-member-down
-                    - ent-conf-change
-                    - av-conserve
-                    - av-bypass
-                    - av-oversize-passed
-                    - av-oversize-blocked
-                    - ips-pkg-update
-                    - ips-fail-open
-                    - faz-disconnect
-                    - wc-ap-up
-                    - wc-ap-down
-                    - fswctl-session-up
-                    - fswctl-session-down
-                    - load-balance-real-server-down
-                    - device-new
-                    - per-cpu-high
+                    - "SNMP trap events. Accepted events are: cpu-high, mem-low, log-full, intf-ip, vpn-tun-up,
+                      vpn-tun-down, ha-switch, ha-hb-failure,ips-signature, ips-anomaly, av-virus, av-oversize
+                      av-pattern, av-fragmented, fm-if-change, fm-conf-change, bgp-established, bgp-backward-transition
+                      ha-member-up, ha-member-down, ent-conf-change, av-conserve, av-bypass, av-oversize-passed
+                      av-oversize-blocked, ips-pkg-update, ips-fail-open, faz-disconnect, wc-ap-up, wc-ap-down
+                      fswctl-session-up, fswctl-session-down, load-balance-real-server-down, device-new, per-cpu-high"
                 type: str
             hosts:
                 description:
@@ -454,18 +424,18 @@ def fortios_system_snmp(data, fos):
 
 def validate_events(data):
 
-    events_set = {"cpu-high","mem-low","log-full","intf-ip",
-                  "vpn-tun-up","vpn-tun-down","ha-switch",
-                  "ha-hb-failure","ips-signature","ips-anomaly",
-                  "av-virus","av-oversize","av-pattern",
-                  "av-fragmented","fm-if-change","fm-conf-change",
-                  "bgp-established","bgp-backward-transition",
-                  "ha-member-up","ha-member-down","ent-conf-change",
-                  "av-conserve","av-bypass","av-oversize-passed",
-                  "av-oversize-blocked","ips-pkg-update","ips-fail-open",
-                  "faz-disconnect","wc-ap-up","wc-ap-down",
-                  "fswctl-session-up","fswctl-session-down","load-balance-real-server-down",
-                  "device-new","per-cpu-high"}
+    events_set = {"cpu-high", "mem-low", "log-full", "intf-ip",
+                  "vpn-tun-up", "vpn-tun-down", "ha-switch",
+                  "ha-hb-failure", "ips-signature", "ips-anomaly",
+                  "av-virus", "av-oversize", "av-pattern",
+                  "av-fragmented", "fm-if-change", "fm-conf-change",
+                  "bgp-established", "bgp-backward-transition",
+                  "ha-member-up", "ha-member-down", "ent-conf-change",
+                  "av-conserve", "av-bypass", "av-oversize-passed",
+                  "av-oversize-blocked", "ips-pkg-update", "ips-fail-open",
+                  "faz-disconnect", "wc-ap-up", "wc-ap-down",
+                  "fswctl-session-up", "fswctl-session-down", "load-balance-real-server-down",
+                  "device-new", "per-cpu-high"}
     # check if the current events is a subset of the events_set
     curr_events_str = data['system_snmp_community']['events']
     if curr_events_str is None:

--- a/test/units/modules/network/fortios/test_fortios_system_snmp_community.py
+++ b/test/units/modules/network/fortios/test_fortios_system_snmp_community.py
@@ -92,6 +92,60 @@ def test_system_snmp_community_creation(mocker):
     assert response['http_status'] == 200
 
 
+def test_system_snmp_community_custom_events_validation__multiple(mocker):
+    schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
+
+    set_method_result = {'status': 'success', 'http_method': 'POST', 'http_status': 200}
+    set_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.set', return_value=set_method_result)
+
+    input_data = {
+        'username': 'admin',
+        'state': 'present',
+        'system_snmp_community': {
+            'events': 'cpu-high mem-low',
+            'id': '4',
+            'name': 'default_name_5',
+            'query_v1_port': '6',
+            'query_v1_status': 'enable',
+            'query_v2c_port': '8',
+            'query_v2c_status': 'enable',
+            'status': 'enable',
+            'trap_v1_lport': '11',
+            'trap_v1_rport': '12',
+            'trap_v1_status': 'enable',
+            'trap_v2c_lport': '14',
+            'trap_v2c_rport': '15',
+            'trap_v2c_status': 'enable'
+        },
+        'vdom': 'root'}
+
+    is_error, changed, response = fortios_system_snmp_community.fortios_system_snmp(input_data, fos_instance)
+
+    expected_data = {
+        'events': 'cpu-high mem-low',
+        'id': '4',
+        'name': 'default_name_5',
+                'query-v1-port': '6',
+                'query-v1-status': 'enable',
+                'query-v2c-port': '8',
+                'query-v2c-status': 'enable',
+                'status': 'enable',
+                'trap-v1-lport': '11',
+                'trap-v1-rport': '12',
+                'trap-v1-status': 'enable',
+                'trap-v2c-lport': '14',
+                'trap-v2c-rport': '15',
+                'trap-v2c-status': 'enable'
+    }
+
+    set_method_mock.assert_called_with('system.snmp', 'community', data=expected_data, vdom='root')
+    schema_method_mock.assert_not_called()
+    assert not is_error
+    assert changed
+    assert response['status'] == 'success'
+    assert response['http_status'] == 200
+
+
 def test_system_snmp_community_creation_fails(mocker):
     schema_method_mock = mocker.patch('ansible.module_utils.network.fortios.fortios.FortiOSHandler.schema')
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add validate_events function in fortios_system_snmp_community.py, which supports multiple events setup at the same time.

fortios_system_snmp_community module only accepts one event before the change. The validate_events function validates the events param and catches all the invalid input before processing it and forwards the events string to the next step. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request