### PR TITLE
Add -r option for OpenBSD's pkg_add

### DIFF
--- a/lib/ansible/modules/packaging/os/openbsd_pkg.py
+++ b/lib/ansible/modules/packaging/os/openbsd_pkg.py
@@ -59,6 +59,12 @@ options:
         type: bool
         default: 'no'
         version_added: "2.3"
+    replace:
+        description:
+          - Replace existing packages with explicit other versions.
+        type: bool
+        default: 'no'
+        version_added: "X.X"
     quick:
         description:
           - Replace or delete packages quickly; do not bother with checksums
@@ -107,6 +113,7 @@ EXAMPLES = '''
   openbsd_pkg:
     name: python%3.5
     state: present
+    replace: yes
 
 - name: Update all packages on the system
   openbsd_pkg:
@@ -271,7 +278,13 @@ def package_latest(names, pkg_spec, module):
     if module.params['clean']:
         upgrade_cmd += 'c'
 
+    if module.params['replace']:
+        upgrade_cmd += 'r'
+
+    if module.params['
+
     if module.params['quick']:
+        upgrade_cmd += 'q'']:
         upgrade_cmd += 'q'
 
     for name in names:
@@ -527,6 +540,7 @@ def main():
             build=dict(type='bool', default=False),
             ports_dir=dict(type='path', default='/usr/ports'),
             quick=dict(type='bool', default=False),
+            replace=dict(type='bool', default=False),
             clean=dict(type='bool', default=False),
         ),
         supports_check_mode=True

--- a/lib/ansible/modules/packaging/os/openbsd_pkg.py
+++ b/lib/ansible/modules/packaging/os/openbsd_pkg.py
@@ -281,10 +281,7 @@ def package_latest(names, pkg_spec, module):
     if module.params['replace']:
         upgrade_cmd += 'r'
 
-    if module.params['
-
     if module.params['quick']:
-        upgrade_cmd += 'q'']:
         upgrade_cmd += 'q'
 
     for name in names:

--- a/lib/ansible/modules/packaging/os/openbsd_pkg.py
+++ b/lib/ansible/modules/packaging/os/openbsd_pkg.py
@@ -64,7 +64,7 @@ options:
           - Replace existing packages with explicit other versions.
         type: bool
         default: 'no'
-        version_added: "X.X"
+        version_added: "2.10"
     quick:
         description:
           - Replace or delete packages quickly; do not bother with checksums


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Hi, I would like to have a way to enable the -r flag in the openbsd_pkg module.

I needed this to replace the libxml on an older machine with a new patch-level version.
So there were no incompatibilities between the two port versions but due to the dependencies according to the package database I could not just replace the package in another way without first removing all the ports that required the old libxml version.

I added another yes/no switch because it is a flag to pkg_add and it can be combined with the other options on the command line.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Replace option for openbsd_pkg

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
According to http://man.openbsd.org/pkg_add -r is used the following way:
```
     o   Replace existing packages with explicit other versions, using option
         -r.  The pkg-name ... specified on the command line are new packages
         that should replace already installed packages, with other versions
         or flavors.
...
     -r       Replace existing packages.  pkg_add will try to take every
              precaution to make sure the replacement can proceed before
              removing the old package and adding the new one, and it should
              also handle shared libraries correctly.  Among other things,
              pkg_add will refuse to replace packages as soon as it needs to
              run scripts that might fail (use -D update to force the
              replacement); pkg_add will also refuse to replace packages when
              the dependencies don't quite match (use -D updatedepends to
              force the replacement).
```

The task:
```
- name: install specific packages from update mirror
  openbsd_pkg:
    name: "{{ custom_packages }}"
    state: present
    replace: yes
  tags:
    - XXX
```

output of running a task with `replace: yes`:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [XXX : install specific packages from update mirror] *************************************************************************
changed: [XXX] => {"changed": true, "cmd": ["pkg_add", "-r",  "XXX" ], "delta": "0:00:03.466001", "end": "2020-03-04 13:22:10.120918", "rc": 0, "start": "2020-03-04 13:22:06.654917", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
```

Task before the change:
```
- name: xxx
  shell: pkg_add -r {{ custom_packages | join(' ') }}
  environment:
    - TRUSTED_PKG_PATH: "{{ update_mirror }}"
```