### PR TITLE
[stable-2.8] Update tests to use RHEL 7.8. (#68787)

### DIFF
--- a/changelogs/fragments/ansible-test-rhel-7.8.yml
+++ b/changelogs/fragments/ansible-test-rhel-7.8.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - ansible-test now supports testing against RHEL 7.8 when using the ``--remote`` option.

--- a/shippable.yml
+++ b/shippable.yml
@@ -65,7 +65,7 @@ matrix:
     - env: T=network
 
     - env: T=osx/10.11/1
-    - env: T=rhel/7.6/1
+    - env: T=rhel/7.8/1
     - env: T=rhel/8.1/1
     - env: T=freebsd/11.1/1
     - env: T=freebsd/12.0/1
@@ -79,7 +79,7 @@ matrix:
     - env: T=linux/ubuntu1804/1
 
     - env: T=osx/10.11/2
-    - env: T=rhel/7.6/2
+    - env: T=rhel/7.8/2
     - env: T=rhel/8.1/2
     - env: T=freebsd/11.1/2
     - env: T=freebsd/12.0/2
@@ -93,7 +93,7 @@ matrix:
     - env: T=linux/ubuntu1804/2
 
     - env: T=osx/10.11/3
-    - env: T=rhel/7.6/3
+    - env: T=rhel/7.8/3
     - env: T=rhel/8.1/3
     - env: T=freebsd/11.1/3
     - env: T=freebsd/12.0/3
@@ -107,7 +107,7 @@ matrix:
     - env: T=linux/ubuntu1804/3
 
     - env: T=osx/10.11/4
-    - env: T=rhel/7.6/4
+    - env: T=rhel/7.8/4
     - env: T=rhel/8.1/4
     - env: T=freebsd/11.1/4
     - env: T=freebsd/12.0/4

--- a/test/integration/targets/setup_docker/tasks/RedHat-7.yml
+++ b/test/integration/targets/setup_docker/tasks/RedHat-7.yml
@@ -11,7 +11,8 @@
     name: setup_epel
 
 - name: Enable extras repository for RHEL on AWS
-  command: yum-config-manager --enable rhui-REGION-rhel-server-extras
+  # RHEL 7.6 uses rhui-REGION-rhel-server-extras and RHEL 7.7+ use rhui-rhel-7-server-rhui-extras-rpms
+  command: yum-config-manager --enable rhui-REGION-rhel-server-extras rhui-rhel-7-server-rhui-extras-rpms
   args:
     warn: no
 

--- a/test/runner/completion/remote.txt
+++ b/test/runner/completion/remote.txt
@@ -2,4 +2,5 @@ freebsd/11.1 python=2.7,3.6 python_dir=/usr/local/bin
 freebsd/12.0 python=3.6,2.7 python_dir=/usr/local/bin
 osx/10.11 python=2.7 python_dir=/usr/local/bin
 rhel/7.6 python=2.7
+rhel/7.8 python=2.7
 rhel/8.1 python=3.6


### PR DESCRIPTION
##### SUMMARY

[stable-2.8] Update tests to use RHEL 7.8. (#68787)

Backport of https://github.com/ansible/ansible/pull/68787

(cherry picked from commit 04edd77c4273b321867c0f08d6ff2b67dacfcf2d)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
