### PR TITLE
Use Templar for galaxy skeletons

### DIFF
--- a/changelogs/fragments/69104-galaxy-cli-templar.yml
+++ b/changelogs/fragments/69104-galaxy-cli-templar.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- ansible-galaxy - Utilize ``Templar`` for templating skeleton files, so that
+  they have access to Ansible filters/tests/lookups
+  (https://github.com/ansible/ansible/issues/69104)

--- a/lib/ansible/galaxy/data/default/collection/galaxy.yml.j2
+++ b/lib/ansible/galaxy/data/default/collection/galaxy.yml.j2
@@ -1,11 +1,11 @@
 ### REQUIRED
 {% for option in required_config %}
 {{ option.description | comment_ify }}
-{{ {option.key: option.value} | to_yaml }}
+{{ {option.key: option.value} | to_nice_yaml }}
 {% endfor %}
 
 ### OPTIONAL but strongly recommended
 {% for option in optional_config %}
 {{ option.description | comment_ify }}
-{{ {option.key: option.value} | to_yaml }}
+{{ {option.key: option.value} | to_nice_yaml }}
 {% endfor %}

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -728,7 +728,7 @@ def test_collection_build(collection_artifact):
             elif file_entry['name'] == 'README.md':
                 assert file_entry['ftype'] == 'file'
                 assert file_entry['chksum_type'] == 'sha256'
-                assert file_entry['chksum_sha256'] == '45923ca2ece0e8ce31d29e5df9d8b649fe55e2f5b5b61c9724d7cc187bd6ad4a'
+                assert file_entry['chksum_sha256'] == '6d8b5f9b5d53d346a8cd7638a0ec26e75e8d9773d952162779a49d25da6ef4f5'
             else:
                 assert file_entry['ftype'] == 'dir'
                 assert file_entry['chksum_type'] is None


### PR DESCRIPTION
##### SUMMARY
Use Templar for galaxy skeletons. Fixes #69104

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/cli/galaxy.py

##### ADDITIONAL INFORMATION
The existing tests verify this, because of previously using a different `to_yaml` that worked like `to_nice_yaml`.  `to_nice_yaml` is now used in `galaxy.yml.j2`
