### PR TITLE
Prefer parsing JSON-like strings over splitting on commas

### DIFF
--- a/changelogs/fragments/68151-jsonify-list-parameters.yml
+++ b/changelogs/fragments/68151-jsonify-list-parameters.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - module parameters of list type are parsed as JSON if given as string that starts [ and ends with ].

--- a/lib/ansible/module_utils/common/validation.py
+++ b/lib/ansible/module_utils/common/validation.py
@@ -372,6 +372,14 @@ def check_type_list(value):
         return value
 
     if isinstance(value, string_types):
+        if value.startswith("[") and value.endswith("]"):
+            try:
+                return json.loads(value)
+            except Exception:
+                (result, exc) = safe_eval(value, dict(), include_exceptions=True)
+                if exc is not None:
+                    raise TypeError('unable to evaluate string as list')
+                return result
         return value.split(",")
     elif isinstance(value, int) or isinstance(value, float):
         return [str(value)]


### PR DESCRIPTION
##### SUMMARY
This seems like a necessary tweak in order to collections to comply with the rules `doc-missing-type` and `parameter-list-no-elements` for lists of dicts. I'll go deeper into my justification in the additional information section.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/common/validation.py

##### ADDITIONAL INFORMATION

We had a module that ultimately needed a list of dicts. Here is a test task for that module:

https://github.com/ansible/awx/blob/9f948e90d93ba8f84a9a73a8200c9e516f17e887/awx_collection/tests/integration/targets/tower_workflow_template/tasks/main.yml#L51-L55

This was introduced before the rule `doc-missing-type`, that basically means it was processed as a string type. But, if we are to be accurate in any way, then it's a list. If it's a list, then we need to specify that elements are dict type to satisfy `parameter-list-no-elements`.

But, people still have playbooks that will be using the old syntax. This is supported in almost all cases, like for dicts themselves.

https://github.com/ansible/ansible/blob/4e8b240b8b74db2453851f12ec82c7f782289187/lib/ansible/module_utils/common/validation.py#L395-L402

this PR is almost a direct ripoff of that logic.

Because without this, that test task produces:

```
TASK [Create a workflow job template] ***************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Elements value for option schema is of type <class 'str'> and we were unable to convert to dict: dictionary requested, could not parse JSON or key=value"}
```

That happens because when it gets `schema: '[{"success": [{"job_template": "my-job-1"}], "job_template": "my-job-2"}]'`, it splits on the `,` character. This produces 2 garbled entries when 1 was desired.

It strains reasonability that it JSON parses dict-like strings for dict parameters, but will not do the same for strings that clearly start and end with list syntax. IMO, this just makes the 2 types behave more similarly (automatically).

Additionally, it's the only way I can see legacy content adhering to the current sanity rules without breaking playbook functionality.
