### PR TITLE
redfish_config: fix support for boolean BIOS attributes

### DIFF
--- a/changelogs/fragments/68251-redfish_config-fix-boolean-bios-attr-support.yaml
+++ b/changelogs/fragments/68251-redfish_config-fix-boolean-bios-attr-support.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- redfish_config - fix support for boolean bios attrs (https://github.com/ansible/ansible/pull/68251)

--- a/lib/ansible/module_utils/redfish_utils.py
+++ b/lib/ansible/module_utils/redfish_utils.py
@@ -853,9 +853,9 @@ class RedfishUtils(object):
 
         set_bios_attr_uri = data["@Redfish.Settings"]["SettingsObject"]["@odata.id"]
 
-        # Example: bios_attr = {\"name\":\"value\"}
-        bios_attr = "{\"" + attr['bios_attr_name'] + "\":\"" + attr['bios_attr_value'] + "\"}"
-        payload = {"Attributes": json.loads(bios_attr)}
+        # patch_request() will use json.dumps() on the payload, we can pass a
+        # python dict as our payload.
+        payload = {"Attributes": {attr['bios_attr_name']: attr['bios_attr_value']}}
         response = self.patch_request(self.root_uri + set_bios_attr_uri, payload)
         if response['ret'] is False:
             return response

--- a/lib/ansible/modules/remote_management/redfish/redfish_config.py
+++ b/lib/ansible/modules/remote_management/redfish/redfish_config.py
@@ -54,6 +54,7 @@ options:
     description:
       - value of BIOS attribute to update
     default: 'null'
+    type: raw
     version_added: "2.8"
   timeout:
     description:
@@ -135,7 +136,7 @@ def main():
             username=dict(required=True),
             password=dict(required=True, no_log=True),
             bios_attribute_name=dict(default='null'),
-            bios_attribute_value=dict(default='null'),
+            bios_attribute_value=dict(default='null', type='raw'),
             timeout=dict(type='int', default=10)
         ),
         supports_check_mode=False


### PR DESCRIPTION
##### SUMMARY
Backport of ansible-collections/community.general#189 to stable-2.8.

For reference, backport for stable-2.9: #68986

Note that the stable-2.8 backport requires an extra change to `redfish_utils.py` because stable-2.8 doesn't have #62764.

Currently the redfish_config module will convert boolean bios_attribute_value
settings to strings (type str). This will cause BMCs expecting booleans to
error out.

This PR will change the default type of bios_attribute_value to 'raw' in order
to support strings and booleans.

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
redfish_config
redfish_utils.py

##### ADDITIONAL INFORMATION
