### PR TITLE
[WIP] Reduce memory use with fetch and slurp

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2090,12 +2090,11 @@ class AnsibleModule(object):
                                    (filename, algorithm, ', '.join(AVAILABLE_HASH_ALGORITHMS)))
 
         blocksize = 64 * 1024
-        infile = open(os.path.realpath(b_filename), 'rb')
-        block = infile.read(blocksize)
-        while block:
-            digest_method.update(block)
-            block = infile.read(blocksize)
-        infile.close()
+        with open(os.path.realpath(b_filename), 'rb') as f:
+            block = f.read(blocksize)
+            while block:
+                digest_method.update(block)
+                block = f.read(blocksize)
         return digest_method.hexdigest()
 
     def md5(self, filename):

--- a/lib/ansible/modules/net_tools/basics/slurp.py
+++ b/lib/ansible/modules/net_tools/basics/slurp.py
@@ -77,13 +77,23 @@ MAXBINSIZE = (MAXLINESIZE//4)*3
 
 
 def b64encode_and_checksum(filename, output):
+    '''Read and base64 encode small blocks of a file,
+    while also calculating the sha1 sum of the data
+
+    This code is inspired by ``base64.encode``
+
+    :arg filename: Filename to be read, encoded, and hashed
+    :arg output: File handle to stream base64 encoded data to
+    :return: sha1 checksum
+    '''
+
     digest = hashlib.sha1()
-    with open(filename, 'rb') as f:
-        for block in iter(partial(f.read, MAXBINSIZE), b''):
+    with open(to_bytes(filename, errors='surrogate_or_strict'), 'rb') as f:
+        for b_block in iter(partial(f.read, MAXBINSIZE), b''):
             output.write(
-                binascii.b2a_base64(block)
+                binascii.b2a_base64(b_block)
             )
-            digest.update(block)
+            digest.update(b_block)
     return digest.hexdigest()
 
 

--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -17,8 +17,9 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import os
 import binascii
+import io
+import os
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes
@@ -122,6 +123,13 @@ class ActionModule(ActionBase):
                     return result
                 else:
                     remote_checksum = slurpres.get('checksum')
+                    if remote_checksum is None:
+                        # Backwards compat for any slurp override that doesn't
+                        # include a checksum in return data
+                        with io.BytesIO() as f:
+                            b64decode(slurpres['content'], f)
+                            remote_checksum = checksum_s(f.getvalue())
+
                     # the source path may have been expanded on the
                     # target system, so we compare it here and use the
                     # expanded version if it's different

--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -36,6 +36,18 @@ MAXLINESIZE = 76  # Excluding the CRLF
 
 
 def b64decode(data, output):
+    '''Read a string in 76 character max blocks, and decode
+    to prevent decoding the full string from base64 and then
+    writing to a file. This will stream smaller blocks directly
+    to a file
+
+    This code is inspired by ``base64.decode``
+
+    :arg data: ascii base64 string
+    :arg output: File handle to write base64 decoded data to
+    :returns: None
+    '''
+
     # Determine if the base64 data is CRLF separated
     # The matched version of slurp will, but do this to be
     # careful


### PR DESCRIPTION
##### SUMMARY
This PR attempts a few things:

1. Use context managers to open files in a few locations
1. Where possible, don't keep multiple copies of the file in memory
1. Don't assume because we use become that a non-become user (scp/sftp/dd) cannot access the file. As such, don't run `stat` with become, so we know whether `slurp` is actually required.
1. Have `slurp` return the checksum of the data, so we don't have to use the data on the controller to calculate it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
```
lib/ansible/module_utils/basic.py
lib/ansible/modules/net_tools/basics/slurp.py
lib/ansible/plugins/action/__init__.py
lib/ansible/plugins/action/fetch.py
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
