### PR TITLE
Openstack inventory script moved to openstack.cloud

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -3250,7 +3250,7 @@ files:
     maintainers: $team_openstack
     labels:
     - cloud
-    migrated_to: community.general
+    migrated_to: openstack.cloud
   contrib/inventory/ovirt4.py: *id003
   contrib/inventory/infoblox.py:
     keywords:

--- a/changelogs/fragments/openstack_botmeta.yml
+++ b/changelogs/fragments/openstack_botmeta.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Openstack inventory script is moved to openstack.cloud from community.general.


### PR DESCRIPTION
##### SUMMARY

Openstack dynamic inventory script is moved from community.general to
openstack.cloud, adjust the bot meta accordingly.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml
changelogs/fragments/openstack_botmeta.yml
