### PR TITLE
[stable-2.7] pip - Fix check_mode for prerelease packages (#68690)

### DIFF
--- a/changelogs/fragments/68592-pip-check_mode-prereleases.yml
+++ b/changelogs/fragments/68592-pip-check_mode-prereleases.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "pip - check_mode with ``state: present`` now returns the correct state for pre-release versioned packages"

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -523,7 +523,7 @@ class Package:
         if not self._plain_package:
             return False
         try:
-            return self._requirement.specifier.contains(version_to_test)
+            return self._requirement.specifier.contains(version_to_test, prereleases=True)
         except AttributeError:
             # old setuptools has no specifier, do fallback
             version_to_test = LooseVersion(version_to_test)

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -530,3 +530,38 @@
     assert:
       that: "'distribute' in remove_distribute.cmd"
   when: ansible_python.version.major == 2
+
+# https://github.com/ansible/ansible/issues/68592
+# Handle pre-release version numbers in check_mode for already-installed
+# packages.
+# TODO: Limiting to py3 test boxes for now so the example of 'black' installs,
+# we should probably find another package to use with a similar versioning
+# scheme or make a small one and enable this test for py2 as well.
+- block:
+  - name: Install a beta version of a package
+    pip:
+      name: black
+      version: 19.10b0
+      state: present
+
+  - name: Use check_mode and ensure that the package is shown as installed
+    check_mode: true
+    pip:
+      name: black
+      state: present
+    register: pip_prereleases
+
+  - name: Uninstall the beta package if we need to
+    pip:
+      name: black
+      version: 19.10b0
+      state: absent
+    when: pip_prereleases is changed
+
+  - assert:
+      that:
+        - pip_prereleases is successful
+        - pip_prereleases is not changed
+        - '"black==19.10b0" in pip_prereleases.stdout_lines'
+
+  when: ansible_python.version.major == 3

--- a/test/integration/targets/pip/vars/main.yml
+++ b/test/integration/targets/pip/vars/main.yml
@@ -3,7 +3,7 @@ pip_test_packages:
   - sampleproject
   - decorator
 pip_test_pkg_ver:
-  - sampleproject<=100, !=9.0.0,>=0.0.1 
+  - sampleproject<=100, !=9.0.0,>=0.0.1
   - decorator<100 ,!=9,>=0.0.1
 pip_test_pkg_ver_unsatisfied:
   - sampleproject>= 999.0.0


### PR DESCRIPTION
##### SUMMARY
Fix pip check_mode for prerelease packages.

Fixes #68592

Signed-off-by: Rick Elrod <rick@elrod.me>
Co-authored-by: Matt Martz <matt@sivel.net>
Co-authored-by: Rick Elrod <rick@elrod.me>

Backport of https://github.com/ansible/ansible/pull/68690

(cherry picked from commit 82c60db49b7b2f64c68308bcdb9d61231c21df24)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

pip
