### PR TITLE
true and false commands have to be quoted

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_debugger.rst
+++ b/docs/docsite/rst/user_guide/playbooks_debugger.rst
@@ -42,7 +42,7 @@ On a task
 ::
 
     - name: Execute a command
-      command: false
+      command: "false"
       debugger: on_failed
 
 On a play
@@ -55,7 +55,7 @@ On a play
       debugger: on_skipped
       tasks:
         - name: Execute a command
-          command: true
+          command: "true"
           when: False
 
 When provided at a generic level and a more specific level, the more specific wins::
@@ -65,7 +65,7 @@ When provided at a generic level and a more specific level, the more specific wi
       debugger: never
       tasks:
         - name: Execute a command
-          command: false
+          command: "false"
           debugger: on_failed
 
 


### PR DESCRIPTION
##### SUMMARY

otherwise they will be parsed as bool instead of string by YAML.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

https://docs.ansible.com/ansible/latest/user_guide/playbooks_debugger.html

##### ADDITIONAL INFORMATION

Without the change, the following error is reported:

```
ERROR! unexpected parameter type in action: <class 'bool'>
```
