### PR TITLE
Rename package to ansible-base

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -257,7 +257,7 @@ static_setup_params = dict(
         'install_scripts': InstallScriptsCommand,
         'sdist': SDistCommand,
     },
-    name='ansible',
+    name='ansible-base',
     version=__version__,
     description='Radically simple IT automation',
     author=__author__,


### PR DESCRIPTION
##### SUMMARY
Rename the package from ansible to ansible-base

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Ansible build scripts:
* setup.py

##### ADDITIONAL INFORMATION
In order for people to test the ACD package that I'm shooting to have ready by the end of the week, we'll need  to have an ansible-base package that people can install.  We'll need the package names to not conflict in order to install from git.  Would be even nicer if we could upload a version of this to testpypi (maybe changing the version so that it doesn't conflict with our eventual 2.10.0 alphas?)

@webknjaz Could you look this over and make sure I didn't miss anything?  I think this is all that has to be done to make setup.py do the right thing but I am a little leary since I had done some things wrong with the `package_dir` key before.