### PR TITLE
module change from ast to json

### DIFF
--- a/lib/ansible/module_utils/network/nxos/facts/vlans/vlans.py
+++ b/lib/ansible/module_utils/network/nxos/facts/vlans/vlans.py
@@ -13,6 +13,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import re
+import json
 import ast
 from copy import deepcopy
 

--- a/lib/ansible/module_utils/network/nxos/facts/vlans/vlans.py
+++ b/lib/ansible/module_utils/network/nxos/facts/vlans/vlans.py
@@ -135,6 +135,8 @@ class VlansFacts(object):
         """
         # device output may be string, convert to list
         structured = json.loads(structured)
+        structured = ast.literal_eval(str(structured))
+
 
         vlanbrief = []
         mtuinfo = []

--- a/lib/ansible/module_utils/network/nxos/facts/vlans/vlans.py
+++ b/lib/ansible/module_utils/network/nxos/facts/vlans/vlans.py
@@ -136,8 +136,6 @@ class VlansFacts(object):
         # device output may be string, convert to list
         structured = json.loads(structured)
         structured = ast.literal_eval(str(structured))
-
-
         vlanbrief = []
         mtuinfo = []
         if 'TABLE_vlanbrief' in structured:

--- a/lib/ansible/module_utils/network/nxos/facts/vlans/vlans.py
+++ b/lib/ansible/module_utils/network/nxos/facts/vlans/vlans.py
@@ -134,7 +134,7 @@ class VlansFacts(object):
           and adds a 'run_cfg' key containing raw cli from the device.
         """
         # device output may be string, convert to list
-        structured = ast.literal_eval(str(structured))
+        structured = json.loads(structured)
 
         vlanbrief = []
         mtuinfo = []


### PR DESCRIPTION
##### SUMMARY
exchanged the usage of the ast module towards json module, because in some circumstances it could happen that a nxos device hase a null value on vlan1 vlan-name. Data used is in json format anyway what the json module is written for.

"Fixes ##67960" 

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
nxos_vlans module

##### ADDITIONAL INFORMATION
none