### PR TITLE
Add punctuation marks to comments in hosts file

### DIFF
--- a/examples/hosts
+++ b/examples/hosts
@@ -8,14 +8,14 @@
 #   - You can enter hostnames or ip addresses
 #   - A hostname/ip can be a member of multiple groups
 
-# Ex 1: Ungrouped hosts, specify before any group headers.
+# Ex 1: Ungrouped hosts, specify before any group headers:
 
 ## green.example.com
 ## blue.example.com
 ## 192.168.100.1
 ## 192.168.100.10
 
-# Ex 2: A collection of hosts belonging to the 'webservers' group
+# Ex 2: A collection of hosts belonging to the 'webservers' group:
 
 ## [webservers]
 ## alpha.example.org
@@ -23,12 +23,12 @@
 ## 192.168.1.100
 ## 192.168.1.110
 
-# If you have multiple hosts following a pattern you can specify
+# If you have multiple hosts following a pattern, you can specify
 # them like this:
 
 ## www[001:006].example.com
 
-# Ex 3: A collection of database servers in the 'dbservers' group
+# Ex 3: A collection of database servers in the 'dbservers' group:
 
 ## [dbservers]
 ## 


### PR DESCRIPTION
This PR adds these punctuation marks to hosts file:
-  comma (,) to a comment to clarify the meaning.
- colons (:) at the end of all examples sentences for consistency instead of one ending with full stop and others don't have any!