### PR TITLE
Fix ansible-test unit test requirements.

### DIFF
--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -49,4 +49,3 @@ mccabe == 0.6.1
 pylint == 2.3.1
 typed-ast == 1.4.0  # 1.4.0 is required to compile on Python 3.8
 wrapt == 1.11.1
-semantic_version == 2.6.0 # newer versions are not supported on Python 2.6

--- a/test/lib/ansible_test/_data/requirements/units.txt
+++ b/test/lib/ansible_test/_data/requirements/units.txt
@@ -5,6 +5,3 @@ pytest
 pytest-mock
 pytest-xdist
 pyyaml
-
-# requirement for maven_artifact
-semantic_version


### PR DESCRIPTION
##### SUMMARY

Requirements were incorrectly added to ansible-test in https://github.com/ansible/ansible/pull/61813

These requirements should have been placed into `test/units/requirements.txt` instead.
Now that the relevant content has been migrated out of the repository, the requirements are no longer necessary there either.

No changelog entry for this change since the original changes were not included in any release and also lacked a changelog entry.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
