### PR TITLE
[2.9] Fix warning message in dense callback plugin

### DIFF
--- a/changelogs/fragments/64628-dense-callback-warning.yml
+++ b/changelogs/fragments/64628-dense-callback-warning.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- dense callback - fix plugin access to its configuration variables and remove a warning message (https://github.com/ansible/ansible/issues/64628).

--- a/lib/ansible/plugins/callback/dense.py
+++ b/lib/ansible/plugins/callback/dense.py
@@ -145,7 +145,7 @@ colors = dict(
 states = ('skipped', 'ok', 'changed', 'failed', 'unreachable')
 
 
-class CallbackModule_dense(CallbackModule_default):
+class CallbackModule(CallbackModule_default):
 
     '''
     This is the dense callback interface, where screen estate is still valued.
@@ -498,5 +498,3 @@ class CallbackModule_dense(CallbackModule_default):
 # When using -vv or higher, simply do the default action
 if display.verbosity >= 2 or not HAS_OD:
     CallbackModule = CallbackModule_default
-else:
-    CallbackModule = CallbackModule_dense


### PR DESCRIPTION
##### SUMMARY

Fix dense callback plugin access to its configuration variables
and remove a warning message

Backport of https://github.com/ansible-collections/community.general/pull/83

Fixes: #64628


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/64628-dense-callback-warning.yml
lib/ansible/plugins/callback/dense.py
