### PR TITLE
Internally redirect win modules to collection name

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -165,14 +165,19 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             # Check to determine if PowerShell modules are supported, and apply
             # some fixes (hacks) to module name + args.
             if mod_type == '.ps1':
-                # win_stat, win_file, and win_copy are not just like their
+                win_collection = 'ansible.windows'
+
+                # async_status, win_stat, win_file, win_copy, and win_ping are not just like their
                 # python counterparts but they are compatible enough for our
                 # internal usage
-                if module_name in ('stat', 'file', 'copy') and self._task.action != module_name:
-                    module_name = 'win_%s' % module_name
+                if module_name in ('stat', 'file', 'copy', 'ping') and self._task.action != module_name:
+                    module_name = '%s.win_%s' % (win_collection, module_name)
+                elif module_name in ['async_status']:
+                    module_name = '%s.%s' % (win_collection, module_name)
 
                 # Remove extra quotes surrounding path parameters before sending to module.
-                if module_name in ('win_stat', 'win_file', 'win_copy', 'slurp') and module_args and hasattr(self._connection._shell, '_unquote'):
+                if module_name.split('.')[-1] in ['win_stat', 'win_file', 'win_copy', 'slurp'] and module_args and \
+                        hasattr(self._connection._shell, '_unquote'):
                     for key in ('src', 'dest', 'path'):
                         if key in module_args:
                             module_args[key] = self._connection._shell._unquote(module_args[key])

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -165,6 +165,8 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             # Check to determine if PowerShell modules are supported, and apply
             # some fixes (hacks) to module name + args.
             if mod_type == '.ps1':
+                # FIXME: This should be temporary and moved to an exec subsystem plugin where we can define the mapping
+                # for each subsystem.
                 win_collection = 'ansible.windows'
 
                 # async_status, win_stat, win_file, win_copy, and win_ping are not just like their

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -88,11 +88,7 @@ class ActionModule(ActionBase):
             except AttributeError:
                 pass
 
-            # Use win_ping on winrm/powershell, else use ping
-            if getattr(self._connection._shell, "_IS_WINDOWS", False):
-                ping_result = self._execute_module(module_name='win_ping', module_args=dict(), task_vars=task_vars)
-            else:
-                ping_result = self._execute_module(module_name='ping', module_args=dict(), task_vars=task_vars)
+            ping_result = self._execute_module(module_name='ping', module_args=dict(), task_vars=task_vars)
 
             # Test module output
             if ping_result['ping'] != 'pong':

--- a/test/lib/ansible_test/_data/playbooks/windows_coverage_teardown.yml
+++ b/test/lib/ansible_test/_data/playbooks/windows_coverage_teardown.yml
@@ -2,10 +2,6 @@
 - name: collect the coverage files from the Windows host
   hosts: windows
   gather_facts: no
-  # The collections keyword is required to allow fetch to work.
-  # See: https://github.com/ansible/ansible/issues/68269
-  collections:
-  - ansible.windows
   tasks:
   - name: make sure all vars have been set
     assert:

--- a/test/support/windows-integration/collections/ansible_collections/ansible/windows/plugins/modules/async_status.ps1
+++ b/test/support/windows-integration/collections/ansible_collections/ansible/windows/plugins/modules/async_status.ps1
@@ -1,0 +1,1 @@
+../../../../../../plugins/modules/async_status.ps1

--- a/test/support/windows-integration/collections/ansible_collections/ansible/windows/plugins/modules/win_copy.ps1
+++ b/test/support/windows-integration/collections/ansible_collections/ansible/windows/plugins/modules/win_copy.ps1
@@ -1,0 +1,1 @@
+../../../../../../plugins/modules/win_copy.ps1

--- a/test/support/windows-integration/collections/ansible_collections/ansible/windows/plugins/modules/win_copy.py
+++ b/test/support/windows-integration/collections/ansible_collections/ansible/windows/plugins/modules/win_copy.py
@@ -1,0 +1,1 @@
+../../../../../../plugins/modules/win_copy.py

--- a/test/support/windows-integration/collections/ansible_collections/ansible/windows/plugins/modules/win_stat.ps1
+++ b/test/support/windows-integration/collections/ansible_collections/ansible/windows/plugins/modules/win_stat.ps1
@@ -1,0 +1,1 @@
+../../../../../../plugins/modules/win_stat.ps1

--- a/test/support/windows-integration/collections/ansible_collections/ansible/windows/plugins/modules/win_stat.py
+++ b/test/support/windows-integration/collections/ansible_collections/ansible/windows/plugins/modules/win_stat.py
@@ -1,0 +1,1 @@
+../../../../../../plugins/modules/win_stat.py


### PR DESCRIPTION
##### SUMMARY
Also append the FQCN for Windows modules when being called internally by Ansible action plugins. This redirects the following

* `copy` -> `ansible.windows.win_copy`
* `file` -> `ansible.windows.win_file`
* `ping` -> `ansible.windows.win_ping`
* `stat` -> `ansible.windows.win_stat`

This also adds a blanket redirection of `async_status` to the FQCN of `ansible.windows.async_status` to get Async working again on the Windows collections. Without this the `async_status` action plugin will never be able to find the PowerShell equivalent module as it does a blanket execute of just `async_status` so the Python module is always called.

Fixes https://github.com/ansible/ansible/issues/68269

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
action/__init__.py
