### PR TITLE
Add resource_from_fqcr utility function

### DIFF
--- a/lib/ansible/executor/powershell/module_manifest.py
+++ b/lib/ansible/executor/powershell/module_manifest.py
@@ -19,6 +19,7 @@ from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.compat.importlib import import_module
 from ansible.plugins.loader import ps_module_utils_loader
+from ansible.utils.collection_loader import resource_from_fqcr
 
 
 class PSModuleDepFinder(object):
@@ -309,7 +310,7 @@ def _create_powershell_wrapper(b_module_data, module_path, module_args,
         exec_manifest["async_timeout_sec"] = async_timeout
         exec_manifest["async_startup_timeout"] = C.config.get_config_value("WIN_ASYNC_STARTUP_TIMEOUT", variables=task_vars)
 
-    if become and become_method.split('.')[-1] == 'runas':  # runas and namespace.collection.runas
+    if become and resource_from_fqcr(become_method) == 'runas':  # runas and namespace.collection.runas
         finder.scan_exec_script('exec_wrapper')
         finder.scan_exec_script('become_wrapper')
 

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -28,6 +28,7 @@ from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.parsing.utils.jsonify import jsonify
 from ansible.release import __version__
+from ansible.utils.collection_loader import resource_from_fqcr
 from ansible.utils.display import Display
 from ansible.utils.unsafe_proxy import wrap_var, AnsibleUnsafeText
 from ansible.vars.clean import remove_internal_keys
@@ -178,7 +179,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                     module_name = '%s.%s' % (win_collection, module_name)
 
                 # Remove extra quotes surrounding path parameters before sending to module.
-                if module_name.split('.')[-1] in ['win_stat', 'win_file', 'win_copy', 'slurp'] and module_args and \
+                if resource_from_fqcr(module_name) in ['win_stat', 'win_file', 'win_copy', 'slurp'] and module_args and \
                         hasattr(self._connection._shell, '_unquote'):
                     for key in ('src', 'dest', 'path'):
                         if key in module_args:
@@ -1060,7 +1061,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         ruser = self._get_remote_user()
         buser = self.get_become_option('become_user')
         if (sudoable and self._connection.become and  # if sudoable and have become
-                self._connection.transport.split('.')[-1] != 'network_cli' and  # if not using network_cli
+                resource_from_fqcr(self._connection.transport) != 'network_cli' and  # if not using network_cli
                 (C.BECOME_ALLOW_SAME_USER or (buser != ruser or not any((ruser, buser))))):  # if we allow same user PE or users are different and either is set
             display.debug("_low_level_execute_command(): using become for this command")
             cmd = self._connection.become.build_become_command(cmd, self._connection._shell)

--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -31,6 +31,7 @@ from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.common._collections_compat import MutableMapping
 from ansible.plugins import AnsiblePlugin
 from ansible.plugins.loader import cache_loader
+from ansible.utils.collection_loader import resource_from_fqcr
 from ansible.utils.display import Display
 from ansible.vars.fact_cache import FactCache as RealFactCache
 
@@ -63,6 +64,7 @@ class BaseCacheModule(AnsiblePlugin):
         if not hasattr(self, '_load_name'):
             display.deprecated('Rather than importing custom CacheModules directly, use ansible.plugins.loader.cache_loader', version='2.14')
             self._load_name = self.__module__.split('.')[-1]
+            self._load_name = resource_from_fqcr(self.__module__)
         super(BaseCacheModule, self).__init__()
         self.set_options(var_options=args, direct=kwargs)
 
@@ -108,7 +110,7 @@ class BaseFileCacheModule(BaseCacheModule):
         except KeyError:
             self._cache_dir = self._get_cache_connection(C.CACHE_PLUGIN_CONNECTION)
             self._timeout = float(C.CACHE_PLUGIN_TIMEOUT)
-        self.plugin_name = self.__module__.split('.')[-1]
+        self.plugin_name = resource_from_fqcr(self.__module__)
         self._cache = {}
         self.validate_cache_connection()
 

--- a/lib/ansible/utils/collection_loader.py
+++ b/lib/ansible/utils/collection_loader.py
@@ -586,3 +586,18 @@ def get_collection_name_from_path(path):
 
 def set_collection_playbook_paths(b_playbook_paths):
     AnsibleCollectionLoader().set_playbook_paths(b_playbook_paths)
+
+
+def resource_from_fqcr(ref):
+    """
+    Return resource from a fully-qualified collection reference,
+    or from a simple resource name.
+
+    For fully-qualified collection references, this is equivalent to
+    ``AnsibleCollectionRef.from_fqcr(ref).resource``.
+
+    :param ref: collection reference to parse
+    :return: the resource as a unicode string
+    """
+    ref = to_text(ref, errors='strict')
+    return ref.split(u'.')[-1]


### PR DESCRIPTION
##### SUMMARY
~~Currently become plugins in community.general are broken (if `become_exe` is not explicitly specified by the user), since~~ https://github.com/ansible/ansible/blob/01638e0ea222b115909bfd73677b97be92744ff2/lib/ansible/playbook/play_context.py#L358 ~~explicitly uses the `become_name` as a default value, which for become plugins in community.general is prefixed with `community.general.`.~~ (No longer needed.)

Also adds a helper method `resource_from_fqcr` to collection_loader, which avoids the tedious `.split('.')[-1]` found in several places.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
```
lib/ansible/executor/powershell/module_manifest.py
lib/ansible/playbook/play_context.py
lib/ansible/plugins/action/__init__.py
lib/ansible/plugins/cache/__init__.py
lib/ansible/utils/collection_loader.py
```