### PR TITLE
redfish: support boolean BIOS attributes

### DIFF
--- a/changelogs/fragments/68251-redfish_config-add-boolean-bios-attr-support.yaml
+++ b/changelogs/fragments/68251-redfish_config-add-boolean-bios-attr-support.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- redfish_config: add support for boolean bios attrs (https://github.com/ansible/ansible/pull/68251)

--- a/changelogs/fragments/68251-redfish_config-add-boolean-bios-attr-support.yaml
+++ b/changelogs/fragments/68251-redfish_config-add-boolean-bios-attr-support.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-- redfish_config: add support for boolean bios attrs (https://github.com/ansible/ansible/pull/68251)
+- redfish_config - add support for boolean bios attrs (https://github.com/ansible/ansible/pull/68251)

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -1113,9 +1113,9 @@ class RedfishUtils(object):
 
         set_bios_attr_uri = data["@Redfish.Settings"]["SettingsObject"]["@odata.id"]
 
-        # Example: bios_attr = {\"name\":\"value\"}
-        bios_attr = "{\"" + attr['bios_attr_name'] + "\":\"" + attr['bios_attr_value'] + "\"}"
-        payload = {"Attributes": json.loads(bios_attr)}
+        # patch_request() will use json.dumps() on the payload, we can pass a
+        # python dict as our payload without proactively converting to json.
+        payload = {"Attributes": {attr['bios_attr_name']: attr['bios_attr_value']}}
         response = self.patch_request(self.root_uri + set_bios_attr_uri, payload)
         if response['ret'] is False:
             return response

--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -142,7 +142,7 @@ def main():
             username=dict(required=True),
             password=dict(required=True, no_log=True),
             bios_attribute_name=dict(default='null'),
-            bios_attribute_value=dict(default='null'),
+            bios_attribute_value=dict(default='null', type='raw'),
             timeout=dict(type='int', default=10)
         ),
         supports_check_mode=False

--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -60,7 +60,7 @@ options:
     description:
       - value of BIOS attribute to update
     default: 'null'
-    type: str
+    type: raw
     version_added: "2.8"
   timeout:
     description:


### PR DESCRIPTION
Currently the redfish_config module will convert boolean bios_attribute_value
settings to strings (type str). This will cause BMCs expecting booleans to
error out.

This PR will change the default type of bios_attribute_value to 'raw' in order
to support strings and booleans. Additionally, it makes a minor tweak to
set_bios_attributes() in redfish_utils.py to correctly serialize the python dict
to JSON.

Fixes #68251

##### SUMMARY
This fixes the behavior in Ansible 2.9 (also present in Ansible 2.8) that converts boolean based BIOS values to strings.

Note that I based this PR on `stable-2.9` and not `devel`. I _think_ the changes introduced in #62764 will require slightly different change.

Please let me know if I should rebase this PR on `devel` and create different PRs for backport requests for 2.8 and 2.9.

Fixes #68251

Backport of #68382

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
redfish_config
redfish_utils.py

##### ADDITIONAL INFORMATION
Using the same [ansible snippet from 68251](https://github.com/ansible/ansible/issues/68251#issue-582376982), the playbook now works as expected:
```
(68251) [jyundt@aurora ansible]$ cat tests/supermicro_redfish.yml 
---
- hosts: all
  gather_facts: false
  vars:
    bmc_username: admin
    bmc_password: hunter2
    bmc_address: 192.168.100.100
  tasks:
  - name: Configure boolean BIOS Settings
    redfish_config:
      category: Systems
      command: SetBiosAttributes
      bios_attribute_name: "ConsoleRedirection"
      bios_attribute_value: True
      baseuri: "{{ bmc_address }}"
      username: "{{ bmc_username }}"
      password: "{{ bmc_password }}"

  - name: Configure string BIOS Settings
    redfish_config:
      category: Systems
      command: SetBiosAttributes
      bios_attribute_name: "IPv4HTTPSupport"
      bios_attribute_value: "Disabled"
      baseuri: "{{ bmc_address }}"
      username: "{{ bmc_username }}"
      password: "{{ bmc_password }}"
(68251) [jyundt@aurora ansible]$ time ansible-playbook -i 10.39.67.209, tests/supermicro_redfish.yml

PLAY [all] *********************************************************************************************************************************

TASK [Configure boolean BIOS Settings] *****************************************************************************************************
[DEPRECATION WARNING]: Distribution Ubuntu 18.04 on host 10.39.67.209 should use /usr/bin/python3, but is using /usr/bin/python for 
backward compatibility with prior Ansible releases. A future Ansible release will default to using the discovered platform python for this 
host. See https://docs.ansible.com/ansible/2.9/reference_appendices/interpreter_discovery.html for more information. This feature will be 
removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
changed: [10.39.67.209]

TASK [Configure string BIOS Settings] ******************************************************************************************************
ok: [10.39.67.209]

PLAY RECAP *********************************************************************************************************************************
10.39.67.209               : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


real	0m7.701s
user	0m2.157s
sys	0m0.270s
(68251) [jyundt@aurora ansible]$ 

```


cc @nlopez 

(edit: fix formatting for ansible output.)