### PR TITLE
Get url checksum fix

### DIFF
--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -496,6 +496,7 @@ def main():
                 lines = [line.rstrip('\n') for line in f]
             os.remove(checksum_tmpsrc)
             checksum_map = {}
+            filename = url_filename(url)
             if len(lines) == 1 and len(lines[0].split()) == 1:
                 # Only a single line with a single string
                 # treat it as a checksum only file
@@ -507,7 +508,6 @@ def main():
                     parts = line.split(None, 1)
                     if len(parts) == 2:
                         checksum_map[parts[0]] = parts[1]
-            filename = url_filename(url)
 
             # Look through each line in the checksum file for a hash corresponding to
             # the filename in the url, returning the first hash that is found.

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -496,10 +496,17 @@ def main():
                 lines = [line.rstrip('\n') for line in f]
             os.remove(checksum_tmpsrc)
             checksum_map = {}
-            for line in lines:
-                parts = line.split(None, 1)
-                if len(parts) == 2:
-                    checksum_map[parts[0]] = parts[1]
+            if len(lines) == 1 and len(lines[0].split()) == 1:
+                # Only a single line with a single string
+                # treat it as a checksum only file
+                checksum_map[lines[0]] = filename
+            else:
+                # The assumption here is the file is in the format of
+                # filename checksum
+                for line in lines:
+                    parts = line.split(None, 1)
+                    if len(parts) == 2:
+                        checksum_map[parts[0]] = parts[1]
             filename = url_filename(url)
 
             # Look through each line in the checksum file for a hash corresponding to


### PR DESCRIPTION
##### SUMMARY
Adding sivel's patch for get_url checksum issue
Fixes #54390 
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
get_url

##### ADDITIONAL INFORMATION
Added and tested the change provided by @sivel . Please see the test output from a development environment with the changes and the 2.9.3 comparison. 

```
//////////////////////////////////////////////////////////////////////////////////////////////////////////Test playbook: 
[zephyr@webhost ansible]$ cat urltest.yml
---
- hosts: localhost
  gather_facts : no
  tasks:
  - name: Demo error with plain checksum file
    get_url:
      checksum: sha512:http://<redacted>/testhash.sha512
      dest: /tmp/kube-scheduler
      mode: 0755
      url: http://<redacted>/testfile.txt

	  
//////////////////////////////////////////////////////////////////////////////////////////////////////////Before: 
[zephyr@webhost ansible]$ ansible-playbook urltest.yml  -vvv
ansible-playbook 2.9.3
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/zephyr/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.5 (default, Aug  7 2019, 00:51:29) [GCC 4.8.5 20150623 (Red Hat 4.8.5-39)]
Using /etc/ansible/ansible.cfg as config file
host_list declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
script declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Parsed /etc/ansible/hosts inventory source with ini plugin
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'


PLAYBOOK: urltest.yml **********************************************************
1 plays in urltest.yml

PLAY [localhost] ***************************************************************
META: ran handlers

TASK [Demo error with plain checksum file] *************************************
task path: /home/zephyr/ansible/urltest.yml:5
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: zephyr
<127.0.0.1> EXEC /bin/sh -c 'echo ~zephyr && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/zephyr/.ansible/tmp/ansible-tmp-1586586441.14-106737176792781 `" && echo ansible-tmp-1586586441.14-106737176792781="` echo /home/zephyr/.ansible/tmp/ansible-tmp-1586586441.14-106737176792781 `" ) && sleep 0'
Using module file /usr/lib/python2.7/site-packages/ansible/modules/net_tools/basics/get_url.py
<127.0.0.1> PUT /home/zephyr/.ansible/tmp/ansible-local-2590wiKUXF/tmpBos1Rm TO /home/zephyr/.ansible/tmp/ansible-tmp-1586586441.14-106737176792781/AnsiballZ_get_url.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/zephyr/.ansible/tmp/ansible-tmp-1586586441.14-106737176792781/ /home/zephyr/.ansible/tmp/ansible-tmp-1586586441.14-106737176792781/AnsiballZ_get_url.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python2 /home/zephyr/.ansible/tmp/ansible-tmp-1586586441.14-106737176792781/AnsiballZ_get_url.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/zephyr/.ansible/tmp/ansible-tmp-1586586441.14-106737176792781/ > /dev/null 2>&1 && sleep 0'
fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "attributes": null,
            "backup": null,
            "checksum": "sha512:http://<redacted>/testhash.sha512",
            "client_cert": null,
            "client_key": null,
            "content": null,
            "delimiter": null,
            "dest": "/tmp/kube-scheduler",
            "directory_mode": null,
            "follow": false,
            "force": false,
            "force_basic_auth": false,
            "group": null,
            "headers": null,
            "http_agent": "ansible-httpget",
            "mode": 493,
            "owner": null,
            "regexp": null,
            "remote_src": null,
            "selevel": null,
            "serole": null,
            "setype": null,
            "seuser": null,
            "sha256sum": "",
            "src": null,
            "timeout": 10,
            "tmp_dest": null,
            "unsafe_writes": null,
            "url": "http://zype76.com/testfile.txt",
            "url_password": null,
            "url_username": null,
            "use_proxy": true,
            "validate_certs": true
        }
    },
    "msg": "Unable to find a checksum for file 'testfile.txt' in 'http://zype76.com/testhash.sha512'"
}

PLAY RECAP *********************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0


//////////////////////////////////////////////////////////////////////////////////////////////////////////After: 
(venv) [zephyr@webhost ansible]$ ansible-playbook urltest.yml -vvv
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible
engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
ansible-playbook 2.10.0.dev0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/zephyr/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/zephyr/ansible/lib/ansible
  executable location = /home/zephyr/ansible/bin/ansible-playbook
  python version = 3.6.8 (default, Aug  7 2019, 17:28:10) [GCC 4.8.5 20150623 (Red Hat 4.8.5-39)]
Using /etc/ansible/ansible.cfg as config file
host_list declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
script declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Parsed /etc/ansible/hosts inventory source with ini plugin
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAYBOOK: urltest.yml ********************************************************************************************************************
1 plays in urltest.yml

PLAY [localhost] *************************************************************************************************************************
META: ran handlers

TASK [Demo error with plain checksum file] ***********************************************************************************************
task path: /home/zephyr/ansible/urltest.yml:5
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: zephyr
<127.0.0.1> EXEC /bin/sh -c 'echo ~zephyr && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/zephyr/.ansible/tmp/ansible-tmp-1586586361.409275-270547238543546 `" && echo ansible-tmp-1586586361.409275-270547238543546="` echo /home/zephyr/.ansible/tmp/ansible-tmp-1586586361.409275-270547238543546 `" ) && sleep 0'
Using module file /home/zephyr/ansible/lib/ansible/modules/net_tools/basics/get_url.py
<127.0.0.1> PUT /home/zephyr/.ansible/tmp/ansible-local-2454pmiul7ae/tmpxg_1rqri TO /home/zephyr/.ansible/tmp/ansible-tmp-1586586361.409275-270547238543546/AnsiballZ_get_url.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/zephyr/.ansible/tmp/ansible-tmp-1586586361.409275-270547238543546/ /home/zephyr/.ansible/tmp/ansible-tmp-1586586361.409275-270547238543546/AnsiballZ_get_url.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/home/zephyr/ansible/venv/bin/python /home/zephyr/.ansible/tmp/ansible-tmp-1586586361.409275-270547238543546/AnsiballZ_get_url.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/zephyr/.ansible/tmp/ansible-tmp-1586586361.409275-270547238543546/ > /dev/null 2>&1 && sleep 0'
ok: [localhost] => {
    "changed": false,
    "checksum_dest": null,
    "checksum_src": null,
    "dest": "/tmp/kube-scheduler",
    "elapsed": 0,
    "gid": 1000,
    "group": "zephyr",
    "invocation": {
        "module_args": {
            "attributes": null,
            "backup": null,
            "checksum": "sha512:http://<redacted>/testhash.sha512",
            "client_cert": null,
            "client_key": null,
            "dest": "/tmp/kube-scheduler",
            "force": false,
            "force_basic_auth": false,
            "group": null,
            "headers": null,
            "http_agent": "ansible-httpget",
            "mode": 493,
            "owner": null,
            "selevel": null,
            "serole": null,
            "setype": null,
            "seuser": null,
            "sha256sum": "",
            "timeout": 10,
            "tmp_dest": null,
            "unsafe_writes": false,
            "url": "http://<redacted>/testfile.txt",
            "url_password": null,
            "url_username": null,
            "use_proxy": true,
            "validate_certs": true
        }
    },
    "mode": "0755",
    "msg": "file already exists",
    "owner": "zephyr",
    "size": 11,
    "state": "file",
    "uid": 1000,
    "url": "http://<redacted>/testfile.txt"
}
META: ran handlers
META: ran handlers

PLAY RECAP *******************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

```
