### PR TITLE
[2.9] mysql_user: Fix idempotence when long grant lists are used

### DIFF
--- a/changelogs/fragments/68044-mysql_user_idempotency.yml
+++ b/changelogs/fragments/68044-mysql_user_idempotency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "mysql_user - Fix idempotence when long grant lists are used (https://github.com/ansible/ansible/issues/68044)"

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -490,14 +490,14 @@ def privileges_get(cursor, user, host):
         res = re.match("""GRANT (.+) ON (.+) TO (['`"]).*\\3@(['`"]).*\\4( IDENTIFIED BY PASSWORD (['`"]).+\\6)? ?(.*)""", grant[0])
         if res is None:
             raise InvalidPrivsError('unable to parse the MySQL grant string: %s' % grant[0])
-        privileges = res.group(1).split(", ")
-        privileges = [pick(x) for x in privileges]
+        privileges = res.group(1).split(",")
+        privileges = [pick(x.strip()) for x in privileges]
         if "WITH GRANT OPTION" in res.group(7):
             privileges.append('GRANT')
         if "REQUIRE SSL" in res.group(7):
             privileges.append('REQUIRESSL')
         db = res.group(2)
-        output[db] = privileges
+        output.setdefault(db, []).extend(privileges)
     return output
 
 

--- a/test/integration/targets/mysql_user/tasks/test_privs.yml
+++ b/test/integration/targets/mysql_user/tasks/test_privs.yml
@@ -28,7 +28,7 @@
 
 - include: assert_user.yml user_name={{user_name_2}} priv='SELECT'
   when: current_append_privs ==  "yes"
- 
+
 - name: create user with current privileges (expect changed=true)
   mysql_user:
     name: '{{ user_name_2 }}'
@@ -39,18 +39,18 @@
     login_unix_socket: '{{ mysql_socket }}'
   register: result
 
-- name: assert output message for current privileges 
+- name: assert output message for current privileges
   assert: { that: "result.changed == true" }
 
 - name: run command to show privileges for user (expect privileges in stdout)
   command: mysql "-e SHOW GRANTS FOR '{{user_name_2}}'@'localhost';"
   register: result
 
-- name: assert user has correct privileges 
+- name: assert user has correct privileges
   assert: { that: "'GRANT {{current_privilege | replace(',', ', ')}} ON *.*' in result.stdout" }
   when: current_append_privs ==  "no"
 
-- name: assert user has correct privileges 
+- name: assert user has correct privileges
   assert: { that: "'GRANT SELECT, {{current_privilege | replace(',', ', ')}} ON *.*' in result.stdout" }
   when: current_append_privs ==  "yes"
 
@@ -60,7 +60,7 @@
     state: present
     login_user: '{{ user_name_2 }}'
     login_password: '{{ user_password_2 }}'
-  ignore_errors: true 
+  ignore_errors: true
 
 - name: run command to test that database was not created
   command: mysql "-e show databases like '{{ db_name }}';"
@@ -95,7 +95,7 @@
   assert: { that: "result.changed == false" }
 
 # ============================================================
-- name: update user with all privileges 
+- name: update user with all privileges
   mysql_user:
     name: '{{ user_name_2 }}'
     password: '{{ user_password_2 }}'
@@ -113,7 +113,7 @@
     login_password: '{{ user_password_2 }}'
 
 - name: run command to test database was created using user new privileges
-  command: mysql "-e SHOW CREATE DATABASE {{ db_name }};" 
+  command: mysql "-e SHOW CREATE DATABASE {{ db_name }};"
 
 - name: drop database using user
   mysql_db:
@@ -121,6 +121,31 @@
     state: absent
     login_user: '{{ user_name_2 }}'
     login_password: '{{ user_password_2 }}'
+
+# ============================================================
+- name: update user with a long privileges list (mysql has a special multiline grant output)
+  mysql_user:
+    name: '{{ user_name_2 }}'
+    password: '{{ user_password_2 }}'
+    priv: '*.*:CREATE USER,FILE,PROCESS,RELOAD,REPLICATION CLIENT,REPLICATION SLAVE,SHOW DATABASES,SHUTDOWN,SUPER,CREATE,DROP,EVENT,LOCK TABLES,INSERT,UPDATE,DELETE,SELECT,SHOW VIEW,GRANT'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
+  register: result
+
+- name: Assert that priv changed
+  assert: { that: "result.changed == true" }
+
+- name: Test idempotency (expect ok)
+  mysql_user:
+    name: '{{ user_name_2 }}'
+    password: '{{ user_password_2 }}'
+    priv: '*.*:CREATE USER,FILE,PROCESS,RELOAD,REPLICATION CLIENT,REPLICATION SLAVE,SHOW DATABASES,SHUTDOWN,SUPER,CREATE,DROP,EVENT,LOCK TABLES,INSERT,UPDATE,DELETE,SELECT,SHOW VIEW,GRANT'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
+  register: result
+
+- name: Assert that priv did not change
+  assert: { that: "result.changed == false" }
 
 - name: remove username
   mysql_user:


### PR DESCRIPTION
(cherry-picked from commit https://github.com/ansible-collections/community.general/commit/8d203225d35d1db952bfee89ad72572bc96fe845)

Backport of https://github.com/ansible-collections/community.general/pull/58