### PR TITLE
Address compat issue for collection loading on py26

### DIFF
--- a/changelogs/fragments/py26-collection-loader.yml
+++ b/changelogs/fragments/py26-collection-loader.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Update the plugin loader as it pertains to collections to work with Python2.6

--- a/changelogs/fragments/py26-collection-loader.yml
+++ b/changelogs/fragments/py26-collection-loader.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- Update the plugin loader as it pertains to collections to work with Python2.6
+- Create an ``import_module`` compat util, for use across the codebase, to allow collection loading to work properly on Python26

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -44,7 +44,7 @@ from ansible.plugins.loader import module_utils_loader
 from ansible.executor import action_write_locks
 
 from ansible.utils.display import Display
-
+from ansible.utils.import_module import import_module
 
 try:
     import importlib.util
@@ -52,13 +52,6 @@ try:
     imp = None
 except ImportError:
     import imp
-
-
-# HACK: keep Python 2.6 controller tests happy in CI until they're properly split
-try:
-    from importlib import import_module
-except ImportError:
-    import_module = __import__
 
 # if we're on a Python that doesn't have FNFError, redefine it as IOError (since that's what we'll see)
 try:

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -37,6 +37,7 @@ from ansible.errors import AnsibleError
 from ansible.executor.interpreter_discovery import InterpreterDiscoveryRequiredError
 from ansible.executor.powershell import module_manifest as ps_manifest
 from ansible.module_utils._text import to_bytes, to_text, to_native
+from ansible.module_utils.compat.importlib import import_module
 from ansible.plugins.loader import module_utils_loader
 # Must import strategy and use write_locks from there
 # If we import write_locks directly then we end up binding a
@@ -44,7 +45,6 @@ from ansible.plugins.loader import module_utils_loader
 from ansible.executor import action_write_locks
 
 from ansible.utils.display import Display
-from ansible.utils.import_module import import_module
 
 try:
     import importlib.util

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -46,6 +46,7 @@ from ansible.executor import action_write_locks
 
 from ansible.utils.display import Display
 
+
 try:
     import importlib.util
     import importlib.machinery

--- a/lib/ansible/executor/powershell/module_manifest.py
+++ b/lib/ansible/executor/powershell/module_manifest.py
@@ -17,8 +17,8 @@ from distutils.version import LooseVersion
 from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.compat.importlib import import_module
 from ansible.plugins.loader import ps_module_utils_loader
-from ansible.utils.import_module import import_module
 
 
 class PSModuleDepFinder(object):

--- a/lib/ansible/executor/powershell/module_manifest.py
+++ b/lib/ansible/executor/powershell/module_manifest.py
@@ -14,16 +14,11 @@ import re
 
 from distutils.version import LooseVersion
 
-# HACK: keep Python 2.6 controller tests happy in CI until they're properly split
-try:
-    from importlib import import_module
-except ImportError:
-    import_module = __import__
-
 from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.plugins.loader import ps_module_utils_loader
+from ansible.utils.import_module import import_module
 
 
 class PSModuleDepFinder(object):

--- a/lib/ansible/module_utils/compat/importlib.py
+++ b/lib/ansible/module_utils/compat/importlib.py
@@ -7,7 +7,6 @@ __metaclass__ = type
 
 import sys
 
-# HACK: keep Python 2.6 controller tests happy in CI until they're properly split
 try:
     from importlib import import_module
 except ImportError:

--- a/lib/ansible/module_utils/compat/importlib.py
+++ b/lib/ansible/module_utils/compat/importlib.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2020 Matt Martz <matt@sivel.net>
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -24,6 +24,7 @@ from ansible.parsing.yaml.loader import AnsibleLoader
 from ansible.plugins import get_plugin_class, MODULE_CACHE, PATH_CACHE, PLUGIN_PATH_CACHE
 from ansible.utils.collection_loader import AnsibleCollectionLoader, AnsibleFlatMapLoader, AnsibleCollectionRef
 from ansible.utils.display import Display
+from ansible.utils.import_module import import_module
 from ansible.utils.plugin_docs import add_fragments
 
 try:
@@ -31,19 +32,6 @@ try:
     imp = None
 except ImportError:
     import imp
-
-# HACK: keep Python 2.6 controller tests happy in CI until they're properly split
-try:
-    from importlib import import_module
-except ImportError:
-    # importlib.import_module returns the tail
-    # whereas __import__ returns the head
-    # compat to work like importlib.import_module
-    def import_module(name):
-        module = __import__(name)
-        for part in name.split('.')[1:]:
-            module = getattr(module, part)
-        return module
 
 display = Display()
 

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -18,13 +18,13 @@ from collections import defaultdict
 from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes, to_text, to_native
+from ansible.module_utils.compat.importlib import import_module
 from ansible.module_utils.six import string_types
 from ansible.parsing.utils.yaml import from_yaml
 from ansible.parsing.yaml.loader import AnsibleLoader
 from ansible.plugins import get_plugin_class, MODULE_CACHE, PATH_CACHE, PLUGIN_PATH_CACHE
 from ansible.utils.collection_loader import AnsibleCollectionLoader, AnsibleFlatMapLoader, AnsibleCollectionRef
 from ansible.utils.display import Display
-from ansible.utils.import_module import import_module
 from ansible.utils.plugin_docs import add_fragments
 
 try:

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -36,7 +36,14 @@ except ImportError:
 try:
     from importlib import import_module
 except ImportError:
-    import_module = __import__
+    # importlib.import_module returns the tail
+    # whereas __import__ returns the head
+    # compat to work like importlib.import_module
+    def import_module(name):
+        module = __import__(name)
+        for part in name.split('.')[1:]:
+            module = getattr(module, part)
+        return module
 
 display = Display()
 

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -51,13 +51,8 @@ from ansible.template.template import AnsibleJ2Template
 from ansible.template.vars import AnsibleJ2Vars
 from ansible.utils.collection_loader import AnsibleCollectionRef
 from ansible.utils.display import Display
+from ansible.utils.import_module import import_module
 from ansible.utils.unsafe_proxy import wrap_var
-
-# HACK: keep Python 2.6 controller tests happy in CI until they're properly split
-try:
-    from importlib import import_module
-except ImportError:
-    import_module = __import__
 
 display = Display()
 

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -45,13 +45,13 @@ from ansible.module_utils.six import iteritems, string_types, text_type
 from ansible.module_utils._text import to_native, to_text, to_bytes
 from ansible.module_utils.common._collections_compat import Sequence, Mapping, MutableMapping
 from ansible.module_utils.common.collections import is_sequence
+from ansible.module_utils.compat.importlib import import_module
 from ansible.plugins.loader import filter_loader, lookup_loader, test_loader
 from ansible.template.safe_eval import safe_eval
 from ansible.template.template import AnsibleJ2Template
 from ansible.template.vars import AnsibleJ2Vars
 from ansible.utils.collection_loader import AnsibleCollectionRef
 from ansible.utils.display import Display
-from ansible.utils.import_module import import_module
 from ansible.utils.unsafe_proxy import wrap_var
 
 display = Display()

--- a/lib/ansible/utils/collection_loader.py
+++ b/lib/ansible/utils/collection_loader.py
@@ -14,13 +14,8 @@ from types import ModuleType
 
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.six import iteritems, string_types, with_metaclass
+from ansible.utils.import_module import import_module
 from ansible.utils.singleton import Singleton
-
-# HACK: keep Python 2.6 controller tests happy in CI until they're properly split
-try:
-    from importlib import import_module
-except ImportError:
-    import_module = __import__
 
 _SYNTHETIC_PACKAGES = {
     # these provide fallback package definitions when there are no on-disk paths

--- a/lib/ansible/utils/collection_loader.py
+++ b/lib/ansible/utils/collection_loader.py
@@ -13,8 +13,8 @@ import sys
 from types import ModuleType
 
 from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.compat.importlib import import_module
 from ansible.module_utils.six import iteritems, string_types, with_metaclass
-from ansible.utils.import_module import import_module
 from ansible.utils.singleton import Singleton
 
 _SYNTHETIC_PACKAGES = {

--- a/lib/ansible/utils/import_module.py
+++ b/lib/ansible/utils/import_module.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import sys
 
 # HACK: keep Python 2.6 controller tests happy in CI until they're properly split
 try:
@@ -14,7 +15,5 @@ except ImportError:
     # whereas __import__ returns the head
     # compat to work like importlib.import_module
     def import_module(name):
-        module = __import__(name)
-        for part in name.split('.')[1:]:
-            module = getattr(module, part)
-        return module
+        __import__(name)
+        return sys.modules[name]

--- a/lib/ansible/utils/import_module.py
+++ b/lib/ansible/utils/import_module.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 Matt Martz <matt@sivel.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+# HACK: keep Python 2.6 controller tests happy in CI until they're properly split
+try:
+    from importlib import import_module
+except ImportError:
+    # importlib.import_module returns the tail
+    # whereas __import__ returns the head
+    # compat to work like importlib.import_module
+    def import_module(name):
+        module = __import__(name)
+        for part in name.split('.')[1:]:
+            module = getattr(module, part)
+        return module

--- a/test/integration/targets/collections/aliases
+++ b/test/integration/targets/collections/aliases
@@ -1,5 +1,4 @@
 posix
 shippable/posix/group4
 shippable/windows/group1
-skip/python2.6
 windows

--- a/test/integration/targets/collections_plugin_namespace/aliases
+++ b/test/integration/targets/collections_plugin_namespace/aliases
@@ -1,2 +1,1 @@
 shippable/posix/group1
-skip/python2.6

--- a/test/integration/targets/collections_relative_imports/aliases
+++ b/test/integration/targets/collections_relative_imports/aliases
@@ -1,2 +1,1 @@
 shippable/posix/group1
-skip/python2.6


### PR DESCRIPTION
##### SUMMARY
Address compat issue for collection loading on py26

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/loader.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
