### PR TITLE
doc: explain default "required" value for argument_spec

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
@@ -610,7 +610,7 @@ choices
 required
 """"""""
 
-``required`` accepts a boolean, either ``True`` or ``False`` that indicates that the argument is required. This should not be used in combination with ``default``.
+``required`` accepts a boolean, either ``True`` or ``False`` that indicates that the argument is required. When not specified, ``required`` defaults to ``False``. This should not be used in combination with ``default``.
 
 no_log
 """"""


### PR DESCRIPTION
##### SUMMARY
The AnsibleModule class will treat every argument in the argument_spec as optional by default. This means that when module developers omit the "required=" setting for a parameter in an argument_spec, Ansible treats that parameter as optional.

This pull request describes the current behavior in the developer guide. This helps developers write simpler argument_spec definitions.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com