### PR TITLE
Fix label lookup in the default callback for includes

### DIFF
--- a/changelogs/fragments/65904-fix-loop-label.yml
+++ b/changelogs/fragments/65904-fix-loop-label.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix label lookup in the default callback for includes (https://github.com/ansible/ansible/issues/65904)

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -350,8 +350,9 @@ class CallbackModule(CallbackBase):
 
     def v2_playbook_on_include(self, included_file):
         msg = 'included: %s for %s' % (included_file._filename, ", ".join([h.name for h in included_file._hosts]))
-        if 'item' in included_file._args:
-            msg += " => (item=%s)" % (self._get_item_label(included_file._args),)
+        label = self._get_item_label(included_file._vars)
+        if label:
+            msg += " => (item=%s)" % label
         self._display.display(msg, color=C.COLOR_SKIP)
 
     def v2_playbook_on_stats(self, stats):

--- a/test/integration/targets/callback_default/callback_default.out.default.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.default.stdout
@@ -42,6 +42,14 @@ fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed as requested fro
 TASK [Rescue task] *************************************************************
 changed: [testhost]
 
+TASK [include_tasks] ***********************************************************
+included: .../test/integration/targets/callback_default/include_me.yml for testhost => (item=1)
+
+TASK [debug] *******************************************************************
+ok: [testhost] => {
+    "item": 1
+}
+
 RUNNING HANDLER [Test handler 1] ***********************************************
 changed: [testhost]
 
@@ -60,5 +68,5 @@ TASK [Second free task] ********************************************************
 changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+testhost                   : ok=14   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stdout
@@ -39,6 +39,14 @@ TASK [EXPECTED FAILURE Failed task to be rescued] ******************************
 TASK [Rescue task] *************************************************************
 changed: [testhost]
 
+TASK [include_tasks] ***********************************************************
+included: .../test/integration/targets/callback_default/include_me.yml for testhost => (item=1)
+
+TASK [debug] *******************************************************************
+ok: [testhost] => {
+    "item": 1
+}
+
 RUNNING HANDLER [Test handler 1] ***********************************************
 changed: [testhost]
 
@@ -57,5 +65,5 @@ TASK [Second free task] ********************************************************
 changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+testhost                   : ok=14   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_ok.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_ok.stdout
@@ -35,6 +35,7 @@ fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed as requested fro
 
 TASK [Rescue task] *************************************************************
 changed: [testhost]
+included: .../test/integration/targets/callback_default/include_me.yml for testhost => (item=1)
 
 RUNNING HANDLER [Test handler 1] ***********************************************
 changed: [testhost]
@@ -51,5 +52,5 @@ TASK [Second free task] ********************************************************
 changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+testhost                   : ok=14   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_skipped.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_skipped.stdout
@@ -37,6 +37,12 @@ fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed as requested fro
 
 TASK [Rescue task] *************************************************************
 changed: [testhost]
+included: .../test/integration/targets/callback_default/include_me.yml for testhost => (item=1)
+
+TASK [debug] *******************************************************************
+ok: [testhost] => {
+    "item": 1
+}
 
 RUNNING HANDLER [Test handler 1] ***********************************************
 changed: [testhost]
@@ -56,5 +62,5 @@ TASK [Second free task] ********************************************************
 changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+testhost                   : ok=14   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok.stdout
@@ -31,6 +31,7 @@ fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed as requested fro
 
 TASK [Rescue task] *************************************************************
 changed: [testhost]
+included: .../test/integration/targets/callback_default/include_me.yml for testhost => (item=1)
 
 RUNNING HANDLER [Test handler 1] ***********************************************
 changed: [testhost]
@@ -47,5 +48,5 @@ TASK [Second free task] ********************************************************
 changed: [testhost]
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+testhost                   : ok=14   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/include_me.yml
+++ b/test/integration/targets/callback_default/include_me.yml
@@ -1,0 +1,2 @@
+- debug:
+    var: item

--- a/test/integration/targets/callback_default/runme.sh
+++ b/test/integration/targets/callback_default/runme.sh
@@ -23,6 +23,7 @@ run_test() {
 		2> >(set +x; tee "${OUTFILE}.${testname}.stderr" >&2)
 	# Scrub deprication warning that shows up in Python 2.6 on CentOS 6
 	sed -i -e '/RandomPool_DeprecationWarning/d' "${OUTFILE}.${testname}.stderr"
+    sed -i -e 's/included: .*\/test\/integration/included: ...\/test\/integration/g' "${OUTFILE}.${testname}.stdout"
 
 	diff -u "${ORIGFILE}.${testname}.stdout" "${OUTFILE}.${testname}.stdout" || diff_failure
 	diff -u "${ORIGFILE}.${testname}.stderr" "${OUTFILE}.${testname}.stderr" || diff_failure
@@ -143,6 +144,7 @@ run_test failed_to_stderr
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS=1
 export ANSIBLE_DISPLAY_OK_HOSTS=1
 export ANSIBLE_DISPLAY_FAILED_STDERR=1
+export ANSIBLE_TIMEOUT=1
 
 # Check if UNREACHBLE is available in stderr
 set +e

--- a/test/integration/targets/callback_default/test.yml
+++ b/test/integration/targets/callback_default/test.yml
@@ -57,6 +57,10 @@
         - name: Rescue task
           command: echo rescued
 
+    - include_tasks: include_me.yml
+      loop:
+        - 1
+
   handlers:
     - name: Test handler 1
       command: echo foo


### PR DESCRIPTION
##### SUMMARY
Fix label lookup in the default callback for includes

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/callback/default.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
