### PR TITLE
Force collections to be static

### DIFF
--- a/changelogs/fragments/68723-force-static-collections.yaml
+++ b/changelogs/fragments/68723-force-static-collections.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- Force collection names to be static so that a warning is generated because
+  templating currently does not work (see https://github.com/ansible/ansible/issues/68704).

--- a/lib/ansible/playbook/collectionsearch.py
+++ b/lib/ansible/playbook/collectionsearch.py
@@ -40,18 +40,20 @@ class CollectionSearch:
                                   always_post_validate=True, static=True)
 
     def _load_collections(self, attr, ds):
-        # This duplicates static attr checking logic from post_validate()
-        # because if the user attempts to template a collection name, it will
-        # error before it ever gets to the post_validate() warning.
-        for collection_name in ds:
-            if is_template(collection_name, Environment()):
-                display.warning('"collections" is not templatable, but we found: %s, '
-                                'it will not be templated and will be used "as is".' % (collection_name))
-
         # this will only be called if someone specified a value; call the shared value
         _ensure_default_collection(collection_list=ds)
 
         if not ds:  # don't return an empty collection list, just return None
             return None
+
+        # This duplicates static attr checking logic from post_validate()
+        # because if the user attempts to template a collection name, it will
+        # error before it ever gets to the post_validate() warning.
+        env = Environment()
+        for collection_name in ds:
+            if is_template(collection_name, env):
+                display.warning('"collections" is not templatable, but we found: %s, '
+                                'it will not be templated and will be used "as is".' % (collection_name))
+
 
         return ds

--- a/lib/ansible/playbook/collectionsearch.py
+++ b/lib/ansible/playbook/collectionsearch.py
@@ -55,5 +55,4 @@ class CollectionSearch:
                 display.warning('"collections" is not templatable, but we found: %s, '
                                 'it will not be templated and will be used "as is".' % (collection_name))
 
-
         return ds

--- a/lib/ansible/playbook/collectionsearch.py
+++ b/lib/ansible/playbook/collectionsearch.py
@@ -7,6 +7,10 @@ __metaclass__ = type
 from ansible.module_utils.six import string_types
 from ansible.playbook.attribute import FieldAttribute
 from ansible.utils.collection_loader import AnsibleCollectionLoader
+from ansible.template import is_template, Environment
+from ansible.utils.display import Display
+
+display = Display()
 
 
 def _ensure_default_collection(collection_list=None):
@@ -32,9 +36,18 @@ def _ensure_default_collection(collection_list=None):
 class CollectionSearch:
 
     # this needs to be populated before we can resolve tasks/roles/etc
-    _collections = FieldAttribute(isa='list', listof=string_types, priority=100, default=_ensure_default_collection)
+    _collections = FieldAttribute(isa='list', listof=string_types, priority=100, default=_ensure_default_collection,
+                                  always_post_validate=True, static=True)
 
     def _load_collections(self, attr, ds):
+        # This duplicates static attr checking logic from post_validate()
+        # because if the user attempts to template a collection name, it will
+        # error before it ever gets to the post_validate() warning.
+        for collection_name in ds:
+            if is_template(collection_name, Environment()):
+                display.warning('"collections" is not templatable, but we found: %s, '
+                                'it will not be templated and will be used "as is".' % (collection_name))
+
         # this will only be called if someone specified a value; call the shared value
         _ensure_default_collection(collection_list=ds)
 

--- a/test/units/playbook/test_collectionsearch.py
+++ b/test/units/playbook/test_collectionsearch.py
@@ -19,21 +19,20 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.playbook.collectionsearch import CollectionSearch
-from ansible.module_utils._text import to_bytes, to_native, to_text
-from ansible.utils.display import Display
-from units.compat.mock import MagicMock
+
+import pytest
 
 
-def test_collection_static_warning(monkeypatch):
-    mock_display = MagicMock()
-    monkeypatch.setattr(Display, 'display', mock_display)
+def test_collection_static_warning(capsys):
+    """Test that collection name is not templated.
+
+    Also, make sure that users see the warning message for the referenced name.
+    """
 
     collection_name = 'foo.{{bar}}'
     cs = CollectionSearch()
     assert collection_name in cs._load_collections(None, [collection_name])
 
-    assert mock_display.call_count == 1
-    actual_warn = ' '.join(mock_display.mock_calls[0][1][0].split('\n'))
-    expected_warn = '"collections" is not templatable, but we found: %s' \
-        % to_text(collection_name)
-    assert expected_warn in actual_warn
+    std_out, std_err = capsys.readouterr()
+    assert '[WARNING]: "collections" is not templatable, but we found: %s' % collection_name in std_err
+    assert '' == std_out

--- a/test/units/playbook/test_collectionsearch.py
+++ b/test/units/playbook/test_collectionsearch.py
@@ -1,0 +1,42 @@
+# (c) 2020 Ansible Project
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from units.compat import unittest
+from ansible.playbook.collectionsearch import CollectionSearch
+from units.compat.mock import patch
+
+
+class TestCollectionSearch(unittest.TestCase):
+
+    @patch('ansible.utils.display.Display.display')
+    def test_collection_static_warning(self, mock_display):
+        '''
+        Test that collection name is not templated and a warning message is
+        generated for the referenced name.
+        '''
+        cs = CollectionSearch()
+        self.assertIn(
+            'foo.{{bar}}',
+            cs._load_collections(None, ['foo.{{bar}}'])
+        )
+        self.assertEqual(mock_display.call_count, 1)
+        self.assertIn(
+            '[WARNING]: "collections" is not templatable, but we found: foo.{{bar}}',
+            mock_display.call_args[0][0])


### PR DESCRIPTION
Templating of collection names does not work at all. Force them to
be static so that a warning is generated for the user.

##### SUMMARY

Attempting to template a collection name within a playbook results in any of the collection roles/modules/etc not being found and generates an error. This will force the collection to be a static attribute, disallowing templating, and generating a warning message for the user.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

collections

##### ADDITIONAL INFORMATION

Closes #68704
