### PR TITLE
Ignore test files in new package-data sanity test

### DIFF
--- a/test/sanity/code-smell/package-data.py
+++ b/test/sanity/code-smell/package-data.py
@@ -29,6 +29,7 @@ def assemble_files_to_ship(complete_file_list):
         'hacking/shippable/*',
         'hacking/tests/*',
         'hacking/ticket_stubs/*',
+        'metadata-*.json',  # ansible-test with --docker produces this tmp file.
         'test/sanity/code-smell/botmeta.*',
         'test/utils/*',
         'test/utils/*/*',
@@ -55,6 +56,7 @@ def assemble_files_to_ship(complete_file_list):
         'hacking/return_skeleton_generator.py',
         'hacking/test-module',
         'hacking/test-module.py',
+        'test/support/README.md',
         '.cherry_picker.toml',
         '.mailmap',
         # Possibly should be included


### PR DESCRIPTION
##### SUMMARY
New file added by https://github.com/ansible/ansible/pull/68450 broke a sanity test. This PR ignores that file as well as a temp file created by ansible-test with the `--docker` option.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test