### PR TITLE
moving zabbix modules to a dedicated collection

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -908,6 +908,7 @@ files:
   $modules/monitoring/zabbix/:
     maintainers: $team_zabbix
     ignored: cove
+    migrated_to: community.zabbix
   $modules/net_tools/basics/get_url.py: ptux
   $modules/net_tools/basics/slurp.py: $team_ansible
   $modules/net_tools/basics/uri.py:
@@ -4407,8 +4408,12 @@ files:
   test/integration/targets/setup_docker: *id011
   test/integration/targets/setup_openssl: *id012
   test/integration/targets/setup_mysql_db: *id004
-  test/integration/targets/setup_zabbix: $team_zabbix
-  test/integration/targets/zabbix_: $team_zabbix
+  test/integration/targets/setup_zabbix:
+    maintainers: $team_zabbix
+    migrated_to: community.zabbix
+  test/integration/targets/zabbix_:
+    maintainers: $team_zabbix
+    migrated_to: community.zabbix
   test/integration/targets/ucs_: *id031
   test/integration/targets/vultr: *id035
   test/lib/:
@@ -7186,7 +7191,7 @@ files:
   lib/ansible/plugins/doc_fragments/vexata.py:
     migrated_to: community.general
   lib/ansible/plugins/doc_fragments/zabbix.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/plugins/filter/gcp_kms_filters.py:
     migrated_to: community.general
   lib/ansible/plugins/filter/json_query.py:
@@ -7384,9 +7389,9 @@ files:
   contrib/inventory/vbox.py:
     migrated_to: community.general
   contrib/inventory/zabbix.ini:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   contrib/inventory/zabbix.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   contrib/inventory/zone.py:
     migrated_to: community.general
   lib/ansible/plugins/lookup/avi.py:
@@ -8824,45 +8829,45 @@ files:
   lib/ansible/modules/monitoring/uptimerobot.py:
     migrated_to: community.general
   lib/ansible/modules/monitoring/zabbix/_zabbix_group_facts.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/modules/monitoring/zabbix/_zabbix_host_facts.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/modules/monitoring/zabbix/zabbix_action.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/modules/monitoring/zabbix/zabbix_group.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/modules/monitoring/zabbix/zabbix_group_info.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/modules/monitoring/zabbix/zabbix_host.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/modules/monitoring/zabbix/zabbix_host_events_info.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/modules/monitoring/zabbix/zabbix_host_info.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/modules/monitoring/zabbix/zabbix_hostmacro.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/modules/monitoring/zabbix/zabbix_maintenance.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/modules/monitoring/zabbix/zabbix_map.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/modules/monitoring/zabbix/zabbix_mediatype.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/modules/monitoring/zabbix/zabbix_proxy.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/modules/monitoring/zabbix/zabbix_screen.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/modules/monitoring/zabbix/zabbix_service.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/modules/monitoring/zabbix/zabbix_template.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/modules/monitoring/zabbix/zabbix_template_info.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/modules/monitoring/zabbix/zabbix_user.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/modules/monitoring/zabbix/zabbix_user_info.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/modules/monitoring/zabbix/zabbix_valuemap.py:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   lib/ansible/modules/net_tools/dnsimple.py:
     migrated_to: community.general
   lib/ansible/modules/net_tools/dnsmadeeasy.py:
@@ -14612,53 +14617,53 @@ files:
   test/integration/targets/sensu_handler/tasks/tcp.yml:
     migrated_to: community.general
   test/integration/targets/zabbix_host/aliases:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/zabbix_host/defaults/main.yml:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/zabbix_host/tasks/zabbix_host_tests.yml:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/zabbix_host/tasks/zabbix_host_doc.yml:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/zabbix_host/tasks/zabbix_host_setup.yml:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/zabbix_host/tasks/main.yml:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/zabbix_host/tasks/zabbix_host_teardown.yml:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/zabbix_host/meta/main.yml:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/setup_zabbix/aliases:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/setup_zabbix/defaults/main.yml:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/setup_zabbix/tasks/setup.yml:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/setup_zabbix/tasks/main.yml:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/setup_zabbix/meta/main.yml:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/setup_zabbix/templates/zabbix_server.conf.j2:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/setup_zabbix/templates/zabbix.conf.php.j2:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/setup_zabbix/handlers/main.yml:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/zabbix_template/aliases:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/zabbix_template/defaults/main.yml:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/zabbix_template/tasks/main.yml:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/zabbix_template/meta/main.yml:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/zabbix_user/aliases:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/zabbix_user/defaults/main.yml:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/zabbix_user/tasks/main.yml:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/zabbix_user/meta/main.yml:
-    migrated_to: community.general
+    migrated_to: community.zabbix
   test/integration/targets/ipify_facts/aliases:
     migrated_to: community.general
   test/integration/targets/ipify_facts/vars/main.yml:

--- a/lib/ansible/config/routing.yml
+++ b/lib/ansible/config/routing.yml
@@ -1594,45 +1594,45 @@ plugin_routing:
     uptimerobot:
       redirect: community.general.uptimerobot
     zabbix_group_facts:
-      redirect: community.general.zabbix_group_facts
+      redirect: community.zabbix.zabbix_group_facts
     zabbix_host_facts:
-      redirect: community.general.zabbix_host_facts
+      redirect: community.zabbix.zabbix_host_facts
     zabbix_action:
-      redirect: community.general.zabbix_action
+      redirect: community.zabbix.zabbix_action
     zabbix_group:
-      redirect: community.general.zabbix_group
+      redirect: community.zabbix.zabbix_group
     zabbix_group_info:
-      redirect: community.general.zabbix_group_info
+      redirect: community.zabbix.zabbix_group_info
     zabbix_host:
-      redirect: community.general.zabbix_host
+      redirect: community.zabbix.zabbix_host
     zabbix_host_events_info:
-      redirect: community.general.zabbix_host_events_info
+      redirect: community.zabbix.zabbix_host_events_info
     zabbix_host_info:
-      redirect: community.general.zabbix_host_info
+      redirect: community.zabbix.zabbix_host_info
     zabbix_hostmacro:
-      redirect: community.general.zabbix_hostmacro
+      redirect: community.zabbix.zabbix_hostmacro
     zabbix_maintenance:
-      redirect: community.general.zabbix_maintenance
+      redirect: community.zabbix.zabbix_maintenance
     zabbix_map:
-      redirect: community.general.zabbix_map
+      redirect: community.zabbix.zabbix_map
     zabbix_mediatype:
-      redirect: community.general.zabbix_mediatype
+      redirect: community.zabbix.zabbix_mediatype
     zabbix_proxy:
-      redirect: community.general.zabbix_proxy
+      redirect: community.zabbix.zabbix_proxy
     zabbix_screen:
-      redirect: community.general.zabbix_screen
+      redirect: community.zabbix.zabbix_screen
     zabbix_service:
-      redirect: community.general.zabbix_service
+      redirect: community.zabbix.zabbix_service
     zabbix_template:
-      redirect: community.general.zabbix_template
+      redirect: community.zabbix.zabbix_template
     zabbix_template_info:
-      redirect: community.general.zabbix_template_info
+      redirect: community.zabbix.zabbix_template_info
     zabbix_user:
-      redirect: community.general.zabbix_user
+      redirect: community.zabbix.zabbix_user
     zabbix_user_info:
-      redirect: community.general.zabbix_user_info
+      redirect: community.zabbix.zabbix_user_info
     zabbix_valuemap:
-      redirect: community.general.zabbix_valuemap
+      redirect: community.zabbix.zabbix_valuemap
     cloudflare_dns:
       redirect: community.general.cloudflare_dns
     dnsimple:


### PR DESCRIPTION
##### SUMMARY
Everything related to zabbix going to a [dedicated collection repo](https://github.com/ansible-collections/community.zabbix)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml
lib/ansible/config/routing.yml
