### PR TITLE
Add configurable option for paramiko auth timeout

### DIFF
--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -125,6 +125,17 @@ DOCUMENTATION = """
         ini:
           - section: defaults
             key: use_persistent_connections
+      auth_timeout:
+        type: float
+        default: 5.0
+        description:
+          - Configures, in seconds, the amount of time to wait for the authentication
+            to be successful.
+        ini:
+          - section: paramiko_connection
+            key: auth_timeout
+        env:
+          - name: ANSIBLE_PARAMIKO_AUTH_TIMEOUT
 # TODO:
 #timeout=self._play_context.timeout,
 """
@@ -347,6 +358,7 @@ class Connection(ConnectionBase):
                 password=self._play_context.password,
                 timeout=self._play_context.timeout,
                 port=port,
+                auth_timeout=self.get_option('auth_timeout'),
                 **ssh_connect_kwargs
             )
         except paramiko.ssh_exception.BadHostKeyException as e:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes vyos integration test failure due to auth timeout
https://github.com/ansible-collections/vyos.vyos/pull/13/checks?check_run_id=566639558

The default auth timeout in paramiko connection plugin is set to 5
seconds.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
paramiko_ssh
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
