### PR TITLE
Update gcp_storage_object.py

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_storage_object.py
+++ b/lib/ansible/modules/cloud/google/gcp_storage_object.py
@@ -62,12 +62,12 @@ options:
     type: bool
   src:
     description:
-    - Source location of file (may be local machine or cloud depending on action).
+    - Source location of file (may be local machine or cloud depending on action). Google Cloud locations need to be urlencoded including the slashes.
     required: false
     type: path
   dest:
     description:
-    - Destination location of file (may be local machine or cloud depending on action).
+    - Destination location of file (may be local machine or cloud depending on action). Google Cloud locations need to be urlencoded including the slashes.
     required: false
     type: path
   bucket:
@@ -125,6 +125,18 @@ EXAMPLES = '''
     auth_kind: serviceaccount
     service_account_file: "/tmp/auth.pem"
     state: present
+    
+- name: download an object not in the root of the bucket
+  gcp_storage_object:
+    action: download
+    bucket: ansible-bucket
+    src: "{{ 'some-folder/modules.zip'| urlencode|replace('/','%2f') }}"
+    dest: "~/modules.zip"
+    project: test_project
+    auth_kind: serviceaccount
+    service_account_file: "/tmp/auth.pem"
+    state: present
+
 '''
 
 RETURN = '''


### PR DESCRIPTION
##### SUMMARY
Nothing in the documentation says that the paths on GCS need to be URL encoded. Through a few hours of trial and error I discovered that this is the case and the documentation should reflect that.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
