### PR TITLE
update ActionBase._low_level_execute_command to honor executable (#68…

### DIFF
--- a/changelogs/fragments/68310-low_level_execute_command-honor-executable.yml
+++ b/changelogs/fragments/68310-low_level_execute_command-honor-executable.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Update ActionBase._low_level_execute_command to honor executable (https://github.com/ansible/ansible/issues/68054)

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1045,6 +1045,10 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             display.debug("_low_level_execute_command(): changing cwd to %s for this command" % chdir)
             cmd = self._connection._shell.append_command('cd %s' % chdir, cmd)
 
+        # https://github.com/ansible/ansible/issues/68054
+        if executable:
+            self._connection._shell.executable = executable
+
         ruser = self._get_remote_user()
         buser = self.get_become_option('become_user')
         if (sudoable and self._connection.become and  # if sudoable and have become

--- a/test/integration/targets/raw/runme.sh
+++ b/test/integration/targets/raw/runme.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -ux
+export ANSIBLE_BECOME_ALLOW_SAME_USER=1
+export ANSIBLE_ROLES_PATH=../
+ansible-playbook -i ../../inventory runme.yml -e "output_dir=${OUTPUT_DIR}" -v "$@"

--- a/test/integration/targets/raw/runme.yml
+++ b/test/integration/targets/raw/runme.yml
@@ -1,0 +1,4 @@
+- hosts: testhost
+  gather_facts: no
+  roles:
+    - { role: raw }

--- a/test/integration/targets/raw/tasks/main.yml
+++ b/test/integration/targets/raw/tasks/main.yml
@@ -81,3 +81,27 @@
           - 'raw_result2.stdout_lines is defined'
           - 'raw_result2.rc == 0'
           - 'raw_result2.stdout_lines == ["foobar"]'
+# the following five tests added to test https://github.com/ansible/ansible/pull/68315
+- name: get the path to sh
+  shell: which sh
+  register: sh_path
+- name: use sh
+  raw: echo $0
+  args:
+    executable: "{{ sh_path.stdout }}"
+  become: true
+  become_method: su
+  register: sh_output
+- name: assert sh
+  assert:
+    that: "(sh_output.stdout | trim) == sh_path.stdout"
+- name: use bash
+  raw: echo $0
+  args:
+    executable: "{{ bash_path.stdout }}"
+  become: true
+  become_method: su
+  register: bash_output
+- name: assert bash
+  assert:
+    that: "(bash_output.stdout | trim) == bash_path.stdout"


### PR DESCRIPTION
…315)

* update ActionBase._low_level_execute_command to honor executable

* adding changelog fragment

* renaming changelog fragment to .yml

* noop change to bump shippable

* adding raw_executable integration test

* copying aliases from raw

* removing blank lines

* skipping aix and freebsd

* noop to bump shippable

* moving tests to raw/

* removing become_method: sudo ; it doesn't work on AIX

* removing trailing blank line

* forcing become_method: su to try to get AIX to work

Co-authored-by: Rob Wagner <rob.wagner@sas.com>
(cherry picked from commit 977b58740b7dbb328355c7c6970e1a6684101d13)

##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/68315

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #68054.  Backporting from 2.10 into 2.9.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ActionBase
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Before:

(venv) rowagn@localhost:~/testcase$ ansible-playbook a.yml -i ./hosts -K -k -utestuser
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or
trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
SSH password: 
BECOME password[defaults to SSH password]: 

PLAY [all] ******************************************************************************************************************************************

TASK [whoami] ***************************************************************************************************************************************
fatal: [rowagn-tower-test01.vsp.sas.com]: FAILED! => {"changed": true, "msg": "non-zero return code", "rc": 1, "stderr": "Shared connection to rowagn-tower-test01.vsp.sas.com closed.\r\n", "stderr_lines": ["Shared connection to rowagn-tower-test01.vsp.sas.com closed."], "stdout": "\r\n", "stdout_lines": [""]}

PLAY RECAP ******************************************************************************************************************************************
rowagn-tower-test01.vsp.sas.com : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   



After:

(venv) rowagn@localhost:~/testcase$ ansible-playbook a.yml -i ./hosts -K -k -utestuser
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or
trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
SSH password: 
BECOME password[defaults to SSH password]: 

PLAY [all] ******************************************************************************************************************************************

TASK [whoami] ***************************************************************************************************************************************
changed: [rowagn-tower-test01.vsp.sas.com]

PLAY RECAP ******************************************************************************************************************************************
rowagn-tower-test01.vsp.sas.com : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


```
