### PR TITLE
Add a custom selinux policy for hackers using ansible-test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,8 @@ ansible.egg-info/
 /test/integration/cloud-config-*.*
 !/test/integration/cloud-config-*.*.template
 .python-version
+/hacking/tests/selinux/*.mod
+/hacking/tests/selinux/*.pp
 # Release directory
 packaging/release/ansible_release
 /.cache/

--- a/hacking/tests/selinux/README.md
+++ b/hacking/tests/selinux/README.md
@@ -1,0 +1,22 @@
+# ansible-podman selinux module
+
+On Fedora-derived systems (and possibly others), selinux can prevent podman
+from running the way we need it to for our tests to work.
+
+Loading this module (hopefully) allows you to
+[keep selinux enabled](https://stopdisablingselinux.com/) and still be able to
+run our tests.
+
+To use it, just run:
+
+```
+./build.sh
+```
+
+...which will build the module. Then run:
+
+```
+sudo semodule -i ansible-podman.pp
+```
+
+to insert and enable the module.

--- a/hacking/tests/selinux/ansible-podman.te
+++ b/hacking/tests/selinux/ansible-podman.te
@@ -1,0 +1,17 @@
+module ansible-podman 1.0;
+
+require {
+        type container_t;
+        type cgroup_t;
+        type fusefs_t;
+        class dir { add_name create remove_name rmdir write };
+        class file { create relabelto write };
+        class bpf map_create;
+}
+
+
+allow container_t cgroup_t:dir { add_name create remove_name rmdir write };
+
+allow container_t cgroup_t:file { create write };
+allow container_t fusefs_t:file relabelto;
+allow container_t self:bpf map_create;

--- a/hacking/tests/selinux/build.sh
+++ b/hacking/tests/selinux/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -x
+set -e
+checkmodule -Mmo ansible-podman.mod ansible-podman.te
+semodule_package -o ansible-podman.pp -m ansible-podman.mod
+
+set +x
+echo "Module built. Now run this as root:"
+echo "semodule -i $(pwd)/ansible-podman.pp"


### PR DESCRIPTION
##### SUMMARY

Makes `ansible-test` work without fully disabling selinux.

We shouldn't officially support this, but other hackers of ansible/ansible might find it useful.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME

hacking/tests/selinux