### PR TITLE
Add support for iptables match addrtype

### DIFF
--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -282,6 +282,14 @@ options:
       - Specifies the destination IP range to match in the iprange module.
     type: str
     version_added: "2.8"
+  src_type:
+    description:
+      - Matches if the source address is of given type (e. g. UNSPEC, LOCAL).
+    type: str
+  dst_type:
+    description:
+      - Matches if the destination address is of given type (e. g. UNSPEC, LOCAL).
+    type: str
   limit:
     description:
       - Specifies the maximum average number of matches to allow per second.
@@ -571,6 +579,9 @@ def construct_rule(params):
     if 'iprange' in params['match']:
         append_param(rule, params['src_range'], '--src-range', False)
         append_param(rule, params['dst_range'], '--dst-range', False)
+    if 'addrtype' in params['match']:
+        append_param(rule, params['src_type'], '--src-type', False)
+        append_param(rule, params['dst_type'], '--dst-type', False)
     elif params['src_range'] or params['dst_range']:
         append_match(rule, params['src_range'] or params['dst_range'], 'iprange')
         append_param(rule, params['src_range'], '--src-range', False)
@@ -699,6 +710,8 @@ def main():
             ctstate=dict(type='list', default=[]),
             src_range=dict(type='str'),
             dst_range=dict(type='str'),
+            src_type=dict(type='str'),
+            dst_type=dict(type='str'),
             limit=dict(type='str'),
             limit_burst=dict(type='str'),
             uid_owner=dict(type='str'),


### PR DESCRIPTION
##### SUMMARY

The linux package iptables has a support for controlling address types. Address types are used within the kernel networking stack and categorize addresses into various groups.
If the `--match` option is set to `addrtype`, a `--src-type` or `--dst-type` is required. 

A good example where this is necessary is docker. 

`iptables -t nat -A OUTPUT ! -d 127.0.0.0/8 -m addrtype --dst-type LOCAL -j DOCKER`.

Docs about `addrtype` can be found here: https://linux.die.net/man/8/iptables.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
iptables 

##### ADDITIONAL INFORMATION
