### PR TITLE
Fix missing persistent connection messages

### DIFF
--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -148,21 +148,7 @@ class ConnectionProcess(object):
                     resp = self.srv.handle_request(data)
                     signal.alarm(0)
 
-                    # This should be handled elsewhere, but if this is the last task, nothing will
-                    # come back to collect the messages. So now each task will dump its own messages
-                    # to stdout before logging the response message. This may make some other
-                    # pop_messages calls redundant.
-                    for level, message in self.connection.pop_messages():
-                        if level == "log":
-                            display.display(message, log_only=True)
-                        else:
-                            # These should be keyed by valid method names, but
-                            # fail gracefully just in case.
-                            display_method = getattr(display, level, None)
-                            if display_method:
-                                display_method(message)
-                            else:
-                                display.display((level, message))
+                    display_messages(self.connection)
 
                     if log_messages:
                         display.display("jsonrpc response: %s" % resp, log_only=True)
@@ -213,9 +199,7 @@ class ConnectionProcess(object):
                     self.sock.close()
                 if self.connection:
                     self.connection.close()
-                    if self.connection.get_option("persistent_log_messages"):
-                        for _level, message in self.connection.pop_messages():
-                            display.display(message, log_only=True)
+                    display_messages(self.connection)
             except Exception:
                 pass
             finally:
@@ -351,6 +335,24 @@ def main():
         sys.stdout.write(json.dumps(result, cls=AnsibleJSONEncoder))
 
     sys.exit(rc)
+
+
+def display_messages(connection):
+    # This should be handled elsewhere, but if this is the last task, nothing will
+    # come back to collect the messages. So now each task will dump its own messages
+    # to stdout before logging the response message. This may make some other
+    # pop_messages calls redundant.
+    for level, message in connection.pop_messages():
+        if connection.get_option('persistent_log_messages') and level == "log":
+            display.display(message, log_only=True)
+        else:
+            # These should be keyed by valid method names, but
+            # fail gracefully just in case.
+            display_method = getattr(display, level, None)
+            if display_method:
+                display_method(message)
+            else:
+                display.display((level, message))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -148,6 +148,22 @@ class ConnectionProcess(object):
                     resp = self.srv.handle_request(data)
                     signal.alarm(0)
 
+                    # This should be handled elsewhere, but if this is the last task, nothing will
+                    # come back to collect the messages. So now each task will dump its own messages
+                    # to stdout before logging the response message. This may make some other
+                    # pop_messages calls redundant.
+                    for level, message in self.connection.pop_messages():
+                        if level == "log":
+                            display.display(message, log_only=True)
+                        else:
+                            # These should be keyed by valid method names, but
+                            # fail gracefully just in case.
+                            display_method = getattr(display, level, None)
+                            if display_method:
+                                display_method(message)
+                            else:
+                                display.display((level, message))
+
                     if log_messages:
                         display.display("jsonrpc response: %s" % resp, log_only=True)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Logged messages in persistent connection plugins have to be collected and returned to the controller process to be displayed. This tends not to happen until the following task starts. This PR attempts to flush all queued messages before returning the response.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
network_cli