### PR TITLE
Fix: nmcli bridge-slave returns "Error: invalid or not allowed settin…

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -1100,8 +1100,9 @@ class Nmcli(object):
         elif self.conn_name is not None:
             cmd.append(self.conn_name)
 
+        if self.master is not None:
+            cmd.extend(['master', self.master])
         options = {
-            'master': self.master,
             'bridge-port.path-cost': self.path_cost,
             'bridge-port.hairpin': self.bool_to_string(self.hairpin),
             'bridge-port.priority': self.slavepriority,
@@ -1116,8 +1117,9 @@ class Nmcli(object):
     def modify_connection_bridge_slave(self):
         # format for modifying bond-slave interface
         cmd = [self.nmcli_bin, 'con', 'mod', self.conn_name]
+        if self.master is not None:
+            cmd.extend(['master', self.master])
         options = {
-            'master': self.master,
             'bridge-port.path-cost': self.path_cost,
             'bridge-port.hairpin': self.bool_to_string(self.hairpin),
             'bridge-port.priority': self.slavepriority,


### PR DESCRIPTION
##### SUMMARY
Fix error for adding bridge slaves: `nmcli bridge-slave returns "Error: invalid or not allowed setting 'bridge-port'`

Fixes: https://github.com/ansible/ansible/issues/42460
And also: https://github.com/ansible/ansible/pull/54617

Affected ansible from 2.7.x to 2.9.x and devel!

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nmcli

##### ADDITIONAL INFORMATION

Example tasks:

```yaml
- name: Add bridge
  nmcli:
    type: bridge
    conn_name: br0
    ip4: "{{ ansible_default_ipv4.address }}/{{ ansible_default_ipv4.netmask | ipaddr('prefix') }}"
    gw4: "{{ ansible_default_ipv4.gateway }}"
    state: present

- name: Add bridge slave
  nmcli:
    type: bridge-slave
    conn_name: "{{ ansible_default_ipv4.interface }}"
    ifname: "{{ ansible_default_ipv4.interface }}"
    master: br0
    state: present
```

Before:

```bash
< TASK [network : Add bridge slaves] >
Friday 06 March 2020  14:34:29 +0700 (0:00:01.028)       0:00:04.899 ********** 
fatal: [172.16.100.2]: FAILED! => {
    "changed": false,
    "name": "ens3",
    "rc": 2
}

MSG:

Error: invalid or not allowed setting 'bridge-port': 'bridge-port' not among [connection, tun, 802-3-ethernet (ethernet), ethtool, match, ipv4, ipv6, tc, proxy].
```

After:

```bash
< TASK [network : Add bridge slaves] >
Friday 06 March 2020  14:42:17 +0700 (0:00:01.087)       0:00:04.685 ********** 
changed: [172.16.100.2]
```
