### PR TITLE
get_url pass incorrect If-Modified-Since header(#67417) (#67419)

### DIFF
--- a/changelogs/fragments/67417-get_url-incorrect-if-modified-since.yaml
+++ b/changelogs/fragments/67417-get_url-incorrect-if-modified-since.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - get_url pass incorrect If-Modified-Since header (https://github.com/ansible/ansible/issues/67417)

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1274,7 +1274,7 @@ class Request:
             request.add_header('cache-control', 'no-cache')
         # or we do it if the original is more recent than our copy
         elif last_mod_time:
-            tstamp = rfc2822_date_string(last_mod_time.timetuple())
+            tstamp = rfc2822_date_string(last_mod_time.timetuple(), 'GMT')
             request.add_header('If-Modified-Since', tstamp)
 
         # user defined headers now, which may override things we've set above

--- a/test/units/module_utils/urls/test_Request.py
+++ b/test/units/module_utils/urls/test_Request.py
@@ -415,7 +415,7 @@ def test_Request_open_last_mod(urlopen_mock, install_opener_mock):
     args = urlopen_mock.call_args[0]
     req = args[0]
 
-    assert req.headers.get('If-modified-since') == now.strftime('%a, %d %b %Y %H:%M:%S -0000')
+    assert req.headers.get('If-modified-since') == now.strftime('%a, %d %b %Y %H:%M:%S GMT')
 
 
 def test_Request_open_headers_not_dict(urlopen_mock, install_opener_mock):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport #67419 to 2.9

Fix #67417. HTTP header value of `If-Modified-Since` set by `get_url` does not follow HTTP protocol.

(cherry picked from commit 109769435549355191f57d89ea1145e3c5c938a7)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
