### PR TITLE
Rename AWS collections

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -13,72 +13,72 @@ files:
     maintainers: $team_aws
   $modules/cloud/amazon/aws_kms.py:
     ignored: tedder
-    migrated_to: community.amazon
+    migrated_to: community.aws
   $modules/cloud/amazon/cloudformation.py:
     maintainers: ryansb
     ignored: tedder
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   $modules/cloud/amazon/cloudtrail.py:
     maintainers: $team_ansible
-    migrated_to: community.amazon
+    migrated_to: community.aws
   $modules/cloud/amazon/ec2.py:
     maintainers: $team_ansible
     ignored: skvidal
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   $modules/cloud/amazon/ec2_asg.py:
     maintainers: $team_ansible s-hertel ryansb
-    migrated_to: community.amazon
+    migrated_to: community.aws
   $modules/cloud/amazon/ec2_group.py:
     maintainers: $team_ansible
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   $modules/cloud/amazon/ec2_instance.py:
     maintainers: Shaps
-    migrated_to: community.amazon
+    migrated_to: community.aws
   $modules/cloud/amazon/ec2_key.py:
     maintainers: $team_ansible
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   $modules/cloud/amazon/ec2_lc.py:
     maintainers: $team_ansible
-    migrated_to: community.amazon
+    migrated_to: community.aws
   $modules/cloud/amazon/ec2_metric_alarm.py:
     maintainers: $team_ansible
-    migrated_to: community.amazon
+    migrated_to: community.aws
   $modules/cloud/amazon/ec2_tag.py:
     maintainers: $team_ansible
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   $modules/cloud/amazon/ec2_vol.py:
     maintainers: $team_ansible
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   $modules/cloud/amazon/ec2_vpc_net.py:
     maintainers: $team_ansible
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   $modules/cloud/amazon/ec2_vpc_net_info.py:
     maintainers: whiter
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   $modules/cloud/amazon/elasticache.py:
     maintainers: alachaum
-    migrated_to: community.amazon
+    migrated_to: community.aws
   $modules/cloud/amazon/iam.py:
     maintainers: $team_ansible
-    migrated_to: community.amazon
+    migrated_to: community.aws
   $modules/cloud/amazon/iam_cert.py:
     maintainers: $team_ansible
-    migrated_to: community.amazon
+    migrated_to: community.aws
   $modules/cloud/amazon/iam_policy.py:
     maintainers: $team_ansible
-    migrated_to: community.amazon
+    migrated_to: community.aws
   $modules/cloud/amazon/rds.py:
     ignored: bpennypacker
-    migrated_to: community.amazon
+    migrated_to: community.aws
   $modules/cloud/amazon/rds_param_group.py:
     maintainers: scottanderson42
-    migrated_to: community.amazon
+    migrated_to: community.aws
   $modules/cloud/amazon/rds_subnet_group.py:
     maintainers: scottanderson42
-    migrated_to: community.amazon
+    migrated_to: community.aws
   $modules/cloud/amazon/route53.py:
     ignored: bpennypacker
-    migrated_to: community.amazon
+    migrated_to: community.aws
   $modules/cloud/atomic/: krsacme
   $modules/cloud/azure/:
     ignored: chouseknecht jwhitbeck
@@ -3365,7 +3365,7 @@ files:
     labels:
     - aws
     - cloud
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   $module_utils/ecs/:
     maintainers: ctrufan tylert $team_crypto
   $module_utils/facts:
@@ -3645,7 +3645,7 @@ files:
     support: core
   $plugins/action/aws_s3.py:
     support: core
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   $plugins/action/command.py:
     support: core
   $plugins/action/cli:
@@ -4043,7 +4043,7 @@ files:
     support: core
   $plugins/inventory/aws_ec2.py:
     maintainers: $team_aws
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   $plugins/inventory/azure_rm.py:
     migrated_to: azure.azcollection
   $plugins/inventory/docker: *id011
@@ -4671,443 +4671,443 @@ files:
   test/units/modules/network/frr/test_frr_bgp.py:
     migrated_to: frr.frr
   lib/ansible/plugins/connection/aws_ssm.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/script_inventory_ec2/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/script_inventory_ec2/inventory_diff.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/script_inventory_ec2/ec2.sh:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/script_inventory_ec2/runme.sh:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/script_inventory_ec2/lib/__init__.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/script_inventory_ec2/lib/boto/route53.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/script_inventory_ec2/lib/boto/__init__.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/script_inventory_ec2/lib/boto/session.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/script_inventory_ec2/lib/boto/rds.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/script_inventory_ec2/lib/boto/exception.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/script_inventory_ec2/lib/boto/exceptions.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/script_inventory_ec2/lib/boto/sts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/script_inventory_ec2/lib/boto/ec2/__init__.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/script_inventory_ec2/lib/boto/mocks/instances.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/script_inventory_ec2/lib/boto/mocks/__init__.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/script_inventory_ec2/lib/boto/elasticache/__init__.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   contrib/inventory/ec2.ini:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   contrib/inventory/ec2.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_aws_acm_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_aws_kms_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_aws_region_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_aws_s3_bucket_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_aws_sgw_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_aws_waf_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_cloudfront_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_cloudwatchlogs_log_group_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_ec2_asg_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_ec2_customer_gateway_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_ec2_instance_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_ec2_eip_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_ec2_elb_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_ec2_lc_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_ec2_placement_group_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_ec2_vpc_endpoint_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_ec2_vpc_igw_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_ec2_vpc_nacl_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_ec2_vpc_nat_gateway_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_ec2_vpc_peering_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_ec2_vpc_route_table_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_ec2_vpc_vgw_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_ec2_vpc_vpn_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_ecs_service_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_ecs_taskdefinition_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_efs_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_elasticache_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_elb_application_lb_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_elb_classic_lb_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_elb_target_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_elb_target_group_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_iam_cert_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_iam_mfa_device_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_iam_role_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_iam_server_certificate_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_lambda_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_rds_instance_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_rds_snapshot_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_redshift_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/_route53_facts.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_acm.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_acm_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_api_gateway.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_application_scaling_policy.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_batch_compute_environment.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_batch_job_definition.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_batch_job_queue.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_codebuild.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_codecommit.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_codepipeline.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_config_aggregation_authorization.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_config_aggregator.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_config_delivery_channel.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_config_recorder.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_config_rule.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_direct_connect_connection.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_direct_connect_gateway.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_direct_connect_link_aggregation_group.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_direct_connect_virtual_interface.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_eks_cluster.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_elasticbeanstalk_app.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_glue_connection.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_glue_job.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_inspector_target.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_kms_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_region_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_s3_bucket_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_s3_cors.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_secret.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_ses_identity.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_ses_identity_policy.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_ses_rule_set.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_sgw_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_step_functions_state_machine.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_step_functions_state_machine_execution.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_waf_condition.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_waf_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_waf_rule.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/aws_waf_web_acl.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/cloudformation_stack_set.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/cloudformation_exports_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/cloudfront_distribution.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/cloudfront_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/cloudfront_invalidation.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/cloudfront_origin_access_identity.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/cloudwatchlogs_log_group.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/cloudwatchlogs_log_group_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/cloudwatchlogs_log_group_metric_filter.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/data_pipeline.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/dms_endpoint.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/dms_replication_subnet_group.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/dynamodb_table.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/dynamodb_ttl.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_ami_copy.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_asg_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_asg_lifecycle_hook.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_customer_gateway.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_customer_gateway_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_eip.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_eip_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_elb.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_elb_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_instance_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_launch_template.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_lc_find.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_lc_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_placement_group.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_placement_group_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_scaling_policy.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_snapshot_copy.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_transit_gateway.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_transit_gateway_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_egress_igw.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_endpoint.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_endpoint_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_igw_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_peering_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_route_table_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_vgw.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_vgw_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_vpn.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_vpn_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ec2_win_password.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ecs_attribute.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ecs_cluster.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ecs_ecr.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ecs_service.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ecs_service_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ecs_tag.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ecs_task.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/ecs_taskdefinition_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/efs.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/efs_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/elasticache_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/elasticache_snapshot.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/elasticache_subnet_group.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/elb_application_lb.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/elb_application_lb_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/elb_classic_lb.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/elb_classic_lb_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/elb_instance.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/elb_network_lb.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/elb_target.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/elb_target_group.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/elb_target_group_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/elb_target_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/execute_lambda.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/iam_group.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/iam_managed_policy.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/iam_mfa_device_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/iam_password_policy.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/iam_policy_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/iam_role.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/iam_role_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/iam_saml_federation.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/iam_server_certificate_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/iam_user.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/iam_user_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/kinesis_stream.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/lambda.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/lambda_alias.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/lambda_event.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/lambda_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/lambda_policy.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/lightsail.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/rds_instance.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/rds_instance_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/rds_snapshot.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/rds_snapshot_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/redshift.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/redshift_cross_region_snapshots.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/redshift_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/redshift_subnet_group.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/route53_health_check.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/route53_info.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/route53_zone.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/s3_bucket_notification.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/s3_lifecycle.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/s3_logging.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/s3_sync.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/s3_website.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/sns.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/sns_topic.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/sqs_queue.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/sts_assume_role.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/modules/cloud/amazon/sts_session_token.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/units/plugins/connection/test_aws_ssm.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/units/plugins/connection/__init__.py:
     migrated_to: ansible.netcommon
   test/units/modules/cloud/amazon/test_aws_acm.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/units/modules/cloud/amazon/fixtures/certs/chain-1.3.cert:
     migrated_to: netapp.aws
   test/units/modules/cloud/amazon/fixtures/certs/a.pem:
@@ -6159,81 +6159,81 @@ files:
   test/units/modules/cloud/amazon/__init__.py:
     migrated_to: netapp.aws
   test/units/modules/cloud/amazon/test_aws_api_gateway.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/units/modules/cloud/amazon/test_aws_direct_connect_connection.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/units/modules/cloud/amazon/test_aws_direct_connect_link_aggregation_group.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/units/modules/cloud/amazon/test_data_pipeline.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/units/modules/cloud/amazon/test_ec2_vpc_nat_gateway.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/units/modules/cloud/amazon/test_ec2_vpc_vpn.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/units/modules/cloud/amazon/test_iam_password_policy.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/units/modules/cloud/amazon/test_kinesis_stream.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/units/modules/cloud/amazon/test_lambda.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/units/modules/cloud/amazon/test_lambda_policy.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/units/modules/cloud/amazon/test_redshift_cross_region_snapshots.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/units/modules/cloud/amazon/test_route53_zone.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/units/modules/cloud/amazon/test_s3_bucket_notification.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/connection_aws_ssm/aws_ssm_integration_test_teardown.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/connection_aws_ssm/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/connection_aws_ssm/inventory.aws_ssm.template:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/connection_aws_ssm/runme.sh:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/README.md:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/files/ec2-trust-policy.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/tasks/redhat.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/tasks/debian.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/templates/inventory-linux.aws_ssm.j2:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/templates/iam_role_vars_to_delete.yml.j2:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/templates/ec2_linux_vars_to_delete.yml.j2:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/templates/ec2_windows_vars_to_delete.yml.j2:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/templates/inventory-windows.aws_ssm.j2:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/templates/s3_vars_to_delete.yml.j2:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/connection_aws_ssm/aws_ssm_integration_test_setup/templates/aws-env-vars.j2:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/connection_aws_ssm/aws_ssm_integration_test_teardown/README.md:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/connection_aws_ssm/aws_ssm_integration_test_teardown/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_acm/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_acm/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_acm/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_acm/tasks/full_acm_test.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_acm/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/setup_remote_tmp_dir/tasks/windows-cleanup.yml:
     migrated_to: ansible.windows
   test/integration/targets/setup_remote_tmp_dir/tasks/default-cleanup.yml:
@@ -6247,729 +6247,729 @@ files:
   test/integration/targets/setup_remote_tmp_dir/handlers/main.yml:
     migrated_to: ansible.windows
   test/integration/targets/aws_api_gateway/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_api_gateway/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_api_gateway/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_api_gateway/templates/minimal-swagger-api.yml.j2:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/prepare_tests/tasks/main.yml:
     migrated_to: ansible.posix
   test/integration/targets/setup_ec2/vars/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/setup_ec2/defaults/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/setup_ec2/tasks/common.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/aws_codebuild/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_codebuild/vars/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_codebuild/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_codebuild/files/codebuild_iam_trust_policy.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_codebuild/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_codecommit/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_codecommit/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_codepipeline/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_codepipeline/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_codepipeline/files/codepipeline_iam_trust_policy.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_codepipeline/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_config/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_config/defaults/main.yaml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_config/files/config-trust-policy.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_config/tasks/main.yaml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_config/templates/config-s3-policy.json.j2:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_eks_cluster/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_eks_cluster/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_eks_cluster/files/eks-trust-policy.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_eks_cluster/tasks/botocore_lt_1.12.38.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_eks_cluster/tasks/botocore_lt_1.10.1.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_eks_cluster/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_eks_cluster/tasks/full_test.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_eks_cluster/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_elasticbeanstalk_app/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_elasticbeanstalk_app/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_elasticbeanstalk_app/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_elasticbeanstalk_app/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_glue_connection/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_glue_connection/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_inspector_target/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_inspector_target/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_inspector_target/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_kms/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_kms/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_kms/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_kms/templates/console-policy.j2:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_secret/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_secret/defaults/main.yaml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_secret/files/secretsmanager-trust-policy.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_secret/files/hello_world.zip:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_secret/tasks/main.yaml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_ses_identity/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_ses_identity/defaults/main.yaml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_ses_identity/tasks/main.yaml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_ses_identity/tasks/assert_defaults.yaml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_ses_identity/meta/main.yaml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_ses_identity_policy/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_ses_identity_policy/defaults/main.yaml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_ses_identity_policy/tasks/main.yaml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_ses_identity_policy/templates/policy.json.j2:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_ses_rule_set/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_ses_rule_set/defaults/main.yaml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_ses_rule_set/tasks/inactive-rule-set-tests.yaml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_ses_rule_set/tasks/obtain-lock.yaml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_ses_rule_set/tasks/cleanup-lock.yaml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_ses_rule_set/tasks/main.yaml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_ses_rule_set/tasks/obtain-lock-wrapper.yaml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_ses_rule_set/tasks/active-rule-set-tests.yaml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_ssm_parameter_store/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_ssm_parameter_store/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_ssm_parameter_store/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_step_functions_state_machine/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_step_functions_state_machine/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_step_functions_state_machine/files/alternative_state_machine.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_step_functions_state_machine/files/state_machines_iam_trust_policy.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_step_functions_state_machine/files/state_machine.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_step_functions_state_machine/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_waf_web_acl/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_waf_web_acl/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudformation_stack_set/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudformation_stack_set/runme.sh:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudformation_stack_set/playbooks/full_test.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudformation_stack_set/files/test_modded_bucket_stack.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudformation_stack_set/files/test_bucket_stack.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudformation_stack_set/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudformation_exports_info/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudformation_exports_info/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudformation_exports_info/files/test_stack.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudformation_exports_info/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudfront_distribution/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudfront_distribution/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudfront_distribution/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudfront_distribution/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudtrail/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudtrail/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudtrail/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudtrail/templates/sns-policy.j2:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudtrail/templates/kms-policy.j2:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudtrail/templates/cloudwatch-assume-policy.j2:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudtrail/templates/cloudwatch-policy.j2:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudtrail/templates/s3-policy.j2:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudwatchlogs/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudwatchlogs/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/cloudwatchlogs/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/dms_endpoint/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/dms_endpoint/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/dms_replication_subnet_group/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/dms_replication_subnet_group/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/dms_replication_subnet_group/files/dmsAssumeRolePolicyDocument.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/dms_replication_subnet_group/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_asg/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_asg/vars/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_asg/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_asg/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_eip/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_eip/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_eip/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_eip/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/inventory:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/runme.sh:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/roles/ec2_instance/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/roles/ec2_instance/files/assume-role-policy.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/roles/ec2_instance/tasks/external_resource_attach.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/roles/ec2_instance/tasks/ebs_optimized.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/roles/ec2_instance/tasks/version_fail_wrapper.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/roles/ec2_instance/tasks/checkmode_tests.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/roles/ec2_instance/tasks/block_devices.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/roles/ec2_instance/tasks/tags_and_vpc_settings.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/roles/ec2_instance/tasks/env_cleanup.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/roles/ec2_instance/tasks/default_vpc_tests.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/roles/ec2_instance/tasks/instance_no_wait.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/roles/ec2_instance/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/roles/ec2_instance/tasks/version_fail.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/roles/ec2_instance/tasks/cpu_options.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/roles/ec2_instance/tasks/env_setup.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/roles/ec2_instance/tasks/termination_protection.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/roles/ec2_instance/tasks/iam_instance_role.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/roles/ec2_instance/tasks/find_ami.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_instance/roles/ec2_instance/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_launch_template/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_launch_template/runme.sh:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_launch_template/playbooks/version_fail.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_launch_template/playbooks/full_test.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/files/assume-role-policy.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/tasks/versions.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/tasks/tags_and_vpc_settings.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/tasks/cpu_options.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/tasks/iam_instance_role.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_launch_template/playbooks/roles/ec2_launch_template/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_launch_template/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_metric_alarm/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_metric_alarm/vars/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_metric_alarm/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_metric_alarm/tasks/env_cleanup.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_metric_alarm/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_metric_alarm/tasks/env_setup.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_metric_alarm/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_transit_gateway/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_transit_gateway/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_egress_igw/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_egress_igw/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_igw/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_igw/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_nacl/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_nacl/tasks/ingress_and_egress.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_nacl/tasks/subnet_ids.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_nacl/tasks/ipv6.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_nacl/tasks/tags.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_nacl/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_nacl/tasks/subnet_names.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_nacl/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_nat_gateway/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_nat_gateway/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_route_table/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_route_table/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_route_table/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_vgw/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_vgw/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_vpn_info/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ec2_vpc_vpn_info/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ecs_cluster/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ecs_cluster/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ecs_cluster/files/ec2-trust-policy.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ecs_cluster/files/ecs-trust-policy.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ecs_cluster/tasks/network_force_new_deployment_fail.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ecs_cluster/tasks/network_assign_public_ip_fail.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ecs_cluster/tasks/network_fail.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ecs_cluster/tasks/network_force_new_deployment.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ecs_cluster/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ecs_cluster/tasks/full_test.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ecs_cluster/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ecs_ecr/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ecs_ecr/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ecs_ecr/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ecs_ecr/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ecs_tag/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/ecs_tag/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/efs/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/efs/runme.sh:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/efs/playbooks/version_fail.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/efs/playbooks/full_test.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/efs/playbooks/roles/efs/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_application_lb/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_application_lb/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_application_lb/tasks/test_multiple_actions.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_application_lb/tasks/test_modifying_alb_listeners.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_application_lb/tasks/test_multiple_actions_fail.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_application_lb/tasks/test_alb_tags.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_application_lb/tasks/test_creating_alb.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_application_lb/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_application_lb/tasks/full_test.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_application_lb/tasks/test_deleting_alb.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_application_lb/tasks/test_alb_bad_listener_options.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_application_lb/tasks/multiple_actions_fail.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_application_lb/tasks/test_alb_with_asg.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_application_lb/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_classic_lb/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_classic_lb/vars/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_classic_lb/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_classic_lb/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_classic_lb/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_network_lb/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_network_lb/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_network_lb/files/key.pem:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_network_lb/files/cert.pem:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_network_lb/tasks/test_nlb_bad_listener_options.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_network_lb/tasks/test_modifying_nlb_listeners.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_network_lb/tasks/test_nlb_tags.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_network_lb/tasks/test_deleting_nlb.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_network_lb/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_network_lb/tasks/test_creating_nlb.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_network_lb/tasks/test_nlb_with_asg.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_network_lb/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_target/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_target/runme.sh:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_target/playbooks/version_fail.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_target/playbooks/full_test.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_target/playbooks/roles/elb_target/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_target/playbooks/roles/elb_target/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_target/playbooks/roles/elb_lambda_target/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_target/playbooks/roles/elb_lambda_target/files/ansible_lambda_target.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_target/playbooks/roles/elb_lambda_target/files/assume-role.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_target/playbooks/roles/elb_lambda_target/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_target_info/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_target_info/runme.sh:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_target_info/playbooks/full_test.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_target_info/playbooks/roles/elb_target_info/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/elb_target_info/playbooks/roles/elb_target_info/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_lambda/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_lambda/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_lambda/files/mini_lambda.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_lambda/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/aws_lambda/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_group/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_group/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_group/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_group/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_password_policy/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_password_policy/tasks/main.yaml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_policy/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_policy/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_policy/files/no_access_with_id.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_policy/files/no_trust.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_policy/files/no_access.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_policy/files/no_access_with_second_id.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_policy/tasks/object.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_policy/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_role/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_role/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_role/files/deny-all-a.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_role/files/deny-all.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_role/files/deny-assume.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_role/files/deny-all-b.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_role/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_role/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_saml_federation/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_saml_federation/files/example1.xml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_saml_federation/files/example2.xml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_saml_federation/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_saml_federation/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_user/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_user/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_user/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/iam_user/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/lambda_policy/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/lambda_policy/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/lambda_policy/files/mini_http_lambda.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/lambda_policy/files/minimal_trust_policy.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/lambda_policy/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/lambda_policy/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/lambda_policy/templates/endpoint-test-swagger-api.yml.j2:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/lightsail/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/lightsail/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/lightsail/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_instance/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_instance/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_instance/tasks/test_processor_features.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_instance/tasks/test_states.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_instance/tasks/test_encryption.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_instance/tasks/test_tags.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_instance/tasks/test_final_snapshot.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_instance/tasks/test_vpc_security_groups.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_instance/tasks/test_bad_options.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_instance/tasks/test_modification.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_instance/tasks/test_read_replica.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_instance/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_instance/tasks/test_restore_instance.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_instance/tasks/test_aurora.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_instance/tasks/credential_tests.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_instance/tasks/test_snapshot.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_param_group/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_param_group/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_param_group/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_param_group/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_subnet_group/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_subnet_group/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_subnet_group/tasks/params.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_subnet_group/tasks/tests.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_subnet_group/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/rds_subnet_group/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/redshift/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/redshift/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/redshift/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/redshift/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/route53/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/route53/vars/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/route53/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/route53/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/route53_zone/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/route53_zone/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/s3_bucket_notification/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/s3_bucket_notification/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/s3_bucket_notification/files/mini_lambda.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/s3_bucket_notification/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/s3_bucket_notification/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/s3_lifecycle/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/s3_lifecycle/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/s3_logging/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/s3_logging/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/s3_logging/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/sns/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/sns/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/sns/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/sns_topic/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/sns_topic/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/sns_topic/files/lambda-policy.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/sns_topic/files/lambda-trust-policy.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/sns_topic/files/sns_topic_lambda/sns_topic_lambda.py:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/sns_topic/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/sns_topic/templates/updated-policy.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/sns_topic/templates/initial-policy.json:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/sqs_queue/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/sqs_queue/defaults/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/sqs_queue/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/sts_assume_role/aliases:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/sts_assume_role/tasks/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/sts_assume_role/meta/main.yml:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   test/integration/targets/sts_assume_role/templates/policy.json.j2:
-    migrated_to: community.amazon
+    migrated_to: community.aws
   lib/ansible/plugins/action/ce_template.py:
     migrated_to: community.general
   lib/ansible/plugins/action/cnos.py:
@@ -10429,9 +10429,9 @@ files:
   test/units/plugins/lookup/test_avi.py:
     migrated_to: community.general
   test/units/plugins/lookup/fixtures/avi.json:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/units/plugins/lookup/__init__.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/units/plugins/lookup/test_conjur_variable.py:
     migrated_to: community.general
   test/units/plugins/lookup/test_lastpass.py:
@@ -18887,363 +18887,363 @@ files:
   test/integration/targets/azure_rm_automationaccount/meta/main.yml:
     migrated_to: azure.azcollection
   lib/ansible/plugins/callback/aws_resource_actions.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/plugins/doc_fragments/aws.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/plugins/doc_fragments/aws_credentials.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/plugins/doc_fragments/aws_region.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/plugins/doc_fragments/ec2.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/plugins/inventory/aws_rds.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/plugins/lookup/aws_account_attribute.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/plugins/lookup/aws_secret.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/plugins/lookup/aws_service_ip_ranges.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/plugins/lookup/aws_ssm.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/module_utils/aws/__init__.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/module_utils/aws/acm.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/module_utils/aws/batch.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/module_utils/aws/cloudfront_facts.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/module_utils/aws/core.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/module_utils/aws/direct_connect.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/module_utils/aws/elb_utils.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/module_utils/aws/elbv2.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/module_utils/aws/iam.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/module_utils/aws/rds.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/module_utils/aws/s3.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/module_utils/aws/urls.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/module_utils/aws/waf.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/module_utils/aws/waiters.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/_aws_az_facts.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/_aws_caller_facts.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/_cloudformation_facts.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/_ec2_ami_facts.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/_ec2_eni_facts.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/_ec2_group_facts.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/_ec2_snapshot_facts.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/_ec2_vol_facts.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/_ec2_vpc_dhcp_option_facts.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/_ec2_vpc_net_facts.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/_ec2_vpc_subnet_facts.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/aws_az_info.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/aws_caller_info.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/aws_s3.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/cloudformation_info.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/ec2_ami.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/ec2_ami_info.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/ec2_elb_lb.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/ec2_eni.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/ec2_eni_info.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/ec2_group_info.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/ec2_snapshot.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/ec2_snapshot_info.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/ec2_tag_info.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/ec2_vol_info.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_option_info.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/ec2_vpc_subnet_info.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/modules/cloud/amazon/s3_bucket.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/units/module_utils/aws/test_aws_module.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/units/plugins/inventory/test_aws_ec2.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/units/plugins/lookup/test_aws_secret.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/units/plugins/lookup/test_aws_ssm.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/units/module_utils/test_ec2.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/units/module_utils/ec2/test_aws.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/units/module_utils/ec2/__init__.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/units/modules/cloud/amazon/test_aws_s3.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/units/modules/cloud/amazon/test_cloudformation.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/units/modules/cloud/amazon/test_ec2_group.py:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/aws_s3/aliases:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/aws_s3/defaults/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/aws_s3/files/hello.txt:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/aws_s3/tasks/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/aws_s3/meta/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_ec2/test.aws_ec2.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_ec2/aliases:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_ec2/runme.sh:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_ec2/playbooks/tear_down.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_ec2/playbooks/empty_inventory_config.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_ec2/playbooks/setup.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_ec2/playbooks/test_invalid_aws_ec2_inventory_config.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_ec2/playbooks/create_inventory_config.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_ec2/playbooks/populate_cache.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_ec2/playbooks/test_inventory_cache.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_constructed.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_ec2/playbooks/test_refresh_inventory.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_ec2/templates/inventory_with_cache.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_ec2/templates/inventory.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_ec2/templates/inventory_with_constructed.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_rds/aliases:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_rds/test.aws_rds.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_rds/runme.sh:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_rds/playbooks/empty_inventory_config.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_rds/playbooks/create_inventory_config.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_rds/playbooks/populate_cache.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_rds/playbooks/test_populating_inventory.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_rds/playbooks/test_invalid_aws_rds_inventory_config.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_rds/playbooks/test_inventory_cache.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_rds/playbooks/test_populating_inventory_with_constructed.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_rds/playbooks/test_refresh_inventory.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_rds/templates/inventory_with_constructed.j2:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_rds/templates/inventory_with_cache.j2:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/inventory_aws_rds/templates/inventory.j2:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/aws_caller_info/aliases:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/aws_caller_info/tasks/main.yaml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/cloudformation/aliases:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/cloudformation/defaults/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/cloudformation/files/cf_template.json:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/cloudformation/tasks/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_ami/aliases:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_ami/vars/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_ami/defaults/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_ami/tasks/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_ami/meta/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_elb_lb/aliases:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_elb_lb/vars/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_elb_lb/defaults/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_elb_lb/tasks/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_elb_lb/meta/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_group/aliases:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_group/defaults/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_group/tasks/ec2_classic.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_group/tasks/numeric_protos.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_group/tasks/multi_nested_target.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_group/tasks/diff_mode.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_group/tasks/ipv6_default_tests.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_group/tasks/egress_tests.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_group/tasks/multi_account.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_group/tasks/data_validation.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_group/tasks/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_group/tasks/credential_tests.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_group/tasks/rule_group_create.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_group/meta/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_key/aliases:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_key/defaults/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_key/tasks/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_key/meta/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/setup_sshkey/tasks/main.yml:
     migrated_to: hetzner.hcloud
   test/integration/targets/ec2_metadata_facts/aliases:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_metadata_facts/vars/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_metadata_facts/defaults/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_metadata_facts/tasks/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_metadata_facts/meta/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_snapshot/aliases:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_snapshot/defaults/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_snapshot/tasks/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_tag/aliases:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_tag/vars/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_tag/defaults/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_tag/tasks/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_tag/meta/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_vol/aliases:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_vol/defaults/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_vol/tasks/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_vol_info/aliases:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_vol_info/tasks/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_vol_info/meta/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_vpc_net/aliases:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_vpc_net/defaults/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_vpc_net/tasks/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_vpc_net/meta/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_vpc_subnet/aliases:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_vpc_subnet/defaults/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_vpc_subnet/tasks/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/ec2_vpc_subnet/meta/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/s3_bucket/aliases:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/s3_bucket/inventory:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/s3_bucket/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/s3_bucket/runme.sh:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/s3_bucket/meta/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/s3_bucket/roles/s3_bucket/defaults/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/s3_bucket/roles/s3_bucket/tasks/dotted.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_kms.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/s3_bucket/roles/s3_bucket/tasks/complex.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/s3_bucket/roles/s3_bucket/tasks/missing.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/s3_bucket/roles/s3_bucket/tasks/tags.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/s3_bucket/roles/s3_bucket/tasks/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_sse.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/s3_bucket/roles/s3_bucket/tasks/simple.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/s3_bucket/roles/s3_bucket/meta/main.yml:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/s3_bucket/roles/s3_bucket/templates/policy.json:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   test/integration/targets/s3_bucket/roles/s3_bucket/templates/policy-updated.json:
-    migrated_to: ansible.amazon
+    migrated_to: amazon.aws
   lib/ansible/plugins/action/cli_command.py:
     migrated_to: ansible.netcommon
   lib/ansible/plugins/action/cli_config.py:

--- a/lib/ansible/config/routing.yml
+++ b/lib/ansible/config/routing.yml
@@ -5,7 +5,7 @@ plugin_routing:
     podman:
       redirect: containers.podman.podman
     aws_ssm:
-      redirect: community.amazon.aws_ssm
+      redirect: community.aws.aws_ssm
     chroot:
       redirect: community.general.chroot
     docker:
@@ -58,427 +58,427 @@ plugin_routing:
     frr_bgp:
       redirect: frr.frr.frr_bgp
     aws_acm_facts:
-      redirect: community.amazon.aws_acm_facts
+      redirect: community.aws.aws_acm_facts
     aws_kms_facts:
-      redirect: community.amazon.aws_kms_facts
+      redirect: community.aws.aws_kms_facts
     aws_region_facts:
-      redirect: community.amazon.aws_region_facts
+      redirect: community.aws.aws_region_facts
     aws_s3_bucket_facts:
-      redirect: community.amazon.aws_s3_bucket_facts
+      redirect: community.aws.aws_s3_bucket_facts
     aws_sgw_facts:
-      redirect: community.amazon.aws_sgw_facts
+      redirect: community.aws.aws_sgw_facts
     aws_waf_facts:
-      redirect: community.amazon.aws_waf_facts
+      redirect: community.aws.aws_waf_facts
     cloudfront_facts:
-      redirect: community.amazon.cloudfront_facts
+      redirect: community.aws.cloudfront_facts
     cloudwatchlogs_log_group_facts:
-      redirect: community.amazon.cloudwatchlogs_log_group_facts
+      redirect: community.aws.cloudwatchlogs_log_group_facts
     ec2_asg_facts:
-      redirect: community.amazon.ec2_asg_facts
+      redirect: community.aws.ec2_asg_facts
     ec2_customer_gateway_facts:
-      redirect: community.amazon.ec2_customer_gateway_facts
+      redirect: community.aws.ec2_customer_gateway_facts
     ec2_instance_facts:
-      redirect: community.amazon.ec2_instance_facts
+      redirect: community.aws.ec2_instance_facts
     ec2_eip_facts:
-      redirect: community.amazon.ec2_eip_facts
+      redirect: community.aws.ec2_eip_facts
     ec2_elb_facts:
-      redirect: community.amazon.ec2_elb_facts
+      redirect: community.aws.ec2_elb_facts
     ec2_lc_facts:
-      redirect: community.amazon.ec2_lc_facts
+      redirect: community.aws.ec2_lc_facts
     ec2_placement_group_facts:
-      redirect: community.amazon.ec2_placement_group_facts
+      redirect: community.aws.ec2_placement_group_facts
     ec2_vpc_endpoint_facts:
-      redirect: community.amazon.ec2_vpc_endpoint_facts
+      redirect: community.aws.ec2_vpc_endpoint_facts
     ec2_vpc_igw_facts:
-      redirect: community.amazon.ec2_vpc_igw_facts
+      redirect: community.aws.ec2_vpc_igw_facts
     ec2_vpc_nacl_facts:
-      redirect: community.amazon.ec2_vpc_nacl_facts
+      redirect: community.aws.ec2_vpc_nacl_facts
     ec2_vpc_nat_gateway_facts:
-      redirect: community.amazon.ec2_vpc_nat_gateway_facts
+      redirect: community.aws.ec2_vpc_nat_gateway_facts
     ec2_vpc_peering_facts:
-      redirect: community.amazon.ec2_vpc_peering_facts
+      redirect: community.aws.ec2_vpc_peering_facts
     ec2_vpc_route_table_facts:
-      redirect: community.amazon.ec2_vpc_route_table_facts
+      redirect: community.aws.ec2_vpc_route_table_facts
     ec2_vpc_vgw_facts:
-      redirect: community.amazon.ec2_vpc_vgw_facts
+      redirect: community.aws.ec2_vpc_vgw_facts
     ec2_vpc_vpn_facts:
-      redirect: community.amazon.ec2_vpc_vpn_facts
+      redirect: community.aws.ec2_vpc_vpn_facts
     ecs_service_facts:
-      redirect: community.amazon.ecs_service_facts
+      redirect: community.aws.ecs_service_facts
     ecs_taskdefinition_facts:
-      redirect: community.amazon.ecs_taskdefinition_facts
+      redirect: community.aws.ecs_taskdefinition_facts
     efs_facts:
-      redirect: community.amazon.efs_facts
+      redirect: community.aws.efs_facts
     elasticache_facts:
-      redirect: community.amazon.elasticache_facts
+      redirect: community.aws.elasticache_facts
     elb_application_lb_facts:
-      redirect: community.amazon.elb_application_lb_facts
+      redirect: community.aws.elb_application_lb_facts
     elb_classic_lb_facts:
-      redirect: community.amazon.elb_classic_lb_facts
+      redirect: community.aws.elb_classic_lb_facts
     elb_target_facts:
-      redirect: community.amazon.elb_target_facts
+      redirect: community.aws.elb_target_facts
     elb_target_group_facts:
-      redirect: community.amazon.elb_target_group_facts
+      redirect: community.aws.elb_target_group_facts
     iam_cert_facts:
-      redirect: community.amazon.iam_cert_facts
+      redirect: community.aws.iam_cert_facts
     iam_mfa_device_facts:
-      redirect: community.amazon.iam_mfa_device_facts
+      redirect: community.aws.iam_mfa_device_facts
     iam_role_facts:
-      redirect: community.amazon.iam_role_facts
+      redirect: community.aws.iam_role_facts
     iam_server_certificate_facts:
-      redirect: community.amazon.iam_server_certificate_facts
+      redirect: community.aws.iam_server_certificate_facts
     lambda_facts:
-      redirect: community.amazon.lambda_facts
+      redirect: community.aws.lambda_facts
     rds_instance_facts:
-      redirect: community.amazon.rds_instance_facts
+      redirect: community.aws.rds_instance_facts
     rds_snapshot_facts:
-      redirect: community.amazon.rds_snapshot_facts
+      redirect: community.aws.rds_snapshot_facts
     redshift_facts:
-      redirect: community.amazon.redshift_facts
+      redirect: community.aws.redshift_facts
     route53_facts:
-      redirect: community.amazon.route53_facts
+      redirect: community.aws.route53_facts
     aws_acm:
-      redirect: community.amazon.aws_acm
+      redirect: community.aws.aws_acm
     aws_acm_info:
-      redirect: community.amazon.aws_acm_info
+      redirect: community.aws.aws_acm_info
     aws_api_gateway:
-      redirect: community.amazon.aws_api_gateway
+      redirect: community.aws.aws_api_gateway
     aws_application_scaling_policy:
-      redirect: community.amazon.aws_application_scaling_policy
+      redirect: community.aws.aws_application_scaling_policy
     aws_batch_compute_environment:
-      redirect: community.amazon.aws_batch_compute_environment
+      redirect: community.aws.aws_batch_compute_environment
     aws_batch_job_definition:
-      redirect: community.amazon.aws_batch_job_definition
+      redirect: community.aws.aws_batch_job_definition
     aws_batch_job_queue:
-      redirect: community.amazon.aws_batch_job_queue
+      redirect: community.aws.aws_batch_job_queue
     aws_codebuild:
-      redirect: community.amazon.aws_codebuild
+      redirect: community.aws.aws_codebuild
     aws_codecommit:
-      redirect: community.amazon.aws_codecommit
+      redirect: community.aws.aws_codecommit
     aws_codepipeline:
-      redirect: community.amazon.aws_codepipeline
+      redirect: community.aws.aws_codepipeline
     aws_config_aggregation_authorization:
-      redirect: community.amazon.aws_config_aggregation_authorization
+      redirect: community.aws.aws_config_aggregation_authorization
     aws_config_aggregator:
-      redirect: community.amazon.aws_config_aggregator
+      redirect: community.aws.aws_config_aggregator
     aws_config_delivery_channel:
-      redirect: community.amazon.aws_config_delivery_channel
+      redirect: community.aws.aws_config_delivery_channel
     aws_config_recorder:
-      redirect: community.amazon.aws_config_recorder
+      redirect: community.aws.aws_config_recorder
     aws_config_rule:
-      redirect: community.amazon.aws_config_rule
+      redirect: community.aws.aws_config_rule
     aws_direct_connect_connection:
-      redirect: community.amazon.aws_direct_connect_connection
+      redirect: community.aws.aws_direct_connect_connection
     aws_direct_connect_gateway:
-      redirect: community.amazon.aws_direct_connect_gateway
+      redirect: community.aws.aws_direct_connect_gateway
     aws_direct_connect_link_aggregation_group:
-      redirect: community.amazon.aws_direct_connect_link_aggregation_group
+      redirect: community.aws.aws_direct_connect_link_aggregation_group
     aws_direct_connect_virtual_interface:
-      redirect: community.amazon.aws_direct_connect_virtual_interface
+      redirect: community.aws.aws_direct_connect_virtual_interface
     aws_eks_cluster:
-      redirect: community.amazon.aws_eks_cluster
+      redirect: community.aws.aws_eks_cluster
     aws_elasticbeanstalk_app:
-      redirect: community.amazon.aws_elasticbeanstalk_app
+      redirect: community.aws.aws_elasticbeanstalk_app
     aws_glue_connection:
-      redirect: community.amazon.aws_glue_connection
+      redirect: community.aws.aws_glue_connection
     aws_glue_job:
-      redirect: community.amazon.aws_glue_job
+      redirect: community.aws.aws_glue_job
     aws_inspector_target:
-      redirect: community.amazon.aws_inspector_target
+      redirect: community.aws.aws_inspector_target
     aws_kms:
-      redirect: community.amazon.aws_kms
+      redirect: community.aws.aws_kms
     aws_kms_info:
-      redirect: community.amazon.aws_kms_info
+      redirect: community.aws.aws_kms_info
     aws_region_info:
-      redirect: community.amazon.aws_region_info
+      redirect: community.aws.aws_region_info
     aws_s3_bucket_info:
-      redirect: community.amazon.aws_s3_bucket_info
+      redirect: community.aws.aws_s3_bucket_info
     aws_s3_cors:
-      redirect: community.amazon.aws_s3_cors
+      redirect: community.aws.aws_s3_cors
     aws_secret:
-      redirect: community.amazon.aws_secret
+      redirect: community.aws.aws_secret
     aws_ses_identity:
-      redirect: community.amazon.aws_ses_identity
+      redirect: community.aws.aws_ses_identity
     aws_ses_identity_policy:
-      redirect: community.amazon.aws_ses_identity_policy
+      redirect: community.aws.aws_ses_identity_policy
     aws_ses_rule_set:
-      redirect: community.amazon.aws_ses_rule_set
+      redirect: community.aws.aws_ses_rule_set
     aws_sgw_info:
-      redirect: community.amazon.aws_sgw_info
+      redirect: community.aws.aws_sgw_info
     aws_ssm_parameter_store:
-      redirect: community.amazon.aws_ssm_parameter_store
+      redirect: community.aws.aws_ssm_parameter_store
     aws_step_functions_state_machine:
-      redirect: community.amazon.aws_step_functions_state_machine
+      redirect: community.aws.aws_step_functions_state_machine
     aws_step_functions_state_machine_execution:
-      redirect: community.amazon.aws_step_functions_state_machine_execution
+      redirect: community.aws.aws_step_functions_state_machine_execution
     aws_waf_condition:
-      redirect: community.amazon.aws_waf_condition
+      redirect: community.aws.aws_waf_condition
     aws_waf_info:
-      redirect: community.amazon.aws_waf_info
+      redirect: community.aws.aws_waf_info
     aws_waf_rule:
-      redirect: community.amazon.aws_waf_rule
+      redirect: community.aws.aws_waf_rule
     aws_waf_web_acl:
-      redirect: community.amazon.aws_waf_web_acl
+      redirect: community.aws.aws_waf_web_acl
     cloudformation_stack_set:
-      redirect: community.amazon.cloudformation_stack_set
+      redirect: community.aws.cloudformation_stack_set
     cloudformation_exports_info:
-      redirect: community.amazon.cloudformation_exports_info
+      redirect: community.aws.cloudformation_exports_info
     cloudfront_distribution:
-      redirect: community.amazon.cloudfront_distribution
+      redirect: community.aws.cloudfront_distribution
     cloudfront_info:
-      redirect: community.amazon.cloudfront_info
+      redirect: community.aws.cloudfront_info
     cloudfront_invalidation:
-      redirect: community.amazon.cloudfront_invalidation
+      redirect: community.aws.cloudfront_invalidation
     cloudfront_origin_access_identity:
-      redirect: community.amazon.cloudfront_origin_access_identity
+      redirect: community.aws.cloudfront_origin_access_identity
     cloudtrail:
-      redirect: community.amazon.cloudtrail
+      redirect: community.aws.cloudtrail
     cloudwatchevent_rule:
-      redirect: community.amazon.cloudwatchevent_rule
+      redirect: community.aws.cloudwatchevent_rule
     cloudwatchlogs_log_group:
-      redirect: community.amazon.cloudwatchlogs_log_group
+      redirect: community.aws.cloudwatchlogs_log_group
     cloudwatchlogs_log_group_info:
-      redirect: community.amazon.cloudwatchlogs_log_group_info
+      redirect: community.aws.cloudwatchlogs_log_group_info
     cloudwatchlogs_log_group_metric_filter:
-      redirect: community.amazon.cloudwatchlogs_log_group_metric_filter
+      redirect: community.aws.cloudwatchlogs_log_group_metric_filter
     data_pipeline:
-      redirect: community.amazon.data_pipeline
+      redirect: community.aws.data_pipeline
     dms_endpoint:
-      redirect: community.amazon.dms_endpoint
+      redirect: community.aws.dms_endpoint
     dms_replication_subnet_group:
-      redirect: community.amazon.dms_replication_subnet_group
+      redirect: community.aws.dms_replication_subnet_group
     dynamodb_table:
-      redirect: community.amazon.dynamodb_table
+      redirect: community.aws.dynamodb_table
     dynamodb_ttl:
-      redirect: community.amazon.dynamodb_ttl
+      redirect: community.aws.dynamodb_ttl
     ec2_ami_copy:
-      redirect: community.amazon.ec2_ami_copy
+      redirect: community.aws.ec2_ami_copy
     ec2_asg:
-      redirect: community.amazon.ec2_asg
+      redirect: community.aws.ec2_asg
     ec2_asg_info:
-      redirect: community.amazon.ec2_asg_info
+      redirect: community.aws.ec2_asg_info
     ec2_asg_lifecycle_hook:
-      redirect: community.amazon.ec2_asg_lifecycle_hook
+      redirect: community.aws.ec2_asg_lifecycle_hook
     ec2_customer_gateway:
-      redirect: community.amazon.ec2_customer_gateway
+      redirect: community.aws.ec2_customer_gateway
     ec2_customer_gateway_info:
-      redirect: community.amazon.ec2_customer_gateway_info
+      redirect: community.aws.ec2_customer_gateway_info
     ec2_eip:
-      redirect: community.amazon.ec2_eip
+      redirect: community.aws.ec2_eip
     ec2_eip_info:
-      redirect: community.amazon.ec2_eip_info
+      redirect: community.aws.ec2_eip_info
     ec2_elb:
-      redirect: community.amazon.ec2_elb
+      redirect: community.aws.ec2_elb
     ec2_elb_info:
-      redirect: community.amazon.ec2_elb_info
+      redirect: community.aws.ec2_elb_info
     ec2_instance:
-      redirect: community.amazon.ec2_instance
+      redirect: community.aws.ec2_instance
     ec2_instance_info:
-      redirect: community.amazon.ec2_instance_info
+      redirect: community.aws.ec2_instance_info
     ec2_launch_template:
-      redirect: community.amazon.ec2_launch_template
+      redirect: community.aws.ec2_launch_template
     ec2_lc:
-      redirect: community.amazon.ec2_lc
+      redirect: community.aws.ec2_lc
     ec2_lc_find:
-      redirect: community.amazon.ec2_lc_find
+      redirect: community.aws.ec2_lc_find
     ec2_lc_info:
-      redirect: community.amazon.ec2_lc_info
+      redirect: community.aws.ec2_lc_info
     ec2_metric_alarm:
-      redirect: community.amazon.ec2_metric_alarm
+      redirect: community.aws.ec2_metric_alarm
     ec2_placement_group:
-      redirect: community.amazon.ec2_placement_group
+      redirect: community.aws.ec2_placement_group
     ec2_placement_group_info:
-      redirect: community.amazon.ec2_placement_group_info
+      redirect: community.aws.ec2_placement_group_info
     ec2_scaling_policy:
-      redirect: community.amazon.ec2_scaling_policy
+      redirect: community.aws.ec2_scaling_policy
     ec2_snapshot_copy:
-      redirect: community.amazon.ec2_snapshot_copy
+      redirect: community.aws.ec2_snapshot_copy
     ec2_transit_gateway:
-      redirect: community.amazon.ec2_transit_gateway
+      redirect: community.aws.ec2_transit_gateway
     ec2_transit_gateway_info:
-      redirect: community.amazon.ec2_transit_gateway_info
+      redirect: community.aws.ec2_transit_gateway_info
     ec2_vpc_egress_igw:
-      redirect: community.amazon.ec2_vpc_egress_igw
+      redirect: community.aws.ec2_vpc_egress_igw
     ec2_vpc_endpoint:
-      redirect: community.amazon.ec2_vpc_endpoint
+      redirect: community.aws.ec2_vpc_endpoint
     ec2_vpc_endpoint_info:
-      redirect: community.amazon.ec2_vpc_endpoint_info
+      redirect: community.aws.ec2_vpc_endpoint_info
     ec2_vpc_igw:
-      redirect: community.amazon.ec2_vpc_igw
+      redirect: community.aws.ec2_vpc_igw
     ec2_vpc_igw_info:
-      redirect: community.amazon.ec2_vpc_igw_info
+      redirect: community.aws.ec2_vpc_igw_info
     ec2_vpc_nacl:
-      redirect: community.amazon.ec2_vpc_nacl
+      redirect: community.aws.ec2_vpc_nacl
     ec2_vpc_nacl_info:
-      redirect: community.amazon.ec2_vpc_nacl_info
+      redirect: community.aws.ec2_vpc_nacl_info
     ec2_vpc_nat_gateway:
-      redirect: community.amazon.ec2_vpc_nat_gateway
+      redirect: community.aws.ec2_vpc_nat_gateway
     ec2_vpc_nat_gateway_info:
-      redirect: community.amazon.ec2_vpc_nat_gateway_info
+      redirect: community.aws.ec2_vpc_nat_gateway_info
     ec2_vpc_peer:
-      redirect: community.amazon.ec2_vpc_peer
+      redirect: community.aws.ec2_vpc_peer
     ec2_vpc_peering_info:
-      redirect: community.amazon.ec2_vpc_peering_info
+      redirect: community.aws.ec2_vpc_peering_info
     ec2_vpc_route_table:
-      redirect: community.amazon.ec2_vpc_route_table
+      redirect: community.aws.ec2_vpc_route_table
     ec2_vpc_route_table_info:
-      redirect: community.amazon.ec2_vpc_route_table_info
+      redirect: community.aws.ec2_vpc_route_table_info
     ec2_vpc_vgw:
-      redirect: community.amazon.ec2_vpc_vgw
+      redirect: community.aws.ec2_vpc_vgw
     ec2_vpc_vgw_info:
-      redirect: community.amazon.ec2_vpc_vgw_info
+      redirect: community.aws.ec2_vpc_vgw_info
     ec2_vpc_vpn:
-      redirect: community.amazon.ec2_vpc_vpn
+      redirect: community.aws.ec2_vpc_vpn
     ec2_vpc_vpn_info:
-      redirect: community.amazon.ec2_vpc_vpn_info
+      redirect: community.aws.ec2_vpc_vpn_info
     ec2_win_password:
-      redirect: community.amazon.ec2_win_password
+      redirect: community.aws.ec2_win_password
     ecs_attribute:
-      redirect: community.amazon.ecs_attribute
+      redirect: community.aws.ecs_attribute
     ecs_cluster:
-      redirect: community.amazon.ecs_cluster
+      redirect: community.aws.ecs_cluster
     ecs_ecr:
-      redirect: community.amazon.ecs_ecr
+      redirect: community.aws.ecs_ecr
     ecs_service:
-      redirect: community.amazon.ecs_service
+      redirect: community.aws.ecs_service
     ecs_service_info:
-      redirect: community.amazon.ecs_service_info
+      redirect: community.aws.ecs_service_info
     ecs_tag:
-      redirect: community.amazon.ecs_tag
+      redirect: community.aws.ecs_tag
     ecs_task:
-      redirect: community.amazon.ecs_task
+      redirect: community.aws.ecs_task
     ecs_taskdefinition:
-      redirect: community.amazon.ecs_taskdefinition
+      redirect: community.aws.ecs_taskdefinition
     ecs_taskdefinition_info:
-      redirect: community.amazon.ecs_taskdefinition_info
+      redirect: community.aws.ecs_taskdefinition_info
     efs:
-      redirect: community.amazon.efs
+      redirect: community.aws.efs
     efs_info:
-      redirect: community.amazon.efs_info
+      redirect: community.aws.efs_info
     elasticache:
-      redirect: community.amazon.elasticache
+      redirect: community.aws.elasticache
     elasticache_info:
-      redirect: community.amazon.elasticache_info
+      redirect: community.aws.elasticache_info
     elasticache_parameter_group:
-      redirect: community.amazon.elasticache_parameter_group
+      redirect: community.aws.elasticache_parameter_group
     elasticache_snapshot:
-      redirect: community.amazon.elasticache_snapshot
+      redirect: community.aws.elasticache_snapshot
     elasticache_subnet_group:
-      redirect: community.amazon.elasticache_subnet_group
+      redirect: community.aws.elasticache_subnet_group
     elb_application_lb:
-      redirect: community.amazon.elb_application_lb
+      redirect: community.aws.elb_application_lb
     elb_application_lb_info:
-      redirect: community.amazon.elb_application_lb_info
+      redirect: community.aws.elb_application_lb_info
     elb_classic_lb:
-      redirect: community.amazon.elb_classic_lb
+      redirect: community.aws.elb_classic_lb
     elb_classic_lb_info:
-      redirect: community.amazon.elb_classic_lb_info
+      redirect: community.aws.elb_classic_lb_info
     elb_instance:
-      redirect: community.amazon.elb_instance
+      redirect: community.aws.elb_instance
     elb_network_lb:
-      redirect: community.amazon.elb_network_lb
+      redirect: community.aws.elb_network_lb
     elb_target:
-      redirect: community.amazon.elb_target
+      redirect: community.aws.elb_target
     elb_target_group:
-      redirect: community.amazon.elb_target_group
+      redirect: community.aws.elb_target_group
     elb_target_group_info:
-      redirect: community.amazon.elb_target_group_info
+      redirect: community.aws.elb_target_group_info
     elb_target_info:
-      redirect: community.amazon.elb_target_info
+      redirect: community.aws.elb_target_info
     execute_lambda:
-      redirect: community.amazon.execute_lambda
+      redirect: community.aws.execute_lambda
     iam:
-      redirect: community.amazon.iam
+      redirect: community.aws.iam
     iam_cert:
-      redirect: community.amazon.iam_cert
+      redirect: community.aws.iam_cert
     iam_group:
-      redirect: community.amazon.iam_group
+      redirect: community.aws.iam_group
     iam_managed_policy:
-      redirect: community.amazon.iam_managed_policy
+      redirect: community.aws.iam_managed_policy
     iam_mfa_device_info:
-      redirect: community.amazon.iam_mfa_device_info
+      redirect: community.aws.iam_mfa_device_info
     iam_password_policy:
-      redirect: community.amazon.iam_password_policy
+      redirect: community.aws.iam_password_policy
     iam_policy:
-      redirect: community.amazon.iam_policy
+      redirect: community.aws.iam_policy
     iam_policy_info:
-      redirect: community.amazon.iam_policy_info
+      redirect: community.aws.iam_policy_info
     iam_role:
-      redirect: community.amazon.iam_role
+      redirect: community.aws.iam_role
     iam_role_info:
-      redirect: community.amazon.iam_role_info
+      redirect: community.aws.iam_role_info
     iam_saml_federation:
-      redirect: community.amazon.iam_saml_federation
+      redirect: community.aws.iam_saml_federation
     iam_server_certificate_info:
-      redirect: community.amazon.iam_server_certificate_info
+      redirect: community.aws.iam_server_certificate_info
     iam_user:
-      redirect: community.amazon.iam_user
+      redirect: community.aws.iam_user
     iam_user_info:
-      redirect: community.amazon.iam_user_info
+      redirect: community.aws.iam_user_info
     kinesis_stream:
-      redirect: community.amazon.kinesis_stream
+      redirect: community.aws.kinesis_stream
     lambda:
-      redirect: community.amazon.lambda
+      redirect: community.aws.lambda
     lambda_alias:
-      redirect: community.amazon.lambda_alias
+      redirect: community.aws.lambda_alias
     lambda_event:
-      redirect: community.amazon.lambda_event
+      redirect: community.aws.lambda_event
     lambda_info:
-      redirect: community.amazon.lambda_info
+      redirect: community.aws.lambda_info
     lambda_policy:
-      redirect: community.amazon.lambda_policy
+      redirect: community.aws.lambda_policy
     lightsail:
-      redirect: community.amazon.lightsail
+      redirect: community.aws.lightsail
     rds:
-      redirect: community.amazon.rds
+      redirect: community.aws.rds
     rds_instance:
-      redirect: community.amazon.rds_instance
+      redirect: community.aws.rds_instance
     rds_instance_info:
-      redirect: community.amazon.rds_instance_info
+      redirect: community.aws.rds_instance_info
     rds_param_group:
-      redirect: community.amazon.rds_param_group
+      redirect: community.aws.rds_param_group
     rds_snapshot:
-      redirect: community.amazon.rds_snapshot
+      redirect: community.aws.rds_snapshot
     rds_snapshot_info:
-      redirect: community.amazon.rds_snapshot_info
+      redirect: community.aws.rds_snapshot_info
     rds_subnet_group:
-      redirect: community.amazon.rds_subnet_group
+      redirect: community.aws.rds_subnet_group
     redshift:
-      redirect: community.amazon.redshift
+      redirect: community.aws.redshift
     redshift_cross_region_snapshots:
-      redirect: community.amazon.redshift_cross_region_snapshots
+      redirect: community.aws.redshift_cross_region_snapshots
     redshift_info:
-      redirect: community.amazon.redshift_info
+      redirect: community.aws.redshift_info
     redshift_subnet_group:
-      redirect: community.amazon.redshift_subnet_group
+      redirect: community.aws.redshift_subnet_group
     route53:
-      redirect: community.amazon.route53
+      redirect: community.aws.route53
     route53_health_check:
-      redirect: community.amazon.route53_health_check
+      redirect: community.aws.route53_health_check
     route53_info:
-      redirect: community.amazon.route53_info
+      redirect: community.aws.route53_info
     route53_zone:
-      redirect: community.amazon.route53_zone
+      redirect: community.aws.route53_zone
     s3_bucket_notification:
-      redirect: community.amazon.s3_bucket_notification
+      redirect: community.aws.s3_bucket_notification
     s3_lifecycle:
-      redirect: community.amazon.s3_lifecycle
+      redirect: community.aws.s3_lifecycle
     s3_logging:
-      redirect: community.amazon.s3_logging
+      redirect: community.aws.s3_logging
     s3_sync:
-      redirect: community.amazon.s3_sync
+      redirect: community.aws.s3_sync
     s3_website:
-      redirect: community.amazon.s3_website
+      redirect: community.aws.s3_website
     sns:
-      redirect: community.amazon.sns
+      redirect: community.aws.sns
     sns_topic:
-      redirect: community.amazon.sns_topic
+      redirect: community.aws.sns_topic
     sqs_queue:
-      redirect: community.amazon.sqs_queue
+      redirect: community.aws.sqs_queue
     sts_assume_role:
-      redirect: community.amazon.sts_assume_role
+      redirect: community.aws.sts_assume_role
     sts_session_token:
-      redirect: community.amazon.sts_session_token
+      redirect: community.aws.sts_session_token
     ali_instance_facts:
       redirect: community.general.ali_instance_facts
     ali_instance:
@@ -3954,83 +3954,83 @@ plugin_routing:
     snow_record_find:
       redirect: servicenow.servicenow.snow_record_find
     aws_az_facts:
-      redirect: ansible.amazon.aws_az_facts
+      redirect: amazon.aws.aws_az_facts
     aws_caller_facts:
-      redirect: ansible.amazon.aws_caller_facts
+      redirect: amazon.aws.aws_caller_facts
     cloudformation_facts:
-      redirect: ansible.amazon.cloudformation_facts
+      redirect: amazon.aws.cloudformation_facts
     ec2_ami_facts:
-      redirect: ansible.amazon.ec2_ami_facts
+      redirect: amazon.aws.ec2_ami_facts
     ec2_eni_facts:
-      redirect: ansible.amazon.ec2_eni_facts
+      redirect: amazon.aws.ec2_eni_facts
     ec2_group_facts:
-      redirect: ansible.amazon.ec2_group_facts
+      redirect: amazon.aws.ec2_group_facts
     ec2_snapshot_facts:
-      redirect: ansible.amazon.ec2_snapshot_facts
+      redirect: amazon.aws.ec2_snapshot_facts
     ec2_vol_facts:
-      redirect: ansible.amazon.ec2_vol_facts
+      redirect: amazon.aws.ec2_vol_facts
     ec2_vpc_dhcp_option_facts:
-      redirect: ansible.amazon.ec2_vpc_dhcp_option_facts
+      redirect: amazon.aws.ec2_vpc_dhcp_option_facts
     ec2_vpc_net_facts:
-      redirect: ansible.amazon.ec2_vpc_net_facts
+      redirect: amazon.aws.ec2_vpc_net_facts
     ec2_vpc_subnet_facts:
-      redirect: ansible.amazon.ec2_vpc_subnet_facts
+      redirect: amazon.aws.ec2_vpc_subnet_facts
     aws_az_info:
-      redirect: ansible.amazon.aws_az_info
+      redirect: amazon.aws.aws_az_info
     aws_caller_info:
-      redirect: ansible.amazon.aws_caller_info
+      redirect: amazon.aws.aws_caller_info
     aws_s3:
-      redirect: ansible.amazon.aws_s3
+      redirect: amazon.aws.aws_s3
     cloudformation:
-      redirect: ansible.amazon.cloudformation
+      redirect: amazon.aws.cloudformation
     cloudformation_info:
-      redirect: ansible.amazon.cloudformation_info
+      redirect: amazon.aws.cloudformation_info
     ec2:
-      redirect: ansible.amazon.ec2
+      redirect: amazon.aws.ec2
     ec2_ami:
-      redirect: ansible.amazon.ec2_ami
+      redirect: amazon.aws.ec2_ami
     ec2_ami_info:
-      redirect: ansible.amazon.ec2_ami_info
+      redirect: amazon.aws.ec2_ami_info
     ec2_elb_lb:
-      redirect: ansible.amazon.ec2_elb_lb
+      redirect: amazon.aws.ec2_elb_lb
     ec2_eni:
-      redirect: ansible.amazon.ec2_eni
+      redirect: amazon.aws.ec2_eni
     ec2_eni_info:
-      redirect: ansible.amazon.ec2_eni_info
+      redirect: amazon.aws.ec2_eni_info
     ec2_group:
-      redirect: ansible.amazon.ec2_group
+      redirect: amazon.aws.ec2_group
     ec2_group_info:
-      redirect: ansible.amazon.ec2_group_info
+      redirect: amazon.aws.ec2_group_info
     ec2_key:
-      redirect: ansible.amazon.ec2_key
+      redirect: amazon.aws.ec2_key
     ec2_metadata_facts:
-      redirect: ansible.amazon.ec2_metadata_facts
+      redirect: amazon.aws.ec2_metadata_facts
     ec2_snapshot:
-      redirect: ansible.amazon.ec2_snapshot
+      redirect: amazon.aws.ec2_snapshot
     ec2_snapshot_info:
-      redirect: ansible.amazon.ec2_snapshot_info
+      redirect: amazon.aws.ec2_snapshot_info
     ec2_tag:
-      redirect: ansible.amazon.ec2_tag
+      redirect: amazon.aws.ec2_tag
     ec2_tag_info:
-      redirect: ansible.amazon.ec2_tag_info
+      redirect: amazon.aws.ec2_tag_info
     ec2_vol:
-      redirect: ansible.amazon.ec2_vol
+      redirect: amazon.aws.ec2_vol
     ec2_vol_info:
-      redirect: ansible.amazon.ec2_vol_info
+      redirect: amazon.aws.ec2_vol_info
     ec2_vpc_dhcp_option:
-      redirect: ansible.amazon.ec2_vpc_dhcp_option
+      redirect: amazon.aws.ec2_vpc_dhcp_option
     ec2_vpc_dhcp_option_info:
-      redirect: ansible.amazon.ec2_vpc_dhcp_option_info
+      redirect: amazon.aws.ec2_vpc_dhcp_option_info
     ec2_vpc_net:
-      redirect: ansible.amazon.ec2_vpc_net
+      redirect: amazon.aws.ec2_vpc_net
     ec2_vpc_net_info:
-      redirect: ansible.amazon.ec2_vpc_net_info
+      redirect: amazon.aws.ec2_vpc_net_info
     ec2_vpc_subnet:
-      redirect: ansible.amazon.ec2_vpc_subnet
+      redirect: amazon.aws.ec2_vpc_subnet
     ec2_vpc_subnet_info:
-      redirect: ansible.amazon.ec2_vpc_subnet_info
+      redirect: amazon.aws.ec2_vpc_subnet_info
     s3_bucket:
-      redirect: ansible.amazon.s3_bucket
+      redirect: amazon.aws.s3_bucket
     telnet:
       redirect: ansible.netcommon.telnet
     cli_command:
@@ -7683,7 +7683,7 @@ plugin_routing:
     legacy:
       redirect: community.general.legacy
     urls:
-      redirect: ansible.amazon.urls
+      redirect: amazon.aws.urls
     fortianalyzer:
       redirect: community.general.fortianalyzer
     configuration:
@@ -7787,31 +7787,31 @@ plugin_routing:
     service_now:
       redirect: servicenow.servicenow.service_now
     acm:
-      redirect: ansible.amazon.acm
+      redirect: amazon.aws.acm
     batch:
-      redirect: ansible.amazon.batch
+      redirect: amazon.aws.batch
     cloudfront_facts:
-      redirect: ansible.amazon.cloudfront_facts
+      redirect: amazon.aws.cloudfront_facts
     core:
-      redirect: ansible.amazon.core
+      redirect: amazon.aws.core
     direct_connect:
-      redirect: ansible.amazon.direct_connect
+      redirect: amazon.aws.direct_connect
     elb_utils:
-      redirect: ansible.amazon.elb_utils
+      redirect: amazon.aws.elb_utils
     elbv2:
-      redirect: ansible.amazon.elbv2
+      redirect: amazon.aws.elbv2
     iam:
-      redirect: ansible.amazon.iam
+      redirect: amazon.aws.iam
     rds:
-      redirect: ansible.amazon.rds
+      redirect: amazon.aws.rds
     s3:
-      redirect: ansible.amazon.s3
+      redirect: amazon.aws.s3
     waf:
-      redirect: ansible.amazon.waf
+      redirect: amazon.aws.waf
     waiters:
-      redirect: ansible.amazon.waiters
+      redirect: amazon.aws.waiters
     ec2:
-      redirect: ansible.amazon.ec2
+      redirect: amazon.aws.ec2
     ipaddress:
       redirect: f5networks.f5_modules.ipaddress
     network:
@@ -8078,7 +8078,7 @@ plugin_routing:
     voss:
       redirect: community.general.voss
     aws_s3:
-      redirect: ansible.amazon.aws_s3
+      redirect: amazon.aws.aws_s3
     cli_command:
       redirect: ansible.netcommon.cli_command
     cli_config:
@@ -8249,7 +8249,7 @@ plugin_routing:
     grafana_annotations:
       redirect: community.grafana.grafana_annotations
     aws_resource_actions:
-      redirect: ansible.amazon.aws_resource_actions
+      redirect: amazon.aws.aws_resource_actions
     cgroup_perf_recap:
       redirect: ansible.posix.cgroup_perf_recap
     debug:
@@ -8422,13 +8422,13 @@ plugin_routing:
     service_now:
       redirect: servicenow.servicenow.service_now
     aws:
-      redirect: ansible.amazon.aws
+      redirect: amazon.aws.aws
     aws_credentials:
-      redirect: ansible.amazon.aws_credentials
+      redirect: amazon.aws.aws_credentials
     aws_region:
-      redirect: ansible.amazon.aws_region
+      redirect: amazon.aws.aws_region
     ec2:
-      redirect: ansible.amazon.ec2
+      redirect: amazon.aws.ec2
     netconf:
       redirect: ansible.netcommon.netconf
     network_agnostic:
@@ -8605,9 +8605,9 @@ plugin_routing:
     vmware_vm_inventory:
       redirect: community.vmware.vmware_vm_inventory
     aws_ec2:
-      redirect: ansible.amazon.aws_ec2
+      redirect: amazon.aws.aws_ec2
     aws_rds:
-      redirect: ansible.amazon.aws_rds
+      redirect: amazon.aws.aws_rds
     foreman:
       redirect: theforeman.foreman.foreman
     netbox:
@@ -8690,13 +8690,13 @@ plugin_routing:
     laps_password:
       redirect: community.windows.laps_password
     aws_account_attribute:
-      redirect: ansible.amazon.aws_account_attribute
+      redirect: amazon.aws.aws_account_attribute
     aws_secret:
-      redirect: ansible.amazon.aws_secret
+      redirect: amazon.aws.aws_secret
     aws_service_ip_ranges:
-      redirect: ansible.amazon.aws_service_ip_ranges
+      redirect: amazon.aws.aws_service_ip_ranges
     aws_ssm:
-      redirect: ansible.amazon.aws_ssm
+      redirect: amazon.aws.aws_ssm
     skydive:
       redirect: skydive.skydive.skydive
     cpm_metering:


### PR DESCRIPTION
##### SUMMARY
Both AWS collections have been renamed due to restrictions on the
ansible collections namespace.  Update botmeta and routing.yml for
the new paths.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
BOTMETA
routing.yml
