### PR TITLE
Extend dev guide for collection testing and collection hacking

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -21,8 +21,7 @@ You can publish and use collections through `Ansible Galaxy <https://galaxy.ansi
 Collection structure
 ====================
 
-Collections follow a simple data structure. None of the directories are required unless you have specific content that belongs in one of them. A collection does require a ``galaxy.yml`` file at the root level of the collection. This file contains all of the metadata that Galaxy
-and other tools need in order to package, build and publish the collection::
+Collections follow a simple data structure. None of the directories are required unless you have specific content that belongs in one of them. A collection does require a ``galaxy.yml`` file at the root level of the collection. This file contains all of the metadata that Galaxy and other tools need in order to package, build and publish the collection::
 
     collection/
     ├── docs/
@@ -71,9 +70,9 @@ Use ``ansible-doc`` to view documentation for plugins inside a collection:
 
     ansible-doc -t lookup my_namespace.my_collection.lookup1
 
-The ``ansible-doc`` command requires the fully qualified collection name (FQCN) to display specific plugin documentation. In this example, ``my_namespace`` is the namespace and ``my_collection`` is the collection name within that namespace.
+The ``ansible-doc`` command requires the fully qualified collection name (FQCN) to display specific plugin documentation. In this example, ``my_namespace`` is the Galaxy namespace and ``my_collection`` is the collection name within that namespace.
 
-.. note:: The Ansible collection namespace is defined in the ``galaxy.yml`` file and is not equivalent to the GitHub repository name.
+.. note:: The Galaxy namespace of an Ansible collection is defined in the ``galaxy.yml`` file. It can be different from the GitHub organization or repository name.
 
 .. _collections_plugin_dir:
 
@@ -162,9 +161,7 @@ You can migrate 'traditional roles' into a collection but they must follow the r
 
 .. note::
 
-    For roles imported into Galaxy directly from a GitHub repository, setting the ``role_name`` value in the role's
-    metadata overrides the role name used by Galaxy. For collections, that value is ignored. When importing a
-    collection, Galaxy uses the role directory as the name of the role and ignores the ``role_name`` metadata value.
+    For roles imported into Galaxy directly from a GitHub repository, setting the ``role_name`` value in the role's metadata overrides the role name used by Galaxy. For collections, that value is ignored. When importing a collection, Galaxy uses the role directory as the name of the role and ignores the ``role_name`` metadata value.
 
 playbooks directory
 --------------------
@@ -468,7 +465,7 @@ See the `content_collector README <https://github.com/ansible/content_collector>
 BOTMETA.yml
 -----------
 
-The `BOTMETA.yml <https://github.com/ansible/ansible/blob/devel/.github/BOTMETA.yml>`_ in the Ansible main repository is the source of truth for:
+The `BOTMETA.yml <https://github.com/ansible/ansible/blob/devel/.github/BOTMETA.yml>`_ in the ansible/ansible GitHub repository is the source of truth for:
 
 * ansibullbot
 * the docs build for collections-based modules
@@ -517,7 +514,7 @@ Testing collections
 
 The main tool for testing collections is ``ansible-test``, Ansible's testing tool described in :ref:`developing_testing`. You can run several compile and sanity checks, as well as run unit and integration tests for plugins using ``ansible-test``.
 
-You must always execute ``ansible-test`` from the root directory of a collection. You can run ``ansible-test`` in Docker containers without installing any special requirements. The Ansible team uses this approach in Shippable both in Ansible's main repository and in the large community collections such as `community.general <https://github.com/ansible-collections/community.general/>`_ and `community.network <https://github.com/ansible-collections/community.network/>`_. The examples below demonstrate running tests in Docker containers.
+You must always execute ``ansible-test`` from the root directory of a collection. You can run ``ansible-test`` in Docker containers without installing any special requirements. The Ansible team uses this approach in Shippable both in the ansible/ansible GitHub repository and in the large community collections such as `community.general <https://github.com/ansible-collections/community.general/>`_ and `community.network <https://github.com/ansible-collections/community.network/>`_. The examples below demonstrate running tests in Docker containers.
 
 Compile and sanity tests
 ------------------------
@@ -580,7 +577,7 @@ Contributing to collections
 
 If you want to add functionality to an existing collection, modify a collection you are using to fix a bug, or change the behavior of a module in a collection, clone the git repository for that collection and make changes on a branch. You can combine changes to a collection with a local checkout of Ansible (``source hacking/env-setup``).
 
-This section describes the process for `community.general <https://github.com/ansible-collections/community.general/>`_. To contribute to other collections, replace the folder names ``community`` and ``general`` with the namespace and collection name of a different collection1.
+This section describes the process for `community.general <https://github.com/ansible-collections/community.general/>`_. To contribute to other collections, replace the folder names ``community`` and ``general`` with the namespace and collection name of a different collection.
 
 We assume that you have included ``~/dev/ansible/collections/`` in :ref:`COLLECTIONS_PATHS`, and if that path mentions multiple directories, that you made sure that no other directory earlier in the search path contains a copy of ``community.general``. Create the directory ``~/dev/ansible/collections/ansible_collections/community``, and in it clone `the community.general Git repository <https://github.com/ansible-collections/community.general/>`_ or a fork of it into the folder ``general``::
 
@@ -595,7 +592,7 @@ If you clone a fork, add the original repository as a remote ``upstream``::
 
 Now you can use this checkout of ``community.general`` in playbooks and roles with whichever version of Ansible you have installed locally, including a local checkout of the ``devel`` branch.
 
-For collections in the ``ansible_collections`` namespace, create a branch and commit your changes on the branch. When you are done (remember to add tests, see :ref:`testing_collections`), push your changes to your fork of the collection and create a Pull Request. For other collections, especially for collections not hosted on GitHub, check the ``README.md`` of the collection for information on contributing to it.
+For collections hosted in the ``ansible_collections`` GitHub org, create a branch and commit your changes on the branch. When you are done (remember to add tests, see :ref:`testing_collections`), push your changes to your fork of the collection and create a Pull Request. For other collections, especially for collections not hosted on GitHub, check the ``README.md`` of the collection for information on contributing to it.
 
 
 .. seealso::

--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -512,14 +512,14 @@ The build process for docs.ansible.com will know where to find the module docs.
 
 .. _testing_collections:
 
-Testing Collections
+Testing collections
 ===================
 
 The main tool for testing collections is ``ansible-test``, Ansible's testing tool described in :ref:`developing_testing`. This tool provides several compile and sanity checks, and allows to run unit and integration tests for plugins.
 
 ``ansible-test`` must always be executed in the root directory of a collection. In the following, we will describe how to run ``ansible-test`` with Docker containers. This is the easiest way to use ``ansible-test`` as no special requirements have to be installed, and this is also the way it is run in Shippable both in Ansible's main repository and in the large community collections such as `community.general <https://github.com/ansible-collections/community.general/>`_ and `community.network <https://github.com/ansible-collections/community.network/>`_.
 
-Compile and Sanity Tests
+Compile and sanity tests
 ------------------------
 
 To run all compile and sanity tests, execute::
@@ -528,7 +528,7 @@ To run all compile and sanity tests, execute::
 
 See :ref:`testing_compile` and :ref:`testing_sanity` for more information on the tests run. See the :ref:`full list of sanity tests <all_sanity_tests>` for details on he sanity tests and how to fix identified issues.
 
-Unit Tests
+Unit tests
 ----------
 
 Unit tests must be located in the ``tests/unit/plugins/`` directory. The tests for ``plugins/module_utils/foo/bar.py`` must be in ``tests/unit/plugins/module_utils/foo/test_bar.py`` or ``tests/unit/plugins/module_utils/foo/bar/test_bar.py``. For examples, see the `unit tests in community.general <https://github.com/ansible-collections/community.general/tree/master/tests/unit/>`_.
@@ -547,7 +547,7 @@ To run only a specific unit test::
 
 Python requirements can be specified in the ``tests/unit/requirements.txt`` file. See :ref:`testing_units` for more information, especially on fixture files.
 
-Integration Tests
+Integration tests
 -----------------
 
 Integration tests must be located in the ``tests/integration/targets``` directory. For every module ``foo``, a directory of name ``foo`` will contain the tests for that module. For lookup plugins, the directory must be called ``lookup_foo``; for connection plugins, ``connection_foo``; for inventory plugins, ``inventory_foo``.
@@ -575,7 +575,7 @@ Multiple target names can be specified. A target name is the name of a directory
 
 .. _hacking_collections:
 
-Hacking Collections
+Hacking collections
 ===================
 
 This section describes how to work on a collection cloned from a Git repository. This is useful for example if you want to contribute to an existing collection, or if you want to modify a collection you are using to find a bug, change a module's behavior, etc.

--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -573,6 +573,32 @@ The integration tests for a specific target can be executed as follows::
 
 Multiple target names can be specified. A target name is the name of a directory in ``tests/integration/targets/``.
 
+.. _hacking_collections:
+
+Hacking Collections
+===================
+
+This section describes how to work on a collection cloned from a Git repository. This is useful for example if you want to contribute to an existing collection, or if you want to modify a collection you are using to find a bug, change a module's behavior, etc.
+
+This can be combined with a local checkout of Ansible (``source hacking/env-setup``).
+
+In the following, we will describe the process for `community.general <https://github.com/ansible-collections/community.general/>`_. You can simply adjust this by replacing the appropriate folder names ``community`` and ``general`` with the namespace and collection name of the collection you are interested in.
+
+We assume that you have included ``~/dev/ansible/collections/`` in :ref:`COLLECTIONS_PATHS`, and if that path mentiones multiple directories, that you made sure that no other directory earlier in the search path contains a copy of ``community.general``. Make sure that the directory ``~/dev/ansible/collections/ansible_collections/community`` exists, and in it clone `the community.general Git repository <https://github.com/ansible-collections/community.general/>`_ or a fork of it into the folder ``general``::
+
+    mkdir -p ~/dev/ansible/collections/ansible_collections/community
+    cd ~/dev/ansible/collections/ansible_collections/community
+    git clone git@github.com:ansible-collections/community.general.git general
+
+If you clone a fork, it is suggested to add the original repository as a remote ``upstream``::
+
+    cd ~/dev/ansible/collections/ansible_collections/community/general
+    git remote add upstream git@github.com:ansible-collections/community.general.git
+
+This allows you to use this checkout of ``community.general`` in playbooks and roles with the installed version of Ansible, respectively with the active hacking version of Ansible.
+
+For many collections, it is recommended to create a branch and add your changes to that one. When you are done (don't forget testing: :ref:`testing_collections`), push your changes to your fork of the collection and create a Pull Request. If the repository is not hosted on GitHub, the details might differ. Check out the ``README.md`` of the collection for information on contributing to it.
+
 
 .. seealso::
 

--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -554,7 +554,7 @@ Integration tests must be located in the ``tests/integration/targets``` director
 
 There are two types of integration tests:
 
-* Ansible roles: they will be run with ``ansible-playbook`` and expect to validate various aspects of the module. They can depend on other integration tests (usually named ``prepare_bar`` or ``setup_bar``) to set-up required resources, such as installing required libraries or setting up server services.
+* Ansible roles: they will be run with ``ansible-playbook`` and expect to validate various aspects of the module. They can depend on other integration tests (usually named ``prepare_bar`` or ``setup_bar``, which prepare a service or install a requirement named ``bar`` in order to test module ``foo``) to set-up required resources, such as installing required libraries or setting up server services.
 * ``runme.sh`` tests: if the directory contains an executable shell script ``runme.sh``, it will be run directly. These can for example setup inventory files, and execute ``ansible-playbook`` or ``ansible-inventory`` with various settings.
 
 For examples, see the `integration tests in community.general <https://github.com/ansible-collections/community.general/tree/master/tests/integration/targets/>`_. See also :ref:`testing_integration` for more details.

--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -463,7 +463,8 @@ See the `content_collector README <https://github.com/ansible/content_collector>
 BOTMETA.yml
 -----------
 
-The `BOTMETA.yml <https://github.com/ansible/ansible/blob/devel/.github/BOTMETA.yml>`_ is the source of truth for:
+The `BOTMETA.yml <https://github.com/ansible/ansible/blob/devel/.github/BOTMETA.yml>`_ in the Ansible main repository is the source of truth for:
+
 * ansibullbot
 * the docs build for collections-based modules
 

--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -569,7 +569,7 @@ If you want more detailed output, run the command with ``-vvv`` instead of ``-v`
 
 To execute only the integration tests in a specific directory::
 
-    ansible-test integration --docker centos8 -v tests/integration/targets/connection_bar/
+    ansible-test integration --docker centos8 -v connection_bar
 
 You can specify multiple target names. Each target name is the name of a directory in ``tests/integration/targets/``.
 

--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -524,7 +524,7 @@ Compile and Sanity Tests
 
 To run all compile and sanity tests, execute::
 
-    ansible-test sanity --docker default --color -v
+    ansible-test sanity --docker default -v
 
 See :ref:`testing_compile` and :ref:`testing_sanity` for more information on the tests run. See the :ref:`full list of sanity tests <all_sanity_tests>` for details on he sanity tests and how to fix identified issues.
 
@@ -535,15 +535,15 @@ Unit tests must be located in the ``tests/unit/plugins/`` directory. The tests f
 
 All unit tests can be run as follows::
 
-    ansible-test units --docker default --color -v
+    ansible-test units --docker default -v
 
 This will run all unit tests for all supported Python versions. To run them only for a specific Python version::
 
-    ansible-test units --docker default --color -v --python 3.6
+    ansible-test units --docker default -v --python 3.6
 
 To run only a specific unit test::
 
-    ansible-test units --docker default --color -v --python 3.6 tests/unit/plugins/module_utils/foo/test_bar.py
+    ansible-test units --docker default -v --python 3.6 tests/unit/plugins/module_utils/foo/test_bar.py
 
 Python requirements can be specified in the ``tests/unit/requirements.txt`` file. See :ref:`testing_units` for more information, especially on fixture files.
 
@@ -563,13 +563,13 @@ Since integration tests can install requirements, and set-up, start and stop ser
 
 All integration tests for a collection can be executed as follows::
 
-    ansible-test integration --docker centos8 --color -v
+    ansible-test integration --docker centos8 -v
 
 If you want more detailed output, run the command with ``-vvv`` instead of ``-v``. Alternatively, specify ``--retry-on-error`` to automatically re-run failed tests with higher verbosity levels.
 
 The integration tests for a specific target can be executed as follows::
 
-    ansible-test integration --docker centos8 --color -v target_name
+    ansible-test integration --docker centos8 -v target_name
 
 Multiple target names can be specified. A target name is the name of a directory in ``tests/integration/targets/``.
 

--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -515,29 +515,29 @@ The build process for docs.ansible.com will know where to find the module docs.
 Testing collections
 ===================
 
-The main tool for testing collections is ``ansible-test``, Ansible's testing tool described in :ref:`developing_testing`. This tool provides several compile and sanity checks, and allows to run unit and integration tests for plugins.
+The main tool for testing collections is ``ansible-test``, Ansible's testing tool described in :ref:`developing_testing`. You can run several compile and sanity checks, as well as run unit and integration tests for plugins using ``ansible-test``.
 
-``ansible-test`` must always be executed in the root directory of a collection. In the following, we will describe how to run ``ansible-test`` with Docker containers. This is the easiest way to use ``ansible-test`` as no special requirements have to be installed, and this is also the way it is run in Shippable both in Ansible's main repository and in the large community collections such as `community.general <https://github.com/ansible-collections/community.general/>`_ and `community.network <https://github.com/ansible-collections/community.network/>`_.
+You must always execute ``ansible-test`` from the root directory of a collection. You can run ``ansible-test`` in Docker containers without installing any special requirements. The Ansible team uses this approach in Shippable both in Ansible's main repository and in the large community collections such as `community.general <https://github.com/ansible-collections/community.general/>`_ and `community.network <https://github.com/ansible-collections/community.network/>`_. The examples below demonstrate running tests in Docker containers.
 
 Compile and sanity tests
 ------------------------
 
-To run all compile and sanity tests, execute::
+To run all compile and sanity tests::
 
     ansible-test sanity --docker default -v
 
-See :ref:`testing_compile` and :ref:`testing_sanity` for more information on the tests run. See the :ref:`full list of sanity tests <all_sanity_tests>` for details on he sanity tests and how to fix identified issues.
+See :ref:`testing_compile` and :ref:`testing_sanity` for more information. See the :ref:`full list of sanity tests <all_sanity_tests>` for details on the sanity tests and how to fix identified issues.
 
 Unit tests
 ----------
 
-Unit tests must be located in the ``tests/unit/plugins/`` directory. The tests for ``plugins/module_utils/foo/bar.py`` must be in ``tests/unit/plugins/module_utils/foo/test_bar.py`` or ``tests/unit/plugins/module_utils/foo/bar/test_bar.py``. For examples, see the `unit tests in community.general <https://github.com/ansible-collections/community.general/tree/master/tests/unit/>`_.
+You must place unit tests in the appropriate``tests/unit/plugins/`` directory. For example, you would place tests for ``plugins/module_utils/foo/bar.py`` in ``tests/unit/plugins/module_utils/foo/test_bar.py`` or ``tests/unit/plugins/module_utils/foo/bar/test_bar.py``. For examples, see the `unit tests in community.general <https://github.com/ansible-collections/community.general/tree/master/tests/unit/>`_.
 
-All unit tests can be run as follows::
+To run all unit tests for all supported Python versions::
 
     ansible-test units --docker default -v
 
-This will run all unit tests for all supported Python versions. To run them only for a specific Python version::
+To run all unit tests only for a specific Python version::
 
     ansible-test units --docker default -v --python 3.6
 
@@ -545,59 +545,57 @@ To run only a specific unit test::
 
     ansible-test units --docker default -v --python 3.6 tests/unit/plugins/module_utils/foo/test_bar.py
 
-Python requirements can be specified in the ``tests/unit/requirements.txt`` file. See :ref:`testing_units` for more information, especially on fixture files.
+You can specify Python requirements in the ``tests/unit/requirements.txt`` file. See :ref:`testing_units` for more information, especially on fixture files.
 
 Integration tests
 -----------------
 
-Integration tests must be located in the ``tests/integration/targets``` directory. For every module ``foo``, a directory of name ``foo`` will contain the tests for that module. For lookup plugins, the directory must be called ``lookup_foo``; for connection plugins, ``connection_foo``; for inventory plugins, ``inventory_foo``.
+You must place integration tests in the appropriate ``tests/integration/targets/`` directory. For module integration tests, you can use the module name alone. For example, you would place integration tests for ``plugins/modules/foo.py`` in a directory called ``tests/integration/targets/foo/``. For non-module plugin integration tests, you must add the plugin type to the directory name. For example, you would place integration tests for ``plugins/connections/bar.py`` in a directory called ``tests/integration/targets/connection_bar/``. For lookup plugins, the directory must be called ``lookup_foo``, for inventory plugins, ``inventory_foo``, and so on.
 
-There are two types of integration tests:
+You can write two different kinds of integration tests:
 
-* Ansible roles: they will be run with ``ansible-playbook`` and expect to validate various aspects of the module. They can depend on other integration tests (usually named ``prepare_bar`` or ``setup_bar``, which prepare a service or install a requirement named ``bar`` in order to test module ``foo``) to set-up required resources, such as installing required libraries or setting up server services.
-* ``runme.sh`` tests: if the directory contains an executable shell script ``runme.sh``, it will be run directly. These can for example setup inventory files, and execute ``ansible-playbook`` or ``ansible-inventory`` with various settings.
+* Ansible role tests run with ``ansible-playbook`` and validate various aspects of the module. They can depend on other integration tests (usually named ``prepare_bar`` or ``setup_bar``, which prepare a service or install a requirement named ``bar`` in order to test module ``foo``) to set-up required resources, such as installing required libraries or setting up server services.
+* ``runme.sh`` tests run directly as scripts. They can set up inventory files, and execute ``ansible-playbook`` or ``ansible-inventory`` with various settings.
 
 For examples, see the `integration tests in community.general <https://github.com/ansible-collections/community.general/tree/master/tests/integration/targets/>`_. See also :ref:`testing_integration` for more details.
 
-Since integration tests can install requirements, and set-up, start and stop services, it is recommended to run them in docker containers or otherwise restricted environments whenever possible. By default, ``ansible-test`` supports Docker images for several operating systems. See the `list of supported docker images <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt>`_ for all options. The ``default`` image is used mainly for platform independent integration tests, such as those for cloud modules. The following examples show ``centos8``.
+Since integration tests can install requirements, and set-up, start and stop services, we recommended running them in docker containers or otherwise restricted environments whenever possible. By default, ``ansible-test`` supports Docker images for several operating systems. See the `list of supported docker images <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt>`_ for all options. Use the ``default`` image mainly for platform-independent integration tests, such as those for cloud modules. The following examples use the ``centos8`` image.
 
-All integration tests for a collection can be executed as follows::
+To execute all integration tests for a collection::
 
     ansible-test integration --docker centos8 -v
 
 If you want more detailed output, run the command with ``-vvv`` instead of ``-v``. Alternatively, specify ``--retry-on-error`` to automatically re-run failed tests with higher verbosity levels.
 
-The integration tests for a specific target can be executed as follows::
+To execute only the integration tests in a specific directory::
 
-    ansible-test integration --docker centos8 -v target_name
+    ansible-test integration --docker centos8 -v tests/integration/targets/connection_bar/
 
-Multiple target names can be specified. A target name is the name of a directory in ``tests/integration/targets/``.
+You can specify multiple target names. Each target name is the name of a directory in ``tests/integration/targets/``.
 
 .. _hacking_collections:
 
-Hacking collections
-===================
+Contributing to collections
+===========================
 
-This section describes how to work on a collection cloned from a Git repository. This is useful for example if you want to contribute to an existing collection, or if you want to modify a collection you are using to find a bug, change a module's behavior, etc.
+If you want to add functionality to an existing collection, modify a collection you are using to fix a bug, or change the behavior of a module in a collection, clone the git repository for that collection and make changes on a branch. You can combine changes to a collection with a local checkout of Ansible (``source hacking/env-setup``).
 
-This can be combined with a local checkout of Ansible (``source hacking/env-setup``).
+This section describes the process for `community.general <https://github.com/ansible-collections/community.general/>`_. To contribute to other collections, replace the folder names ``community`` and ``general`` with the namespace and collection name of a different collection1.
 
-In the following, we will describe the process for `community.general <https://github.com/ansible-collections/community.general/>`_. You can simply adjust this by replacing the appropriate folder names ``community`` and ``general`` with the namespace and collection name of the collection you are interested in.
-
-We assume that you have included ``~/dev/ansible/collections/`` in :ref:`COLLECTIONS_PATHS`, and if that path mentions multiple directories, that you made sure that no other directory earlier in the search path contains a copy of ``community.general``. Make sure that the directory ``~/dev/ansible/collections/ansible_collections/community`` exists, and in it clone `the community.general Git repository <https://github.com/ansible-collections/community.general/>`_ or a fork of it into the folder ``general``::
+We assume that you have included ``~/dev/ansible/collections/`` in :ref:`COLLECTIONS_PATHS`, and if that path mentions multiple directories, that you made sure that no other directory earlier in the search path contains a copy of ``community.general``. Create the directory ``~/dev/ansible/collections/ansible_collections/community``, and in it clone `the community.general Git repository <https://github.com/ansible-collections/community.general/>`_ or a fork of it into the folder ``general``::
 
     mkdir -p ~/dev/ansible/collections/ansible_collections/community
     cd ~/dev/ansible/collections/ansible_collections/community
     git clone git@github.com:ansible-collections/community.general.git general
 
-If you clone a fork, it is suggested to add the original repository as a remote ``upstream``::
+If you clone a fork, add the original repository as a remote ``upstream``::
 
     cd ~/dev/ansible/collections/ansible_collections/community/general
     git remote add upstream git@github.com:ansible-collections/community.general.git
 
-This allows you to use this checkout of ``community.general`` in playbooks and roles with the installed version of Ansible, respectively with the active hacking version of Ansible.
+Now you can use this checkout of ``community.general`` in playbooks and roles with whichever version of Ansible you have installed locally, including a local checkout of the ``devel`` branch.
 
-For many collections, it is recommended to create a branch and add your changes to that one. When you are done (don't forget testing: :ref:`testing_collections`), push your changes to your fork of the collection and create a Pull Request. If the repository is not hosted on GitHub, the details might differ. Check out the ``README.md`` of the collection for information on contributing to it.
+For collections in the ``ansible_collections`` namespace, create a branch and commit your changes on the branch. When you are done (remember to add tests, see :ref:`testing_collections`), push your changes to your fork of the collection and create a Pull Request. For other collections, especially for collections not hosted on GitHub, check the ``README.md`` of the collection for information on contributing to it.
 
 
 .. seealso::

--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -584,7 +584,7 @@ This can be combined with a local checkout of Ansible (``source hacking/env-setu
 
 In the following, we will describe the process for `community.general <https://github.com/ansible-collections/community.general/>`_. You can simply adjust this by replacing the appropriate folder names ``community`` and ``general`` with the namespace and collection name of the collection you are interested in.
 
-We assume that you have included ``~/dev/ansible/collections/`` in :ref:`COLLECTIONS_PATHS`, and if that path mentiones multiple directories, that you made sure that no other directory earlier in the search path contains a copy of ``community.general``. Make sure that the directory ``~/dev/ansible/collections/ansible_collections/community`` exists, and in it clone `the community.general Git repository <https://github.com/ansible-collections/community.general/>`_ or a fork of it into the folder ``general``::
+We assume that you have included ``~/dev/ansible/collections/`` in :ref:`COLLECTIONS_PATHS`, and if that path mentions multiple directories, that you made sure that no other directory earlier in the search path contains a copy of ``community.general``. Make sure that the directory ``~/dev/ansible/collections/ansible_collections/community`` exists, and in it clone `the community.general Git repository <https://github.com/ansible-collections/community.general/>`_ or a fork of it into the folder ``general``::
 
     mkdir -p ~/dev/ansible/collections/ansible_collections/community
     cd ~/dev/ansible/collections/ansible_collections/community

--- a/docs/docsite/rst/dev_guide/testing.rst
+++ b/docs/docsite/rst/dev_guide/testing.rst
@@ -91,7 +91,8 @@ Occasionally you may find your PR fails due to a reason unrelated to your change
 
 If either of these issues appear to be the case, you can rerun the Shippable test by:
 
-* closing and re-opening the PR
+* adding a comment with ``/rebuild`` (full rebuild) or ``/rebuild_failed`` (rebuild only failed CI nodes) to the PR
+* closing and re-opening the PR (full rebuild)
 * making another change to the PR and pushing to GitHub
 
 If the issue persists, please contact us in ``#ansible-devel`` on Freenode IRC.

--- a/docs/docsite/rst/dev_guide/testing.rst
+++ b/docs/docsite/rst/dev_guide/testing.rst
@@ -17,6 +17,8 @@ Ansible users who understand how to write playbooks and roles should be able to 
 
 Read on to learn how Ansible is tested, how to test your contributions locally, and how to extend testing capabilities.
 
+If you want to learn on how testing collections, you should read :ref:`testing_collections`
+
 
 
 Types of tests

--- a/docs/docsite/rst/dev_guide/testing_compile.rst
+++ b/docs/docsite/rst/dev_guide/testing_compile.rst
@@ -18,6 +18,9 @@ Compile tests check source files for valid syntax on all supported python versio
 - 2.7
 - 3.5
 - 3.6
+- 3.7
+- 3.8
+- 3.9
 
 NOTE: In Ansible 2.4 and earlier the compile test was provided by a dedicated sub-command ``ansible-test compile`` instead of a sanity test using ``ansible-test sanity --test compile``.
 


### PR DESCRIPTION
##### SUMMARY
This extends the dev guide with details for working with collections:
 1. running ansible-test in collections;
 2. hacking collections (cloning them and using the cloned ones).

Also contains three tiny only somewhat related improvements:
 1. document new bot commands `/rebuild` and `/rebuild_failed` (141d2c2289ef316e443cdec44f9f0bd95f8b70aa), CC @jctanner;
 2. fix/improve first paragraph of BOTMETA.yml docs for collections (55ae0b5ce37b06933170028cabf05d832bdeb94a);
 3. update list of Python versions for compile tests (a608b58fe90b29411a16efbe59f42ac3f2c3e15c).

CC @gundalow @maxamillion @mattclay 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/developing_collections.rst
docs/docsite/rst/dev_guide/testing_compile.rst
docs/docsite/rst/dev_guide/testing.rst
