### PR TITLE
Add script for getting URLs of coverage runs

### DIFF
--- a/hacking/shippable/README.md
+++ b/hacking/shippable/README.md
@@ -5,6 +5,7 @@
 This directory contains the following scripts:
 
 - download.py - Download results from Shippable.
+- get_recent_coverage_runs.py - Retrieve Shippable URLs of recent coverage test runs.
 - incidental.py - Report on incidental code coverage using data from Shippable.
 - run.py - Start new runs on Shippable.
 
@@ -32,6 +33,11 @@ Reducing incidental test coverage, and eventually removing incidental tests invo
 
 1. Run the entire test suite with code coverage enabled. 
    This is done automatically each day on Shippable.
+   The URLs and statuses of the most recent such test runs can be found with:
+   ```shell
+   hacking/shippable/get_recent_coverage_runs.py <optional branch name>
+   ```
+   For now the branch name defaults to `temp-2.10-devel`.
 2. Download code coverage data from Shippable for local analysis. 
    Example:
    ```shell

--- a/hacking/shippable/get_recent_coverage_runs.py
+++ b/hacking/shippable/get_recent_coverage_runs.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+# (c) 2020 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import requests
+import sys
+
+BRANCH = 'temp-2.10-devel'
+
+if len(sys.argv) > 1:
+    BRANCH = sys.argv[1]
+
+
+def get_coverage_runs():
+    response = requests.get(
+        'https://api.shippable.com/runs?projectIds=573f79d02a8192902e20e34b'
+        '&branch=%s&limit=1000' % BRANCH)
+
+    if response.status_code != 200:
+        raise Exception(response.content)
+
+    runs = response.json()
+
+    coverage_runs = []
+    criteria = ['COMPLETE="yes"', 'COVERAGE="yes"']
+
+    for run in runs:
+        injected_vars = run.get('cleanRunYml', {}).get('env', {}).get('injected')
+        if not injected_vars:
+            continue
+        if all(criterion in injected_vars for criterion in criteria):
+            coverage_runs.append(run)
+
+    return coverage_runs
+
+
+def pretty_coverage_runs(runs):
+    for run in sorted(runs, key=lambda x: x['endedAt']):
+        if run['statusCode'] == 30:
+            print('🙂 [PASS] https://app.shippable.com/github/ansible/ansible/runs/%s (%s)' % (run['runNumber'], run['endedAt']))
+        else:
+            print('😢 [FAIL] https://app.shippable.com/github/ansible/ansible/runs/%s (%s)' % (run['runNumber'], run['endedAt']))
+
+
+def main():
+    pretty_coverage_runs(get_coverage_runs())
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY

Used to pass to the download script for collecting results and analyzing them as per README.md in `hacking/shippable/`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

`hacking/shippable`