### PR TITLE
Add Kubernetes Working Group to Communicating guide

### DIFF
--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -60,6 +60,7 @@ Many of our community `Working Groups <https://github.com/ansible/community/wiki
 - `Documentation Working Group <https://github.com/ansible/community/wiki/Docs>`_- ``#ansible-docs``
 - `Galaxy Working Group <https://github.com/ansible/community/wiki/Galaxy>`_ - ``#ansible-galaxy``
 - `JBoss Working Group <https://github.com/ansible/community/wiki/JBoss>`_ - ``#ansible-jboss``
+- `Kubernetes Working Group <https://github.com/ansible/community/wiki/Kubernetes>`_ - ``#ansible-kubernetes``
 - `Lightbulb Training <https://github.com/ansible/lightbulb>`_ - ``#ansible-lightbulb`` - Ansible training
 - `Linode Working Group <https://github.com/ansible/community/wiki/Linode>`_ - ``#ansible-linode``
 - `Molecule Working Group <https://github.com/ansible/community/wiki/Molecule>`_ | `molecule.io <https://molecule.readthedocs.io>`_ - ``#ansible-molecule`` - testing platform for Ansible playbooks and roles


### PR DESCRIPTION
##### SUMMARY

Add the Kubernetes Working Group details to the 'Communicating' community guide in the docs.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

Documentation

##### ADDITIONAL INFORMATION

N/A
