### PR TITLE
Add TTY check and argument to disable it (#50603)

### DIFF
--- a/changelogs/fragments/50603-tty-check.yaml
+++ b/changelogs/fragments/50603-tty-check.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+- ansible-vault create: Now raises an error when opening the editor without tty. 
+  The flag --skip-tty-check restores previous behaviour. 

--- a/changelogs/fragments/50603-tty-check.yaml
+++ b/changelogs/fragments/50603-tty-check.yaml
@@ -1,3 +1,4 @@
+---
 minor_changes:
-- ansible-vault create: Now raises an error when opening the editor without tty. 
-  The flag --skip-tty-check restores previous behaviour. 
+  - "ansible-vault create: Now raises an error when opening the editor without
+    tty. The flag --skip-tty-check restores previous behaviour."

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -76,7 +76,7 @@ class VaultCLI(CLI):
         create_parser = subparsers.add_parser('create', help='Create new vault encrypted file', parents=[vault_id, common])
         create_parser.set_defaults(func=self.execute_create)
         create_parser.add_argument('args', help='Filename', metavar='file_name', nargs='*')
-        create_parser.add_argument('-n', '--no-check', default=False, help='skip TTY check', dest='no_check', action='store_true')
+        create_parser.add_argument('--skip-tty-check', default=False, help='allows editor to be opened when no tty attached', dest='skip_tty_check', action='store_true')
 
         decrypt_parser = subparsers.add_parser('decrypt', help='Decrypt vault encrypted file', parents=[output, common])
         decrypt_parser.set_defaults(func=self.execute_decrypt)
@@ -428,7 +428,7 @@ class VaultCLI(CLI):
         if len(context.CLIARGS['args']) > 1:
             raise AnsibleOptionsError("ansible-vault create can take only one filename argument")
 
-        if sys.stdout.isatty() or context.CLIARGS['no_check']:
+        if sys.stdout.isatty() or context.CLIARGS['skip_tty_check']:
             self.editor.create_file(context.CLIARGS['args'][0], self.encrypt_secret,
                                     vault_id=self.encrypt_vault_id)
         else:

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -76,6 +76,7 @@ class VaultCLI(CLI):
         create_parser = subparsers.add_parser('create', help='Create new vault encrypted file', parents=[vault_id, common])
         create_parser.set_defaults(func=self.execute_create)
         create_parser.add_argument('args', help='Filename', metavar='file_name', nargs='*')
+        create_parser.add_argument('-n','--no-check',default=False, help='skip TTY check', dest='no_check', action='store_true')
 
         decrypt_parser = subparsers.add_parser('decrypt', help='Decrypt vault encrypted file', parents=[output, common])
         decrypt_parser.set_defaults(func=self.execute_decrypt)
@@ -427,8 +428,11 @@ class VaultCLI(CLI):
         if len(context.CLIARGS['args']) > 1:
             raise AnsibleOptionsError("ansible-vault create can take only one filename argument")
 
-        self.editor.create_file(context.CLIARGS['args'][0], self.encrypt_secret,
+        if sys.stdout.isatty() or context.CLIARGS['no_check']:
+            self.editor.create_file(context.CLIARGS['args'][0], self.encrypt_secret,
                                 vault_id=self.encrypt_vault_id)
+        else:
+            raise AnsibleOptionsError("not a tty, editor cannot be opened")
 
     def execute_edit(self):
         ''' open and decrypt an existing vaulted file in an editor, that will be encrypted again when closed'''
@@ -455,3 +459,4 @@ class VaultCLI(CLI):
                                    self.new_encrypt_vault_id)
 
         display.display("Rekey successful", stderr=True)
+

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -76,7 +76,7 @@ class VaultCLI(CLI):
         create_parser = subparsers.add_parser('create', help='Create new vault encrypted file', parents=[vault_id, common])
         create_parser.set_defaults(func=self.execute_create)
         create_parser.add_argument('args', help='Filename', metavar='file_name', nargs='*')
-        create_parser.add_argument('-n','--no-check',default=False, help='skip TTY check', dest='no_check', action='store_true')
+        create_parser.add_argument('-n', '--no-check', default=False, help='skip TTY check', dest='no_check', action='store_true')
 
         decrypt_parser = subparsers.add_parser('decrypt', help='Decrypt vault encrypted file', parents=[output, common])
         decrypt_parser.set_defaults(func=self.execute_decrypt)
@@ -430,7 +430,7 @@ class VaultCLI(CLI):
 
         if sys.stdout.isatty() or context.CLIARGS['no_check']:
             self.editor.create_file(context.CLIARGS['args'][0], self.encrypt_secret,
-                                vault_id=self.encrypt_vault_id)
+                                    vault_id=self.encrypt_vault_id)
         else:
             raise AnsibleOptionsError("not a tty, editor cannot be opened")
 
@@ -459,4 +459,3 @@ class VaultCLI(CLI):
                                    self.new_encrypt_vault_id)
 
         display.display("Rekey successful", stderr=True)
-

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -76,7 +76,8 @@ class VaultCLI(CLI):
         create_parser = subparsers.add_parser('create', help='Create new vault encrypted file', parents=[vault_id, common])
         create_parser.set_defaults(func=self.execute_create)
         create_parser.add_argument('args', help='Filename', metavar='file_name', nargs='*')
-        create_parser.add_argument('--skip-tty-check', default=False, help='allows editor to be opened when no tty attached', dest='skip_tty_check', action='store_true')
+        create_parser.add_argument('--skip-tty-check', default=False, help='allows editor to be opened when no tty attached',
+                                   dest='skip_tty_check', action='store_true')
 
         decrypt_parser = subparsers.add_parser('decrypt', help='Decrypt vault encrypted file', parents=[output, common])
         decrypt_parser.set_defaults(func=self.execute_decrypt)

--- a/test/units/cli/test_vault.py
+++ b/test/units/cli/test_vault.py
@@ -70,7 +70,7 @@ class TestVaultCli(unittest.TestCase):
         mock_setup_vault_secrets.return_value = []
         cli = VaultCLI(args=['ansible-vault', 'view', '/dev/null/foo'])
         cli.parse()
-        self.assertRaisesRegexp(errors.AnsibleOptionsError,
+        self.assertRaisesRegex(errors.AnsibleOptionsError,
                                 "A vault password is required to use Ansible's Vault",
                                 cli.run)
 
@@ -79,7 +79,7 @@ class TestVaultCli(unittest.TestCase):
         mock_setup_vault_secrets.return_value = []
         cli = VaultCLI(args=['ansible-vault', 'encrypt', '/dev/null/foo'])
         cli.parse()
-        self.assertRaisesRegexp(errors.AnsibleOptionsError,
+        self.assertRaisesRegex(errors.AnsibleOptionsError,
                                 "A vault password is required to use Ansible's Vault",
                                 cli.run)
 

--- a/test/units/cli/test_vault.py
+++ b/test/units/cli/test_vault.py
@@ -154,7 +154,28 @@ class TestVaultCli(unittest.TestCase):
         mock_setup_vault_secrets.return_value = [('default', TextVaultSecret('password'))]
         cli = VaultCLI(args=['ansible-vault', 'create', '/dev/null/foo'])
         cli.parse()
+        self.assertRaisesRegex(errors.AnsibleOptionsError,
+                                "not a tty, editor cannot be opened",
+                                cli.run)
+
+    @patch('ansible.cli.vault.VaultCLI.setup_vault_secrets')
+    @patch('ansible.cli.vault.VaultEditor')
+    def test_create_skip_tty_check(self, mock_vault_editor, mock_setup_vault_secrets):
+        mock_setup_vault_secrets.return_value = [('default', TextVaultSecret('password'))]
+        cli = VaultCLI(args=['ansible-vault', 'create', '--skip-tty-check', '/dev/null/foo'])
+        cli.parse()
         cli.run()
+
+    @patch('ansible.cli.vault.VaultCLI.setup_vault_secrets')
+    @patch('ansible.cli.vault.VaultEditor')
+    def test_create_with_tty(self, mock_vault_editor, mock_setup_vault_secrets):
+        mock_setup_vault_secrets.return_value = [('default', TextVaultSecret('password'))]
+        self.tty_stdout_patcher = patch('ansible.cli.sys.stdout.isatty', return_value=True)
+        self.tty_stdout_patcher.start()
+        cli = VaultCLI(args=['ansible-vault', 'create', '/dev/null/foo'])
+        cli.parse()
+        cli.run()
+        self.tty_stdout_patcher.stop()
 
     @patch('ansible.cli.vault.VaultCLI.setup_vault_secrets')
     @patch('ansible.cli.vault.VaultEditor')

--- a/test/units/cli/test_vault.py
+++ b/test/units/cli/test_vault.py
@@ -154,7 +154,7 @@ class TestVaultCli(unittest.TestCase):
         mock_setup_vault_secrets.return_value = [('default', TextVaultSecret('password'))]
         cli = VaultCLI(args=['ansible-vault', 'create', '/dev/null/foo'])
         cli.parse()
-        self.assertRaisesRegex(errors.AnsibleOptionsError,
+        self.assertRaisesRegexp(errors.AnsibleOptionsError,
                                 "not a tty, editor cannot be opened",
                                 cli.run)
 

--- a/test/units/cli/test_vault.py
+++ b/test/units/cli/test_vault.py
@@ -70,7 +70,7 @@ class TestVaultCli(unittest.TestCase):
         mock_setup_vault_secrets.return_value = []
         cli = VaultCLI(args=['ansible-vault', 'view', '/dev/null/foo'])
         cli.parse()
-        self.assertRaisesRegex(errors.AnsibleOptionsError,
+        self.assertRaisesRegexp(errors.AnsibleOptionsError,
                                 "A vault password is required to use Ansible's Vault",
                                 cli.run)
 
@@ -79,7 +79,7 @@ class TestVaultCli(unittest.TestCase):
         mock_setup_vault_secrets.return_value = []
         cli = VaultCLI(args=['ansible-vault', 'encrypt', '/dev/null/foo'])
         cli.parse()
-        self.assertRaisesRegex(errors.AnsibleOptionsError,
+        self.assertRaisesRegexp(errors.AnsibleOptionsError,
                                 "A vault password is required to use Ansible's Vault",
                                 cli.run)
 


### PR DESCRIPTION
##### SUMMARY
Fixes #50603

Runs a TTY check before launching the editor and raises an error if false. One can add the --no-check flag to override this check and launch the editor anyways.
##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ansible-vault create
##### ADDITIONAL INFORMATION
Running the command 
```
bash $(ansible-vault --vault-password-file=key create file.yaml) 
```
now returns the following output instead of creating an invisible editor window.
```
~/ansible$ bash $(ansible-vault create --vault-password-file=key file.yaml)
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are
modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and
can become unstable at any point.
ERROR! not a tty, editor cannot be opened
bash: usage:: No such file or directory
```
