### PR TITLE
fix flatten loop control issue (break -> continue)

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -467,7 +467,7 @@ def flatten(mylist, levels=None):
     for element in mylist:
         if element in (None, 'None', 'null'):
             # ignore undefined items
-            break
+            continue
         elif is_sequence(element):
             if levels is None:
                 ret.extend(flatten(element))


### PR DESCRIPTION
Fixes #69012 

##### SUMMARY
Flatten field yields unexpected results when it hits None. Instead of skipping over none it silently discards the to-be-flatten list

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
flatten filter plugin 

Fixes #69012 