### PR TITLE
Fix wrong parameter name in example

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_workflow_launch.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_workflow_launch.py
@@ -60,7 +60,7 @@ job_info:
 EXAMPLES = '''
 - name: Launch a workflow
   tower_workflow_launch:
-    name: "Test Workflow"
+    workflow_template: "Test Workflow"
   delegate_to: localhost
   run_once: true
   register: workflow_results


### PR DESCRIPTION
Changed from name to workflow_template (the right parameter name)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Change the example of use where was used a wrong parameter (name instead of workflow_template
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

tower_workflow_launch

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
