### PR TITLE
iptables: add NETMAP Support

### DIFF
--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -343,8 +343,9 @@ options:
     version_added: "2.10"
   to:
     description:
-      - Network address to map to. For use with C(jump): NETMAP
+      - Network address to map to. For use with C(jump) NETMAP
     type: str
+    version_added: "2.10"
 '''
 
 EXAMPLES = r'''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
adding Support for `--to` option for use in conjunction with `-j NETMAP`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
iptables

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
in ip6tables it is possible to do [IPv6-to-IPv6 Network Prefix Translation](https://en.wikipedia.org/wiki/IPv6-to-IPv6_Network_Prefix_Translation) by using the option `-j NETMAP` like this:
```
# iptables -t nat -A PREROUTING -d 2001:DB8::/64 -i eth0 -j NETMAP --to fd::/64
```
this PR would implement it like this:
```
- iptables:
    ip_version: ipv6
    table: nat
    chain: PREROUTING
    destination: 2001:DB8::/64
    in_interface: eth0
    jump: NETMAP
    to: fd::/64
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
