### PR TITLE
support rabbitmq 3.8.x in version check (#66855)

### DIFF
--- a/changelogs/fragments/rabbitmq-3.8.yml
+++ b/changelogs/fragments/rabbitmq-3.8.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- rabbitmq_policy - Fix version parsing for RabbitMQ 3.8.

--- a/lib/ansible/modules/messaging/rabbitmq/rabbitmq_policy.py
+++ b/lib/ansible/modules/messaging/rabbitmq/rabbitmq_policy.py
@@ -125,7 +125,13 @@ class RabbitMqPolicy(object):
     def _rabbit_version(self):
         status = self._exec(['status'], True, False, False)
 
+        # 3.7.x erlang style output
         version_match = re.search('{rabbit,".*","(?P<version>.*)"}', status)
+        if version_match:
+            return Version(version_match.group('version'))
+
+        # 3.8.x style ouput
+        version_match = re.search('RabbitMQ version: (?P<version>.*)', status)
         if version_match:
             return Version(version_match.group('version'))
 


### PR DESCRIPTION
### SUMMARY

Support rabbitmq 3.8.x in the rabbitmq_policy version check.
Fixes #66731

Backport of #66855

### ISSUE TYPE
Bugfix Pull Request
COMPONENT NAME
rabbitmq_policy

### ADDITIONAL INFORMATION
rabbitmqctl status drastically changed its status in 3.8.x. thus breaking the parsing that rabbitmq_policy does to parse the version. This change just adds a second parse for the 3.8 format if it doesn't find the 3.7 version. It may make sense to flip the order of the checks on the assumption that 3.8 will become the prevalent version.
```
- name: set up topic mirroring
  rabbitmq_policy:
    name: HA Mode
    pattern: mqtt-.*
  args:
    tags:
      ha-mode: nodes
      ha-params: "{{ rabbitmq_mirrors }}"
  run_once: true
```

when the policy already exists results in the following failure due to version check failing
```
ansible-playbook -i rabbitmq configure-rabbitmq-debug.yml -b --private-key master.key -u master -vvv

The full traceback is:
Traceback (most recent call last):
  File "/home/clouddevmaster/.ansible/tmp/ansible-tmp-1579794428.83-164555296831546/AnsiballZ_rabbitmq_policy.py", line 102, in <module>
    _ansiballz_main()
  File "/home/clouddevmaster/.ansible/tmp/ansible-tmp-1579794428.83-164555296831546/AnsiballZ_rabbitmq_policy.py", line 94, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/clouddevmaster/.ansible/tmp/ansible-tmp-1579794428.83-164555296831546/AnsiballZ_rabbitmq_policy.py", line 40, in invoke_module
    runpy.run_module(mod_name='ansible.modules.messaging.rabbitmq.rabbitmq_policy', init_globals=None, run_name='__main__', alter_sys=True)
  File "/usr/lib/python2.7/runpy.py", line 188, in run_module
    fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 82, in _run_module_code
    mod_name, mod_fname, mod_loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/tmp/ansible_rabbitmq_policy_payload_OEqAxO/ansible_rabbitmq_policy_payload.zip/ansible/modules/messaging/rabbitmq/rabbitmq_policy.py", line 241, in <module>
  File "/tmp/ansible_rabbitmq_policy_payload_OEqAxO/ansible_rabbitmq_policy_payload.zip/ansible/modules/messaging/rabbitmq/rabbitmq_policy.py", line 230, in main
  File "/tmp/ansible_rabbitmq_policy_payload_OEqAxO/ansible_rabbitmq_policy_payload.zip/ansible/modules/messaging/rabbitmq/rabbitmq_policy.py", line 154, in has_modifications
  File "/tmp/ansible_rabbitmq_policy_payload_OEqAxO/ansible_rabbitmq_policy_payload.zip/ansible/modules/messaging/rabbitmq/rabbitmq_policy.py", line 154, in <genexpr>
  File "/tmp/ansible_rabbitmq_policy_payload_OEqAxO/ansible_rabbitmq_policy_payload.zip/ansible/modules/messaging/rabbitmq/rabbitmq_policy.py", line 191, in _policy_check
  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```

After the change is applied, the rabbitmq_policy task succeeds as expected because it takes the correct branch in _list_polices