### PR TITLE
Prevent rewriting nested Block's data in filter_tagged_tasks

### DIFF
--- a/changelogs/fragments/prevent-rewriting-nested-block-data-in-filter_tagged_tasks.yml
+++ b/changelogs/fragments/prevent-rewriting-nested-block-data-in-filter_tagged_tasks.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Prevent rewriting nested Block's data in filter_tagged_tasks

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -379,7 +379,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
             return tmp_list
 
         def evaluate_block(block):
-            new_block = self.copy(exclude_tasks=True)
+            new_block = block.copy(exclude_tasks=True)
             new_block.block = evaluate_and_append_task(block.block)
             new_block.rescue = evaluate_and_append_task(block.rescue)
             new_block.always = evaluate_and_append_task(block.always)

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -379,7 +379,8 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
             return tmp_list
 
         def evaluate_block(block):
-            new_block = block.copy(exclude_tasks=True)
+            new_block = block.copy(exclude_parent=True, exclude_tasks=True)
+            new_block._parent = block._parent
             new_block.block = evaluate_and_append_task(block.block)
             new_block.rescue = evaluate_and_append_task(block.rescue)
             new_block.always = evaluate_and_append_task(block.always)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This patch fixes the issue where nested Block copies were created from
incorrect Block object. This resulted in nested Blocks data like ``name``
or ``_uuid`` to contain values from the Block the filter_tagged_tasks
method was called on.

ci_complete
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/playbook/block.py`
