### PR TITLE
Handle Slackware OS version strings containing a plus (“+”)

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -210,7 +210,7 @@ class DistributionFiles:
         if 'Slackware' not in data:
             return False, slackware_facts  # TODO: remove
         slackware_facts['distribution'] = name
-        version = re.findall(r'\w+[.]\w+', data)
+        version = re.findall(r'\w+[.]\w+\+?', data)
         if version:
             slackware_facts['distribution_version'] = version[0]
         return True, slackware_facts


### PR DESCRIPTION
A couple of years ago Slackware -current began using a plus (“+”) at the end of the distribution version string to indicate the os distribution being used is an in-progress/future version. No-plus: stable. Plus: in-progress

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Slackware distribution version strings can contain a plus ("+") when the Slackware OS being used is the in-progress/future release version.

For example:
Slackware stable OS distribution string: `Slackware 14.2`
Slackware -current (in-progress) OS distribution string: `Slackware 14.2+`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes https://github.com/ansible/ansible/issues/38760

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible/module_utils/facts/system/distribution.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
`ansible -m setup HOST_RUNNING_SLACKWARE_CURRENT | grep ansible_distribution_version`

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before change:
```
"ansible_distribution_version": "14.2",
```

After change:
```
"ansible_distribution_version": "14.2+",
```
