### PR TITLE
Don't crash ansible-vault create when no arguments

### DIFF
--- a/changelogs/fragments/68667-dont-crash-ansible-vault-create-when-no-arguments.yaml
+++ b/changelogs/fragments/68667-dont-crash-ansible-vault-create-when-no-arguments.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-vault create - Fix exception on no arguments given

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -424,7 +424,7 @@ class VaultCLI(CLI):
     def execute_create(self):
         ''' create and open a file in an editor that will be encrypted with the provided vault secret when closed'''
 
-        if len(context.CLIARGS['args']) > 1:
+        if len(context.CLIARGS['args']) != 1:
             raise AnsibleOptionsError("ansible-vault create can take only one filename argument")
 
         self.editor.create_file(context.CLIARGS['args'][0], self.encrypt_secret,


### PR DESCRIPTION
##### SUMMARY
Fixes ansible-vault throwing an exception when no arguments are given

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cli vault

##### ADDITIONAL INFORMATION
Before:
```
$ ansible-vault create
New Vault password:
Confirm New Vault password:
ERROR! Unexpected Exception, this is probably a bug: tuple index out of range
to see the full traceback, use -vvv
```

After:
```
$ ansible-vault create
New Vault password:
Confirm New Vault password:
usage: ansible-vault [-h] [--version] [-v] {create,decrypt,edit,view,encrypt,encrypt_string,rekey} ...

encryption/decryption utility for Ansible data files

positional arguments:
  {create,decrypt,edit,view,encrypt,encrypt_string,rekey}
    create              Create new vault encrypted file
    decrypt             Decrypt vault encrypted file
    edit                Edit vault encrypted file
    view                View vault encrypted file
    encrypt             Encrypt YAML file
    encrypt_string      Encrypt a string
    rekey               Re-key a vault encrypted file

optional arguments:
  --version             show program's version number, config file location, configured module search path, module location, executable location and exit
  -h, --help            show this help message and exit
  -v, --verbose         verbose mode (-vvv for more, -vvvv to enable connection debugging)

See 'ansible-vault <command> --help' for more information on a specific command.
ERROR! ansible-vault create can take only one filename argument
```