### PR TITLE
Store host facts inside a variable example

### DIFF
--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -107,10 +107,10 @@ EXAMPLES = """
   setup:
   register: setupvar
  
- - name: Store facts indexed by I(hostname) at C(/tmp/facts)
+- name: Store facts indexed by I(hostname) at C(/tmp/facts)
   copy:
     content: '{{ setupvar }}'
-    dest: /tmp/facts/{{ ansible_hostname }}
+    dest: /tmp/facts/{{ ansible_hostname }}.yaml
 
 - name: Collect only facts returned by facter
   setup:

--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -106,7 +106,7 @@ EXAMPLES = """
 - name: Collect default facts and add them to variable setupvar
   setup:
   register: setupvar
- 
+
 - name: Store facts indexed by hostname in /tmp/facts
   copy:
     content: '{{ setupvar }}'

--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -103,14 +103,14 @@ EXAMPLES = """
 # Collect only facts returned by facter.
 # ansible all -m setup -a 'gather_subset=!all,!any,facter'
 
-- name: Collect all default facts and add them to variable setupvar
+- name: Collect default facts and add them to variable setupvar
   setup:
   register: setupvar
  
-- name: Store facts indexed by I(hostname) at C(/tmp/facts)
+- name: Store facts indexed by hostname in /tmp/facts
   copy:
     content: '{{ setupvar }}'
-    dest: /tmp/facts/{{ ansible_hostname }}.yaml
+    dest: /tmp/facts/{{ ansible_hostname }}
 
 - name: Collect only facts returned by facter
   setup:

--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -103,6 +103,15 @@ EXAMPLES = """
 # Collect only facts returned by facter.
 # ansible all -m setup -a 'gather_subset=!all,!any,facter'
 
+- name: Collect all default facts and add them to variable setupvar
+  setup:
+  register: setupvar
+ 
+ - name: Store facts indexed by I(hostname) at C(/tmp/facts)
+  copy:
+    content: '{{ setupvar }}'
+    dest: /tmp/facts/{{ ansible_hostname }}
+
 - name: Collect only facts returned by facter
   setup:
     gather_subset:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I couldn't find an example for what I was trying to do (I checked this page previously) so had to work it out. You have lots of ansible CLI examples but only one example of using it within a playbook. It would be great if this could be added in to help others.

This update shows how to collect host facts inside a playbook and store them in a variable (setupvar) before copying them, indexed via their hostname to /tmp/facts.

It's the equivalent of this ansible cli (but for a playbook): # ansible all -m setup --tree /tmp/facts

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Store host facts inside a variable

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
