### PR TITLE
[2.9] vmware_cluster: Improve documentation for deprecated parameters

### DIFF
--- a/changelogs/fragments/68175-vmware_cluster-document_alternatives_for_deprecated_parameters.yml
+++ b/changelogs/fragments/68175-vmware_cluster-document_alternatives_for_deprecated_parameters.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_cluster - Document alternatives for deprecated parameters

--- a/lib/ansible/modules/cloud/vmware/vmware_cluster.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_cluster.py
@@ -64,12 +64,16 @@ options:
     enable_drs:
       description:
       - If set to C(yes), will enable DRS when the cluster is created.
+      - Use C(enable_drs) of M(vmware_cluster_drs) instead.
+      - Deprecated option, will be removed in version 2.12.
       type: bool
       default: 'no'
     drs_enable_vm_behavior_overrides:
       description:
       - Determines whether DRS Behavior overrides for individual virtual machines are enabled.
       - If set to C(True), overrides C(drs_default_vm_behavior).
+      - Use C(drs_enable_vm_behavior_overrides) of M(vmware_cluster_drs) instead.
+      - Deprecated option, will be removed in version 2.12.
       type: bool
       default: True
       version_added: 2.8
@@ -82,18 +86,24 @@ options:
         for the placement with a host. vCenter should not implement the recommendations automatically.
       - If set to C(fullyAutomated), then vCenter should automate both the migration of virtual machines
         and their placement with a host at power on.
+      - Use C(drs_default_vm_behavior) of M(vmware_cluster_drs) instead.
+      - Deprecated option, will be removed in version 2.12.
       default: fullyAutomated
       choices: [ fullyAutomated, manual, partiallyAutomated ]
       version_added: 2.8
     drs_vmotion_rate:
       description:
       - Threshold for generated ClusterRecommendations.
+      - Use C(drs_vmotion_rate) of M(vmware_cluster_drs) instead.
+      - Deprecated option, will be removed in version 2.12.
       default: 3
       choices: [ 1, 2, 3, 4, 5 ]
       version_added: 2.8
     enable_ha:
       description:
       - If set to C(yes) will enable HA when the cluster is created.
+      - Use C(enable_ha) of M(vmware_cluster_ha) instead.
+      - Deprecated option, will be removed in version 2.12.
       type: bool
       default: 'no'
     ha_host_monitoring:
@@ -102,6 +112,8 @@ options:
       - If set to C(enabled), HA restarts virtual machines after a host fails.
       - If set to C(disabled), HA does not restart virtual machines after a host fails.
       - If C(enable_ha) is set to C(no), then this value is ignored.
+      - Use C(ha_host_monitoring) of M(vmware_cluster_ha) instead.
+      - Deprecated option, will be removed in version 2.12.
       choices: [ 'enabled', 'disabled' ]
       default: 'enabled'
       version_added: 2.8
@@ -112,6 +124,8 @@ options:
       - If set to C(vmMonitoringDisabled), virtual machine health monitoring is disabled.
       - If set to C(vmMonitoringOnly), HA response to virtual machine heartbeat failure.
       - If C(enable_ha) is set to C(no), then this value is ignored.
+      - Use C(ha_vm_monitoring) of M(vmware_cluster_ha) instead.
+      - Deprecated option, will be removed in version 2.12.
       choices: ['vmAndAppMonitoring', 'vmMonitoringOnly', 'vmMonitoringDisabled']
       default: 'vmMonitoringDisabled'
       version_added: 2.8
@@ -120,12 +134,16 @@ options:
       - Number of host failures that should be tolerated, still guaranteeing sufficient resources to
         restart virtual machines on available hosts.
       - Accepts integer values only.
+      - Use C(slot_based_admission_control), C(reservation_based_admission_control) or C(failover_host_admission_control) of M(vmware_cluster_ha) instead.
+      - Deprecated option, will be removed in version 2.12.
       default: 2
       version_added: 2.8
     ha_admission_control_enabled:
       description:
       - Determines if strict admission control is enabled.
       - It is recommended to set this parameter to C(True), please refer documentation for more details.
+      - Use C(slot_based_admission_control), C(reservation_based_admission_control) or C(failover_host_admission_control) of M(vmware_cluster_ha) instead.
+      - Deprecated option, will be removed in version 2.12.
       default: True
       type: bool
       version_added: 2.8
@@ -135,6 +153,8 @@ options:
         if no heartbeat has been received.
       - This setting is only valid if C(ha_vm_monitoring) is set to, either C(vmAndAppMonitoring) or C(vmMonitoringOnly).
       - Unit is seconds.
+      - Use C(ha_vm_failure_interval) of M(vmware_cluster_ha) instead.
+      - Deprecated option, will be removed in version 2.12.
       default: 30
       version_added: 2.8
     ha_vm_min_up_time:
@@ -143,6 +163,8 @@ options:
         the virtual machine has been powered on.
       - This setting is only valid if C(ha_vm_monitoring) is set to, either C(vmAndAppMonitoring) or C(vmMonitoringOnly).
       - Unit is seconds.
+      - Use C(ha_vm_min_up_time) of M(vmware_cluster_ha) instead.
+      - Deprecated option, will be removed in version 2.12.
       default: 120
       version_added: 2.8
     ha_vm_max_failures:
@@ -150,6 +172,8 @@ options:
       - Maximum number of failures and automated resets allowed during the time
        that C(ha_vm_max_failure_window) specifies.
       - This setting is only valid if C(ha_vm_monitoring) is set to, either C(vmAndAppMonitoring) or C(vmMonitoringOnly).
+      - Use C(ha_vm_max_failures) of M(vmware_cluster_ha) instead.
+      - Deprecated option, will be removed in version 2.12.
       default: 3
       version_added: 2.8
     ha_vm_max_failure_window:
@@ -159,6 +183,8 @@ options:
       - This setting is only valid if C(ha_vm_monitoring) is set to, either C(vmAndAppMonitoring) or C(vmMonitoringOnly).
       - Unit is seconds.
       - Default specifies no failure window.
+      - Use C(ha_vm_max_failure_window) of M(vmware_cluster_ha) instead.
+      - Deprecated option, will be removed in version 2.12.
       default: -1
       version_added: 2.8
     ha_restart_priority:
@@ -173,18 +199,24 @@ options:
         when there is insufficient capacity on hosts to meet all virtual machine needs.
       - If set to C(low), then virtual machine with this priority have a lower chance of powering on after a failure,
         when there is insufficient capacity on hosts to meet all virtual machine needs.
+      - Use C(ha_restart_priority) of M(vmware_cluster_ha) instead.
+      - Deprecated option, will be removed in version 2.12.
       default: 'medium'
       version_added: 2.8
       choices: [ 'disabled', 'high', 'low', 'medium' ]
     enable_vsan:
       description:
       - If set to C(yes) will enable vSAN when the cluster is created.
+      - Use C(enable_vsan) of M(vmware_cluster_vsan) instead.
+      - Deprecated option, will be removed in version 2.12.
       type: bool
       default: 'no'
     vsan_auto_claim_storage:
       description:
       - Determines whether the VSAN service is configured to automatically claim local storage
         on VSAN-enabled hosts in the cluster.
+      - Use C(vsan_auto_claim_storage) of M(vmware_cluster_vsan) instead.
+      - Deprecated option, will be removed in version 2.12.
       type: bool
       default: False
       version_added: 2.8
@@ -193,6 +225,10 @@ options:
       - Create C(present) or remove C(absent) a VMware vSphere cluster.
       choices: [ absent, present ]
       default: present
+seealso:
+- module: vmware_cluster_drs
+- module: vmware_cluster_ha
+- module: vmware_cluster_vsan
 extends_documentation_fragment: vmware.documentation
 '''
 


### PR DESCRIPTION
##### SUMMARY
Fix #68041, backport of VMware collection [#47](https://github.com/ansible-collections/vmware/pull/47)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_cluster

##### ADDITIONAL INFORMATION
Document alternatives for deprecated parameters.