### PR TITLE
Fix slurp error handling for unreadable files and directories

### DIFF
--- a/changelogs/fragments/67340-slurp_error_message.yml
+++ b/changelogs/fragments/67340-slurp_error_message.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "slurp - Fix error messages for unreadable files and directories(https://github.com/ansible/ansible/issues/67340)."

--- a/test/integration/targets/slurp/defaults/main.yml
+++ b/test/integration/targets/slurp/defaults/main.yml
@@ -1,0 +1,1 @@
+become_test_user: testuser

--- a/test/integration/targets/slurp/handlers/main.yml
+++ b/test/integration/targets/slurp/handlers/main.yml
@@ -1,0 +1,6 @@
+- name: remove test user and their home dir
+  user:
+    name: "{{ become_test_user }}"
+    state: absent
+    remove: yes
+    force: yes

--- a/test/integration/targets/slurp/tasks/main.yml
+++ b/test/integration/targets/slurp/tasks/main.yml
@@ -96,3 +96,7 @@
       - "slurp_no_args is failed"
       - "slurp_no_args.msg"
       - "slurp_no_args is not changed"
+
+# Ensure unreadable file and directory handling and error messages
+# https://github.com/ansible/ansible/issues/67340
+- import_tasks: 'test_unreadable.yml'

--- a/test/integration/targets/slurp/tasks/test_unreadable.yml
+++ b/test/integration/targets/slurp/tasks/test_unreadable.yml
@@ -1,0 +1,52 @@
+- name: create test user
+  user:
+    name: "{{ become_test_user }}"
+    create_home: yes
+  notify:
+    - "remove test user and their home dir"
+
+- name: create unreadable file
+  copy:
+    content: "Hello, World!"
+    dest: /tmp/qux.txt
+    mode: 0600
+    owner: root
+
+- name: test slurp unreadable file
+  slurp:
+    src: '/tmp/qux.txt'
+  register: slurp_unreadable_file
+  become: true
+  become_user: "{{ become_test_user }}"
+  become_method: su
+  ignore_errors: true
+
+- name: check slurp unreadable file result
+  assert:
+    that:
+      - "slurp_unreadable_file is failed"
+      - "slurp_unreadable_file.msg is regex('^file is not readable:')"
+      - "slurp_unreadable_file is not changed"
+
+- name: create unreadable directory
+  file:
+    path: /tmp/test_data
+    state: directory
+    mode: 0700
+    owner: root
+
+- name: test slurp unreadable directory
+  slurp:
+    src: /tmp/test_data
+  register: slurp_unreadable_dir
+  become: true
+  become_user: "{{ become_test_user }}"
+  become_method: su
+  ignore_errors: true
+
+- name: check slurp unreadable directory result
+  assert:
+    that:
+      - "slurp_unreadable_dir is failed"
+      - "slurp_unreadable_dir.msg is regex('^file is not readable:')"
+      - "slurp_unreadable_dir is not changed"


### PR DESCRIPTION
##### SUMMARY
This PR fixes unreadable files and directories handling in `slurp` module. After applied this PR, If users access unreadable files and directories, slurp module will fail with `file is not readable` error.

- Fixes #67340

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- slurp module

##### ADDITIONAL INFORMATION
```
None
```
