### PR TITLE
Make "terminal length 0" failure a warning, not error.

### DIFF
--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -57,7 +57,8 @@ class TerminalModule(TerminalBase):
         try:
             self._exec_cli_command(b'terminal length 0')
         except AnsibleConnectionFailure:
-            raise AnsibleConnectionFailure('unable to set terminal parameters')
+            display.display('WARNING: Unable to set terminal length, command responses may be truncated')
+            # raise AnsibleConnectionFailure('unable to set terminal parameters')
 
         try:
             self._exec_cli_command(b'terminal width 512')

--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -58,7 +58,6 @@ class TerminalModule(TerminalBase):
             self._exec_cli_command(b'terminal length 0')
         except AnsibleConnectionFailure:
             display.display('WARNING: Unable to set terminal length, command responses may be truncated')
-            # raise AnsibleConnectionFailure('unable to set terminal parameters')
 
         try:
             self._exec_cli_command(b'terminal width 512')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Maybe this should be configurable as warning vs. error, but as such, it matches the handling of "terminal width" in https://github.com/ansible/ansible/pull/47290 and makes the error of "terminal length 0" a warning instead.

User that Ansible uses to interact with Cisco IOS needs to have EXEC level privileges (>= 1) and ios_user module itself doesn't allow a privilege level = 0, so we'd see this situation on transitioning from a manually configured Cisco device to an Ansible configured one.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #68149

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/terminal/ios.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
