### PR TITLE
Add configurable option for paramiko banner_ssh timeout

### DIFF
--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -130,7 +130,8 @@ DOCUMENTATION = """
         default: 30
         description:
           - Configures, in seconds, the amount of time to wait for the SSH
-            banner to be presented.
+            banner to be presented. This option is supported by paramiko
+            version 1.15.0 or newer.
         ini:
           - section: paramiko_connection
             key: banner_timeout
@@ -348,16 +349,10 @@ class Connection(ConnectionBase):
             # paramiko 2.2 introduced auth_timeout parameter
             if LooseVersion(paramiko.__version__) >= LooseVersion('2.2.0'):
                 ssh_connect_kwargs['auth_timeout'] = self._play_context.timeout
-            else:
-                display.warning('auth_timeout ignored.'
-                                ' Please upgrade to Paramiko 2.2.0 or newer.')
 
             # paramiko 1.15 introduced banner timeout parameter
             if LooseVersion(paramiko.__version__) >= LooseVersion('1.15.0'):
                 ssh_connect_kwargs['banner_timeout'] = self.get_option('banner_timeout')
-            else:
-                display.warning('banner_timeout ignored.'
-                                ' Please upgrade to Paramiko 1.15.0 or newer.')
 
             ssh.connect(
                 self._play_context.remote_addr.lower(),

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -125,6 +125,17 @@ DOCUMENTATION = """
         ini:
           - section: defaults
             key: use_persistent_connections
+      banner_timeout:
+        type: float
+        default: 30
+        description:
+          - Configures, in seconds, the amount of time to wait for the SSH
+            banner to be presented.
+        ini:
+          - section: paramiko_connection
+            key: banner_timeout
+        env:
+          - name: ANSIBLE_PARAMIKO_BANNER_TIMEOUT
 # TODO:
 #timeout=self._play_context.timeout,
 """
@@ -347,6 +358,7 @@ class Connection(ConnectionBase):
                 password=self._play_context.password,
                 timeout=self._play_context.timeout,
                 port=port,
+                banner_timeout=self.get_option('banner_timeout'),
                 **ssh_connect_kwargs
             )
         except paramiko.ssh_exception.BadHostKeyException as e:

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -348,6 +348,16 @@ class Connection(ConnectionBase):
             # paramiko 2.2 introduced auth_timeout parameter
             if LooseVersion(paramiko.__version__) >= LooseVersion('2.2.0'):
                 ssh_connect_kwargs['auth_timeout'] = self._play_context.timeout
+            else:
+                display.warning('auth_timeout ignored.'
+                                ' Please upgrade to Paramiko 2.2.0 or newer.')
+
+            # paramiko 1.15 introduced banner timeout parameter
+            if LooseVersion(paramiko.__version__) >= LooseVersion('1.15.0'):
+                ssh_connect_kwargs['banner_timeout'] = self.get_option('banner_timeout')
+            else:
+                display.warning('banner_timeout ignored.'
+                                ' Please upgrade to Paramiko 1.15.0 or newer.')
 
             ssh.connect(
                 self._play_context.remote_addr.lower(),
@@ -358,7 +368,6 @@ class Connection(ConnectionBase):
                 password=self._play_context.password,
                 timeout=self._play_context.timeout,
                 port=port,
-                banner_timeout=self.get_option('banner_timeout'),
                 **ssh_connect_kwargs
             )
         except paramiko.ssh_exception.BadHostKeyException as e:

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -135,8 +135,10 @@ DOCUMENTATION = """
         ini:
           - section: paramiko_connection
             key: banner_timeout
+            version_added: '2.10'
         env:
           - name: ANSIBLE_PARAMIKO_BANNER_TIMEOUT
+            version_added: '2.10'
 # TODO:
 #timeout=self._play_context.timeout,
 """


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds a configurable option for paramiko connection
to control the value of banner timeout in paramiko library.
The banner timeout value can be set in ansible.cfg file as
```
[paramiko_connection]
banner_timeout = 30
```
or using enviornment variable
```
export ANSIBLE_PARAMIKO_BANNER_TIMEOUT=30
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/connection/paramiko_ssh.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
