### PR TITLE
Ignore GPG key checks on test repo

### DIFF
--- a/test/integration/targets/yum_repository/aliases
+++ b/test/integration/targets/yum_repository/aliases
@@ -1,4 +1,3 @@
 shippable/posix/group1
 destructive
 skip/aix
-skip/power/centos

--- a/test/integration/targets/yum_repository/tasks/main.yml
+++ b/test/integration/targets/yum_repository/tasks/main.yml
@@ -62,6 +62,7 @@
         name: "{{ yum_repository_test_repo.name }}"
         description: "{{ yum_repository_test_repo.description }}"
         baseurl: "{{ yum_repository_test_repo.baseurl }}"
+        gpgcheck: no
         state: present
       register: test_repo_add
 


### PR DESCRIPTION
Disable GPG key checks when installing packages from the test repo.
