### PR TITLE
systemd: should fail in check_mode when service not found on host

### DIFF
--- a/changelogs/fragments/68136-systemd_should_fail_in_check_mode_when_service_not_found.yml
+++ b/changelogs/fragments/68136-systemd_should_fail_in_check_mode_when_service_not_found.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- systemd - the module should fail in check_mode when service not found on host (https://github.com/ansible/ansible/pull/68136).

--- a/lib/ansible/module_utils/service.py
+++ b/lib/ansible/module_utils/service.py
@@ -105,8 +105,7 @@ def get_ps(module, pattern):
 
 def fail_if_missing(module, found, service, msg=''):
     '''
-    This function will return an error or exit gracefully depending on check mode status
-    and if the service is missing or not.
+    This function will return an error if the service is missing.
 
     :arg module: is an  AnsibleModule object, used for it's utility methods
     :arg found: boolean indicating if services was found or not
@@ -114,10 +113,7 @@ def fail_if_missing(module, found, service, msg=''):
     :kw msg: extra info to append to error/success msg when missing
     '''
     if not found:
-        if module.check_mode:
-            module.exit_json(msg="Service %s not found on %s, assuming it will exist on full run" % (service, msg), changed=True)
-        else:
-            module.fail_json(msg='Could not find the requested service %s: %s' % (service, msg))
+        module.fail_json(msg='Could not find the requested service %s: %s' % (service, msg))
 
 
 def fork_process():

--- a/lib/ansible/module_utils/service.py
+++ b/lib/ansible/module_utils/service.py
@@ -103,9 +103,10 @@ def get_ps(module, pattern):
     return found
 
 
-def fail_if_missing(module, found, service, msg=''):
+def fail_if_missing(module, found, service, msg='', fail_in_check_mode=False):
     '''
-    This function will return an error if the service is missing.
+    This function will return an error or exit gracefully depending on check mode status
+    and if the service is missing or not.
 
     :arg module: is an  AnsibleModule object, used for it's utility methods
     :arg found: boolean indicating if services was found or not
@@ -113,7 +114,10 @@ def fail_if_missing(module, found, service, msg=''):
     :kw msg: extra info to append to error/success msg when missing
     '''
     if not found:
-        module.fail_json(msg='Could not find the requested service %s: %s' % (service, msg))
+        if module.check_mode and not fail_in_check_mode:
+            module.exit_json(msg="Service %s not found on %s, assuming it will exist on full run" % (service, msg), changed=True)
+        else:
+            module.fail_json(msg='Could not find the requested service %s: %s' % (service, msg))
 
 
 def fork_process():

--- a/lib/ansible/module_utils/service.py
+++ b/lib/ansible/module_utils/service.py
@@ -103,7 +103,7 @@ def get_ps(module, pattern):
     return found
 
 
-def fail_if_missing(module, found, service, msg='', fail_in_check_mode=False):
+def fail_if_missing(module, found, service, msg=''):
     '''
     This function will return an error or exit gracefully depending on check mode status
     and if the service is missing or not.
@@ -114,10 +114,7 @@ def fail_if_missing(module, found, service, msg='', fail_in_check_mode=False):
     :kw msg: extra info to append to error/success msg when missing
     '''
     if not found:
-        if module.check_mode and not fail_in_check_mode:
-            module.exit_json(msg="Service %s not found on %s, assuming it will exist on full run" % (service, msg), changed=True)
-        else:
-            module.fail_json(msg='Could not find the requested service %s: %s' % (service, msg))
+        module.fail_json(msg='Could not find the requested service %s: %s' % (service, msg))
 
 
 def fork_process():

--- a/lib/ansible/modules/systemd.py
+++ b/lib/ansible/modules/systemd.py
@@ -467,7 +467,7 @@ def main():
                     (rc, out, err) = module.run_command("%s %s '%s'" % (systemctl, action, unit))
                     if rc != 0:
                         # some versions of system CAN mask/unmask non existing services, we only fail on missing if they don't
-                        fail_if_missing(module, found, unit, msg='host')
+                        fail_if_missing(module, found, unit, msg='host', fail_in_check_mode=True)
 
         # Enable/disable service startup at boot if requested
         if module.params['enabled'] is not None:
@@ -477,7 +477,7 @@ def main():
             else:
                 action = 'disable'
 
-            fail_if_missing(module, found, unit, msg='host')
+            fail_if_missing(module, found, unit, msg='host', fail_in_check_mode=True)
 
             # do we need to enable the service?
             enabled = False
@@ -510,7 +510,7 @@ def main():
 
         # set service state if requested
         if module.params['state'] is not None:
-            fail_if_missing(module, found, unit, msg="host")
+            fail_if_missing(module, found, unit, msg="host", fail_in_check_mode=True)
 
             # default to desired state
             result['state'] = module.params['state']

--- a/lib/ansible/modules/systemd.py
+++ b/lib/ansible/modules/systemd.py
@@ -467,7 +467,7 @@ def main():
                     (rc, out, err) = module.run_command("%s %s '%s'" % (systemctl, action, unit))
                     if rc != 0:
                         # some versions of system CAN mask/unmask non existing services, we only fail on missing if they don't
-                        fail_if_missing(module, found, unit, msg='host', fail_in_check_mode=True)
+                        fail_if_missing(module, found, unit, msg='host')
 
         # Enable/disable service startup at boot if requested
         if module.params['enabled'] is not None:
@@ -477,7 +477,7 @@ def main():
             else:
                 action = 'disable'
 
-            fail_if_missing(module, found, unit, msg='host', fail_in_check_mode=True)
+            fail_if_missing(module, found, unit, msg='host')
 
             # do we need to enable the service?
             enabled = False
@@ -510,7 +510,7 @@ def main():
 
         # set service state if requested
         if module.params['state'] is not None:
-            fail_if_missing(module, found, unit, msg="host", fail_in_check_mode=True)
+            fail_if_missing(module, found, unit, msg="host")
 
             # default to desired state
             result['state'] = module.params['state']

--- a/test/integration/targets/service/tasks/tests.yml
+++ b/test/integration/targets/service/tasks/tests.yml
@@ -201,11 +201,13 @@
     state: stopped
   register: result
   ignore_errors: yes
+  when: ansible_distribution != 'FreeBSD'
 
 - assert:
     that:
       - result is failed
       - result is search("Could not find the requested service nonexisting")
+  when: ansible_distribution != 'FreeBSD'
 
 - name: the module must fail in check_mode as well when a service is not found
   service:
@@ -214,8 +216,10 @@
   register: result
   check_mode: yes
   ignore_errors: yes
+  when: ansible_distribution != 'FreeBSD'
 
 - assert:
     that:
       - result is failed
       - result is search("Could not find the requested service nonexisting")
+  when: ansible_distribution != 'FreeBSD'

--- a/test/integration/targets/service/tasks/tests.yml
+++ b/test/integration/targets/service/tasks/tests.yml
@@ -194,3 +194,28 @@
     that:
       - "remove_result.path == '/usr/sbin/ansible_test_service'"
       - "remove_result.state == 'absent'"
+
+- name: the module must fail when a service is not found
+  service:
+    name: 'nonexisting'
+    state: stopped
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - result is failed
+      - result is search("Could not find the requested service nonexisting")
+
+- name: the module must fail in check_mode as well when a service is not found
+  service:
+    name: 'nonexisting'
+    state: stopped
+  register: result
+  check_mode: yes
+  ignore_errors: yes
+
+- assert:
+    that:
+      - result is failed
+      - result is search("Could not find the requested service nonexisting")

--- a/test/integration/targets/systemd/defaults/main.yml
+++ b/test/integration/targets/systemd/defaults/main.yml
@@ -1,0 +1,1 @@
+fake_service: nonexisting

--- a/test/integration/targets/systemd/tasks/main.yml
+++ b/test/integration/targets/systemd/tasks/main.yml
@@ -47,4 +47,29 @@
               - 'not systemd_test0.changed'
               - 'systemd_test0.state == "started"'
 
+    - name: the module must fail when a service is not found
+      systemd:
+          name: '{{ fake_service }}'
+          state: stopped
+      register: result
+      ignore_errors: yes
+
+    - assert:
+          that:
+              - result is failed
+              - result is search("Could not find the requested service {{ fake_service }}")
+
+    - name: the module must fail in check_mode as well when a service is not found
+      systemd:
+          name: '{{ fake_service }}'
+          state: stopped
+      register: result
+      check_mode: yes
+      ignore_errors: yes
+
+    - assert:
+          that:
+              - result is failed
+              - result is search("Could not find the requested service {{ fake_service }}")
+
   when: 'systemctl_check.rc == 0'


### PR DESCRIPTION
##### SUMMARY
Related to: https://github.com/ansible/ansible/issues/66291
```systemd``` module doesn't fail in check_mode when a service has not been found on a host,
it returns ```changed=True```, e.g. something like:
```
changed: [test] => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    }, 
    "changed": true, 
    "invocation": {
        "module_args": {
            "daemon_reexec": false, 
            "daemon_reload": false, 
            "enabled": null, 
            "force": null, 
            "masked": null, 
            "name": "mongodb", 
            "no_block": false, 
            "scope": null, 
            "state": "stopped", 
            "user": null
        }
    }, 
    "msg": "Service mongodb not found on host, assuming it will exist on full run"
}
```
it would be fair if it failed in check_mode as the same as in the real mode when a service hasn't been found on a host, otherwise it can be a bit confusing (because we expect the same behavior in check_mode besides it won't change anything).

I've added a new kwarg because service.py is used by several modules.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/module_utils/service.py```
