### PR TITLE
Fix collection module info quirk

### DIFF
--- a/changelogs/fragments/ansiballz-collection-module-info.yml
+++ b/changelogs/fragments/ansiballz-collection-module-info.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - AnsiballZ - Fix detection of module_utils when an identifier being imported
+    has the same name as the Python module it belongs in

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -666,8 +666,9 @@ class CollectionModuleInfo(ModuleInfo):
             # way our CollectionLoader works but not how python module loaders work in general.
 
             try:
-                module_found = AnsibleCollectionLoader().is_module_found(module_name)
-            except Exception as e:
+                module_found = AnsibleCollectionLoader().is_module_found(
+                    to_native(module_name, errors='surrogate_or_strict'))
+            except Exception:
                 # Just move on to trying the next version
                 continue
 

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/quirk.py
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/quirk.py
@@ -1,2 +1,6 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
 def quirk():
     return 'Quirk Avoidance'

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/quirk.py
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/quirk.py
@@ -1,0 +1,2 @@
+def quirk():
+    return 'Quirk Avoidance'

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/test_quirk.py
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/test_quirk.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+import sys
+
+DOCUMENTATION = r'''
+module: test_quirk
+description: for testing
+extends_documentation_fragment:
+  - testns.testcoll.frag
+  - testns.testcoll.frag.other_documentation
+'''
+
+from ansible_collections.testns.testcoll.plugins.module_utils.quirk import quirk
+
+
+def main():
+    print(json.dumps({'changed': False,
+                      'msg': quirk()}
+                     ))
+
+
+if __name__ == '__main__':
+    main()
+    sys.exit(0)

--- a/test/integration/targets/collections/runme.sh
+++ b/test/integration/targets/collections/runme.sh
@@ -15,6 +15,9 @@ export INVENTORY_PATH="$ipath"
 # test callback
 ANSIBLE_CALLBACK_WHITELIST=testns.testcoll.usercallback ansible localhost -m ping | grep "usercallback says ok"
 
+# Test module_utils.  This tests that from module_utils.NAME import NAME works.
+ansible localhost -m testns.testcoll.test_quirk "$@" | grep -- '"msg": "Quirk Avoidance"'
+
 # test documentation
 ansible-doc testns.testcoll.testmodule -vvv | grep -- "- normal_doc_frag"
 


### PR DESCRIPTION
##### SUMMARY
    Fix the detection of collection module_utils
    
    Before, when you imported an identifier from a module_util with the same
    name as the Python module it belongs in, the CollectionModuleInfo class
    would think that the identifier was a Python module and return the
    source for the Python module when requested.  This change fixes the code
    so that the class will throw an error in this case.
    
    The lack of error was causing an issue when constructing AnsiballZs.
    For instance:
    
        from ..module_utils.ismount import ismount
    
    The former code would create the file:
        ansible_collections/ansible/posix/plugins/module_utils/ismount/ismount.py
    
    Instead of:
        ansible_collections/ansible/posix/plugins/module_utils/ismount.py

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
* This also implements pkg_dir in the CollectionModuleInfo class.  I'm not sure if there's more that needs to be done to make use of that.
* In a similar vein, the FIXMEs around collections in Ansiballz should be reviewed to see if any of them are also resolved by this change.
* Lastly.... As I wrote this I kept feeling like there was probably a better way to do this.  It feels like there should be an API in pkg_utils or importlib/imp or something else that a python loader or python finder might implement that would do the same thing as my code.  I couldn't find it, though, so maybe that's just something to keep in mind as a potential refactor when the collection loader is next worked on.