### PR TITLE
Specify numeric range can contain a stride

### DIFF
--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -168,6 +168,24 @@ In YAML:
       webservers:
         hosts:
           www[01:50].example.com:
+          
+You can specify a stride (increments between sequence numbers) when defining a numeric range of hosts:
+
+In INI:
+
+.. code-block:: text
+
+    [webservers]
+    www[01:50:2].example.com
+
+In YAML:
+
+.. code-block:: yaml
+
+    ...
+      webservers:
+        hosts:
+          www[01:50:2].example.com:
 
 For numeric patterns, leading zeros can be included or removed, as desired. Ranges are inclusive. You can also define alphabetic ranges:
 


### PR DESCRIPTION
Updated the range creation example to show that you can also specify a stride value when creating a hostname by numeric range. 
