### PR TITLE
Cap cryptography version for macOS openssl test

### DIFF
--- a/test/integration/targets/incidental_setup_openssl/tasks/main.yml
+++ b/test/integration/targets/incidental_setup_openssl/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: Install pyOpenSSL (Darwin)
   become: True
   pip:
-    name: pyOpenSSL
+    name: pyOpenSSL<2.9.1
   when: ansible_os_family == 'Darwin'
 
 - name: register pyOpenSSL version


### PR DESCRIPTION
##### SUMMARY

Change:
New `cryptography` statically links an openssl that is too new for macOS
10.11, so limit to an older cryptography for now.

Test Plan:
Ran the test with `--remote osx/10.11` and it passed.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

tests