### PR TITLE
[2.9] podman_image: use correct option for remove_signatures flag

### DIFF
--- a/changelogs/fragments/67965_podman_image.yml
+++ b/changelogs/fragments/67965_podman_image.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Fix a typo in remove_signature flag in podman_image module (https://github.com/ansible/ansible/issues/67965).

--- a/lib/ansible/modules/cloud/podman/podman_image.py
+++ b/lib/ansible/modules/cloud/podman/podman_image.py
@@ -573,7 +573,7 @@ class PodmanImageManager(object):
             args.extend(['--format', push_format])
 
         if self.push_args.get('remove_signatures'):
-            args.append('--remove_signatures')
+            args.append('--remove-signatures')
 
         sign_by_key = self.push_args.get('sign_by')
         if sign_by_key:

--- a/test/integration/targets/setup_podman/defaults/main.yml
+++ b/test/integration/targets/setup_podman/defaults/main.yml
@@ -1,1 +1,1 @@
-podman_package: podman-1.4.*
+podman_package: podman-1.3.*

--- a/test/integration/targets/setup_podman/tasks/main.yml
+++ b/test/integration/targets/setup_podman/tasks/main.yml
@@ -1,4 +1,7 @@
 - block:
+    - name: Include distribution specific variables
+      include_vars: "{{ ansible_facts.distribution }}-{{ ansible_facts.distribution_major_version }}.yml"
+
     - name: Enable extras repo
       command: "{{ repo_command[ansible_facts.distribution ~ ansible_facts.distribution_major_version]['enable'] | default('echo') }}"
       notify: cleanup podman

--- a/test/integration/targets/setup_podman/vars/RedHat-7.yml
+++ b/test/integration/targets/setup_podman/vars/RedHat-7.yml
@@ -1,0 +1,1 @@
+podman_package: podman-1.3.*

--- a/test/integration/targets/setup_podman/vars/RedHat-8.yml
+++ b/test/integration/targets/setup_podman/vars/RedHat-8.yml
@@ -1,0 +1,1 @@
+podman_package: '@container-tools:1.0'

--- a/test/integration/targets/setup_podman/vars/main.yml
+++ b/test/integration/targets/setup_podman/vars/main.yml
@@ -1,4 +1,4 @@
 repo_command:
   RedHat7:
-    enable: yum-config-manager --enable rhui-REGION-rhel-server-extras
-    disable: yum-config-manager --disable rhui-REGION-rhel-server-extras
+    enable: yum-config-manager --enable rhui-REGION-rhel-server-extras rhui-rhel-7-server-rhui-extras-rpms
+    disable: yum-config-manager --disable rhui-REGION-rhel-server-extras rhui-rhel-7-server-rhui-extras-rpms


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/containers/ansible-podman-collections/pull/22


podman_image module uses 'podman push' command with wrong
flag '--remove_signatures' instead of '--remove-signatures'

This patch fixes the given typo.

Fixes: ansible/ansible#67965

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/67965_podman_image.yml
lib/ansible/modules/cloud/podman/podman_image.py
