### PR TITLE
routing: Adjust openssl_certificate* module names

### DIFF
--- a/lib/ansible/config/routing.yml
+++ b/lib/ansible/config/routing.yml
@@ -3260,9 +3260,9 @@ plugin_routing:
     openssl_csr:
       redirect: community.crypto.openssl_csr
     openssl_certificate:
-      redirect: community.crypto.openssl_certificate
+      redirect: community.crypto.x509_certificate
     openssl_certificate_info:
-      redirect: community.crypto.openssl_certificate_info
+      redirect: community.crypto.x509_certificate_info
     x509_crl:
       redirect: community.crypto.x509_crl
     openssl_privatekey_info:


### PR DESCRIPTION
##### SUMMARY
In community.general, `openssl_certificate` and `openssl_certificate_info` have been renamed to `x509_certificate` resp. `x509_certificate_info`. To avoid deprecation warnings for the old names in the collection, this PR updates Ansible's routing.yml so that existing playbooks will continue to work without any deprecation warnings.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/config/routing.yml
