### PR TITLE
Remove old example playbooks dir.

### DIFF
--- a/examples/playbooks/README.md
+++ b/examples/playbooks/README.md
@@ -1,7 +1,0 @@
-Playbook Examples
-=================
-
-Playbook examples have moved.
-
-See [the Ansible-Examples repo](https://github.com/ansible/ansible-examples).
-


### PR DESCRIPTION
##### SUMMARY

Remove old example playbooks dir.

The content was relocated nearly 7 years ago.

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

examples/playbooks/README.md