### PR TITLE
Adjust Openstack Inventory script path

### DIFF
--- a/changelogs/fragments/openstack_inventory_migrated.yml
+++ b/changelogs/fragments/openstack_inventory_migrated.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Openstack inventory script is migrated to ansible-openstack-collection, adjusted the link in documentation accordingly.

--- a/docs/docsite/rst/user_guide/intro_dynamic_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_dynamic_inventory.rst
@@ -269,7 +269,7 @@ Inventory script example: OpenStack
 
 If you use an OpenStack-based cloud, instead of manually maintaining your own inventory file, you can use the ``openstack_inventory.py`` dynamic inventory to pull information about your compute instances directly from OpenStack.
 
-You can download the latest version of the OpenStack inventory script `here <https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/openstack_inventory.py>`_.
+You can download the latest version of the OpenStack inventory script `here <https://raw.githubusercontent.com/openstack/ansible-collections-openstack/master/scripts/inventory/openstack_inventory.py>`_.
 
 You can use the inventory script explicitly (by passing the `-i openstack_inventory.py` argument to Ansible) or implicitly (by placing the script at `/etc/ansible/hosts`).
 
@@ -278,7 +278,7 @@ Explicit use of OpenStack inventory script
 
 Download the latest version of the OpenStack dynamic inventory script and make it executable::
 
-    wget https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/openstack_inventory.py
+    wget https://raw.githubusercontent.com/openstack/ansible-collections-openstack/master/scripts/inventory/openstack_inventory.py
     chmod +x openstack_inventory.py
 
 .. note::
@@ -319,7 +319,7 @@ Download the latest version of the OpenStack dynamic inventory script, make it e
 
 .. code-block:: bash
 
-    wget https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/openstack_inventory.py
+    wget https://raw.githubusercontent.com/openstack/ansible-collections-openstack/master/scripts/inventory/openstack_inventory.py
     chmod +x openstack_inventory.py
     sudo cp openstack_inventory.py /etc/ansible/hosts
 
@@ -327,7 +327,7 @@ Download the sample configuration file, modify it to suit your needs and copy it
 
 .. code-block:: bash
 
-    wget https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/openstack.yml
+    wget https://raw.githubusercontent.com/openstack/ansible-collections-openstack/master/scripts/inventory/openstack.yml
     vi openstack.yml
     sudo cp openstack.yml /etc/ansible/
 


### PR DESCRIPTION
##### SUMMARY

Openstack Inventory migrated from community.general to
ansible-openstack-collection, adjusted the links in the documentation
accrodingly.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/openstack_inventory_migrated.yml
docs/docsite/rst/user_guide/intro_dynamic_inventory.rst
