### PR TITLE
Bypass GPG check during tests

### DIFF
--- a/test/integration/targets/yum_repository/aliases
+++ b/test/integration/targets/yum_repository/aliases
@@ -1,4 +1,3 @@
 shippable/posix/group1
 destructive
 skip/aix
-skip/power/centos

--- a/test/integration/targets/yum_repository/tasks/main.yml
+++ b/test/integration/targets/yum_repository/tasks/main.yml
@@ -205,6 +205,11 @@
         name: "{{ yum_repository_test_repo.name }}"
         state: absent
 
+    - name: CLEANUP | Install GPG key
+      rpm_key:
+          state: present
+          key: "{{ yum_repository_epel.gpgkey }}"
+
     - name: CLEANUP | Enable EPEL
       yum_repository:
         name: epel


### PR DESCRIPTION
Don't perform GPG checks during test package installations.
