### PR TITLE
validate-modules - fix ps module delegate type inspection

### DIFF
--- a/changelogs/fragments/ps-argspec-type.yaml
+++ b/changelogs/fragments/ps-argspec-type.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- validate-modules - Fix hang when inspecting module with a delegate args spec type


### PR DESCRIPTION
##### SUMMARY
PowerShell modules allow you to set a delegate function to define the module option type. Unfortunately a delegate function when serialized causes a circular reference so having `-Depth 99` will fill the stdout buffer and cause an out of memory error. Instead we process the argument spec and convert each type as a delegate to `raw` so that the documentation can be validated.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
validate-modules