### PR TITLE
Increase network integration test auth timeout

### DIFF
--- a/test/integration/network-integration.cfg
+++ b/test/integration/network-integration.cfg
@@ -3,6 +3,7 @@
 
 [defaults]
 host_key_checking = False
+timeout = 30
 
 [ssh_connection]
 ssh_args = '-o UserKnownHostsFile=/dev/null'


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Bump auth timeout for network integration test to 30 seconds
to resolve vyos test failue `Authentication timeout.`
https://github.com/ansible-collections/vyos.vyos/pull/13/checks?check_run_id=566639558
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test/integration/network-integration.cfg

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
