### PR TITLE
small fix to install command as no longer needs -p by default

### DIFF
--- a/docs/docsite/rst/shared_snippets/installing_multiple_collections.txt
+++ b/docs/docsite/rst/shared_snippets/installing_multiple_collections.txt
@@ -35,4 +35,4 @@ file used in older Ansible releases.
 .. note::
     While both roles and collections can be specified in one requirements file, they need to be installed separately.
     The ``ansible-galaxy role install -r requirements.yml`` will only install roles and
-    ``ansible-galaxy collection install -r requirements.yml -p ./`` will only install collections.
+    ``ansible-galaxy collection install -r requirements.yml`` will only install collections.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-galaxy
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
