### PR TITLE
Add additional storage classes to S3 lifecycle transition list

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_lifecycle.py
+++ b/lib/ansible/modules/cloud/amazon/s3_lifecycle.py
@@ -445,7 +445,7 @@ def destroy_lifecycle_rule(client, module):
 
 def main():
 
-    s3_storage_class=['glacier', 'onezone_ia', 'standard_ia', 'intelligent_tiering', 'deep_archive']
+    s3_storage_class = ['glacier', 'onezone_ia', 'standard_ia', 'intelligent_tiering', 'deep_archive']
 
     argument_spec = dict(
         name=dict(required=True, type='str'),

--- a/lib/ansible/modules/cloud/amazon/s3_lifecycle.py
+++ b/lib/ansible/modules/cloud/amazon/s3_lifecycle.py
@@ -63,7 +63,7 @@ options:
     description:
       - 'Transition noncurrent versions to this storage class'
     default: glacier
-    choices: ['glacier', 'onezone_ia', 'standard_ia']
+    choices: [ 'glacier', 'onezone_ia', 'standard_ia', 'intelligent_tiering', 'deep_archive' ]
     required: false
     version_added: 2.6
     type: str
@@ -100,10 +100,9 @@ options:
     type: str
   storage_class:
     description:
-      - "The storage class to transition to. Currently there are two supported values - 'glacier',  'onezone_ia', or 'standard_ia'."
-      - "The 'standard_ia' class is only being available from Ansible version 2.2."
+      - "The storage class to transition to."
     default: glacier
-    choices: [ 'glacier', 'onezone_ia', 'standard_ia']
+    choices: [ 'glacier', 'onezone_ia', 'standard_ia', 'intelligent_tiering', 'deep_archive' ]
     type: str
   transition_date:
     description:
@@ -445,12 +444,15 @@ def destroy_lifecycle_rule(client, module):
 
 
 def main():
+
+    s3_storage_class=['glacier', 'onezone_ia', 'standard_ia', 'intelligent_tiering', 'deep_archive']
+
     argument_spec = dict(
         name=dict(required=True, type='str'),
         expiration_days=dict(type='int'),
         expiration_date=dict(),
         noncurrent_version_expiration_days=dict(type='int'),
-        noncurrent_version_storage_class=dict(default='glacier', type='str', choices=['glacier', 'onezone_ia', 'standard_ia']),
+        noncurrent_version_storage_class=dict(default='glacier', type='str', choices=s3_storage_class),
         noncurrent_version_transition_days=dict(type='int'),
         noncurrent_version_transitions=dict(type='list'),
         prefix=dict(),
@@ -458,7 +460,7 @@ def main():
         rule_id=dict(),
         state=dict(default='present', choices=['present', 'absent']),
         status=dict(default='enabled', choices=['enabled', 'disabled']),
-        storage_class=dict(default='glacier', type='str', choices=['glacier', 'onezone_ia', 'standard_ia']),
+        storage_class=dict(default='glacier', type='str', choices=s3_storage_class),
         transition_days=dict(type='int'),
         transition_date=dict(),
         transitions=dict(type='list'),


### PR DESCRIPTION
S3 Lifecycle rules does not include all storage classes.  Add INTELLIGENT_TIERING and DEEP_ARCHIVE.  Minor documentation updates.

Closes #68234

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Move STORAGE_CLASS to a list for reference by both rule types to ensure future consistency.
Add INTELLIGENT_TIERING and DEEP_ARCHIVE to the list.

https://docs.aws.amazon.com/AmazonS3/latest/API/API_Transition.html
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
s3_lifecycle

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
