### PR TITLE
Prefer specific nic for ansible_host ip address

### DIFF
--- a/contrib/inventory/ovirt.ini
+++ b/contrib/inventory/ovirt.ini
@@ -33,3 +33,4 @@ ovirt_url =
 ovirt_username =
 ovirt_password =
 ovirt_ca_file =
+ovirt_host_nic =


### PR DESCRIPTION
##### SUMMARY
Add ovirt_host_nic to ovirt.ini and OVIRT_HOST_NIC environment variables
Return ip address of preferred nic name instead of first ip found

Associated to #47511

##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME
contrib/inventory/ovirt4.py

Get IP address from specific nic (if defined) for ansible_host ip

Add ovirt_host_nic to ovirt.ini and OVIRT_HOST_NIC environment variables to define prefrered interface name

##### ADDITIONAL INFORMATION
Before:
```
python ovirt4.py --host awxtest
{
"status": "up",
"affinity_labels": [],
"tags": [],
"cluster": "Development",
"host": "ovirt03.example.com",
"id": "6a5989bf-d361-4758-9d50-75a966aa2167",
"description": "Ansible AWX (Docker)",
"statistics": {
"memory.used": 1889785610.0,
"cpu.current.hypervisor": 0.13,
"memory.buffered": 0.0,
"cpu.usage.history": 0.0,
"migration.progress": 100.0,
"memory.cached": 220921856.0,
"elapsed.time": 20610.0,
"cpu.current.guest": 1.3,
"memory.usage.history": 22.0,
"memory.installed": 8589934592.0,
"network.current.total": 0.0,
"disks.usage": null,
"memory.free": 6438473728.0,
"network.usage.history": 0.0,
"cpu.current.total": 1.4
},
"name": "awxtest",
"fqdn": "awxtest.example.com",
"devices": {
"docker0": [
"172.17.0.1"
],
"br-9fc396bc2d69": [
"172.18.0.1",
"fe80::42:36ff:fe73:6ed8"
],
"veth824d46b": [
"fe80::d078:3cff:feb4:7693"
],
"veth67dac3b": [
"fe80::1431:ffff:fe36:a1a9"
],
"veth496f306": [
"fe80::b831:c7ff:fe84:c4ce"
],
"veth35139b9": [
"fe80::78f6:a2ff:fe8e:dafa"
],
"veth1feceee": [
"fe80::7c0d:afff:fea8:1629"
],
"eth0": [
"192.168.0.23",
"fe80::546f:ccff:fe9c:1"
]
},
"ansible_host": "172.17.0.1",
"affinity_groups": [],
"template": "Blank",
"os_type": "rhel_7x64"
}
```
after
```
python ovirt4.py --host awxtest
{
"status": "up",
"affinity_labels": [],
"tags": [],
"cluster": "Development",
"host": "ovirt03.example.com",
"id": "6a5989bf-d361-4758-9d50-75a966aa2167",
"description": "Ansible AWX (Docker)",
"statistics": {
"memory.used": 1889785610.0,
"cpu.current.hypervisor": 0.13,
"memory.buffered": 0.0,
"cpu.usage.history": 0.0,
"migration.progress": 100.0,
"memory.cached": 220921856.0,
"elapsed.time": 20610.0,
"cpu.current.guest": 1.3,
"memory.usage.history": 22.0,
"memory.installed": 8589934592.0,
"network.current.total": 0.0,
"disks.usage": null,
"memory.free": 6438473728.0,
"network.usage.history": 0.0,
"cpu.current.total": 1.4
},
"name": "awxtest",
"fqdn": "awxtest.example.com",
"devices": {
"docker0": [
"172.17.0.1"
],
"br-9fc396bc2d69": [
"172.18.0.1",
"fe80::42:36ff:fe73:6ed8"
],
"veth824d46b": [
"fe80::d078:3cff:feb4:7693"
],
"veth67dac3b": [
"fe80::1431:ffff:fe36:a1a9"
],
"veth496f306": [
"fe80::b831:c7ff:fe84:c4ce"
],
"veth35139b9": [
"fe80::78f6:a2ff:fe8e:dafa"
],
"veth1feceee": [
"fe80::7c0d:afff:fea8:1629"
],
"eth0": [
"192.168.0.23",
"fe80::546f:ccff:fe9c:1"
]
},
"ansible_host": "192.168.0.23",
"affinity_groups": [],
"template": "Blank",
"os_type": "rhel_7x64"
}
```