### PR TITLE
windows - add docs for UNC path in PSModulePath error

### DIFF
--- a/docs/docsite/rst/user_guide/windows_setup.rst
+++ b/docs/docsite/rst/user_guide/windows_setup.rst
@@ -436,6 +436,20 @@ Sometimes an installer may restart the WinRM or HTTP service and cause this erro
 best way to deal with this is to use ``win_psexec`` from another
 Windows host.
 
+Failure to Load Builtin Modules
++++++++++++++++++++++++++++++++
+If powershell fails with an error message similar to ``The 'Out-String' command was found in the module 'Microsoft.PowerShell.Utility', but the module could not be loaded.``
+then there could be a problem trying to access all the paths specified by the ``PSModulePath`` environment variable.
+A common cause of this issue is that the ``PSModulePath`` environment variable contains a UNC path to a file share and
+because of the double hop/credential delegation issue the Ansible process cannot access these folders. The way around
+this problems is to either:
+
+* Remove the UNC path from the ``PSModulePath`` environment variable, or
+* Use an authentication option that supports credential delegation like ``credssp`` or ``kerberos`` with credential delegation enabled
+
+See `KB4076842 <https://support.microsoft.com/en-us/help/4076842>`_ for more information on this problem.
+
+
 Windows SSH Setup
 `````````````````
 Ansible 2.8 has added an experimental SSH connection for Windows managed nodes.


### PR DESCRIPTION
##### SUMMARY
Added helpful hint around `PSModulePath` having a UNC path causing an unhelpful error from Ansible. We can't fix the underlying issue but we can at least document it.

Fixes: https://github.com/ansible/ansible/issues/68185

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
user_guide/windows_setup.rst