### PR TITLE
Add 'is not running' to list of stopped strings

### DIFF
--- a/lib/ansible/modules/system/sysvinit.py
+++ b/lib/ansible/modules/system/sysvinit.py
@@ -203,7 +203,7 @@ def main():
 
                 cleanout = out.lower().replace(name.lower(), '')
 
-                for stopped in ['stop', 'is dead ', 'dead but ', 'could not access pid file', 'inactive']:
+                for stopped in ['stop', 'is dead ', 'dead but ', 'could not access pid file', 'inactive', 'is not running']:
                     if stopped in cleanout:
                         worked = True
                         break


### PR DESCRIPTION
##### SUMMARY
Consider 'is not running' in stdout to be a valid indicator that a service is not running.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sysvinit
Ansible 2.9.6

##### ADDITIONAL INFORMATION
I have a service, FAHClient (Folding@Home volunteer computing for COVID19 research) that uses a sysv script.  When it is stopped, the output is:
```
$ sudo /etc/init.d/FAHClient status 
fahclient is not running
$ echo $?
0
```

This is not caught by any of the logic except the "hail mary" 
https://github.com/ansible/ansible/blob/v2.9.6/lib/ansible/modules/system/sysvinit.py#L224
which assumes a return code of zero for a status check means it is not running (maybe not a reliable assumption). The result is that Ansible never starts the service because it thinks it is already running.

Although it is true that each script may behave differently and handling for special cases should be minimized, if the script outputs "<service> is not running" this should be considered a fairly strong and reliable indicator that it is not running. 