### PR TITLE
passwordstore: Honor equal sign in userpass

### DIFF
--- a/changelogs/fragments/passwordstore_fix.yml
+++ b/changelogs/fragments/passwordstore_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Handle equal sign in password while using passwordstore lookup plugin.

--- a/lib/ansible/plugins/lookup/passwordstore.py
+++ b/lib/ansible/plugins/lookup/passwordstore.py
@@ -156,7 +156,7 @@ class LookupModule(LookupBase):
             # next parse the optional parameters in keyvalue pairs
             try:
                 for param in params[1:]:
-                    name, value = param.split('=')
+                    name, value = param.split('=', 1)
                     if name not in self.paramvals:
                         raise AnsibleAssertionError('%s not in paramvals' % name)
                     self.paramvals[name] = value

--- a/test/integration/targets/lookup_passwordstore/tasks/tests.yml
+++ b/test/integration/targets/lookup_passwordstore/tasks/tests.yml
@@ -47,3 +47,16 @@
   assert:
     that:
       - readpass == newpass
+
+- name: Create a password with equal sign
+  set_fact:
+    newpass: "{{ lookup('passwordstore', 'test-pass-equal userpass=SimpleSample= create=yes') }}"
+
+- name: Fetch a password with equal sign
+  set_fact:
+    readpass: "{{ lookup('passwordstore', 'test-pass-equal') }}"
+
+- name: Verify password
+  assert:
+    that:
+      - readpass == newpass


### PR DESCRIPTION
##### SUMMARY

passwordstore lookup plugin now can handle equal sign in user input

Fixes: ansible/ansible#68265

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

Backport of https://github.com/ansible-collections/community.general/pull/19

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/passwordstore_fix.yml
lib/ansible/plugins/lookup/passwordstore.py
test/integration/targets/lookup_passwordstore/tasks/tests.yml
