### PR TITLE
Handle Slackware OS version strings containing a plus (“+”)

### DIFF
--- a/changelogs/fragments/38760-slackware-os-dist.yml
+++ b/changelogs/fragments/38760-slackware-os-dist.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - facts - account for Slackware OS with ``+`` in the name (https://github.com/ansible/ansible/issues/38760)

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -211,7 +211,7 @@ class DistributionFiles:
         if 'Slackware' not in data:
             return False, slackware_facts  # TODO: remove
         slackware_facts['distribution'] = name
-        version = re.findall(r'\w+[.]\w+', data)
+        version = re.findall(r'\w+[.]\w+\+?', data)
         if version:
             slackware_facts['distribution_version'] = version[0]
         return True, slackware_facts

--- a/test/units/module_utils/facts/fixtures/distribution_files/ClearLinux
+++ b/test/units/module_utils/facts/fixtures/distribution_files/ClearLinux
@@ -1,0 +1,10 @@
+NAME="Clear Linux OS"
+VERSION=1
+ID=clear-linux-os
+ID_LIKE=clear-linux-os
+VERSION_ID=28120
+PRETTY_NAME="Clear Linux OS"
+ANSI_COLOR="1;35"
+HOME_URL="https://clearlinux.org"
+SUPPORT_URL="https://clearlinux.org"
+BUG_REPORT_URL="mailto:dev@lists.clearlinux.org"',

--- a/test/units/module_utils/facts/fixtures/distribution_files/CoreOS
+++ b/test/units/module_utils/facts/fixtures/distribution_files/CoreOS
@@ -1,0 +1,10 @@
+NAME="Container Linux by CoreOS"
+ID=coreos
+VERSION=1911.5.0
+VERSION_ID=1911.5.0
+BUILD_ID=2018-12-15-2317
+PRETTY_NAME="Container Linux by CoreOS 1911.5.0 (Rhyolite)"
+ANSI_COLOR="38;5;75"
+HOME_URL="https://coreos.com/"
+BUG_REPORT_URL="https://issues.coreos.com"
+COREOS_BOARD="amd64-usr"

--- a/test/units/module_utils/facts/fixtures/distribution_files/LinuxMint
+++ b/test/units/module_utils/facts/fixtures/distribution_files/LinuxMint
@@ -1,0 +1,12 @@
+NAME="Linux Mint"
+VERSION="19.1 (Tessa)"
+ID=linuxmint
+ID_LIKE=ubuntu
+PRETTY_NAME="Linux Mint 19.1"
+VERSION_ID="19.1"
+HOME_URL="https://www.linuxmint.com/"
+SUPPORT_URL="https://forums.ubuntu.com/"
+BUG_REPORT_URL="http://linuxmint-troubleshooting-guide.readthedocs.io/en/latest/"
+PRIVACY_POLICY_URL="https://www.linuxmint.com/"
+VERSION_CODENAME=tessa
+UBUNTU_CODENAME=bionic

--- a/test/units/module_utils/facts/fixtures/distribution_files/Slackware
+++ b/test/units/module_utils/facts/fixtures/distribution_files/Slackware
@@ -1,0 +1,10 @@
+NAME=Slackware
+VERSION="14.1"
+ID=slackware
+VERSION_ID=14.1
+PRETTY_NAME="Slackware 14.1"
+ANSI_COLOR="0;34"
+CPE_NAME="cpe:/o:slackware:slackware_linux:14.1"
+HOME_URL="http://slackware.com/"
+SUPPORT_URL="http://www.linuxquestions.org/questions/slackware-14/"
+BUG_REPORT_URL="http://www.linuxquestions.org/questions/slackware-14/"

--- a/test/units/module_utils/facts/fixtures/distribution_files/Slackware
+++ b/test/units/module_utils/facts/fixtures/distribution_files/Slackware
@@ -1,10 +1,1 @@
-NAME=Slackware
-VERSION="14.1"
-ID=slackware
-VERSION_ID=14.1
-PRETTY_NAME="Slackware 14.1"
-ANSI_COLOR="0;34"
-CPE_NAME="cpe:/o:slackware:slackware_linux:14.1"
-HOME_URL="http://slackware.com/"
-SUPPORT_URL="http://www.linuxquestions.org/questions/slackware-14/"
-BUG_REPORT_URL="http://www.linuxquestions.org/questions/slackware-14/"
+Slackware 14.1

--- a/test/units/module_utils/facts/fixtures/distribution_files/SlackwareCurrent
+++ b/test/units/module_utils/facts/fixtures/distribution_files/SlackwareCurrent
@@ -1,0 +1,10 @@
+NAME=Slackware
+VERSION="14.1+"
+ID=slackware
+VERSION_ID=14.1+
+PRETTY_NAME="Slackware 14.1+"
+ANSI_COLOR="0;34"
+CPE_NAME="cpe:/o:slackware:slackware_linux:14.1+"
+HOME_URL="http://slackware.com/"
+SUPPORT_URL="http://www.linuxquestions.org/questions/slackware-14/"
+BUG_REPORT_URL="http://www.linuxquestions.org/questions/slackware-14/"

--- a/test/units/module_utils/facts/fixtures/distribution_files/SlackwareCurrent
+++ b/test/units/module_utils/facts/fixtures/distribution_files/SlackwareCurrent
@@ -1,10 +1,1 @@
-NAME=Slackware
-VERSION="14.1+"
-ID=slackware
-VERSION_ID=14.1+
-PRETTY_NAME="Slackware 14.1+"
-ANSI_COLOR="0;34"
-CPE_NAME="cpe:/o:slackware:slackware_linux:14.1+"
-HOME_URL="http://slackware.com/"
-SUPPORT_URL="http://www.linuxquestions.org/questions/slackware-14/"
-BUG_REPORT_URL="http://www.linuxquestions.org/questions/slackware-14/"
+Slackware 14.2+

--- a/test/units/module_utils/facts/system/distribution/conftest.py
+++ b/test/units/module_utils/facts/system/distribution/conftest.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+import pytest
+
+from units.compat.mock import Mock
+
+
+@pytest.fixture
+def mock_module():
+    mock_module = Mock()
+    mock_module.params = {'gather_subset': ['all'],
+                          'gather_timeout': 5,
+                          'filter': '*'}
+    mock_module.get_bin_path = Mock(return_value=None)
+    return mock_module

--- a/test/units/module_utils/facts/system/distribution/test_parse_distribution_file_ClearLinux.py
+++ b/test/units/module_utils/facts/system/distribution/test_parse_distribution_file_ClearLinux.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import os
+import pytest
+
+from ansible.module_utils.facts.system.distribution import DistributionFiles
+
+
+@pytest.fixture
+def test_input():
+    return {
+        'name': 'Clearlinux',
+        'path': '/usr/lib/os-release',
+        'collected_facts': None,
+    }
+
+
+def test_parse_distribution_file_clear_linux(mock_module, test_input):
+    test_input['data'] = open(os.path.join(os.path.dirname(__file__), '../../fixtures/distribution_files/ClearLinux')).read()
+
+    result = (
+        True,
+        {
+            'distribution': 'Clear Linux OS',
+            'distribution_major_version': '28120',
+            'distribution_release': 'clear-linux-os',
+            'distribution_version': '28120'
+        }
+    )
+
+    distribution = DistributionFiles(module=mock_module())
+    assert result == distribution.parse_distribution_file_ClearLinux(**test_input)
+
+
+@pytest.mark.parametrize('distro_file', ('CoreOS', 'LinuxMint'))
+def test_parse_distribution_file_clear_linux_no_match(mock_module, distro_file, test_input):
+    """
+    Test against data from Linux Mint and CoreOS to ensure we do not get a reported
+    match from parse_distribution_file_ClearLinux()
+    """
+    test_input['data'] = open(os.path.join(os.path.dirname(__file__), '../../fixtures/distribution_files', distro_file)).read()
+
+    result = (False, {})
+
+    distribution = DistributionFiles(module=mock_module())
+    assert result == distribution.parse_distribution_file_ClearLinux(**test_input)

--- a/test/units/module_utils/facts/system/distribution/test_parse_distribution_file_Slackware.py
+++ b/test/units/module_utils/facts/system/distribution/test_parse_distribution_file_Slackware.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import os
+import pytest
+
+from ansible.module_utils.facts.system.distribution import DistributionFiles
+
+
+@pytest.mark.parametrize(
+    ('distro_file', 'expected_version'),
+    (
+        ('Slackware', '14.1'),
+        ('SlackwareCurrent', '14.1+'),
+    )
+)
+def test_parse_distribution_file_slackware(mock_module, distro_file, expected_version):
+    test_input = {
+        'name': 'Slackware',
+        'data': open(os.path.join(os.path.dirname(__file__), '../../fixtures/distribution_files', distro_file)).read(),
+        'path': '/etc/os-release',
+        'collected_facts': None,
+    }
+
+    result = (
+        True,
+        {
+            'distribution': 'Slackware',
+            'distribution_version': expected_version
+        }
+    )
+    distribution = DistributionFiles(module=mock_module())
+    assert result == distribution.parse_distribution_file_Slackware(**test_input)

--- a/test/units/module_utils/facts/system/distribution/test_parse_distribution_file_Slackware.py
+++ b/test/units/module_utils/facts/system/distribution/test_parse_distribution_file_Slackware.py
@@ -15,7 +15,7 @@ from ansible.module_utils.facts.system.distribution import DistributionFiles
     ('distro_file', 'expected_version'),
     (
         ('Slackware', '14.1'),
-        ('SlackwareCurrent', '14.1+'),
+        ('SlackwareCurrent', '14.2+'),
     )
 )
 def test_parse_distribution_file_slackware(mock_module, distro_file, expected_version):


### PR DESCRIPTION
A couple of years ago Slackware -current began using a plus (“+”) at the end of the distribution version string to indicate the os distribution being used is an in-progress/future version. No-plus: stable. Plus: in-progress

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Slackware distribution version strings can contain a plus ("+") when the Slackware OS being used is the in-progress/future release version.

For example:
Slackware stable OS distribution string: `Slackware 14.2`
Slackware -current (in-progress) OS distribution string: `Slackware 14.2+`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes https://github.com/ansible/ansible/issues/38760

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible/module_utils/facts/system/distribution.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
`ansible -m setup HOST_RUNNING_SLACKWARE_CURRENT | grep ansible_distribution_version`

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before change:
```
"ansible_distribution_version": "14.2",
```

After change:
```
"ansible_distribution_version": "14.2+",
```
