### PR TITLE
Fix yum test case on ppc64le

### DIFF
--- a/test/integration/targets/setup_rpm_repo/tasks/main.yml
+++ b/test/integration/targets/setup_rpm_repo/tasks/main.yml
@@ -3,7 +3,7 @@
     include_role:
       name: setup_epel
     when:
-      - ansible_distribution in ['RedHat']
+      - ansible_distribution in ['RedHat', 'CentOS']
       - ansible_distribution_major_version is version('7', '==')
 
   - name: Include distribution specific variables

--- a/test/integration/targets/yum/aliases
+++ b/test/integration/targets/yum/aliases
@@ -1,6 +1,5 @@
 destructive
 shippable/posix/group4
 skip/aix
-skip/power/centos
 skip/freebsd
 skip/osx

--- a/test/integration/targets/yum/tasks/proxy.yml
+++ b/test/integration/targets/yum/tasks/proxy.yml
@@ -183,4 +183,4 @@
         line: "proxy_password=1testpassword"
         state: absent
   when:
-    - (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and ansible_distribution_major_version|int == 7)
+    - (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and ansible_distribution_major_version|int == 7 and ansible_architecture in ['x86_64'])

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -576,12 +576,23 @@
       - "not yum_result is changed"
       - "'Packages providing httpd not installed due to update_only specified' in yum_result.results"
 
-- name: try to install not compatible arch rpm, should fail
+- name: try to install uncompatible arch rpm on non-ppc64le, should fail
   yum:
     name: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/yum/banner-1.3.4-3.el7.ppc64le.rpm
     state: present
   register: yum_result
   ignore_errors: True
+  when:
+    - ansible_architecture not in ['ppc64le']
+
+- name: try to install uncompatible arch rpm on ppc64le, should fail
+  yum:
+    name: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/yum/tinyproxy-1.10.0-3.el7.x86_64.rpm
+    state: present
+  register: yum_result
+  ignore_errors: True
+  when:
+    - ansible_architecture in ['ppc64le']
 
 - name: verify that yum failed
   assert:


### PR DESCRIPTION
This patch covers a few changes to get the yum test case working on ppc64le
CentOS.  Specifically we needed to enable the EPEL repository on CentOS
as well as ensure some of the architecture-specific tasks use the right
set of binaries during their test.