### PR TITLE
Prevent copy/check_mode from creating a directory

### DIFF
--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -587,14 +587,16 @@ def main():
                 e.result['msg'] += ' Could not copy to {0}'.format(dest)
                 module.fail_json(**e.results)
 
-            os.makedirs(b_dirname)
+            if not module.check_mode:
+                os.makedirs(b_dirname)
             directory_args = module.load_file_common_arguments(module.params)
             directory_mode = module.params["directory_mode"]
             if directory_mode is not None:
                 directory_args['mode'] = directory_mode
             else:
                 directory_args['mode'] = None
-            adjust_recursive_directory_permissions(pre_existing_dir, new_directory_list, module, directory_args, changed)
+            if not module.check_mode:
+                adjust_recursive_directory_permissions(pre_existing_dir, new_directory_list, module, directory_args, changed)
 
     if os.path.isdir(b_dest):
         basename = os.path.basename(src)
@@ -612,7 +614,7 @@ def main():
         if os.access(b_dest, os.R_OK) and os.path.isfile(b_dest):
             checksum_dest = module.sha1(dest)
     else:
-        if not os.path.exists(os.path.dirname(b_dest)):
+        if not os.path.exists(os.path.dirname(b_dest)) and not module.check_mode:
             try:
                 # os.path.exists() can return false in some
                 # circumstances where the directory does not have
@@ -624,7 +626,7 @@ def main():
                     module.fail_json(msg="Destination directory %s is not accessible" % (os.path.dirname(dest)))
             module.fail_json(msg="Destination directory %s does not exist" % (os.path.dirname(dest)))
 
-    if not os.access(os.path.dirname(b_dest), os.W_OK) and not module.params['unsafe_writes']:
+    if not os.access(os.path.dirname(b_dest), os.W_OK) and not module.params['unsafe_writes'] and not module.check_mode:
         module.fail_json(msg="Destination %s not writable" % (os.path.dirname(dest)))
 
     backup_file = None

--- a/test/integration/targets/copy/tasks/check_mode.yml
+++ b/test/integration/targets/copy/tasks/check_mode.yml
@@ -1,0 +1,125 @@
+- block:
+
+  - name: check_mode - Create another clean copy of 'subdir' not messed with by previous tests (check_mode)
+    copy:
+      src: subdir
+      dest: 'checkmode_subdir/'
+      directory_mode: 0700
+      local_follow: False
+    check_mode: true
+    register: check_mode_subdir_first
+
+  - name: check_mode - Stat the new dir to make sure it really doesn't exist
+    stat:
+      path: 'checkmode_subdir/'
+    register: check_mode_subdir_first_stat
+
+  - name: check_mode - Actually do it
+    copy:
+      src: subdir
+      dest: 'checkmode_subdir/'
+      directory_mode: 0700
+      local_follow: False
+    register: check_mode_subdir_real
+
+  - name: check_mode - Stat the new dir to make sure it really doesn't exist
+    stat:
+      path: 'checkmode_subdir/'
+    register: check_mode_subdir_real_stat
+
+  # Quick sanity before we move on
+  - assert:
+      that:
+      - check_mode_subdir_first is changed
+      - not check_mode_subdir_first_stat.stat.exists
+      - check_mode_subdir_real is changed
+      - check_mode_subdir_real_stat.stat.exists
+
+  # Do some finagling here. First, use check_mode to ensure it never gets
+  # created. Then actualy create it, and use check_mode to ensure that doing
+  # the same copy gets marked as no change.
+  #
+  # This same pattern repeats for several other src/dest combinations.
+  - name: check_mode - Ensure dest with trailing / never gets created but would be without check_mode
+    copy:
+      remote_src: true
+      src: 'checkmode_subdir/'
+      dest: 'destdir_should_never_exist_because_of_check_mode/'
+      follow: true
+    check_mode: true
+    register: check_mode_trailing_slash_first
+
+  - name: check_mode - Stat the new dir to make sure it really doesn't exist
+    stat:
+      path: 'destdir_should_never_exist_because_of_check_mode/'
+    register: check_mode_trailing_slash_first_stat
+
+  - name: check_mode - Create the above copy for real now (without check_mode)
+    copy:
+      remote_src: true
+      src: 'checkmode_subdir/'
+      dest: 'destdir_should_never_exist_because_of_check_mode/'
+    register: check_mode_trailing_slash_real
+
+  - name: check_mode - Stat the new dir to make sure it really exists
+    stat:
+      path: 'destdir_should_never_exist_because_of_check_mode/'
+    register: check_mode_trailing_slash_real_stat
+
+  - name: check_mode - Do the same copy yet again (with check_mode this time) to ensure it's marked unchanged
+    copy:
+      remote_src: true
+      src: 'checkmode_subdir/'
+      dest: 'destdir_should_never_exist_because_of_check_mode/'
+    check_mode: true
+    register: check_mode_trailing_slash_second
+
+  # Repeat the same basic pattern here.
+
+  - name: check_mode - Do another basic copy (with check_mode)
+    copy:
+      src: foo.txt
+      dest: "{{ remote_dir }}/foo-check_mode.txt"
+      mode: 0444
+    check_mode: true
+    register: check_mode_foo_first
+
+  - name: check_mode - Stat the new file to make sure it really doesn't exist
+    stat:
+      path: "{{ remote_dir }}/foo-check_mode.txt"
+    register: check_mode_foo_first_stat
+
+  - name: check_mode - Do the same basic copy (without check_mode)
+    copy:
+      src: foo.txt
+      dest: "{{ remote_dir }}/foo-check_mode.txt"
+      mode: 0444
+    register: check_mode_foo_real
+
+  - name: check_mode - Stat the new file to make sure it really exists
+    stat:
+      path: "{{ remote_dir }}/foo-check_mode.txt"
+    register: check_mode_foo_real_stat
+
+  - name: check_mode - And again (with check_mode)
+    copy:
+      src: foo.txt
+      dest: "{{ remote_dir }}/foo-check_mode.txt"
+      mode: 0444
+    register: check_mode_foo_second
+
+  - assert:
+      that:
+      - check_mode_subdir_first is changed
+
+      - check_mode_trailing_slash_first is changed
+      - not check_mode_trailing_slash_first_stat.stat.exists
+      - check_mode_trailing_slash_real is changed
+      - check_mode_trailing_slash_real_stat.stat.exists
+      - check_mode_trailing_slash_second is not changed
+
+      - check_mode_foo_first is changed
+      - not check_mode_foo_first_stat.stat.exists
+      - check_mode_foo_real is changed
+      - check_mode_foo_real_stat.stat.exists
+      - check_mode_foo_second is not changed

--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -74,6 +74,8 @@
     - import_tasks: acls.yml
       when: ansible_system == 'Linux'
 
+    - import_tasks: check_mode.yml
+
     # https://github.com/ansible/ansible/issues/57618
     - name: Test diff contents
       copy:
@@ -101,7 +103,7 @@
       delegate_to: localhost
       with_dict: "{{ symlinks }}"
 
-    - name: Remote unprivileged remote user
+    - name: Remove unprivileged remote user
       user:
         name: '{{ remote_unprivileged_user }}'
         state: absent


### PR DESCRIPTION
##### SUMMARY

If one has `dest: anything_ending_with_a_/` (i.e. any destination
directory that ends with a trailing slash), and runs `copy` with
`check_mode: true`, the directory will get created on the remote node
despite being in check mode.

This attempts to eliminate that bug and also sets up to add future
`check_mode` tests (some of which are needed to improve code coverage of
`modules/files/copy.py`.

Here is a reproducer for the bug that this commit solves:

```yaml
- hosts: localhost
  connection: local

  tasks:
  - copy:
      remote_src: true
      src: '/etc'
      dest: 'destdir_should_never_exist_because_of_check_mode/'
    check_mode: true
```

Before this commit, upon running the playbook, a directory
`destdir_should_never_exist_because_of_check_mode` will get created in
the same directory in which the playbook resides. After this commit, the
directory is no longer created.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

`modules/files/copy.py`