### PR TITLE
ansible_native_concat: use to_text rather than jinja2's text_type

### DIFF
--- a/changelogs/fragments/ansible_native_concat-use-to_text-rather-than-text_type.yml
+++ b/changelogs/fragments/ansible_native_concat-use-to_text-rather-than-text_type.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible_native_concat() - use ``to_text`` function rather than Jinja2's ``text_type`` which has been removed in Jinja2 master branch.

--- a/lib/ansible/template/native_helpers.py
+++ b/lib/ansible/template/native_helpers.py
@@ -10,9 +10,9 @@ from ast import literal_eval
 from itertools import islice, chain
 import types
 
-from jinja2._compat import text_type
-
 from jinja2.runtime import StrictUndefined
+
+from ansible.module_utils._text import to_text
 from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
 
 
@@ -46,7 +46,7 @@ def ansible_native_concat(nodes):
             # (see Jinja2 source of StrictUndefined to get up to date info)
             # Otherwise the undefined error would be raised on the next access which might not be properly handled.
             # See https://github.com/ansible/ansible/issues/52158
-            # We do that only here because it is taken care of by text_type() in the else block below already.
+            # We do that only here because it is taken care of by to_text() in the else block below already.
             str(out)
 
         # short circuit literal_eval when possible
@@ -57,7 +57,7 @@ def ansible_native_concat(nodes):
             nodes = chain(head, nodes)
         # Stringifying the nodes is important as it takes care of
         # StrictUndefined by side-effect - by raising an exception.
-        out = u''.join([text_type(v) for v in nodes])
+        out = u''.join([to_text(v) for v in nodes])
 
     try:
         return literal_eval(out)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
jinja2._compat.text_type has been removed in jinja2's master branch so
use ansible's to_text instead.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT
`lib/ansible/template/native_helpers.py `