### PR TITLE
module_common: handle ansible-vault in json.dumps

### DIFF
--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -38,6 +38,7 @@ from ansible.executor.interpreter_discovery import InterpreterDiscoveryRequiredE
 from ansible.executor.powershell import module_manifest as ps_manifest
 from ansible.module_utils._text import to_bytes, to_text, to_native
 from ansible.module_utils.compat.importlib import import_module
+from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
 from ansible.plugins.loader import module_utils_loader
 # Must import strategy and use write_locks from there
 # If we import write_locks directly then we end up binding a
@@ -1011,6 +1012,11 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
         display.debug('ANSIBALLZ: Could not determine module FQN')
         remote_module_fqn = 'ansible.modules.%s' % module_name
 
+    # decrypted AnsibleVaultEncryptedUnicode befor json.dumps
+    module_args = module_args.copy()
+    for k, v in module_args.items():
+        if isinstance(v, AnsibleVaultEncryptedUnicode):
+            module_args[k] = v.data
     if module_substyle == 'python':
         params = dict(ANSIBLE_MODULE_ARGS=module_args,)
         try:


### PR DESCRIPTION
In module synchronize, it will put task_vars into module_args which may has type AnsibleVaultEncryptedUnicode.
json.dumps(params) can not deal with the type AnsibleVaultEncryptedUnicode. Make it happen as below.
Use ansible-vault encrypt_string in inventory hosts like this:

    ansible_ssh_pass: !vault |
              $ANSIBLE_VAULT;1.1;

run module synchronize, You will meet this fatal:
"msg": "Unable to pass options to module, they must be JSON serializable: Object of type 'AnsibleVaultEncryptedUnicode' is not JSON serializable"

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
