### PR TITLE
[stable-2.9] adhoc: Load callbacks before sending v2_playbook_on_start (#67673)

### DIFF
--- a/changelogs/fragments/ansible-adhoc-cb-playbook_start.yaml
+++ b/changelogs/fragments/ansible-adhoc-cb-playbook_start.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible command now correctly sends v2_playbook_on_start to callbacks

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -160,6 +160,7 @@ class AdHocCLI(CLI):
                 forks=context.CLIARGS['forks'],
             )
 
+            self._tqm.load_callbacks()
             self._tqm.send_callback('v2_playbook_on_start', playbook)
 
             result = self._tqm.run(play)

--- a/test/integration/targets/ansible-runner/tasks/adhoc_example1.yml
+++ b/test/integration/targets/ansible-runner/tasks/adhoc_example1.yml
@@ -12,5 +12,5 @@
 - assert:
     that:
         - "adexec1_json.rc == 0"
-        - "adexec1_json.events|length == 3"
+        - "adexec1_json.events|length == 4"
         - "'localhost' in adexec1_json.stats.ok"

--- a/test/integration/targets/ansible/adhoc-callback.stdout
+++ b/test/integration/targets/ansible/adhoc-callback.stdout
@@ -1,0 +1,12 @@
+v2_playbook_on_start
+v2_on_any
+v2_playbook_on_play_start
+v2_on_any
+v2_playbook_on_task_start
+v2_on_any
+v2_runner_on_start
+v2_on_any
+v2_runner_on_ok
+v2_on_any
+v2_playbook_on_stats
+v2_on_any

--- a/test/integration/targets/ansible/callback_plugins/callback_debug.py
+++ b/test/integration/targets/ansible/callback_plugins/callback_debug.py
@@ -1,0 +1,24 @@
+# (c) 2020 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.callback import CallbackBase
+
+
+class CallbackModule(CallbackBase):
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'stdout'
+    CALLBACK_NAME = 'callback_debug'
+
+    def __init__(self, *args, **kwargs):
+        super(CallbackModule, self).__init__(*args, **kwargs)
+        self._display.display('__init__')
+
+        for cb in [x for x in dir(CallbackBase) if x.startswith('v2_')]:
+            delattr(CallbackBase, cb)
+
+    def __getattr__(self, name):
+        if name.startswith('v2_'):
+            return(lambda *args, **kwargs: self._display.display(name))

--- a/test/integration/targets/ansible/runme.sh
+++ b/test/integration/targets/ansible/runme.sh
@@ -27,6 +27,9 @@ ansible localhost -m debug -a var=playbook_dir --playbook-dir=/tmp | grep '"play
 # test setting playbook dir via ansible.cfg
 env -u ANSIBLE_PLAYBOOK_DIR ANSIBLE_CONFIG=./playbookdir_cfg.ini ansible localhost -m debug -a var=playbook_dir | grep '"playbook_dir": "/tmp"'
 
+# test adhoc callback triggers
+ANSIBLE_STDOUT_CALLBACK=callback_debug ANSIBLE_LOAD_CALLBACK_PLUGINS=1 ansible --playbook-dir . testhost -i ../../inventory -m ping | grep -E '^v2_' | diff -u adhoc-callback.stdout -
+
 # Test that no tmp dirs are left behind when running ansible-config
 TMP_DIR=~/.ansible/tmptest
 if [[ -d "$TMP_DIR" ]]; then


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #67673 for Ansible 2.9
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
adhoc CLI