### PR TITLE
Make aws modules work with minio as endpoint

### DIFF
--- a/lib/ansible/module_utils/aws/core.py
+++ b/lib/ansible/module_utils/aws/core.py
@@ -150,7 +150,7 @@ class AnsibleAWSModule(object):
             found_operational_request = re.search(r"OperationModel\(name=.*?\)", ln)
             if found_operational_request:
                 operation_request = found_operational_request.group(0)[20:-1]
-                resource = re.search(r"https://.*?\.", ln).group(0)[8:-1]
+                resource = re.search(r"https?://.*?\.", ln).group(0)[8:-1]
                 actions.append("{0}:{1}".format(resource, operation_request))
         return list(set(actions))
 


### PR DESCRIPTION
##### SUMMARY
This change makes it possible to use an http-based minio endpoint
with the Ansible AWS modules.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aws modules