### PR TITLE
scaleway: Fix case mismatch causing key lookup failure

### DIFF
--- a/lib/ansible/module_utils/scaleway.py
+++ b/lib/ansible/module_utils/scaleway.py
@@ -90,7 +90,7 @@ class Scaleway(object):
         self.headers = {
             'X-Auth-Token': self.module.params.get('api_token'),
             'User-Agent': self.get_user_agent_string(module),
-            'Content-type': 'application/json',
+            'Content-Type': 'application/json',
         }
         self.name = None
 


### PR DESCRIPTION
##### SUMMARY
Since commit f70dc261c, automatic jsonification only happens if the Content-Type header is application/json, but the class only included Content-type in its default set of headers (notice the case variation).

This caused a KeyError on send() if the caller relied on the default content-type value.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible.module_utils.scaleway

##### ADDITIONAL INFORMATION
* I noticed this with the scaleway_compute module, but as it's shared widely among all the scaleway modules, I think more are affected.
* The commit f70dc261c has not been part of any ansible releases. (So, I omitted a changelog fragment, as I think that superfluous? Correct me if I'm wrong.)