### PR TITLE
[ssh] Add new sshpass_prompt option

### DIFF
--- a/changelogs/fragments/34722-ssh-sshpass-prompt-variable.yml
+++ b/changelogs/fragments/34722-ssh-sshpass-prompt-variable.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ssh - connection plugin now supports a new variable ``sshpass_prompt`` which gets passed to ``sshpass`` allowing the user to set a custom substring to search for a password prompt (requires sshpass 1.06+)

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -160,6 +160,7 @@ MAGIC_VARIABLE_MAPPING = dict(
     scp_extra_args=('ansible_scp_extra_args', ),
     ssh_extra_args=('ansible_ssh_extra_args', ),
     ssh_transfer_method=('ansible_ssh_transfer_method', ),
+    sshpass_prompt=('ansible_sshpass_prompt', ),
 
     # docker TODO: remove
     docker_extra_args=('ansible_docker_extra_args', ),

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -160,7 +160,6 @@ MAGIC_VARIABLE_MAPPING = dict(
     scp_extra_args=('ansible_scp_extra_args', ),
     ssh_extra_args=('ansible_ssh_extra_args', ),
     ssh_transfer_method=('ansible_ssh_transfer_method', ),
-    sshpass_prompt=('ansible_sshpass_prompt', ),
 
     # docker TODO: remove
     docker_extra_args=('ansible_docker_extra_args', ),

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -48,6 +48,17 @@ DOCUMENTATION = '''
               - name: ansible_password
               - name: ansible_ssh_pass
               - name: ansible_ssh_password
+      sshpass_prompt:
+          description: Password prompt that sshpass should search for. Supported by sshpass 1.06 and up.
+          default: ''
+          ini:
+              - section: 'ssh_connection'
+                key: 'sshpass_prompt'
+          env:
+              - name: ANSIBLE_SSHPASS_PROMPT
+          vars:
+              - name: ansible_sshpass_prompt
+          version_added: '2.10'
       ssh_args:
           description: Arguments to pass to all ssh cli tools
           default: '-C -o ControlMaster=auto -o ControlPersist=60s'
@@ -331,13 +342,18 @@ def _handle_error(remaining_retries, command, return_tuple, no_log, host, displa
             raise AnsibleAuthenticationFailure(msg)
 
         # sshpass returns codes are 1-6. We handle 5 previously, so this catches other scenarios.
-        # No exception is raised, so the connection is retried.
+        # No exception is raised, so the connection is retried - except when attempting to use
+        # sshpass_prompt with an sshpass that won't let us pass -P, in which case we fail loudly.
         elif return_tuple[0] in [1, 2, 3, 4, 6]:
             msg = 'sshpass error:'
             if no_log:
                 msg = '{0} <error censored due to no log>'.format(msg)
             else:
-                msg = '{0} {1}'.format(msg, to_native(return_tuple[2]).rstrip())
+                details = to_native(return_tuple[2]).rstrip()
+                if "sshpass: invalid option -- 'P'" in details:
+                    details = 'Installed sshpass version does not support customized password prompts. Upgrade sshpass to use sshpass_prompt, or otherwise switch to ssh keys.'
+                    raise AnsibleError('{0} {1}'.format(msg, details))
+                msg = '{0} {1}'.format(msg, details)
 
     if return_tuple[0] == 255:
         SSH_ERROR = True
@@ -561,6 +577,10 @@ class Connection(ConnectionBase):
 
             self.sshpass_pipe = os.pipe()
             b_command += [b'sshpass', b'-d' + to_bytes(self.sshpass_pipe[0], nonstring='simplerepr', errors='surrogate_or_strict')]
+
+            password_prompt = self.get_option('sshpass_prompt')
+            if password_prompt:
+                b_command += [b'-P', to_bytes(password_prompt, errors='surrogate_or_strict')]
 
         if binary == 'ssh':
             b_command += [to_bytes(self._play_context.ssh_executable, errors='surrogate_or_strict')]

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -351,7 +351,8 @@ def _handle_error(remaining_retries, command, return_tuple, no_log, host, displa
             else:
                 details = to_native(return_tuple[2]).rstrip()
                 if "sshpass: invalid option -- 'P'" in details:
-                    details = 'Installed sshpass version does not support customized password prompts. Upgrade sshpass to use sshpass_prompt, or otherwise switch to ssh keys.'
+                    details = 'Installed sshpass version does not support customized password prompts. ' \
+                              'Upgrade sshpass to use sshpass_prompt, or otherwise switch to ssh keys.'
                     raise AnsibleError('{0} {1}'.format(msg, details))
                 msg = '{0} {1}'.format(msg, details)
 

--- a/test/integration/targets/connection_ssh/runme.sh
+++ b/test/integration/targets/connection_ssh/runme.sh
@@ -1,6 +1,46 @@
 #!/usr/bin/env bash
 
-set -eux
+set -ux
+
+# We skip this whole section if the test node doesn't have sshpass on it.
+if command -v sshpass > /dev/null; then
+    # Check if our sshpass supports -P
+    sshpass -P foo > /dev/null
+    sshpass_supports_prompt=$?
+    if [[ $sshpass_supports_prompt -eq 0 ]]; then
+        # If the prompt is wrong, we'll end up hanging (due to sshpass hanging).
+        # We should probably do something better here, like timing out in Ansible,
+        # but this has been the behavior for a long time, before we supported custom
+        # password prompts.
+        #
+        # So we search for a custom password prompt that is clearly wrong and call
+        # ansible with timeout. If we time out, our custom prompt was successfully
+        # searched for. It's a weird way of doing things, but it does ensure
+        # that the flag gets passed to sshpass.
+        timeout 5 ansible -m ping \
+            -e ansible_connection=ssh \
+     	-e ansible_sshpass_prompt=notThis: \
+     	-e ansible_password=foo \
+     	-e ansible_user=definitelynotroot \
+     	localhost
+        ret=$?
+        if [[ $ret -ne 124 ]]; then
+            echo "Expected to time out and we did not. Exiting with failure."
+     	exit 1
+        fi
+    else
+        ansible -m ping \
+            -e ansible_connection=ssh \
+     	-e ansible_sshpass_prompt=notThis: \
+     	-e ansible_password=foo \
+     	-e ansible_user=definitelynotroot \
+     	localhost
+        ret=$?
+        [[ $ret -eq 0 ]] || exit $ret
+    fi
+fi
+
+set -e
 
 # temporary work-around for issues due to new scp filename checking
 # https://github.com/ansible/ansible/issues/52640

--- a/test/integration/targets/connection_ssh/runme.sh
+++ b/test/integration/targets/connection_ssh/runme.sh
@@ -4,8 +4,6 @@ set -ux
 
 # We skip this whole section if the test node doesn't have sshpass on it.
 if command -v sshpass > /dev/null; then
-    # Save this off to make ansible-test happy
-    cp ~/.ssh/known_hosts ~
     # Check if our sshpass supports -P
     sshpass -P foo > /dev/null
     sshpass_supports_prompt=$?
@@ -24,7 +22,8 @@ if command -v sshpass > /dev/null; then
             -e ansible_sshpass_prompt=notThis: \
             -e ansible_password=foo \
             -e ansible_user=definitelynotroot \
-            localhost
+	    -i test_connection.inventory \
+            ssh-pipelining
         ret=$?
         if [[ $ret -ne 124 ]]; then
             echo "Expected to time out and we did not. Exiting with failure."
@@ -36,12 +35,11 @@ if command -v sshpass > /dev/null; then
             -e ansible_sshpass_prompt=notThis: \
             -e ansible_password=foo \
             -e ansible_user=definitelynotroot \
-            localhost | grep 'customized password prompts'
+	    -i test_connection.inventory \
+            ssh-pipelining | grep 'customized password prompts'
         ret=$?
         [[ $ret -eq 0 ]] || exit $ret
     fi
-    # Restore this for ansible-test to remain happy. Wouldn't want it to get sad.
-    mv -f ~/known_hosts ~/.ssh/known_hosts
 fi
 
 set -e

--- a/test/integration/targets/connection_ssh/runme.sh
+++ b/test/integration/targets/connection_ssh/runme.sh
@@ -4,6 +4,8 @@ set -ux
 
 # We skip this whole section if the test node doesn't have sshpass on it.
 if command -v sshpass > /dev/null; then
+    # Save this off to make ansible-test happy
+    cp ~/.ssh/known_hosts ~
     # Check if our sshpass supports -P
     sshpass -P foo > /dev/null
     sshpass_supports_prompt=$?
@@ -19,10 +21,10 @@ if command -v sshpass > /dev/null; then
         # that the flag gets passed to sshpass.
         timeout 5 ansible -m ping \
             -e ansible_connection=ssh \
-     	-e ansible_sshpass_prompt=notThis: \
-     	-e ansible_password=foo \
-     	-e ansible_user=definitelynotroot \
-     	localhost
+            -e ansible_sshpass_prompt=notThis: \
+            -e ansible_password=foo \
+            -e ansible_user=definitelynotroot \
+            localhost
         ret=$?
         if [[ $ret -ne 124 ]]; then
             echo "Expected to time out and we did not. Exiting with failure."
@@ -31,13 +33,15 @@ if command -v sshpass > /dev/null; then
     else
         ansible -m ping \
             -e ansible_connection=ssh \
-     	-e ansible_sshpass_prompt=notThis: \
-     	-e ansible_password=foo \
-     	-e ansible_user=definitelynotroot \
-     	localhost
+            -e ansible_sshpass_prompt=notThis: \
+            -e ansible_password=foo \
+            -e ansible_user=definitelynotroot \
+            localhost | grep 'customized password prompts'
         ret=$?
         [[ $ret -eq 0 ]] || exit $ret
     fi
+    # Restore this for ansible-test to remain happy. Wouldn't want it to get sad.
+    mv -f ~/known_hosts ~/.ssh/known_hosts
 fi
 
 set -e


### PR DESCRIPTION
##### SUMMARY

Change:
Allows the user to configure sshpass (1.06+) to look for a different
substring than the default "assword" that it comes with.

Test Plan:
Set a custom ssh password prompt on a VM with PAM and tried connecting to
it. Without `ansible_sshpass_prompt` set in inventory: experienced hang.
With `ansible_sshpass_prompt` in inventory: connected successfully.

Tried setting `ansible_sshpass_prompt` with an older `sshpass` in PATH
and got a loud error, as expected.

Tickets:
Fixes #34722, fixes #54743, refs #11565.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME

ssh connection plugin