### PR TITLE
Dev guide: add notes about different image types for integration and unit/sanity tests

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -66,6 +66,8 @@ outside of those test subdirectories.  They will also not reconfigure or bounce 
 
    To protect your system from any potential changes caused by integration tests, and to ensure a sensible set of dependencies are available we recommend that you always run integration tests with the ``--docker`` option. See the `list of supported docker images <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt>`_ for options.
 
+   Don't use the ``default`` docker image (used for sanity and unit tests only), always pass an image name explicitly.
+
 .. note:: Avoiding pulling new Docker images
 
    Use the ``--docker-no-pull`` option to avoid pulling the latest container image. This is required when using custom local images that are not available for download.

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -64,7 +64,7 @@ outside of those test subdirectories.  They will also not reconfigure or bounce 
 
 .. note:: Running integration tests within Docker
 
-   To protect your system from any potential changes caused by integration tests, and to ensure a sensible set of dependencies are available we recommend that you always run integration tests with the ``--docker`` option. See the `list of supported docker images <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt>`_ for options (the ``default`` image is used for sanity and unit tests only, not for integration tests).
+   To protect your system from any potential changes caused by integration tests, and to ensure a sensible set of dependencies are available we recommend that you always run integration tests with the ``--docker`` option, for example ``--docker centos8``. See the `list of supported docker images <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt>`_ for options (the ``default`` image is used for sanity and unit tests only, not for integration tests).
 
 .. note:: Avoiding pulling new Docker images
 

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -64,7 +64,7 @@ outside of those test subdirectories.  They will also not reconfigure or bounce 
 
 .. note:: Running integration tests within Docker
 
-   To protect your system from any potential changes caused by integration tests, and to ensure a sensible set of dependencies are available we recommend that you always run integration tests with the ``--docker`` option, for example ``--docker centos8``. See the `list of supported docker images <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt>`_ for options (the ``default`` image is used for sanity and unit tests only, not for integration tests).
+   To protect your system from any potential changes caused by integration tests, and to ensure a sensible set of dependencies are available we recommend that you always run integration tests with the ``--docker`` option, for example ``--docker centos8``. See the `list of supported docker images <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt>`_ for options (the ``default`` image is used for sanity and unit tests, as well as for platform independent integration tests such as those for cloud modules).
 
 .. note:: Avoiding pulling new Docker images
 

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -64,9 +64,7 @@ outside of those test subdirectories.  They will also not reconfigure or bounce 
 
 .. note:: Running integration tests within Docker
 
-   To protect your system from any potential changes caused by integration tests, and to ensure a sensible set of dependencies are available we recommend that you always run integration tests with the ``--docker`` option. See the `list of supported docker images <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt>`_ for options.
-
-   Don't use the ``default`` docker image (used for sanity and unit tests only), always pass an image name explicitly.
+   To protect your system from any potential changes caused by integration tests, and to ensure a sensible set of dependencies are available we recommend that you always run integration tests with the ``--docker`` option. See the `list of supported docker images <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt>`_ for options (the ``default`` image is used for sanity and unit tests only, not for integration tests).
 
 .. note:: Avoiding pulling new Docker images
 

--- a/docs/docsite/rst/dev_guide/testing_sanity.rst
+++ b/docs/docsite/rst/dev_guide/testing_sanity.rst
@@ -18,6 +18,10 @@ All available tests are run unless the ``--test`` option is used.
 How to run
 ==========
 
+.. note::
+   To run sanity tests using docker, always use the default docker image
+   by passing the ``--docker`` or ``--docker default`` argument.
+
 .. code:: shell
 
    source hacking/env-setup

--- a/docs/docsite/rst/dev_guide/testing_units.rst
+++ b/docs/docsite/rst/dev_guide/testing_units.rst
@@ -23,6 +23,10 @@ structure of the tests matches that of ``lib/ansible/``.
 Running Tests
 =============
 
+.. note::
+   To run unit tests using docker, always use the default docker image
+   by passing the ``--docker`` or ``--docker default`` argument.
+
 The Ansible unit tests can be run across the whole code base by doing:
 
 .. code:: shell


### PR DESCRIPTION
##### SUMMARY
Dev guide: add notes about different image types for integration and unit/sanity tests.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
```docs/docsite/rst/dev_guide/testing_integration.rst```
```docs/docsite/rst/dev_guide/testing_sanity.rst```
```docs/docsite/rst/dev_guide/testing_units.rst```
