### PR TITLE
Add Redfish VirtualMedia insert and eject commands

### DIFF
--- a/changelogs/fragments/68053-add-redfish-virtual-media-commands.yml
+++ b/changelogs/fragments/68053-add-redfish-virtual-media-commands.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - redfish_command - Support for virtual media insert and eject commands (https://github.com/ansible/ansible/issues/58941)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds commands to insert and eject virtual media on a Redfish service. This enables, for example, the ability to "insert" a bootable image from a URL into a virtual drive and then boot from that drive into the OS on the image.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #58941

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
redfish_utils.py
redfish_command.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

Example playbook snippets for the new VirtualMediaInsert and VirtualMediaEject commands:

```
 - name: Insert Virtual Media
    redfish_command:
      category: Manager
      command: VirtualMediaInsert
      baseuri: "{{ baseuri }}"
      username: "{{ username }}"
      password: "{{ password }}"
      virtual_media:
        image_url: 'http://example.com/images/SomeLinux-current.iso'
        media_types:
          - CD
          - DVD
      resource_id: BMC
```

```
 - name: Eject Virtual Media
    redfish_command:
      category: Manager
      command: VirtualMediaEject
      baseuri: "{{ baseuri }}"
      username: "{{ username }}"
      password: "{{ password }}"
      virtual_media:
        image_url: 'http://example.com/images/SomeLinux-current.iso'
      resource_id: BMC
```
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Output for the new commands:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ ansible-playbook -i myinventory.yml playbooks/manager/ilo/insert_virtual_media.yml
[WARNING]: You are running the development version of Ansible. You should only
run Ansible from "devel" if you are modifying the Ansible engine, or trying out
features under development. This is a rapidly changing source of code and can
become unstable at any point.

PLAY [Insert Virtual Media] ****************************************************

TASK [Insert Virtual Media] ****************************************************
changed: [ilo]

PLAY RECAP *********************************************************************
ilo                        : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

```
$ ansible-playbook -i myinventory.yml playbooks/manager/ilo/eject_virtual_media.yml
[WARNING]: You are running the development version of Ansible. You should only
run Ansible from "devel" if you are modifying the Ansible engine, or trying out
features under development. This is a rapidly changing source of code and can
become unstable at any point.

PLAY [Eject Virtual Media] *****************************************************

TASK [Eject Virtual Media] *****************************************************
changed: [ilo]

PLAY RECAP *********************************************************************
ilo                        : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```