### PR TITLE
Revert "stricter permissions on atomic_move when creating new file"

### DIFF
--- a/changelogs/fragments/atomic_move_permissions.yml
+++ b/changelogs/fragments/atomic_move_permissions.yml
@@ -1,2 +1,0 @@
-bugfixes:
-    - stricter permissions when atomic_move creates a file due to target not existing yet CVE-2020-1736

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -59,7 +59,7 @@ PERMS_RE = re.compile(r'[^rwxXstugo]')
 
 _PERM_BITS = 0o7777          # file mode permission bits
 _EXEC_PERM_BITS = 0o0111     # execute permission bits
-_DEFAULT_PERM = 0o0660       # default file permission bits
+_DEFAULT_PERM = 0o0666       # default file permission bits
 
 
 def is_executable(path):

--- a/test/integration/targets/apt_repository/tasks/mode.yaml
+++ b/test/integration/targets/apt_repository/tasks/mode.yaml
@@ -41,7 +41,6 @@
   apt_repository:
     repo: "{{ test_repo_spec }}"
     state: present
-    mode: 0644
   register: no_mode_results
 
 - name: Gather no mode stat


### PR DESCRIPTION
Reverts ansible/ansible#68970

many more tests are affected than apparent (since they were moved to collections).