### PR TITLE
feature: add iptables_state module & action plugin

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -3251,7 +3251,7 @@ files:
     maintainers: $team_openstack
     labels:
     - cloud
-    migrated_to: community.general
+    migrated_to: openstack.cloud
   contrib/inventory/ovirt4.py: *id003
   contrib/inventory/infoblox.py:
     keywords:

--- a/changelogs/fragments/67050-yum-releasever.yaml
+++ b/changelogs/fragments/67050-yum-releasever.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - yum - fixed the handling of releasever parameter

--- a/changelogs/fragments/67407-pip-virtualenv_command-args.yml
+++ b/changelogs/fragments/67407-pip-virtualenv_command-args.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - pip - The virtualenv_command option can now include arguments without
+    requiring the full path to the binary.
+    (https://github.com/ansible/ansible/issues/52275)

--- a/changelogs/fragments/68310-low_level_execute_command-honor-executable.yml
+++ b/changelogs/fragments/68310-low_level_execute_command-honor-executable.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Update ActionBase._low_level_execute_command to honor executable (https://github.com/ansible/ansible/issues/68054)

--- a/changelogs/fragments/68667-dont-crash-ansible-vault-create-when-no-arguments.yaml
+++ b/changelogs/fragments/68667-dont-crash-ansible-vault-create-when-no-arguments.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-vault create - Fix exception on no arguments given

--- a/changelogs/fragments/69029-module-ignore-exts.yml
+++ b/changelogs/fragments/69029-module-ignore-exts.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - plugin loader - Add MODULE_IGNORE_EXTS config option to skip over certain extensions when looking for script and binary modules.

--- a/changelogs/fragments/69101-collection-role-to-standalone-role.yml
+++ b/changelogs/fragments/69101-collection-role-to-standalone-role.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- Collections - Allow a collection role to call a stand alone role, without
+  needing to explicitly add ``ansible.legacy`` to the collection search
+  order within the collection role.
+  (https://github.com/ansible/ansible/issues/69101)

--- a/changelogs/fragments/69104-galaxy-cli-templar.yml
+++ b/changelogs/fragments/69104-galaxy-cli-templar.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- ansible-galaxy - Utilize ``Templar`` for templating skeleton files, so that
+  they have access to Ansible filters/tests/lookups
+  (https://github.com/ansible/ansible/issues/69104)

--- a/changelogs/fragments/openstack_botmeta.yml
+++ b/changelogs/fragments/openstack_botmeta.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Openstack inventory script is moved to openstack.cloud from community.general.

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -424,7 +424,7 @@ class VaultCLI(CLI):
     def execute_create(self):
         ''' create and open a file in an editor that will be encrypted with the provided vault secret when closed'''
 
-        if len(context.CLIARGS['args']) > 1:
+        if len(context.CLIARGS['args']) != 1:
             raise AnsibleOptionsError("ansible-vault create can take only one filename argument")
 
         self.editor.create_file(context.CLIARGS['args'][0], self.encrypt_secret,

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1588,7 +1588,7 @@ INVENTORY_EXPORT:
   type: bool
 INVENTORY_IGNORE_EXTS:
   name: Inventory ignore extensions
-  default: "{{(BLACKLIST_EXTS + ( '.orig', '.ini', '.cfg', '.retry'))}}"
+  default: "{{(BLACKLIST_EXTS + ('.orig', '.ini', '.cfg', '.retry'))}}"
   description: List of extensions to ignore when using a directory as an inventory source
   env: [{name: ANSIBLE_INVENTORY_IGNORE}]
   ini:
@@ -1648,6 +1648,16 @@ INJECT_FACTS_AS_VARS:
   - {key: inject_facts_as_vars, section: defaults}
   type: boolean
   version_added: "2.5"
+MODULE_IGNORE_EXTS:
+  name: Module ignore extensions
+  default: "{{(BLACKLIST_EXTS + ('.yaml', '.yml', '.ini'))}}"
+  description:
+    - List of extensions to ignore when looking for modules to load
+    - This is for blacklisting script and binary module fallback extensions
+  env: [{name: ANSIBLE_MODULE_IGNORE_EXTS}]
+  ini:
+  - {key: module_ignore_exts, section: defaults}
+  type: list
 OLD_PLUGIN_CACHE_CLEARING:
   description: Previouslly Ansible would only clear some of the plugin loading caches when loading new roles, this led to some behaviours in which a plugin loaded in prevoius plays would be unexpectedly 'sticky'. This setting allows to return to that behaviour.
   env: [{name: ANSIBLE_OLD_PLUGIN_CACHE_CLEAR}]

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -844,6 +844,7 @@ def _build_files_manifest(b_collection_path, namespace, name, ignore_patterns):
     # patterns can be extended by the build_ignore key in galaxy.yml
     b_ignore_patterns = [
         b'galaxy.yml',
+        b'.git',
         b'*.pyc',
         b'*.retry',
         b'tests/output',  # Ignore ansible-test result output directory.

--- a/lib/ansible/galaxy/data/default/collection/galaxy.yml.j2
+++ b/lib/ansible/galaxy/data/default/collection/galaxy.yml.j2
@@ -1,11 +1,11 @@
 ### REQUIRED
 {% for option in required_config %}
 {{ option.description | comment_ify }}
-{{ {option.key: option.value} | to_yaml }}
+{{ {option.key: option.value} | to_nice_yaml }}
 {% endfor %}
 
 ### OPTIONAL but strongly recommended
 {% for option in optional_config %}
 {{ option.description | comment_ify }}
-{{ {option.key: option.value} | to_yaml }}
+{{ {option.key: option.value} | to_nice_yaml }}
 {% endfor %}

--- a/lib/ansible/module_utils/_text.py
+++ b/lib/ansible/module_utils/_text.py
@@ -6,4 +6,8 @@
 """
 
 # Backwards compat for people still calling it from this package
+import codecs
+
+from ansible.module_utils.six import PY3, text_type, binary_type
+
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text

--- a/lib/ansible/module_utils/common/text/converters.py
+++ b/lib/ansible/module_utils/common/text/converters.py
@@ -30,69 +30,6 @@ _COMPOSED_ERROR_HANDLERS = frozenset((None, 'surrogate_or_replace',
                                       'surrogate_then_replace'))
 
 
-def _json_encode_fallback(obj):
-    if isinstance(obj, Set):
-        return list(obj)
-    elif isinstance(obj, datetime.datetime):
-        return obj.isoformat()
-    raise TypeError("Cannot json serialize %s" % to_native(obj))
-
-
-def jsonify(data, **kwargs):
-    for encoding in ("utf-8", "latin-1"):
-        try:
-            return json.dumps(data, encoding=encoding, default=_json_encode_fallback, **kwargs)
-        # Old systems using old simplejson module does not support encoding keyword.
-        except TypeError:
-            try:
-                new_data = container_to_text(data, encoding=encoding)
-            except UnicodeDecodeError:
-                continue
-            return json.dumps(new_data, default=_json_encode_fallback, **kwargs)
-        except UnicodeDecodeError:
-            continue
-    raise UnicodeError('Invalid unicode encoding encountered')
-
-
-def container_to_bytes(d, encoding='utf-8', errors='surrogate_or_strict'):
-    ''' Recursively convert dict keys and values to byte str
-
-        Specialized for json return because this only handles, lists, tuples,
-        and dict container types (the containers that the json module returns)
-    '''
-
-    if isinstance(d, text_type):
-        return to_bytes(d, encoding=encoding, errors=errors)
-    elif isinstance(d, dict):
-        return dict(container_to_bytes(o, encoding, errors) for o in iteritems(d))
-    elif isinstance(d, list):
-        return [container_to_bytes(o, encoding, errors) for o in d]
-    elif isinstance(d, tuple):
-        return tuple(container_to_bytes(o, encoding, errors) for o in d)
-    else:
-        return d
-
-
-def container_to_text(d, encoding='utf-8', errors='surrogate_or_strict'):
-    """Recursively convert dict keys and values to byte str
-
-    Specialized for json return because this only handles, lists, tuples,
-    and dict container types (the containers that the json module returns)
-    """
-
-    if isinstance(d, binary_type):
-        # Warning, can traceback
-        return to_text(d, encoding=encoding, errors=errors)
-    elif isinstance(d, dict):
-        return dict(container_to_text(o, encoding, errors) for o in iteritems(d))
-    elif isinstance(d, list):
-        return [container_to_text(o, encoding, errors) for o in d]
-    elif isinstance(d, tuple):
-        return tuple(container_to_text(o, encoding, errors) for o in d)
-    else:
-        return d
-
-
 def to_bytes(obj, encoding='utf-8', errors=None, nonstring='simplerepr'):
     """Make sure that a string is a byte string
 
@@ -320,3 +257,66 @@ if PY3:
     to_native = to_text
 else:
     to_native = to_bytes
+
+
+def _json_encode_fallback(obj):
+    if isinstance(obj, Set):
+        return list(obj)
+    elif isinstance(obj, datetime.datetime):
+        return obj.isoformat()
+    raise TypeError("Cannot json serialize %s" % to_native(obj))
+
+
+def jsonify(data, **kwargs):
+    for encoding in ("utf-8", "latin-1"):
+        try:
+            return json.dumps(data, encoding=encoding, default=_json_encode_fallback, **kwargs)
+        # Old systems using old simplejson module does not support encoding keyword.
+        except TypeError:
+            try:
+                new_data = container_to_text(data, encoding=encoding)
+            except UnicodeDecodeError:
+                continue
+            return json.dumps(new_data, default=_json_encode_fallback, **kwargs)
+        except UnicodeDecodeError:
+            continue
+    raise UnicodeError('Invalid unicode encoding encountered')
+
+
+def container_to_bytes(d, encoding='utf-8', errors='surrogate_or_strict'):
+    ''' Recursively convert dict keys and values to byte str
+
+        Specialized for json return because this only handles, lists, tuples,
+        and dict container types (the containers that the json module returns)
+    '''
+
+    if isinstance(d, text_type):
+        return to_bytes(d, encoding=encoding, errors=errors)
+    elif isinstance(d, dict):
+        return dict(container_to_bytes(o, encoding, errors) for o in iteritems(d))
+    elif isinstance(d, list):
+        return [container_to_bytes(o, encoding, errors) for o in d]
+    elif isinstance(d, tuple):
+        return tuple(container_to_bytes(o, encoding, errors) for o in d)
+    else:
+        return d
+
+
+def container_to_text(d, encoding='utf-8', errors='surrogate_or_strict'):
+    """Recursively convert dict keys and values to byte str
+
+    Specialized for json return because this only handles, lists, tuples,
+    and dict container types (the containers that the json module returns)
+    """
+
+    if isinstance(d, binary_type):
+        # Warning, can traceback
+        return to_text(d, encoding=encoding, errors=errors)
+    elif isinstance(d, dict):
+        return dict(container_to_text(o, encoding, errors) for o in iteritems(d))
+    elif isinstance(d, list):
+        return [container_to_text(o, encoding, errors) for o in d]
+    elif isinstance(d, tuple):
+        return tuple(container_to_text(o, encoding, errors) for o in d)
+    else:
+        return d

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -471,23 +471,30 @@ def setup_virtualenv(module, env, chdir, out, err):
     if module.check_mode:
         module.exit_json(changed=True)
 
-    cmd = module.params['virtualenv_command']
-    if os.path.basename(cmd) == cmd:
-        cmd = module.get_bin_path(cmd, True)
+    cmd = shlex.split(module.params['virtualenv_command'])
 
+    # Find the binary for the command in the PATH
+    # and switch the command for the explicit path.
+    if os.path.basename(cmd[0]) == cmd[0]:
+        cmd[0] = module.get_bin_path(cmd[0], True)
+
+    # Add the system-site-packages option if that
+    # is enabled, otherwise explicitly set the option
+    # to not use system-site-packages if that is an
+    # option provided by the command's help function.
     if module.params['virtualenv_site_packages']:
-        cmd += ' --system-site-packages'
+        cmd.append('--system-site-packages')
     else:
-        cmd_opts = _get_cmd_options(module, cmd)
+        cmd_opts = _get_cmd_options(module, cmd[0])
         if '--no-site-packages' in cmd_opts:
-            cmd += ' --no-site-packages'
+            cmd.append('--no-site-packages')
 
     virtualenv_python = module.params['virtualenv_python']
     # -p is a virtualenv option, not compatible with pyenv or venv
-    # this if validates if the command being used is not any of them
+    # this conditional validates if the command being used is not any of them
     if not any(ex in module.params['virtualenv_command'] for ex in ('pyvenv', '-m venv')):
         if virtualenv_python:
-            cmd += ' -p%s' % virtualenv_python
+            cmd.append('-p%s' % virtualenv_python)
         elif PY3:
             # Ubuntu currently has a patch making virtualenv always
             # try to use python2.  Since Ubuntu16 works without
@@ -495,7 +502,7 @@ def setup_virtualenv(module, env, chdir, out, err):
             # the upstream behaviour of using the python which invoked
             # virtualenv to determine which python is used inside of
             # the virtualenv (when none are specified).
-            cmd += ' -p%s' % sys.executable
+            cmd.append('-p%s' % sys.executable)
 
     # if venv or pyvenv are used and virtualenv_python is defined, then
     # virtualenv_python is ignored, this has to be acknowledged
@@ -505,7 +512,7 @@ def setup_virtualenv(module, env, chdir, out, err):
                 ' using the venv module or pyvenv as virtualenv_command'
         )
 
-    cmd = "%s %s" % (cmd, env)
+    cmd.append(env)
     rc, out_venv, err_venv = module.run_command(cmd, cwd=chdir)
     out += out_venv
     err += err_venv

--- a/lib/ansible/modules/system/iptables_state.py
+++ b/lib/ansible/modules/system/iptables_state.py
@@ -266,9 +266,9 @@ def string_to_filtered_b_lines(string, counters):
     by default. And return the result as a list of bytes.
     '''
     b_string = to_bytes(string, errors='surrogate_or_strict')
-    b_string = re.sub('((^|\n)# (Generated|Completed)[^\n]*) on [^\n]*', '\\1', b_string)
+    b_string = re.sub(b'((^|\n)# (Generated|Completed)[^\n]*) on [^\n]*', b'\\1', b_string)
     if not counters:
-        b_string = re.sub('[[][0-9]+:[0-9]+[]]', '[0:0]', b_string)
+        b_string = re.sub(b'[[][0-9]+:[0-9]+[]]', b'[0:0]', b_string)
     b_lines = b_string.splitlines()
     while '' in b_lines:
         b_lines.remove('')

--- a/lib/ansible/modules/system/iptables_state.py
+++ b/lib/ansible/modules/system/iptables_state.py
@@ -211,7 +211,7 @@ def write_state(b_path, b_lines, validator, changed):
     tmpfd, tmpfile = tempfile.mkstemp()
     with os.fdopen(tmpfd, 'wb') as f:
         for b_line in b_lines:
-            f.write('%s\n' % b_line)
+            f.write(b'%s\n' % b_line)
 
     # Test it, i.e. ensure it is in good shape (not a oneliner, no litteral '\n'
     # at EOL, and so on).

--- a/lib/ansible/modules/system/iptables_state.py
+++ b/lib/ansible/modules/system/iptables_state.py
@@ -1,0 +1,444 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, quidame <quidame@poivron.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: iptables_state
+short_description: Save iptables state into a file or restore it from a file
+version_added: "2.10"
+author:
+  - quidame (@quidame)
+description:
+  - C(iptables) is used to set up, maintain, and inspect the tables of IP
+    packet filter rules in the Linux kernel.
+  - This module handles the saving and/or loading of rules. This is the same
+    as the behaviour of the C(iptables-save) and C(iptables-restore) (or
+    C(ip6tables-save) and C(ip6tables-restore) for IPv6) commands which this
+    module uses internally.
+  - Modifying the state of the firewall remotely may lead to loose access to
+    the host in case of mistake in new ruleset. This module embeds a rollback
+    feature to avoid this, by telling the host to restore previous rules if a
+    cookie is still there after a given delay, and all this time telling the
+    controller to try to remove this cookie on the host through a new
+    connection.
+notes:
+  - The rollback feature is not a module option and depends on task's
+    attributes. To enable it, the module must be played asynchronously, i.e.
+    by setting task attributes I(poll) to I(0), and I(async) to a value less
+    or equal to C(ANSIBLE_TIMEOUT). If I(async) is greater, the rollback will
+    still happen if it shall happen, but you will experience a connection
+    timeout instead of more relevant info returned by the module after its
+    failure.
+options:
+  counters:
+    description:
+      - Save or restore the values of all packet and byte counters.
+      - When I(True), the module is not idempotent.
+    type: bool
+    default: false
+  ip_version:
+    description:
+      - Which version of the IP protocol this module should apply to.
+    type: str
+    choices: [ ipv4, ipv6 ]
+    default: ipv4
+  modprobe:
+    description:
+      - Specify the path to the modprobe program internally used by iptables
+        related commands to load kernel modules.
+      - By default, /proc/sys/kernel/modprobe is inspected to determine the
+        executable's path.
+    type: path
+  noflush:
+    description:
+      - For I(state=restored), ignored otherwise.
+      - If I(False), restoring iptables rules from a file flushes (deletes)
+        all previous contents of the respective table(s). If I(True), the
+        previous rules are left untouched (but policies are updated if they're
+        specified in the file to restore state from).
+    type: bool
+    default: false
+  path:
+    description:
+      - The file the iptables state should be saved to.
+      - The file the iptables state should be restored from.
+      - Required when I(state=saved) or I(state=restored).
+    type: path
+  state:
+    description:
+      - Whether the firewall state should be saved (into a file) or restored
+        (from a file).
+      - When this option is not set, the current iptables state is returned.
+    type: str
+    choices: [ saved, restored ]
+  table:
+    description:
+      - When C(state=restored), restore only the named table even if the input
+        file contains other tables.
+      - When C(state=saved) (or left unset), restrict output to only one table.
+        If not specified, output includes all active tables.
+    type: str
+    choices: [ filter, nat, mangle, raw, security ]
+  _timeout:
+    description:
+      - Internal parameter passed in to the module by its action plugin.
+      - Delay, in seconds, before rolling back to the previous rules if the
+        action plugin is unable to remove the backup/cookie storing these rules.
+      - Gets the same value than C(async) task attribute.
+    type: int
+  _back:
+    description:
+      - Internal parameter passed in to the module by its action plugin.
+      - Path of the backup/cookie storing rules to restore if the action plugin
+        is unable to remove it.
+      - Gets a value built from C(async_dir).
+    type: path
+requirements: [iptables, ip6tables]
+'''
+
+EXAMPLES = r'''
+# This will only retrieve information
+- name: get current state of the firewall
+  iptables_state:
+  register: iptables_state
+
+- name: show current state of the firewall
+  debug:
+    var: iptables_state.initial_state
+
+# This will apply to all loaded/active IPv4 tables.
+- name: Save current state of the firewall in system file
+  iptables_state:
+    state: saved
+    path: /etc/sysconfig/iptables
+
+# This will apply only to IPv6 filter table.
+- name: save current state of the firewall in system file
+  iptables_state:
+    ip_version: ipv6
+    table: filter
+    state: saved
+    path: /etc/iptables/rules.v6
+
+# This will load a state from a file, with a rollback in case of access loss
+- name: restore firewall state from a file
+  iptables_state:
+    state: restored
+    path: /run/iptables.apply
+  async: "{{ ansible_timeout }}"
+  poll: 0
+
+# This will load new rules by appending them to the current ones
+- name: restore firewall state from a file
+  iptables_state:
+    state: restored
+    path: /run/iptables.apply
+    noflush: true
+  async: "{{ ansible_timeout }}"
+  poll: 0
+'''
+
+RETURN = r'''
+applied:
+    description: whether or not the wanted state has been successfully applied
+    type: bool
+    returned: always
+initial_state:
+    description: the current state of the firewall when module starts
+    type: list
+    returned: always
+restored_state:
+    description: the state the module restored, whenever it is applied or not
+    type: list
+    returned: always
+rollback_complete:
+    description: whether or not firewall state is the same than the initial one
+    type: bool
+    returned: failure
+'''
+
+
+import re
+import os
+import time
+import tempfile
+import filecmp
+import shutil
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_bytes, to_native
+
+
+IPTABLES = dict(
+    ipv4='iptables',
+    ipv6='ip6tables',
+)
+
+SAVE = dict(
+    ipv4='iptables-save',
+    ipv6='ip6tables-save',
+)
+
+RESTORE = dict(
+    ipv4='iptables-restore',
+    ipv6='ip6tables-restore',
+)
+
+TABLES = dict(
+    filter=['INPUT', 'FORWARD', 'OUTPUT'],
+    mangle=['PREROUTING', 'INPUT', 'FORWARD', 'OUTPUT', 'POSTROUTING'],
+    nat=['PREROUTING', 'INPUT', 'OUTPUT', 'POSTROUTING'],
+    raw=['PREROUTING', 'OUTPUT'],
+    security=['INPUT', 'FORWARD', 'OUTPUT'],
+)
+
+
+def write_state(b_path, b_lines, validator, changed=False):
+    '''
+    Write given contents to the given path, and return changed status.
+    '''
+    # Populate a temporary file
+    tmpfd, tmpfile = tempfile.mkstemp()
+    with os.fdopen(tmpfd, 'wb') as f:
+        for b_line in b_lines:
+            f.write('%s\n' % b_line)
+
+    # Test it, i.e. ensure it is in good shape (not a oneliner, no litteral '\n'
+    # at EOL, and so on).
+    (rc, out, err) = module.run_command([validator, '--test', tmpfile], check_rc=True)
+
+    # Prepare to copy temporary file to the final destination
+    if not os.path.exists(b_path):
+        b_destdir = os.path.dirname(b_path)
+        destdir = to_native(b_destdir, errors='surrogate_or_strict')
+        if b_destdir and not os.path.exists(b_destdir) and not module.check_mode:
+            try:
+                os.makedirs(b_destdir)
+            except Exception as e:
+                module.fail_json(msg='Error creating %s. Error code: %s. Error description: %s' % (destdir, e[0], e[1]))
+        changed = True
+
+    elif not filecmp.cmp(tmpfile, b_path):
+        changed = True
+
+    # Do it
+    if not module.check_mode:
+        shutil.copyfile(tmpfile, b_path)
+
+    return changed
+
+
+def initialize_from_null_state(bin_iptables, initcommand, table=None):
+    '''
+    This ensures iptables-state output is suitable for iptables-restore to roll
+    back to it, i.e. iptables-save output is not empty. This also works for the
+    iptables-nft-save alternative.
+    '''
+    if table is None:
+        table = 'filter'
+    PARTCOMMAND = [bin_iptables, '-t', table, '-P']
+
+    for chain in TABLES[table]:
+        RESETPOLICY = list(PARTCOMMAND)
+        RESETPOLICY.append(chain)
+        RESETPOLICY.append('ACCEPT')
+        (rc, out, err) = module.run_command(RESETPOLICY, check_rc=True)
+
+    (rc, out, err) = module.run_command(initcommand, check_rc=True)
+    return (rc, out, err)
+
+
+def string_to_filtered_b_lines(string, counters):
+    '''
+    Remove timestamps to ensure idempotency between runs. Also remove counters
+    by default. And return the result as a list of bytes.
+    '''
+    b_string = to_bytes(string, errors='surrogate_or_strict')
+    b_string = re.sub('((^|\n)# (Generated|Completed)[^\n]*) on [^\n]*', '\\1', b_string)
+    if not counters:
+        b_string = re.sub('[[][0-9]+:[0-9]+[]]', '[0:0]', b_string)
+    b_lines = b_string.splitlines()
+    while '' in b_lines:
+        b_lines.remove('')
+    return b_lines
+
+
+def main():
+
+    global module
+
+    module = AnsibleModule(
+        supports_check_mode=True,
+        argument_spec=dict(
+            path=dict(type='path'),
+            state=dict(type='str', choices=['saved', 'restored']),
+            table=dict(type='str', choices=['filter', 'nat', 'mangle', 'raw', 'security']),
+            noflush=dict(type='bool', default=False),
+            counters=dict(type='bool', default=False),
+            modprobe=dict(type='path'),
+            ip_version=dict(type='str', choices=['ipv4', 'ipv6'], default='ipv4'),
+            _timeout=dict(type='int'),
+            _back=dict(type='path'),
+        ),
+        required_together=[
+            ['state', 'path'],
+            ['_timeout', '_back'],
+        ],
+    )
+
+    path = module.params['path']
+    state = module.params['state']
+    table = module.params['table']
+    noflush = module.params['noflush']
+    counters = module.params['counters']
+    modprobe = module.params['modprobe']
+    ip_version = module.params['ip_version']
+    _timeout = module.params['_timeout']
+    _back = module.params['_back']
+
+    bin_iptables = module.get_bin_path(IPTABLES[ip_version], True)
+    bin_iptables_save = module.get_bin_path(SAVE[ip_version], True)
+    bin_iptables_restore = module.get_bin_path(RESTORE[ip_version], True)
+
+    os.umask(0o077)
+    changed = False
+    COMMANDARGS = []
+
+    if counters:
+        COMMANDARGS.append('--counters')
+
+    if modprobe is not None:
+        COMMANDARGS.append('--modprobe')
+        COMMANDARGS.append(modprobe)
+
+    if table is not None:
+        COMMANDARGS.append('--table')
+        COMMANDARGS.append(table)
+
+    INITCOMMAND = list(COMMANDARGS)
+    INITCOMMAND.insert(0, bin_iptables_save)
+
+    for chance in (1, 2):
+        (rc, stdout, stderr) = module.run_command(INITCOMMAND, check_rc=True)
+        if stdout and (table is None or len(stdout.splitlines()) >= len(TABLES[table]) + 4):
+            break
+        (rc, stdout, stderr) = initialize_from_null_state(bin_iptables, INITCOMMAND, table=table)
+
+    initial_state = string_to_filtered_b_lines(stdout, counters)
+    if initial_state is None:
+        module.fail_json(msg="Unable to initialize firewall from NULL state.")
+
+    if path is not None:
+        b_path = to_bytes(path, errors='surrogate_or_strict')
+
+    if state == 'saved':
+        changed = write_state(b_path, initial_state, bin_iptables_restore, changed=changed)
+
+    if state != 'restored':
+        cmd = ' '.join(INITCOMMAND)
+        module.exit_json(changed=changed, cmd=cmd, initial_state=initial_state)
+
+    #
+    # All remaining code is for state=restored
+    #
+    if not os.path.exists(b_path):
+        module.fail_json(msg="Source %s not found" % (path))
+    if not os.path.isfile(b_path):
+        module.fail_json(msg="Source %s not a file" % (path))
+    if not os.access(b_path, os.R_OK):
+        module.fail_json(msg="Source %s not readable" % (path))
+
+    MAINCOMMAND = list(COMMANDARGS)
+    MAINCOMMAND.insert(0, bin_iptables_restore)
+
+    if _back is not None:
+        b_back = to_bytes(_back, errors='surrogate_or_strict')
+        garbage = write_state(b_back, initial_state, bin_iptables_restore)
+        BACKCOMMAND = list(MAINCOMMAND)
+        BACKCOMMAND.append(_back)
+
+    if noflush:
+        MAINCOMMAND.append('--noflush')
+
+    MAINCOMMAND.append(path)
+    cmd = ' '.join(MAINCOMMAND)
+
+    TESTCOMMAND = list(MAINCOMMAND)
+    TESTCOMMAND.insert(1, '--test')
+
+    (rc, stdout, stderr) = module.run_command(TESTCOMMAND)
+    if rc != 0:
+        module.fail_json(
+            msg="Source %s is not suitable for input to %s" % (path, os.path.basename(bin_iptables_restore)),
+            rc=rc,
+            stdout=stdout,
+            stderr=stderr)
+
+    (rc, stdout, stderr) = module.run_command(MAINCOMMAND, check_rc=True)
+    (rc, stdout, stderr) = module.run_command(INITCOMMAND, check_rc=True)
+    restored_state = string_to_filtered_b_lines(stdout, counters)
+    if restored_state != initial_state:
+        changed = True
+
+    if _back is None:
+        module.exit_json(
+            applied=True,
+            changed=changed,
+            cmd=cmd,
+            initial_state=initial_state,
+            restored_state=restored_state)
+
+    # The rollback implementation currently needs:
+    # Here:
+    # * test existence of the backup file, exit with success if it doesn't exist
+    # * otherwise, restore iptables from this file and return failure
+    # Action plugin:
+    # * try to remove the backup file
+    # * wait async task is finished and retrieve its final status
+    # * modify it and return the result
+    # Task:
+    # * task attribute 'async' set to the same value (or lower) than ansible
+    #   timeout
+    # * task attribute 'poll' equals 0
+    #
+    for x in range(_timeout):
+        if os.path.exists(b_back):
+            time.sleep(1)
+            continue
+        module.exit_json(
+            applied=True,
+            changed=changed,
+            cmd=cmd,
+            initial_state=initial_state,
+            restored_state=restored_state)
+
+    # Here we are: for whatever reason, but probably due to the current ruleset,
+    # the action plugin (i.e. on the controller) was unable to remove the backup
+    # cookie, so we restore initial state from it.
+    (rc, stdout, stderr) = module.run_command(BACKCOMMAND, check_rc=True)
+    os.remove(b_back)
+
+    (rc, stdout, stderr) = module.run_command(INITCOMMAND, check_rc=True)
+    backed_state = string_to_filtered_b_lines(stdout, counters)
+
+    module.fail_json(
+        rollback_complete=(backed_state == initial_state),
+        applied=False,
+        msg="Failed to confirm state restored from %s. Firewall has been rolled back to initial state." % (path),
+        cmd=cmd,
+        initial_state=initial_state,
+        restored_state=restored_state)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/system/iptables_state.py
+++ b/lib/ansible/modules/system/iptables_state.py
@@ -203,7 +203,7 @@ TABLES = dict(
 )
 
 
-def write_state(b_path, b_lines, validator, changed=False):
+def write_state(b_path, b_lines, validator, changed):
     '''
     Write given contents to the given path, and return changed status.
     '''
@@ -342,7 +342,7 @@ def main():
         b_path = to_bytes(path, errors='surrogate_or_strict')
 
     if state == 'saved':
-        changed = write_state(b_path, initial_state, bin_iptables_restore, changed=changed)
+        changed = write_state(b_path, initial_state, bin_iptables_restore, changed)
 
     if state != 'restored':
         cmd = ' '.join(INITCOMMAND)
@@ -363,7 +363,7 @@ def main():
 
     if _back is not None:
         b_back = to_bytes(_back, errors='surrogate_or_strict')
-        garbage = write_state(b_back, initial_state, bin_iptables_restore)
+        garbage = write_state(b_back, initial_state, bin_iptables_restore, changed)
         BACKCOMMAND = list(MAINCOMMAND)
         BACKCOMMAND.append(_back)
 

--- a/lib/ansible/modules/system/iptables_state.py
+++ b/lib/ansible/modules/system/iptables_state.py
@@ -225,7 +225,9 @@ def write_state(b_path, b_lines, validator, changed):
             try:
                 os.makedirs(b_destdir)
             except Exception as e:
-                module.fail_json(msg='Error creating %s. Error code: %s. Error description: %s' % (destdir, e[0], e[1]))
+                module.fail_json(
+                    msg='Error creating %s. Error code: %s. Error description: %s' % (destdir, e[0], e[1]),
+                    initial_state=b_lines)
         changed = True
 
     elif not filecmp.cmp(tmpfile, b_path):
@@ -352,11 +354,11 @@ def main():
     # All remaining code is for state=restored
     #
     if not os.path.exists(b_path):
-        module.fail_json(msg="Source %s not found" % (path))
+        module.fail_json(msg="Source %s not found" % (path), initial_state=initial_state)
     if not os.path.isfile(b_path):
-        module.fail_json(msg="Source %s not a file" % (path))
+        module.fail_json(msg="Source %s not a file" % (path), initial_state=initial_state)
     if not os.access(b_path, os.R_OK):
-        module.fail_json(msg="Source %s not readable" % (path))
+        module.fail_json(msg="Source %s not readable" % (path), initial_state=initial_state)
 
     MAINCOMMAND = list(COMMANDARGS)
     MAINCOMMAND.insert(0, bin_iptables_restore)
@@ -382,7 +384,8 @@ def main():
             msg="Source %s is not suitable for input to %s" % (path, os.path.basename(bin_iptables_restore)),
             rc=rc,
             stdout=stdout,
-            stderr=stderr)
+            stderr=stderr,
+            initial_state=initial_state)
 
     if module.check_mode:
         tmpfd, tmpfile = tempfile.mkstemp()

--- a/lib/ansible/modules/system/iptables_state.py
+++ b/lib/ansible/modules/system/iptables_state.py
@@ -391,7 +391,7 @@ def main():
         tmpfd, tmpfile = tempfile.mkstemp()
         with os.fdopen(tmpfd, 'wb') as f:
             for b_line in initial_state:
-                f.write('%s\n' % b_line)
+                f.write(b'%s\n' % b_line)
 
         if filecmp.cmp(tmpfile, b_path):
             restored_state = initial_state

--- a/lib/ansible/playbook/role/definition.py
+++ b/lib/ansible/playbook/role/definition.py
@@ -162,9 +162,9 @@ class RoleDefinition(Base, Conditional, Taggable, CollectionSearch):
             self._role_collection = role_tuple[2]
             return role_tuple[0:2]
 
-        # FUTURE: refactor this to be callable from internal so we can properly order ansible.legacy searches with the collections keyword
-        if self._collection_list and 'ansible.legacy' not in self._collection_list:
-            raise AnsibleError("the role '%s' was not found in %s" % (role_name, ":".join(self._collection_list)), obj=self._ds)
+        # We didn't find a collection role, look in defined role paths
+        # FUTURE: refactor this to be callable from internal so we can properly order
+        # ansible.legacy searches with the collections keyword
 
         # we always start the search for roles in the base directory of the playbook
         role_search_paths = [
@@ -198,7 +198,8 @@ class RoleDefinition(Base, Conditional, Taggable, CollectionSearch):
             role_name = os.path.basename(role_name)
             return (role_name, role_path)
 
-        raise AnsibleError("the role '%s' was not found in %s" % (role_name, ":".join(role_search_paths)), obj=self._ds)
+        searches = (self._collection_list or []) + role_search_paths
+        raise AnsibleError("the role '%s' was not found in %s" % (role_name, ":".join(searches)), obj=self._ds)
 
     def _split_role_params(self, ds):
         '''

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1053,6 +1053,10 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             display.debug("_low_level_execute_command(): changing cwd to %s for this command" % chdir)
             cmd = self._connection._shell.append_command('cd %s' % chdir, cmd)
 
+        # https://github.com/ansible/ansible/issues/68054
+        if executable:
+            self._connection._shell.executable = executable
+
         ruser = self._get_remote_user()
         buser = self.get_become_option('become_user')
         if (sudoable and self._connection.become and  # if sudoable and have become

--- a/lib/ansible/plugins/action/iptables_state.py
+++ b/lib/ansible/plugins/action/iptables_state.py
@@ -1,0 +1,168 @@
+# Copyright: (c) 2020, quidame <quidame@poivron.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import time
+
+from ansible.plugins.action import ActionBase
+from ansible.errors import AnsibleError, AnsibleActionFail, AnsibleConnectionFailure
+from ansible.utils.vars import merge_hash
+from ansible.utils.display import Display
+
+display = Display()
+
+class ActionModule(ActionBase):
+
+    # Keep internal params away from user interactions
+    _VALID_ARGS = frozenset(('path', 'state', 'table', 'noflush', 'counters', 'modprobe', 'ip_version'))
+    DEFAULT_SUDOABLE = True
+
+    MSG_ERROR__ASYNC_AND_POLL_NOT_ZERO = (
+            "This module doesn't support async>0 and poll>0 when its 'state' param "
+            "is set to 'restored'. To enable its rollback feature (that needs the "
+            "module to run asynchronously on the remote), please set task attribute "
+            "'poll' to 0, and 'async' to a value not greater than 'ansible_timeout' "
+            "(recommended).")
+    MSG_WARNING__NO_ASYNC_IS_NO_ROLLBACK = (
+            "Attempts to restore iptables state without rollback in case of mistake "
+            "may lead the ansible controller to loose access to the hosts and never "
+            "regain it before fixing firewall rules through a serial console, or any "
+            "other way except SSH. Please set task attribute 'poll' to 0, and 'async' "
+            "to a value not greater than 'ansible_timeout' (recommended).")
+
+
+    def _async_result(self, module_args, task_vars, timeout):
+        '''
+        Retrieve results of the asynchonous task, and display them in place of
+        the async wrapper results (those with the ansible_job_id key).
+        '''
+        for i in range(timeout):
+            async_result = self._execute_module(
+                    module_name='async_status',
+                    module_args=module_args,
+                    task_vars=task_vars,
+                    wrap_async=False)
+            if async_result['finished'] == 1:
+                break
+            time.sleep(1)
+
+        del async_result['ansible_job_id']
+        del async_result['finished']
+
+        if async_result.get('restored_state', None) == async_result['initial_state']:
+            async_result['changed'] = False
+
+        return async_result
+
+
+    def run(self, tmp=None, task_vars=None):
+
+        # individual modules might disagree but as the generic the action plugin, pass at this point.
+        self._supports_check_mode = True
+        self._supports_async = True
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        task_async = self._task.async_val
+        task_poll = self._task.poll
+        module_name = self._task.action
+        module_args = self._task.args
+
+
+        if not result.get('skipped'):
+
+            if result.get('invocation', {}).get('module_args'):
+                # avoid passing to modules in case of no_log
+                # should not be set anymore but here for backwards compatibility
+                del result['invocation']['module_args']
+
+            # FUTURE: better to let _execute_module calculate this internally?
+            wrap_async = self._task.async_val and not self._connection.has_native_async
+
+            if module_args.get('state', None) == 'restored':
+                if not task_async:
+                    display.warning(self.MSG_WARNING__NO_ASYNC_IS_NO_ROLLBACK)
+                elif task_poll:
+                    raise AnsibleActionFail(self.MSG_ERROR__ASYNC_AND_POLL_NOT_ZERO)
+                else:
+                    # BEGIN snippet from async_status action plugin
+                    env_async_dir = [e for e in self._task.environment if
+                                     "ANSIBLE_ASYNC_DIR" in e]
+                    if len(env_async_dir) > 0:
+                        # for backwards compatibility we need to get the dir from
+                        # ANSIBLE_ASYNC_DIR that is defined in the environment. This is
+                        # deprecated and will be removed in favour of shell options
+                        async_dir = env_async_dir[0]['ANSIBLE_ASYNC_DIR']
+
+                        msg = "Setting the async dir from the environment keyword " \
+                              "ANSIBLE_ASYNC_DIR is deprecated. Set the async_dir " \
+                              "shell option instead"
+                        display.deprecated(msg, "2.12")
+                    else:
+                        # inject the async directory based on the shell option into the
+                        # module args
+                        async_dir = self.get_shell_option('async_dir', default="~/.ansible_async")
+                    ### END snippet from async_status action plugin
+
+                    # Bind the loop max duration to the same value on both
+                    # remote and local sides, and set a backup file path.
+                    module_args['_timeout'] = task_async
+                    module_args['_back'] = '%s/iptables.state' % async_dir
+
+
+            # do work!
+            result = merge_hash(result, self._execute_module(module_args=module_args, task_vars=task_vars, wrap_async=wrap_async))
+
+            # Remove internal params from results when not used
+            if result.get('invocation', {}).get('module_args'):
+                del result['invocation']['module_args']['_timeout']
+                del result['invocation']['module_args']['_back']
+
+            # Then the 3-steps "go ahead or rollback":
+            # - reset connection to ensure a persistent one will not be reused
+            # - confirm the restored state by removing the backup on the remote
+            # - retrieve the results of the asynchronous task to return them
+            if '_back' in module_args:
+                try:
+                    self._connection.reset()
+                    display.v("%s: reset connection" % (module_name))
+                except AttributeError:
+                    display.warning("Connection plugin does not allow to reset the connection.")
+
+                confirm_cmd = 'rm %s' % module_args['_back']
+                remaining_time = int(module_args['_timeout'])
+                for x in range(int(module_args['_timeout'])):
+                    time.sleep(1)
+                    remaining_time -= 1
+                    # - AnsibleConnectionFailure covers rejected requests (i.e.
+                    #   by rules with '--jump REJECT')
+                    # - ansible_timeout is able to cover dropped requests (due
+                    #   to a rule or policy DROP) if not lower than async_val.
+                    try:
+                        confirm_res = self._low_level_execute_command(confirm_cmd, sudoable=self.DEFAULT_SUDOABLE)
+                        break
+                    except AnsibleConnectionFailure:
+                        continue
+
+                async_status_args = {}
+                async_status_args['jid'] = result.get('ansible_job_id', None)
+                if async_status_args['jid'] is None:
+                    raise AnsibleActionFail("Unable to get 'ansible_job_id'.")
+
+                async_status_args['_async_dir'] = async_dir
+                result = self._async_result(async_status_args, task_vars, remaining_time)
+
+                async_status_args['mode'] = 'cleanup'
+                garbage = self._execute_module(
+                        module_name='async_status',
+                        module_args=async_status_args,
+                        task_vars=task_vars,
+                        wrap_async=False)
+
+        # remove a temporary path we created
+        self._remove_tmp_path(self._connection._shell.tmpdir)
+
+        return result

--- a/lib/ansible/plugins/action/iptables_state.py
+++ b/lib/ansible/plugins/action/iptables_state.py
@@ -13,6 +13,7 @@ from ansible.utils.display import Display
 
 display = Display()
 
+
 class ActionModule(ActionBase):
 
     # Keep internal params away from user interactions
@@ -20,18 +21,17 @@ class ActionModule(ActionBase):
     DEFAULT_SUDOABLE = True
 
     MSG_ERROR__ASYNC_AND_POLL_NOT_ZERO = (
-            "This module doesn't support async>0 and poll>0 when its 'state' param "
-            "is set to 'restored'. To enable its rollback feature (that needs the "
-            "module to run asynchronously on the remote), please set task attribute "
-            "'poll' to 0, and 'async' to a value not greater than 'ansible_timeout' "
-            "(recommended).")
+        "This module doesn't support async>0 and poll>0 when its 'state' param "
+        "is set to 'restored'. To enable its rollback feature (that needs the "
+        "module to run asynchronously on the remote), please set task attribute "
+        "'poll' to 0, and 'async' to a value not greater than 'ansible_timeout' "
+        "(recommended).")
     MSG_WARNING__NO_ASYNC_IS_NO_ROLLBACK = (
-            "Attempts to restore iptables state without rollback in case of mistake "
-            "may lead the ansible controller to loose access to the hosts and never "
-            "regain it before fixing firewall rules through a serial console, or any "
-            "other way except SSH. Please set task attribute 'poll' to 0, and 'async' "
-            "to a value not greater than 'ansible_timeout' (recommended).")
-
+        "Attempts to restore iptables state without rollback in case of mistake "
+        "may lead the ansible controller to loose access to the hosts and never "
+        "regain it before fixing firewall rules through a serial console, or any "
+        "other way except SSH. Please set task attribute 'poll' to 0, and 'async' "
+        "to a value not greater than 'ansible_timeout' (recommended).")
 
     def _async_result(self, module_args, task_vars, timeout):
         '''
@@ -40,10 +40,10 @@ class ActionModule(ActionBase):
         '''
         for i in range(timeout):
             async_result = self._execute_module(
-                    module_name='async_status',
-                    module_args=module_args,
-                    task_vars=task_vars,
-                    wrap_async=False)
+                module_name='async_status',
+                module_args=module_args,
+                task_vars=task_vars,
+                wrap_async=False)
             if async_result['finished'] == 1:
                 break
             time.sleep(1)
@@ -55,7 +55,6 @@ class ActionModule(ActionBase):
             async_result['changed'] = False
 
         return async_result
-
 
     def run(self, tmp=None, task_vars=None):
 
@@ -70,7 +69,6 @@ class ActionModule(ActionBase):
         task_poll = self._task.poll
         module_name = self._task.action
         module_args = self._task.args
-
 
         if not result.get('skipped'):
 
@@ -105,13 +103,12 @@ class ActionModule(ActionBase):
                         # inject the async directory based on the shell option into the
                         # module args
                         async_dir = self.get_shell_option('async_dir', default="~/.ansible_async")
-                    ### END snippet from async_status action plugin
+                    # END snippet from async_status action plugin
 
                     # Bind the loop max duration to the same value on both
                     # remote and local sides, and set a backup file path.
                     module_args['_timeout'] = task_async
                     module_args['_back'] = '%s/iptables.state' % async_dir
-
 
             # do work!
             result = merge_hash(result, self._execute_module(module_args=module_args, task_vars=task_vars, wrap_async=wrap_async))
@@ -157,10 +154,10 @@ class ActionModule(ActionBase):
 
                 async_status_args['mode'] = 'cleanup'
                 garbage = self._execute_module(
-                        module_name='async_status',
-                        module_args=async_status_args,
-                        task_vars=task_vars,
-                        wrap_async=False)
+                    module_name='async_status',
+                    module_args=async_status_args,
+                    task_vars=task_vars,
+                    wrap_async=False)
 
         # remove a temporary path we created
         self._remove_tmp_path(self._connection._shell.tmpdir)

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -347,8 +347,9 @@ class PluginLoader:
             return full_name, to_text(n_resource_path)
 
         # look for any matching extension in the package location (sans filter)
-        ext_blacklist = ['.pyc', '.pyo']
-        found_files = [f for f in glob.iglob(os.path.join(pkg_path, n_resource) + '.*') if os.path.isfile(f) and os.path.splitext(f)[1] not in ext_blacklist]
+        found_files = [f
+                       for f in glob.iglob(os.path.join(pkg_path, n_resource) + '.*')
+                       if os.path.isfile(f) and not f.endswith(C.MODULE_IGNORE_EXTS)]
 
         if not found_files:
             return None, None
@@ -448,7 +449,7 @@ class PluginLoader:
                 # HACK: We have no way of executing python byte compiled files as ansible modules so specifically exclude them
                 # FIXME: I believe this is only correct for modules and module_utils.
                 # For all other plugins we want .pyc and .pyo should be valid
-                if any(full_path.endswith(x) for x in C.BLACKLIST_EXTS):
+                if any(full_path.endswith(x) for x in C.MODULE_IGNORE_EXTS):
                     continue
 
                 splitname = os.path.splitext(full_name)

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/uses_leaf_mu_flat_import.bak
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/uses_leaf_mu_flat_import.bak
@@ -1,0 +1,3 @@
+# Intentionally blank, and intentionally attempting to shadow
+# uses_leaf_mu_flat_import.py. MODULE_IGNORE_EXTS should prevent this file
+# from ever being loaded.

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/uses_leaf_mu_flat_import.yml
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/uses_leaf_mu_flat_import.yml
@@ -1,0 +1,3 @@
+# Intentionally blank, and intentionally attempting to shadow
+# uses_leaf_mu_flat_import.py. MODULE_IGNORE_EXTS should prevent this file
+# from ever being loaded.

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/roles/call_standalone/tasks/main.yml
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/roles/call_standalone/tasks/main.yml
@@ -1,0 +1,6 @@
+- include_role:
+    name: standalone
+
+- assert:
+    that:
+      - standalone_role_var is defined

--- a/test/integration/targets/collections/posix.yml
+++ b/test/integration/targets/collections/posix.yml
@@ -401,3 +401,8 @@
     handler_counter: 0
   roles:
     - testns.testcoll.test_fqcn_handlers
+
+- name: Ensure a collection role can call a standalone role
+  hosts: testhost
+  roles:
+    - testns.testcoll.call_standalone

--- a/test/integration/targets/collections/roles/standalone/tasks/main.yml
+++ b/test/integration/targets/collections/roles/standalone/tasks/main.yml
@@ -1,0 +1,2 @@
+- set_fact:
+    standalone_role_var: True

--- a/test/integration/targets/incidental_setup_openssl/tasks/main.yml
+++ b/test/integration/targets/incidental_setup_openssl/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: Install pyOpenSSL (Darwin)
   become: True
   pip:
-    name: pyOpenSSL<2.9.1
+    name: pyOpenSSL
   when: ansible_os_family == 'Darwin'
 
 - name: register pyOpenSSL version

--- a/test/integration/targets/iptables_state/aliases
+++ b/test/integration/targets/iptables_state/aliases
@@ -1,0 +1,5 @@
+destructive
+shippable/posix/group1
+skip/freebsd            # no iptables/netfilter (Linux specific)
+skip/osx                # no iptables/netfilter (Linux specific)
+skip/aix                # no iptables/netfilter (Linux specific)

--- a/test/integration/targets/iptables_state/aliases
+++ b/test/integration/targets/iptables_state/aliases
@@ -1,6 +1,7 @@
 needs/ssh
 destructive
 shippable/posix/group1
+skip/docker             # iptables not installed
 skip/freebsd            # no iptables/netfilter (Linux specific)
 skip/osx                # no iptables/netfilter (Linux specific)
 skip/aix                # no iptables/netfilter (Linux specific)

--- a/test/integration/targets/iptables_state/aliases
+++ b/test/integration/targets/iptables_state/aliases
@@ -1,3 +1,4 @@
+needs/ssh
 destructive
 shippable/posix/group1
 skip/freebsd            # no iptables/netfilter (Linux specific)

--- a/test/integration/targets/iptables_state/tasks/main.yml
+++ b/test/integration/targets/iptables_state/tasks/main.yml
@@ -3,8 +3,13 @@
 # Copyright: (c) 2020, quidame <quidame@poivron.org>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-- name: include tasks to test iptables_state module
-  include_tasks: "{{ item }}"
-  loop:
-    - tests/00-basic.yml
-    - tests/01-rollback.yml
+- name: include tasks to test basic behaviour
+  include_tasks: tests/00-basic.yml
+  when:
+    - ansible_system in ['Linux']
+
+- name: include tasks to test rollback feature
+  include_tasks: tests/01-rollback.yml
+  when:
+    - ansible_system in ['Linux']
+    - ansible_connection in ['ssh', 'paramiko']

--- a/test/integration/targets/iptables_state/tasks/main.yml
+++ b/test/integration/targets/iptables_state/tasks/main.yml
@@ -1,0 +1,11 @@
+# Test code for iptables_state module
+#
+# Copyright: (c) 2020, quidame <quidame@poivron.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+- name: include tasks to test iptables_state module
+  block:
+    - include_tasks: "{{ item }}"
+      with_fileglob:
+        - "tests/*.yml"
+  become: yes

--- a/test/integration/targets/iptables_state/tasks/main.yml
+++ b/test/integration/targets/iptables_state/tasks/main.yml
@@ -4,8 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: include tasks to test iptables_state module
-  block:
-    - include_tasks: "{{ item }}"
-      with_fileglob:
-        - "tests/*.yml"
-  become: yes
+  - include_tasks: "{{ item }}"
+    loop:
+      - tests/00-basic.yml
+      - tests/01-rollback.yml

--- a/test/integration/targets/iptables_state/tasks/main.yml
+++ b/test/integration/targets/iptables_state/tasks/main.yml
@@ -4,7 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - name: include tasks to test iptables_state module
-  - include_tasks: "{{ item }}"
-    loop:
-      - tests/00-basic.yml
-      - tests/01-rollback.yml
+  include_tasks: "{{ item }}"
+  loop:
+    - tests/00-basic.yml
+    - tests/01-rollback.yml

--- a/test/integration/targets/iptables_state/tasks/tests/00-basic.yml
+++ b/test/integration/targets/iptables_state/tasks/tests/00-basic.yml
@@ -1,0 +1,172 @@
+---
+# Start with no param at all, i.e. only get current state without doing anything
+- name: "[IPTABLES_STATE 0001] test module without param (must NOT report a change)"
+  iptables_state:
+  register: iptables_state
+
+- name: "[IPTABLES_STATE 0001] assert that results are as expected"
+  assert:
+    that:
+      - iptables_state is not changed
+      - iptables_state.initial_state | length > 6
+
+
+- name: "[IPTABLES_STATE 00--] ensure our next backup is not there"
+  file:
+    path: /tmp/iptables.saved
+    state: absent
+
+
+#
+# Play with the current state first. We will create a file to store it in, but
+# no more. These tests are for:
+# - idempotence
+# - check_mode
+#
+- name: "[IPTABLES_STATE 0002] save state (check_mode=yes, must report a change)"
+  iptables_state:
+    path: /tmp/iptables.saved
+    state: saved
+  register: iptables_state
+  check_mode: yes
+
+- name: "[IPTABLES_STATE 0002] assert that results are as expected"
+  assert:
+    that:
+      - iptables_state is changed
+
+
+
+- name: "[IPTABLES_STATE 0003] save state (must report a change)"
+  iptables_state:
+    path: /tmp/iptables.saved
+    state: saved
+  register: iptables_state
+
+- name: "[IPTABLES_STATE 0003] assert that results are as expected"
+  assert:
+    that:
+      - iptables_state is changed
+
+
+
+- name: "[IPTABLES_STATE 0004] save state (idempotence, must NOT report a change)"
+  iptables_state:
+    path: /tmp/iptables.saved
+    state: saved
+  register: iptables_state
+
+- name: "[IPTABLES_STATE 0004] assert that results are as expected"
+  assert:
+    that:
+      - iptables_state is not changed
+
+
+
+- name: "[IPTABLES_STATE 0005] save state (check_mode=yes, must NOT report a change)"
+  iptables_state:
+    path: /tmp/iptables.saved
+    state: saved
+  register: iptables_state
+  check_mode: yes
+
+- name: "[IPTABLES_STATE 0005] assert that results are as expected"
+  assert:
+    that:
+      - iptables_state is not changed
+
+
+
+# We begin with 'state=restored' by restoring the current state on itself.
+
+- name: "[IPTABLES_STATE 0006] restore state (check_mode=yes, must NOT report a change)"
+  iptables_state:
+    path: /tmp/iptables.saved
+    state: restored
+  register: iptables_state
+  check_mode: yes
+
+- name: "[IPTABLES_STATE 0006] assert that results are as expected"
+  assert:
+    that:
+      - iptables_state is not changed
+
+
+
+- name: "[IPTABLES_STATE 0007] restore state (must NOT report a change)"
+  iptables_state:
+    path: /tmp/iptables.saved
+    state: restored
+  register: iptables_state
+  async: "{{ ansible_timeout }}"
+  poll: 0
+
+- name: "[IPTABLES_STATE 0007] assert that results are as expected"
+  assert:
+    that:
+      - iptables_state is not changed
+
+
+
+- name: "[IPTABLES_STATE 00--] change iptables state (with iptables)"
+  iptables:
+    chain: OUTPUT
+    jump: ACCEPT
+
+
+
+- name: "[IPTABLES_STATE 0008] restore state (check_mode=yes, must report a change)"
+  iptables_state:
+    path: /tmp/iptables.saved
+    state: restored
+  register: iptables_state
+  check_mode: yes
+
+- name: "[IPTABLES_STATE 0008] assert that results are as expected"
+  assert:
+    that:
+      - iptables_state is changed
+
+
+
+- name: "[IPTABLES_STATE 0009] restore state (must report a change)"
+  iptables_state:
+    path: /tmp/iptables.saved
+    state: restored
+  register: iptables_state
+  async: "{{ ansible_timeout }}"
+  poll: 0
+
+- name: "[IPTABLES_STATE 0009] assert that results are as expected"
+  assert:
+    that:
+      - iptables_state is changed
+
+
+
+- name: "[IPTABLES_STATE 0010] restore state (must NOT report a change)"
+  iptables_state:
+    path: /tmp/iptables.saved
+    state: restored
+  register: iptables_state
+  async: "{{ ansible_timeout }}"
+  poll: 0
+
+- name: "[IPTABLES_STATE 0010] assert that results are as expected"
+  assert:
+    that:
+      - iptables_state is not changed
+
+
+
+- name: "[IPTABLES_STATE 0011] restore state (check_mode=yes, must NOT report a change)"
+  iptables_state:
+    path: /tmp/iptables.saved
+    state: restored
+  register: iptables_state
+  check_mode: yes
+
+- name: "[IPTABLES_STATE 0011] assert that results are as expected"
+  assert:
+    that:
+      - iptables_state is not changed

--- a/test/integration/targets/iptables_state/tasks/tests/00-basic.yml
+++ b/test/integration/targets/iptables_state/tasks/tests/00-basic.yml
@@ -18,6 +18,13 @@
     state: absent
   become: yes
 
+- name: "[IPTABLES_STATE 00--] ensure our next rule is not there"
+  iptables:
+    chain: OUTPUT
+    jump: ACCEPT
+    state: absent
+  become: yes
+
 
 #
 # Play with the current state first. We will create a file to store it in, but

--- a/test/integration/targets/iptables_state/tasks/tests/00-basic.yml
+++ b/test/integration/targets/iptables_state/tasks/tests/00-basic.yml
@@ -2,6 +2,7 @@
 # Start with no param at all, i.e. only get current state without doing anything
 - name: "[IPTABLES_STATE 0001] test module without param (must NOT report a change)"
   iptables_state:
+  become: yes
   register: iptables_state
 
 - name: "[IPTABLES_STATE 0001] assert that results are as expected"
@@ -15,6 +16,7 @@
   file:
     path: /tmp/iptables.saved
     state: absent
+  become: yes
 
 
 #
@@ -27,6 +29,7 @@
   iptables_state:
     path: /tmp/iptables.saved
     state: saved
+  become: yes
   register: iptables_state
   check_mode: yes
 
@@ -41,6 +44,7 @@
   iptables_state:
     path: /tmp/iptables.saved
     state: saved
+  become: yes
   register: iptables_state
 
 - name: "[IPTABLES_STATE 0003] assert that results are as expected"
@@ -54,6 +58,7 @@
   iptables_state:
     path: /tmp/iptables.saved
     state: saved
+  become: yes
   register: iptables_state
 
 - name: "[IPTABLES_STATE 0004] assert that results are as expected"
@@ -67,6 +72,7 @@
   iptables_state:
     path: /tmp/iptables.saved
     state: saved
+  become: yes
   register: iptables_state
   check_mode: yes
 
@@ -83,6 +89,7 @@
   iptables_state:
     path: /tmp/iptables.saved
     state: restored
+  become: yes
   register: iptables_state
   check_mode: yes
 
@@ -97,6 +104,7 @@
   iptables_state:
     path: /tmp/iptables.saved
     state: restored
+  become: yes
   register: iptables_state
   async: "{{ ansible_timeout }}"
   poll: 0
@@ -119,6 +127,7 @@
   iptables_state:
     path: /tmp/iptables.saved
     state: restored
+  become: yes
   register: iptables_state
   check_mode: yes
 
@@ -133,6 +142,7 @@
   iptables_state:
     path: /tmp/iptables.saved
     state: restored
+  become: yes
   register: iptables_state
   async: "{{ ansible_timeout }}"
   poll: 0
@@ -148,6 +158,7 @@
   iptables_state:
     path: /tmp/iptables.saved
     state: restored
+  become: yes
   register: iptables_state
   async: "{{ ansible_timeout }}"
   poll: 0
@@ -163,6 +174,7 @@
   iptables_state:
     path: /tmp/iptables.saved
     state: restored
+  become: yes
   register: iptables_state
   check_mode: yes
 

--- a/test/integration/targets/iptables_state/tasks/tests/01-rollback.yml
+++ b/test/integration/targets/iptables_state/tasks/tests/01-rollback.yml
@@ -83,7 +83,7 @@
       async: "{{ ansible_timeout }}"
       poll: 0
       vars:
-        ansible_timeout: 10
+        ansible_timeout: 100
 
   rescue:
     - name: "[IPTABLES_STATE 0104] explain expected failure"

--- a/test/integration/targets/iptables_state/tasks/tests/01-rollback.yml
+++ b/test/integration/targets/iptables_state/tasks/tests/01-rollback.yml
@@ -1,0 +1,118 @@
+---
+- name: "[IPTABLES_STATE 0101] save state into a test file"
+  iptables_state:
+    path: /tmp/iptables.tests
+    state: saved
+
+- name: "[IPTABLES_STATE 01--] replace all policies to DROP in the test file"
+  replace:
+    path: /tmp/iptables.tests
+    regexp: '^(:.*)ACCEPT(.*)'
+    replace: '\1DROP\2'
+
+- name: "[IPTABLES_STATE 01--] flush all rules in the test file"
+  lineinfile:
+    path: /tmp/iptables.tests
+    regexp: '^-A'
+    state: absent
+
+
+
+- name: "[IPTABLES_STATE 0102] restore state (check_mode=yes, must report a change)"
+  iptables_state:
+    path: /tmp/iptables.tests
+    state: restored
+  register: iptables_state
+  check_mode: yes
+
+- name: "[IPTABLES_STATE 0102] assert that results are as expected"
+  assert:
+    that:
+      - iptables_state is changed
+
+
+
+- name: "[IPTABLES_STATE 0103] fail to restore iptables state from the test file"
+  block:
+    - name: "[IPTABLES_STATE 0103] restore state (expected error -> rollback)"
+      iptables_state:
+        path: /tmp/iptables.tests
+        state: restored
+      register: iptables_state
+      async: "{{ ansible_timeout }}"
+      poll: 0
+
+  rescue:
+    - name: "[IPTABLES_STATE 0103] explain expected failure"
+      assert:
+        that:
+          - iptables_state is not changed
+          - iptables_state.rollback_complete
+          - not iptables_state.applied
+        success_msg: >-
+          The previous error has been triggered to test the rollback. If you
+          are there, it means that 1) connection has been lost right after the
+          bad rules have been restored; 2) a rollback happened, so the bad
+          rules are not applied, finally; 3) module failed because it didn't
+          reach the wanted state, but at least host is not lost !!!
+        fail_msg: >-
+          The previous error has been triggered but its results are not as
+          expected.
+
+  always:
+    - name: "[IPTABLES_STATE 0103] check that the expected failure happened"
+      assert:
+        that:
+          - iptables_state is failed
+
+
+
+- name: "[IPTABLES_STATE 0104] fail to restore iptables state from the test file (again)"
+  block:
+    - name: "[IPTABLES_STATE 0104] try again, with a higher timeout (same expected error)"
+      iptables_state:
+        path: /tmp/iptables.tests
+        state: restored
+      register: iptables_state
+      async: "{{ ansible_timeout }}"
+      poll: 0
+      vars:
+        ansible_timeout: 10
+
+  rescue:
+    - name: "[IPTABLES_STATE 0104] explain expected failure"
+      assert:
+        that:
+          - iptables_state is not changed
+          - iptables_state.rollback_complete
+          - not iptables_state.applied
+        success_msg: >-
+          The previous error has been triggered to test the rollback. If you
+          are there, it means that 1) connection has been lost right after the
+          bad rules have been restored; 2) a rollback happened, so the bad
+          rules are not applied, finally; 3) module failed because it didn't
+          reach the wanted state, but at least host is not lost !!!
+        fail_msg: >-
+          The previous error has been triggered but its results are not as
+          expected.
+
+  always:
+    - name: "[IPTABLES_STATE 0104] check that the expected failure happened"
+      assert:
+        that:
+          - iptables_state is failed
+
+
+
+- name: "[IPTABLES_STATE 0105] restore state from backup (must NOT report a change)"
+  iptables_state:
+    path: /tmp/iptables.saved
+    state: restored
+  register: iptables_state
+  async: "{{ ansible_timeout }}"
+  poll: 0
+
+- name: "[IPTABLES_STATE 0105] assert that results are as expected"
+  assert:
+    that:
+      - iptables_state is not changed

--- a/test/integration/targets/iptables_state/tasks/tests/01-rollback.yml
+++ b/test/integration/targets/iptables_state/tasks/tests/01-rollback.yml
@@ -3,18 +3,21 @@
   iptables_state:
     path: /tmp/iptables.tests
     state: saved
+  become: yes
 
 - name: "[IPTABLES_STATE 01--] replace all policies to DROP in the test file"
   replace:
     path: /tmp/iptables.tests
     regexp: '^(:.*)ACCEPT(.*)'
     replace: '\1DROP\2'
+  become: yes
 
 - name: "[IPTABLES_STATE 01--] flush all rules in the test file"
   lineinfile:
     path: /tmp/iptables.tests
     regexp: '^-A'
     state: absent
+  become: yes
 
 
 
@@ -22,6 +25,7 @@
   iptables_state:
     path: /tmp/iptables.tests
     state: restored
+  become: yes
   register: iptables_state
   check_mode: yes
 
@@ -38,6 +42,7 @@
       iptables_state:
         path: /tmp/iptables.tests
         state: restored
+      become: yes
       register: iptables_state
       async: "{{ ansible_timeout }}"
       poll: 0
@@ -73,6 +78,7 @@
       iptables_state:
         path: /tmp/iptables.tests
         state: restored
+      become: yes
       register: iptables_state
       async: "{{ ansible_timeout }}"
       poll: 0
@@ -108,6 +114,7 @@
   iptables_state:
     path: /tmp/iptables.saved
     state: restored
+  become: yes
   register: iptables_state
   async: "{{ ansible_timeout }}"
   poll: 0

--- a/test/integration/targets/module_precedence/lib_with_extension/a.ini
+++ b/test/integration/targets/module_precedence/lib_with_extension/a.ini
@@ -1,0 +1,13 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+
+def main():
+    print(json.dumps(dict(changed=False, location='a.ini')))
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/module_precedence/lib_with_extension/a.py
+++ b/test/integration/targets/module_precedence/lib_with_extension/a.py
@@ -1,0 +1,13 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+
+def main():
+    print(json.dumps(dict(changed=False, location='a.py')))
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/module_precedence/lib_with_extension/ping.ini
+++ b/test/integration/targets/module_precedence/lib_with_extension/ping.ini
@@ -1,0 +1,13 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+
+def main():
+    print(json.dumps(dict(changed=False, location='ping.ini')))
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/module_precedence/modules_test_envvar_ext.yml
+++ b/test/integration/targets/module_precedence/modules_test_envvar_ext.yml
@@ -1,0 +1,16 @@
+- hosts: testhost
+  gather_facts: no
+  tasks:
+  - name: Use ping from library path
+    ping:
+    register: result
+
+  - name: Use a from library path
+    a:
+    register: a_res
+
+  - assert:
+      that:
+        - '"location" in result'
+        - 'result["location"] == "library"'
+        - 'a_res["location"] == "a.py"'

--- a/test/integration/targets/module_precedence/modules_test_role_ext.yml
+++ b/test/integration/targets/module_precedence/modules_test_role_ext.yml
@@ -1,0 +1,18 @@
+- hosts: testhost
+  gather_facts: no
+  roles:
+    - foo
+  tasks:
+  - name: Use ping from role
+    ping:
+    register: result
+
+  - name: Use  from role
+    a:
+    register: a_res
+
+  - assert:
+      that:
+        - '"location" in result'
+        - 'result["location"] == "role: foo"'
+        - 'a_res["location"] == "role: foo, a.py"'

--- a/test/integration/targets/module_precedence/roles_with_extension/foo/library/a.ini
+++ b/test/integration/targets/module_precedence/roles_with_extension/foo/library/a.ini
@@ -1,0 +1,13 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+
+def main():
+    print(json.dumps(dict(changed=False, location='role: foo, a.ini')))
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/module_precedence/roles_with_extension/foo/library/a.py
+++ b/test/integration/targets/module_precedence/roles_with_extension/foo/library/a.py
@@ -1,0 +1,13 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+
+def main():
+    print(json.dumps(dict(changed=False, location='role: foo, a.py')))
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/module_precedence/roles_with_extension/foo/library/ping.ini
+++ b/test/integration/targets/module_precedence/roles_with_extension/foo/library/ping.ini
@@ -1,0 +1,13 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+
+def main():
+    print(json.dumps(dict(changed=False, location='role: foo, ping.ini')))
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/module_precedence/runme.sh
+++ b/test/integration/targets/module_precedence/runme.sh
@@ -28,3 +28,22 @@ ANSIBLE_LIBRARY=lib_with_extension ANSIBLE_ROLES_PATH=multiple_roles ansible-pla
 
 # And prove that with multiple roles, it's the order the roles are listed in the play that matters
 ANSIBLE_LIBRARY=lib_with_extension ANSIBLE_ROLES_PATH=multiple_roles ansible-playbook modules_test_multiple_roles_reverse_order.yml -i ../../inventory -v "$@"
+
+# Tests for MODULE_IGNORE_EXTS.
+#
+# Very similar to two tests above, but adds a check to test extension
+# precedence. Separate from the above playbooks because we *only* care about
+# extensions here and 'a' will not exist when the above playbooks run with
+# non-extension library/role paths. There is also no way to guarantee that
+# these tests will be useful due to how the pluginloader seems to work. It uses
+# os.listdir which returns things in an arbitrary order (likely dependent on
+# filesystem). If it happens to return 'a.py' on the test node before it
+# returns 'a.ini', then this test is pointless anyway because there's no chance
+# that 'a.ini' would ever have run regardless of what MODULE_IGNORE_EXTS is set
+# to. The hope is that we test across enough systems that one would fail this
+# test if the MODULE_IGNORE_EXTS broke, but there is no guarantee. This would
+# perhaps be better as a mocked unit test because of this but would require
+# a fair bit of work to be feasible as none of that loader logic is tested at
+# all right now.
+ANSIBLE_LIBRARY=lib_with_extension ansible-playbook modules_test_envvar_ext.yml -i ../../inventory -v "$@"
+ANSIBLE_ROLES_PATH=roles_with_extension ansible-playbook modules_test_role_ext.yml -i ../../inventory -v "$@"

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -517,6 +517,32 @@
       that: "'distribute' in remove_distribute.cmd"
   when: ansible_python.version.major == 2
 
+### test virtualenv_command begin ###
+
+- name: Test virtualenv command with arguments
+  when: "ansible_system == 'Linux'"
+  block:
+    - name: make sure the virtualenv does not exist
+      file:
+        state: absent
+        name: "{{ output_dir }}/pipenv"
+
+    # ref: https://github.com/ansible/ansible/issues/52275
+    - name: install using virtualenv_command with arguments
+      pip:
+        name: "{{ pip_test_package }}"
+        virtualenv: "{{ output_dir }}/pipenv"
+        virtualenv_command: "virtualenv --verbose"
+        state: present
+      register: version13
+
+    - name: ensure install using virtualenv_command with arguments was successful
+      assert:
+        that:
+          - "version13 is success"
+
+### test virtualenv_command end ###
+
 # https://github.com/ansible/ansible/issues/68592
 # Handle pre-release version numbers in check_mode for already-installed
 # packages.

--- a/test/integration/targets/raw/runme.sh
+++ b/test/integration/targets/raw/runme.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -ux
+export ANSIBLE_BECOME_ALLOW_SAME_USER=1
+export ANSIBLE_ROLES_PATH=../
+ansible-playbook -i ../../inventory runme.yml -e "output_dir=${OUTPUT_DIR}" -v "$@"

--- a/test/integration/targets/raw/runme.yml
+++ b/test/integration/targets/raw/runme.yml
@@ -1,0 +1,4 @@
+- hosts: testhost
+  gather_facts: no
+  roles:
+    - { role: raw }

--- a/test/integration/targets/raw/tasks/main.yml
+++ b/test/integration/targets/raw/tasks/main.yml
@@ -81,3 +81,27 @@
           - 'raw_result2.stdout_lines is defined'
           - 'raw_result2.rc == 0'
           - 'raw_result2.stdout_lines == ["foobar"]'
+# the following five tests added to test https://github.com/ansible/ansible/pull/68315
+- name: get the path to sh
+  shell: which sh
+  register: sh_path
+- name: use sh
+  raw: echo $0
+  args:
+    executable: "{{ sh_path.stdout }}"
+  become: true
+  become_method: su
+  register: sh_output
+- name: assert sh
+  assert:
+    that: "(sh_output.stdout | trim) == sh_path.stdout"
+- name: use bash
+  raw: echo $0
+  args:
+    executable: "{{ bash_path.stdout }}"
+  become: true
+  become_method: su
+  register: bash_output
+- name: assert bash
+  assert:
+    that: "(bash_output.stdout | trim) == bash_path.stdout"

--- a/test/integration/targets/setup_rpm_repo/tasks/main.yml
+++ b/test/integration/targets/setup_rpm_repo/tasks/main.yml
@@ -3,7 +3,7 @@
     include_role:
       name: setup_epel
     when:
-      - ansible_distribution in ['RedHat']
+      - ansible_distribution in ['RedHat', 'CentOS']
       - ansible_distribution_major_version is version('7', '==')
 
   - name: Include distribution specific variables

--- a/test/integration/targets/yum/aliases
+++ b/test/integration/targets/yum/aliases
@@ -1,6 +1,5 @@
 destructive
 shippable/posix/group4
 skip/aix
-skip/power/centos
 skip/freebsd
 skip/osx

--- a/test/integration/targets/yum/tasks/proxy.yml
+++ b/test/integration/targets/yum/tasks/proxy.yml
@@ -183,4 +183,4 @@
         line: "proxy_password=1testpassword"
         state: absent
   when:
-    - (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and ansible_distribution_major_version|int == 7)
+    - (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and ansible_distribution_major_version|int == 7 and ansible_architecture in ['x86_64'])

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -576,18 +576,39 @@
       - "not yum_result is changed"
       - "'Packages providing httpd not installed due to update_only specified' in yum_result.results"
 
-- name: try to install not compatible arch rpm, should fail
+- name: try to install uncompatible arch rpm on non-ppc64le, should fail
   yum:
     name: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/yum/banner-1.3.4-3.el7.ppc64le.rpm
     state: present
   register: yum_result
   ignore_errors: True
+  when:
+    - ansible_architecture not in ['ppc64le']
 
-- name: verify that yum failed
+- name: verify that yum failed on non-ppc64le
   assert:
     that:
         - "not yum_result is changed"
         - "yum_result is failed"
+  when:
+    - ansible_architecture not in ['ppc64le']
+
+- name: try to install uncompatible arch rpm on ppc64le, should fail
+  yum:
+    name: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/yum/tinyproxy-1.10.0-3.el7.x86_64.rpm
+    state: present
+  register: yum_result
+  ignore_errors: True
+  when:
+    - ansible_architecture in ['ppc64le']
+
+- name: verify that yum failed on ppc64le
+  assert:
+    that:
+        - "not yum_result is changed"
+        - "yum_result is failed"
+  when:
+    - ansible_architecture in ['ppc64le']
 
 # setup for testing installing an RPM from url
 

--- a/test/integration/targets/yum/tasks/yuminstallroot.yml
+++ b/test/integration/targets/yum/tasks/yuminstallroot.yml
@@ -60,3 +60,63 @@
   file:
     path: "{{ yumroot.stdout }}/"
     state: absent
+
+# Test for releasever working correctly
+#
+# Bugfix: https://github.com/ansible/ansible/issues/67050
+#
+# This test case is based on a reproducer originally reported on Reddit:
+#   https://www.reddit.com/r/ansible/comments/g2ps32/ansible_yum_module_throws_up_an_error_when/
+#
+# NOTE: For the Ansible upstream CI we can only run this for RHEL7 because the
+#       containerized runtimes in shippable don't allow the nested mounting of
+#       buildah container volumes.
+- name: perform yuminstallroot in a buildah mount with releasever
+  when:
+    - ansible_facts["distribution_major_version"] == "7"
+    - ansible_facts["distribution"] == "RedHat"
+  block:
+    # Need to enable this RHUI repo for RHEL7 testing in AWS, CentOS has Extras
+    # enabled by default and this is not needed there.
+    - name: enable rhui-rhel-7-server-rhui-extras-rpms repo for RHEL7
+      command: yum-config-manager --enable rhui-rhel-7-server-rhui-extras-rpms
+    - name: update cache to pull repodata
+      yum:
+        update_cache: yes
+    - name: install required packages for buildah test
+      yum:
+        state: present
+        name:
+          - buildah
+    - name: create buildah container from scratch
+      command: "buildah --name yum_installroot_releasever_test from scratch"
+    - name: mount the buildah container
+      command: "buildah mount yum_installroot_releasever_test"
+      register: buildah_mount
+    - name: figure out yum value of $releasever
+      shell: python -c 'import yum; yb = yum.YumBase(); print(yb.conf.yumvar["releasever"])' | tail -1
+      register: buildah_host_releasever
+    - name: test yum install of python using releasever
+      yum:
+        name: 'python'
+        state: present
+        installroot: "{{ buildah_mount.stdout }}"
+        releasever: "{{ buildah_host_releasever.stdout }}"
+      register: yum_result
+    - name: verify installation of python
+      assert:
+        that:
+            - "yum_result.rc == 0"
+            - "yum_result.changed"
+            - "rpm_result.rc == 0"
+  always:
+    - name: remove buildah container
+      command: "buildah rm yum_installroot_releasever_test"
+      ignore_errors: yes
+    - name: remove buildah from CI system
+      yum:
+        state: absent
+        name:
+          - buildah
+    - name: disable rhui-rhel-7-server-rhui-extras-rpms repo for RHEL7
+      command: yum-config-manager --disable rhui-rhel-7-server-rhui-extras-rpms

--- a/test/integration/targets/yum_repository/aliases
+++ b/test/integration/targets/yum_repository/aliases
@@ -1,4 +1,3 @@
 shippable/posix/group1
 destructive
 skip/aix
-skip/power/centos

--- a/test/integration/targets/yum_repository/tasks/main.yml
+++ b/test/integration/targets/yum_repository/tasks/main.yml
@@ -62,6 +62,7 @@
         name: "{{ yum_repository_test_repo.name }}"
         description: "{{ yum_repository_test_repo.description }}"
         baseurl: "{{ yum_repository_test_repo.baseurl }}"
+        gpgcheck: no
         state: present
       register: test_repo_add
 

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -287,12 +287,16 @@ test/integration/targets/incidental_win_dsc/files/xTestDsc/1.0.1/xTestDsc.psd1 p
 test/integration/targets/incidental_win_ping/library/win_ping_syntax_error.ps1 pslint!skip
 test/integration/targets/incidental_win_reboot/templates/post_reboot.ps1 pslint!skip
 test/integration/targets/lookup_ini/lookup-8859-15.ini no-smart-quotes
+test/integration/targets/module_precedence/lib_with_extension/a.ini shebang
+test/integration/targets/module_precedence/lib_with_extension/ping.ini shebang
 test/integration/targets/module_precedence/lib_with_extension/ping.py future-import-boilerplate
 test/integration/targets/module_precedence/lib_with_extension/ping.py metaclass-boilerplate
 test/integration/targets/module_precedence/multiple_roles/bar/library/ping.py future-import-boilerplate
 test/integration/targets/module_precedence/multiple_roles/bar/library/ping.py metaclass-boilerplate
 test/integration/targets/module_precedence/multiple_roles/foo/library/ping.py future-import-boilerplate
 test/integration/targets/module_precedence/multiple_roles/foo/library/ping.py metaclass-boilerplate
+test/integration/targets/module_precedence/roles_with_extension/foo/library/a.ini shebang
+test/integration/targets/module_precedence/roles_with_extension/foo/library/ping.ini shebang
 test/integration/targets/module_precedence/roles_with_extension/foo/library/ping.py future-import-boilerplate
 test/integration/targets/module_precedence/roles_with_extension/foo/library/ping.py metaclass-boilerplate
 test/integration/targets/module_utils/library/test.py future-import-boilerplate

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -728,7 +728,7 @@ def test_collection_build(collection_artifact):
             elif file_entry['name'] == 'README.md':
                 assert file_entry['ftype'] == 'file'
                 assert file_entry['chksum_type'] == 'sha256'
-                assert file_entry['chksum_sha256'] == '45923ca2ece0e8ce31d29e5df9d8b649fe55e2f5b5b61c9724d7cc187bd6ad4a'
+                assert file_entry['chksum_sha256'] == '6d8b5f9b5d53d346a8cd7638a0ec26e75e8d9773d952162779a49d25da6ef4f5'
             else:
                 assert file_entry['ftype'] == 'dir'
                 assert file_entry['chksum_type'] is None


### PR DESCRIPTION
##### SUMMARY
This adds a new module with a corresponding action plugin.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
iptables_state

##### ADDITIONAL INFORMATION
The module saves iptables state to or restores it from a file. When used in conjunction with `async` and `poll` task attributes, the module allows to restore iptables state with a rollback to the previous state in case the action plugin becomes unable to reconnect to the host (right after resetting connection, to ensure to not reuse a persistent one)