### PR TITLE
Fix error in example task in `find` module

### DIFF
--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -146,6 +146,7 @@ EXAMPLES = r'''
 - name: Find /var/log files equal or greater than 10 megabytes ending with .old or .log.gz
   find:
     paths: /var/log
+    use_regex: yes
     patterns: '*.old,*.log.gz'
     size: 10m
 


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
module: find

##### ADDITIONAL INFORMATION
use_regex should be set to yes if we want to use regex in pattern