### PR TITLE
Fix ansible-test module_utils import analysis.

### DIFF
--- a/changelogs/fragments/ansible-test-change-detection-fix.yml
+++ b/changelogs/fragments/ansible-test-change-detection-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now ignores empty ``*.py`` files when analyzing module_utils imports for change detection

--- a/test/lib/ansible_test/_internal/import_analysis.py
+++ b/test/lib/ansible_test/_internal/import_analysis.py
@@ -148,10 +148,10 @@ def enumerate_module_utils():
     for path in data_context().content.walk_files(data_context().content.module_utils_path):
         ext = os.path.splitext(path)[1]
 
-        if path == os.path.join(data_context().content.module_utils_path, '__init__.py'):
+        if ext != '.py':
             continue
 
-        if ext != '.py':
+        if os.path.getsize(path) == 0:
             continue
 
         module_utils.append(get_python_module_utils_name(path))


### PR DESCRIPTION
##### SUMMARY

Now empty `*.py` files are ignored during module_utils import analysis for change detection.
This eliminates "No imports found" warnings for files which should have no imports.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
