### PR TITLE
redfish_config: fix support for boolean BIOS attributes

### DIFF
--- a/changelogs/fragments/68251-redfish_config-fix-boolean-bios-attr-support.yaml
+++ b/changelogs/fragments/68251-redfish_config-fix-boolean-bios-attr-support.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- redfish_config - fix support for boolean bios attrs (https://github.com/ansible/ansible/pull/68251)

--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -60,7 +60,7 @@ options:
     description:
       - value of BIOS attribute to update
     default: 'null'
-    type: str
+    type: raw
     version_added: "2.8"
   timeout:
     description:
@@ -142,7 +142,7 @@ def main():
             username=dict(required=True),
             password=dict(required=True, no_log=True),
             bios_attribute_name=dict(default='null'),
-            bios_attribute_value=dict(default='null'),
+            bios_attribute_value=dict(default='null', type='raw'),
             timeout=dict(type='int', default=10)
         ),
         supports_check_mode=False


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible-collections/community.general/pull/189

 Backport of ansible-collections/community.general#189 to stable-2.9.

Originally opened as #68382.

Currently the redfish_config module will convert boolean bios_attribute_value
settings to strings (type str). This will cause BMCs expecting booleans to
error out.

This PR will change the default type of bios_attribute_value to 'raw' in order
to support strings and booleans.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
redfish_config

##### ADDITIONAL INFORMATION
