### PR TITLE
[2.9] Handle get_tags_for_object in vmware_rest_client

### DIFF
--- a/changelogs/fragments/vmware_rest_client_tag_fix.yml
+++ b/changelogs/fragments/vmware_rest_client_tag_fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Handle get_tags_for_object API correctly in vmware_rest_client.

--- a/lib/ansible/module_utils/vmware_rest_client.py
+++ b/lib/ansible/module_utils/vmware_rest_client.py
@@ -177,7 +177,7 @@ class VmwareRestClient(object):
             return tags
         dynamic_managed_object = DynamicID(type=type, id=mid)
 
-        temp_tags_model = self.get_tags_for_object(dynamic_managed_object)
+        temp_tags_model = self.get_tags_for_object(dobj=dynamic_managed_object)
 
         category_service = self.api_client.tagging.Category
 


### PR DESCRIPTION
##### SUMMARY

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/vmware_rest_client_tag_fix.yml
lib/ansible/module_utils/vmware_rest_client.py
