### PR TITLE
fix: update keyvault access policies correctly

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_keyvault.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_keyvault.py
@@ -380,16 +380,16 @@ class AzureRMVaults(AzureRMModuleBase):
                             if n.get('application_id', None) != o.get('application_id', None):
                                 self.to_do = Actions.Update
                                 break
-                            if sorted(n.get('keys', [])) != sorted(o.get('keys', [])):
+                            if sorted(n.get('permissions', {}).get('keys', []) or []) != sorted(o.get('permissions', {}).get('keys', []) or []):
                                 self.to_do = Actions.Update
                                 break
-                            if sorted(n.get('secrets', [])) != sorted(o.get('secrets', [])):
+                            if sorted(n.get('permissions', {}).get('secrets', []) or []) != sorted(o.get('permissions', {}).get('secrets', []) or []):
                                 self.to_do = Actions.Update
                                 break
-                            if sorted(n.get('certificates', [])) != sorted(o.get('certificates', [])):
+                            if sorted(n.get('permissions', {}).get('certificates', []) or []) != sorted(o.get('permissions', {}).get('certificates', []) or []):
                                 self.to_do = Actions.Update
                                 break
-                            if sorted(n.get('storage', [])) != sorted(o.get('storage', [])):
+                            if sorted(n.get('permissions', {}).get('storage', []) or []) != sorted(o.get('permissions', {}).get('storage', []) or []):
                                 self.to_do = Actions.Update
                                 break
 


### PR DESCRIPTION
##### SUMMARY
Hi.

When we try to update  access policies for keyvault, access policies are not updated. This is because
the part of code that  compare the old access policies with new not work properly. 
The problem is, the keys, secrets, certificates, storage  fields are not properly accessed.  This fields are inside of "permissions" structure.

This is the example format of  one access_policy:
```yaml
object_id:  xxx
tenant_id: yyy
application_id: ccc
permissions:
    keys: None
    secrets: None
    certificates:
        - List
        - get
        - delete
    storage: None
```

Fixes #68160

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_keyvault

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
None

```
