### PR TITLE
Add --docker-terminate flag to ansible-test

### DIFF
--- a/changelogs/fragments/ansible-test-docker-terminate.yml
+++ b/changelogs/fragments/ansible-test-docker-terminate.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - --docker flag now has an associated --docker-terminate flag which controls if and when the docker container is removed following tests

--- a/test/lib/ansible_test/_internal/cli.py
+++ b/test/lib/ansible_test/_internal/cli.py
@@ -1031,6 +1031,12 @@ def add_extra_docker_options(parser, integration=True):
                         default=None,
                         help='set seccomp confinement for the test container: %(choices)s')
 
+    docker.add_argument('--docker-terminate',
+                        metavar='WHEN',
+                        help='terminate docker container: %(choices)s (default: %(default)s)',
+                        choices=['never', 'always', 'success'],
+                        default='always')
+
     if not integration:
         return
 

--- a/test/lib/ansible_test/_internal/config.py
+++ b/test/lib/ansible_test/_internal/config.py
@@ -59,6 +59,7 @@ class EnvironmentConfig(CommonConfig):
         self.docker_keep_git = args.docker_keep_git if 'docker_keep_git' in args else False  # type: bool
         self.docker_seccomp = args.docker_seccomp if 'docker_seccomp' in args else None  # type: str
         self.docker_memory = args.docker_memory if 'docker_memory' in args else None
+        self.docker_terminate = args.docker_terminate if 'docker_terminate' in args else None  # type: str
 
         if self.docker_seccomp is None:
             self.docker_seccomp = get_docker_completion().get(self.docker_raw, {}).get('seccomp', 'default')

--- a/test/lib/ansible_test/_internal/delegation.py
+++ b/test/lib/ansible_test/_internal/delegation.py
@@ -230,6 +230,7 @@ def delegate_docker(args, exclude, require, integration_targets):
 
     httptester_id = None
     test_id = None
+    success = False
 
     options = {
         '--docker': 1,
@@ -264,8 +265,6 @@ def delegate_docker(args, exclude, require, integration_targets):
 
     if isinstance(args, ShellConfig) or (isinstance(args, IntegrationConfig) and args.debug_strategy):
         cmd_options.append('-it')
-
-    success = False
 
     with tempfile.NamedTemporaryFile(prefix='ansible-source-', suffix='.tgz') as local_source_fd:
         try:


### PR DESCRIPTION
##### SUMMARY

This allows the user to control if and when the docker container gets terminated.
Sometimes containers are useful to keep around and `exec` into, to debug why a test failed.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

ansible-test