### PR TITLE
Get full error message from Jira

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jira.py
+++ b/lib/ansible/modules/web_infrastructure/jira.py
@@ -258,7 +258,7 @@ def request(url, user, passwd, timeout, data=None, method=None):
                                         'Authorization': "Basic %s" % auth})
 
     if info['status'] not in (200, 201, 204):
-        module.fail_json(msg=info['msg'])
+        module.fail_json(msg=info['body'])
 
     body = response.read()
 


### PR DESCRIPTION
##### Display full error message from Jira
info['msg'] only displays HTTP 400 - and not the actual error. The "body" contains the full message.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

