### PR TITLE
The option for bios_type was missing addresses #68347

### DIFF
--- a/changelogs/fragments/68392-ovirt_vm_add_bios_type.yml
+++ b/changelogs/fragments/68392-ovirt_vm_add_bios_type.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ovirt_vm - add bios_type option (https://github.com/ansible/ansible/issues/63437)


### PR DESCRIPTION
##### SUMMARY
Addresses issue #68347.  Adds a bios_type option to the ovirt_vm module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ovirt_vm
##### ADDITIONAL INFORMATION
Example usage:
```yaml
- ovirt_vm:
    name: myvm
    sso: False
    boot_menu: True
# Valid options for bios_type are: 'q35_ovmf', 'i440fx_sea_bios', 'q35_sea_bios', 'q35_secure_boot'
# Default is i440fx_sea_bios
    bios_type: q35_ovmf 
    usb_support: True
    serial_console: True
    quota_id: "{{ ovirt_quotas[0]['id'] }}"
```
