### PR TITLE
refactored to reduce block nesting to 3

### DIFF
--- a/changelogs/fragments/68825-systemd-remove-extra-ifs.yaml
+++ b/changelogs/fragments/68825-systemd-remove-extra-ifs.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - systemd.py - Removed extra if statements in parse_systemctl_show() for clarity

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -297,23 +297,22 @@ def parse_systemctl_show(lines):
     # span multiple lines.
     parsed = {}
     multival = []
-    k = None
+    key = None
     for line in lines:
-        if k is None:
-            if '=' in line:
-                k, v = line.split('=', 1)
-                if k.startswith('Exec') and v.lstrip().startswith('{'):
-                    if not v.rstrip().endswith('}'):
-                        multival.append(v)
-                        continue
-                parsed[k] = v.strip()
-                k = None
+        if key is None and '=' in line:
+            key, val = line.split('=', 1)
+            val = val.strip()
+            if key.startswith('Exec') and val.startswith('{') and not val.endswith('}'):
+                multival.append(val)
+                continue
+            parsed[key] = val
+            key = None
         else:
             multival.append(line)
             if line.rstrip().endswith('}'):
-                parsed[k] = '\n'.join(multival).strip()
+                parsed[key] = '\n'.join(multival).strip()
                 multival = []
-                k = None
+                key = None
     return parsed
 
 


### PR DESCRIPTION
##### SUMMARY
This is a basic refactoring done to reduce the block nesting of parse_systemctl_show to improve clarity and remove extra if statements.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
systemd
