### PR TITLE
stricter permissions on atomic_move when creating new file (#68970)

### DIFF
--- a/changelogs/fragments/atomic_move_permissions.yml
+++ b/changelogs/fragments/atomic_move_permissions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - stricter permissions when atomic_move creates a file due to target not existing yet CVE-2020-1736

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -59,7 +59,7 @@ PERMS_RE = re.compile(r'[^rwxXstugo]')
 
 _PERM_BITS = 0o7777          # file mode permission bits
 _EXEC_PERM_BITS = 0o0111     # execute permission bits
-_DEFAULT_PERM = 0o0666       # default file permission bits
+_DEFAULT_PERM = 0o0660       # default file permission bits
 
 
 def is_executable(path):

--- a/test/units/module_utils/basic/test_atomic_move.py
+++ b/test/units/module_utils/basic/test_atomic_move.py
@@ -59,7 +59,7 @@ def atomic_mocks(mocker):
 @pytest.fixture
 def fake_stat(mocker):
     stat1 = mocker.MagicMock()
-    stat1.st_mode = 0o0644
+    stat1.st_mode = 0o0640
     stat1.st_uid = 0
     stat1.st_gid = 0
     stat1.st_flags = 0
@@ -76,7 +76,8 @@ def test_new_file(atomic_am, atomic_mocks, mocker, selinux):
     atomic_am.atomic_move('/path/to/src', '/path/to/dest')
 
     atomic_mocks['rename'].assert_called_with(b'/path/to/src', b'/path/to/dest')
-    assert atomic_mocks['chmod'].call_args_list == [mocker.call(b'/path/to/dest', basic.DEFAULT_PERM & ~18)]
+    # 416 is what we expect with default perms set to 0640
+    assert atomic_mocks['chmod'].call_args_list == [mocker.call(b'/path/to/dest', 416)]
 
     if selinux:
         assert atomic_am.selinux_default_context.call_args_list == [mocker.call('/path/to/dest')]
@@ -97,7 +98,7 @@ def test_existing_file(atomic_am, atomic_mocks, fake_stat, mocker, selinux):
     atomic_am.atomic_move('/path/to/src', '/path/to/dest')
 
     atomic_mocks['rename'].assert_called_with(b'/path/to/src', b'/path/to/dest')
-    assert atomic_mocks['chmod'].call_args_list == [mocker.call(b'/path/to/src', basic.DEFAULT_PERM & ~18)]
+    assert atomic_mocks['chmod'].call_args_list == [mocker.call(b'/path/to/src', 416)]
 
     if selinux:
         assert atomic_am.set_context_if_different.call_args_list == [mocker.call('/path/to/dest', mock_context, False)]
@@ -120,10 +121,9 @@ def test_no_tty_fallback(atomic_am, atomic_mocks, fake_stat, mocker):
     atomic_am.atomic_move('/path/to/src', '/path/to/dest')
 
     atomic_mocks['rename'].assert_called_with(b'/path/to/src', b'/path/to/dest')
-    assert atomic_mocks['chmod'].call_args_list == [mocker.call(b'/path/to/src', basic.DEFAULT_PERM & ~18)]
-
     assert atomic_am.set_context_if_different.call_args_list == [mocker.call('/path/to/dest', mock_context, False)]
     assert atomic_am.selinux_context.call_args_list == [mocker.call('/path/to/dest')]
+    atomic_am.atomic_move('/path/to/src', '/path/to/dest')
 
 
 @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
@@ -148,9 +148,8 @@ def test_existing_file_stat_perms_failure(atomic_am, atomic_mocks, mocker):
     atomic_am.atomic_move('/path/to/src', '/path/to/dest')
 
     atomic_mocks['rename'].assert_called_with(b'/path/to/src', b'/path/to/dest')
-    # FIXME: Should atomic_move() set a default permission value when it cannot retrieve the
-    # existing file's permissions?  (Right now it's up to the calling code.
-    # assert atomic_mocks['chmod'].call_args_list == [mocker.call(b'/path/to/src', basic.DEFAULT_PERM & ~18)]
+    # atomic_move() will set a default permission value when it cannot retrieve the
+    # existing file's permissions.
     assert atomic_am.set_context_if_different.call_args_list == [mocker.call('/path/to/dest', mock_context, False)]
     assert atomic_am.selinux_context.call_args_list == [mocker.call('/path/to/dest')]
 
@@ -207,7 +206,7 @@ def test_rename_perms_fail_temp_succeeds(atomic_am, atomic_mocks, fake_stat, moc
     atomic_am.atomic_move('/path/to/src', '/path/to/dest')
     assert atomic_mocks['rename'].call_args_list == [mocker.call(b'/path/to/src', b'/path/to/dest'),
                                                      mocker.call(b'/path/to/tempfile', b'/path/to/dest')]
-    assert atomic_mocks['chmod'].call_args_list == [mocker.call(b'/path/to/dest', basic.DEFAULT_PERM & ~18)]
+    assert atomic_mocks['chmod'].call_args_list == [mocker.call(b'/path/to/dest', 416)]
 
     if selinux:
         assert atomic_am.selinux_default_context.call_args_list == [mocker.call('/path/to/dest')]


### PR DESCRIPTION
fixes #67794
  updated some tests that expected previous defaults
  CVE-2020-1736

(cherry picked from commit 566f2467f6ca6e0e817ea793ef802116ad469858)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
atomic_move