### PR TITLE
Revert "Cap cryptography version for macOS openssl test (#69083)"

### DIFF
--- a/test/integration/targets/incidental_setup_openssl/tasks/main.yml
+++ b/test/integration/targets/incidental_setup_openssl/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: Install pyOpenSSL (Darwin)
   become: True
   pip:
-    name: pyOpenSSL<2.9.1
+    name: pyOpenSSL
   when: ansible_os_family == 'Darwin'
 
 - name: register pyOpenSSL version


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This reverts commit 1e08bb7a6fc8cc5c54034b469920d64984d8af47.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

tests