### PR TITLE
Partially revert "mount: Check if src exists before mounted (#61752)"

### DIFF
--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -719,9 +719,6 @@ def main():
 
             changed = True
     elif state == 'mounted':
-        if not os.path.exists(args['src']):
-            module.fail_json(msg="Unable to mount %s as it does not exist" % args['src'])
-
         if not os.path.exists(name) and not module.check_mode:
             try:
                 os.makedirs(name)


### PR DESCRIPTION
This reverts part of commit 72023d7462e78635264fd12bfdb23894b4163cba.

The immediate reason is that it breaks mounts where src is not a path.
Examples of such mounts are nfs, cifs, glusterfs, ceph, tmpfs,
overlayfs, and it is too hard to come with an exhaustive list,
especially if we take non-Linux systems into account.

Additionally, it did not really fix the issue (#59183) that it intended
to fix, because the mount could fail but leave a non-working fstab entry
for reasons other than non-existing src path.

##### SUMMARY

This was originally submitted as #65869, with some extra commits that attempt to re-fix #59183. However, that pull request was not properly reviewed in 2+ months, presumably because the additional commits are too complex. Therefore, I am resubmitting just the minimal fix that is hopefully easier to review.

Fixes: #65855
Fixes: #67588
Fixes: #67966

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mount

##### ADDITIONAL INFORMATION
See #65544 and #65869.