### PR TITLE
New EC2 Image Builder modules

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_component.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_component.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python\
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2020, Tom Wright (@tomwwright)
@@ -23,24 +23,38 @@ author: "Tom Wright (@tomwwright)"
 options:
   change_description:
     type: str
+    description: ''
   data:
     type: str
+    description: ''
   uri:
     type: str
+    description: ''
   description:
     type: str
+    description: ''
   kms_key_id:
     type: str
+    description: ''
   name:
     type: str
     required: true
+    description: ''
   platform:
     type: str
-    choices: ['Windows', 'Linux']
+    description: ''
   semantic_version:
     type: str
+    required: True
+    description: ''
+  state:
+    type: str
+    required: True
+    choices: ['present', 'absent']
+    description: ''
   tags:
     type: dict
+    description: ''
 extends_documentation_fragment:
     - aws
     - ec2
@@ -119,9 +133,9 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-name
 component:
-  description: Component configuration details. Refer to U(https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/imagebuilder.html#imagebuilder.Client.get_component)
+  description: Component configuration details. \
+    Refer to U(https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/imagebuilder.html#imagebuilder.Client.get_component)
   returned: always
   type: complex
   contains:
@@ -132,9 +146,11 @@ component:
     change_description:
       returned: when state is present
       type: str
+      description: ''
     data:
       returned: when state is present
       type: str
+      description: ''
     date_created:
       description: The time and date that this component version was created.
       returned: when state is present
@@ -143,35 +159,43 @@ component:
     description:
       returned: when state is present
       type: str
+      description: ''
     encrypted:
       returned: when state is present
       type: bool
+      description: ''
     uri:
       returned: when state is present
       type: str
+      description: ''
     kms_key_id:
       returned: when state is present
       type: str
+      description: ''
     name:
       returned: when state is present
       type: str
-      required: true
+      description: ''
     owner:
       returned: when state is present
       type: str
+      description: ''
     platform:
       returned: when state is present
       type: str
-      choices: ['Windows', 'Linux']
+      description: ''
     semantic_version:
       returned: when state is present
       type: str
+      description: ''
     tags:
       returned: when state is present
       type: dict
+      description: ''
     type:
       returned: when state is present
       type: str
+      description: ''
 '''
 
 import copy

--- a/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_component.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_component.py
@@ -1,0 +1,375 @@
+#!/usr/bin/python\
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, Tom Wright (@tomwwright)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: ec2_imagebuilder_component
+short_description: Manage an EC2 Image Builder component
+description:
+    - Manage an EC2 Image Builder component. See U(https://docs.aws.amazon.com/imagebuilder/latest/userguide/) for information about EC2 Image Builder.
+version_added: "2.10"
+requirements: [ boto3 ]
+author: "Tom Wright (@tomwwright)"
+options:
+  change_description:
+    type: str
+  data:
+    type: str
+  uri:
+    type: str
+  description:
+    type: str
+  kms_key_id:
+    type: str
+  name:
+    type: str
+    required: true
+  platform:
+    type: str
+    choices: ['Windows', 'Linux']
+  semantic_version:
+    type: str
+  tags:
+    type: dict
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
+- name: create a component
+  ec2_imagebuilder_component:
+    name: test_component
+    data:
+      schemaVersion: "1.0"
+      phases:
+        - name: "build"
+          steps:
+            - name: "RunScript"
+              action: "ExecuteBash"
+              timeoutSeconds: 120
+              onFailure: "Abort"
+              maxAttempts: 3
+              inputs:
+                commands:
+                  - |
+                    #!/bin/bash
+                    echo 'scripty things!'
+                    ...
+    description: this is a test component
+    platform: Linux
+    semantic_version: 1.0.0
+    state: present
+    tags:
+      this: isatag
+
+- name: publish a new version of a component
+  ec2_imagebuilder_component:
+    name: test_component
+    data:
+      schemaVersion: "1.0"
+      phases:
+        - name: "build"
+          steps:
+            - name: "RunScript"
+              action: "ExecuteBash"
+              timeoutSeconds: 120
+              onFailure: "Abort"
+              maxAttempts: 3
+              inputs:
+                commands:
+                  - |
+                    #!/bin/bash
+                    echo 'new and improved!'
+                    ...
+    description: this is a test component -- updated
+    platform: Linux
+    semantic_version: 1.0.1
+    state: present
+    tags:
+      this: isatag
+
+- name: update tags for existing component version
+  ec2_imagebuilder_component:
+    name: test_component
+    platform: Linux
+    semantic_version: 1.0.1
+    state: present
+    tags:
+      this: isatag
+      another: tag
+
+- name: delete a version of a component
+  ec2_imagebuilder_component:
+    name: test_component
+    semantic_version: 1.0.0
+    state: absent
+'''
+
+RETURN = '''
+name
+component:
+  description: Component configuration details. Refer to U(https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/imagebuilder.html#imagebuilder.Client.get_component)
+  returned: always
+  type: complex
+  contains:
+    arn:
+      description: The ARN of the resource
+      returned: always
+      type: str
+    change_description:
+      returned: when state is present
+      type: str
+    data:
+      returned: when state is present
+      type: str
+    date_created:
+      description: The time and date that this component version was created.
+      returned: when state is present
+      type: str
+      sample: "2018-04-21T05:19:58.326000+00:00"
+    description:
+      returned: when state is present
+      type: str
+    encrypted:
+      returned: when state is present
+      type: bool
+    uri:
+      returned: when state is present
+      type: str
+    kms_key_id:
+      returned: when state is present
+      type: str
+    name:
+      returned: when state is present
+      type: str
+      required: true
+    owner:
+      returned: when state is present
+      type: str
+    platform:
+      returned: when state is present
+      type: str
+      choices: ['Windows', 'Linux']
+    semantic_version:
+      returned: when state is present
+      type: str
+    tags:
+      returned: when state is present
+      type: dict
+    type:
+      returned: when state is present
+      type: str
+'''
+
+import copy
+from ansible.module_utils.ec2 import get_aws_connection_info, camel_dict_to_snake_dict, snake_dict_to_camel_dict
+from ansible.module_utils.aws.core import AnsibleAWSModule
+
+try:
+    import botocore
+except ImportError:
+    pass  # caught by AnsibleAWSModule
+
+
+# Non-ansible imports
+try:
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    pass
+
+
+def construct_component_arn(region, account_id, name, semantic_version):
+    return "arn:aws:imagebuilder:%s:%s:component/%s/%s/1" % (
+        region, account_id, name.replace('_', '-'), semantic_version)
+
+
+def construct_create_params(module):
+    params = dict()
+
+    # required params
+    params['name'] = module.params.get('name')
+    params['platform'] = module.params.get('platform')
+    params['semantic_version'] = module.params.get('semantic_version')
+
+    # optional params
+    optional_params_keys = [
+        'change_description',
+        'data',
+        'description',
+        'kms_key_id',
+        'uri',
+        'tags']
+
+    for k in optional_params_keys:
+        if module.params.get(k) is not None:
+            params[k] = module.params.get(k)
+
+    # ensure params are in camel case for compatibility with EC2 Image Builder API
+    params = snake_dict_to_camel_dict(params)
+
+    return params
+
+
+def create_or_tag_component(connection, module, arn, current_component_params):
+    params = construct_create_params(module)
+
+    changed = False
+
+    # attempt to create component if it does not exist or its parameters have changed
+    if not current_component_params or has_component_params_changed(
+            params, current_component_params):
+        connection.create_component(**params)
+        changed = True
+
+    # update tags if component exists and tags have changed
+    if current_component_params and have_component_tags_changed(params, current_component_params):
+        update_component_tags(connection, arn, params, current_component_params)
+        changed = True
+
+    # if a change has been made, refetch
+    if changed:
+        current_component_params = get_component(connection, module, arn)
+
+    module.exit_json(changed=changed, component=camel_dict_to_snake_dict(current_component_params))
+
+
+def delete_component(connection, module, arn, component):
+    """
+    Delete an EC2 Image Builder component if it exists
+
+    :param connection: AWS boto3 imagebuilder connection
+    :param module: Ansible module
+    :param component: a dict of EC2 Image Builder component representing current state of resource, or None
+    :return: True if component was deleted else False
+    """
+
+    changed = False
+
+    if component:
+        try:
+            connection.delete_component(
+                componentBuildVersionArn=arn)
+            changed = True
+        except (BotoCoreError, ClientError) as e:
+            module.fail_json_aws(e)
+
+    module.exit_json(changed=changed, component=dict(arn=arn))
+
+
+def get_aws_account_id(module):
+    return module.client('sts').get_caller_identity()['Account']
+
+
+def get_component(connection, module, arn):
+    """
+    Get an EC2 Image Builder component by ARN. If not found, return None.
+
+    :param connection: AWS boto3 imagebuilder connection
+    :param module: Ansible module
+    :param arn: ARN of Image Builder component to get
+    :return: boto3 Image Builder component dict or None if not found
+    """
+
+    try:
+        return connection.get_component(componentBuildVersionArn=arn)['component']
+    except (BotoCoreError, ClientError) as e:
+        if e.response['Error']['Code'] == 'ResourceNotFoundException':
+            return None
+        else:
+            module.fail_json_aws(e)
+
+
+def has_component_params_changed(params, current_component_params):
+    """
+    Compare components (sans tags). If there is a difference, return True immediately else return False
+
+    :param params: the component params
+    :param current_component_params: the current state of the component params
+    :return: True if any parameter is mismatched else False
+    """
+
+    simple_comparison_keys = ['change_description', 'data',
+                              'description', 'kms_key_id', 'platform', 'semantic_version', 'uri']
+    for k in simple_comparison_keys:
+        if k in params and params[k] != current_component_params[k]:
+            return True
+
+    return False
+
+
+def have_component_tags_changed(params, current_component_params):
+    return 'tags' in params and params['tags'] != current_component_params['tags']
+
+
+def update_component_tags(connection, arn, params, current_component_params):
+    if len(params['tags']) == 0:
+        existing_tag_keys = list(current_component_params['tags'])
+        connection.untag_resource(
+            resourceArn=arn, tagKeys=existing_tag_keys)
+    else:
+        connection.tag_resource(resourceArn=arn, tags=params['tags'])
+
+
+def main():
+
+    argument_spec = (
+        dict(
+            change_description=dict(type='str'),
+            description=dict(type='str'),
+            data=dict(type='str'),
+            kms_key_id=dict(type='str'),
+            name=dict(required=True, type='str'),
+            platform=dict(type='str'),
+            semantic_version=dict(required=True, type='str'),
+            state=dict(required=True, choices=['present', 'absent'], type='str'),
+            tags=dict(type='dict'),
+            uri=dict(type='str')
+        )
+    )
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        required_if=[
+            ('state', 'present', ['platform'])
+        ]
+    )
+
+    connection = module.client('imagebuilder')
+
+    region = get_aws_connection_info(module, boto3=True)[0]
+
+    try:
+        account_id = get_aws_account_id(module)
+    except(BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e)
+
+    arn = construct_component_arn(
+        region, account_id, module.params.get('name'), module.params.get('semantic_version'))
+    component = get_component(connection, module, arn)
+
+    state = module.params.get("state")
+
+    try:
+        if state == 'present':
+            create_or_tag_component(connection, module, arn, component)
+        else:
+            delete_component(connection, module, arn, component)
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_distribution_configuration.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_distribution_configuration.py
@@ -1,0 +1,346 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, Tom Wright (@tomwwright)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: ec2_imagebuilder_distribution_configuration
+short_description: Manage an EC2 Image Builder distribution configuration
+description:
+    - Manage an EC2 Image Builder distribution configuration. See U(https://docs.aws.amazon.com/imagebuilder/latest/userguide/) for information about EC2 Image Builder.
+version_added: "2.10"
+requirements: [ boto3, deepdiff ]
+author: "Tom Wright (@tomwwright)"
+options:
+  description:
+    description: Description of the resource
+    returned: when state is present
+    type: str
+    sample: This is a test distribution configuration
+  distributions:
+    description: List of distributions of the resource. See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/imagebuilder.html#imagebuilder.Client.get_distribution_configuration
+    returned: when state is present
+    type: list
+  name:
+    description: The name of the resource
+    returned: when state is present
+    type: str
+    sample: test_distribution_configuration
+  tags:
+    description: The tags on the resource
+    returned: when state is present
+    type: dict
+    sample: "{ 'key': 'value' }"
+  state:
+    description:
+      - Create or delete the EC2 Image Builder distribution configuration.
+    required: true
+    choices: [ 'present', 'absent' ]
+    type: str
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
+# Create a distribution configuration
+- ec2_imagebuilder_distribution_configuration:
+    name: test_distribution_config
+    description: this is a test distribution configuration
+    distributions:
+      - region: ap-southeast-2
+    tags:
+      test: a
+      test2: a2
+    state: present
+
+
+# Delete a distribution configuration
+- ec2_imagebuilder_distribution_configuration:
+    name: test_distribution_config
+    state: absent
+
+'''
+
+RETURN = '''
+name
+distribution_configuration:
+  description: Distribution configuration details
+  returned: always
+  type: complex
+  contains:
+    arn:
+      description: The ARN of the resource
+      returned: when state is present
+      type: str
+      sample: arn:aws:imagebuilder:ap-southeast-2:111122223333:distribution-configuration/test-distribution-configuration
+    date_created:
+      description: The time and date that this job definition was created.
+      returned: when state is present
+      type: str
+      sample: "2018-04-21T05:19:58.326000+00:00"
+    description:
+      description: Description of the resource
+      returned: when state is present
+      type: str
+      sample: This is a test distribution configuration
+    distributions:
+      description: List of distributions of the resource with snake case keys. See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/imagebuilder.html#imagebuilder.Client.get_distribution_configuration
+      returned: when state is present
+      type: list
+    name:
+      description: The name of the resource
+      returned: when state is present
+      type: str
+      sample: test_distribution_configuration
+    tags:
+      description: The tags on the resource
+      returned: when state is present
+      type: dict
+      sample: "{ 'key': 'value' }"
+'''
+
+from deepdiff import DeepDiff
+import copy
+from ansible.module_utils.ec2 import get_aws_connection_info, camel_dict_to_snake_dict, snake_dict_to_camel_dict
+from ansible.module_utils.aws.core import AnsibleAWSModule
+
+try:
+    import botocore
+except ImportError:
+    pass  # caught by AnsibleAWSModule
+
+
+# Non-ansible imports
+try:
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    pass
+
+
+def _construct_distribution_configuration_arn(region, account_id, name):
+    return "arn:aws:imagebuilder:%s:%s:distribution-configuration/%s" % (
+        region, account_id, name.replace('_', '-'))
+
+
+def _get_distribution_configuration(connection, module, arn):
+    """
+    Get an EC2 Image Builder distribution configuration by ARN. If not found, return None.
+
+    :param connection: AWS boto3 imagebuilder connection
+    :param module: Ansible module
+    :param arn: ARN of Image Builder distribution configuration to get
+    :return: boto3 Image Builder distribution configuration dict or None if not found
+    """
+
+    try:
+        return connection.get_distribution_configuration(distributionConfigurationArn=arn)['distributionConfiguration']
+    except (BotoCoreError, ClientError) as e:
+        if e.response['Error']['Code'] == 'ResourceNotFoundException':
+            return None
+        else:
+            module.fail_json_aws(e)
+
+
+def _compare_distribution_configuration_params(params, current_distribution_configuration_params):
+    """
+    Compare distribution configurations (sans tags). If there is a difference, return True immediately else return False
+
+    :param params: the distribution configuration parameters
+    :param current_distribution_configuration_params: the current state of the distribution configuration params
+    :return: True if any parameter is mismatched else False
+    """
+
+    if 'description' in params and params['description'] != current_distribution_configuration_params['description']:
+        return True
+    if DeepDiff(params['distributions'], current_distribution_configuration_params['distributions'], ignore_order=True) != {}:
+        return True
+
+    return False
+
+
+def _compare_distribution_configuration_tags(params, current_distribution_configuration_params):
+    """
+    Compare state of  tags for distribution configurations. If there is a difference, return True immediately else return False
+
+    :param params: the distribution configuration parameters
+    :param current_distribution_configuration_params: the current state of the distribution configuration params
+    :return: True if tags differ else False
+    """
+    if 'tags' in params and params['tags'] != current_distribution_configuration_params['tags']:
+        return True
+
+    return False
+
+
+def delete_distribution_configuration(connection, module, arn, distribution_configuration):
+    """
+    Delete an EC2 Image Builder distribution configuration if it exists
+
+    :param connection: AWS boto3 imagebuilder connection
+    :param module: Ansible module
+    :param distribution_configuration: a dict of EC2 Image Builder distribution configuration or None
+    :return: True if distribution configuration was deleted else False
+    """
+
+    changed = False
+
+    if distribution_configuration:
+        try:
+            connection.delete_distribution_configuration(
+                distributionConfigurationArn=distribution_configuration['arn'])
+            changed = True
+        except (BotoCoreError, ClientError) as e:
+            module.fail_json_aws(e)
+
+    module.exit_json(changed=changed, distribution_configuration=dict(
+        arn=arn))
+
+
+def construct_update_params_from_create_params(create_params, arn):
+    update_params = {
+        **create_params,
+        'distributionConfigurationArn': arn,
+    }
+    del update_params['name']
+    if 'tags' in update_params:
+        del update_params['tags']
+    return update_params
+
+
+def handle_existing_distribution_configuration(connection, module, arn, params, current_distribution_configuration):
+    """
+    Handle applying necessary updates (if any) to existing EC2 Image Builder distribution configuration
+
+    :param connection: AWS boto3 imagebuilder connection
+    :param module: Ansible module
+    :param arn: ARN of the EC2 Image Builder distribution configuration being managed
+    :param params: provided parameters for desired state of distribution configuration
+    :param current_distribution_configuration: a dict of current EC2 Image Builder distribution configuration state or None
+    :return: True if changes were applied else False
+    """
+    requires_update = _compare_distribution_configuration_params(
+        params, current_distribution_configuration)
+    requires_tagging = _compare_distribution_configuration_tags(
+        params, current_distribution_configuration)
+
+    changed = False
+
+    if requires_update:
+        # updating requires different parameters to creating
+        update_params = construct_update_params_from_create_params(params, arn)
+        connection.update_distribution_configuration(**update_params)
+        changed = True
+    if requires_tagging:
+        if len(params['tags']) == 0:
+            existing_tag_keys = list(current_distribution_configuration['tags'])
+            connection.untag_resource(
+                resourceArn=arn, tagKeys=existing_tag_keys)
+        else:
+            connection.tag_resource(resourceArn=arn, tags=params['tags'])
+        changed = True
+
+    return changed
+
+
+def create_or_update_distribution_configuration(connection, module, arn, current_distribution_configuration):
+    """
+    Create or update an EC2 Image Builder distribution configuration
+
+    :param connection: AWS boto3 imagebuilder connection
+    :param module: Ansible module
+    :param arn: ARN of the EC2 Image Builder distribution configuration being managed
+    :param current_distribution_configuration: a dict of current EC2 Image Builder distribution configuration state or None
+    :return:
+    """
+
+    params = dict()
+    params['name'] = module.params.get('name')
+    if module.params.get("distributions") is not None:
+        params['distributions'] = module.params.get('distributions')
+    if module.params.get("description") is not None:
+        params['description'] = module.params.get("description")
+    if module.params.get("tags") is not None:
+        params['tags'] = module.params.get("tags")
+
+    # ensure params are in camel case to match the AWS API
+    params = snake_dict_to_camel_dict(params)
+
+    changed = False
+
+    # If distribution_configuration is not None then check if it needs to be modified, else create it
+    if current_distribution_configuration:
+        changed = handle_existing_distribution_configuration(
+            connection, module, arn, params, current_distribution_configuration)
+    else:
+        connection.create_distribution_configuration(**params)
+        changed = True
+
+    # If changed, refetch
+    if changed:
+        current_distribution_configuration = _get_distribution_configuration(
+            connection, module, arn)
+
+    module.exit_json(changed=changed, distribution_configuration=camel_dict_to_snake_dict(
+        current_distribution_configuration))
+
+
+def get_aws_account_id(module):
+    return module.client('sts').get_caller_identity()['Account']
+
+
+def main():
+
+    argument_spec = (
+        dict(
+            description=dict(type='str'),
+            distributions=dict(type='list'),
+            name=dict(required=True, type='str'),
+            state=dict(required=True, choices=['present', 'absent'], type='str'),
+            tags=dict(type='dict')
+        )
+    )
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec
+    )
+
+    connection = module.client('imagebuilder')
+
+    region = get_aws_connection_info(module, boto3=True)[0]
+
+    try:
+        account_id = get_aws_account_id(module)
+    except(BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e)
+
+    arn = _construct_distribution_configuration_arn(
+        region, account_id, module.params.get('name'))
+    distribution_configuration = _get_distribution_configuration(
+        connection, module, arn)
+
+    state = module.params.get("state")
+
+    try:
+        if state == 'present':
+            create_or_update_distribution_configuration(
+                connection, module, arn, distribution_configuration)
+        else:
+            delete_distribution_configuration(connection, module, arn, distribution_configuration)
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_distribution_configuration.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_distribution_configuration.py
@@ -16,30 +16,27 @@ DOCUMENTATION = '''
 module: ec2_imagebuilder_distribution_configuration
 short_description: Manage an EC2 Image Builder distribution configuration
 description:
-    - Manage an EC2 Image Builder distribution configuration. See U(https://docs.aws.amazon.com/imagebuilder/latest/userguide/) for information about EC2 Image Builder.
+    - Manage an EC2 Image Builder distribution configuration. \
+      See U(https://docs.aws.amazon.com/imagebuilder/latest/userguide/) for information about EC2 Image Builder.
 version_added: "2.10"
 requirements: [ boto3, deepdiff ]
 author: "Tom Wright (@tomwwright)"
 options:
   description:
     description: Description of the resource
-    returned: when state is present
     type: str
-    sample: This is a test distribution configuration
   distributions:
-    description: List of distributions of the resource. See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/imagebuilder.html#imagebuilder.Client.get_distribution_configuration
-    returned: when state is present
+    description: List of distributions of the resource. \
+      See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/imagebuilder.html#imagebuilder.Client.get_distribution_configuration
     type: list
+    elements: dict
   name:
     description: The name of the resource
-    returned: when state is present
+    required: true
     type: str
-    sample: test_distribution_configuration
   tags:
     description: The tags on the resource
-    returned: when state is present
     type: dict
-    sample: "{ 'key': 'value' }"
   state:
     description:
       - Create or delete the EC2 Image Builder distribution configuration.
@@ -74,7 +71,6 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-name
 distribution_configuration:
   description: Distribution configuration details
   returned: always
@@ -96,9 +92,11 @@ distribution_configuration:
       type: str
       sample: This is a test distribution configuration
     distributions:
-      description: List of distributions of the resource with snake case keys. See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/imagebuilder.html#imagebuilder.Client.get_distribution_configuration
+      description: List of distributions of the resource with snake case keys. \
+        See https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/imagebuilder.html#imagebuilder.Client.get_distribution_configuration
       returned: when state is present
       type: list
+      elements: dict
     name:
       description: The name of the resource
       returned: when state is present
@@ -111,10 +109,14 @@ distribution_configuration:
       sample: "{ 'key': 'value' }"
 '''
 
-from deepdiff import DeepDiff
 import copy
 from ansible.module_utils.ec2 import get_aws_connection_info, camel_dict_to_snake_dict, snake_dict_to_camel_dict
 from ansible.module_utils.aws.core import AnsibleAWSModule
+
+try:
+    from deepdiff import DeepDiff
+except ImportError:
+    pass
 
 try:
     import botocore
@@ -305,7 +307,7 @@ def main():
     argument_spec = (
         dict(
             description=dict(type='str'),
-            distributions=dict(type='list'),
+            distributions=dict(type='list', elements='dict'),
             name=dict(required=True, type='str'),
             state=dict(required=True, choices=['present', 'absent'], type='str'),
             tags=dict(type='dict')

--- a/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_infrastructure_configuration.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_infrastructure_configuration.py
@@ -1,0 +1,393 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, Tom Wright (@tomwwright)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: ec2_imagebuilder_infrastructure_configuration
+short_description: Manage an EC2 Image Builder infrastructure configuration
+description:
+    - Manage an EC2 Image Builder infrastructure configuration. See U(https://docs.aws.amazon.com/imagebuilder/latest/userguide/) for information about EC2 Image Builder.
+version_added: "2.10"
+requirements: [ boto3, deepdiff ]
+author: "Tom Wright (@tomwwright)"
+options:
+  description:
+    type: str
+  instance_profile_name:
+    required: True
+    type: str
+  instance_types:
+    type: list
+  key_pair:
+    type: str
+  logging:
+    type: complex
+  name:
+    required: True
+    type: str
+  security_group_ids:
+    type: list
+  sns_topic_arn:
+    type: str
+  subnet_id:
+    type: str
+  tags:
+    type: dict
+  terminate_instance_on_failure:
+    type: bool
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
+# Create a infrastructure configuration
+- ec2_imagebuilder_infrastructure_configuration:
+    name: test_infrastructure_config
+    description: this is a test infrastructure configuration
+    instance_profile_name: my-instance-profile
+    logging:
+      s3_logs:
+        s3_bucket_name: my-bucket-for-logs
+        s3_key_prefix: logs
+    security_group_ids:
+      - sg-xxxx
+    subnet_id: subnet-xxxx
+    tags:
+      test: a
+      test2: a2
+    terminate_instance_on_failure: false
+    state: present
+
+
+# Delete a infrastructure configuration
+- ec2_imagebuilder_infrastructure_configuration:
+    name: test_infrastructure_config
+    state: absent
+
+'''
+
+RETURN = '''
+name
+infrastructure:
+  description: Infrastructure configuration details in snake case. Refer to https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/imagebuilder.html#imagebuilder.Client.get_distribution_configuration
+  returned: always
+  type: complex
+  contains:
+    arn:
+      description: The ARN of the resource
+      returned: always
+      type: str
+      sample: arn:aws:imagebuilder:ap-southeast-2:111122223333:infrastructure-configuration/test-infrastructure-configuration
+    date_created:
+      returned: when state is present
+      type: str
+    date_updated:
+      returned: when state is present
+      type: str
+    description:
+      returned: when state is present
+      type: str
+    instance_profile_name:
+      returned: when state is present
+      type: str
+    instance_types:
+      returned: when state is present
+      type: list
+    key_pair:
+      returned: when state is present
+      type: str
+    logging:
+      returned: when state is present
+      type: complex
+    name:
+      returned: when state is present
+      type: str
+    security_group_ids:
+      returned: when state is present
+      type: list
+    sns_topic_arn:
+      returned: when state is present
+      type: str
+    subnet_id:
+      returned: when state is present
+      type: str
+    tags:
+      returned: when state is present
+      type: dict
+    terminate_instance_on_failure:
+      returned: when state is present
+      type: bool
+'''
+
+from deepdiff import DeepDiff
+import copy
+from ansible.module_utils.ec2 import get_aws_connection_info, camel_dict_to_snake_dict, snake_dict_to_camel_dict
+from ansible.module_utils.aws.core import AnsibleAWSModule
+
+try:
+    import botocore
+except ImportError:
+    pass  # caught by AnsibleAWSModule
+
+
+# Non-ansible imports
+try:
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    pass
+
+
+def _construct_infrastructure_configuration_arn(region, account_id, name):
+    return "arn:aws:imagebuilder:%s:%s:infrastructure-configuration/%s" % (
+        region, account_id, name.replace('_', '-'))
+
+
+def _get_infrastructure_configuration(connection, module, arn):
+    """
+    Get an EC2 Image Builder infrastructure configuration by ARN. If not found, return None.
+
+    :param connection: AWS boto3 imagebuilder connection
+    :param module: Ansible module
+    :param arn: ARN of Image Builder infrastructure configuration to get
+    :return: boto3 Image Builder infrastructure configuration dict or None if not found
+    """
+
+    try:
+        return connection.get_infrastructure_configuration(infrastructureConfigurationArn=arn)['infrastructureConfiguration']
+    except (BotoCoreError, ClientError) as e:
+        if e.response['Error']['Code'] == 'ResourceNotFoundException':
+            snake_dict_to_camel_dict
+            return None
+        else:
+            module.fail_json_aws(e)
+
+
+def _compare_infrastructure_configuration_params(params, current_infrastructure_configuration_params):
+    """
+    Compare infrastructure configurations (sans tags). If there is a difference, return True immediately else return False
+
+    :param params: the infrastructure configuration parameters
+    :param current_infrastructure_configuration_params: the current state of the infrastructure configuration params
+    :return: True if any parameter is mismatched else False
+    """
+
+    simple_comparison_keys = ['description', 'instanceTypes', 'keyPair', 'logging',
+                              'securityGroupIds', 'snsTopicArn', 'subnetId', 'terminateInstanceOnFailure']
+    for k in simple_comparison_keys:
+        if k in params and params[k] != current_infrastructure_configuration_params[k]:
+            return True
+
+    if 'logging' in params and DeepDiff(params['logging'], current_infrastructure_configuration_params['logging'], ignore_order=True) != {}:
+        return True
+
+    return False
+
+
+def _compare_infrastructure_configuration_tags(params, current_infrastructure_configuration_params):
+    """
+    Compare state of  tags for infrastructure configurations. If there is a difference, return True immediately else return False
+
+    :param params: the infrastructure configuration parameters
+    :param current_infrastructure_configuration_params: the current state of the infrastructure configuration params
+    :return: True if tags differ else False
+    """
+    if 'tags' in params and params['tags'] != current_infrastructure_configuration_params['tags']:
+        return True
+
+    return False
+
+
+def construct_create_params(module):
+    params = dict()
+
+    # required params
+    params['name'] = module.params.get('name')
+    params['instance_profile_name'] = module.params.get('instance_profile_name')
+
+    # optional params
+    optional_params_keys = ['description', 'instance_types', 'key_pair', 'logging',
+                            'security_group_ids', 'sns_topic_arn', 'subnet_id', 'terminate_instance_on_failure', 'tags']
+
+    for k in optional_params_keys:
+        if module.params.get(k) is not None:
+            params[k] = module.params.get(k)
+
+    # ensure params are in camel case for compatibility with EC2 Image Builder API
+    params = snake_dict_to_camel_dict(params)
+
+    return params
+
+
+def construct_update_params_from_create_params(create_params, arn):
+    update_params = {
+        **create_params,
+        'infrastructureConfigurationArn': arn,
+    }
+    del update_params['name']
+    if 'tags' in update_params:
+        del update_params['tags']
+    return update_params
+
+
+def delete_infrastructure_configuration(connection, module, arn, infrastructure_configuration):
+    """
+    Delete an EC2 Image Builder infrastructure configuration if it exists
+
+    :param connection: AWS boto3 imagebuilder connection
+    :param module: Ansible module
+    :param infrastructure_configuration: a dict of EC2 Image Builder infrastructure configuration or None
+    :return: True if infrastructure configuration was deleted else False
+    """
+
+    changed = False
+
+    if infrastructure_configuration:
+        try:
+            connection.delete_infrastructure_configuration(
+                infrastructureConfigurationArn=infrastructure_configuration['arn'])
+            changed = True
+        except (BotoCoreError, ClientError) as e:
+            module.fail_json_aws(e)
+
+    module.exit_json(changed=changed, infrastructure_configuration=dict(
+        arn=arn))
+
+
+def handle_existing_infrastructure_configuration(connection, module, arn, params, current_infrastructure_configuration):
+    """
+    Handle applying necessary updates (if any) to existing EC2 Image Builder infrastructure configuration
+
+    :param connection: AWS boto3 imagebuilder connection
+    :param module: Ansible module
+    :param arn: ARN of the EC2 Image Builder infrastructure configuration being managed
+    :param params: provided parameters for desired state of infrastructure configuration
+    :param current_infrastructure_configuration: a dict of current EC2 Image Builder infrastructure configuration state or None
+    :return: True if changes were applied else False
+    """
+    requires_update = _compare_infrastructure_configuration_params(
+        params, current_infrastructure_configuration)
+    requires_tagging = _compare_infrastructure_configuration_tags(
+        params, current_infrastructure_configuration)
+
+    changed = False
+
+    if requires_update:
+        # updating requires different parameters to creating
+        update_params = construct_update_params_from_create_params(params, arn)
+        connection.update_infrastructure_configuration(**update_params)
+        changed = True
+    if requires_tagging:
+        if len(params['tags']) == 0:
+            existing_tag_keys = list(current_infrastructure_configuration['tags'])
+            connection.untag_resource(
+                resourceArn=arn, tagKeys=existing_tag_keys)
+        else:
+            connection.tag_resource(resourceArn=arn, tags=params['tags'])
+        changed = True
+
+    return changed
+
+
+def create_or_update_infrastructure_configuration(connection, module, arn, current_infrastructure_configuration):
+    """
+    Create or update an EC2 Image Builder infrastructure configuration
+
+    :param connection: AWS boto3 imagebuilder connection
+    :param module: Ansible module
+    :param arn: ARN of the EC2 Image Builder infrastructure configuration being managed
+    :param current_infrastructure_configuration: a dict of current EC2 Image Builder infrastructure configuration state or None
+    :return:
+    """
+
+    params = construct_create_params(module)
+    changed = False
+
+    # If infrastructure_configuration is not None then check if it needs to be modified, else create it
+    if current_infrastructure_configuration:
+        changed = handle_existing_infrastructure_configuration(
+            connection, module, arn, params, current_infrastructure_configuration)
+    else:
+        connection.create_infrastructure_configuration(**params)
+        changed = True
+
+    # If changed, refetch
+    if changed:
+        current_infrastructure_configuration = _get_infrastructure_configuration(
+            connection, module, arn)
+
+    module.exit_json(changed=changed, infrastructure_configuration=camel_dict_to_snake_dict(
+        current_infrastructure_configuration))
+
+
+def get_aws_account_id(module):
+    return module.client('sts').get_caller_identity()['Account']
+
+
+def main():
+
+    argument_spec = (
+        dict(
+            description=dict(type='str'),
+            key_pair=dict(type='str'),
+            instance_profile_name=dict(type='str'),
+            instance_types=dict(type='list'),
+            logging=dict(type='dict'),
+            name=dict(required=True, type='str'),
+            security_group_ids=dict(type='list'),
+            sns_topic_arn=dict(type='str'),
+            subnet_id=dict(type='str'),
+            state=dict(required=True, choices=['present', 'absent'], type='str'),
+            tags=dict(type='dict'),
+            terminate_instance_on_failure=dict(type='bool', default=True)
+        )
+    )
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        required_if=[
+            ('state', 'present', ['instance_profile_name'])
+        ]
+    )
+
+    connection = module.client('imagebuilder')
+
+    region = get_aws_connection_info(module, boto3=True)[0]
+
+    try:
+        account_id = get_aws_account_id(module)
+    except(BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e)
+
+    arn = _construct_infrastructure_configuration_arn(
+        region, account_id, module.params.get('name'))
+    infrastructure_configuration = _get_infrastructure_configuration(
+        connection, module, arn)
+
+    state = module.params.get("state")
+
+    try:
+        if state == 'present':
+            create_or_update_infrastructure_configuration(
+                connection, module, arn, infrastructure_configuration)
+        else:
+            delete_infrastructure_configuration(
+                connection, module, arn, infrastructure_configuration)
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_infrastructure_configuration.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_infrastructure_configuration.py
@@ -16,35 +16,54 @@ DOCUMENTATION = '''
 module: ec2_imagebuilder_infrastructure_configuration
 short_description: Manage an EC2 Image Builder infrastructure configuration
 description:
-    - Manage an EC2 Image Builder infrastructure configuration. See U(https://docs.aws.amazon.com/imagebuilder/latest/userguide/) for information about EC2 Image Builder.
+    - Manage an EC2 Image Builder infrastructure configuration. \
+      See U(https://docs.aws.amazon.com/imagebuilder/latest/userguide/) for information about EC2 Image Builder.
 version_added: "2.10"
 requirements: [ boto3, deepdiff ]
 author: "Tom Wright (@tomwwright)"
 options:
   description:
     type: str
+    description: ''
   instance_profile_name:
-    required: True
     type: str
+    description: ''
   instance_types:
     type: list
+    elements: str
+    description: ''
   key_pair:
     type: str
+    description: ''
   logging:
-    type: complex
+    type: dict
+    description: ''
   name:
     required: True
     type: str
+    description: ''
   security_group_ids:
     type: list
+    elements: str
+    description: ''
   sns_topic_arn:
     type: str
+    description: ''
   subnet_id:
     type: str
+    description: ''
+  state:
+    type: str
+    required: True
+    choices: ['present', 'absent']
+    description: ''
   tags:
     type: dict
+    description: ''
   terminate_instance_on_failure:
     type: bool
+    description: ''
+    default: true
 extends_documentation_fragment:
     - aws
     - ec2
@@ -80,9 +99,9 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-name
 infrastructure:
-  description: Infrastructure configuration details in snake case. Refer to https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/imagebuilder.html#imagebuilder.Client.get_distribution_configuration
+  description: Infrastructure configuration details in snake case. \
+    Refer to https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/imagebuilder.html#imagebuilder.Client.get_distribution_configuration
   returned: always
   type: complex
   contains:
@@ -94,48 +113,67 @@ infrastructure:
     date_created:
       returned: when state is present
       type: str
+      description: ''
     date_updated:
       returned: when state is present
       type: str
+      description: ''
     description:
       returned: when state is present
       type: str
+      description: ''
     instance_profile_name:
       returned: when state is present
       type: str
+      description: ''
     instance_types:
       returned: when state is present
       type: list
+      elements: str
+      description: ''
     key_pair:
       returned: when state is present
       type: str
+      description: ''
     logging:
       returned: when state is present
-      type: complex
+      type: dict
+      description: ''
     name:
       returned: when state is present
       type: str
+      description: ''
     security_group_ids:
       returned: when state is present
       type: list
+      elements: str
+      description: ''
     sns_topic_arn:
       returned: when state is present
       type: str
+      description: ''
     subnet_id:
       returned: when state is present
       type: str
+      description: ''
     tags:
       returned: when state is present
       type: dict
+      description: ''
     terminate_instance_on_failure:
       returned: when state is present
       type: bool
+      description: ''
 '''
 
-from deepdiff import DeepDiff
 import copy
 from ansible.module_utils.ec2 import get_aws_connection_info, camel_dict_to_snake_dict, snake_dict_to_camel_dict
 from ansible.module_utils.aws.core import AnsibleAWSModule
+
+try:
+    from deepdiff import DeepDiff
+except ImportError:
+    pass
 
 try:
     import botocore
@@ -343,10 +381,10 @@ def main():
             description=dict(type='str'),
             key_pair=dict(type='str'),
             instance_profile_name=dict(type='str'),
-            instance_types=dict(type='list'),
+            instance_types=dict(type='list', elements='str'),
             logging=dict(type='dict'),
             name=dict(required=True, type='str'),
-            security_group_ids=dict(type='list'),
+            security_group_ids=dict(type='list', elements='str'),
             sns_topic_arn=dict(type='str'),
             subnet_id=dict(type='str'),
             state=dict(required=True, choices=['present', 'absent'], type='str'),

--- a/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_pipeline.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_pipeline.py
@@ -23,22 +23,37 @@ author: "Tom Wright (@tomwwright)"
 options:
   description:
     type: str
+    description: ''
   distribution_configuration_arn:
     type: str
+    description: ''
   image_recipe_arn:
     type: str
+    description: ''
   image_tests_configuration:
     type: dict
+    description: ''
   infrastructure_configuration_arn:
     type: str
+    description: ''
   name:
     type: str
+    required: true
+    description: ''
   schedule:
     type: dict
+    description: ''
+  state:
+    type: str
+    required: True
+    choices: ['present', 'absent']
+    description: ''
   status:
     type: str
+    description: ''
   tags:
     type: dict
+    description: ''
 extends_documentation_fragment:
     - aws
     - ec2
@@ -71,7 +86,6 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-name
 infrastructure:
   description: pipeline details with keys in snake case. Refer to https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/imagebuilder.html#imagebuilder.Client.get_image_pipeline
   returned: always
@@ -85,42 +99,55 @@ infrastructure:
     date_created:
       returned: when state is present
       type: str
+      description: ''
     date_last_run:
       returned: when state is present
       type: str
+      description: ''
     date_next_run:
       returned: when state is present
       type: str
+      description: ''
     date_updated:
       returned: when state is present
       type: str
+      description: ''
     description:
       returned: when state is present
       type: str
+      description: ''
     distribution_configuration_arn:
       returned: when state is present
       type: str
+      description: ''
     image_recipe_arn:
       returned: when state is present
       type: str
+      description: ''
     image_tests_configuration:
       returned: when state is present
-      type: complex
+      type: dict
+      description: ''
     infrastructure_configuration_arn:
       returned: when state is present
       type: str
+      description: ''
     name:
       returned: when state is present
       type: str
+      description: ''
     schedule:
       returned: when state is present
-      type: complex
+      type: dict
+      description: ''
     status:
       returned: when state is present
       type: str
+      description: ''
     tags:
       returned: when state is present
       type: dict
+      description: ''
 '''
 
 import copy

--- a/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_pipeline.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_pipeline.py
@@ -1,0 +1,375 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, Tom Wright (@tomwwright)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: ec2_imagebuilder_pipeline
+short_description: Manage an EC2 Image Builder pipeline
+description:
+    - Manage an EC2 Image Builder pipeline. See U(https://docs.aws.amazon.com/imagebuilder/latest/userguide/) for information about EC2 Image Builder.
+version_added: "2.10"
+requirements: [ boto3, deepdiff ]
+author: "Tom Wright (@tomwwright)"
+options:
+  description:
+    type: str
+  distribution_configuration_arn:
+    type: str
+  image_recipe_arn:
+    type: str
+  image_tests_configuration:
+    type: dict
+  infrastructure_configuration_arn:
+    type: str
+  name:
+    type: str
+  schedule:
+    type: dict
+  status:
+    type: str
+  tags:
+    type: dict
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
+# Create a pipeline
+- ec2_imagebuilder_pipeline:
+    name: test_pipeline
+    description: this is a test pipeline
+    image_recipe_arn: xxxx
+    infrastructure_recipe_arn: xxxx
+    schedule:
+      schedule_expression: cron(0 12 1 * *)
+      pipeline_execution_start_condition: EXPRESSION_MATCH_ONLY
+    state: present
+    status: ENABLED
+    tags:
+      test: a
+      test2: a2
+
+
+# Delete a pipeline
+- ec2_imagebuilder_pipeline:
+    name: test_pipeline
+    state: absent
+
+'''
+
+RETURN = '''
+name
+infrastructure:
+  description: pipeline details with keys in snake case. Refer to https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/imagebuilder.html#imagebuilder.Client.get_image_pipeline
+  returned: always
+  type: complex
+  contains:
+    arn:
+      description: The ARN of the resource
+      returned: always
+      type: str
+      sample: arn:aws:imagebuilder:ap-southeast-2:111122223333:image-pipeline/test-pipeline
+    date_created:
+      returned: when state is present
+      type: str
+    date_last_run:
+      returned: when state is present
+      type: str
+    date_next_run:
+      returned: when state is present
+      type: str
+    date_updated:
+      returned: when state is present
+      type: str
+    description:
+      returned: when state is present
+      type: str
+    distribution_configuration_arn:
+      returned: when state is present
+      type: str
+    image_recipe_arn:
+      returned: when state is present
+      type: str
+    image_tests_configuration:
+      returned: when state is present
+      type: complex
+    infrastructure_configuration_arn:
+      returned: when state is present
+      type: str
+    name:
+      returned: when state is present
+      type: str
+    schedule:
+      returned: when state is present
+      type: complex
+    status:
+      returned: when state is present
+      type: str
+    tags:
+      returned: when state is present
+      type: dict
+'''
+
+import copy
+from ansible.module_utils.ec2 import get_aws_connection_info, camel_dict_to_snake_dict, snake_dict_to_camel_dict
+from ansible.module_utils.aws.core import AnsibleAWSModule
+
+try:
+    import botocore
+except ImportError:
+    pass  # caught by AnsibleAWSModule
+
+
+# Non-ansible imports
+try:
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    pass
+
+
+def compare_pipeline_params(params, current_pipeline_params):
+    """
+    Compare pipelines (sans tags). If there is a difference, return True immediately else return False
+
+    :param params: the pipeline parameters
+    :param current_pipeline_params: the current state of the pipeline params
+    :return: True if any parameter is mismatched else False
+    """
+
+    simple_comparison_keys = ['description', 'distributionConfigurationArn', 'imageRecipeArn',
+                              'imageTestsConfiguration', 'infrastructureConfigurationArn', 'schedule', 'status']
+    for k in simple_comparison_keys:
+        if k in params and params[k] != current_pipeline_params[k]:
+            return True
+
+    return False
+
+
+def compare_pipeline_tags(params, current_pipeline_params):
+    """
+    Compare state of  tags for pipelines. If there is a difference, return True immediately else return False
+
+    :param params: the pipeline parameters
+    :param current_pipeline_params: the current state of the pipeline params
+    :return: True if tags differ else False
+    """
+    if 'tags' in params and params['tags'] != current_pipeline_params['tags']:
+        return True
+
+    return False
+
+
+def construct_create_params(module):
+    params = dict()
+
+    # required params
+    params['name'] = module.params.get('name')
+    params['image_recipe_arn'] = module.params.get('image_recipe_arn')
+    params['infrastructure_configuration_arn'] = module.params.get(
+        'infrastructure_configuration_arn')
+
+    # optional params
+    optional_params_keys = ['description', 'distribution_configuration_arn',
+                            'image_tests_configuration', 'schedule', 'status', 'tags']
+
+    for k in optional_params_keys:
+        if module.params.get(k) is not None:
+            params[k] = module.params.get(k)
+
+    # ensure params are in camel case for compatibility with EC2 Image Builder API
+    params = snake_dict_to_camel_dict(params)
+
+    return params
+
+
+def construct_pipeline_arn(region, account_id, name):
+    return "arn:aws:imagebuilder:%s:%s:image-pipeline/%s" % (
+        region, account_id, name.replace('_', '-'))
+
+
+def construct_update_params_from_create_params(create_params, arn):
+    update_params = {
+        **create_params,
+        'imagePipelineArn': arn,
+    }
+    del update_params['name']
+    if 'tags' in update_params:
+        del update_params['tags']
+    return update_params
+
+
+def handle_create_or_update_pipeline(connection, module, arn, current_pipeline):
+    """
+    Create or update an EC2 Image Builder pipeline
+
+    :param connection: AWS boto3 imagebuilder connection
+    :param module: Ansible module
+    :param arn: ARN of the EC2 Image Builder pipeline being managed
+    :param current_pipeline: a dict of current EC2 Image Builder pipeline state or None
+    :return:
+    """
+
+    params = construct_create_params(module)
+    changed = False
+
+    # If pipeline is not None then check if it needs to be modified, else create it
+    if current_pipeline:
+        changed = update_pipeline(
+            connection, module, arn, params, current_pipeline)
+    else:
+        connection.create_image_pipeline(**params)
+        changed = True
+
+    # If changed, refetch
+    if changed:
+        current_pipeline = get_pipeline(
+            connection, module, arn)
+
+    module.exit_json(changed=changed, pipeline=camel_dict_to_snake_dict(
+        current_pipeline))
+
+
+def handle_delete_pipeline(connection, module, arn, pipeline):
+    """
+    Delete an EC2 Image Builder pipeline if it exists
+
+    :param connection: AWS boto3 imagebuilder connection
+    :param module: Ansible module
+    :param pipeline: a dict of EC2 Image Builder pipeline or None
+    :return: True if pipeline was deleted else False
+    """
+
+    changed = False
+
+    if pipeline:
+        try:
+            connection.delete_image_pipeline(
+                imagePipelineArn=pipeline['arn'])
+            changed = True
+        except (BotoCoreError, ClientError) as e:
+            module.fail_json_aws(e)
+
+    module.exit_json(changed=changed, pipeline=dict(
+        arn=arn))
+
+
+def get_aws_account_id(module):
+    return module.client('sts').get_caller_identity()['Account']
+
+
+def get_pipeline(connection, module, arn):
+    """
+    Get an EC2 Image Builder pipeline by ARN. If not found, return None.
+
+    :param connection: AWS boto3 imagebuilder connection
+    :param module: Ansible module
+    :param arn: ARN of Image Builder pipeline to get
+    :return: boto3 Image Builder pipeline dict or None if not found
+    """
+
+    try:
+        return connection.get_image_pipeline(imagePipelineArn=arn)['imagePipeline']
+    except (BotoCoreError, ClientError) as e:
+        if e.response['Error']['Code'] == 'ResourceNotFoundException':
+            return None
+        else:
+            module.fail_json_aws(e)
+
+
+def update_pipeline(connection, module, arn, params, current_pipeline):
+    """
+    Handle applying necessary updates (if any) to existing EC2 Image Builder pipeline
+
+    :param connection: AWS boto3 imagebuilder connection
+    :param module: Ansible module
+    :param arn: ARN of the EC2 Image Builder pipeline being managed
+    :param params: provided parameters for desired state of pipeline
+    :param current_pipeline: a dict of current EC2 Image Builder pipeline state or None
+    :return: True if changes were applied else False
+    """
+    requires_update = compare_pipeline_params(
+        params, current_pipeline)
+    requires_tagging = compare_pipeline_tags(
+        params, current_pipeline)
+
+    changed = False
+
+    if requires_update:
+        # updating requires different parameters to creating
+        update_params = construct_update_params_from_create_params(params, arn)
+        connection.update_image_pipeline(**update_params)
+        changed = True
+    if requires_tagging:
+        if len(params['tags']) == 0:
+            existing_tag_keys = list(current_pipeline['tags'])
+            connection.untag_resource(
+                resourceArn=arn, tagKeys=existing_tag_keys)
+        else:
+            connection.tag_resource(resourceArn=arn, tags=params['tags'])
+        changed = True
+
+    return changed
+
+
+def main():
+
+    argument_spec = (
+        dict(
+            description=dict(type='str'),
+            distribution_configuration_arn=dict(type='str'),
+            image_recipe_arn=dict(type='str'),
+            image_tests_configuration=dict(type='dict'),
+            infrastructure_configuration_arn=dict(type='str'),
+            name=dict(required=True, type='str'),
+            schedule=dict(type='dict'),
+            state=dict(required=True, choices=['present', 'absent'], type='str'),
+            status=dict(type='str'),
+            tags=dict(type='dict')
+        )
+    )
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec
+    )
+
+    connection = module.client('imagebuilder')
+
+    region = get_aws_connection_info(module, boto3=True)[0]
+
+    try:
+        account_id = get_aws_account_id(module)
+    except(BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e)
+
+    arn = construct_pipeline_arn(
+        region, account_id, module.params.get('name'))
+    pipeline = get_pipeline(
+        connection, module, arn)
+
+    state = module.params.get("state")
+
+    try:
+        if state == 'present':
+            handle_create_or_update_pipeline(
+                connection, module, arn, pipeline)
+        else:
+            handle_delete_pipeline(connection, module, arn, pipeline)
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_recipe.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_recipe.py
@@ -24,9 +24,11 @@ options:
   block_device_mappings:
     type: list
     description: ''
+    elements: dict
   components:
     type: list
     description: ''
+    elements: dict
   description:
     type: str
     description: ''

--- a/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_recipe.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_recipe.py
@@ -150,9 +150,13 @@ recipe:
 '''
 
 import copy
-from deepdiff import DeepDiff
 from ansible.module_utils.ec2 import get_aws_connection_info, camel_dict_to_snake_dict, snake_dict_to_camel_dict
 from ansible.module_utils.aws.core import AnsibleAWSModule
+
+try:
+    from deepdiff import DeepDiff
+except ImportError:
+    pass
 
 try:
     import botocore

--- a/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_recipe.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_recipe.py
@@ -21,23 +21,34 @@ version_added: "2.10"
 requirements: [ boto3, deepdiff ]
 author: "Tom Wright (@tomwwright)"
 options:
-  arn:
-    description: The ARN of the resource
-    returned: always
-    type: str
   block_device_mappings:
     type: list
+    description: ''
   components:
     type: list
+    description: ''
   description:
     type: str
+    description: ''
   name:
     type: str
     required: true
+    description: ''
+  parent_image:
+    type: str
+    description: ''
   semantic_version:
     type: str
+    required: True
+    description: ''
+  state:
+    type: str
+    required: True
+    choices: ['present', 'absent']
+    description: ''
   tags:
     type: dict
+    description: ''
 extends_documentation_fragment:
     - aws
     - ec2
@@ -77,7 +88,7 @@ EXAMPLES = '''
     state: present
     tags:
       this: isatag
-      this: isanothertag
+      thisis: anothertag
 
 - name: delete a version of a recipe
   ec2_imagebuilder_recipe:
@@ -87,9 +98,9 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-name
 recipe:
-  description: Recipe configuration details. Refer to U(https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/imagebuilder.html#imagebuilder.Client.get_image_recipe)
+  description: Recipe configuration details. \
+    Refer to U(https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/imagebuilder.html#imagebuilder.Client.get_image_recipe)
   returned: always
   type: complex
   contains:
@@ -100,9 +111,13 @@ recipe:
     block_device_mappings:
       returned: when state is present
       type: list
+      elements: dict
+      description: ''
     components:
       returned: when state is present
       type: list
+      elements: dict
+      description: ''
     date_created:
       description: The time and date that this recipe version was created.
       returned: when state is present
@@ -111,22 +126,27 @@ recipe:
     description:
       returned: when state is present
       type: str
+      description: ''
     name:
       returned: when state is present
       type: str
-      required: true
+      description: ''
     owner:
       returned: when state is present
       type: str
+      description: ''
     platform:
       returned: when state is present
       type: str
+      description: ''
     tags:
       returned: when state is present
       type: dict
+      description: ''
     version:
       returned: when state is present
       type: str
+      description: ''
 '''
 
 import copy
@@ -282,8 +302,8 @@ def main():
 
     argument_spec = (
         dict(
-            block_device_mappings=dict(type='dict'),
-            components=dict(type='list'),
+            block_device_mappings=dict(type='list', elements='dict'),
+            components=dict(type='list', elements='dict'),
             description=dict(type='str'),
             name=dict(required=True, type='str'),
             parent_image=dict(type='str'),

--- a/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_recipe.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_imagebuilder_recipe.py
@@ -1,0 +1,325 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, Tom Wright (@tomwwright)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: ec2_imagebuilder_recipe
+short_description: Manage an EC2 Image Builder recipe
+description:
+    - Manage an EC2 Image Builder recipe. See U(https://docs.aws.amazon.com/imagebuilder/latest/userguide/) for information about EC2 Image Builder.
+version_added: "2.10"
+requirements: [ boto3, deepdiff ]
+author: "Tom Wright (@tomwwright)"
+options:
+  arn:
+    description: The ARN of the resource
+    returned: always
+    type: str
+  block_device_mappings:
+    type: list
+  components:
+    type: list
+  description:
+    type: str
+  name:
+    type: str
+    required: true
+  semantic_version:
+    type: str
+  tags:
+    type: dict
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
+- name: create a recipe
+  ec2_imagebuilder_recipe:
+    name: test_recipe
+    components:
+      - component_arn: "arn:aws:xxx"
+    description: "this is a test recipe"
+    parent_image: "arn:aws:imagebuilder:ap-southeast-2:aws:image/xxx/x.x.x"
+    semantic_version: 1.0.0
+    state: present
+    tags:
+      this: isatag
+
+- name: publish a new version of a recipe
+  ec2_imagebuilder_recipe:
+    name: test_recipe
+    components:
+      - component_arn: "arn:aws:xxx"
+    description: "this is a test recipe -- updated!"
+    parent_image: "arn:aws:imagebuilder:ap-southeast-2:aws:image/xxx/x.x.x"
+    semantic_version: 1.0.1
+    state: present
+    tags:
+      this: isatag
+
+- name: update tags for an existing recipe version
+  ec2_imagebuilder_recipe:
+    name: test_recipe
+    semantic_version: 1.0.1
+    state: present
+    tags:
+      this: isatag
+      this: isanothertag
+
+- name: delete a version of a recipe
+  ec2_imagebuilder_recipe:
+    name: test_recipe
+    semantic_version: 1.0.0
+    state: absent
+'''
+
+RETURN = '''
+name
+recipe:
+  description: Recipe configuration details. Refer to U(https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/imagebuilder.html#imagebuilder.Client.get_image_recipe)
+  returned: always
+  type: complex
+  contains:
+    arn:
+      description: The ARN of the resource
+      returned: always
+      type: str
+    block_device_mappings:
+      returned: when state is present
+      type: list
+    components:
+      returned: when state is present
+      type: list
+    date_created:
+      description: The time and date that this recipe version was created.
+      returned: when state is present
+      type: str
+      sample: "2018-04-21T05:19:58.326000+00:00"
+    description:
+      returned: when state is present
+      type: str
+    name:
+      returned: when state is present
+      type: str
+      required: true
+    owner:
+      returned: when state is present
+      type: str
+    platform:
+      returned: when state is present
+      type: str
+    tags:
+      returned: when state is present
+      type: dict
+    version:
+      returned: when state is present
+      type: str
+'''
+
+import copy
+from deepdiff import DeepDiff
+from ansible.module_utils.ec2 import get_aws_connection_info, camel_dict_to_snake_dict, snake_dict_to_camel_dict
+from ansible.module_utils.aws.core import AnsibleAWSModule
+
+try:
+    import botocore
+except ImportError:
+    pass  # caught by AnsibleAWSModule
+
+
+# Non-ansible imports
+try:
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    pass
+
+
+def construct_recipe_arn(region, account_id, name, semantic_version):
+    return "arn:aws:imagebuilder:%s:%s:image-recipe/%s/%s" % (
+        region, account_id, name.replace('_', '-'), semantic_version)
+
+
+def construct_create_params(module):
+    params = dict()
+
+    # required params
+    params['name'] = module.params.get('name')
+    params['semantic_version'] = module.params.get('semantic_version')
+
+    # optional params
+    optional_params_keys = ['block_device_mappings',
+                            'components', 'description', 'parent_image', 'tags']
+
+    for k in optional_params_keys:
+        if module.params.get(k) is not None:
+            params[k] = module.params.get(k)
+
+    # ensure params are in camel case for compatibility with EC2 Image Builder API
+    params = snake_dict_to_camel_dict(params)
+
+    return params
+
+
+def create_or_tag_recipe(connection, module, arn, current_recipe_params):
+    params = construct_create_params(module)
+
+    changed = False
+
+    # attempt to create recipe if it does not exist or its parameters have changed
+    if not current_recipe_params or has_recipe_params_changed(params, current_recipe_params):
+        connection.create_image_recipe(**params)
+        changed = True
+
+    # update tags if recipe exists and tags have changed
+    if current_recipe_params and have_recipe_tags_changed(params, current_recipe_params):
+        update_recipe_tags(connection, arn, params, current_recipe_params)
+        changed = True
+
+    # if a change has been made, refetch
+    if changed:
+        current_recipe_params = get_recipe(connection, module, arn)
+
+    module.exit_json(changed=changed, recipe=camel_dict_to_snake_dict(current_recipe_params))
+
+
+def delete_recipe(connection, module, arn, recipe):
+    """
+    Delete an EC2 Image Builder recipe if it exists
+
+    :param connection: AWS boto3 imagebuilder connection
+    :param module: Ansible module
+    :param recipe: a dict of EC2 Image Builder recipe representing current state of resource, or None
+    :return: True if recipe was deleted else False
+    """
+
+    changed = False
+
+    if recipe:
+        try:
+            connection.delete_image_recipe(
+                imageRecipeArn=arn)
+            changed = True
+        except (BotoCoreError, ClientError) as e:
+            module.fail_json_aws(e)
+
+    module.exit_json(changed=changed, recipe=dict(arn=arn))
+
+
+def get_aws_account_id(module):
+    return module.client('sts').get_caller_identity()['Account']
+
+
+def get_recipe(connection, module, arn):
+    """
+    Get an EC2 Image Builder recipe by ARN. If not found, return None.
+
+    :param connection: AWS boto3 imagebuilder connection
+    :param module: Ansible module
+    :param arn: ARN of Image Builder recipe to get
+    :return: boto3 Image Builder recipe dict or None if not found
+    """
+
+    try:
+        return connection.get_image_recipe(imageRecipeArn=arn)['imageRecipe']
+    except (BotoCoreError, ClientError) as e:
+        if e.response['Error']['Code'] == 'ResourceNotFoundException':
+            return None
+        else:
+            module.fail_json_aws(e)
+
+
+def has_recipe_params_changed(params, current_recipe_params):
+    """
+    Compare recipes (sans tags). If there is a difference, return True immediately else return False
+
+    :param params: the recipe params
+    :param current_recipe_params: the current state of the recipe params
+    :return: True if any parameter is mismatched else False
+    """
+
+    simple_comparison_keys = ['description', 'parent_image']
+
+    for k in simple_comparison_keys:
+        if k in params and params[k] != current_recipe_params[k]:
+            return True
+
+    deepdiff_comparison_keys = ['block_device_mappings', 'components']
+
+    for k in deepdiff_comparison_keys:
+        if k in params and DeepDiff(params[k], current_recipe_params[k], ignore_order=True) != {}:
+            return True
+
+    return False
+
+
+def have_recipe_tags_changed(params, current_recipe_params):
+    return 'tags' in params and params['tags'] != current_recipe_params['tags']
+
+
+def update_recipe_tags(connection, arn, params, current_recipe_params):
+    if len(params['tags']) == 0:
+        existing_tag_keys = list(current_recipe_params['tags'])
+        connection.untag_resource(
+            resourceArn=arn, tagKeys=existing_tag_keys)
+    else:
+        connection.tag_resource(resourceArn=arn, tags=params['tags'])
+
+
+def main():
+
+    argument_spec = (
+        dict(
+            block_device_mappings=dict(type='dict'),
+            components=dict(type='list'),
+            description=dict(type='str'),
+            name=dict(required=True, type='str'),
+            parent_image=dict(type='str'),
+            semantic_version=dict(required=True, type='str'),
+            state=dict(required=True, choices=['present', 'absent'], type='str'),
+            tags=dict(type='dict'),
+        )
+    )
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec
+    )
+
+    connection = module.client('imagebuilder')
+
+    region = get_aws_connection_info(module, boto3=True)[0]
+
+    try:
+        account_id = get_aws_account_id(module)
+    except(BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e)
+
+    arn = construct_recipe_arn(
+        region, account_id, module.params.get('name'), module.params.get('semantic_version'))
+    recipe = get_recipe(connection, module, arn)
+
+    state = module.params.get("state")
+
+    try:
+        if state == 'present':
+            create_or_tag_recipe(connection, module, arn, recipe)
+        else:
+            delete_recipe(connection, module, arn, recipe)
+    except (BotoCoreError, ClientError) as e:
+        module.fail_json_aws(e)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/cloud/amazon/test_ec2_imagebuilder_component.py
+++ b/test/units/modules/cloud/amazon/test_ec2_imagebuilder_component.py
@@ -240,7 +240,7 @@ class TestEC2ImageBuilderComponentModule(ModuleTestCase):
         assert client_mock.return_value.get_component.call_count == 2
         assert client_mock.return_value.create_component.call_count == 0
         assert client_mock.return_value.tag_resource.call_count == 1
-        _, kwargs = client_mock.return_value.tag_resource.call_args
+        args, kwargs = client_mock.return_value.tag_resource.call_args
         assert kwargs['tags'] == updated_test_component['tags']
 
     @patch.object(ec2_imagebuilder_component.AnsibleAWSModule, 'client')
@@ -284,5 +284,5 @@ class TestEC2ImageBuilderComponentModule(ModuleTestCase):
         assert result['component'] == dict(arn=test_component['arn'])
         assert client_mock.return_value.get_component.call_count == 1
         assert client_mock.return_value.delete_component.call_count == 1
-        _, kwargs = client_mock.return_value.delete_component.call_args
+        args, kwargs = client_mock.return_value.delete_component.call_args
         assert kwargs['componentBuildVersionArn'] == test_component['arn']

--- a/test/units/modules/cloud/amazon/test_ec2_imagebuilder_component.py
+++ b/test/units/modules/cloud/amazon/test_ec2_imagebuilder_component.py
@@ -1,0 +1,288 @@
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from units.compat.mock import MagicMock, patch
+from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
+
+from ansible.module_utils.ec2 import snake_dict_to_camel_dict
+from ansible.modules.cloud.amazon import ec2_imagebuilder_component
+
+try:
+    from botocore.exceptions import ClientError
+except ImportError:
+    pass
+
+
+class TestEC2ImageBuilderComponentModule(ModuleTestCase):
+
+    mocked_get_caller_identity = {
+        "UserId": "AROAJxxxxxxxxxxIPWZY:user.id",
+        "Account": "111222333444",
+        "Arn": "arn:aws:sts::111222333444:assumed-role/admin/test.user"
+    }
+
+    def test_required_parameters(self):
+        set_module_args({})
+        with pytest.raises(AnsibleFailJson) as context:
+            ec2_imagebuilder_component.main()
+
+        result = context.value.args[0]
+
+        assert result['failed'] is True
+        assert "name" in result['msg']
+        assert "semantic_version" in result['msg']
+        assert "state" in result['msg']
+
+    @patch.object(ec2_imagebuilder_component.AnsibleAWSModule, 'client')
+    def test_absent_when_not_exists(self, client_mock):
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+
+        client_mock.return_value.get_component.side_effect = ClientError(
+            {'Error': {'Code': 'ResourceNotFoundException'}}, 'GetComponent')
+        set_module_args({
+            'name': 'test_component',
+            'semantic_version': '1.0.0',
+            'state': 'absent'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_component.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is False
+        assert result['component'] is not None
+        assert result['component']['arn'] is not None
+
+    @patch.object(ec2_imagebuilder_component.AnsibleAWSModule, 'client')
+    def test_present_when_not_exists(self, client_mock):
+        test_component = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:component/test-component/1.0.0/1",
+            "name": "test_component",
+            "version": "1.0.0",
+            "description": "this is a test component",
+            "type": "BUILD",
+            "platform": "Linux",
+            "owner": "111222333444",
+            "data": "{'schemaVersion': '1.0', 'phases': [{'name': 'build', 'steps': [{'name': 'RunScript', 'action': 'ExecuteBash', 'timeoutSeconds': 120, 'onFailure': 'Abort', 'maxAttempts': 3, 'inputs': {'commands': [\"echo 'scripty things!'\\n\"]}}]}]}",
+            "encrypted": True,
+            "date_created": "2020-03-04T05:41:55.939Z",
+            "tags": {
+                "this": "isatag"
+            }
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_component.side_effect = [
+            ClientError(
+                {'Error': {'Code': 'ResourceNotFoundException'}}, 'GetComponent'),
+            dict(component=snake_dict_to_camel_dict(test_component))
+        ]
+
+        client_mock.return_value.create_component.return_value = dict(
+            requestId='mock_request_id', clientToken='mock_client_token', componentBuildVersionArn=test_component['arn'])
+
+        set_module_args({
+            **{k: test_component[k] for k in ('name', 'description', 'platform', 'data', 'tags')},
+            'semantic_version': test_component['version'],  # thanks aws
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_component.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is True
+        assert result['component'] is not None
+        assert result['component'] == test_component
+        assert client_mock.return_value.get_component.call_count == 2
+        assert client_mock.return_value.create_component.call_count == 1
+
+    @patch.object(ec2_imagebuilder_component.AnsibleAWSModule, 'client')
+    def test_present_when_exists(self, client_mock):
+        test_component = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:component/test-component/1.0.0/1",
+            "name": "test_component",
+            "version": "1.0.0",
+            "description": "this is a test component",
+            "type": "BUILD",
+            "platform": "Linux",
+            "owner": "111222333444",
+            "data": "{'schemaVersion': '1.0', 'phases': [{'name': 'build', 'steps': [{'name': 'RunScript', 'action': 'ExecuteBash', 'timeoutSeconds': 120, 'onFailure': 'Abort', 'maxAttempts': 3, 'inputs': {'commands': [\"echo 'scripty things!'\\n\"]}}]}]}",
+            "encrypted": True,
+            "date_created": "2020-03-04T05:41:55.939Z",
+            "tags": {
+                "this": "isatag"
+            }
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_component.return_value = dict(
+            component=snake_dict_to_camel_dict(test_component))
+
+        set_module_args({
+            **{k: test_component[k] for k in ('name', 'description', 'platform', 'data', 'tags')},
+            'semantic_version': test_component['version'],  # thanks aws
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_component.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is False
+        assert result['component'] is not None
+        assert result['component'] == test_component
+        assert client_mock.return_value.get_component.call_count == 1
+
+    @patch.object(ec2_imagebuilder_component.AnsibleAWSModule, 'client')
+    def test_present_when_component_different(self, client_mock):
+        test_component = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:component/test-component/1.0.0/1",
+            "name": "test_component",
+            "version": "1.0.0",
+            "description": "this is a test component",
+            "type": "BUILD",
+            "platform": "Linux",
+            "owner": "111222333444",
+            "data": "{'schemaVersion': '1.0', 'phases': [{'name': 'build', 'steps': [{'name': 'RunScript', 'action': 'ExecuteBash', 'timeoutSeconds': 120, 'onFailure': 'Abort', 'maxAttempts': 3, 'inputs': {'commands': [\"echo 'scripty things!'\\n\"]}}]}]}",
+            "encrypted": True,
+            "date_created": "2020-03-04T05:41:55.939Z",
+            "tags": {
+                "this": "isatag"
+            }
+        }
+
+        updated_test_component = {
+            **test_component,
+            'version': "1.0.1",
+            'description': "this is a test component -- updated!"
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_component.side_effect = [
+            dict(
+                component=snake_dict_to_camel_dict(test_component)),
+            dict(
+                component=snake_dict_to_camel_dict(updated_test_component)),
+        ]
+        client_mock.return_value.create_component.return_value = dict(
+            requestId='mock_request_id', clientToken='mock_client_token', componentBuildVersionArn=updated_test_component['arn'])
+
+        set_module_args({
+            **{k: updated_test_component[k] for k in ('name', 'description', 'platform', 'data', 'tags')},
+            'semantic_version': updated_test_component['version'],  # thanks aws
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_component.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is True
+        assert result['component'] is not None
+        assert result['component'] == updated_test_component
+        assert client_mock.return_value.get_component.call_count == 2
+        assert client_mock.return_value.create_component.call_count == 1
+
+    @patch.object(ec2_imagebuilder_component.AnsibleAWSModule, 'client')
+    def test_present_when_tags_different(self, client_mock):
+        test_component = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:component/test-component/1.0.0/1",
+            "name": "test_component",
+            "version": "1.0.0",
+            "description": "this is a test component",
+            "type": "BUILD",
+            "platform": "Linux",
+            "owner": "111222333444",
+            "data": "{'schemaVersion': '1.0', 'phases': [{'name': 'build', 'steps': [{'name': 'RunScript', 'action': 'ExecuteBash', 'timeoutSeconds': 120, 'onFailure': 'Abort', 'maxAttempts': 3, 'inputs': {'commands': [\"echo 'scripty things!'\\n\"]}}]}]}",
+            "encrypted": True,
+            "date_created": "2020-03-04T05:41:55.939Z",
+            "tags": {
+                "this": "isatag"
+            }
+        }
+
+        updated_test_component = {
+            **test_component,
+            'tags': {
+                'thisis': 'adifferenttag'
+            }
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_component.side_effect = [
+            dict(
+                component=snake_dict_to_camel_dict(test_component)),
+            dict(
+                component=snake_dict_to_camel_dict(updated_test_component)),
+        ]
+        client_mock.return_value.create_component.return_value = dict(
+            requestId='mock_request_id', clientToken='mock_client_token', componentBuildVersionArn=updated_test_component['arn'])
+        client_mock.return_value.untag_resource.return_value = {}
+        client_mock.return_value.tag_resource.return_value = {}
+
+        set_module_args({
+            **{k: updated_test_component[k] for k in ('name', 'description', 'platform', 'data', 'tags')},
+            'semantic_version': updated_test_component['version'],  # thanks aws
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_component.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is True
+        assert result['component'] is not None
+        assert result['component'] == updated_test_component
+        assert client_mock.return_value.get_component.call_count == 2
+        assert client_mock.return_value.create_component.call_count == 0
+        assert client_mock.return_value.tag_resource.call_count == 1
+        _, kwargs = client_mock.return_value.tag_resource.call_args
+        assert kwargs['tags'] == updated_test_component['tags']
+
+    @patch.object(ec2_imagebuilder_component.AnsibleAWSModule, 'client')
+    def test_absent_when_exists(self, client_mock):
+        test_component = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:component/test-component/1.0.0/1",
+            "name": "test_component",
+            "version": "1.0.0",
+            "description": "this is a test component",
+            "type": "BUILD",
+            "platform": "Linux",
+            "owner": "111222333444",
+            "data": "{'schemaVersion': '1.0', 'phases': [{'name': 'build', 'steps': [{'name': 'RunScript', 'action': 'ExecuteBash', 'timeoutSeconds': 120, 'onFailure': 'Abort', 'maxAttempts': 3, 'inputs': {'commands': [\"echo 'scripty things!'\\n\"]}}]}]}",
+            "encrypted": True,
+            "date_created": "2020-03-04T05:41:55.939Z",
+            "tags": {
+                "this": "isatag"
+            }
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_component.side_effect = [
+            dict(
+                component=snake_dict_to_camel_dict(test_component)),
+        ]
+        client_mock.return_value.delete_component.return_value = dict(
+            requestId='mock_request_id', componentBuildVersionArn=test_component['arn'])
+
+        set_module_args({
+            'name': test_component['name'],
+            'semantic_version': test_component['version'],  # thanks aws
+            'state': 'absent'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_component.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is True
+        assert result['component'] is not None
+        assert result['component'] == dict(arn=test_component['arn'])
+        assert client_mock.return_value.get_component.call_count == 1
+        assert client_mock.return_value.delete_component.call_count == 1
+        _, kwargs = client_mock.return_value.delete_component.call_args
+        assert kwargs['componentBuildVersionArn'] == test_component['arn']

--- a/test/units/modules/cloud/amazon/test_ec2_imagebuilder_distribution_configuration.py
+++ b/test/units/modules/cloud/amazon/test_ec2_imagebuilder_distribution_configuration.py
@@ -255,7 +255,7 @@ class TestEC2ImageBuilderDistributionConfigurationModule(ModuleTestCase):
         assert client_mock.return_value.get_distribution_configuration.call_count == 2
         assert client_mock.return_value.update_distribution_configuration.call_count == 0
         assert client_mock.return_value.tag_resource.call_count == 1
-        _, kwargs = client_mock.return_value.tag_resource.call_args
+        args, kwargs = client_mock.return_value.tag_resource.call_args
         assert kwargs['tags'] == updated_test_distribution_configuration['tags']
 
     @patch.object(ec2_imagebuilder_distribution_configuration.AnsibleAWSModule, 'client')
@@ -300,5 +300,5 @@ class TestEC2ImageBuilderDistributionConfigurationModule(ModuleTestCase):
             arn=test_distribution_configuration['arn'])
         assert client_mock.return_value.get_distribution_configuration.call_count == 1
         assert client_mock.return_value.delete_distribution_configuration.call_count == 1
-        _, kwargs = client_mock.return_value.delete_distribution_configuration.call_args
+        args, kwargs = client_mock.return_value.delete_distribution_configuration.call_args
         assert kwargs['distributionConfigurationArn'] == test_distribution_configuration['arn']

--- a/test/units/modules/cloud/amazon/test_ec2_imagebuilder_distribution_configuration.py
+++ b/test/units/modules/cloud/amazon/test_ec2_imagebuilder_distribution_configuration.py
@@ -1,0 +1,304 @@
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from units.compat.mock import MagicMock, patch
+from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
+
+from ansible.module_utils.ec2 import snake_dict_to_camel_dict
+from ansible.modules.cloud.amazon import ec2_imagebuilder_distribution_configuration
+
+try:
+    from botocore.exceptions import ClientError
+except ImportError:
+    pass
+
+
+class TestEC2ImageBuilderDistributionConfigurationModule(ModuleTestCase):
+
+    mocked_get_caller_identity = {
+        "UserId": "AROAJxxxxxxxxxxIPWZY:user.id",
+        "Account": "111222333444",
+        "Arn": "arn:aws:sts::111222333444:assumed-role/admin/test.user"
+    }
+
+    def test_required_parameters(self):
+        set_module_args({})
+        with pytest.raises(AnsibleFailJson) as context:
+            ec2_imagebuilder_distribution_configuration.main()
+
+        result = context.value.args[0]
+
+        assert result['failed'] is True
+        assert "name" in result['msg']
+        assert "state" in result['msg']
+
+    @patch.object(ec2_imagebuilder_distribution_configuration.AnsibleAWSModule, 'client')
+    def test_absent_when_not_exists(self, client_mock):
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+
+        client_mock.return_value.get_distribution_configuration.side_effect = ClientError(
+            {'Error': {'Code': 'ResourceNotFoundException'}}, 'GetDistributionConfiguration')
+        set_module_args({
+            'name': 'test_distribution_configuration',
+            'state': 'absent'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_distribution_configuration.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is False
+        assert result['distribution_configuration'] is not None
+        assert result['distribution_configuration']['arn'] is not None
+
+    @patch.object(ec2_imagebuilder_distribution_configuration.AnsibleAWSModule, 'client')
+    def test_present_when_not_exists(self, client_mock):
+        test_distribution_configuration = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:distribution-configuration/test-distribution-configuration",
+            "name": "test_distribution_configuration",
+            "description": "this is a test distribution configuration",
+            "distributions": [
+                {
+                    "region": "ap-southeast-2",
+                    "ami_distribution_configuration": {
+                        "name": "amazon_linux_ansible {{imagebuilder:buildDate}}"
+                    }
+                }
+            ],
+            "date_created": "2020-02-28T04:20:16.710Z",
+            "tags": {
+                "this": "isatag"
+            }
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_distribution_configuration.side_effect = [
+            ClientError(
+                {'Error': {'Code': 'ResourceNotFoundException'}}, 'GetDistributionConfiguration'),
+            dict(distributionConfiguration=snake_dict_to_camel_dict(test_distribution_configuration))
+        ]
+
+        client_mock.return_value.create_distribution_configuration.return_value = dict(
+            requestId='mock_request_id', clientToken='mock_client_token', distributionConfigurationArn=test_distribution_configuration['arn'])
+
+        set_module_args({
+            **{k: test_distribution_configuration[k] for k in ('name', 'description', 'distributions', 'tags')},
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_distribution_configuration.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is True
+        assert result['distribution_configuration'] is not None
+        assert result['distribution_configuration'] == test_distribution_configuration
+        assert client_mock.return_value.get_distribution_configuration.call_count == 2
+        assert client_mock.return_value.create_distribution_configuration.call_count == 1
+
+    @patch.object(ec2_imagebuilder_distribution_configuration.AnsibleAWSModule, 'client')
+    def test_present_when_exists(self, client_mock):
+        test_distribution_configuration = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:distribution-configuration/test-distribution-configuration",
+            "name": "test_distribution_configuration",
+            "description": "this is a test distribution configuration",
+            "distributions": [
+                {
+                    "region": "ap-southeast-2",
+                    "ami_distribution_configuration": {
+                        "name": "amazon_linux_ansible {{imagebuilder:buildDate}}"
+                    }
+                }
+            ],
+            "date_created": "2020-02-28T04:20:16.710Z",
+            "tags": {
+                "this": "isatag"
+            }
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_distribution_configuration.side_effect = [
+            dict(distributionConfiguration=snake_dict_to_camel_dict(test_distribution_configuration))
+        ]
+
+        set_module_args({
+            **{k: test_distribution_configuration[k] for k in ('name', 'description', 'distributions', 'tags')},
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_distribution_configuration.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is False
+        assert result['distribution_configuration'] is not None
+        assert result['distribution_configuration'] == test_distribution_configuration
+        assert client_mock.return_value.get_distribution_configuration.call_count == 1
+        assert client_mock.return_value.create_distribution_configuration.call_count == 0
+
+    @patch.object(ec2_imagebuilder_distribution_configuration.AnsibleAWSModule, 'client')
+    def test_present_when_distribution_configuration_different(self, client_mock):
+        test_distribution_configuration = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:distribution-configuration/test-distribution-configuration",
+            "name": "test_distribution_configuration",
+            "description": "this is a test distribution configuration",
+            "distributions": [
+                {
+                    "region": "ap-southeast-2",
+                    "ami_distribution_configuration": {
+                        "name": "amazon_linux_ansible {{imagebuilder:buildDate}}"
+                    }
+                }
+            ],
+            "date_created": "2020-02-28T04:20:16.710Z",
+            "tags": {
+                "this": "isatag"
+            }
+        }
+
+        updated_test_distribution_configuration = {
+            **test_distribution_configuration,
+            "distributions": [
+                {
+                    "region": "ap-southeast-2",
+                    "ami_distribution_configuration": {
+                        "name": "amazon_linux_ansible {{imagebuilder:buildDate}}"
+                    }
+                },
+                {
+                    "region": "us-east-1",
+                    "ami_distribution_configuration": {
+                        "name": "amazon_linux_ansible {{imagebuilder:buildDate}}"
+                    }
+                }
+            ],
+            'description': "this is a test distribution configuration -- updated!"
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_distribution_configuration.side_effect = [
+            dict(distributionConfiguration=snake_dict_to_camel_dict(test_distribution_configuration)),
+            dict(distributionConfiguration=snake_dict_to_camel_dict(
+                updated_test_distribution_configuration))
+        ]
+
+        client_mock.return_value.update_distribution_configuration.return_value = dict(
+            requestId='mock_request_id', clientToken='mock_client_token', distributionConfigurationArn=updated_test_distribution_configuration['arn'])
+
+        set_module_args({
+            **{k: updated_test_distribution_configuration[k] for k in ('name', 'description', 'distributions', 'tags')},
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_distribution_configuration.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is True
+        assert result['distribution_configuration'] is not None
+        assert result['distribution_configuration'] == updated_test_distribution_configuration
+        assert client_mock.return_value.get_distribution_configuration.call_count == 2
+        assert client_mock.return_value.update_distribution_configuration.call_count == 1
+
+    @patch.object(ec2_imagebuilder_distribution_configuration.AnsibleAWSModule, 'client')
+    def test_present_when_tags_different(self, client_mock):
+        test_distribution_configuration = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:distribution-configuration/test-distribution-configuration",
+            "name": "test_distribution_configuration",
+            "description": "this is a test distribution configuration",
+            "distributions": [
+                {
+                    "region": "ap-southeast-2",
+                    "ami_distribution_configuration": {
+                        "name": "amazon_linux_ansible {{imagebuilder:buildDate}}"
+                    }
+                }
+            ],
+            "date_created": "2020-02-28T04:20:16.710Z",
+            "tags": {
+                "this": "isatag"
+            }
+        }
+
+        updated_test_distribution_configuration = {
+            **test_distribution_configuration,
+            "tags": {
+                "thisis": "adifferenttag"
+            }
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_distribution_configuration.side_effect = [
+            dict(distributionConfiguration=snake_dict_to_camel_dict(test_distribution_configuration)),
+            dict(distributionConfiguration=snake_dict_to_camel_dict(
+                updated_test_distribution_configuration))
+        ]
+
+        client_mock.return_value.update_distribution_configuration.return_value = dict(
+            requestId='mock_request_id', clientToken='mock_client_token', distributionConfigurationArn=updated_test_distribution_configuration['arn'])
+
+        set_module_args({
+            **{k: updated_test_distribution_configuration[k] for k in ('name', 'description', 'distributions', 'tags')},
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_distribution_configuration.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is True
+        assert result['distribution_configuration'] is not None
+        assert result['distribution_configuration'] == updated_test_distribution_configuration
+        assert client_mock.return_value.get_distribution_configuration.call_count == 2
+        assert client_mock.return_value.update_distribution_configuration.call_count == 0
+        assert client_mock.return_value.tag_resource.call_count == 1
+        _, kwargs = client_mock.return_value.tag_resource.call_args
+        assert kwargs['tags'] == updated_test_distribution_configuration['tags']
+
+    @patch.object(ec2_imagebuilder_distribution_configuration.AnsibleAWSModule, 'client')
+    def test_absent_when_exists(self, client_mock):
+        test_distribution_configuration = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:distribution-configuration/test-distribution-configuration",
+            "name": "test_distribution_configuration",
+            "description": "this is a test distribution configuration",
+            "distributions": [
+                {
+                    "region": "ap-southeast-2",
+                    "ami_distribution_configuration": {
+                        "name": "amazon_linux_ansible {{imagebuilder:buildDate}}"
+                    }
+                }
+            ],
+            "date_created": "2020-02-28T04:20:16.710Z",
+            "tags": {
+                "this": "isatag"
+            }
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_distribution_configuration.side_effect = [
+            dict(distributionConfiguration=snake_dict_to_camel_dict(test_distribution_configuration))
+        ]
+        client_mock.return_value.delete_distribution_configuration.return_value = dict(
+            requestId='mock_request_id', distributionConfigurationArn=test_distribution_configuration['arn'])
+
+        set_module_args({
+            'name': test_distribution_configuration['name'],
+            'state': 'absent'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_distribution_configuration.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is True
+        assert result['distribution_configuration'] is not None
+        assert result['distribution_configuration'] == dict(
+            arn=test_distribution_configuration['arn'])
+        assert client_mock.return_value.get_distribution_configuration.call_count == 1
+        assert client_mock.return_value.delete_distribution_configuration.call_count == 1
+        _, kwargs = client_mock.return_value.delete_distribution_configuration.call_args
+        assert kwargs['distributionConfigurationArn'] == test_distribution_configuration['arn']

--- a/test/units/modules/cloud/amazon/test_ec2_imagebuilder_infrastructure_configuration.py
+++ b/test/units/modules/cloud/amazon/test_ec2_imagebuilder_infrastructure_configuration.py
@@ -1,0 +1,309 @@
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from units.compat.mock import MagicMock, patch
+from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
+
+from ansible.module_utils.ec2 import snake_dict_to_camel_dict
+from ansible.modules.cloud.amazon import ec2_imagebuilder_infrastructure_configuration
+
+try:
+    from botocore.exceptions import ClientError
+except ImportError:
+    pass
+
+
+class TestEC2ImageBuilderInfrastructureConfigurationModule(ModuleTestCase):
+
+    mocked_get_caller_identity = {
+        "UserId": "AROAJxxxxxxxxxxIPWZY:user.id",
+        "Account": "111222333444",
+        "Arn": "arn:aws:sts::111222333444:assumed-role/admin/test.user"
+    }
+
+    def test_required_parameters(self):
+        set_module_args({})
+        with pytest.raises(AnsibleFailJson) as context:
+            ec2_imagebuilder_infrastructure_configuration.main()
+
+        result = context.value.args[0]
+
+        assert result['failed'] is True
+        assert "name" in result['msg']
+        assert "state" in result['msg']
+
+    @patch.object(ec2_imagebuilder_infrastructure_configuration.AnsibleAWSModule, 'client')
+    def test_absent_when_not_exists(self, client_mock):
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+
+        client_mock.return_value.get_infrastructure_configuration.side_effect = ClientError(
+            {'Error': {'Code': 'ResourceNotFoundException'}}, 'GetInfrastructureConfiguration')
+        set_module_args({
+            'name': 'test_infrastructure_configuration',
+            'state': 'absent'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_infrastructure_configuration.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is False
+        assert result['infrastructure_configuration'] is not None
+        assert result['infrastructure_configuration']['arn'] is not None
+
+    @patch.object(ec2_imagebuilder_infrastructure_configuration.AnsibleAWSModule, 'client')
+    def test_present_when_not_exists(self, client_mock):
+        test_infrastructure_configuration = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:infrastructure-configuration/test-infrastructure-configuration",
+            "name": "test_infrastructure_configuration",
+            "description": "this is a test infrastructure configuration",
+            "instance_profile_name": "test_instance_profile",
+            "key_pair": "test_key_pair",
+            "security_group_ids": [
+                "sg-xxxx",
+                "sg-yyyy"
+            ],
+            "subnet_id": "subnet-xxxx",
+            "terminate_instance_on_failure": True,
+            "date_created": "2020-03-03T00:44:15.092Z",
+            "date_updated": "2020-03-03T01:04:05.200Z",
+            "tags": {
+                "key": "value",
+                "another": "tag"
+            }
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_infrastructure_configuration.side_effect = [
+            ClientError(
+                {'Error': {'Code': 'ResourceNotFoundException'}}, 'GetInfrastructureConfiguration'),
+            dict(infrastructureConfiguration=snake_dict_to_camel_dict(
+                test_infrastructure_configuration))
+        ]
+
+        client_mock.return_value.create_infrastructure_configuration.return_value = dict(
+            requestId='mock_request_id', clientToken='mock_client_token', infrastructureConfigurationArn=test_infrastructure_configuration['arn'])
+
+        set_module_args({
+            **{k: test_infrastructure_configuration[k] for k in ('name', 'description', 'instance_profile_name', 'key_pair', 'security_group_ids', 'subnet_id', 'terminate_instance_on_failure', 'tags')},
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_infrastructure_configuration.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is True
+        assert result['infrastructure_configuration'] is not None
+        assert result['infrastructure_configuration'] == test_infrastructure_configuration
+        assert client_mock.return_value.get_infrastructure_configuration.call_count == 2
+        assert client_mock.return_value.create_infrastructure_configuration.call_count == 1
+
+    @patch.object(ec2_imagebuilder_infrastructure_configuration.AnsibleAWSModule, 'client')
+    def test_present_when_exists(self, client_mock):
+        test_infrastructure_configuration = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:infrastructure-configuration/test-infrastructure-configuration",
+            "name": "test_infrastructure_configuration",
+            "description": "this is a test infrastructure configuration",
+            "instance_profile_name": "test_instance_profile",
+            "key_pair": "test_key_pair",
+            "security_group_ids": [
+                "sg-xxxx",
+                "sg-yyyy"
+            ],
+            "subnet_id": "subnet-xxxx",
+            "terminate_instance_on_failure": True,
+            "date_created": "2020-03-03T00:44:15.092Z",
+            "date_updated": "2020-03-03T01:04:05.200Z",
+            "tags": {
+                "key": "value",
+                "another": "tag"
+            }
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_infrastructure_configuration.side_effect = [
+            dict(infrastructureConfiguration=snake_dict_to_camel_dict(
+                test_infrastructure_configuration))
+        ]
+
+        set_module_args({
+            **{k: test_infrastructure_configuration[k] for k in ('name', 'description', 'instance_profile_name', 'key_pair', 'security_group_ids', 'subnet_id', 'terminate_instance_on_failure', 'tags')},
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_infrastructure_configuration.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is False
+        assert result['infrastructure_configuration'] is not None
+        assert result['infrastructure_configuration'] == test_infrastructure_configuration
+        assert client_mock.return_value.get_infrastructure_configuration.call_count == 1
+        assert client_mock.return_value.create_infrastructure_configuration.call_count == 0
+
+    @patch.object(ec2_imagebuilder_infrastructure_configuration.AnsibleAWSModule, 'client')
+    def test_present_when_infrastructure_configuration_different(self, client_mock):
+        test_infrastructure_configuration = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:infrastructure-configuration/test-infrastructure-configuration",
+            "name": "test_infrastructure_configuration",
+            "description": "this is a test infrastructure configuration",
+            "instance_profile_name": "test_instance_profile",
+            "key_pair": "test_key_pair",
+            "security_group_ids": [
+                "sg-xxxx",
+                "sg-yyyy"
+            ],
+            "subnet_id": "subnet-xxxx",
+            "terminate_instance_on_failure": True,
+            "date_created": "2020-03-03T00:44:15.092Z",
+            "date_updated": "2020-03-03T01:04:05.200Z",
+            "tags": {
+                "key": "value",
+                "another": "tag"
+            }
+        }
+
+        updated_test_infrastructure_configuration = {
+            **test_infrastructure_configuration,
+            'description': "this is a test infrastructure configuration -- updated!",
+            "security_group_ids": [
+                "sg-xxxx"
+            ],
+            "terminate_instance_on_failure": False
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_infrastructure_configuration.side_effect = [
+            dict(infrastructureConfiguration=snake_dict_to_camel_dict(
+                test_infrastructure_configuration)),
+            dict(infrastructureConfiguration=snake_dict_to_camel_dict(
+                updated_test_infrastructure_configuration))
+        ]
+
+        client_mock.return_value.update_infrastructure_configuration.return_value = dict(
+            requestId='mock_request_id', clientToken='mock_client_token', infrastructureConfigurationArn=updated_test_infrastructure_configuration['arn'])
+
+        set_module_args({
+            **{k: updated_test_infrastructure_configuration[k] for k in ('name', 'description', 'instance_profile_name', 'key_pair', 'security_group_ids', 'subnet_id', 'terminate_instance_on_failure', 'tags')},
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_infrastructure_configuration.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is True
+        assert result['infrastructure_configuration'] is not None
+        assert result['infrastructure_configuration'] == updated_test_infrastructure_configuration
+        assert client_mock.return_value.get_infrastructure_configuration.call_count == 2
+        assert client_mock.return_value.update_infrastructure_configuration.call_count == 1
+
+    @patch.object(ec2_imagebuilder_infrastructure_configuration.AnsibleAWSModule, 'client')
+    def test_present_when_tags_different(self, client_mock):
+        test_infrastructure_configuration = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:infrastructure-configuration/test-infrastructure-configuration",
+            "name": "test_infrastructure_configuration",
+            "description": "this is a test infrastructure configuration",
+            "instance_profile_name": "test_instance_profile",
+            "key_pair": "test_key_pair",
+            "security_group_ids": [
+                "sg-xxxx",
+                "sg-yyyy"
+            ],
+            "subnet_id": "subnet-xxxx",
+            "terminate_instance_on_failure": True,
+            "date_created": "2020-03-03T00:44:15.092Z",
+            "date_updated": "2020-03-03T01:04:05.200Z",
+            "tags": {
+                "key": "value",
+                "another": "tag"
+            }
+        }
+
+        updated_test_infrastructure_configuration = {
+            **test_infrastructure_configuration,
+            "tags": {
+                "thisis": "adifferenttag"
+            }
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_infrastructure_configuration.side_effect = [
+            dict(infrastructureConfiguration=snake_dict_to_camel_dict(
+                test_infrastructure_configuration)),
+            dict(infrastructureConfiguration=snake_dict_to_camel_dict(
+                updated_test_infrastructure_configuration))
+        ]
+
+        client_mock.return_value.update_infrastructure_configuration.return_value = dict(
+            requestId='mock_request_id', clientToken='mock_client_token', infrastructureConfigurationArn=updated_test_infrastructure_configuration['arn'])
+
+        set_module_args({
+            **{k: updated_test_infrastructure_configuration[k] for k in ('name', 'description', 'instance_profile_name', 'key_pair', 'security_group_ids', 'subnet_id', 'terminate_instance_on_failure', 'tags')},
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_infrastructure_configuration.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is True
+        assert result['infrastructure_configuration'] is not None
+        assert result['infrastructure_configuration'] == updated_test_infrastructure_configuration
+        assert client_mock.return_value.get_infrastructure_configuration.call_count == 2
+        assert client_mock.return_value.update_infrastructure_configuration.call_count == 0
+        assert client_mock.return_value.tag_resource.call_count == 1
+        _, kwargs = client_mock.return_value.tag_resource.call_args
+        assert kwargs['tags'] == updated_test_infrastructure_configuration['tags']
+
+    @patch.object(ec2_imagebuilder_infrastructure_configuration.AnsibleAWSModule, 'client')
+    def test_absent_when_exists(self, client_mock):
+        test_infrastructure_configuration = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:infrastructure-configuration/test-infrastructure-configuration",
+            "name": "test_infrastructure_configuration",
+            "description": "this is a test infrastructure configuration",
+            "instance_profile_name": "test_instance_profile",
+            "key_pair": "test_key_pair",
+            "security_group_ids": [
+                "sg-xxxx",
+                "sg-yyyy"
+            ],
+            "subnet_id": "subnet-xxxx",
+            "terminate_instance_on_failure": True,
+            "date_created": "2020-03-03T00:44:15.092Z",
+            "date_updated": "2020-03-03T01:04:05.200Z",
+            "tags": {
+                "key": "value",
+                "another": "tag"
+            }
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_infrastructure_configuration.side_effect = [
+            dict(infrastructureConfiguration=snake_dict_to_camel_dict(
+                test_infrastructure_configuration))
+        ]
+        client_mock.return_value.delete_infrastructure_configuration.return_value = dict(
+            requestId='mock_request_id', infrastructureConfigurationArn=test_infrastructure_configuration['arn'])
+
+        set_module_args({
+            'name': test_infrastructure_configuration['name'],
+            'state': 'absent'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_infrastructure_configuration.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is True
+        assert result['infrastructure_configuration'] is not None
+        assert result['infrastructure_configuration'] == dict(
+            arn=test_infrastructure_configuration['arn'])
+        assert client_mock.return_value.get_infrastructure_configuration.call_count == 1
+        assert client_mock.return_value.delete_infrastructure_configuration.call_count == 1
+        _, kwargs = client_mock.return_value.delete_infrastructure_configuration.call_args
+        assert kwargs['infrastructureConfigurationArn'] == test_infrastructure_configuration['arn']

--- a/test/units/modules/cloud/amazon/test_ec2_imagebuilder_infrastructure_configuration.py
+++ b/test/units/modules/cloud/amazon/test_ec2_imagebuilder_infrastructure_configuration.py
@@ -257,7 +257,7 @@ class TestEC2ImageBuilderInfrastructureConfigurationModule(ModuleTestCase):
         assert client_mock.return_value.get_infrastructure_configuration.call_count == 2
         assert client_mock.return_value.update_infrastructure_configuration.call_count == 0
         assert client_mock.return_value.tag_resource.call_count == 1
-        _, kwargs = client_mock.return_value.tag_resource.call_args
+        args, kwargs = client_mock.return_value.tag_resource.call_args
         assert kwargs['tags'] == updated_test_infrastructure_configuration['tags']
 
     @patch.object(ec2_imagebuilder_infrastructure_configuration.AnsibleAWSModule, 'client')
@@ -305,5 +305,5 @@ class TestEC2ImageBuilderInfrastructureConfigurationModule(ModuleTestCase):
             arn=test_infrastructure_configuration['arn'])
         assert client_mock.return_value.get_infrastructure_configuration.call_count == 1
         assert client_mock.return_value.delete_infrastructure_configuration.call_count == 1
-        _, kwargs = client_mock.return_value.delete_infrastructure_configuration.call_args
+        args, kwargs = client_mock.return_value.delete_infrastructure_configuration.call_args
         assert kwargs['infrastructureConfigurationArn'] == test_infrastructure_configuration['arn']

--- a/test/units/modules/cloud/amazon/test_ec2_imagebuilder_pipeline.py
+++ b/test/units/modules/cloud/amazon/test_ec2_imagebuilder_pipeline.py
@@ -1,0 +1,315 @@
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from units.compat.mock import MagicMock, patch
+from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
+
+from ansible.module_utils.ec2 import snake_dict_to_camel_dict
+from ansible.modules.cloud.amazon import ec2_imagebuilder_pipeline
+
+try:
+    from botocore.exceptions import ClientError
+except ImportError:
+    pass
+
+
+class TestEC2ImageBuilderPipelineModule(ModuleTestCase):
+
+    mocked_get_caller_identity = {
+        "UserId": "AROAJxxxxxxxxxxIPWZY:user.id",
+        "Account": "111222333444",
+        "Arn": "arn:aws:sts::111222333444:assumed-role/admin/test.user"
+    }
+
+    def test_required_parameters(self):
+        set_module_args({})
+        with pytest.raises(AnsibleFailJson) as context:
+            ec2_imagebuilder_pipeline.main()
+
+        result = context.value.args[0]
+
+        assert result['failed'] is True
+        assert "name" in result['msg']
+        assert "state" in result['msg']
+
+    @patch.object(ec2_imagebuilder_pipeline.AnsibleAWSModule, 'client')
+    def test_absent_when_not_exists(self, client_mock):
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+
+        client_mock.return_value.get_image_pipeline.side_effect = ClientError(
+            {'Error': {'Code': 'ResourceNotFoundException'}}, 'GetImagePipeline')
+        set_module_args({
+            'name': 'test_pipeline',
+            'state': 'absent'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_pipeline.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is False
+        assert result['pipeline'] is not None
+        assert result['pipeline']['arn'] is not None
+
+    @patch.object(ec2_imagebuilder_pipeline.AnsibleAWSModule, 'client')
+    def test_present_when_not_exists(self, client_mock):
+        test_pipeline = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:image-pipeline/test-pipeline",
+            "name": "test_pipeline",
+            "description": "this is a test pipeline",
+            "platform": "Linux",
+            "image_recipe_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:image-recipe/test-recipe/1.0.0",
+            "infrastructure_configuration_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:infrastructure-configuration/test",
+            "distribution_configuration_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:distribution-configuration/test",
+            "image_tests_configuration": {
+                "image_tests_enabled": True,
+                "timeout_minutes": 720
+            },
+            "schedule": {
+                "schedule_expression": "cron(0 12 1 * *)",
+                "pipeline_execution_start_condition": "EXPRESSION_MATCH_ONLY"
+            },
+            "status": "ENABLED",
+            "date_created": "2020-02-28T04:20:18.997Z",
+            "date_updated": "2020-03-03T05:50:13.787Z",
+            "tags": {}
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_image_pipeline.side_effect = [
+            ClientError(
+                {'Error': {'Code': 'ResourceNotFoundException'}}, 'GetInfrastructureConfiguration'),
+            dict(imagePipeline=snake_dict_to_camel_dict(test_pipeline))
+        ]
+
+        client_mock.return_value.create_image_pipeline.return_value = dict(
+            requestId='mock_request_id', clientToken='mock_client_token', imagePipelineArn=test_pipeline['arn'])
+
+        set_module_args({
+            **{k: test_pipeline[k] for k in ('name', 'description', 'infrastructure_configuration_arn', 'distribution_configuration_arn', 'image_tests_configuration', 'schedule', 'status', 'tags')},
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_pipeline.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is True
+        assert result['pipeline'] is not None
+        assert result['pipeline'] == test_pipeline
+        assert client_mock.return_value.get_image_pipeline.call_count == 2
+        assert client_mock.return_value.create_image_pipeline.call_count == 1
+
+    @patch.object(ec2_imagebuilder_pipeline.AnsibleAWSModule, 'client')
+    def test_present_when_exists(self, client_mock):
+        test_pipeline = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:image-pipeline/test-pipeline",
+            "name": "test_pipeline",
+            "description": "this is a test pipeline",
+            "platform": "Linux",
+            "image_recipe_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:image-recipe/test-recipe/1.0.0",
+            "infrastructure_configuration_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:infrastructure-configuration/test",
+            "distribution_configuration_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:distribution-configuration/test",
+            "image_tests_configuration": {
+                "image_tests_enabled": True,
+                "timeout_minutes": 720
+            },
+            "schedule": {
+                "schedule_expression": "cron(0 12 1 * *)",
+                "pipeline_execution_start_condition": "EXPRESSION_MATCH_ONLY"
+            },
+            "status": "ENABLED",
+            "date_created": "2020-02-28T04:20:18.997Z",
+            "date_updated": "2020-03-03T05:50:13.787Z",
+            "tags": {}
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_image_pipeline.return_value = dict(
+            imagePipeline=snake_dict_to_camel_dict(test_pipeline))
+
+        set_module_args({
+            **{k: test_pipeline[k] for k in ('name', 'description', 'image_recipe_arn', 'infrastructure_configuration_arn', 'distribution_configuration_arn', 'image_tests_configuration', 'schedule', 'status', 'tags')},
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_pipeline.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is False
+        assert result['pipeline'] is not None
+        assert result['pipeline'] == test_pipeline
+        assert client_mock.return_value.get_image_pipeline.call_count == 1
+        assert client_mock.return_value.create_image_pipeline.call_count == 0
+
+    @patch.object(ec2_imagebuilder_pipeline.AnsibleAWSModule, 'client')
+    def test_present_when_pipeline_different(self, client_mock):
+        test_pipeline = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:image-pipeline/test-pipeline",
+            "name": "test_pipeline",
+            "description": "this is a test pipeline",
+            "platform": "Linux",
+            "image_recipe_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:image-recipe/test-recipe/1.0.0",
+            "infrastructure_configuration_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:infrastructure-configuration/test",
+            "distribution_configuration_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:distribution-configuration/test",
+            "image_tests_configuration": {
+                "image_tests_enabled": True,
+                "timeout_minutes": 720
+            },
+            "schedule": {
+                "schedule_expression": "cron(0 12 1 * *)",
+                "pipeline_execution_start_condition": "EXPRESSION_MATCH_ONLY"
+            },
+            "status": "ENABLED",
+            "date_created": "2020-02-28T04:20:18.997Z",
+            "date_updated": "2020-03-03T05:50:13.787Z",
+            "tags": {}
+        }
+
+        updated_test_pipeline = {
+            **test_pipeline,
+            'description': "this is a test pipeline -- updated!",
+            "image_recipe_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:image-recipe/test-recipe/1.0.1",
+            "infrastructure_configuration_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:infrastructure-configuration/test-2",
+            "distribution_configuration_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:distribution-configuration/test-2",
+            "status": "DISABLED"
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_image_pipeline.side_effect = [
+            dict(imagePipeline=snake_dict_to_camel_dict(test_pipeline)),
+            dict(imagePipeline=snake_dict_to_camel_dict(
+                updated_test_pipeline))
+        ]
+
+        client_mock.return_value.update_image_pipeline.return_value = dict(
+            requestId='mock_request_id', clientToken='mock_client_token', imagePipelineArn=updated_test_pipeline['arn'])
+
+        set_module_args({
+            **{k: updated_test_pipeline[k] for k in ('name', 'description', 'image_recipe_arn', 'infrastructure_configuration_arn', 'distribution_configuration_arn', 'image_tests_configuration', 'schedule', 'status', 'tags')},
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_pipeline.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is True
+        assert result['pipeline'] is not None
+        assert result['pipeline'] == updated_test_pipeline
+        assert client_mock.return_value.get_image_pipeline.call_count == 2
+        assert client_mock.return_value.update_image_pipeline.call_count == 1
+
+    @patch.object(ec2_imagebuilder_pipeline.AnsibleAWSModule, 'client')
+    def test_present_when_tags_different(self, client_mock):
+        test_pipeline = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:image-pipeline/test-pipeline",
+            "name": "test_pipeline",
+            "description": "this is a test pipeline",
+            "platform": "Linux",
+            "image_recipe_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:image-recipe/test-recipe/1.0.0",
+            "infrastructure_configuration_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:infrastructure-configuration/test",
+            "distribution_configuration_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:distribution-configuration/test",
+            "image_tests_configuration": {
+                "image_tests_enabled": True,
+                "timeout_minutes": 720
+            },
+            "schedule": {
+                "schedule_expression": "cron(0 12 1 * *)",
+                "pipeline_execution_start_condition": "EXPRESSION_MATCH_ONLY"
+            },
+            "status": "ENABLED",
+            "date_created": "2020-02-28T04:20:18.997Z",
+            "date_updated": "2020-03-03T05:50:13.787Z",
+            "tags": {
+                "thisis": "atag"
+            }
+        }
+
+        updated_test_pipeline = {
+            **test_pipeline,
+            "tags": {
+            }
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_image_pipeline.side_effect = [
+            dict(imagePipeline=snake_dict_to_camel_dict(test_pipeline)),
+            dict(imagePipeline=snake_dict_to_camel_dict(
+                updated_test_pipeline))
+        ]
+
+        client_mock.return_value.untag_resource.return_value = {}
+        client_mock.return_value.tag_resource.return_value = {}
+
+        set_module_args({
+            **{k: updated_test_pipeline[k] for k in ('name', 'description', 'image_recipe_arn', 'infrastructure_configuration_arn', 'distribution_configuration_arn', 'image_tests_configuration', 'schedule', 'status', 'tags')},
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_pipeline.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is True
+        assert result['pipeline'] is not None
+        assert result['pipeline'] == updated_test_pipeline
+        assert client_mock.return_value.get_image_pipeline.call_count == 2
+        assert client_mock.return_value.update_image_pipeline.call_count == 0
+        assert client_mock.return_value.untag_resource.call_count == 1
+        _, kwargs = client_mock.return_value.untag_resource.call_args
+        assert kwargs['tagKeys'] == list(test_pipeline['tags'])
+
+    @patch.object(ec2_imagebuilder_pipeline.AnsibleAWSModule, 'client')
+    def test_absent_when_exists(self, client_mock):
+        test_pipeline = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:image-pipeline/test-pipeline",
+            "name": "test_pipeline",
+            "description": "this is a test pipeline",
+            "platform": "Linux",
+            "image_recipe_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:image-recipe/test-recipe/1.0.0",
+            "infrastructure_configuration_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:infrastructure-configuration/test",
+            "distribution_configuration_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:distribution-configuration/test",
+            "image_tests_configuration": {
+                "image_tests_enabled": True,
+                "timeout_minutes": 720
+            },
+            "schedule": {
+                "schedule_expression": "cron(0 12 1 * *)",
+                "pipeline_execution_start_condition": "EXPRESSION_MATCH_ONLY"
+            },
+            "status": "ENABLED",
+            "date_created": "2020-02-28T04:20:18.997Z",
+            "date_updated": "2020-03-03T05:50:13.787Z",
+            "tags": {
+                "thisis": "atag"
+            }
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_image_pipeline.return_value = dict(
+            imagePipeline=snake_dict_to_camel_dict(test_pipeline))
+        client_mock.return_value.delete_image_pipeline.return_value = dict(
+            requestId='mock_request_id', imagePipelineArn=test_pipeline['arn'])
+
+        set_module_args({
+            'name': test_pipeline['name'],
+            'state': 'absent'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_pipeline.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is True
+        assert result['pipeline'] is not None
+        assert result['pipeline'] == dict(
+            arn=test_pipeline['arn'])
+        assert client_mock.return_value.get_image_pipeline.call_count == 1
+        assert client_mock.return_value.delete_image_pipeline.call_count == 1
+        _, kwargs = client_mock.return_value.delete_image_pipeline.call_args
+        assert kwargs['imagePipelineArn'] == test_pipeline['arn']

--- a/test/units/modules/cloud/amazon/test_ec2_imagebuilder_pipeline.py
+++ b/test/units/modules/cloud/amazon/test_ec2_imagebuilder_pipeline.py
@@ -261,7 +261,7 @@ class TestEC2ImageBuilderPipelineModule(ModuleTestCase):
         assert client_mock.return_value.get_image_pipeline.call_count == 2
         assert client_mock.return_value.update_image_pipeline.call_count == 0
         assert client_mock.return_value.untag_resource.call_count == 1
-        _, kwargs = client_mock.return_value.untag_resource.call_args
+        args, kwargs = client_mock.return_value.untag_resource.call_args
         assert kwargs['tagKeys'] == list(test_pipeline['tags'])
 
     @patch.object(ec2_imagebuilder_pipeline.AnsibleAWSModule, 'client')
@@ -311,5 +311,5 @@ class TestEC2ImageBuilderPipelineModule(ModuleTestCase):
             arn=test_pipeline['arn'])
         assert client_mock.return_value.get_image_pipeline.call_count == 1
         assert client_mock.return_value.delete_image_pipeline.call_count == 1
-        _, kwargs = client_mock.return_value.delete_image_pipeline.call_args
+        args, kwargs = client_mock.return_value.delete_image_pipeline.call_args
         assert kwargs['imagePipelineArn'] == test_pipeline['arn']

--- a/test/units/modules/cloud/amazon/test_ec2_imagebuilder_recipe.py
+++ b/test/units/modules/cloud/amazon/test_ec2_imagebuilder_recipe.py
@@ -258,7 +258,7 @@ class TestEC2ImageBuilderRecipeModule(ModuleTestCase):
         assert client_mock.return_value.get_image_recipe.call_count == 2
         assert client_mock.return_value.create_image_recipe.call_count == 0
         assert client_mock.return_value.tag_resource.call_count == 1
-        _, kwargs = client_mock.return_value.tag_resource.call_args
+        args, kwargs = client_mock.return_value.tag_resource.call_args
         assert kwargs['tags'] == updated_test_recipe['tags']
 
     @patch.object(ec2_imagebuilder_recipe.AnsibleAWSModule, 'client')
@@ -304,5 +304,5 @@ class TestEC2ImageBuilderRecipeModule(ModuleTestCase):
         assert result['recipe'] == dict(arn=test_recipe['arn'])
         assert client_mock.return_value.get_image_recipe.call_count == 1
         assert client_mock.return_value.delete_image_recipe.call_count == 1
-        _, kwargs = client_mock.return_value.delete_image_recipe.call_args
+        args, kwargs = client_mock.return_value.delete_image_recipe.call_args
         assert kwargs['imageRecipeArn'] == test_recipe['arn']

--- a/test/units/modules/cloud/amazon/test_ec2_imagebuilder_recipe.py
+++ b/test/units/modules/cloud/amazon/test_ec2_imagebuilder_recipe.py
@@ -1,0 +1,308 @@
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from units.compat.mock import MagicMock, patch
+from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
+
+from ansible.module_utils.ec2 import snake_dict_to_camel_dict
+from ansible.modules.cloud.amazon import ec2_imagebuilder_recipe
+
+try:
+    from botocore.exceptions import ClientError
+except ImportError:
+    pass
+
+
+class TestEC2ImageBuilderRecipeModule(ModuleTestCase):
+
+    mocked_get_caller_identity = {
+        "UserId": "AROAJxxxxxxxxxxIPWZY:user.id",
+        "Account": "111222333444",
+        "Arn": "arn:aws:sts::111222333444:assumed-role/admin/test.user"
+    }
+
+    def test_required_parameters(self):
+        set_module_args({})
+        with pytest.raises(AnsibleFailJson) as context:
+            ec2_imagebuilder_recipe.main()
+
+        result = context.value.args[0]
+
+        assert result['failed'] is True
+        assert "name" in result['msg']
+        assert "semantic_version" in result['msg']
+        assert "state" in result['msg']
+
+    @patch.object(ec2_imagebuilder_recipe.AnsibleAWSModule, 'client')
+    def test_absent_when_not_exists(self, client_mock):
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+
+        client_mock.return_value.get_image_recipe.side_effect = ClientError(
+            {'Error': {'Code': 'ResourceNotFoundException'}}, 'GetImageRecipe')
+        set_module_args({
+            'name': 'test_recipe',
+            'semantic_version': '1.0.0',
+            'state': 'absent'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_recipe.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is False
+        assert result['recipe'] is not None
+        assert result['recipe']['arn'] is not None
+
+    @patch.object(ec2_imagebuilder_recipe.AnsibleAWSModule, 'client')
+    def test_present_when_not_exists(self, client_mock):
+        test_recipe = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:image-recipe/test-recipe/1.0.0",
+            "description": "this is a test recipe",
+            "name": "test_recipe",
+            "platform": "Linux",
+            "owner": "111222333444",
+            "version": "1.0.0",
+            "components": [
+                {
+                    "component_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:component/test-component/1.0.0/1"
+                }
+            ],
+            "parent_image": "arn:aws:imagebuilder:ap-southeast-2:aws:image/amazon-linux-2-x86/x.x.x",
+            "date_created": "2020-02-26T04:34:07.168Z",
+            "tags": {
+                "this": "isatag"
+            }
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_image_recipe.side_effect = [
+            ClientError(
+                {'Error': {'Code': 'ResourceNotFoundException'}}, 'GetImageRecipe'),
+            dict(imageRecipe=snake_dict_to_camel_dict(test_recipe))
+        ]
+
+        client_mock.return_value.create_image_recipe.return_value = dict(
+            requestId='mock_request_id', clientToken='mock_client_token', imageRecipeArn=test_recipe['arn'])
+
+        set_module_args({
+            **{k: test_recipe[k] for k in ('name', 'description', 'components', 'parent_image', 'tags')},
+            'semantic_version': test_recipe['version'],  # thanks aws
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_recipe.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is True
+        assert result['recipe'] is not None
+        assert result['recipe'] == test_recipe
+        assert client_mock.return_value.get_image_recipe.call_count == 2
+        assert client_mock.return_value.create_image_recipe.call_count == 1
+
+    @patch.object(ec2_imagebuilder_recipe.AnsibleAWSModule, 'client')
+    def test_present_when_exists(self, client_mock):
+        test_recipe = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:image-recipe/test-recipe/1.0.0",
+            "description": "this is a test recipe",
+            "name": "test_recipe",
+            "platform": "Linux",
+            "owner": "111222333444",
+            "version": "1.0.0",
+            "components": [
+                {
+                    "component_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:component/test-component/1.0.0/1"
+                }
+            ],
+            "parent_image": "arn:aws:imagebuilder:ap-southeast-2:aws:image/amazon-linux-2-x86/x.x.x",
+            "date_created": "2020-02-26T04:34:07.168Z",
+            "tags": {
+                "this": "isatag"
+            }
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_image_recipe.side_effect = [
+            dict(imageRecipe=snake_dict_to_camel_dict(test_recipe))
+        ]
+
+        set_module_args({
+            **{k: test_recipe[k] for k in ('name', 'description', 'components', 'parent_image', 'tags')},
+            'semantic_version': test_recipe['version'],  # thanks aws
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_recipe.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is False
+        assert result['recipe'] is not None
+        assert result['recipe'] == test_recipe
+        assert client_mock.return_value.get_image_recipe.call_count == 1
+        assert client_mock.return_value.create_image_recipe.call_count == 0
+
+    @patch.object(ec2_imagebuilder_recipe.AnsibleAWSModule, 'client')
+    def test_present_when_recipe_different(self, client_mock):
+        test_recipe = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:image-recipe/test-recipe/1.0.0",
+            "description": "this is a test recipe",
+            "name": "test_recipe",
+            "platform": "Linux",
+            "owner": "111222333444",
+            "version": "1.0.0",
+            "components": [
+                {
+                    "component_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:component/test-component/1.0.0/1"
+                }
+            ],
+            "parent_image": "arn:aws:imagebuilder:ap-southeast-2:aws:image/amazon-linux-2-x86/x.x.x",
+            "date_created": "2020-02-26T04:34:07.168Z",
+            "tags": {
+                "this": "isatag"
+            }
+        }
+
+        updated_test_recipe = {
+            **test_recipe,
+            "components": [
+                {
+                    "component_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:component/test-component/1.0.1/1"
+                },
+                {
+                    "component_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:component/test-componen-2/1.0.0/1"
+                }
+            ],
+            'version': "1.0.1",
+            'description': "this is a test recipe -- updated!"
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_image_recipe.side_effect = [
+            dict(imageRecipe=snake_dict_to_camel_dict(test_recipe)),
+            dict(imageRecipe=snake_dict_to_camel_dict(updated_test_recipe))
+        ]
+
+        client_mock.return_value.create_image_recipe.return_value = dict(
+            requestId='mock_request_id', clientToken='mock_client_token', imageRecipeArn=updated_test_recipe['arn'])
+
+        set_module_args({
+            **{k: updated_test_recipe[k] for k in ('name', 'description', 'components', 'parent_image', 'tags')},
+            'semantic_version': updated_test_recipe['version'],  # thanks aws
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_recipe.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is True
+        assert result['recipe'] is not None
+        assert result['recipe'] == updated_test_recipe
+        assert client_mock.return_value.get_image_recipe.call_count == 2
+        assert client_mock.return_value.create_image_recipe.call_count == 1
+
+    @patch.object(ec2_imagebuilder_recipe.AnsibleAWSModule, 'client')
+    def test_present_when_tags_different(self, client_mock):
+        test_recipe = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:image-recipe/test-recipe/1.0.0",
+            "description": "this is a test recipe",
+            "name": "test_recipe",
+            "platform": "Linux",
+            "owner": "111222333444",
+            "version": "1.0.0",
+            "components": [
+                {
+                    "component_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:component/test-component/1.0.0/1"
+                }
+            ],
+            "parent_image": "arn:aws:imagebuilder:ap-southeast-2:aws:image/amazon-linux-2-x86/x.x.x",
+            "date_created": "2020-02-26T04:34:07.168Z",
+            "tags": {
+                "this": "isatag"
+            }
+        }
+
+        updated_test_recipe = {
+            **test_recipe,
+            "tags": {
+                "thisis": "adifferenttag"
+            }
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_image_recipe.side_effect = [
+            dict(imageRecipe=snake_dict_to_camel_dict(test_recipe)),
+            dict(imageRecipe=snake_dict_to_camel_dict(updated_test_recipe))
+        ]
+
+        client_mock.return_value.create_image_recipe.return_value = dict(
+            requestId='mock_request_id', clientToken='mock_client_token', imageRecipeArn=updated_test_recipe['arn'])
+
+        set_module_args({
+            **{k: updated_test_recipe[k] for k in ('name', 'description', 'components', 'parent_image', 'tags')},
+            'semantic_version': updated_test_recipe['version'],  # thanks aws
+            'state': 'present'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_recipe.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is True
+        assert result['recipe'] is not None
+        assert result['recipe'] == updated_test_recipe
+        assert client_mock.return_value.get_image_recipe.call_count == 2
+        assert client_mock.return_value.create_image_recipe.call_count == 0
+        assert client_mock.return_value.tag_resource.call_count == 1
+        _, kwargs = client_mock.return_value.tag_resource.call_args
+        assert kwargs['tags'] == updated_test_recipe['tags']
+
+    @patch.object(ec2_imagebuilder_recipe.AnsibleAWSModule, 'client')
+    def test_absent_when_exists(self, client_mock):
+        test_recipe = {
+            "arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:image-recipe/test-recipe/1.0.0",
+            "description": "this is a test recipe",
+            "name": "test_recipe",
+            "platform": "Linux",
+            "owner": "111222333444",
+            "version": "1.0.0",
+            "components": [
+                {
+                    "component_arn": "arn:aws:imagebuilder:ap-southeast-2:111222333444:component/test-component/1.0.0/1"
+                }
+            ],
+            "parent_image": "arn:aws:imagebuilder:ap-southeast-2:aws:image/amazon-linux-2-x86/x.x.x",
+            "date_created": "2020-02-26T04:34:07.168Z",
+            "tags": {
+                "this": "isatag"
+            }
+        }
+
+        client_mock.return_value.get_caller_identity.return_value = self.mocked_get_caller_identity
+        client_mock.return_value.get_image_recipe.side_effect = [
+            dict(imageRecipe=snake_dict_to_camel_dict(test_recipe))
+        ]
+        client_mock.return_value.delete_image_recipe.return_value = dict(
+            requestId='mock_request_id', imageRecipeArn=test_recipe['arn'])
+
+        set_module_args({
+            'name': test_recipe['name'],
+            'semantic_version': test_recipe['version'],  # thanks aws
+            'state': 'absent'
+        })
+        with pytest.raises(AnsibleExitJson) as context:
+            ec2_imagebuilder_recipe.main()
+
+        result = context.value.args[0]
+
+        assert result['changed'] is True
+        assert result['recipe'] is not None
+        assert result['recipe'] == dict(arn=test_recipe['arn'])
+        assert client_mock.return_value.get_image_recipe.call_count == 1
+        assert client_mock.return_value.delete_image_recipe.call_count == 1
+        _, kwargs = client_mock.return_value.delete_image_recipe.call_args
+        assert kwargs['imageRecipeArn'] == test_recipe['arn']


### PR DESCRIPTION
##### SUMMARY

Modules for new EC2 Image Builder service. At this point is basically one-to-one mapping to the boto3 APIs.

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

New modules that correspond one-to-one to the relevant EC2 Image Builder resources:

- `ec2_imagebuilder_component`
- `ec2_imagebuilder_recipe`
- `ec2_imagebuilder_distribution_configuration`
- `ec2_imagebuilder_infrastructure_configuration`
- `ec2_imagebuilder_pipeline`

##### ADDITIONAL INFORMATION

- Included passing unit tests
- Ansible sanity tests pass
- Have an integration test playbook if there is a relevant place for it