### PR TITLE
Fix routing entry to patch

### DIFF
--- a/lib/ansible/config/routing.yml
+++ b/lib/ansible/config/routing.yml
@@ -1466,7 +1466,7 @@ plugin_routing:
     iso_extract:
       redirect: community.general.iso_extract
     patch:
-      redirect: community.general.patch
+      redirect: ansible.posix.patch
     read_csv:
       redirect: community.general.read_csv
     xattr:


### PR DESCRIPTION
##### SUMMARY
It was moved to ansible.posix (as correctly noted in .github/BOTMETA.yml), not to community.general.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/config/routing.yml
