### PR TITLE
Revert "[stable-2.9] Fix missing persistent connection messages (#68496) (#68562)"

### DIFF
--- a/changelogs/fragments/68496-persistent-logging.yaml
+++ b/changelogs/fragments/68496-persistent-logging.yaml
@@ -1,3 +1,0 @@
-bugfixes:
-- Log additional messages from persistent connection modules that may be
-  missed if the module fails or returns early.

--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -147,8 +147,6 @@ class ConnectionProcess(object):
                     resp = self.srv.handle_request(data)
                     signal.alarm(0)
 
-                    display_messages(self.connection)
-
                     if log_messages:
                         display.display("jsonrpc response: %s" % resp, log_only=True)
 
@@ -198,7 +196,6 @@ class ConnectionProcess(object):
                     self.sock.close()
                 if self.connection:
                     self.connection.close()
-                    display_messages(self.connection)
             except Exception:
                 pass
             finally:
@@ -333,24 +330,6 @@ def main():
         sys.stdout.write(json.dumps(result, cls=AnsibleJSONEncoder))
 
     sys.exit(rc)
-
-
-def display_messages(connection):
-    # This should be handled elsewhere, but if this is the last task, nothing will
-    # come back to collect the messages. So now each task will dump its own messages
-    # to stdout before logging the response message. This may make some other
-    # pop_messages calls redundant.
-    for level, message in connection.pop_messages():
-        if connection.get_option('persistent_log_messages') and level == "log":
-            display.display(message, log_only=True)
-        else:
-            # These should be keyed by valid method names, but
-            # fail gracefully just in case.
-            display_method = getattr(display, level, None)
-            if display_method:
-                display_method(message)
-            else:
-                display.display((level, message))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
Revert missing persistent connection messages

Fixes #69036

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
junos_facts

##### ADDITIONAL INFORMATION
This has introduced several issues in the netconf connection for junos and a few other families, so it's a temporary measure to unlock CI and capability until
a proper fix is pushed
