### PR TITLE
[stable-2.9] Fix missing persistent connection messages (#68496)

### DIFF
--- a/changelogs/fragments/68496-persistent-logging.yaml
+++ b/changelogs/fragments/68496-persistent-logging.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- Log additional messages from persistent connection modules that may be
+  missed if the module fails or returns early.

--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -147,6 +147,8 @@ class ConnectionProcess(object):
                     resp = self.srv.handle_request(data)
                     signal.alarm(0)
 
+                    display_messages(self.connection)
+
                     if log_messages:
                         display.display("jsonrpc response: %s" % resp, log_only=True)
 
@@ -196,6 +198,7 @@ class ConnectionProcess(object):
                     self.sock.close()
                 if self.connection:
                     self.connection.close()
+                    display_messages(self.connection)
             except Exception:
                 pass
             finally:
@@ -330,6 +333,24 @@ def main():
         sys.stdout.write(json.dumps(result, cls=AnsibleJSONEncoder))
 
     sys.exit(rc)
+
+
+def display_messages(connection):
+    # This should be handled elsewhere, but if this is the last task, nothing will
+    # come back to collect the messages. So now each task will dump its own messages
+    # to stdout before logging the response message. This may make some other
+    # pop_messages calls redundant.
+    for level, message in connection.pop_messages():
+        if connection.get_option('persistent_log_messages') and level == "log":
+            display.display(message, log_only=True)
+        else:
+            # These should be keyed by valid method names, but
+            # fail gracefully just in case.
+            display_method = getattr(display, level, None)
+            if display_method:
+                display_method(message)
+            else:
+                display.display((level, message))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### SUMMARY
* Be more proactive about returning module messages

* Move message display to a function, and replace handling already in shutdown().
(cherry picked from commit 5f6427b1fc7449a5c42212013d3f628665701c3d)

Co-authored-by: Nathaniel Case <ncase@redhat.com>

Backport of #68496

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-connection