### PR TITLE
Fix error in zabbix_mediatype.py

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_mediatype.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_mediatype.py
@@ -465,7 +465,7 @@ def get_update_params(module, zbx, mediatype_id, **kwargs):
         'output': 'extend',
         'mediatypeids': [mediatype_id]
     })[0]
-    
+
     temp = dict(existing_mediatype)
     for key in temp.keys():
         existing_mediatype[key.decode('utf-8')] = existing_mediatype[key]

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_mediatype.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_mediatype.py
@@ -278,6 +278,7 @@ def construct_parameters(**kwargs):
     """
     if kwargs['transport_type'] == 'email':
         return dict(
+            name=kwargs['name'],
             description=kwargs['name'],
             status=to_numeric_value(kwargs['status'],
                                     {'enabled': '0',
@@ -464,6 +465,10 @@ def get_update_params(module, zbx, mediatype_id, **kwargs):
         'output': 'extend',
         'mediatypeids': [mediatype_id]
     })[0]
+    
+    temp = dict(existing_mediatype)
+    for key in temp.keys():
+        existing_mediatype[key.decode('utf-8')] = existing_mediatype[key]
 
     if existing_mediatype['type'] != kwargs['type']:
         return kwargs, diff(existing_mediatype, kwargs)


### PR DESCRIPTION
##### SUMMARY
There are two errors in the monitoring/zabbix/zabbix_mediatype.py module.

1) It misses the "name" when you create the HTTP request payload.
2) Encoding error when compare "type" key. Once was "bytes" and other "str".

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
monitoring/zabbix/zabbix_mediatype.py :
This module is used to create some media type on Zabbix server.
=> Email channel

##### ADDITIONAL INFORMATION
I added the "name" key into the HTTP payload generation
```python
267 def construct_parameters(**kwargs):
268     """Translates data to a format suitable for Zabbix API and filters
269     the ones that are related to the specified mediatype type.
270 
271     Args:
272         **kwargs: Arguments passed to the module.
273 
274     Returns:
275         A dictionary of arguments that are related to kwargs['transport_type'],
276         and are in a format that is understandable by Zabbix API.
277     """
278     if kwargs['transport_type'] == 'email':
279         return dict(
280             name=kwargs['name'],
281             description=kwargs['name'],
282             status=to_numeric_value(kwargs['status'],
283                                     {'enabled': '0',
284                                      'disabled': '1'}),
285             type=to_numeric_value(kwargs['transport_type'],
286                                   {'email': '0',
287                                    'script': '1',
288                                    'sms': '2',
289                                    'jabber': '3',
290                                    'ez_texting': '100'}),
291             maxsessions=str(kwargs['max_sessions']),
292             maxattempts=str(kwargs['max_attempts']),
293             attempt_interval=str(kwargs['attempt_interval']),
294             smtp_server=kwargs['smtp_server'],
295             smtp_port=str(kwargs['smtp_server_port']),
296             smtp_helo=kwargs['smtp_helo'],
297             smtp_email=kwargs['smtp_email'],
298             smtp_security=to_numeric_value(str(kwargs['smtp_security']),
299                                            {'None': '0',
300                                             'STARTTLS': '1',
301                                             'SSL/TLS': '2'}),
302             smtp_authentication=to_numeric_value(str(kwargs['smtp_authentication']),
303                                                  {'False': '0',
304                                                   'True': '1'}),
305             smtp_verify_host=to_numeric_value(str(kwargs['smtp_verify_host']),
306                                               {'False': '0',
307                                                'True': '1'}),
308             smtp_verify_peer=to_numeric_value(str(kwargs['smtp_verify_peer']),
309                                               {'False': '0',
310                                                'True': '1'}),
311             username=kwargs['username'],
312             passwd=kwargs['password']
313         )
```

Workaround for encoding 

```python
def get_update_params(module, zbx, mediatype_id, **kwargs):
    """Filters only the parameters that are different and need to be updated.

    Args:
        module: AnsibleModule object.
        zbx: ZabbixAPI object.
        mediatype_id (int): ID of the mediatype to be updated.
        **kwargs: Parameters for the new mediatype.

    Returns:
        A tuple where the first element is a dictionary of parameters
        that need to be updated and the second one is a dictionary
        returned by diff() function with
        existing mediatype data and new params passed to it.
    """
    existing_mediatype = container_to_bytes(zbx.mediatype.get({
        'output': 'extend',
        'mediatypeids': [mediatype_id]
    })[0])
    
    temp = dict(existing_mediatype)
    for key in temp.keys():
        existing_mediatype[key.decode('utf-8')] = existing_mediatype[key]
    
    if existing_mediatype['type'.encode()] != kwargs['type']:
        return kwargs, diff(existing_mediatype, kwargs)
    else:
        params_to_update = {}
        for key in kwargs:
            if (not (kwargs[key] is None and existing_mediatype[key] == '')) and kwargs[key] != existing_mediatype[key]:
                params_to_update[key] = kwargs[key]
        return params_to_update, diff(existing_mediatype, kwargs)
```
