### PR TITLE
OpenStack: ensure min_version is a string

### DIFF
--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -119,8 +119,9 @@ def openstack_cloud_from_module(module, min_version='0.12.0'):
 
     if min_version:
         min_version = max(StrictVersion('0.12.0'), StrictVersion(min_version))
+        min_version = str(min_version)
     else:
-        min_version = StrictVersion('0.12.0')
+        min_version = '0.12.0'
 
     if min_version:
         if StrictVersion(sdk.version.__version__) < StrictVersion(min_version):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

https://github.com/ansible/ansible/pull/67577/files broke OpenStack
modules in Ansible 2.8.9. The problem is that min_version should be a
string, since it is passed to StrictVersion(). However, after that
change min_version ends up as a StrictVersion. This causes a TypeError
when later used to instantiate another StrictVersion:

`TypeError: expected string or buffer`

This change fixes the issue by ensuring min_version is a string. This
change is not required on other branches since the relevant code was
applied only in the 2.8 backport.

Fixes: #68042

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
OpenStack modules.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->