### PR TITLE
url_windows - Add not around no redirection for auth headers

### DIFF
--- a/lib/ansible/plugins/doc_fragments/url_windows.py
+++ b/lib/ansible/plugins/doc_fragments/url_windows.py
@@ -24,6 +24,8 @@ options:
     - C(safe) will follow only "safe" redirects, where "safe" means that the
       client is only doing a C(GET) or C(HEAD) on the URI to which it is being
       redirected.
+    - When following a redirected URL, the C(Authorization) header and any
+      credentials set will be dropped and not redirected.
     choices:
     - all
     - none


### PR DESCRIPTION
##### SUMMARY
The Windows WebRequest code does not preserve the `Authorization` header (including explicit credentials) when encountering a redirect. This is a behaviour of the underlying library and it does not expose a simple way to control this behaviour so we will just document the behaviour.

Fixes https://github.com/ansible/ansible/issues/68771

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
url_windows.py