### PR TITLE
ansible-doc: fix JSON output for broken documentation

### DIFF
--- a/changelogs/fragments/69032-ansible-doc-json.yml
+++ b/changelogs/fragments/69032-ansible-doc-json.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-doc - when using JSON export, do not crash when docs contain ``datetime`` or other non-JSON objects, or when dictionary keys are not strings (https://github.com/ansible/ansible/issues/69031)."


### PR DESCRIPTION
##### SUMMARY
`ansible-doc --json community.aws.aws_s3_bucket_info` crashes before this fix, and works afterwards. Fixes #69031.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-doc
