### PR TITLE
Add variable for DEFAULT_NO_TARGET_SYSLOG

### DIFF
--- a/changelogs/fragments/no_target_syslog-var.yaml
+++ b/changelogs/fragments/no_target_syslog-var.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Added the ability to set ``DEFAULT_NO_TARGET_SYSLOG`` through the ``ansible_no_target_syslog`` variable on a task

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -904,7 +904,8 @@ DEFAULT_NO_TARGET_SYSLOG:
   ini:
   - {key: no_target_syslog, section: defaults}
   vars:
-  - {name: ansible_no_target_syslog}
+  - name: ansible_no_target_syslog
+    version_added: '2.10'
   type: boolean
   yaml: {key: defaults.no_target_syslog}
 DEFAULT_NULL_REPRESENTATION:

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -897,10 +897,14 @@ DEFAULT_NO_LOG:
 DEFAULT_NO_TARGET_SYSLOG:
   name: No syslog on target
   default: False
-  description: Toggle Ansible logging to syslog on the target when it executes tasks.
+  description:
+  - Toggle Ansible logging to syslog on the target when it executes tasks. On Windows hosts this will disable a newer
+    style PowerShell modules from writting to the event log.
   env: [{name: ANSIBLE_NO_TARGET_SYSLOG}]
   ini:
   - {key: no_target_syslog, section: defaults}
+  vars:
+  - {name: ansible_no_target_syslog}
   type: boolean
   yaml: {key: defaults.no_target_syslog}
 DEFAULT_NULL_REPRESENTATION:

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -714,7 +714,8 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             module_args['_ansible_check_mode'] = False
 
         # set no log in the module arguments, if required
-        module_args['_ansible_no_log'] = self._play_context.no_log or C.DEFAULT_NO_TARGET_SYSLOG
+        no_target_syslog = C.config.get_config_value('DEFAULT_NO_TARGET_SYSLOG', variables=task_vars)
+        module_args['_ansible_no_log'] = self._play_context.no_log or no_target_syslog
 
         # set debug in the module arguments, if required
         module_args['_ansible_debug'] = C.DEFAULT_DEBUG


### PR DESCRIPTION
##### SUMMARY
Expose `DEFAULT_NO_TARGET_SYSLOG` through a variable and add notes that this also affects newer style PowerShell modules. Setting it on the task is done like

```
- win_stat:
    path: C:\Windows
  vars:
    ansible_no_target_syslog: True
```

Fixes https://github.com/ansible/ansible/issues/68656

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
config