### PR TITLE
WebRequest - Fix use_proxy: no on module options (#68603) - 2.9

### DIFF
--- a/changelogs/fragments/win-web-request-no_proxy.yaml
+++ b/changelogs/fragments/win-web-request-no_proxy.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- 'Ansible.ModuleUtils.WebRequest - actually set no proxy when ``use_proxy: no`` is set on a Windows module - https://github.com/ansible/ansible/issues/68528'

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.WebRequest.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.WebRequest.psm1
@@ -272,9 +272,9 @@ Function Get-AnsibleWebRequest {
         } else {
             $proxy.Credentials = $null
         }
-
-        $web_request.Proxy = $proxy
     }
+
+    $web_request.Proxy = $proxy
 
     # Some parameters only apply when dealing with a HttpWebRequest
     if ($web_request -is [System.Net.HttpWebRequest]) {


### PR DESCRIPTION
(cherry picked from commit ae1cd27b575a759e9d2477042fc5dbbb3275cd84)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/68603

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils/powershell/Ansible.ModuleUtils.WebRequest.psm1