### PR TITLE
Correct migrated location of kubectl

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -3905,7 +3905,7 @@ files:
     support: community
     maintainers: chouseknecht maxamillion fabianvf flaper87
     labels: k8s
-    migrated_to: community.general
+    migrated_to: community.kubernetes
   $plugins/connection/lxd.py:
     maintainers: mattclay
     migrated_to: community.general

--- a/lib/ansible/config/routing.yml
+++ b/lib/ansible/config/routing.yml
@@ -17,7 +17,7 @@ plugin_routing:
     jail:
       redirect: community.general.jail
     kubectl:
-      redirect: community.general.kubectl
+      redirect: community.kubernetes.kubectl
     libvirt_lxc:
       redirect: community.general.libvirt_lxc
     lxc:


### PR DESCRIPTION
##### SUMMARY

Kubectl connection plugin is moved to community.kubernetes, not
in community.general

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml
lib/ansible/config/routing.yml
