### PR TITLE
WebRequest - Fix use_proxy: no on module options

### DIFF
--- a/changelogs/fragments/win-web-request-no_proxy.yaml
+++ b/changelogs/fragments/win-web-request-no_proxy.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- Ansible.ModuleUtils.WebRequest - actually set no proxy when ``use_proxy: no`` is set on a Windows module - https://github.com/ansible/ansible/issues/68528
+- 'Ansible.ModuleUtils.WebRequest - actually set no proxy when ``use_proxy: no`` is set on a Windows module - https://github.com/ansible/ansible/issues/68528'

--- a/changelogs/fragments/win-web-request-no_proxy.yaml
+++ b/changelogs/fragments/win-web-request-no_proxy.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Ansible.ModuleUtils.WebRequest - actually set no proxy when ``use_proxy: no`` is set on a Windows module - https://github.com/ansible/ansible/issues/68528

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.WebRequest.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.WebRequest.psm1
@@ -272,9 +272,9 @@ Function Get-AnsibleWebRequest {
         } else {
             $proxy.Credentials = $null
         }
-
-        $web_request.Proxy = $proxy
     }
+
+    $web_request.Proxy = $proxy
 
     # Some parameters only apply when dealing with a HttpWebRequest
     if ($web_request -is [System.Net.HttpWebRequest]) {

--- a/test/integration/targets/module_utils_Ansible.ModuleUtils.WebRequest/library/web_request_test.ps1
+++ b/test/integration/targets/module_utils_Ansible.ModuleUtils.WebRequest/library/web_request_test.ps1
@@ -436,6 +436,25 @@ $tests = [Ordered]@{
         } | ConvertFrom-Json
         $actual.headers.'User-Agent' | Assert-Equals -Expected 'actual-agent'
     }
+
+    'Web request with default proxy' = {
+        $params = @{
+            Uri = "https://$httpbin_host/get"
+        }
+        $r = Get-AnsibleWebRequest @params
+
+        $null -ne $r.Proxy | Assert-Equals -Expected $true
+    }
+
+    'Web request with no proxy' = {
+        $params = @{
+            Uri = "https://$httpbin_host/get"
+            UseProxy = $false
+        }
+        $r = Get-AnsibleWebRequest @params
+
+        $null -eq $r.Proxy | Assert-Equals -Expected $true
+    }
 }
 
 # setup and teardown should favour native tools to create and delete the service and not the util we are testing.


### PR DESCRIPTION
##### SUMMARY
When `use_proxy: no` was set we never overwrote the actual WebRequest object with the `$null` proxy value which meant the default proxy was being used. This PR makes sure we always set the proxy based on the module options.

Fixes https://github.com/ansible/ansible/issues/68528

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Ansible.ModuleUtils.WebRequest