### PR TITLE
Update tests to use RHEL 7.8.

### DIFF
--- a/changelogs/fragments/ansible-test-rhel-7.8.yml
+++ b/changelogs/fragments/ansible-test-rhel-7.8.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - ansible-test now supports testing against RHEL 7.8 when using the ``--remote`` option.

--- a/shippable.yml
+++ b/shippable.yml
@@ -29,7 +29,7 @@ matrix:
 
     - env: T=aix/7.2/1
     - env: T=osx/10.11/1
-    - env: T=rhel/7.6/1
+    - env: T=rhel/7.8/1
     - env: T=rhel/8.1/1
     - env: T=freebsd/11.1/1
     - env: T=freebsd/12.1/1
@@ -45,7 +45,7 @@ matrix:
 
     - env: T=aix/7.2/2
     - env: T=osx/10.11/2
-    - env: T=rhel/7.6/2
+    - env: T=rhel/7.8/2
     - env: T=rhel/8.1/2
     - env: T=freebsd/11.1/2
     - env: T=freebsd/12.1/2
@@ -61,7 +61,7 @@ matrix:
 
     - env: T=aix/7.2/3
     - env: T=osx/10.11/3
-    - env: T=rhel/7.6/3
+    - env: T=rhel/7.8/3
     - env: T=rhel/8.1/3
     - env: T=freebsd/11.1/3
     - env: T=freebsd/12.1/3
@@ -77,7 +77,7 @@ matrix:
 
     - env: T=aix/7.2/4
     - env: T=osx/10.11/4
-    - env: T=rhel/7.6/4
+    - env: T=rhel/7.8/4
     - env: T=rhel/8.1/4
     - env: T=freebsd/11.1/4
     - env: T=freebsd/12.1/4
@@ -93,7 +93,7 @@ matrix:
 
     - env: T=aix/7.2/5
     - env: T=osx/10.11/5
-    - env: T=rhel/7.6/5
+    - env: T=rhel/7.8/5
     - env: T=rhel/8.1/5
     - env: T=freebsd/11.1/5
     - env: T=freebsd/12.1/5
@@ -112,7 +112,7 @@ matrix:
 
     - env: T=i/aix/7.2
     - env: T=i/osx/10.11
-    - env: T=i/rhel/7.6
+    - env: T=i/rhel/7.8
     - env: T=i/rhel/8.1
     - env: T=i/freebsd/11.1
     - env: T=i/freebsd/12.1

--- a/test/integration/targets/incidental_setup_docker/tasks/RedHat-7.yml
+++ b/test/integration/targets/incidental_setup_docker/tasks/RedHat-7.yml
@@ -12,7 +12,8 @@
     name: setup_epel
 
 - name: Enable extras repository for RHEL on AWS
-  command: yum-config-manager --enable rhui-REGION-rhel-server-extras
+  # RHEL 7.6 uses rhui-REGION-rhel-server-extras and RHEL 7.7+ use rhui-rhel-7-server-rhui-extras-rpms
+  command: yum-config-manager --enable rhui-REGION-rhel-server-extras rhui-rhel-7-server-rhui-extras-rpms
   args:
     warn: no
 

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -2,5 +2,6 @@ freebsd/11.1 python=2.7,3.6 python_dir=/usr/local/bin
 freebsd/12.1 python=3.6,2.7 python_dir=/usr/local/bin
 osx/10.11 python=2.7 python_dir=/usr/local/bin
 rhel/7.6 python=2.7
+rhel/7.8 python=2.7
 rhel/8.1 python=3.6
 aix/7.2 python=2.7 httptester=disabled temp-unicode=disabled pip-check=disabled


### PR DESCRIPTION
##### SUMMARY

Update tests to use RHEL 7.8.

Keeping support for RHEL 7.6 since collections are still using it.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
