### PR TITLE
Switch network incidental tests to VyOS 1.1.7-R2.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -132,8 +132,8 @@ matrix:
     - env: T=i/windows/2019
 
     - env: T=i/ios/csr1000v//1
-    - env: T=i/vyos/1.1.8/2.7/1
-    - env: T=i/vyos/1.1.8/3.6/1
+    - env: T=i/vyos/1.1.7-R2/2.7/1
+    - env: T=i/vyos/1.1.7-R2/3.6/1
 
     - env: T=i/aws/2.7/1
     - env: T=i/aws/3.6/1

--- a/test/lib/ansible_test/_data/completion/network.txt
+++ b/test/lib/ansible_test/_data/completion/network.txt
@@ -1,2 +1,3 @@
 ios/csr1000v collection=cisco.ios connection=ansible.netcommon.network_cli
 vyos/1.1.8 collection=vyos.vyos connection=ansible.netcommon.network_cli
+vyos/1.1.7-R2 collection=vyos.vyos connection=ansible.netcommon.network_cli


### PR DESCRIPTION
##### SUMMARY

Switch network incidental tests to VyOS 1.1.7-R2.

The previous version being used, VyOS 1.1.8, is currently unavailable in AWS.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

shippable.yml
