### PR TITLE
service_facts: fix for systemd 245

### DIFF
--- a/changelogs/fragments/68211-systemd-list-unit-files-parsing.yml
+++ b/changelogs/fragments/68211-systemd-list-unit-files-parsing.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - service_facts - Now correctly parses systemd list-unit-files for systemd >=245

--- a/lib/ansible/modules/system/service_facts.py
+++ b/lib/ansible/modules/system/service_facts.py
@@ -212,9 +212,10 @@ class SystemctlScanService(BaseService):
             services[service_name] = {"name": service_name, "state": state_val, "status": "unknown", "source": "systemd"}
         rc, stdout, stderr = self.module.run_command("%s list-unit-files --no-pager --type service --all" % systemctl_path, use_unsafe_shell=True)
         for line in [svc_line for svc_line in stdout.split('\n') if '.service' in svc_line and 'not-found' not in svc_line]:
+            # there is one more column (VENDOR PRESET) from `systemctl list-unit-files` for systemd >= 245
             try:
-                service_name, status_val = line.split()
-            except ValueError:
+                service_name, status_val = line.split()[:2]
+            except IndexError:
                 self.module.fail_json(msg="Malformed output discovered from systemd list-unit-files: {0}".format(line))
             if service_name not in services:
                 services[service_name] = {"name": service_name, "state": "unknown", "status": status_val, "source": "systemd"}


### PR DESCRIPTION
##### SUMMARY

Since systemd 245, `systemctl list-unit-files` comes with a new column
"VENDOR PRESET" [1] and breaks the service_facts module (see
additional information below).

This patch drops the third column to make it work with old and new
systemd. With the new slice operation, IndexError instead of ValueError
is raised if the output contains less than 2 columns.

Test plan: running `ansible-test integration -v service_facts` on
up-to-date Arch Linux

[1] https://github.com/systemd/systemd/pull/14445

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
service_facts module

##### ADDITIONAL INFORMATION
```
$ ansible localhost -m service_facts
localhost | FAILED! => {
    "changed": false,
    "msg": "Malformed output discovered from systemd list-unit-files: auditd.service                             disabled        disabled     "
}
```
