### PR TITLE
Remove test support option from ansible-test.

### DIFF
--- a/test/lib/ansible_test/_internal/ansible_util.py
+++ b/test/lib/ansible_test/_internal/ansible_util.py
@@ -113,9 +113,7 @@ def ansible_environment(args, color=True, ansible_config=None):
 
 def configure_plugin_paths(args):  # type: (CommonConfig) -> t.Dict[str, str]
     """Return environment variables with paths to plugins relevant for the current command."""
-    # temporarily require opt-in to this feature
-    # once collection migration has occurred this feature should always be enabled
-    if not isinstance(args, IntegrationConfig) or not args.enable_test_support:
+    if not isinstance(args, IntegrationConfig):
         return {}
 
     support_path = os.path.join(ANSIBLE_SOURCE_ROOT, 'test', 'support', args.command)

--- a/test/lib/ansible_test/_internal/cli.py
+++ b/test/lib/ansible_test/_internal/cli.py
@@ -389,10 +389,6 @@ def parse_args():
                              action='store_true',
                              help='avoid unicode characters in temporary directory (use only for verifying broken tests)')
 
-    integration.add_argument('--enable-test-support',
-                             action='store_true',
-                             help=argparse.SUPPRESS)  # temporary option for side-by-side testing -- remove after collection migration
-
     subparsers = parser.add_subparsers(metavar='COMMAND')
     subparsers.required = True  # work-around for python 3 bug which makes subparsers optional
 

--- a/test/lib/ansible_test/_internal/config.py
+++ b/test/lib/ansible_test/_internal/config.py
@@ -256,7 +256,6 @@ class IntegrationConfig(TestConfig):
         self.diff = args.diff
         self.no_temp_workdir = args.no_temp_workdir
         self.no_temp_unicode = args.no_temp_unicode
-        self.enable_test_support = args.enable_test_support
 
         if self.get_delegated_completion().get('temp-unicode', 'enabled') == 'disabled':
             self.no_temp_unicode = True

--- a/test/utils/shippable/incidental/cloud.sh
+++ b/test/utils/shippable/incidental/cloud.sh
@@ -36,6 +36,5 @@ for python_version in "${python_versions[@]}"; do
     ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
         --remote-terminate "${terminate}" \
         --remote-stage "${stage}" \
-        --enable-test-support \
         --docker --python "${python_version}"
 done

--- a/test/utils/shippable/incidental/linux.sh
+++ b/test/utils/shippable/incidental/linux.sh
@@ -12,4 +12,3 @@ target="shippable/posix/incidental/"
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
     --docker "${image}" \
-    --enable-test-support \

--- a/test/utils/shippable/incidental/network.sh
+++ b/test/utils/shippable/incidental/network.sh
@@ -40,7 +40,6 @@ for python_version in "${python_versions[@]}"; do
         --platform-connection "${platform}=ansible.netcommon.network_cli" \
         --platform-collection "vyos=vyos.vyos" \
         --platform-collection "ios=cisco.ios" \
-        --enable-test-support \
         --docker default --python "${python_version}" \
         --remote-terminate "${terminate}" --remote-stage "${stage}" --remote-provider "${provider}"
 done

--- a/test/utils/shippable/incidental/remote.sh
+++ b/test/utils/shippable/incidental/remote.sh
@@ -16,4 +16,3 @@ provider="${P:-default}"
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
     --remote "${platform}/${version}" --remote-terminate always --remote-stage "${stage}" --remote-provider "${provider}" \
-    --enable-test-support \

--- a/test/utils/shippable/incidental/windows.sh
+++ b/test/utils/shippable/incidental/windows.sh
@@ -72,6 +72,5 @@ for version in "${python_versions[@]}"; do
     ansible-test windows-integration --color -v --retry-on-error "${ci}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
         "${platforms[@]}" \
         --docker default --python "${version}" \
-        --enable-test-support \
         --remote-terminate "${terminate}" --remote-stage "${stage}" --remote-provider "${provider}"
 done

--- a/test/utils/shippable/linux.sh
+++ b/test/utils/shippable/linux.sh
@@ -13,13 +13,6 @@ else
     target="shippable/posix/"
 fi
 
-# detect the post migration ansible/ansible repo and enable test support plugins
-if [ -f lib/ansible/config/routing.yml ]; then
-    # this option is only useful for ansible/ansible (not collections) and should not be used prior to migration (except for incidental tests)
-    enable_test_support=--enable-test-support
-fi
-
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
-    ${enable_test_support:+"$enable_test_support"} \
     --docker "${image}"

--- a/test/utils/shippable/remote.sh
+++ b/test/utils/shippable/remote.sh
@@ -17,13 +17,6 @@ fi
 stage="${S:-prod}"
 provider="${P:-default}"
 
-# detect the post migration ansible/ansible repo and enable test support plugins
-if [ -f lib/ansible/config/routing.yml ]; then
-    # this option is only useful for ansible/ansible (not collections) and should not be used prior to migration (except for incidental tests)
-    enable_test_support=--enable-test-support
-fi
-
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
-    ${enable_test_support:+"$enable_test_support"} \
     --remote "${platform}/${version}" --remote-terminate always --remote-stage "${stage}" --remote-provider "${provider}"

--- a/test/utils/shippable/windows.sh
+++ b/test/utils/shippable/windows.sh
@@ -13,12 +13,6 @@ target="shippable/windows/group${group}/"
 stage="${S:-prod}"
 provider="${P:-default}"
 
-# detect the post migration ansible/ansible repo and enable test support plugins
-if [ -f lib/ansible/config/routing.yml ]; then
-    # this option is only useful for ansible/ansible (not collections) and should not be used prior to migration (except for incidental tests)
-    enable_test_support=--enable-test-support
-fi
-
 # python versions to test in order
 # python 2.7 runs full tests while other versions run minimal tests
 python_versions=(
@@ -99,6 +93,5 @@ for version in "${python_versions[@]}"; do
     ansible-test windows-integration --color -v --retry-on-error "${ci}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
         "${platforms[@]}" --changed-all-target "${changed_all_target}" --changed-all-mode "${changed_all_mode}" \
         --docker default --python "${version}" \
-        ${enable_test_support:+"$enable_test_support"} \
         --remote-terminate "${terminate}" --remote-stage "${stage}" --remote-provider "${provider}"
 done


### PR DESCRIPTION
##### SUMMARY

Remove test support option from ansible-test.

This option was added to facilitate migration and is no longer needed.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
