### PR TITLE
Add option to supress the changed task output

### DIFF
--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -55,6 +55,7 @@ from ansible.utils.color import colorize, hostcolor
 # TODO: Change the default of check_mode_markers to True in a future release (2.13)
 COMPAT_OPTIONS = (('display_skipped_hosts', C.DISPLAY_SKIPPED_HOSTS),
                   ('display_ok_hosts', True),
+                  ('display_changed_hosts', True),
                   ('show_custom_stats', C.SHOW_CUSTOM_STATS),
                   ('display_failed_stderr', False),
                   ('check_mode_markers', False),)
@@ -124,6 +125,9 @@ class CallbackModule(CallbackBase):
         if isinstance(result._task, TaskInclude):
             return
         elif result._result.get('changed', False):
+            if not self.display_changed_hosts:
+                return
+
             if self._last_task_banner != result._task._uuid:
                 self._print_task_banner(result._task)
 
@@ -293,6 +297,9 @@ class CallbackModule(CallbackBase):
         if isinstance(result._task, TaskInclude):
             return
         elif result._result.get('changed', False):
+            if not self.display_changed_hosts:
+                return
+
             if self._last_task_banner != result._task._uuid:
                 self._print_task_banner(result._task)
 

--- a/lib/ansible/plugins/doc_fragments/default_callback.py
+++ b/lib/ansible/plugins/doc_fragments/default_callback.py
@@ -34,6 +34,17 @@ class ModuleDocFragment(object):
           - key: display_ok_hosts
             section: defaults
         version_added: '2.7'
+      display_changed_hosts:
+        name: Show 'changed' hosts
+        description: "Toggle to control displaying 'changed' task/host results in a task"
+        type: bool
+        default: yes
+        env:
+          - name: ANSIBLE_DISPLAY_CHANGED_HOSTS
+        ini:
+          - key: display_changed_hosts
+            section: defaults
+        version_added: '2.10'
       display_failed_stderr:
         name: Use STDERR for failed and unreachable tasks
         description: "Toggle to control whether failed and unreachable tasks are displayed to STDERR (vs. STDOUT)"

--- a/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok_changed.stderr
+++ b/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok_changed.stderr
@@ -1,0 +1,2 @@
++ ansible-playbook -i inventory test.yml
+++ set +x

--- a/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok_changed.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok_changed.stdout
@@ -14,9 +14,10 @@ fatal: [testhost]: FAILED! => {"msg": "All items completed"}
 
 TASK [EXPECTED FAILURE Failed task to be rescued] ******************************
 fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed as requested from task"}
+included: .../test/integration/targets/callback_default/include_me.yml for testhost => (item=1)
 
 PLAY [testhost] ****************************************************************
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+testhost                   : ok=14   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok_changed.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok_changed.stdout
@@ -1,0 +1,22 @@
+
+PLAY [testhost] ****************************************************************
+
+TASK [Failed task] *************************************************************
+fatal: [testhost]: FAILED! => {"changed": false, "msg": "no reason"}
+...ignoring
+
+TASK [debug loop] **************************************************************
+failed: [testhost] (item=debug-2) => {
+    "msg": "debug-2"
+}
+fatal: [testhost]: FAILED! => {"msg": "All items completed"}
+...ignoring
+
+TASK [EXPECTED FAILURE Failed task to be rescued] ******************************
+fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed as requested from task"}
+
+PLAY [testhost] ****************************************************************
+
+PLAY RECAP *********************************************************************
+testhost                   : ok=12   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+

--- a/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok_changed.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok_changed.stdout
@@ -19,5 +19,5 @@ included: .../test/integration/targets/callback_default/include_me.yml for testh
 PLAY [testhost] ****************************************************************
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=14   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2
+testhost                   : ok=14   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/runme.sh
+++ b/test/integration/targets/callback_default/runme.sh
@@ -133,10 +133,18 @@ export ANSIBLE_DISPLAY_OK_HOSTS=0
 
 run_test hide_ok
 
+# Hide skipped/ok/changed
+export ANSIBLE_DISPLAY_SKIPPED_HOSTS=0
+export ANSIBLE_DISPLAY_OK_HOSTS=0
+export ANSIBLE_DISPLAY_CHANGED_HOSTS=0
+
+run_test hide_skipped_ok_changed
+
 # Failed to stderr
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS=1
 export ANSIBLE_DISPLAY_OK_HOSTS=1
 export ANSIBLE_DISPLAY_FAILED_STDERR=1
+export ANSIBLE_DISPLAY_CHANGED_HOSTS=1
 
 run_test failed_to_stderr
 


### PR DESCRIPTION
##### SUMMARY
This allows users to avoid printing changed output.

This is extremely valuable if a user has a large number of hosts where they make a minor change to all of them, and need to run playbooks in a minimal form where only the failed tasks are shown.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/doc_fragments/default_callback.py

##### ADDITIONAL INFORMATION
Demo:

```paste below
(ansible3) arominge-OSX:ansible alancoding$ ANSIBLE_DISPLAY_SKIPPED_HOSTS=false ANSIBLE_DISPLAY_OK_HOSTS=false ANSIBLE_DISPLAY_CHANGED_HOSTS=false ansible-playbook -i ~/Documents/repos/jlaska-ansible-playbooks/inventories/for_gen_host_status.ini ~/Documents/repos/jlaska-ansible-playbooks/gen_host_status.yml 
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under
development. This is a rapidly changing source of code and can become unstable at any point.

PLAY [all] **************************************************************************************************************************************************************************

TASK [All failhosts aboard the failboat] ********************************************************************************************************************************************
fatal: [4_failed]: FAILED! => {"changed": false, "msg": "I did nothing to deserve this."}

TASK [Ignore this failure for some hosts] *******************************************************************************************************************************************
fatal: [5_ignored]: FAILED! => {"changed": false, "msg": "<insert inspirational quote about failure>"}
...ignoring

TASK [fail] *************************************************************************************************************************************************************************
fatal: [6_rescued]: FAILED! => {"changed": false, "msg": "HALP!!!"}

PLAY RECAP **************************************************************************************************************************************************************************
1_ok                       : ok=1    changed=0    unreachable=0    failed=0    skipped=6    rescued=0    ignored=0   
2_skipped                  : ok=0    changed=0    unreachable=0    failed=0    skipped=7    rescued=0    ignored=0   
3_changed                  : ok=2    changed=1    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
4_failed                   : ok=1    changed=0    unreachable=0    failed=1    skipped=1    rescued=0    ignored=0   
5_ignored                  : ok=2    changed=0    unreachable=0    failed=0    skipped=5    rescued=0    ignored=1   
6_rescued                  : ok=2    changed=0    unreachable=0    failed=0    skipped=5    rescued=1    ignored=0   

(ansible3) arominge-OSX:ansible alancoding$ 
(ansible3) arominge-OSX:ansible alancoding$ 
(ansible3) arominge-OSX:ansible alancoding$ ANSIBLE_DISPLAY_SKIPPED_HOSTS=false ANSIBLE_DISPLAY_OK_HOSTS=false ansible-playbook -i ~/Documents/repos/jlaska-ansible-playbooks/inventories/for_gen_host_status.ini ~/Documents/repos/jlaska-ansible-playbooks/gen_host_status.yml 
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under
development. This is a rapidly changing source of code and can become unstable at any point.

PLAY [all] **************************************************************************************************************************************************************************

TASK [Hosts haven't really changed, but we will say they have] **********************************************************************************************************************
changed: [3_changed] => {
    "msg": "I am a changed host."
}

TASK [All failhosts aboard the failboat] ********************************************************************************************************************************************
fatal: [4_failed]: FAILED! => {"changed": false, "msg": "I did nothing to deserve this."}

TASK [Ignore this failure for some hosts] *******************************************************************************************************************************************
fatal: [5_ignored]: FAILED! => {"changed": false, "msg": "<insert inspirational quote about failure>"}
...ignoring

TASK [fail] *************************************************************************************************************************************************************************
fatal: [6_rescued]: FAILED! => {"changed": false, "msg": "HALP!!!"}

PLAY RECAP **************************************************************************************************************************************************************************
1_ok                       : ok=1    changed=0    unreachable=0    failed=0    skipped=6    rescued=0    ignored=0   
2_skipped                  : ok=0    changed=0    unreachable=0    failed=0    skipped=7    rescued=0    ignored=0   
3_changed                  : ok=2    changed=1    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
4_failed                   : ok=1    changed=0    unreachable=0    failed=1    skipped=1    rescued=0    ignored=0   
5_ignored                  : ok=2    changed=0    unreachable=0    failed=0    skipped=5    rescued=0    ignored=1   
6_rescued                  : ok=2    changed=0    unreachable=0    failed=0    skipped=5    rescued=1    ignored=0   


```

----

content:

```yaml
- hosts: all
  gather_facts: false
  tasks:
    - name: A debug msg all hosts will show except for skipped ones
      debug:
        msg: "Playing {{ ansible_host }}"
      when: "'_skipped' not in ansible_host"

    - name: Hosts haven't really changed, but we will say they have
      debug:
        msg: "I am a changed host."
      changed_when: true
      when: "'_changed' in ansible_host"

    - name: All failhosts aboard the failboat
      fail:
        msg: "I did nothing to deserve this."
      when: "'_failed' in ansible_host"

    - name: Ignore this failure for some hosts
      fail:
        msg: "<insert inspirational quote about failure>"
      ignore_errors: true
      when: "'_ignored' in ansible_host"

    - name: Fail and rescue - collection of tasks
      block:
        - fail:
            msg: "HALP!!!"
          when: "'_rescued' in ansible_host"
      rescue:
        - debug: msg="ε-(´・｀) ﾌ"

    - name: Set unreachable fact
      set_fact: 
        unreachable: true
      when: "'_unreachable' in ansible_host"

    - name: Reach out to the unreachable hosts
      ping:
      vars:
        ansible_host: 'invalid.invalid'
      when: unreachable is defined and unreachable
```


inventory

```
1_ok
2_skipped
3_changed
4_failed
5_ignored
6_rescued
```

