### PR TITLE
Fix ansible-test submodule handling.

### DIFF
--- a/changelogs/fragments/ansible-test-env-list-files.yml
+++ b/changelogs/fragments/ansible-test-env-list-files.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - ansible-test now has a ``--list-files`` option to list files using the ``env`` command.

--- a/changelogs/fragments/ansible-test-git-submodule-top-level.yml
+++ b/changelogs/fragments/ansible-test-git-submodule-top-level.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now supports submodules using older ``git`` versions which require querying status from the top level directory of the repo.

--- a/changelogs/fragments/ansible-test-nested-source-control.yml
+++ b/changelogs/fragments/ansible-test-nested-source-control.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test now ignores version control within subdirectories of collections. Previously this condition was an error.

--- a/changelogs/fragments/ansible-test-submodule-dir-as-file.yml
+++ b/changelogs/fragments/ansible-test-submodule-dir-as-file.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - ansible-test no longer detects ``git`` submodule directories as files.

--- a/test/integration/targets/ansible-test/collection-tests/git-at-collection-base.sh
+++ b/test/integration/targets/ansible-test/collection-tests/git-at-collection-base.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+
+export GIT_TOP_LEVEL SUBMODULE_DST
+
+GIT_TOP_LEVEL="${WORK_DIR}/super/ansible_collections/ns/col"
+SUBMODULE_DST="sub"
+
+source collection-tests/git-common.bash

--- a/test/integration/targets/ansible-test/collection-tests/git-at-collection-root.sh
+++ b/test/integration/targets/ansible-test/collection-tests/git-at-collection-root.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+
+export GIT_TOP_LEVEL SUBMODULE_DST
+
+GIT_TOP_LEVEL="${WORK_DIR}/super"
+SUBMODULE_DST="ansible_collections/ns/col/sub"
+
+source collection-tests/git-common.bash

--- a/test/integration/targets/ansible-test/collection-tests/git-common.bash
+++ b/test/integration/targets/ansible-test/collection-tests/git-common.bash
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+
+# make sure git is installed
+git --version || ansible-playbook collection-tests/install-git.yml -i ../../inventory "$@"
+
+# init sub project
+mkdir "${WORK_DIR}/sub"
+cd "${WORK_DIR}/sub"
+touch "README.md"
+git init
+git config user.name 'Ansible Test'
+git config user.email 'ansible-test@ansible.com'
+git add "README.md"
+git commit -m "Initial commit."
+
+# init super project
+rm -rf "${WORK_DIR}/super" # needed when re-creating in place
+mkdir "${WORK_DIR}/super"
+cp -a "${TEST_DIR}/ansible_collections" "${WORK_DIR}/super"
+cd "${GIT_TOP_LEVEL}"
+git init
+
+# add submodule
+git submodule add "${WORK_DIR}/sub" "${SUBMODULE_DST}"
+
+# prepare for tests
+expected="${WORK_DIR}/expected.txt"
+actual="${WORK_DIR}/actual.txt"
+cd "${WORK_DIR}/super/ansible_collections/ns/col"
+mkdir tests/.git
+touch tests/.git/keep.txt  # make sure ansible-test correctly ignores version control within collection subdirectories
+find . -type f ! -path '*/.git/*' ! -name .git | sed 's|^\./||' | sort >"${expected}"
+set -x
+
+# test at the collection base
+ansible-test env --list-files | sort >"${actual}"
+diff --unified "${expected}" "${actual}"
+
+# test at the submodule base
+(cd sub && ansible-test env --list-files | sort >"${actual}")
+diff --unified "${expected}" "${actual}"

--- a/test/integration/targets/ansible-test/collection-tests/install-git.yml
+++ b/test/integration/targets/ansible-test/collection-tests/install-git.yml
@@ -1,0 +1,5 @@
+- hosts: localhost
+  tasks:
+    - name: Make sure git is installed
+      package:
+        name: git

--- a/test/integration/targets/ansible-test/collection-tests/venv.sh
+++ b/test/integration/targets/ansible-test/collection-tests/venv.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+
+cp -a "${TEST_DIR}/ansible_collections" "${WORK_DIR}"
+cd "${WORK_DIR}/ansible_collections/ns/col"
+
+# common args for all tests
+common=(--venv --python "${ANSIBLE_TEST_PYTHON_VERSION}" --color --truncate 0 "${@}")
+
+# prime the venv to work around issue with PyYAML detection in ansible-test
+ansible-test sanity "${common[@]}" --test ignores
+
+# tests
+ansible-test sanity "${common[@]}"
+ansible-test units "${common[@]}"
+ansible-test integration "${common[@]}"

--- a/test/lib/ansible_test/_internal/cli.py
+++ b/test/lib/ansible_test/_internal/cli.py
@@ -636,6 +636,10 @@ def parse_args():
                      action='store_true',
                      help='dump environment to disk')
 
+    env.add_argument('--list-files',
+                     action='store_true',
+                     help='list files on stdout')
+
     # noinspection PyTypeChecker
     env.add_argument('--timeout',
                      type=int,

--- a/test/lib/ansible_test/_internal/env.py
+++ b/test/lib/ansible_test/_internal/env.py
@@ -31,6 +31,7 @@ from .util import (
 )
 
 from .util_common import (
+    data_context,
     write_json_test_results,
     ResultType,
 )
@@ -72,8 +73,9 @@ class EnvConfig(CommonConfig):
         self.show = args.show
         self.dump = args.dump
         self.timeout = args.timeout
+        self.list_files = args.list_files
 
-        if not self.show and not self.dump and self.timeout is None:
+        if not self.show and not self.dump and self.timeout is None and not self.list_files:
             # default to --show if no options were given
             self.show = True
 
@@ -83,6 +85,7 @@ def command_env(args):
     :type args: EnvConfig
     """
     show_dump_env(args)
+    list_files_env(args)
     set_timeout(args)
 
 
@@ -128,6 +131,15 @@ def show_dump_env(args):
 
     if args.dump and not args.explain:
         write_json_test_results(ResultType.BOT, 'data-environment.json', data)
+
+
+def list_files_env(args):  # type: (EnvConfig) -> None
+    """List files on stdout."""
+    if not args.list_files:
+        return
+
+    for path in data_context().content.all_files():
+        display.info(path)
 
 
 def set_timeout(args):

--- a/test/lib/ansible_test/_internal/provider/source/git.py
+++ b/test/lib/ansible_test/_internal/provider/source/git.py
@@ -14,6 +14,10 @@ from ...encoding import (
     to_bytes,
 )
 
+from ...util import (
+    SubprocessError,
+)
+
 from . import (
     SourceProvider,
 )
@@ -28,11 +32,23 @@ class GitSource(SourceProvider):
 
     def get_paths(self, path):  # type: (str) -> t.List[str]
         """Return the list of available content paths under the given path."""
-        git = Git(path)
-
         paths = self.__get_paths(path)
 
-        submodule_paths = git.get_submodule_paths()
+        try:
+            submodule_paths = Git(path).get_submodule_paths()
+        except SubprocessError:
+            if path == self.root:
+                raise
+
+            # older versions of git require submodule commands to be executed from the top level of the working tree
+            # git version 2.18.1 (centos8) does not have this restriction
+            # git version 1.8.3.1 (centos7) does
+            # fall back to using the top level directory of the working tree only when needed
+            # this avoids penalizing newer git versions with a potentially slower analysis due to additional submodules
+            rel_path = os.path.relpath(path, self.root) + os.path.sep
+
+            submodule_paths = Git(self.root).get_submodule_paths()
+            submodule_paths = [os.path.relpath(p, rel_path) for p in submodule_paths if p.startswith(rel_path)]
 
         for submodule_path in submodule_paths:
             paths.extend(os.path.join(submodule_path, p) for p in self.__get_paths(os.path.join(path, submodule_path)))

--- a/test/lib/ansible_test/_internal/provider/source/git.py
+++ b/test/lib/ansible_test/_internal/provider/source/git.py
@@ -53,6 +53,9 @@ class GitSource(SourceProvider):
         for submodule_path in submodule_paths:
             paths.extend(os.path.join(submodule_path, p) for p in self.__get_paths(os.path.join(path, submodule_path)))
 
+        # git reports submodule directories as regular files
+        paths = [p for p in paths if p not in submodule_paths]
+
         return paths
 
     @staticmethod


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test submodule handling:

* `ansible-test` now supports submodules using older `git` versions which require querying status from the top level directory of the repo.
* `ansible-test` no longer detects `git` submodule directories as files.
* `ansible-test` now ignores version control within subdirectories of collections. Previously this condition was an error.

Also added a `--list-files` option to list files using the `env` command to support testing of the fixes.

Resolves https://github.com/ansible/ansible/issues/68728

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
