### PR TITLE
[2.9] VMware: Fix cluster argument of module vmware_content_deploy_template

### DIFF
--- a/changelogs/fragments/65715-vmware-content-deploy-template-fix-cluster.yml
+++ b/changelogs/fragments/65715-vmware-content-deploy-template-fix-cluster.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "`vmware_content_deploy_template`'s `cluster` argument no longer fails with an error message about resource pools."

--- a/lib/ansible/modules/cloud/vmware/vmware_content_deploy_template.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_content_deploy_template.py
@@ -188,7 +188,7 @@ class VmwareContentDeployTemplate(VmwareRestClient):
         # Find the Cluster by the given Cluster name
         self.cluster_id = None
         if self.cluster:
-            self.cluster_id = self.get_resource_pool_by_name(self.datacenter, self.resourcepool)
+            self.cluster_id = self.get_cluster_by_name(self.datacenter, self.cluster)
             if not self.cluster_id:
                 self.module.fail_json(msg="Failed to find the Cluster %s" % self.cluster)
         # Create VM placement specs


### PR DESCRIPTION
##### SUMMARY

(cherry picked from commit 98f19c970fe0533de0dc8938eda713c838617945)

Signed-off-by: gp <gp@gparent.net>
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

Backport of #65715

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/65715-vmware-content-deploy-template-fix-cluster.yml
lib/ansible/modules/cloud/vmware/vmware_content_deploy_template.py
