### PR TITLE
redfish_config: support boolean BIOS attributes

### DIFF
--- a/changelogs/fragments/68251-redfish_config-add-boolean-bios-attr-support.yaml
+++ b/changelogs/fragments/68251-redfish_config-add-boolean-bios-attr-support.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- redfish_config - add support for boolean bios attrs (https://github.com/ansible/ansible/pull/68251)

--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -60,7 +60,7 @@ options:
     description:
       - value of BIOS attr to update (deprecated - use bios_attributes instead)
     default: 'null'
-    type: str
+    type: raw
     version_added: "2.8"
   bios_attributes:
     required: false
@@ -241,7 +241,7 @@ def main():
             username=dict(required=True),
             password=dict(required=True, no_log=True),
             bios_attribute_name=dict(default='null'),
-            bios_attribute_value=dict(default='null'),
+            bios_attribute_value=dict(default='null', type='raw'),
             bios_attributes=dict(type='dict', default={}),
             timeout=dict(type='int', default=10),
             boot_order=dict(type='list', elements='str', default=[]),


### PR DESCRIPTION
Currently the redfish_config module will convert boolean bios_attribute_value
settings to strings (type str). This will cause BMCs expecting booleans to
error out.

This PR will change the default type of bios_attribute_value to 'raw' in order
to support strings and booleans.

Fixes #68251

##### SUMMARY
This fixes the behavior in Ansible 2.10 (also present in Ansible 2.9 and Ansible 2.8) that converts boolean based BIOS values to strings.

Note that I opened another PR against `stable-2.9` initially: #68254 

I can close this out and open a separate backport request to fix this bug in `stable-2.9` and `stable-2.8`. The backport request will require a _slight_ tweak to `redfish_utils.py` to fix this bug because #62764 was only added in `devel`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
redfish_config

##### ADDITIONAL INFORMATION

Sample snippet demonstrating both the "new" `bios_attributes` method (added in `devel`) and the deprecated `bios_attribute_name`/`bios_attribute_value` methods of modifying boolean based attributes:
```
---
- hosts: all
  gather_facts: false
  vars:
    bmc_username: admin
    bmc_password: hunter2
    bmc_address: 192.168.100.100
  tasks:
  - name: Configure boolean BIOS Settings
    redfish_config:
      category: Systems
      command: SetBiosAttributes
      bios_attribute_name: "ConsoleRedirection"
      bios_attribute_value: True
      baseuri: "{{ bmc_address }}"
      username: "{{ bmc_username }}"
      password: "{{ bmc_password }}"

  - name: Configure string BIOS Settings
    redfish_config:
      category: Systems
      command: SetBiosAttributes
      bios_attributes:
        ConsoleRedirection: True
      baseuri: "{{ bmc_address }}"
      username: "{{ bmc_username }}"
      password: "{{ bmc_password }}"
```



```
(68251-devel) [jyundt@aurora tests]$ cat supermicro_redfish.yml 
---
- hosts: all
  gather_facts: false
  vars:
    bmc_username: admin
    bmc_password: hunter2
    bmc_address: 192.168.100.100
  tasks:
  - name: Configure boolean BIOS Settings
    redfish_config:
      category: Systems
      command: SetBiosAttributes
      bios_attribute_name: "ConsoleRedirection"
      bios_attribute_value: True
      baseuri: "{{ bmc_address }}"
      username: "{{ bmc_username }}"
      password: "{{ bmc_password }}"

  - name: Configure string BIOS Settings
    redfish_config:
      category: Systems
      command: SetBiosAttributes
      bios_attributes:
        ConsoleRedirection: True
      baseuri: "{{ bmc_address }}"
      username: "{{ bmc_username }}"
      password: "{{ bmc_password }}"
(68251-devel) [jyundt@aurora tests]$ time ansible-playbook  -i 10.39.70.28, supermicro_redfish.yml 
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible
engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.

PLAY [all] *********************************************************************************************************************************

TASK [Configure boolean BIOS Settings] *****************************************************************************************************
[DEPRECATION WARNING]: The bios_attribute_name/bios_attribute_value options are deprecated. Use bios_attributes instead. This feature will 
be removed in version 2.14. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Distribution Ubuntu 18.04 on host 10.39.70.28 should use /usr/bin/python3, but is using /usr/bin/python for backward
 compatibility with prior Ansible releases. A future Ansible release will default to using the discovered platform python for this host. 
See https://docs.ansible.com/ansible/devel/reference_appendices/interpreter_discovery.html for more information. This feature will be 
removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
changed: [10.39.70.28]

TASK [Configure string BIOS Settings] ******************************************************************************************************
changed: [10.39.70.28]

PLAY RECAP *********************************************************************************************************************************
10.39.70.28                : ok=2    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


real	0m8.885s
user	0m2.631s
sys	0m0.290s
(68251-devel) [jyundt@aurora tests]$ 
```
cc @nlopez  @billdodd 