### PR TITLE
[stable-2.9] Always set the discovered interpreter on the delegated host (#64906)

### DIFF
--- a/changelogs/fragments/64906-always-delegate-fact-prefixes.yml
+++ b/changelogs/fragments/64906-always-delegate-fact-prefixes.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- Fact Delegation - Add ability to indicate which facts must always be delegated. Primarily
+  for ``discovered_interpreter_python`` right now, but extensible later.
+  (https://github.com/ansible/ansible/issues/61002)


### PR DESCRIPTION
* Always set the discovered interpreter on the delegated host. Fixes #63180

* Make code a little more generic

* Move code into a function

* Implement some changes based on reviews

* Add changelog fragment
(cherry picked from commit 123c624)

Backport of #64906

Co-authored-by: Matt Martz <matt@sivel.net>