### PR TITLE
Do not prefix remote_path IF WINDOWS 

### DIFF
--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -272,7 +272,8 @@ class Connection(ConnectionBase):
             Can revisit using $HOME instead if it's a problem
         '''
         if getattr(self._shell, "_IS_WINDOWS", False):
-            return os.path.normpath(remote_path)
+            import ntpath
+            return ntpath.normpath(remote_path)
         else:
             if not remote_path.startswith(os.path.sep):
                 remote_path = os.path.join(os.path.sep, remote_path)

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -271,9 +271,12 @@ class Connection(ConnectionBase):
 
             Can revisit using $HOME instead if it's a problem
         '''
-        if not remote_path.startswith(os.path.sep):
-            remote_path = os.path.join(os.path.sep, remote_path)
-        return os.path.normpath(remote_path)
+        if getattr(self._shell, "_IS_WINDOWS", False):
+            return os.path.normpath(remote_path)
+        else:
+            if not remote_path.startswith(os.path.sep):
+                remote_path = os.path.join(os.path.sep, remote_path)
+            return os.path.normpath(remote_path)
 
     def put_file(self, in_path, out_path):
         """ Transfer a file from local to docker container """

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -329,7 +329,11 @@ class Connection(ConnectionBase):
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         p.communicate()
 
-        actual_out_path = os.path.join(out_dir, os.path.basename(in_path))
+        if getattr(self._shell, "_IS_WINDOWS", False):
+            import ntpath
+            actual_out_path = os.path.join(out_dir, ntpath.basename(in_path))
+        else:
+            actual_out_path = os.path.join(out_dir, os.path.basename(in_path))
 
         if p.returncode != 0:
             # Older docker doesn't have native support for fetching files command `cp`


### PR DESCRIPTION
##### SUMMARY
#67832 fixes the need to run powershell modules on windows containers via docker connection. However, while running win_copy on windows containers, destination path is prefixed with / which doesn't work in the case of windows. The changes in this PR take care of bypassing that while running the role on windows containers.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Docker connection plugin (lib/ansible/plugins/connection/docker.py)

##### ADDITIONAL INFORMATION
For more context: https://github.com/ansible/ansible/pull/67946#issuecomment-594345330