### PR TITLE
Added option to fetch data for all interfaces on host

### DIFF
--- a/lib/ansible/plugins/inventory/netbox.py
+++ b/lib/ansible/plugins/inventory/netbox.py
@@ -388,7 +388,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # Fetch interface data
         return self._fetch_information(url)
 
-    def extract_interfaces(self, host):        
+    def extract_interfaces(self, host):
         try:
             interface = {}
             interfaces = []
@@ -403,7 +403,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                         interface = {}
                     return interfaces
                 else:
-                    return []       
+                    return []
         except Exception:
             return
 
@@ -415,7 +415,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def extract_interface_ip_addresses(self, interface):
         ip_address = {}
         ip_addresses = []
-        try:           
+        try:
             # Get all IP addresses on this interface
             ip_addresses_lookup = self.ip_addresses_lookup(interface)
             if 'results' in ip_addresses_lookup:


### PR DESCRIPTION
##### SUMMARY
When using Netbox as dynamic inventory for deploying hosts to e.g vSphere, it would be convenient to get data regarding all interfaces. 

If host has multiple interfaces, this information can be used to deploy a VM with the correct number if NICs and attached to the correct networks.

This also saves the playbook additional lookups against the Netbox API.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/inventory/netbox.py

