### PR TITLE
[2.9] ipa: Remove redundant encoding in json.loads

### DIFF
--- a/changelogs/fragments/66592_ipa_encoding_fix.yml
+++ b/changelogs/fragments/66592_ipa_encoding_fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Remove redundant encoding in json.load call in ipa module_utils (https://github.com/ansible/ansible/issues/66592).

--- a/lib/ansible/module_utils/ipa.py
+++ b/lib/ansible/module_utils/ipa.py
@@ -156,7 +156,7 @@ class IPAClient(object):
                 charset = response_charset
             else:
                 charset = 'latin-1'
-        resp = json.loads(to_text(resp.read(), encoding=charset), encoding=charset)
+        resp = json.loads(to_text(resp.read(), encoding=charset))
         err = resp.get('error')
         if err is not None:
             self._fail('response %s' % method, err)


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible-collections/community.general/pull/87

Fixes: ansible/ansible#66592

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/66592_ipa_encoding_fix.yml
lib/ansible/module_utils/ipa.py
