### PR TITLE
Fix incorrect CVE reference in changelog fragment (2.7)

### DIFF
--- a/changelogs/fragments/fetch_no_slurp.yml
+++ b/changelogs/fragments/fetch_no_slurp.yml
@@ -1,2 +1,2 @@
 bugfixes:
-    - In fetch action, avoid using slurp return to set up dest, also ensure no dir traversal CVE-2019-3828.
+    - In fetch action, avoid using slurp return to set up dest, also ensure no dir traversal CVE-2020-1735.


### PR DESCRIPTION
Change:
This corrects an incorrect CVE identifier in the changelog entry for
CVE-2020-1735.

Backport of #69022

Test Plan:
N/A

Tickets:
Refs #67793, #68720

Signed-off-by: Rick Elrod <rick@elrod.me>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
changelog