### PR TITLE
vmware_guest_network - delete all interfaces feature

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_network.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_network.py
@@ -39,12 +39,6 @@ options:
      - UUID of the instance to gather info if known, this is VMware's unique identifier.
      - This is a required parameter, if parameter C(name) or C(moid) is not supplied.
      type: str
-   use_instance_uuid:
-     description:
-     - Whether to use the VMware instance UUID rather than the BIOS UUID.
-     default: False
-     type: bool
-     version_added: '2.10'
    moid:
      description:
      - Managed Object ID of the instance to manage if known, this is a unique identifier only within a single vCenter instance.
@@ -83,6 +77,12 @@ options:
      description:
      - The datacenter name to which virtual machine belongs to.
      type: str
+   delete_all:
+    description:
+    - If set to C(True), will delete all network adapters, any network parameters are ignored
+    - If set to C(False), will do nothing. Network adapters must be provided as an alternative.
+    type: bool
+    default: False
    gather_network_info:
      description:
      - If set to C(True), return settings of all network adapters, other parameters are ignored.
@@ -119,8 +119,6 @@ options:
            When reconfigure MAC address, VM should be in powered off state.'
      - ' - C(connected) (bool): Indicates that virtual network adapter connects to the associated virtual machine.'
      - ' - C(start_connected) (bool): Indicates that virtual network adapter starts with associated virtual machine powers on.'
-     - ' - C(directpath_io) (bool): If set, Universal Pass-Through (UPT or DirectPath I/O) will be enabled on the network adapter.
-           UPT is only compatible for Vmxnet3 adapter.'
 extends_documentation_fragment: vmware.documentation
 '''
 
@@ -163,34 +161,17 @@ EXAMPLES = '''
         mac: "00:50:56:44:55:77"
   delegate_to: localhost
 
-- name: Change network adapter settings of virtual machine using instance UUID
-  vmware_guest_network:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    datacenter: "{{ datacenter_name }}"
-    validate_certs: no
-    uuid: 5003b4f5-c705-2f37-ccf6-dfc0b40afeb7
-    use_instance_uuid: True
-    gather_network_info: false
-    networks:
-      - state: absent
-        mac: "00:50:56:44:55:77"
-  delegate_to: localhost
 
-- name: Enable DirectPath I/O on a Vmxnet3 adapter
+- name: Delete all interfaces without mentioning any specific device using vm name
   vmware_guest_network:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter_name }}"
     validate_certs: no
-    name: test-vm
-    gather_network_info: false
-    networks:
-      - state: present
-        mac: "aa:50:56:58:59:61"
-        directpath_io: True
+    name: vm-42
+    delete_all: yes
+    gather_network_info: no
   delegate_to: localhost
 '''
 
@@ -204,7 +185,6 @@ network_data:
             "label": "Network Adapter 1",
             "name": "VM Network",
             "device_type": "E1000E",
-            "directpath_io": "N/A",
             "mac_addr": "00:50:56:89:dc:05",
             "unit_number": 7,
             "wake_onlan": false,
@@ -212,17 +192,6 @@ network_data:
             "connected": true,
             "start_connected": true,
         },
-        "1": {
-            "label": "Network Adapter 2",
-            "name": "VM Network",
-            "device_type": "VMXNET3",
-            "directpath_io": true,
-            "mac_addr": "00:50:56:8d:93:8c",
-            "unit_number": 8,
-            "start_connected": true,
-            "wake_on_lan": true,
-            "connected": true,
-        }
     }
 """
 
@@ -306,27 +275,9 @@ class PyVmomiHelper(PyVmomi):
         nic = vim.vm.device.VirtualDeviceSpec()
         nic.device = self.get_device_type(device_type=device_info.get('device_type', 'vmxnet3'))
         nic.device.deviceInfo = vim.Description()
-        network_object = self.find_network_by_name(network_name=device_info['name'])[0]
-        if network_object:
-            if hasattr(network_object, 'portKeys'):
-                # DistributedVirtualPortGroup
-                nic.device.backing = vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo()
-                nic.device.backing.port = vim.dvs.PortConnection()
-                nic.device.backing.port.switchUuid = network_object.config.distributedVirtualSwitch.uuid
-                nic.device.backing.port.portgroupKey = network_object.key
-            elif isinstance(network_object, vim.OpaqueNetwork):
-                # NSX-T Logical Switch
-                nic.device.backing = vim.vm.device.VirtualEthernetCard.OpaqueNetworkBackingInfo()
-                network_id = network_object.summary.opaqueNetworkId
-                nic.device.backing.opaqueNetworkType = 'nsx.LogicalSwitch'
-                nic.device.backing.opaqueNetworkId = network_id
-                nic.device.deviceInfo.summary = 'nsx.LogicalSwitch: %s' % network_id
-            else:
-                # Standard vSwitch
-                nic.device.deviceInfo.summary = device_info['name']
-                nic.device.backing = vim.vm.device.VirtualEthernetCard.NetworkBackingInfo()
-                nic.device.backing.deviceName = device_info['name']
-                nic.device.backing.network = network_object
+        nic.device.deviceInfo.summary = device_info['name']
+        nic.device.backing = vim.vm.device.VirtualEthernetCard.NetworkBackingInfo()
+        nic.device.backing.deviceName = device_info['name']
         nic.device.connectable = vim.vm.device.VirtualDevice.ConnectInfo()
         nic.device.connectable.startConnected = device_info.get('start_connected', True)
         nic.device.connectable.allowGuestControl = True
@@ -336,12 +287,6 @@ class PyVmomiHelper(PyVmomi):
             nic.device.macAddress = device_info['manual_mac']
         else:
             nic.device.addressType = 'generated'
-        if 'directpath_io' in device_info:
-            if isinstance(nic.device, vim.vm.device.VirtualVmxnet3):
-                nic.device.uptCompatibilityEnabled = device_info['directpath_io']
-            else:
-                self.module.fail_json(msg='UPT is only compatible for Vmxnet3 adapter.'
-                                      + ' Clients can set this property enabled or disabled if ethernet virtual device is Vmxnet3.')
 
         return nic
 
@@ -353,14 +298,12 @@ class PyVmomiHelper(PyVmomi):
         nic_index = 0
         for nic in vm_obj.config.hardware.device:
             nic_type = None
-            directpath_io = 'N/A'
             if isinstance(nic, vim.vm.device.VirtualPCNet32):
                 nic_type = 'PCNet32'
             elif isinstance(nic, vim.vm.device.VirtualVmxnet2):
                 nic_type = 'VMXNET2'
             elif isinstance(nic, vim.vm.device.VirtualVmxnet3):
                 nic_type = 'VMXNET3'
-                directpath_io = nic.uptCompatibilityEnabled
             elif isinstance(nic, vim.vm.device.VirtualE1000):
                 nic_type = 'E1000'
             elif isinstance(nic, vim.vm.device.VirtualE1000e):
@@ -378,7 +321,6 @@ class PyVmomiHelper(PyVmomi):
                     allow_guest_ctl=nic.connectable.allowGuestControl,
                     connected=nic.connectable.connected,
                     start_connected=nic.connectable.startConnected,
-                    directpath_io=directpath_io
                 )
                 nic_index += 1
 
@@ -445,95 +387,83 @@ class PyVmomiHelper(PyVmomi):
 
         return network_list
 
+    def delete_all_interfaces(self, vm_obj):
+        network_data = self.get_network_info(vm_obj)
+        nic_indexes = [nic for nic in network_data]
+        mac_list = [network_data[nic]['mac_addr'] for nic in nic_indexes]
+        nic_devices = []
+        for mac in mac_list:
+            nic = self.get_network_device_by_mac(vm_obj, mac=mac)
+            if nic is not None:
+                nic_devices.append(nic)
+        for device in nic_devices:
+            nic_spec = vim.vm.device.VirtualDeviceSpec()
+            nic_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.remove
+            nic_spec.device = device
+            self.change_detected = True
+            self.config_spec.deviceChange.append(nic_spec)
+
     def get_network_config_spec(self, vm_obj, network_list):
-        # create network adapter config spec for adding, editing, removing
-        for network in network_list:
-            # add new network adapter
-            if network['state'].lower() == 'new':
-                nic_spec = self.create_network_adapter(network)
-                nic_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
-                self.change_detected = True
-                self.config_spec.deviceChange.append(nic_spec)
-            # reconfigure network adapter or remove network adapter
-            else:
-                nic_devices = []
-                if 'mac' in network:
-                    nic = self.get_network_device_by_mac(vm_obj, mac=network['mac'])
-                    if nic is not None:
-                        nic_devices.append(nic)
-                if 'label' in network and len(nic_devices) == 0:
-                    nic = self.get_network_device_by_label(vm_obj, device_label=network['label'])
-                    if nic is not None:
-                        nic_devices.append(nic)
-                if 'device_type' in network and len(nic_devices) == 0:
-                    nic_devices = self.get_network_devices_by_type(vm_obj, device_type=network['device_type'])
-                if len(nic_devices) != 0:
-                    for nic_device in nic_devices:
-                        nic_spec = vim.vm.device.VirtualDeviceSpec()
-                        if network['state'].lower() == 'present':
-                            nic_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
-                            nic_spec.device = nic_device
-                            if 'start_connected' in network and nic_device.connectable.startConnected != network['start_connected']:
-                                nic_device.connectable.startConnected = network['start_connected']
-                                self.change_detected = True
-                            if 'connected' in network and nic_device.connectable.connected != network['connected']:
-                                nic_device.connectable.connected = network['connected']
-                                self.change_detected = True
-                            if 'name' in network:
-                                network_object = self.find_network_by_name(network_name=network['name'])[0]
-                                if network_object and hasattr(network_object, 'portKeys') and hasattr(nic_spec.device.backing, 'port'):
-                                    if network_object.config.distributedVirtualSwitch.uuid != nic_spec.device.backing.port.switchUuid:
-                                        # DistributedVirtualPortGroup
-                                        nic_spec.device.backing = vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo()
-                                        nic_spec.device.backing.port = vim.dvs.PortConnection()
-                                        nic_spec.device.backing.port.switchUuid = network_object.config.distributedVirtualSwitch.uuid
-                                        nic_spec.device.backing.port.portgroupKey = network_object.key
-                                        self.change_detected = True
-                                elif network_object and isinstance(network_object, vim.OpaqueNetwork) and hasattr(nic_spec.device.backing, 'opaqueNetworkId'):
-                                    if nic_spec.device.backing.opaqueNetworkId != network_object.summary.opaqueNetworkId:
-                                        # NSX-T Logical Switch
-                                        nic_spec.device.backing = vim.vm.device.VirtualEthernetCard.OpaqueNetworkBackingInfo()
-                                        network_id = network_object.summary.opaqueNetworkId
-                                        nic_spec.device.backing.opaqueNetworkType = 'nsx.LogicalSwitch'
-                                        nic_spec.device.backing.opaqueNetworkId = network_id
-                                        nic_spec.device.deviceInfo.summary = 'nsx.LogicalSwitch: %s' % network_id
-                                        self.change_detected = True
-                                elif nic_device.deviceInfo.summary != network['name']:
-                                    # Standard vSwitch
-                                    nic_spec.device.backing = vim.vm.device.VirtualEthernetCard.NetworkBackingInfo()
-                                    nic_spec.device.backing.deviceName = network['name']
-                                    nic_spec.device.backing.network = network_object
-                                    self.change_detected = True
-                            if 'manual_mac' in network and nic_device.macAddress != network['manual_mac']:
-                                if vm_obj.runtime.powerState != vim.VirtualMachinePowerState.poweredOff:
-                                    self.module.fail_json(msg='Expected power state is poweredOff to reconfigure MAC address')
-                                nic_device.addressType = 'manual'
-                                nic_device.macAddress = network['manual_mac']
-                                self.change_detected = True
-                            if 'directpath_io' in network:
-                                if isinstance(nic_device, vim.vm.device.VirtualVmxnet3):
-                                    if nic_device.uptCompatibilityEnabled != network['directpath_io']:
-                                        nic_device.uptCompatibilityEnabled = network['directpath_io']
-                                        self.change_detected = True
-                                else:
-                                    self.module.fail_json(msg='UPT is only compatible for Vmxnet3 adapter.'
-                                                          + ' Clients can set this property enabled or disabled if ethernet virtual device is Vmxnet3.')
-                            if self.change_detected:
-                                self.config_spec.deviceChange.append(nic_spec)
-                        elif network['state'].lower() == 'absent':
-                            nic_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.remove
-                            nic_spec.device = nic_device
-                            self.change_detected = True
-                            self.config_spec.deviceChange.append(nic_spec)
+        # deletes all devices
+        if self.params['delete_all']:
+            self.delete_all_interfaces(vm_obj)
+        else:
+            # create network adapter config spec for adding, editing, removing
+            for network in network_list:
+                # add new network adapter
+                if network['state'].lower() == 'new':
+                    nic_spec = self.create_network_adapter(network)
+                    nic_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
+                    self.change_detected = True
+                    self.config_spec.deviceChange.append(nic_spec)
+                # reconfigure network adapter or remove network adapter
                 else:
-                    self.module.fail_json(msg='Unable to find the specified network adapter: %s' % network)
+                    nic_devices = []
+                    if 'mac' in network:
+                        nic = self.get_network_device_by_mac(vm_obj, mac=network['mac'])
+                        if nic is not None:
+                            nic_devices.append(nic)
+                    if 'label' in network and len(nic_devices) == 0:
+                        nic = self.get_network_device_by_label(vm_obj, device_label=network['label'])
+                        if nic is not None:
+                            nic_devices.append(nic)
+                    if 'device_type' in network and len(nic_devices) == 0:
+                        nic_devices = self.get_network_devices_by_type(vm_obj, device_type=network['device_type'])
+                    if len(nic_devices) != 0:
+                        for nic_device in nic_devices:
+                            nic_spec = vim.vm.device.VirtualDeviceSpec()
+                            if network['state'].lower() == 'present':
+                                nic_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
+                                nic_spec.device = nic_device
+                                if 'start_connected' in network and nic_device.connectable.startConnected != network['start_connected']:
+                                    nic_device.connectable.startConnected = network['start_connected']
+                                    self.change_detected = True
+                                if 'connected' in network and nic_device.connectable.connected != network['connected']:
+                                    nic_device.connectable.connected = network['connected']
+                                    self.change_detected = True
+                                if 'name' in network and nic_device.deviceInfo.summary != network['name']:
+                                    nic_device.deviceInfo.summary = network['name']
+                                    self.change_detected = True
+                                if 'manual_mac' in network and nic_device.macAddress != network['manual_mac']:
+                                    if vm_obj.runtime.powerState != vim.VirtualMachinePowerState.poweredOff:
+                                        self.module.fail_json(msg='Expected power state is poweredOff to reconfigure MAC address')
+                                    nic_device.addressType = 'manual'
+                                    nic_device.macAddress = network['manual_mac']
+                                    self.change_detected = True
+                                if self.change_detected:
+                                    self.config_spec.deviceChange.append(nic_spec)
+                            elif network['state'].lower() == 'absent':
+                                nic_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.remove
+                                nic_spec.device = nic_device
+                                self.change_detected = True
+                                self.config_spec.deviceChange.append(nic_spec)
+                    else:
+                        self.module.fail_json(msg='Unable to find the specified network adapter: %s' % network)
 
     def reconfigure_vm_network(self, vm_obj):
         network_list = self.sanitize_network_params()
-        # gather network adapter info only
-        if (self.params['gather_network_info'] is not None and self.params['gather_network_info']) or len(network_list) == 0:
+        if not self.params['delete_all'] and (self.params['gather_network_info'] or (network_list is None or len(network_list) == 0)):
             results = {'changed': False, 'failed': False, 'network_data': self.get_network_info(vm_obj)}
-        # do reconfigure then gather info
         else:
             self.get_network_config_spec(vm_obj, network_list)
             try:
@@ -560,14 +490,14 @@ def main():
     argument_spec.update(
         name=dict(type='str'),
         uuid=dict(type='str'),
-        use_instance_uuid=dict(type='bool', default=False),
         moid=dict(type='str'),
         folder=dict(type='str'),
         datacenter=dict(type='str', default='ha-datacenter'),
         esxi_hostname=dict(type='str'),
         cluster=dict(type='str'),
         gather_network_info=dict(type='bool', default=False, aliases=['gather_network_facts']),
-        networks=dict(type='list', default=[])
+        networks=dict(type='list', default=[]),
+        delete_all=dict(type='bool', default=False)
     )
 
     module = AnsibleModule(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Basically took the original vmware_guest_network (version 2.9) and added the option to delete all interfaces without actually mentioning any specific network device (the module will be able to gather the information itself)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest_network_module

```
