### PR TITLE
[stable-2.9] Optionally support task_uuid if passed from newer modules

### DIFF
--- a/changelogs/fragments/68556-start_conn-forward-compat.yaml
+++ b/changelogs/fragments/68556-start_conn-forward-compat.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- Alter task_executor's start_connection to support newer modules from
+  collections which expect to send task UUID.

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -1049,7 +1049,7 @@ class TaskExecutor:
         return handler
 
 
-def start_connection(play_context, variables):
+def start_connection(play_context, variables, task_uuid=None):
     '''
     Starts the persistent connection
     '''
@@ -1080,7 +1080,7 @@ def start_connection(play_context, variables):
     python = sys.executable
     master, slave = pty.openpty()
     p = subprocess.Popen(
-        [python, ansible_connection, to_text(os.getppid())],
+        [python, ansible_connection, to_text(os.getppid()), to_text(task_uuid)],
         stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
     )
     os.close(slave)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes issues with newer modules from collections running on ansible 2.9. This will show up when using persistent network modules with `connection: local`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
task_executor