### PR TITLE
Fix documentation typos for modules packet_device and packet_sshkey

### DIFF
--- a/lib/ansible/modules/cloud/packet/packet_device.py
+++ b/lib/ansible/modules/cloud/packet/packet_device.py
@@ -35,7 +35,7 @@ author:
 options:
   auth_token:
     description:
-      - Packet api token. You can also supply it in env var C(PACKET_API_TOKEN).
+      - Packet API token. You can also supply it in env var C(PACKET_API_TOKEN).
 
   count:
     description:
@@ -135,7 +135,7 @@ notes:
 '''
 
 EXAMPLES = '''
-# All the examples assume that you have your Packet api token in env var PACKET_API_TOKEN.
+# All the examples assume that you have your Packet API token in env var PACKET_API_TOKEN.
 # You can also pass it to the auth_token parameter of the module instead.
 
 # Creating devices
@@ -151,7 +151,7 @@ EXAMPLES = '''
       facility: sjc1
 
 # Create the same device and wait until it is in state "active", (when it's
-# ready for other API operations). Fail if the devices in not "active" in
+# ready for other API operations). Fail if the device is not "active" in
 # 10 minutes.
 
 - name: create device and wait up to 10 minutes for active state

--- a/lib/ansible/modules/cloud/packet/packet_sshkey.py
+++ b/lib/ansible/modules/cloud/packet/packet_sshkey.py
@@ -28,7 +28,7 @@ options:
     choices: ['present', 'absent']
   auth_token:
     description:
-     - Packet api token. You can also supply it in env var C(PACKET_API_TOKEN).
+     - Packet API token. You can also supply it in env var C(PACKET_API_TOKEN).
   label:
      description:
      - Label for the key. If you keep it empty, it will be read from key string.
@@ -53,7 +53,7 @@ requirements:
 
 EXAMPLES = '''
 # All the examples assume that you have your Packet API token in env var PACKET_API_TOKEN.
-# You can also pass the api token in module param auth_token.
+# You can also pass the API token in module param auth_token.
 
 - name: create sshkey from string
   hosts: localhost
@@ -83,7 +83,7 @@ changed:
     sample: True
     returned: always
 sshkeys:
-    description: Information about sshkeys that were createe/removed.
+    description: Information about sshkeys that were created/removed.
     type: list
     sample: [
         {


### PR DESCRIPTION
Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The following PR fixes a couple of small typos I found while browsing through the docs for the Packet related modules.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/cloud/packet/packet_device.py
lib/ansible/modules/cloud/packet/packet_sshkey.py