### PR TITLE
plugin_formatter: sys.exit does not take a file argument

### DIFF
--- a/hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
+++ b/hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
@@ -678,9 +678,9 @@ def validate_options(options):
     ''' validate option parser options '''
 
     if not options.module_dir:
-        sys.exit("--module-dir is required", file=sys.stderr)
+        sys.exit("--module-dir is required")
     if not os.path.exists(options.module_dir):
-        sys.exit("--module-dir does not exist: %s" % options.module_dir, file=sys.stderr)
+        sys.exit("--module-dir does not exist: %s" % options.module_dir)
     if not options.template_dir:
         sys.exit("--template-dir must be specified")
 


### PR DESCRIPTION
this is a leftover from bcdfdc0cc33155598edfd4752db85c6358b17864 where code like

```python
print("--module-dir is required", file=sys.stderr)
sys.exit(1)
```

was converted to

```python
sys.exit("--module-dir is required", file=sys.stderr)
```

`sys.exit` will write to `stderr` by default and does not accept a `file` keyword argument like `print`

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
hacking/build_library/build_ansible/command_plugins/plugin_formatter.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
