### PR TITLE
Switch testing to VyOS 1.1.7-R2.

### DIFF
--- a/test/lib/ansible_test/_data/completion/network.txt
+++ b/test/lib/ansible_test/_data/completion/network.txt
@@ -2,3 +2,4 @@ ios/csr1000v
 junos/vmx
 junos/vsrx
 vyos/1.1.8
+vyos/1.1.7-R2

--- a/test/utils/shippable/network.sh
+++ b/test/utils/shippable/network.sh
@@ -30,14 +30,14 @@ if [ -s /tmp/network.txt ]; then
     echo "Running network integration tests for multiple platforms concurrently."
 
     platforms=(
-        --platform vyos/1.1.8
+        --platform vyos/1.1.7-R2
     )
 else
     echo "No changes requiring integration tests specific to networking were detected."
     echo "Running network integration tests for a single platform only."
 
     platforms=(
-        --platform vyos/1.1.8
+        --platform vyos/1.1.7-R2
     )
 fi
 


### PR DESCRIPTION
##### SUMMARY

Switch testing to VyOS 1.1.7-R2.

The 1.1.8 image is currently unavailable.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

test/utils/shippable/network.sh
