### PR TITLE
Fix --start-at-task when skipping tasks with no name

### DIFF
--- a/changelogs/fragments/68569-start-at-fix.yaml
+++ b/changelogs/fragments/68569-start-at-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Using --start-at-task would fail when it attempted to skip over tasks with no name.

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -201,7 +201,9 @@ class PlayIterator:
                     (s, task) = self.get_next_task_for_host(host, peek=True)
                     if s.run_state == self.ITERATING_COMPLETE:
                         break
-                    if task.name == play_context.start_at_task or fnmatch.fnmatch(task.name, play_context.start_at_task) or \
+                    if task.name is None:
+                        self.get_next_task_for_host(host)
+                    elif task.name == play_context.start_at_task or fnmatch.fnmatch(task.name, play_context.start_at_task) or \
                        task.get_name() == play_context.start_at_task or fnmatch.fnmatch(task.get_name(), play_context.start_at_task):
                         start_at_matched = True
                         break

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -201,9 +201,7 @@ class PlayIterator:
                     (s, task) = self.get_next_task_for_host(host, peek=True)
                     if s.run_state == self.ITERATING_COMPLETE:
                         break
-                    if task.name is None:
-                        self.get_next_task_for_host(host)
-                    elif task.name == play_context.start_at_task or fnmatch.fnmatch(task.name, play_context.start_at_task) or \
+                    if task.name == play_context.start_at_task or (task.name and fnmatch.fnmatch(task.name, play_context.start_at_task)) or \
                        task.get_name() == play_context.start_at_task or fnmatch.fnmatch(task.get_name(), play_context.start_at_task):
                         start_at_matched = True
                         break

--- a/test/integration/targets/play_iterator/aliases
+++ b/test/integration/targets/play_iterator/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group4

--- a/test/integration/targets/play_iterator/playbook.yml
+++ b/test/integration/targets/play_iterator/playbook.yml
@@ -1,0 +1,10 @@
+---
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name:
+      debug:
+        msg: foo
+    - name: "task 2"
+      debug:
+        msg: bar

--- a/test/integration/targets/play_iterator/runme.sh
+++ b/test/integration/targets/play_iterator/runme.sh
@@ -2,4 +2,4 @@
 
 set -ux
 
-ansible-playbook playbook.yml -vvv --start-at-task 'task 2' "$@"
+ansible-playbook playbook.yml --start-at-task 'task 2' "$@"

--- a/test/integration/targets/play_iterator/runme.sh
+++ b/test/integration/targets/play_iterator/runme.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-set -ux
+set -eux
 
 ansible-playbook playbook.yml --start-at-task 'task 2' "$@"

--- a/test/integration/targets/play_iterator/runme.sh
+++ b/test/integration/targets/play_iterator/runme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -ux
+
+ansible-playbook playbook.yml -vvv --start-at-task 'task 2' "$@"

--- a/test/units/executor/test_play_iterator.py
+++ b/test/units/executor/test_play_iterator.py
@@ -19,6 +19,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import pytest
+
 from units.compat import unittest
 from units.compat.mock import patch, MagicMock
 
@@ -456,3 +458,53 @@ class TestPlayIterator(unittest.TestCase):
         # test a regular insertion
         s_copy = s.copy()
         res_state = itr._insert_tasks_into_state(s_copy, task_list=[MagicMock()])
+
+
+def test_play_iterator_skip_blank_name():
+    """Skipping over a task with no name should not fail."""
+    fake_loader = DictDataLoader({
+        "test_play.yml": """
+        - hosts: all
+          gather_facts: false
+          tasks:
+            - name:
+              debug:
+                msg: foo
+            - name: task 2
+              debug:
+                msg: bar
+        """,
+    })
+
+    mock_var_manager = MagicMock()
+    mock_var_manager._fact_cache = dict()
+    mock_var_manager.get_vars.return_value = dict()
+
+    p = Playbook.load('test_play.yml', loader=fake_loader, variable_manager=mock_var_manager)
+
+    hosts = []
+    host = MagicMock()
+    host.name = host.get_name.return_value = 'host01'
+    hosts.append(host)
+
+    inventory = MagicMock()
+    inventory.get_hosts.return_value = hosts
+    inventory.filter_hosts.return_value = hosts
+
+    play_context = PlayContext(play=p._entries[0])
+    play_context.start_at_task = 'task 2'
+
+    itr = PlayIterator(
+        inventory=inventory,
+        play=p._entries[0],
+        play_context=play_context,
+        variable_manager=mock_var_manager,
+        all_vars=dict(),
+    )
+
+    # First task should be 'task 2'
+    (host_state, task) = itr.get_next_task_for_host(hosts[0])
+    assert task is not None
+    assert task.name == 'task 2'
+    assert task.action == 'debug'
+    assert task.args == dict(msg='bar')


### PR DESCRIPTION
##### SUMMARY
Using --start-at-task on a playbook with tasks with no name would fail
if those unnamed tasks were encountered before the targetted start task.

Fixes #68569 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/executor/play_iterator.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
