### PR TITLE
[contrib] Add filtering DigitalOcean droplets by project

### DIFF
--- a/contrib/inventory/digital_ocean.ini
+++ b/contrib/inventory/digital_ocean.ini
@@ -32,3 +32,10 @@ use_private_network = False
 #   group_variables = { 'ansible_user': 'root' }
 #
 group_variables = {}
+
+# The specific projects you would like your resources to be associated with. Use
+# 'default' if you wish to include the default project.
+#    
+#    projects = ["default", "project-a"]
+#
+#projects = ["default"]

--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -230,14 +230,14 @@ class DoManager:
         return resp['tags']
 
     def show_project_resources(self, project_id):
-        resp = self.send('projects/{}/resources'.format(project_id))
+        resp = self.send('projects/{0}/resources'.format(project_id))
         return resp['resources']
 
     def all_projects(self):
         resp = self.send('projects')
         projects = resp['projects']
 
-        for index, _ in enumerate(projects):
+        for index in range(0, len(projects)):
             cur_project = projects[index]
             cur_project['resources'] = self.show_project_resources(cur_project['id'])
 

--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -553,7 +553,11 @@ class DigitalOceanInventory(object):
                     'default' in self.projects and project['is_default']
                 ):
                     for resource in project['resources']:
-                        resources_in_project.add(int(resource['urn'].split(':')[-1]))
+                        _, type, id = resource['urn'].split(':')
+                        try:
+                            resources_in_project.add(int(id))
+                        except ValueError:
+                            resources_in_project.add(id)
 
         # add all droplets by id and name
         for droplet in self.data['droplets']:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allows for filtering DigitalOcean droplets by [projects](https://www.digitalocean.com/docs/projects/) to support a [team](https://www.digitalocean.com/docs/accounts/teams/) to work on projects in parallel without targeting all infrastructure. The dynamic inventory will only show droplets that match the list of specified projects specified in the .ini (by default matching all projects), but retains the original ansible groups.

I have also run [black](https://github.com/psf/black/) on the code just via my configuration and will be happy to undo any formatting changes as a result.

Please let me know of any problems with the design decisions and/or implementation and I will be happy to correct.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
N/A (contrib)

##### ANSIBLE VERSION
```
ansible 2.9.6
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/kschoon/.ansible/plugins/modules', '/
  ansible python module location = /usr/lib/python3.8/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.8.2 (default, Feb 26 2020, 22:21:03) [GCC 9.2.1 20200130]
```

##### ADDITIONAL INFORMATION
N/A