### PR TITLE
Revert "ansilbe-doc list collections plugins (#67928)"

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -26,7 +26,7 @@ from ansible.parsing.metadata import extract_metadata
 from ansible.parsing.plugin_docs import read_docstub
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.plugins.loader import action_loader, fragment_loader
-from ansible.utils.collection_loader import set_collection_playbook_paths, list_collection_dirs, get_collection_name_from_path
+from ansible.utils.collection_loader import set_collection_playbook_paths
 from ansible.utils.display import Display
 from ansible.utils.plugin_docs import BLACKLIST, get_docstring, get_versioned_doclink
 display = Display()
@@ -34,17 +34,6 @@ display = Display()
 
 def jdump(text):
     display.display(json.dumps(text, sort_keys=True, indent=4))
-
-
-def add_collection_plugins(plugin_list, plugin_type):
-
-    colldirs = list_collection_dirs()
-    for ns in colldirs.keys():
-        for path in colldirs[ns]:
-
-            collname = get_collection_name_from_path(path)
-            ptype = C.COLLECTION_PTYPE_COMPAT.get(plugin_type, plugin_type)
-            plugin_list.update(DocCLI.find_plugins(os.path.join(path, 'plugins', ptype), plugin_type, collname))
 
 
 class RemovedPlugin(Exception):
@@ -136,8 +125,6 @@ class DocCLI(CLI):
             for path in paths:
                 self.plugin_list.update(DocCLI.find_plugins(path, plugin_type))
 
-            add_collection_plugins(self.plugin_list, plugin_type)
-
             plugins = self._get_plugin_list_filenames(loader)
             if do_json:
                 jdump(plugins)
@@ -158,8 +145,6 @@ class DocCLI(CLI):
             paths = loader._get_paths()
             for path in paths:
                 self.plugin_list.update(DocCLI.find_plugins(path, plugin_type))
-
-            add_collection_plugins(self.plugin_list, plugin_type)
 
             descs = self._get_plugin_list_descriptions(loader)
             if do_json:
@@ -364,7 +349,7 @@ class DocCLI(CLI):
         return text
 
     @staticmethod
-    def find_plugins(path, ptype, collection=None):
+    def find_plugins(path, ptype):
 
         display.vvvv("Searching %s for plugins" % path)
 
@@ -401,10 +386,6 @@ class DocCLI(CLI):
             plugin = plugin.lstrip('_')  # remove underscore from deprecated plugins
 
             if plugin not in BLACKLIST.get(bkey, ()):
-
-                if collection:
-                    plugin = '%s.%s' % (collection, plugin)
-
                 plugin_list.add(plugin)
                 display.vvvv("Added %s" % plugin)
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -97,7 +97,6 @@ BECOME_METHODS = _DeprecatedSequenceConstant(
 # CONSTANTS ### yes, actual ones
 BLACKLIST_EXTS = ('.pyc', '.pyo', '.swp', '.bak', '~', '.rpm', '.md', '.txt', '.rst')
 BOOL_TRUE = BOOLEANS_TRUE
-COLLECTION_PTYPE_COMPAT = {'module': 'modules'}
 DEFAULT_BECOME_PASS = None
 DEFAULT_PASSWORD_CHARS = to_text(ascii_letters + digits + ".,:-_", errors='strict')  # characters included in auto-generated passwords
 DEFAULT_REMOTE_PASS = None


### PR DESCRIPTION
##### SUMMARY

This reverts commit 0f5a63f1b99e586f86932907c49b1e8877128957.

Resolves https://github.com/ansible/ansible/issues/68530

The original PR passed CI because there is not testing for this scenario.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

collection loader
