### PR TITLE
Enable service integration tests for FreeBSD

### DIFF
--- a/test/integration/targets/service/aliases
+++ b/test/integration/targets/service/aliases
@@ -1,5 +1,4 @@
 destructive
 shippable/posix/group1
 skip/aix
-skip/freebsd
 skip/osx

--- a/test/integration/targets/service/files/ansible.rc
+++ b/test/integration/targets/service/files/ansible.rc
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# PROVIDE: ansible_test_service
+# REQUIRE: FILESYSTEMS devfs
+# BEFORE:  LOGIN
+# KEYWORD: nojail shutdown
+
+. /etc/rc.subr
+
+name="ansible_test_service"
+rcvar="ansible_test_service_enable"
+command="/usr/sbin/${name}"
+pidfile="/var/run/${name}.pid"
+extra_commands=reload
+load_rc_config $name
+run_rc_command "$1"

--- a/test/integration/targets/service/tasks/main.yml
+++ b/test/integration/targets/service/tasks/main.yml
@@ -30,6 +30,12 @@
       when:
         - ansible_distribution == 'Ubuntu'
         - ansible_distribution_version is version('15.04', '<')
+    - name: detect rc init system
+      set_fact:
+        service_type: rc
+      when:
+        - ansible_distribution.lower().endswith('bsd')
+
 
     - name: display value of ansible_service_mgr
       debug:

--- a/test/integration/targets/service/tasks/rc_cleanup.yml
+++ b/test/integration/targets/service/tasks/rc_cleanup.yml
@@ -1,0 +1,9 @@
+- name: remove the rc init file
+  file: path=/etc/rc.d/ansible_test state=absent
+  register: remove_rc_result
+
+- name: assert that the rc init file was removed
+  assert:
+    that:
+    - "remove_rc_result.path == '/etc/rc.d/ansible_test'"
+    - "remove_rc_result.state == 'absent'"

--- a/test/integration/targets/service/tasks/rc_setup.yml
+++ b/test/integration/targets/service/tasks/rc_setup.yml
@@ -10,7 +10,7 @@
     - "install_rc_result.mode == '0755'"
     - "install_rc_result.checksum == '8526e4571d2ac685fa5a73af723183c194bda35d'"
 
-# FreeBSD (likely others as well)  require the command_interpreter to match the
+# FreeBSD (likely others as well) requires the command_interpreter to match the
 # shebang the script was started with as an extra caution against killing the
 # wrong thing. We add the line here.
 - name: add command_interpreter in rc init file

--- a/test/integration/targets/service/tasks/rc_setup.yml
+++ b/test/integration/targets/service/tasks/rc_setup.yml
@@ -1,0 +1,21 @@
+- name: install the rc init file
+  copy: src=ansible.rc dest=/etc/rc.d/ansible_test mode=0755
+  register: install_rc_result
+
+- name: assert that the rc init file was installed
+  assert:
+    that:
+    - "install_rc_result.dest == '/etc/rc.d/ansible_test'"
+    - "install_rc_result.state == 'file'"
+    - "install_rc_result.mode == '0755'"
+    - "install_rc_result.checksum == '8526e4571d2ac685fa5a73af723183c194bda35d'"
+
+# FreeBSD (likely others as well)  require the command_interpreter to match the
+# shebang the script was started with as an extra caution against killing the
+# wrong thing. We add the line ehre.
+- name: add command_interpreter in rc init file
+  lineinfile:
+    path: /etc/rc.d/ansible_test
+    line: "command_interpreter={{ ansible_python_interpreter | realpath }}"
+    insertafter: '^pidfile.*'
+    firstmatch: yes

--- a/test/integration/targets/service/tasks/rc_setup.yml
+++ b/test/integration/targets/service/tasks/rc_setup.yml
@@ -12,7 +12,7 @@
 
 # FreeBSD (likely others as well)  require the command_interpreter to match the
 # shebang the script was started with as an extra caution against killing the
-# wrong thing. We add the line ehre.
+# wrong thing. We add the line here.
 - name: add command_interpreter in rc init file
   lineinfile:
     path: /etc/rc.d/ansible_test

--- a/test/integration/targets/service/tasks/tests.yml
+++ b/test/integration/targets/service/tasks/tests.yml
@@ -35,6 +35,14 @@
   shell: 'cat /proc/$(cat /var/run/ansible_test_service.pid)/cmdline'
   register: cmdline
   failed_when: cmdline is failed or '\0/usr/sbin/ansible_test_service\0' not in cmdline.stdout
+  # No proc on BSD
+  when: not ansible_distribution.lower().endswith('bsd')
+
+- name: check that the service was started (*bsd)
+  shell: 'ps -p $(cat /var/run/ansible_test_service.pid)'
+  register: cmdline
+  failed_when: cmdline is failed or '/usr/sbin/ansible_test_service' not in cmdline.stdout
+  when: ansible_distribution.lower().endswith('bsd')
 
 - name: find the service with a pattern
   service: name=ansible_test pattern="ansible_test_ser" state=started
@@ -73,6 +81,14 @@
   command: 'cat /proc/{{ pid_after_restart.stdout }}/cmdline'
   register: cmdline
   failed_when: cmdline is failed or '\0/usr/sbin/ansible_test_service\0' not in cmdline.stdout
+  # No proc on BSD
+  when: not ansible_distribution.lower().endswith('bsd')
+
+- name: check that the service is started (*bsd)
+  shell: 'ps -p {{ pid_after_restart.stdout }}'
+  register: cmdline
+  failed_when: cmdline is failed or '/usr/sbin/ansible_test_service' not in cmdline.stdout
+  when: ansible_distribution.lower().endswith('bsd')
 
 - name: restart the ansible test service with a sleep
   service: name=ansible_test state=restarted sleep=2
@@ -117,6 +133,14 @@
   command: 'cat /proc/{{ ansible_test_pid.stdout }}/cmdline'
   register: cmdline
   failed_when: cmdline is failed or '\0/usr/sbin/ansible_test_service\0' not in cmdline.stdout
+  # No proc on BSD
+  when: not ansible_distribution.lower().endswith('bsd')
+
+- name: check that the service is started (*bsd)
+  shell: 'ps -p {{ ansible_test_pid.stdout }}'
+  register: cmdline
+  failed_when: cmdline is failed or '/usr/sbin/ansible_test_service' not in cmdline.stdout
+  when: ansible_distribution.lower().endswith('bsd')
 
 - name: stop the ansible test service
   service: name=ansible_test state=stopped
@@ -126,6 +150,14 @@
   command: 'cat /proc/{{ ansible_test_pid.stdout }}/cmdline'
   register: cmdline
   failed_when: cmdline is not failed or '\0/usr/sbin/ansible_test_service\0' in cmdline.stdout
+  # No proc on BSD
+  when: not ansible_distribution.lower().endswith('bsd')
+
+- name: check that the service is stopped (*bsd)
+  shell: 'ps -p {{ ansible_test_pid.stdout }}'
+  register: cmdline
+  failed_when: cmdline is not failed or '/usr/sbin/ansible_test_service' in cmdline.stdout
+  when: ansible_distribution.lower().endswith('bsd')
 
 - name: assert that the service was stopped
   assert:


### PR DESCRIPTION
##### SUMMARY

Change:
Adds necessary rc file for freebsd, and gets tests passing for it.

Test Plan:
Ran test with `--remote freebsd/12.1` and `--remote freebsd/11.1`. Both
passed.

(This also knocks out an incidental arc.)

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

service tests