### PR TITLE
Allow a collection role to call a standalone role by default

### DIFF
--- a/changelogs/fragments/69101-collection-role-to-standalone-role.yml
+++ b/changelogs/fragments/69101-collection-role-to-standalone-role.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- Collections - Allow a collection to call a stand alone role, without needing
+  to explicitly add ``ansible.legacy`` to the collection search order within the
+  collection role.
+  (https://github.com/ansible/ansible/issues/69101)

--- a/changelogs/fragments/69101-collection-role-to-standalone-role.yml
+++ b/changelogs/fragments/69101-collection-role-to-standalone-role.yml
@@ -1,5 +1,5 @@
 bugfixes:
-- Collections - Allow a collection to call a stand alone role, without needing
-  to explicitly add ``ansible.legacy`` to the collection search order within the
-  collection role.
+- Collections - Allow a collection role to call a stand alone role, without
+  needing to explicitly add ``ansible.legacy`` to the collection search
+  order within the collection role.
   (https://github.com/ansible/ansible/issues/69101)

--- a/lib/ansible/playbook/role/definition.py
+++ b/lib/ansible/playbook/role/definition.py
@@ -162,9 +162,9 @@ class RoleDefinition(Base, Conditional, Taggable, CollectionSearch):
             self._role_collection = role_tuple[2]
             return role_tuple[0:2]
 
-        # FUTURE: refactor this to be callable from internal so we can properly order ansible.legacy searches with the collections keyword
-        if self._collection_list and 'ansible.legacy' not in self._collection_list:
-            raise AnsibleError("the role '%s' was not found in %s" % (role_name, ":".join(self._collection_list)), obj=self._ds)
+        # We didn't find a collection role, look in defined role paths
+        # FUTURE: refactor this to be callable from internal so we can properly order
+        # ansible.legacy searches with the collections keyword
 
         # we always start the search for roles in the base directory of the playbook
         role_search_paths = [
@@ -198,7 +198,8 @@ class RoleDefinition(Base, Conditional, Taggable, CollectionSearch):
             role_name = os.path.basename(role_name)
             return (role_name, role_path)
 
-        raise AnsibleError("the role '%s' was not found in %s" % (role_name, ":".join(role_search_paths)), obj=self._ds)
+        searches = self._collection_list + role_search_paths
+        raise AnsibleError("the role '%s' was not found in %s" % (role_name, ":".join(searches)), obj=self._ds)
 
     def _split_role_params(self, ds):
         '''

--- a/lib/ansible/playbook/role/definition.py
+++ b/lib/ansible/playbook/role/definition.py
@@ -198,7 +198,7 @@ class RoleDefinition(Base, Conditional, Taggable, CollectionSearch):
             role_name = os.path.basename(role_name)
             return (role_name, role_path)
 
-        searches = self._collection_list + role_search_paths
+        searches = (self._collection_list or []) + role_search_paths
         raise AnsibleError("the role '%s' was not found in %s" % (role_name, ":".join(searches)), obj=self._ds)
 
     def _split_role_params(self, ds):

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/roles/call_standalone/tasks/main.yml
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/roles/call_standalone/tasks/main.yml
@@ -1,0 +1,6 @@
+- include_role:
+    name: standalone
+
+- assert:
+    that:
+      - standalone_role_var is defined

--- a/test/integration/targets/collections/posix.yml
+++ b/test/integration/targets/collections/posix.yml
@@ -401,3 +401,8 @@
     handler_counter: 0
   roles:
     - testns.testcoll.test_fqcn_handlers
+
+- name: Ensure a collection role can call a standalone role
+  hosts: testhost
+  roles:
+    - testns.testcoll.call_standalone

--- a/test/integration/targets/collections/roles/standalone/tasks/main.yml
+++ b/test/integration/targets/collections/roles/standalone/tasks/main.yml
@@ -1,0 +1,2 @@
+- set_fact:
+    standalone_role_var: True


### PR DESCRIPTION
##### SUMMARY
Fixes #69101

Allow a collection to call a stand alone role, without needing
to explicitly add `ansible.legacy` to the collection search order within the
collection role.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/role/definition.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
