### PR TITLE
Allow the msg argument to fail_json() to be a positional argument

### DIFF
--- a/changelogs/fragments/allow-fail-json-msg-to-be-positional.yaml
+++ b/changelogs/fragments/allow-fail-json-msg-to-be-positional.yaml
@@ -1,4 +1,4 @@
-minor_features:
+minor_changes:
   - "`AnsibleModule.fail_json()` has always required that a message be passed
     in which informs the end user why the module failed.  In the past this
     message had to be passed as the `msg` keyword argument but it can now be

--- a/changelogs/fragments/allow-fail-json-msg-to-be-positional.yaml
+++ b/changelogs/fragments/allow-fail-json-msg-to-be-positional.yaml
@@ -1,5 +1,5 @@
 minor_features:
-  - `AnsibleModule.fail_json()` has always required that a message be passed
+  - "`AnsibleModule.fail_json()` has always required that a message be passed
     in which informs the end user why the module failed.  In the past this
     message had to be passed as the `msg` keyword argument but it can now be
-    passed as the first positional argument instead.
+    passed as the first positional argument instead."

--- a/changelogs/fragments/allow-fail-json-msg-to-be-positional.yaml
+++ b/changelogs/fragments/allow-fail-json-msg-to-be-positional.yaml
@@ -1,0 +1,5 @@
+minor_features:
+  - `AnsibleModule.fail_json()` has always required that a message be passed
+    in which informs the end user why the module failed.  In the past this
+    message had to be passed as the `msg` keyword argument but it can now be
+    passed as the first positional argument instead.

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2041,12 +2041,11 @@ class AnsibleModule(object):
         self._return_formatted(kwargs)
         sys.exit(0)
 
-    def fail_json(self, **kwargs):
+    def fail_json(self, msg, **kwargs):
         ''' return from the module, with an error message '''
 
-        if 'msg' not in kwargs:
-            raise AssertionError("implementation error -- msg to explain the error is required")
         kwargs['failed'] = True
+        kwargs['msg'] = msg
 
         # Add traceback if debug or high verbosity and it is missing
         # NOTE: Badly named as exception, it really always has been a traceback

--- a/test/units/module_utils/basic/test_exit_json.py
+++ b/test/units/module_utils/basic/test_exit_json.py
@@ -56,10 +56,22 @@ class TestAnsibleModuleExitJson:
         assert return_val == expected
 
     @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
+    def test_fail_json_msg_positional(self, am, capfd):
+        with pytest.raises(SystemExit) as ctx:
+            am.fail_json('This is the msg')
+        assert ctx.value.code == 1
+
+        out, err = capfd.readouterr()
+        return_val = json.loads(out)
+        # Fail_json should add failed=True
+        assert return_val == {'msg': 'This is the msg', 'failed': True,
+                              'invocation': EMPTY_INVOCATION}
+
+    @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
     def test_fail_json_no_msg(self, am):
-        with pytest.raises(AssertionError) as ctx:
+        with pytest.raises(TypeError) as ctx:
             am.fail_json()
-        assert ctx.value.args[0] == "implementation error -- msg to explain the error is required"
+        assert ctx.value.args[0] == "fail_json() missing 1 required positional argument: 'msg'"
 
 
 class TestAnsibleModuleExitValuesRemoved:

--- a/test/units/module_utils/basic/test_exit_json.py
+++ b/test/units/module_utils/basic/test_exit_json.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division)
 __metaclass__ = type
 
 import json
+import sys
 
 import pytest
 
@@ -68,10 +69,30 @@ class TestAnsibleModuleExitJson:
                               'invocation': EMPTY_INVOCATION}
 
     @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
+    def test_fail_json_msg_as_kwarg_after(self, am, capfd):
+        """Test that msg as a kwarg after other kwargs works"""
+        with pytest.raises(SystemExit) as ctx:
+            am.fail_json(arbitrary=42, msg='This is the msg')
+        assert ctx.value.code == 1
+
+        out, err = capfd.readouterr()
+        return_val = json.loads(out)
+        # Fail_json should add failed=True
+        assert return_val == {'msg': 'This is the msg', 'failed': True,
+                              'arbitrary': 42,
+                              'invocation': EMPTY_INVOCATION}
+
+    @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
     def test_fail_json_no_msg(self, am):
         with pytest.raises(TypeError) as ctx:
             am.fail_json()
-        assert ctx.value.args[0] == "fail_json() missing 1 required positional argument: 'msg'"
+
+        if sys.version_info < (3,):
+            error_msg = "fail_json() takes exactly 2 arguments (1 given)"
+        else:
+            error_msg = "fail_json() missing 1 required positional argument: 'msg'"
+
+        assert ctx.value.args[0] == error_msg
 
 
 class TestAnsibleModuleExitValuesRemoved:


### PR DESCRIPTION
fail_json() requires a message be given to it to inform the end user of
why the module failed.  Prior to this commit, the message had to be a
keyword argument:
```
    module.fail_json(msg='Failed due to error')
```
Since this is a required parameter, this commit allows the message to be
given as a positional argument instead:
```
   module.fail_json('Failed due to an error')
```
##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
lib/ansible/module_utils/basic.py

##### ADDITIONAL INFORMATION
If it is an issue that `fail_json()` can raise TypeError if msg is not given instead of AssertionError, I can write this in a different way (but at a slight cost since I'll need a wrapper function).  I didn't think it would be a problem because module code shouldn't be catching exceptions from fail_json()... (it wouldn't be able to do anything to recover if it did.)  sivel concurred that TypeError was a better error to raise in this instance.