### PR TITLE
Add a flag to disable --strict-markers being passed to pytest in `ansible-test units`

### DIFF
--- a/test/lib/ansible_test/_internal/cli.py
+++ b/test/lib/ansible_test/_internal/cli.py
@@ -492,6 +492,10 @@ def parse_args():
                        choices=('only', 'skip'),
                        help=argparse.SUPPRESS)
 
+    units.add_argument('--disable-strict-markers',
+                       action='store_true',
+                       help='do not pass --strict-markers in calls to pytest')
+
     add_extra_docker_options(units, integration=False)
 
     sanity = subparsers.add_parser('sanity',

--- a/test/lib/ansible_test/_internal/config.py
+++ b/test/lib/ansible_test/_internal/config.py
@@ -329,6 +329,7 @@ class UnitsConfig(TestConfig):
 
         self.collect_only = args.collect_only  # type: bool
         self.num_workers = args.num_workers  # type: int
+        self.disable_strict_markers = args.disable_strict_markers  # type: bool
 
         self.requirements_mode = args.requirements_mode if 'requirements_mode' in args else ''
 

--- a/test/lib/ansible_test/_internal/units/__init__.py
+++ b/test/lib/ansible_test/_internal/units/__init__.py
@@ -108,8 +108,8 @@ def command_units(args):
         if not data_context().content.collection:
             cmd.append('--durations=25')
 
-        if version != '2.6':
-            # added in pytest 4.5.0, which requires python 2.7+
+        # added in pytest 4.5.0, which requires python 2.7+
+        if version != '2.6' and not args.disable_strict_markers:
             cmd.append('--strict-markers')
 
         plugins = []


### PR DESCRIPTION
##### SUMMARY

Possible alternative approach to #68734

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

`ansible-test units`