### PR TITLE
native types: literal_eval all the things

### DIFF
--- a/lib/ansible/template/native_helpers.py
+++ b/lib/ansible/template/native_helpers.py
@@ -48,10 +48,6 @@ def ansible_native_concat(nodes):
             # See https://github.com/ansible/ansible/issues/52158
             # We do that only here because it is taken care of by to_text() in the else block below already.
             str(out)
-
-        # short circuit literal_eval when possible
-        if not isinstance(out, list):
-            return out
     else:
         if isinstance(nodes, types.GeneratorType):
             nodes = chain(head, nodes)

--- a/lib/ansible/template/native_helpers.py
+++ b/lib/ansible/template/native_helpers.py
@@ -14,7 +14,7 @@ from jinja2.runtime import StrictUndefined
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.common.text.converters import container_to_text
-from ansible.module_utils.six import binary_type, PY2
+from ansible.module_utils.six import PY2
 from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
 
 

--- a/lib/ansible/template/native_helpers.py
+++ b/lib/ansible/template/native_helpers.py
@@ -13,6 +13,8 @@ import types
 from jinja2.runtime import StrictUndefined
 
 from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import container_to_text
+from ansible.module_utils.six import binary_type, PY2
 from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
 
 
@@ -56,6 +58,10 @@ def ansible_native_concat(nodes):
         out = u''.join([to_text(v) for v in nodes])
 
     try:
-        return literal_eval(out)
+        out = literal_eval(out)
+        if PY2:
+            # ensure bytes are not returned back into Ansible from templating
+            out = container_to_text(out)
+        return out
     except (ValueError, SyntaxError, MemoryError):
         return out

--- a/test/integration/targets/jinja2_native_types/filter_plugins/native_plugins.py
+++ b/test/integration/targets/jinja2_native_types/filter_plugins/native_plugins.py
@@ -1,8 +1,0 @@
-from ansible.module_utils._text import to_text
-
-
-class FilterModule(object):
-    def filters(self):
-        return {
-            'to_text': to_text,
-        }

--- a/test/integration/targets/jinja2_native_types/test_casting.yml
+++ b/test/integration/targets/jinja2_native_types/test_casting.yml
@@ -1,9 +1,9 @@
 - name: cast things to other things
   set_fact:
-      int_to_str: "{{ i_two|to_text }}"
+      int_to_str: "'{{ i_two }}'"
       str_to_int: "{{ s_two|int }}"
-      dict_to_str: "{{ dict_one|to_text }}"
-      list_to_str: "{{ list_one|to_text }}"
+      dict_to_str: "'{{ dict_one }}'"
+      list_to_str: "'{{ list_one }}'"
       int_to_bool: "{{ i_one|bool }}"
       str_true_to_bool: "{{ s_true|bool }}"
       str_false_to_bool: "{{ s_false|bool }}"

--- a/test/integration/targets/jinja2_native_types/test_casting.yml
+++ b/test/integration/targets/jinja2_native_types/test_casting.yml
@@ -11,11 +11,11 @@
 - assert:
     that:
         - 'int_to_str == "2"'
-        - 'int_to_str|type_debug == "unicode"'
+        - 'int_to_str|type_debug in ["str", "unicode"]'
         - 'str_to_int == 2'
         - 'str_to_int|type_debug == "int"'
-        - 'dict_to_str|type_debug == "unicode"'
-        - 'list_to_str|type_debug == "unicode"'
+        - 'dict_to_str|type_debug in ["str", "unicode"]'
+        - 'list_to_str|type_debug in ["str", "unicode"]'
         - 'int_to_bool is sameas true'
         - 'int_to_bool|type_debug == "bool"'
         - 'str_true_to_bool is sameas true'

--- a/test/integration/targets/jinja2_native_types/test_casting.yml
+++ b/test/integration/targets/jinja2_native_types/test_casting.yml
@@ -11,11 +11,11 @@
 - assert:
     that:
         - 'int_to_str == "2"'
-        - 'int_to_str|type_debug in ["str", "unicode"]'
+        - 'int_to_str|type_debug == "unicode"'
         - 'str_to_int == 2'
         - 'str_to_int|type_debug == "int"'
-        - 'dict_to_str|type_debug in ["str", "unicode"]'
-        - 'list_to_str|type_debug in ["str", "unicode"]'
+        - 'dict_to_str|type_debug == "unicode"'
+        - 'list_to_str|type_debug == "unicode"'
         - 'int_to_bool is sameas true'
         - 'int_to_bool|type_debug == "bool"'
         - 'str_true_to_bool is sameas true'

--- a/test/integration/targets/jinja2_native_types/test_concatentation.yml
+++ b/test/integration/targets/jinja2_native_types/test_concatentation.yml
@@ -18,7 +18,7 @@
 
 - name: concatenate int and string
   set_fact:
-      string_sum: "{{ [(i_one|to_text), s_two]|join('') }}"
+      string_sum: "'{{ [i_one, s_two]|join('') }}'"
 
 - assert:
     that:

--- a/test/integration/targets/jinja2_native_types/test_concatentation.yml
+++ b/test/integration/targets/jinja2_native_types/test_concatentation.yml
@@ -23,7 +23,7 @@
 - assert:
     that:
         - 'string_sum == "12"'
-        - 'string_sum|type_debug == "unicode"'
+        - 'string_sum|type_debug in ["str", "unicode"]'
 
 - name: add two lists
   set_fact:
@@ -40,7 +40,7 @@
 
 - assert:
     that:
-        - 'list_sum_multi|type_debug == "unicode"'
+        - 'list_sum_multi|type_debug in ["str", "unicode"]'
 
 - name: add two dicts
   set_fact:
@@ -58,7 +58,7 @@
 - assert:
     that:
         - 'list_for_strings == "onetwo"'
-        - 'list_for_strings|type_debug == "unicode"'
+        - 'list_for_strings|type_debug in ["str", "unicode"]'
 
 - name: loop through list with int
   set_fact:

--- a/test/integration/targets/jinja2_native_types/test_concatentation.yml
+++ b/test/integration/targets/jinja2_native_types/test_concatentation.yml
@@ -23,7 +23,7 @@
 - assert:
     that:
         - 'string_sum == "12"'
-        - 'string_sum|type_debug in ["str", "unicode"]'
+        - 'string_sum|type_debug == "unicode"'
 
 - name: add two lists
   set_fact:
@@ -40,7 +40,7 @@
 
 - assert:
     that:
-        - 'list_sum_multi|type_debug in ["str", "unicode"]'
+        - 'list_sum_multi|type_debug == "unicode"'
 
 - name: add two dicts
   set_fact:
@@ -58,7 +58,7 @@
 - assert:
     that:
         - 'list_for_strings == "onetwo"'
-        - 'list_for_strings|type_debug in ["str", "unicode"]'
+        - 'list_for_strings|type_debug == "unicode"'
 
 - name: loop through list with int
   set_fact:

--- a/test/integration/targets/jinja2_native_types/test_dunder.yml
+++ b/test/integration/targets/jinja2_native_types/test_dunder.yml
@@ -20,4 +20,4 @@
 
 - assert:
     that:
-        - 'const_dunder|type_debug == "unicode"'
+        - 'const_dunder|type_debug in ["str", "unicode"]'

--- a/test/integration/targets/jinja2_native_types/test_dunder.yml
+++ b/test/integration/targets/jinja2_native_types/test_dunder.yml
@@ -20,4 +20,4 @@
 
 - assert:
     that:
-        - 'const_dunder|type_debug in ["str", "unicode"]'
+        - 'const_dunder|type_debug == "unicode"'

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -286,8 +286,6 @@ test/integration/targets/incidental_win_dsc/files/xTestDsc/1.0.1/DSCResources/AN
 test/integration/targets/incidental_win_dsc/files/xTestDsc/1.0.1/xTestDsc.psd1 pslint!skip
 test/integration/targets/incidental_win_ping/library/win_ping_syntax_error.ps1 pslint!skip
 test/integration/targets/incidental_win_reboot/templates/post_reboot.ps1 pslint!skip
-test/integration/targets/jinja2_native_types/filter_plugins/native_plugins.py future-import-boilerplate
-test/integration/targets/jinja2_native_types/filter_plugins/native_plugins.py metaclass-boilerplate
 test/integration/targets/lookup_ini/lookup-8859-15.ini no-smart-quotes
 test/integration/targets/module_precedence/lib_with_extension/ping.py future-import-boilerplate
 test/integration/targets/module_precedence/lib_with_extension/ping.py metaclass-boilerplate


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
With https://github.com/pallets/jinja/pull/1190 merged our short-circuit
is no longer valid (has it ever been?) as now data like ' True ' may go
through our ansible_native_concat function as opposed to going through
intermediate call to Jinja2's native_concat before. Now we need to always
send data through literal_eval to ensure native types are returned.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
 lib/ansible/template/native_helpers.py