### PR TITLE
Added more clarity to when statement

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_conditionals.rst
+++ b/docs/docsite/rst/user_guide/playbooks_conditionals.rst
@@ -20,7 +20,9 @@ Additional groups can be created to manage hosts based on whether the hosts matc
 The When Statement
 ``````````````````
 
-Sometimes you will want to skip a particular step on a particular host.
+The When Statement checks against a conditional, if the conditional is true, the task is ran, if false, the task is skipped.
+
+For example, sometimes you will want to skip a particular step on a particular host.
 This could be something as simple as not installing a certain package if the operating system is a particular version,
 or it could be something like performing some cleanup steps if a filesystem is getting full.
 


### PR DESCRIPTION
##### SUMMARY
I've added more clarity to the when statement description. There has been some confusion around if `when` skips or not. I've experienced this at multiple companies on multiple teams, and thought it needs a simple clarification.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
