### PR TITLE
Don't check mount src if it is not in /dev

### DIFF
--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -719,8 +719,12 @@ def main():
 
             changed = True
     elif state == 'mounted':
-        if not os.path.exists(args['src']):
-            module.fail_json(msg="Unable to mount %s as it does not exist" % args['src'])
+        if args['src'].startswith('/dev/') and not os.path.exists(args['src']):
+            if module.check_mode:
+                # Maybe something earlier in the playbook would have created it "for real"
+                module.warn("%s does not exist, continuing anyway due to check mode" % args['src'])
+            else:
+                module.fail_json(msg="Unable to mount %s as it does not exist" % args['src'])
 
         if not os.path.exists(name) and not module.check_mode:
             try:


### PR DESCRIPTION
It is perfectly legitimate for src not to refer to an existing file,
here are some examples:

 * NFS/CIFS/Ceph and other networked mounts
 * tmpfs and similar non-device filesystems
 * mounts by UUID, PARTUUID, LABEL or similar

Because people still want to catch the common errors, let's restrict the
check only to paths starting with "/dev/". But even that would fail in
check mode if the device is created by one of the previous steps, so
let's exclude the check in check mode.

Fixes: #65855
Fixes: #67588
Fixes: #67966

Note: I am not sure if this is still safe. Every time we tried to
formulate a more precise condition for the check, someone has shown a
counter-example. So I would very much prefer to remove the check
completely, but that didn't pass the review - exactly because during
every attempt a new person (not burnt during previous attempts) has
looked at the change, and thought "let's fix the condition instead".
So this is *really* the last attempt.

##### SUMMARY
This is a response to @bcoca who in #68102 said that he would prefer if the fix would add an additional check `not startswith('UUID=', 'LABEL=')` and then keep the `path.exists` check for those cases. I think this is fundamentally flawed, but the Right Thing (IMHO) (#65869, just let the mount command fail and undo everything when it does) cannot pass the review, so here it goes.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mount

##### ADDITIONAL INFORMATION
See also #68102, #65544 and #65869.