### PR TITLE
Allow unsetting env vars

### DIFF
--- a/changelogs/fragments/unset_environment_variables.yml
+++ b/changelogs/fragments/unset_environment_variables.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Added ability to unset environment variables with support from shell plugins

--- a/docs/docsite/rst/user_guide/playbooks_environment.rst
+++ b/docs/docsite/rst/user_guide/playbooks_environment.rst
@@ -68,6 +68,15 @@ to define an environment hash might be a group_vars file, like so::
       http_proxy: http://proxy.bos.example.com:8080
       https_proxy: http://proxy.bos.example.com:8080
 
+.. versionadded:: 2.10
+
+It's also possible to unset environment variables that are defined by default on the target host by setting a null value for an environment variable (if your shell plugin supports it)::
+
+    - hosts: yourhost
+      environment:
+        http_proxy: ~
+        https_proxy: ~
+
 
 Working With Language-Specific Version Managers
 ===============================================

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -29,6 +29,9 @@ from ansible.module_utils.six import text_type
 from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils._text import to_native
 from ansible.plugins import AnsiblePlugin
+from ansible.utils.display import Display
+
+display = Display()
 
 _USER_HOME_PATH_RE = re.compile(r'^~[_.A-Za-z0-9][-_.A-Za-z0-9]*$')
 
@@ -77,6 +80,8 @@ class ShellBase(AnsiblePlugin):
             pass
 
     def env_prefix(self, **kwargs):
+        if None in kwargs.values():
+            display.warning("You specified a null environment variable value, but your shell plugin does not support unsetting environment variables")
         return ' '.join(['%s=%s' % (k, shlex_quote(text_type(v))) for k, v in kwargs.items()])
 
     def join_path(self, *args):

--- a/lib/ansible/plugins/shell/sh.py
+++ b/lib/ansible/plugins/shell/sh.py
@@ -15,6 +15,7 @@ extends_documentation_fragment:
   - shell_common
 '''
 
+from ansible.module_utils.six import text_type
 from ansible.module_utils.six.moves import shlex_quote
 from ansible.plugins.shell import ShellBase
 
@@ -43,6 +44,15 @@ class ShellModule(ShellBase):
     _SHELL_SUB_RIGHT = '`"'
     _SHELL_GROUP_LEFT = '('
     _SHELL_GROUP_RIGHT = ')'
+
+    def env_prefix(self, **kwargs):
+        ret = []
+        for k, v in kwargs.items():
+            if v is None:
+                ret.append('unset %s;' % k)
+            else:
+                ret.append('export %s=%s;' % (k, shlex_quote(text_type(v))))
+        return ' '.join(ret)
 
     def checksum(self, path, python_interp):
         # In the following test, each condition is a check and logical

--- a/test/integration/targets/environment/test_environment.yml
+++ b/test/integration/targets/environment/test_environment.yml
@@ -171,3 +171,18 @@
       assert:
         that:
           - "{{ test_foo.results[0].stdout == 'outer' }}"
+
+- name: test unsetting environment variables
+  hosts: testhost
+  environment:
+    # We use multiple common env vars to account for platforms where not all of
+    # them are defined by default to make the test meaningful everywhere.
+    # NOTE: make sure not to use env vars such as PATH that may need to have a
+    # meaningful value in order for fact gathering to work
+    HOME: ~
+    TERM: ~
+  tasks:
+    - assert:
+        that:
+          - ansible_env.HOME is undefined
+          - ansible_env.TERM is undefined


### PR DESCRIPTION
##### SUMMARY
Allow unsetting existing environment vars via `environment` by specifying a `null` value

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
shell plugins

##### ADDITIONAL INFORMATION
N/A