### PR TITLE
Change get_url module to always use GET method, even in check mode

### DIFF
--- a/changelogs/fragments/69108-get_url-check-mode-fix.yml
+++ b/changelogs/fragments/69108-get_url-check-mode-fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - get_url - perform GET request (instead of HEAD) and compare file checksums when using check mode

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -139,6 +139,7 @@ Noteworthy module changes
 * The parameter ``message`` in :ref:`datadog_monitor <datadog_monitor_module>` module is renamed to ``notification_message`` since ``message`` is used by Ansible Core engine internally.
 * The parameter ``message`` in :ref:`bigpanda <bigpanda_module>` module is renamed to ``deployment_message`` since ``message`` is used by Ansible Core engine internally.
 * Ansible no longer looks for Python modules in the current working directory (typically the ``remote_user``'s home directory) when an Ansible module is run. This is to fix becoming an unprivileged user on OpenBSD and to mitigate any attack vector if the current working directory is writable by a malicious user. Install any Python modules needed to run the Ansible modules on the managed node in a system-wide location or in another directory which is in the ``remote_user``'s ``$PYTHONPATH`` and readable by the ``become_user``.
+* In check mode, :ref:`get_url <get_url_module>` now issues a full GET request and carries out file content checksum comparison, instead of issuing a HEAD request only.
 
 
 Plugins

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -355,13 +355,9 @@ def url_get(module, url, dest, use_proxy, last_mod_time, force, timeout=10, head
 
     Return (tempfile, info about the request)
     """
-    if module.check_mode:
-        method = 'HEAD'
-    else:
-        method = 'GET'
 
     start = datetime.datetime.utcnow()
-    rsp, info = fetch_url(module, url, use_proxy=use_proxy, force=force, last_mod_time=last_mod_time, timeout=timeout, headers=headers, method=method)
+    rsp, info = fetch_url(module, url, use_proxy=use_proxy, force=force, last_mod_time=last_mod_time, timeout=timeout, headers=headers)
     elapsed = (datetime.datetime.utcnow() - start).seconds
 
     if info['status'] == 304:

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -28,6 +28,8 @@ description:
        your proxy environment for both protocols is correct.
      - From Ansible 2.4 when run with C(--check), it will do a HEAD request to validate the URL but
        will not download the entire file or verify it against hashes.
+     - From Ansible 2.10, when run with C(--check) it will perform a full GET request and verify it 
+       against hashes.
      - For Windows targets, use the M(win_get_url) module instead.
 version_added: '0.6'
 options:

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -28,7 +28,7 @@ description:
        your proxy environment for both protocols is correct.
      - From Ansible 2.4 when run with C(--check), it will do a HEAD request to validate the URL but
        will not download the entire file or verify it against hashes.
-     - From Ansible 2.10, when run with C(--check) it will perform a full GET request and verify it 
+     - From Ansible 2.10, when run with C(--check) it will perform a full GET request and verify it
        against hashes.
      - For Windows targets, use the M(win_get_url) module instead.
 version_added: '0.6'


### PR DESCRIPTION

##### SUMMARY

Makes the get_url module check mode behaviour more realistic by always downloading and comparing the files, instead of using HEAD requests in check mode.

Fixes #61369

When remote checksum files are being used with check mode, ensures that the checksum file content is downloaded so that hash verification can take place and the check mode results will be most realistic.

With this patch applied, get_url's behaviour in check mode matches non-check mode.

Before appliying this patch, get_url in check mode would always report `changed: yes` for an existing, identical destination file.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

get_url

##### ADDITIONAL INFORMATION

Test playbook
```
- hosts: localhost
  tasks:
  - get_url:
      url: https://example.com/index.html
      dest: /tmp/example_index.html
      force: yes
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

# Before patch applied, with no existing destination file:

# Run in check mode

$ ansible-playbook  -C test.yml -v

PLAY [localhost] ***************************************************************

TASK [get_url] *****************************************************************
changed: [localhost] => {"changed": true, "checksum_dest": null, "checksum_src": "da39a3ee5e6b4b0d3255bfef95601890afd80709", "dest": "/tmp/example_index.html", "elapsed": 0, "msg": "OK (648 bytes)", "src": "/home/daniel/.ansible/tmp/ansible-tmp-1587584953.92-4446-80049134333569/tmp9ZIUfh", "url": "http://www.example.com/index.html"}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0 

# now not in check mode:

$ ansible-playbook   test.yml -v

PLAY [localhost] ***************************************************************

TASK [get_url] *****************************************************************
changed: [localhost] => {"changed": true, "checksum_dest": null, "checksum_src": "4a3ce8ee11e091dd7923f4d8c6e5b5e41ec7c047", "dest": "/tmp/example_index.html", "elapsed": 0, "gid": 1000, "group": "daniel", "md5sum": "84238dfc8092e5d9c0dac8ef93371a07", "mode": "0644", "msg": "OK (1256 bytes)", "owner": "daniel", "size": 1256, "src": "/home/daniel/.ansible/tmp/ansible-tmp-1587585032.09-4491-42949354018662/tmpETi0BB", "state": "file", "status_code": 200, "uid": 1000, "url": "http://www.example.com/index.html"}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0 

# dest file now exists, run in check mode:

$ ansible-playbook  -C test.yml -v

PLAY [localhost] ***************************************************************

TASK [get_url] *****************************************************************
changed: [localhost] => {"changed": true, "checksum_dest": "4a3ce8ee11e091dd7923f4d8c6e5b5e41ec7c047", "checksum_src": "da39a3ee5e6b4b0d3255bfef95601890afd80709", "dest": "/tmp/example_index.html", "elapsed": 0, "gid": 1000, "group": "daniel", "mode": "0644", "msg": "OK (648 bytes)", "owner": "daniel", "size": 1256, "src": "/home/daniel/.ansible/tmp/ansible-tmp-1587585082.47-4551-224605562482286/tmpIEG_48", "state": "file", "uid": 1000, "url": "http://www.example.com/index.html"}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0 

# this is less accurate than it could be.  The downloaded temporary file is empty, because a HEAD request was issued.  The value for checksum_src is that of an empty string.
A task that used a remote checksum file would throw an error here, because the downloaded checksum file is also empty.

# Re-running the test after applying the patch:

$ ansible-playbook  -C test.yml -v

PLAY [localhost] ***************************************************************

TASK [get_url] *****************************************************************
ok: [localhost] => {"changed": false, "checksum_dest": "4a3ce8ee11e091dd7923f4d8c6e5b5e41ec7c047", "checksum_src": "4a3ce8ee11e091dd7923f4d8c6e5b5e41ec7c047", "dest": "/tmp/example_index.html", "elapsed": 0, "gid": 1000, "group": "daniel", "mode": "0644", "msg": "OK (1256 bytes)", "owner": "daniel", "size": 1256, "src": "/home/daniel/.ansible/tmp/ansible-tmp-1587585203.3-4812-99300720681182/tmpYGJKR8", "state": "file", "uid": 1000, "url": "http://www.example.com/index.html"}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0 

# src and dest checksums match, task result is "ok" instead of "changed".


```
