### PR TITLE
disable bot notification spam

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1,4 +1,5 @@
 automerge: false
+notifications: false
 files:
   .github/BOTMETA.yml:
     labels: botmeta

--- a/test/sanity/code-smell/botmeta.py
+++ b/test/sanity/code-smell/botmeta.py
@@ -53,6 +53,7 @@ def main():
 
     schema = Schema({
         Required('automerge'): bool,
+        Required('notifications'): bool,
         Required('files'): Any(None, *list_dict_file_schema),
         Required('macros'): dict,  # Any(*list_macros_schema),
     })


### PR DESCRIPTION
##### SUMMARY
notifications are spam and post-NWO we don't really need them. Once issues and PRs have been moved or closed, we can reconsider turning notifications back on.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
botmeta
