### PR TITLE
document-plugins: strip trailing slashes from the module_dir

### DIFF
--- a/hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
+++ b/hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
@@ -719,6 +719,7 @@ class DocumentPlugins(Command):
         if not args.template_dir:
             args.template_dir = ["hacking/templates"]
         validate_options(args)
+        args.module_dir = os.path.normpath(args.module_dir)
         display.verbosity = args.verbosity
         plugin_type = args.plugin_type
 


### PR DESCRIPTION
##### SUMMARY

when building documentation, you have to pass the module_dir:

    build-ansible.py document-plugins --module-dir some/path

however, users might accidentally add a trailing slash:

    build-ansible.py document-plugins --module-dir some/path/

which will result in an ugly error:

    Traceback (most recent call last):
      File "/tmp/ansible/hacking/build-ansible.py", line 92, in <module>
        main()
      File "/tmp/ansible/hacking/build-ansible.py", line 81, in main
        retval = command.main(args)
      File "/tmp/ansible/hacking/build_library/build_ansible/command_plugins/plugin_formatter.py", line 750, in main
        plugin_info, categories = get_plugin_info(args.module_dir, limit_to=args.limit_to, verbose=(args.verbosity > 0))
      File "/tmp/ansible/hacking/build_library/build_ansible/command_plugins/plugin_formatter.py", line 239, in get_plugin_info
        relative_dir = mod_path_only.split('/')[1]
    IndexError: list index out of range

Be nice to users and just stript that slash.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
hacking/build_library/build_ansible/command_plugins/plugin_formatter.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
