### PR TITLE
windows - fix up env var quoting for unicode single quotes

### DIFF
--- a/changelogs/fragments/win_env_var.yaml
+++ b/changelogs/fragments/win_env_var.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- windows environment - Support env vars that contain the unicode variant of single quotes - https://github.com/ansible-collections/ansible.windows/issues/45
+- shell cmd - Properly escape double quotes in the command argument

--- a/lib/ansible/plugins/shell/cmd.py
+++ b/lib/ansible/plugins/shell/cmd.py
@@ -52,6 +52,7 @@ class ShellModule(PSShellModule):
         # https://stackoverflow.com/questions/3411771/multiple-character-replace-with-python
         for c in '^()%!"<>&|':  # '^' must be the first char that we scan and replace
             if c in s:
-                s = s.replace(c, "^" + c)
+                # I can't find any docs that explicitly say this but to escape ", it needs to be prefixed with \^.
+                s = s.replace(c, ("\\^" if c == '"' else "^") + c)
 
         return '^"' + s + '^"'

--- a/test/integration/targets/win_exec_wrapper/tasks/main.yml
+++ b/test/integration/targets/win_exec_wrapper/tasks/main.yml
@@ -164,6 +164,7 @@
     single_quote: "single ' quote"
     hyphen-var: abc@123
     '_-(){}[]<>*+-/\?"''!@#$%^&|;:i,.`~0': '_-(){}[]<>*+-/\?"''!@#$%^&|;:i,.`~0'
+    '‘key': 'value‚'
   register: environment_block
 
 - name: assert environment block for task
@@ -177,6 +178,7 @@
     - '"hyphen-var=abc@123" in environment_block.stdout_lines'
     # yaml escaping rules - (\\ == \), (\" == "), ('' == ')
     - '"_-(){}[]<>*+-/\\?\"''!@#$%^&|;:i,.`~0=_-(){}[]<>*+-/\\?\"''!@#$%^&|;:i,.`~0" in environment_block.stdout_lines'
+    - '"‘key=value‚" in environment_block.stdout_lines'
 
 - name: test out become requires without become_user set
   test_all_options:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -347,6 +347,7 @@ test/integration/targets/wait_for/files/testserver.py metaclass-boilerplate
 test/integration/targets/want_json_modules_posix/library/helloworld.py future-import-boilerplate
 test/integration/targets/want_json_modules_posix/library/helloworld.py metaclass-boilerplate
 test/integration/targets/win_exec_wrapper/library/test_fail.ps1 pslint:PSCustomUseLiteralPath
+test/integration/targets/win_exec_wrapper/tasks/main.yml no-smart-quotes  # We are explicitly testing smart quote support for env vars
 test/integration/targets/win_module_utils/library/legacy_only_new_way_win_line_ending.ps1 line-endings  # Explicitly tests that we still work with Windows line endings
 test/integration/targets/win_module_utils/library/legacy_only_old_way_win_line_ending.ps1 line-endings  # Explicitly tests that we still work with Windows line endings
 test/integration/targets/win_script/files/test_script.ps1 pslint:PSAvoidUsingWriteHost # Keep

--- a/test/units/plugins/shell/test_cmd.py
+++ b/test/units/plugins/shell/test_cmd.py
@@ -7,7 +7,7 @@ from ansible.plugins.shell.cmd import ShellModule
     ['arg1', 'arg1'],
     [None, '""'],
     ['arg1 and 2', '^"arg1 and 2^"'],
-    ['malicious argument\\"&whoami', '^"malicious argument\\^"^&whoami^"'],
+    ['malicious argument\\"&whoami', '^"malicious argument\\\\^"^&whoami^"'],
     ['C:\\temp\\some ^%file% > nul', '^"C:\\temp\\some ^^^%file^% ^> nul^"']
 ])
 def test_quote_args(s, expected):


### PR DESCRIPTION
##### SUMMARY
PowerShell considers a few other unicode quote characters as a substitute for a single quote. If they were used in an env var then it would be skipped due to our quote escaping rules not escaping those chars as well. This removes the need to escape those chars by injecting them directly into the Runspace.

Also fixed up some incorrect escaping rules for `"` in a cmd argument. 

Related: https://github.com/ansible-collections/ansible.windows/pull/48

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
powershell
cmd