### PR TITLE
update ActionBase._low_level_execute_command to honor executable

### DIFF
--- a/changelogs/fragments/68310-low_level_execute_command-honor-executable
+++ b/changelogs/fragments/68310-low_level_execute_command-honor-executable
@@ -1,0 +1,2 @@
+bugfixes:
+- Update ActionBase._low_level_execute_command to honor executable (https://github.com/ansible/ansible/issues/68054)

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1045,6 +1045,10 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             display.debug("_low_level_execute_command(): changing cwd to %s for this command" % chdir)
             cmd = self._connection._shell.append_command('cd %s' % chdir, cmd)
 
+        # https://github.com/ansible/ansible/issues/68054
+        if executable:
+            self._connection._shell.executable = executable
+
         ruser = self._get_remote_user()
         buser = self.get_become_option('become_user')
         if (sudoable and self._connection.become and  # if sudoable and have become


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #68054
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ActionBase

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Before:
(venv) rowagn@localhost:~/testcase$ ansible-playbook a.yml -i ./hosts -K -k -utestuser -vvv
[WARNING]: You are running the development version of Ansible. You should only
run Ansible from "devel" if you are modifying the Ansible engine, or trying out
features under development. This is a rapidly changing source of code and can
become unstable at any point.
ansible-playbook 2.10.0.dev0
  config file = /home/rowagn/testcase/ansible.cfg
  configured module search path = ['/home/rowagn/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/rowagn/ansible/lib/ansible
  executable location = /home/rowagn/ansible/bin/ansible-playbook
  python version = 3.8.1 (default, Feb 13 2020, 14:14:48) [GCC 5.4.0 20160609]
Using /home/rowagn/testcase/ansible.cfg as config file
SSH password: 
BECOME password[defaults to SSH password]: 
host_list declined parsing /home/rowagn/testcase/hosts as it did not pass its verify_file() method
script declined parsing /home/rowagn/testcase/hosts as it did not pass its verify_file() method
auto declined parsing /home/rowagn/testcase/hosts as it did not pass its verify_file() method
Parsed /home/rowagn/testcase/hosts inventory source with ini plugin

PLAYBOOK: a.yml ****************************************************************
1 plays in a.yml

PLAY [all] *********************************************************************
META: ran handlers

TASK [whoami] ******************************************************************
task path: /home/rowagn/testcase/a.yml:5
<rowagn-tower-test01.vsp.sas.com> ESTABLISH SSH CONNECTION FOR USER: testuser
<rowagn-tower-test01.vsp.sas.com> SSH: EXEC sshpass -d10 ssh -C -o ControlMaster=auto -o ControlPersist=60s -o 'User="testuser"' -o ConnectTimeout=10 -o ControlPath=/home/rowagn/.ansible/cp/ff5ffeba46 -tt rowagn-tower-test01.vsp.sas.com '/etc/ansible-wrapper -c '"'"'sudo -H -S  -p "[sudo via ansible, key=jxrtaplymlvrwjdmnrijbjddsgebtoqq] password:" -u root /bin/sh -c '"'"'"'"'"'"'"'"'echo BECOME-SUCCESS-jxrtaplymlvrwjdmnrijbjddsgebtoqq ; echo "test" > /tmp/test'"'"'"'"'"'"'"'"''"'"''
Escalation succeeded
<rowagn-tower-test01.vsp.sas.com> (1, b'\r\n', b'Shared connection to rowagn-tower-test01.vsp.sas.com closed.\r\n')
<rowagn-tower-test01.vsp.sas.com> Failed to connect to the host via ssh: Shared connection to rowagn-tower-test01.vsp.sas.com closed.
fatal: [rowagn-tower-test01.vsp.sas.com]: FAILED! => {
    "changed": true,
    "msg": "non-zero return code",
    "rc": 1,
    "stderr": "Shared connection to rowagn-tower-test01.vsp.sas.com closed.\r\n",
    "stderr_lines": [
        "Shared connection to rowagn-tower-test01.vsp.sas.com closed."
    ],
    "stdout": "\r\n",
    "stdout_lines": [
        ""
    ]
}

PLAY RECAP *********************************************************************
rowagn-tower-test01.vsp.sas.com : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   

After:
(venv) rowagn@localhost:~/testcase$ ansible-playbook a.yml -i ./hosts -K -k -utestuser -vvv
[WARNING]: You are running the development version of Ansible. You should only
run Ansible from "devel" if you are modifying the Ansible engine, or trying out
features under development. This is a rapidly changing source of code and can
become unstable at any point.
ansible-playbook 2.10.0.dev0
  config file = /home/rowagn/testcase/ansible.cfg
  configured module search path = ['/home/rowagn/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/rowagn/ansible/lib/ansible
  executable location = /home/rowagn/ansible/bin/ansible-playbook
  python version = 3.8.1 (default, Feb 13 2020, 14:14:48) [GCC 5.4.0 20160609]
Using /home/rowagn/testcase/ansible.cfg as config file
SSH password: 
BECOME password[defaults to SSH password]: 
host_list declined parsing /home/rowagn/testcase/hosts as it did not pass its verify_file() method
script declined parsing /home/rowagn/testcase/hosts as it did not pass its verify_file() method
auto declined parsing /home/rowagn/testcase/hosts as it did not pass its verify_file() method
Parsed /home/rowagn/testcase/hosts inventory source with ini plugin

PLAYBOOK: a.yml ****************************************************************
1 plays in a.yml

PLAY [all] *********************************************************************
META: ran handlers

TASK [whoami] ******************************************************************
task path: /home/rowagn/testcase/a.yml:5
<rowagn-tower-test01.vsp.sas.com> ESTABLISH SSH CONNECTION FOR USER: testuser
<rowagn-tower-test01.vsp.sas.com> SSH: EXEC sshpass -d10 ssh -C -o ControlMaster=auto -o ControlPersist=60s -o 'User="testuser"' -o ConnectTimeout=10 -o ControlPath=/home/rowagn/.ansible/cp/ff5ffeba46 -tt rowagn-tower-test01.vsp.sas.com '/etc/ansible-wrapper -c '"'"'sudo -H -S  -p "[sudo via ansible, key=ednnimhqaudjdpcngjcfecvqiljgzldn] password:" -u root /etc/ansible-wrapper -c '"'"'"'"'"'"'"'"'echo BECOME-SUCCESS-ednnimhqaudjdpcngjcfecvqiljgzldn ; echo "test" > /tmp/test'"'"'"'"'"'"'"'"''"'"''
Escalation succeeded
<rowagn-tower-test01.vsp.sas.com> (0, b'\r\n', b'Shared connection to rowagn-tower-test01.vsp.sas.com closed.\r\n')
changed: [rowagn-tower-test01.vsp.sas.com] => {
    "changed": true,
    "rc": 0,
    "stderr": "Shared connection to rowagn-tower-test01.vsp.sas.com closed.\r\n",
    "stderr_lines": [
        "Shared connection to rowagn-tower-test01.vsp.sas.com closed."
    ],
    "stdout": "\r\n",
    "stdout_lines": [
        ""
    ]
}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
rowagn-tower-test01.vsp.sas.com : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   



```
