### PR TITLE
Update ansible-runner tests version and deps

### DIFF
--- a/test/integration/targets/ansible-runner/tasks/setup.yml
+++ b/test/integration/targets/ansible-runner/tasks/setup.yml
@@ -1,11 +1,7 @@
-- name: Install docutils
-  pip:
-    name: docutils
-
 - name: Install ansible-runner
   pip:
     name: ansible-runner
-    version: 1.2.0
+    version: 1.4.6
 
 - name: Find location of ansible-runner installation
   command: "'{{ ansible_python_interpreter }}' -c 'import os, ansible_runner; print(os.path.dirname(ansible_runner.__file__))'"


### PR DESCRIPTION
We could not find reason for the docutils install so trying out removing it.
Also bumping to latest version of ansible-runner

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-runner tests