### PR TITLE
Use default network in Google Cloud Platform Guide

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_gce.rst
+++ b/docs/docsite/rst/scenario_guides/guide_gce.rst
@@ -157,11 +157,11 @@ Create an instance
 The full range of GCP modules provide the ability to create a wide variety of
 GCP resources with the full support of the entire GCP API.
 
-The following playbook creates a GCE Instance. This instance relies on a GCP
-network and a Disk. By creating the Disk and Network separately, we can give as
-much detail as necessary about how we want the disk and network formatted. By
-registering a Disk/Network to a variable, we can simply insert the variable
-into the instance task. The gcp_compute_instance module will figure out the
+The following playbook creates a GCE Instance. This instance relies on other GCP
+resources like Disk. By creating other resources separately, we can give as
+much detail as necessary about how we want to configure the other resources, e.g. 
+formatting of the Disk. By registering it to a variable, we can simply insert the 
+variable into the instance task. The gcp_compute_instance module will figure out the
 rest.
 
 .. code-block:: yaml
@@ -190,16 +190,6 @@ rest.
               - https://www.googleapis.com/auth/compute
             state: present
         register: disk
-      - name: create a network
-        gcp_compute_network:
-            name: 'network-instance'
-            project: "{{ gcp_project }}"
-            auth_kind: "{{ gcp_cred_kind }}"
-            service_account_file: "{{ gcp_cred_file }}"
-            scopes:
-              - https://www.googleapis.com/auth/compute
-            state: present
-        register: network
       - name: create a address
         gcp_compute_address:
             name: 'address-instance'
@@ -221,7 +211,7 @@ rest.
                 boot: true
                 source: "{{ disk }}"
             network_interfaces:
-                - network: "{{ network }}"
+                - network: null # use default
                   access_configs:
                     - name: 'External NAT'
                       nat_ip: "{{ address }}"

--- a/docs/docsite/rst/scenario_guides/guide_gce.rst
+++ b/docs/docsite/rst/scenario_guides/guide_gce.rst
@@ -159,7 +159,7 @@ GCP resources with the full support of the entire GCP API.
 
 The following playbook creates a GCE Instance. This instance relies on other GCP
 resources like Disk. By creating other resources separately, we can give as
-much detail as necessary about how we want to configure the other resources, e.g. 
+much detail as necessary about how we want to configure the other resources, for example
 formatting of the Disk. By registering it to a variable, we can simply insert the 
 variable into the instance task. The gcp_compute_instance module will figure out the
 rest.


### PR DESCRIPTION
##### SUMMARY
The given example is not working as a SSH connection is not possible because of #59573. Instead, in this tutorial the default network should be used which allows SSH connections in most cases.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Update for the tutorial in Google Cloud Platform Guide.

##### ADDITIONAL INFORMATION
Using the default network would have saved me a lot of time figuring out why a connection to the created instance was not possible. I hope this contribution will also help others. Feel free to make adjustments to my PR (e.g. wording).