### PR TITLE
Refactoring Coupler Code Smell

### DIFF
--- a/lib/ansible/module_utils/facts/compat.py
+++ b/lib/ansible/module_utils/facts/compat.py
@@ -29,7 +29,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.module_utils.facts.namespace import PrefixFactNamespace
+from ansible.module_utils.facts.namespace import FactNamespace
 from ansible.module_utils.facts import default_collectors
 from ansible.module_utils.facts import ansible_collector
 
@@ -72,7 +72,7 @@ def ansible_facts(module, gather_subset=None):
     all_collector_classes = default_collectors.collectors
 
     # don't add a prefix
-    namespace = PrefixFactNamespace(namespace_name='ansible', prefix='')
+    namespace = FactNamespace(namespace_name='ansible', prefix='')
 
     fact_collector = \
         ansible_collector.get_ansible_collector(all_collector_classes=all_collector_classes,

--- a/lib/ansible/module_utils/facts/namespace.py
+++ b/lib/ansible/module_utils/facts/namespace.py
@@ -30,22 +30,14 @@ __metaclass__ = type
 
 
 class FactNamespace:
-    def __init__(self, namespace_name):
-        self.namespace_name = namespace_name
-
-    def transform(self, name):
-        '''Take a text name, and transforms it as needed (add a namespace prefix, etc)'''
-        return name
-
-    def _underscore(self, name):
-        return name.replace('-', '_')
-
-
-class PrefixFactNamespace(FactNamespace):
     def __init__(self, namespace_name, prefix=None):
-        super(PrefixFactNamespace, self).__init__(namespace_name)
+        self.namespace_name = namespace_name
+        super(FactNamespace, self).__init__(namespace_name)
         self.prefix = prefix
 
     def transform(self, name):
         new_name = self._underscore(name)
         return '%s%s' % (self.prefix, new_name)
+
+    def _underscore(self, name):
+        return name.replace('-', '_')

--- a/lib/ansible/module_utils/facts/other/facter.py
+++ b/lib/ansible/module_utils/facts/other/facter.py
@@ -18,7 +18,7 @@ __metaclass__ = type
 
 import json
 
-from ansible.module_utils.facts.namespace import PrefixFactNamespace
+from ansible.module_utils.facts.namespace import FactNamespace
 
 from ansible.module_utils.facts.collector import BaseFactCollector
 
@@ -28,7 +28,7 @@ class FacterFactCollector(BaseFactCollector):
     _fact_ids = set(['facter'])
 
     def __init__(self, collectors=None, namespace=None):
-        namespace = PrefixFactNamespace(namespace_name='facter',
+        namespace = FactNamespace(namespace_name='facter',
                                         prefix='facter_')
         super(FacterFactCollector, self).__init__(collectors=collectors,
                                                   namespace=namespace)

--- a/lib/ansible/module_utils/facts/other/ohai.py
+++ b/lib/ansible/module_utils/facts/other/ohai.py
@@ -18,7 +18,7 @@ __metaclass__ = type
 
 import json
 
-from ansible.module_utils.facts.namespace import PrefixFactNamespace
+from ansible.module_utils.facts.namespace import FactNamespace
 
 from ansible.module_utils.facts.collector import BaseFactCollector
 
@@ -29,7 +29,7 @@ class OhaiFactCollector(BaseFactCollector):
     _fact_ids = set()
 
     def __init__(self, collectors=None, namespace=None):
-        namespace = PrefixFactNamespace(namespace_name='ohai',
+        namespace = FactNamespace(namespace_name='ohai',
                                         prefix='ohai_')
         super(OhaiFactCollector, self).__init__(collectors=collectors,
                                                 namespace=namespace)

--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -135,7 +135,7 @@ EXAMPLES = """
 # import module snippets
 from ...module_utils.basic import AnsibleModule
 
-from ansible.module_utils.facts.namespace import PrefixFactNamespace
+from ansible.module_utils.facts.namespace import FactNamespace
 from ansible.module_utils.facts import ansible_collector
 
 from ansible.module_utils.facts import default_collectors
@@ -168,7 +168,7 @@ def main():
     all_collector_classes = default_collectors.collectors
 
     # rename namespace_name to root_key?
-    namespace = PrefixFactNamespace(namespace_name='ansible',
+    namespace = FactNamespace(namespace_name='ansible',
                                     prefix='ansible_')
 
     fact_collector = \

--- a/lib/ansible/parsing/utils/addresses.py
+++ b/lib/ansible/parsing/utils/addresses.py
@@ -191,6 +191,7 @@ def parse_address(address, allow_ranges=False):
         if m:
             (address, port) = m.groups()
             port = int(port)
+            continue
 
     # What we're left with now must be an IPv4 or IPv6 address, possibly with
     # numeric ranges, or a hostname with alphanumeric ranges.
@@ -200,6 +201,7 @@ def parse_address(address, allow_ranges=False):
         m = patterns[matching].match(address)
         if m:
             host = address
+            continue
 
     # If it isn't any of the above, we don't understand it.
     if not host:

--- a/lib/ansible/parsing/utils/addresses.py
+++ b/lib/ansible/parsing/utils/addresses.py
@@ -191,7 +191,6 @@ def parse_address(address, allow_ranges=False):
         if m:
             (address, port) = m.groups()
             port = int(port)
-            continue
 
     # What we're left with now must be an IPv4 or IPv6 address, possibly with
     # numeric ranges, or a hostname with alphanumeric ranges.
@@ -201,7 +200,6 @@ def parse_address(address, allow_ranges=False):
         m = patterns[matching].match(address)
         if m:
             host = address
-            continue
 
     # If it isn't any of the above, we don't understand it.
     if not host:

--- a/test/units/module_utils/facts/test_ansible_collector.py
+++ b/test/units/module_utils/facts/test_ansible_collector.py
@@ -117,7 +117,7 @@ def _collectors(module,
     return collectors
 
 
-ns = namespace.PrefixFactNamespace('ansible_facts', 'ansible_')
+ns = namespace.FactNamespace('ansible_facts', 'ansible_')
 
 
 # FIXME: this is brute force, but hopefully enough to get some refactoring to make facts testable


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Simple refactoring, removing the class PrefixFactNamespace that only redirects its calls to FactNamespace. If a class performs only one action, delegating work to another class, it should be combined to clean up the code. 
This was found on lines 32 of namespace.py. 


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Files Changed:
```
lib/ansible/module_utils/facts/namespace.py
lib/ansible/module_utils/facts/other/ohai.py
lib/ansible/module_utils/facts/other/facter.py
lib/ansible/module_utils/facts/compat.py
lib/ansible/modules/system/setup.py
test/units/module_utils/facts/test_ansible_collector.py
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

