### PR TITLE
ansible-test: don't trigger full CI run for changes to changelogs/ and docs/ in collections

### DIFF
--- a/changelogs/fragments/68550-ansible-test-docs-changelogs.yml
+++ b/changelogs/fragments/68550-ansible-test-docs-changelogs.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- "ansible-test change detection - ignore ``docs/`` and ``changelogs/`` in collections, to avoid triggering full CI runs when files in these directories change."
+- "ansible-test change detection - Run only sanity tests on ``docs/`` and ``changelogs/`` in collections, to avoid triggering full CI runs of integration and unit tests when files in these directories change."

--- a/changelogs/fragments/68550-ansible-test-docs-changelogs.yml
+++ b/changelogs/fragments/68550-ansible-test-docs-changelogs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-test change detection - ignore ``docs/`` and ``changelogs/`` in collections, to avoid triggering full CI runs when files in these directories change."

--- a/test/lib/ansible_test/_internal/classification.py
+++ b/test/lib/ansible_test/_internal/classification.py
@@ -641,6 +641,14 @@ class PathMapper:
         if result is not None:
             return result
 
+        minimal = {}
+
+        if path.startswith('changelogs/'):
+            return minimal
+
+        if path.startswith('docs/'):
+            return minimal
+
         return None
 
     def _classify_ansible(self, path):  # type: (str) -> t.Optional[t.Dict[str, str]]


### PR DESCRIPTION
##### SUMMARY
See #68132.

Temporary fix which we can use as Ansible branch for CI which prevents full CI runs for changelogs/ and docs/ changes.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test
