### PR TITLE
IOS_User remove username when keys exist and doesn't exist

### DIFF
--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -294,8 +294,10 @@ def map_obj_to_commands(updates, module):
         if want['state'] == 'absent':
             if have['sshkey']:
                 add_ssh(commands, want)
-            else:
-                commands.append(user_del_cmd(want['name']))
+
+            # Add delete the username on top of deleting user SSH key or just delete user
+            # This should be executed regardless I believe
+            commands.append(user_del_cmd(want['name']))
 
         if needs_update(want, have, 'view'):
             add(commands, want, 'view %s' % want['view'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changes from an if/else statement to an "if ssh key exists, add commands". Then add to the command list regardless the removal of the username.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #68238

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_user

##### ADDITIONAL INFORMATION

<!--- Paste verbatim command output below, e.g. before and after your change -->
**Before**
```
        "commands": [
            "ip ssh pubkey-chain",
            "no username joshv",
            "exit"
        ],
```


**After**
```paste below
        "commands": [
            "ip ssh pubkey-chain",
            "no username joshv",
            "exit",
            {
                "answer": "y",
                "command": "no username joshv",
                "newline": false,
                "prompt": "This operation will remove all username related configurations with same name"
            }
        ],
```

If this needs to be modified feel free. Just a potential fix. It is shown to fix at least this issue. Not sure if there are other potential issues with this change.
