### PR TITLE
ansible-test coverage - fix empty python data and test plugins

### DIFF
--- a/changelogs/fragments/ansible-test-coverage-python.yaml
+++ b/changelogs/fragments/ansible-test-coverage-python.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- ansible-test coverage - Do not fail if no Python coverage data was collected
+- ansible-test coverage - Fix path sanitizer to properly sanitize test plugins

--- a/test/lib/ansible_test/_internal/coverage/__init__.py
+++ b/test/lib/ansible_test/_internal/coverage/__init__.py
@@ -203,6 +203,12 @@ def sanitize_filename(
         new_name = re.sub('^.*/ansible_modlib.zip/ansible/', ansible_path, filename)
         display.info('%s -> %s' % (filename, new_name), verbosity=3)
         filename = new_name
+    elif integration_temp_path in filename:
+        # Rewrite the path of code running from an integration test temporary directory. This needs to be set before
+        # the collection_search_re check or else collection test plugins will be ignored as invalid paths.
+        new_name = re.sub(r'^.*' + re.escape(integration_temp_path) + '[^/]+/', root_path, filename)
+        display.info('%s -> %s' % (filename, new_name), verbosity=3)
+        filename = new_name
     elif collection_search_re and collection_search_re.search(filename):
         new_name = os.path.abspath(collection_sub_re.sub('', filename))
         display.info('%s -> %s' % (filename, new_name), verbosity=3)
@@ -236,11 +242,6 @@ def sanitize_filename(
     elif re.search('^(/.*?)?/root/ansible/', filename):
         # Rewrite the path of code running on a remote host or in a docker container as root.
         new_name = re.sub('^(/.*?)?/root/ansible/', root_path, filename)
-        display.info('%s -> %s' % (filename, new_name), verbosity=3)
-        filename = new_name
-    elif integration_temp_path in filename:
-        # Rewrite the path of code running from an integration test temporary directory.
-        new_name = re.sub(r'^.*' + re.escape(integration_temp_path) + '[^/]+/', root_path, filename)
         display.info('%s -> %s' % (filename, new_name), verbosity=3)
         filename = new_name
 

--- a/test/lib/ansible_test/_internal/coverage/combine.py
+++ b/test/lib/ansible_test/_internal/coverage/combine.py
@@ -99,16 +99,23 @@ def _command_coverage_combine_python(args):
 
         updated = coverage.CoverageData()
 
+        # coverage.py pre v5 fails with an rc of 1 and a message of 'No data to report.'. While it would be nice to
+        # show this there is no sane way to ignore this error without potentially ignoring other errors. Until we
+        # upgrade we just need to skip creating empty coverage files.
+        arcs_present = False
+
         for filename in arc_data:
             if not path_checker.check_path(filename):
                 continue
 
+            arcs_present = True
             updated.add_arcs({filename: list(arc_data[filename])})
 
-        if args.all:
+        if args.all and sources:
+            arcs_present = True
             updated.add_arcs(dict((source[0], []) for source in sources))
 
-        if not args.explain:
+        if arcs_present and not args.explain:
             output_file = coverage_file + group
             updated.write_file(output_file)
             output_files.append(output_file)


### PR DESCRIPTION
##### SUMMARY
Currently `ansible-test coverage` fails if there are no valid paths in the Python coverage output and it also ignores any test plugins in a collection.

This PR makes sure we only report on Python coverage that have actual coverage data which on Windows only collections may not be the case. It also moves the test plugin path sanitizer to be before the collection root sanitizer so the paths are actually valid.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
ansible-test coverage