### PR TITLE
Make `ansible-test units` only pass --strict-markers when on a pytest version that supports it

### DIFF
--- a/test/lib/ansible_test/_data/pytestcheck.py
+++ b/test/lib/ansible_test/_data/pytestcheck.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+"""Show pyyaml version."""
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+try:
+    import pytest
+except ImportError:
+    pytest = None
+
+print(json.dumps(dict(
+    pytest_version=pytest.__version__ if pytest else None,
+)))

--- a/test/lib/ansible_test/_data/pytestcheck.py
+++ b/test/lib/ansible_test/_data/pytestcheck.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Show pyyaml version."""
+"""Show pytest version."""
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 

--- a/test/lib/ansible_test/_internal/units/__init__.py
+++ b/test/lib/ansible_test/_internal/units/__init__.py
@@ -140,6 +140,8 @@ def command_units(args):
             pytest_version = get_pytest_version(args, version)
             if pytest_version and pytest_version >= (4, 5, 0):
                 cmd.append('--strict-markers')
+            else:
+                display.warning("Unable to check pytest markers with '--strict-markers' because pytest version is less than 4.5.0. Consider upgrading pytest.")
 
         plugins = []
 

--- a/test/lib/ansible_test/_internal/units/__init__.py
+++ b/test/lib/ansible_test/_internal/units/__init__.py
@@ -5,6 +5,7 @@ __metaclass__ = type
 import json
 import os
 import sys
+
 from .. import types as t
 
 from ..util import (
@@ -60,7 +61,6 @@ def get_pytest_version(args, python_version):  # type: (EnvironmentConfig, str) 
     """
     Returns the version of pytest if available, otherwise returns None.
     """
-
     python = find_python(python_version)
 
     stdout, _dummy = run_command(


### PR DESCRIPTION
##### SUMMARY

What the title says.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

ansible-test