### PR TITLE
Remove file exists check from botmeta sanity test.

### DIFF
--- a/test/sanity/code-smell/botmeta.py
+++ b/test/sanity/code-smell/botmeta.py
@@ -79,17 +79,6 @@ def main():
             continue
         path_macros.append(macro)
 
-    # Ensure all `files` correspond to a file
-    for file, file_meta in botmeta['files'].items():
-        migrated = isinstance(file_meta, dict) and file_meta.get('migrated_to') is not None
-        for macro in path_macros:
-            file = file.replace('$' + macro, botmeta.get('macros', {}).get(macro, ''))
-        if not os.path.exists(file) and not migrated:
-            # Not a file or directory, though maybe the prefix to one?
-            # https://github.com/ansible/ansibullbot/pull/1023
-            if not glob.glob('%s*' % file):
-                print("%s:%d:%d: Can't find '%s.*' in this branch" % (path, 0, 0, file))
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### SUMMARY

Remove file exists check from botmeta sanity test.

Many of the paths in botmeta will no longer exist after migration, making this check pointless.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

botmeta sanity test
