### PR TITLE
Fix misleading documentation for naming blocks

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_blocks.rst
+++ b/docs/docsite/rst/user_guide/playbooks_blocks.rst
@@ -43,7 +43,9 @@ All tasks in a block inherit directives applied at the block level. Most of what
 
 In the example above, the 'when' condition will be evaluated before Ansible runs each of the three tasks in the block. All three tasks also inherit the privilege escalation directives, running as the root user. Finally, ``ignore_errors: yes`` ensures that Ansible continues to execute the playbook even if some of the tasks fail.
 
-Names for tasks within blocks have been available since Ansible 2.3. We recommend using names in all tasks, within blocks or elsewhere, for better visibility into the tasks being executed when you run the playbook.
+.. versionadded:: 2.3
+
+    The ``name:`` keyword for ``block:`` was added in Ansible 2.3.
 
 .. _block_error_handling:
 

--- a/docs/docsite/rst/user_guide/playbooks_blocks.rst
+++ b/docs/docsite/rst/user_guide/playbooks_blocks.rst
@@ -43,9 +43,7 @@ All tasks in a block inherit directives applied at the block level. Most of what
 
 In the example above, the 'when' condition will be evaluated before Ansible runs each of the three tasks in the block. All three tasks also inherit the privilege escalation directives, running as the root user. Finally, ``ignore_errors: yes`` ensures that Ansible continues to execute the playbook even if some of the tasks fail.
 
-.. versionadded:: 2.3
-
-    The ``name:`` keyword for ``block:`` was added in Ansible 2.3.
+Names for blocks have been available since Ansible 2.3. We recommend using names in all tasks, within blocks or elsewhere, for better visibility into the tasks being executed when you run the playbook.
 
 .. _block_error_handling:
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

From what I have observed it is the block itself that doesn't support the name attribute rather than the tasks inside the block.
The error I'm getting when I try to use a named block with Ansible 2.0 is: `'name' is not a valid attribute for a Block`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
blocks documentation

##### ADDITIONAL INFORMATION

According to the current documentation the following should fail to execute in Ansible versions prior to 2.3:

```
- block:

       - name: Task 1
          debug: 
              msg: "Some Task"

       - name: Task 2
          debug: 
              msg: "Some other Task"
```

This is however not the case and it executes fine. 
The following however fails due to the name attribute in the block.

```
- name: "Block that executes some tasks" 
   block:

       - name: Task 1
          debug: 
              msg: "Some Task"

       - name: Task 2
          debug: 
              msg: "Some other Task"
```
```
ERROR! 'name' is not a valid attribute for a Block
```
