### PR TITLE
Fix aci examples

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_general_aci.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general_aci.rst
@@ -263,32 +263,32 @@ Example: ``aci.post_config()``
 
 Example code
 """"""""""""
-.. code-block:: guess
+.. code-block:: python
 
-    if state == 'present':
-        aci.payload(
-            aci_class='<object APIC class>',
-            class_config=dict(
-                name=object_id,
-                prop1=object_prop1,
-                prop2=object_prop2,
-                prop3=object_prop3,
-            ),
-            child_configs=[
-                dict(
-                    '<child APIC class>'=dict(
-                        attributes=dict(
-                            child_key=child_object_id,
-                            child_prop=child_object_prop
-                        ),
-                    ),
-                ),
-            ],
-        )
+   if state == 'present':
+       aci.payload(
+           aci_class='<object APIC class>',
+           class_config=dict(
+               name=object_id,
+               prop1=object_prop1,
+               prop2=object_prop2,
+               prop3=object_prop3,
+           ),
+           child_configs=[
+               {
+                   '<child APIC class>': dict(
+                       attributes=dict(
+                           child_key=child_object_id,
+                           child_prop=child_object_prop
+                       ),
+                   ),
+               },
+           ],
+       )
 
-        aci.get_diff(aci_class='<object APIC class>')
+       aci.get_diff(aci_class='<object APIC class>')
 
-        aci.post_config()
+       aci.post_config()
 
 
 When state is absent

--- a/docs/docsite/rst/dev_guide/developing_modules_general_aci.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general_aci.rst
@@ -295,7 +295,7 @@ When state is absent
 ^^^^^^^^^^^^^^^^^^^^
 If the task sets the state to absent, then the ``delete_config()`` method is all that is needed. This method does not take any arguments, and handles check mode.
 
-.. code-block:: guess
+.. code-block:: text
 
         elif state == 'absent':
             aci.delete_config()
@@ -305,7 +305,7 @@ Exiting the module
 ^^^^^^^^^^^^^^^^^^
 To have the module exit, call the ACIModule method ``exit_json()``. This method automatically takes care of returning the common return values for you.
 
-.. code-block:: guess
+.. code-block:: text
 
         aci.exit_json()
 
@@ -319,7 +319,7 @@ Testing ACI library functions
 =============================
 You can test your ``construct_url()`` and ``payload()`` arguments without accessing APIC hardware by using the following python script:
 
-.. code-block:: guess
+.. code-block:: python
 
     #!/usr/bin/python
     import json


### PR DESCRIPTION
##### SUMMARY
Gets rid of the last `Could not lex literal_block as "guess". Highlighting skipped.` errors in the docs build.

Thanks to @mattclay for the code revisions to the example!

Related to #63217.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ACI
docs.ansible.com