### PR TITLE
Use the connection loader to get local, instead of direct import

### DIFF
--- a/test/units/plugins/connection/test_local.py
+++ b/test/units/plugins/connection/test_local.py
@@ -24,7 +24,7 @@ from io import StringIO
 import pytest
 
 from units.compat import unittest
-from ansible.plugins.connection import local
+from ansible.plugins.loader import connection_loader
 from ansible.playbook.play_context import PlayContext
 
 
@@ -37,4 +37,5 @@ class TestLocalConnectionClass(unittest.TestCase):
         )
         in_stream = StringIO()
 
-        self.assertIsInstance(local.Connection(play_context, in_stream), local.Connection)
+        conn = connection_loader.get('local', play_context, in_stream)
+        self.assertEqual(conn.transport, 'local')


### PR DESCRIPTION
##### SUMMARY
Use the connection loader to get local, instead of direct import

Our plugin loader can mess up the ability to import plugins, if the plugin loader loads the plugin first.

`test_raw.py` does this, and it runs before `test_local.py`.

FWIW, I'm not sure what this test really does for us, or the original for that matter.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/units/plugins/connection/test_local.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
