### PR TITLE
Add example setting for collections_paths to ansible.cfg

### DIFF
--- a/changelogs/fragments/examples_add_collections_paths_to_config_file.yml
+++ b/changelogs/fragments/examples_add_collections_paths_to_config_file.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - "Add example setting for ``collections_paths`` parameter to ``examples/ansible.cfg``"

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -60,6 +60,9 @@
 #
 #inject_facts_as_vars = True
 
+# Paths to search for collections, colon separated
+# collections_paths = ~/.ansible/collections:/usr/share/ansible/collections
+
 # Paths to search for roles, colon separated
 #roles_path = ~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
 


### PR DESCRIPTION
##### SUMMARY
Add example setting for ``collections_paths`` parameter to ``examples/ansible.cfg``

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- examples/ansible.cfg

##### ADDITIONAL INFORMATION
None