### PR TITLE
DOC fix: typo in group addressing syntax

### DIFF
--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -420,7 +420,7 @@ Anyway, here's the trick:
 Notice how we're pulling out the hostname of the first machine of the webservers group.  If you are doing this in a template, you
 could use the Jinja2 '#set' directive to simplify this, or in a playbook, you could also use set_fact::
 
-    - set_fact: headnode={{ groups[['webservers'][0]] }}
+    - set_fact: headnode={{ groups['webservers'][0] }}
 
     - debug: msg={{ hostvars[headnode].ansible_eth0.ipv4.address }}
 


### PR DESCRIPTION
##### SUMMARY
Fix typo in group addressing syntax

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

