### PR TITLE
2.9: native types: literal_eval all the things (#68938)

### DIFF
--- a/test/integration/targets/inventory_aws_conformance/runme.sh
+++ b/test/integration/targets/inventory_aws_conformance/runme.sh
@@ -83,7 +83,7 @@ compose:
   ec2_kernel: kernel_id | default("")
   ec2_monitored:  monitoring['state'] in ['enabled', 'pending']
   ec2_monitoring_state: monitoring['state']
-  ec2_account_id: owner_id
+  ec2_account_id: owner_id | string | regex_replace('^(.*)$', '"\\1"')  # work around the fact that the string filter is not reliable on native jinja
   ec2_placement: placement['availability_zone']
   ec2_ramdisk: ramdisk_id | default("")
   ec2_reason: state_transition_reason
@@ -95,7 +95,7 @@ compose:
   ec2_sourceDestCheck: source_dest_check | lower | string  # butchered snake_case case not a typo.
 
   # vars that just need ec2_ prefix
-  ec2_ami_launch_index: ami_launch_index | string
+  ec2_ami_launch_index: ami_launch_index | string | regex_replace('^(.*)$', '"\\1"')  # see ec2_account_id for why this needs to be quoted
   ec2_architecture: architecture
   ec2_client_token: client_token
   ec2_ebs_optimized: ebs_optimized

--- a/test/integration/targets/jinja2_native_types/filter_plugins/native_plugins.py
+++ b/test/integration/targets/jinja2_native_types/filter_plugins/native_plugins.py
@@ -1,8 +1,0 @@
-from ansible.module_utils._text import to_text
-
-
-class FilterModule(object):
-    def filters(self):
-        return {
-            'to_text': to_text,
-        }

--- a/test/integration/targets/jinja2_native_types/test_casting.yml
+++ b/test/integration/targets/jinja2_native_types/test_casting.yml
@@ -1,9 +1,9 @@
 - name: cast things to other things
   set_fact:
-      int_to_str: "{{ i_two|to_text }}"
+      int_to_str: "'{{ i_two }}'"
       str_to_int: "{{ s_two|int }}"
-      dict_to_str: "{{ dict_one|to_text }}"
-      list_to_str: "{{ list_one|to_text }}"
+      dict_to_str: "'{{ dict_one }}'"
+      list_to_str: "'{{ list_one }}'"
       int_to_bool: "{{ i_one|bool }}"
       str_true_to_bool: "{{ s_true|bool }}"
       str_false_to_bool: "{{ s_false|bool }}"

--- a/test/integration/targets/jinja2_native_types/test_concatentation.yml
+++ b/test/integration/targets/jinja2_native_types/test_concatentation.yml
@@ -18,7 +18,7 @@
 
 - name: concatenate int and string
   set_fact:
-      string_sum: "{{ [(i_one|to_text), s_two]|join('') }}"
+      string_sum: "'{{ [i_one, s_two]|join('') }}'"
 
 - assert:
     that:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -5984,8 +5984,6 @@ test/integration/targets/inventory_kubevirt_conformance/inventory_diff.py future
 test/integration/targets/inventory_kubevirt_conformance/inventory_diff.py metaclass-boilerplate
 test/integration/targets/inventory_kubevirt_conformance/server.py future-import-boilerplate
 test/integration/targets/inventory_kubevirt_conformance/server.py metaclass-boilerplate
-test/integration/targets/jinja2_native_types/filter_plugins/native_plugins.py future-import-boilerplate
-test/integration/targets/jinja2_native_types/filter_plugins/native_plugins.py metaclass-boilerplate
 test/integration/targets/lambda_policy/files/mini_http_lambda.py future-import-boilerplate
 test/integration/targets/lambda_policy/files/mini_http_lambda.py metaclass-boilerplate
 test/integration/targets/lookup_properties/lookup-8859-15.ini no-smart-quotes


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
With https://github.com/pallets/jinja/pull/1190 merged our short-circuit
is no longer valid (has it ever been?) as now data like ' True ' may go
through our ansible_native_concat function as opposed to going through
intermediate call to Jinja2's native_concat before. Now we need to always
send data through literal_eval to ensure native types are returned.

(cherry picked from commit acdc9eb76d23e25ed8b1c7fc4fe8e4f9fd6f49fd)

Backport of https://github.com/ansible/ansible/pull/68938
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
 lib/ansible/template/native_helpers.py 
