### PR TITLE
validate-modules: deprecated modules in collections

### DIFF
--- a/changelogs/fragments/validate-modules-deprecated-collections.yml
+++ b/changelogs/fragments/validate-modules-deprecated-collections.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - validate-modules checks for deprecated in collections against meta/routing.yml

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -238,7 +238,7 @@ class ModuleValidator(Validator):
 
     WHITELIST_FUTURE_IMPORTS = frozenset(('absolute_import', 'division', 'print_function'))
 
-    def __init__(self, path, analyze_arg_spec=False, collection=None, base_branch=None, git_cache=None, reporter=None, routing=None):
+    def __init__(self, path, analyze_arg_spec=False, collection=None, base_branch=None, git_cache=None, reporter=None):
         super(ModuleValidator, self).__init__(reporter=reporter or Reporter())
 
         self.path = path
@@ -253,6 +253,8 @@ class ModuleValidator(Validator):
         self.git_cache = git_cache or GitCache()
 
         self._python_module_override = False
+
+        self.routing = None
 
         with open(path) as f:
             self.text = f.read()

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -1092,14 +1092,13 @@ class ModuleValidator(Validator):
                     mismatched_deprecation = False
 
             if mismatched_deprecation:
-                if not self.collection:
-                    self.reporter.error(
-                        path=self.object_path,
-                        code='deprecation-mismatch',
-                        msg='Module deprecation/removed must agree in Metadata, by prepending filename with'
-                            ' "_", and setting DOCUMENTATION.deprecated for deprecation or by removing all'
-                            ' documentation for removed'
-                    )
+                self.reporter.error(
+                    path=self.object_path,
+                    code='deprecation-mismatch',
+                    msg='Module deprecation/removed must agree in Metadata, by prepending filename with'
+                        ' "_", and setting DOCUMENTATION.deprecated for deprecation or by removing all'
+                        ' documentation for removed'
+                )
         else:
             # We are testing a collection
             if self.object_name.startswith('_'):

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -254,7 +254,7 @@ class ModuleValidator(Validator):
 
         self._python_module_override = False
 
-        self.routing = None
+        self.routing = {}
 
         with open(path) as f:
             self.text = f.read()
@@ -941,7 +941,7 @@ class ModuleValidator(Validator):
                     )
         else:
             # We are testing a collection
-            if self.routing.get('plugin_routing', {}).get('modules', {}).get(self.name, {}).get('deprecation', {}):
+            if self.routing and self.routing.get('plugin_routing', {}).get('modules', {}).get(self.name, {}).get('deprecation', {}):
                 # meta/routing.yml says this is deprecated
                 routing_says_deprecated = True
                 deprecated = True
@@ -1121,7 +1121,7 @@ class ModuleValidator(Validator):
                         code='collections-no-underscore-on-deprecation',
                         msg='Deprecated content in collections MUST NOT start with "_", update meta/routing.yml instead',
                         )
-            
+
             if not (doc_deprecated == routing_says_deprecated):
                 # DOCUMENTATION.deprecated and meta/routing.yml disagree
                 self.reporter.error(

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -268,7 +268,6 @@ class ModuleValidator(Validator):
         else:
             self.base_module = None
 
-
     def __enter__(self):
         return self
 

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -1005,7 +1005,7 @@ class ModuleValidator(Validator):
                             doc_schema(
                                 os.readlink(self.object_path).split('.')[0],
                                 version_added=not bool(self.collection),
-                                deprecated_module=deprecated
+                                deprecated_module=deprecated,
                             ),
                             'DOCUMENTATION',
                             'invalid-documentation',
@@ -1017,7 +1017,7 @@ class ModuleValidator(Validator):
                             doc_schema(
                                 self.object_name.split('.')[0],
                                 version_added=not bool(self.collection),
-                                deprecated_module=deprecated
+                                deprecated_module=deprecated,
                             ),
                             'DOCUMENTATION',
                             'invalid-documentation',

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -1117,10 +1117,10 @@ class ModuleValidator(Validator):
             # We are testing a collection
             if self.object_name.startswith('_'):
                 self.reporter.error(
-                        path=self.object_path,
-                        code='collections-no-underscore-on-deprecation',
-                        msg='Deprecated content in collections MUST NOT start with "_", update meta/routing.yml instead',
-                        )
+                    path=self.object_path,
+                    code='collections-no-underscore-on-deprecation',
+                    msg='Deprecated content in collections MUST NOT start with "_", update meta/routing.yml instead',
+                )
 
             if not (doc_deprecated == routing_says_deprecated):
                 # DOCUMENTATION.deprecated and meta/routing.yml disagree

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -276,8 +276,11 @@ def author(value):
             raise Invalid("Invalid author")
 
 
-def doc_schema(module_name, version_added=True, deprecated_module = False):
+def doc_schema(module_name, version_added=True, deprecated_module=False):
 
+    if module_name.startswith('_'):
+        module_name = module_name[1:]
+        deprecated_module = True
     doc_schema_dict = {
         Required('module'): module_name,
         Required('short_description'): Any(*string_types),

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -276,12 +276,8 @@ def author(value):
             raise Invalid("Invalid author")
 
 
-def doc_schema(module_name, version_added=True):
-    deprecated_module = False
+def doc_schema(module_name, version_added=True, deprecated_module = False):
 
-    if module_name.startswith('_'):
-        module_name = module_name[1:]
-        deprecated_module = True
     doc_schema_dict = {
         Required('module'): module_name,
         Required('short_description'): Any(*string_types),


### PR DESCRIPTION
#### SUMMARY
In Collections, a module is marked as deprecated via meta/routing.yml

Use this file, rather than the leading `_` as part of the deprecated
test.


Example:
`ERROR: plugins/modules/cloud/vultr/_vultr_account_facts.py:0:0: collections-no-underscore-on-deprecation: Deprecated content in collections MUST NOT start with "_", update meta/routing.yml instead
ERROR: plugins/modules/cloud/vultr/_vultr_account_facts.py:0:0: deprecation-mismatch: "meta/routing.yml" and DOCUMENTATION.deprecation do not agree.`


##### ISSUE TYPE
- Bugfix Pull Request
