### PR TITLE
Add feature migrate from Distrubuted Switch to Standard Switch

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_migrate_vmk.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_migrate_vmk.py
@@ -139,7 +139,7 @@ class VMwareMigrateVmk(object):
     def state_migrate_vds_vss(self):
         host_network_system = self.host_system.configManager.networkSystem
         config = vim.host.NetworkConfig()
-        config.portgroup =  [self.create_port_group_config_vds_vss()]
+        config.portgroup = [self.create_port_group_config_vds_vss()]
         host_network_system.UpdateNetworkConfig(config, "modify")
         config = vim.host.NetworkConfig()
         config.vnic = [self.create_host_vnic_config_vds_vss()]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Edited the funtion state_migrate_vds_vss which returns the message "Currently Not Implemented" to allow migration from a VMware vSphere Distrubuted Switch to a ESXi Standard Switch


##### COMPONENT NAME
cloud/vmware/vmware_migrate_vmk

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

- Create a portgroup on the named destination standard vSwitch "migrate_switch_name"
- Update the ESXi host network settings
- Create a VirtualNic (vmk) in edit mode on the portgroup (above) to allow a migration to happen
- Update the ESXi host network settings - causing the migration to start

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
