### PR TITLE
Replace the use of the function string.replace with the method str.replace

### DIFF
--- a/changelogs/fragments/bsd_rcconf_string_replace.yaml
+++ b/changelogs/fragments/bsd_rcconf_string_replace.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- service - Fix for the BSD rcconf code using a Python 2 specific string replace function

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -1116,7 +1116,7 @@ class DragonFlyBsdService(FreeBsdService):
             if os.path.isfile(rcfile):
                 self.rcconf_file = rcfile
 
-        self.rcconf_key = "%s" % string.replace(self.name, "-", "_")
+        self.rcconf_key = "%s" % self.name.replace("-", "_")
 
         return self.service_enable_rcconf()
 
@@ -1274,7 +1274,7 @@ class NetBsdService(Service):
     """
     This is the NetBSD Service manipulation class - it uses the /etc/rc.conf
     file for controlling services started at boot, check status and perform
-    direct service manipulation. Init scripts in /etc/rcd are used for
+    direct service manipulation. Init scripts in /etc/rc.d are used for
     controlling services (start/stop) as well as for controlling the current
     state.
     """
@@ -1304,7 +1304,7 @@ class NetBsdService(Service):
             if os.path.isfile(rcfile):
                 self.rcconf_file = rcfile
 
-        self.rcconf_key = "%s" % string.replace(self.name, "-", "_")
+        self.rcconf_key = "%s" % self.name.replace("-", "_")
 
         return self.service_enable_rcconf()
 

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -418,7 +418,7 @@ class Service(object):
 
             # Write out the contents of the list into our temporary file.
             for rcline in new_rc_conf:
-                os.write(TMP_RCCONF, rcline)
+                os.write(TMP_RCCONF, rcline.encode())
 
             # Close temporary file.
             os.close(TMP_RCCONF)

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -135,7 +135,6 @@ import platform
 import re
 import select
 import shlex
-import string
 import subprocess
 import tempfile
 import time


### PR DESCRIPTION
##### SUMMARY
Python 3 no longer has the module function `string.replace`, but it still shares the `str` method `replace` with Python 2. This PR replaces both uses of `string.replace()` in the Ansible source code with `str.replace()`. 

I also fixed a typo in a nearby comment.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
service

##### ADDITIONAL INFORMATION
A couple of bits of code for managing BSD rc.conf style service configuration files still used the obsolete `string.replace()` function.

I have successfully tested this with the following trivial playbook
```
- hosts: fog
  tasks:
  - name: NTP service
    service:
      name: ntpd
      enabled: yes
```