### PR TITLE
YAML representer for VarsWithSources

### DIFF
--- a/changelogs/fragments/68525-add-varswithsources-yaml-representer.yml
+++ b/changelogs/fragments/68525-add-varswithsources-yaml-representer.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Add yaml representer for VarsWithSources (https://github.com/ansible/ansible/pull/68525).

--- a/lib/ansible/parsing/yaml/dumper.py
+++ b/lib/ansible/parsing/yaml/dumper.py
@@ -26,6 +26,7 @@ from ansible.module_utils.common.yaml import SafeDumper
 from ansible.parsing.yaml.objects import AnsibleUnicode, AnsibleSequence, AnsibleMapping, AnsibleVaultEncryptedUnicode
 from ansible.utils.unsafe_proxy import AnsibleUnsafeText, AnsibleUnsafeBytes
 from ansible.vars.hostvars import HostVars, HostVarsVars
+from ansible.vars.manager import VarsWithSources
 
 
 class AnsibleDumper(SafeDumper):
@@ -80,6 +81,11 @@ AnsibleDumper.add_representer(
 
 AnsibleDumper.add_representer(
     HostVarsVars,
+    represent_hostvars,
+)
+
+AnsibleDumper.add_representer(
+    VarsWithSources,
     represent_hostvars,
 )
 

--- a/test/units/parsing/yaml/test_dumper.py
+++ b/test/units/parsing/yaml/test_dumper.py
@@ -19,6 +19,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import io
+import yaml
 
 from units.compat import unittest
 from ansible.parsing import vault
@@ -29,6 +30,7 @@ from ansible.utils.unsafe_proxy import AnsibleUnsafeText, AnsibleUnsafeBytes
 
 from units.mock.yaml_helper import YamlTestUtils
 from units.mock.vault_helper import TextVaultSecret
+from ansible.vars.manager import VarsWithSources
 
 
 class TestAnsibleDumper(unittest.TestCase, YamlTestUtils):
@@ -101,3 +103,9 @@ class TestAnsibleDumper(unittest.TestCase, YamlTestUtils):
         data_from_yaml = loader.get_single_data()
 
         self.assertEqual(u_text, data_from_yaml)
+
+    def test_vars_with_sources(self):
+        try:
+            self._dump_string(VarsWithSources(), dumper=self.dumper)
+        except yaml.representer.RepresenterError:
+            self.fail("Dump VarsWithSources raised RepresenterError unexpectedly!")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR to fix a bug when list inventory in YAML format with debug output enabled.
- [x] [bug] Add yaml representer for VarsWithSources
Toggles debug output

Related PRs:
- ansible/ansible#66102
- ansible-collections/vmware#80
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/parsing/yaml/dumper.py 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```bash
$ ANSIBLE_DEBUG=True ansible-inventory -i 'localhost,' --list --yaml
Traceback (most recent call last):
 ...
  File "ansible/venv/lib/python3.7/site-packages/yaml/representer.py", line 231, in represent_undefined
    raise RepresenterError("cannot represent an object", data)
yaml.representer.RepresenterError: ('cannot represent an object', <ansible.vars.manager.VarsWithSources object at 0x103644d90>)
```
