### PR TITLE
sns_topic: add tags support (#65613)

### DIFF
--- a/hacking/aws_config/testing_policies/compute-policy.json
+++ b/hacking/aws_config/testing_policies/compute-policy.json
@@ -220,10 +220,13 @@
               "SNS:GetTopicAttributes",
               "SNS:ListSubscriptions",
               "SNS:ListSubscriptionsByTopic",
+              "SNS:ListTagsForResource",
               "SNS:ListTopics",
               "SNS:SetTopicAttributes",
               "SNS:Subscribe",
-              "SNS:Unsubscribe"
+              "SNS:TagResource",
+              "SNS:Unsubscribe",
+              "SNS:UntagResource"
             ],
             "Resource": [
               "*"

--- a/test/integration/targets/sns_topic/tasks/main.yml
+++ b/test/integration/targets/sns_topic/tasks/main.yml
@@ -41,12 +41,20 @@
       sns_topic:
         name: "{{ sns_topic_topic_name }}"
         display_name: "My topic name"
+        tags:
+          First: one
       register: sns_topic_create
 
     - name: assert that creation worked
       assert:
         that:
           - sns_topic_create.changed
+
+    - name: assert that tag was added on creation
+      assert:
+        that:
+          - sns_topic_create.sns_topic.tags | length == 1
+          - sns_topic_create.sns_topic.tags.First == 'one'
 
     - name: set sns_arn fact
       set_fact:
@@ -63,6 +71,34 @@
         that:
           - not sns_topic_no_change.changed
           - sns_topic_no_change.sns_arn == sns_topic_create.sns_arn
+
+    - name: add topic tag
+      sns_topic:
+        name: "{{ sns_topic_topic_name }}"
+        tags:
+          Second: two
+      register: sns_topic_tags
+
+    - name: assert that second tag was added
+      assert:
+        that:
+          - sns_topic_tags.sns_topic.tags | length == 2
+          - sns_topic_tags.sns_topic.tags.First == 'one'
+          - sns_topic_tags.sns_topic.tags.Second == 'two'
+
+    - name: purge old topic tags and add a new one
+      sns_topic:
+        name: "{{ sns_topic_topic_name }}"
+        purge_tags: yes
+        tags:
+          Third: three
+      register: sns_topic_tags
+
+    - name: assert topic tags purging
+      assert:
+        that:
+          - sns_topic_tags.sns_topic.tags | length == 1
+          - sns_topic_tags.sns_topic.tags.Third == 'three'
 
     - name: update display name
       sns_topic:


### PR DESCRIPTION
##### SUMMARY

Add tags support to AWS sns_topic module
Fixes: #65613 

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- sns_topic

##### ADDITIONAL INFORMATION

```yaml
- name: Create alarm SNS topic
  sns_topic:
    name: "alarms"
    display_name: "alarm SNS topic"
    tags:
      Environment: dev
      Automated: 'true'
```
