### PR TITLE
Revert "Switch network incidental tests to VyOS 1.1.7-R2."

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -132,8 +132,8 @@ matrix:
     - env: T=i/windows/2019
 
     - env: T=i/ios/csr1000v//1
-    - env: T=i/vyos/1.1.7-R2/2.7/1
-    - env: T=i/vyos/1.1.7-R2/3.6/1
+    - env: T=i/vyos/1.1.8/2.7/1
+    - env: T=i/vyos/1.1.8/3.6/1
 
     - env: T=i/aws/2.7/1
     - env: T=i/aws/3.6/1

--- a/test/lib/ansible_test/_data/completion/network.txt
+++ b/test/lib/ansible_test/_data/completion/network.txt
@@ -1,3 +1,2 @@
 ios/csr1000v collection=cisco.ios connection=ansible.netcommon.network_cli
 vyos/1.1.8 collection=vyos.vyos connection=ansible.netcommon.network_cli
-vyos/1.1.7-R2 collection=vyos.vyos connection=ansible.netcommon.network_cli


### PR DESCRIPTION
##### SUMMARY

Revert "Switch network incidental tests to VyOS 1.1.7-R2."

This reverts commit 7d5177d6a06154c19ed6b400bdb2b17beeee9606.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

shippable.yml
