### PR TITLE
Add collection path in CLI version info

### DIFF
--- a/changelogs/fragments/collection-ad-hoc.yml
+++ b/changelogs/fragments/collection-ad-hoc.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Add path of collection location in Ansible CLI version info.

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -178,6 +178,7 @@ def version(prog=None):
         cpath = C.DEFAULT_MODULE_PATH
     result = result + "\n  configured module search path = %s" % cpath
     result = result + "\n  ansible python module location = %s" % ':'.join(ansible.__path__)
+    result = result + "\n  ansible collection location = %s" % ':'.join(C.COLLECTIONS_PATHS)
     result = result + "\n  executable location = %s" % sys.argv[0]
     result = result + "\n  python version = %s" % ''.join(sys.version.splitlines())
     return result

--- a/test/integration/targets/ansible/ansible-testé.cfg
+++ b/test/integration/targets/ansible/ansible-testé.cfg
@@ -1,2 +1,3 @@
 [defaults]
 remote_user = admin
+collections_paths = /tmp/collections

--- a/test/integration/targets/ansible/runme.sh
+++ b/test/integration/targets/ansible/runme.sh
@@ -13,6 +13,12 @@ ansible-config dump -c ./ansible-testé.cfg | grep 'DEFAULT_REMOTE_USER([^)]*) =
 ANSIBLE_REMOTE_USER=administrator ansible-config dump| grep 'DEFAULT_REMOTE_USER([^)]*) = administrator\>'
 ansible-config list | grep 'DEFAULT_REMOTE_USER'
 
+# Collection
+ansible-config view -c ./ansible-testé.cfg | grep 'collections_paths = /tmp/collections'
+ansible-config dump -c ./ansible-testé.cfg | grep 'COLLECTIONS_PATHS([^)]*) ='
+ANSIBLE_COLLECTIONS_PATHS=/tmp/collections ansible-config dump| grep 'COLLECTIONS_PATHS([^)]*) ='
+ansible-config list | grep 'COLLECTIONS_PATHS'
+
 # 'view' command must fail when config file is missing or has an invalid file extension
 ansible-config view -c ./ansible-non-existent.cfg 2> err1.txt || grep -Eq 'ERROR! The provided configuration file is missing or not accessible:' err1.txt || (cat err*.txt; rm -f err1.txt; exit 1)
 ansible-config view -c ./no-extension 2> err2.txt || grep -q 'Unsupported configuration file extension' err2.txt || (cat err2.txt; rm -f err*.txt; exit 1)

--- a/test/units/cli/arguments/test_optparse_helpers.py
+++ b/test/units/cli/arguments/test_optparse_helpers.py
@@ -29,6 +29,7 @@ VERSION_OUTPUT = opt_help.version(prog=FAKE_PROG)
         u'config file = %s' % C.CONFIG_FILE,
         u'configured module search path = %s' % cpath,
         u'ansible python module location = %s' % ':'.join(ansible_path),
+        u'ansible collection location = %s' % ':'.join(C.COLLECTIONS_PATHS),
         u'executable location = ',
         u'python version = %s' % ''.join(sys.version.splitlines()),
     ]

--- a/test/units/cli/test_adhoc.py
+++ b/test/units/cli/test_adhoc.py
@@ -104,10 +104,11 @@ def test_ansible_version(capsys, mocker):
         # Python 2.6 does return a named tuple, so get the first item
         version_lines = version[0].splitlines()
 
-    assert len(version_lines) == 6, 'Incorrect number of lines in "ansible --version" output'
+    assert len(version_lines) == 7, 'Incorrect number of lines in "ansible --version" output'
     assert re.match('ansible [0-9.a-z]+$', version_lines[0]), 'Incorrect ansible version line in "ansible --version" output'
     assert re.match('  config file = .*$', version_lines[1]), 'Incorrect config file line in "ansible --version" output'
     assert re.match('  configured module search path = .*$', version_lines[2]), 'Incorrect module search path in "ansible --version" output'
     assert re.match('  ansible python module location = .*$', version_lines[3]), 'Incorrect python module location in "ansible --version" output'
-    assert re.match('  executable location = .*$', version_lines[4]), 'Incorrect executable locaction in "ansible --version" output'
-    assert re.match('  python version = .*$', version_lines[5]), 'Incorrect python version in "ansible --version" output'
+    assert re.match('  ansible collection location = .*$', version_lines[4]), 'Incorrect collection location in "ansible --version" output'
+    assert re.match('  executable location = .*$', version_lines[5]), 'Incorrect executable locaction in "ansible --version" output'
+    assert re.match('  python version = .*$', version_lines[6]), 'Incorrect python version in "ansible --version" output'

--- a/test/units/cli/test_cli.py
+++ b/test/units/cli/test_cli.py
@@ -61,7 +61,7 @@ class TestCliBuildVaultIds(unittest.TestCase):
         self.assertEqual(res, [])
 
     def test_no_vault_id_no_auto_prompt(self):
-        # similate 'ansible-playbook site.yml' with out --ask-vault-pass, should not prompt
+        # simulate 'ansible-playbook site.yml' with out --ask-vault-pass, should not prompt
         res = cli.CLI.build_vault_ids([], auto_prompt=False)
         self.assertEqual(res, [])
 


### PR DESCRIPTION
##### SUMMARY

This will provide the user default path of the collection

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
changelogs/fragments/collection-ad-hoc.yml
lib/ansible/cli/arguments/option_helpers.py
test/units/cli/arguments/test_optparse_helpers.py
test/units/cli/test_adhoc.py
