### PR TITLE
[2.9] mysql_user: fix error No database selected

### DIFF
--- a/changelogs/fragments/225-mysql_user_fix_no_database_selected.yml
+++ b/changelogs/fragments/225-mysql_user_fix_no_database_selected.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- mysql_user - fix the error No database selected (https://github.com/ansible/ansible/issues/68070).

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -386,7 +386,7 @@ def user_mod(cursor, user, host, host_all, password, encrypted, new_priv, append
                         # Replacing empty root password with new authentication mechanisms fails with error 1396
                         if e.args[0] == 1396:
                             cursor.execute(
-                                "UPDATE user SET plugin = %s, authentication_string = %s, Password = '' WHERE User = %s AND Host = %s",
+                                "UPDATE mysql.user SET plugin = %s, authentication_string = %s, Password = '' WHERE User = %s AND Host = %s",
                                 ('mysql_native_password', encrypted_password, user, host)
                             )
                             cursor.execute("FLUSH PRIVILEGES")


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible-collections/community.general/pull/225
mysql_user: fix error No database selected

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/mysql/mysql_user.py```
