### PR TITLE
ansible-test - fix up powershell module_util analysis for collections

### DIFF
--- a/changelogs/fragments/test-ps-utils.yaml
+++ b/changelogs/fragments/test-ps-utils.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- ansible-test - Fix PowerShell module util analysis to properly detect the names of a util when running in a collection
+- ansible-test - Do not warn on missing PowerShell or C# util that are in other collections

--- a/test/lib/ansible_test/_internal/csharp_import_analysis.py
+++ b/test/lib/ansible_test/_internal/csharp_import_analysis.py
@@ -92,10 +92,11 @@ def extract_csharp_module_utils_imports(path, module_utils, is_pure_csharp):
                 continue
 
             import_name = match.group(1)
-            if import_name not in module_utils:
-                display.warning('%s:%d Invalid module_utils import: %s' % (path, line_number, import_name))
-                continue
 
-            imports.add(import_name)
+            if import_name in module_utils:
+                imports.add(import_name)
+            elif data_context().content.is_ansible or \
+                    import_name.startswith('ansible_collections.%s' % data_context().content.prefix):
+                display.warning('%s:%d Invalid module_utils import: %s' % (path, line_number, import_name))
 
     return imports

--- a/test/lib/ansible_test/_internal/powershell_import_analysis.py
+++ b/test/lib/ansible_test/_internal/powershell_import_analysis.py
@@ -49,7 +49,7 @@ def get_powershell_module_utils_name(path):  # type: (str) -> str
     base_path = data_context().content.module_utils_powershell_path
 
     if data_context().content.collection:
-        prefix = 'ansible_collections.' + data_context().content.collection.prefix + '.plugins.module_utils.'
+        prefix = 'ansible_collections.' + data_context().content.collection.prefix + 'plugins.module_utils.'
     else:
         prefix = ''
 
@@ -77,7 +77,7 @@ def extract_powershell_module_utils_imports(path, module_utils):
 
     code = read_text_file(path)
 
-    if '# POWERSHELL_COMMON' in code:
+    if data_context().content.is_ansible and '# POWERSHELL_COMMON' in code:
         imports.add('Ansible.ModuleUtils.Legacy')
 
     lines = code.splitlines()
@@ -94,7 +94,8 @@ def extract_powershell_module_utils_imports(path, module_utils):
 
         if import_name in module_utils:
             imports.add(import_name)
-        else:
+        elif data_context().content.is_ansible or \
+                import_name.startswith('ansible_collections.%s' % data_context().content.prefix):
             display.warning('%s:%d Invalid module_utils import: %s' % (path, line_number, import_name))
 
     return imports


### PR DESCRIPTION
##### SUMMARY
When running the PS util analysis inside a collection we were adding the `Ansible.ModuleUtils.Legacy` util for modules that had `# POWERSHELL_COMMON` when only modules in base should be adding that.

The PS util name builder also erroneously added an extra `.` after the prefix which already ends with `.` leading to missing import checks when finding a PS util in a collection.

Finally we display an invalid warning for all utils not found, not just utils that are namespaced to the current collection.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test