### PR TITLE
Fix plugins loader for collection's cache plugin

### DIFF
--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -59,7 +59,6 @@ class BaseCacheModule(AnsiblePlugin):
     _display = display
 
     def __init__(self, *args, **kwargs):
-        self._load_name = self.__module__.split('.')[-1]
         super(BaseCacheModule, self).__init__()
         self.set_options(var_options=args, direct=kwargs)
 

--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -59,6 +59,9 @@ class BaseCacheModule(AnsiblePlugin):
     _display = display
 
     def __init__(self, *args, **kwargs):
+        if not hasattr(self, '_load_name'):
+            self._load_name = self.__module__.split('.')[-1]
+
         super(BaseCacheModule, self).__init__()
         self.set_options(var_options=args, direct=kwargs)
 

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -568,6 +568,8 @@ class PluginLoader:
 
         self._display_plugin_load(self.class_name, name, self._searched_paths, path, found_in_cache=found_in_cache, class_only=class_only)
 
+        self._update_object(obj, name, path)
+
         if not class_only:
             try:
                 obj = obj(*args, **kwargs)
@@ -578,7 +580,6 @@ class PluginLoader:
                     return None
                 raise
 
-        self._update_object(obj, name, path)
         return obj
 
     def _display_plugin_load(self, class_name, name, searched_paths, path, found_in_cache=None, class_only=None):
@@ -695,13 +696,14 @@ class PluginLoader:
 
             self._display_plugin_load(self.class_name, basename, self._searched_paths, path, found_in_cache=found_in_cache, class_only=class_only)
 
+            self._update_object(obj, basename, path)
+
             if not class_only:
                 try:
                     obj = obj(*args, **kwargs)
                 except TypeError as e:
                     display.warning("Skipping plugin (%s) as it seems to be incomplete: %s" % (path, to_text(e)))
 
-            self._update_object(obj, basename, path)
             yield obj
 
 


### PR DESCRIPTION
##### SUMMARY
- [x] **[fix]** Fix plugins loader for collection's cache plugins

This PR fixes a bug that let collection cache plugins(e.g `community.general.jsonfile`) not load correctly.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/loader.py
lib/ansible/plugins/cache/__init__.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
To reproduce the bug:
- Install `community.general` collection
- Use `community.general.jsonfile` with a Cacheable-based inventory plugin (e.g vmware)

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Unable to use cache plugin community.general.jsonfile for inventory. Cache options were provided
but may not reconcile correctly unless set via set_options. Refer to the porting guide if the
plugin derives user settings from ansible.constants.
```
