### PR TITLE
Fix idempotent issue when using lvol with %VG or %PVS size options

### DIFF
--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -477,6 +477,10 @@ def main():
                 size_requested = size_percent * this_vg['size'] / 100
             else:  # size_whole == 'FREE':
                 size_requested = size_percent * this_vg['free'] / 100
+
+            # Round down to the next lowest whole physical extent
+            size_requested -= (size_requested % this_vg['ext_size'])
+
             if '+' in size:
                 size_requested += this_lv['size']
             if this_lv['size'] < size_requested:


### PR DESCRIPTION
##### SUMMARY
Changed the behavior when using %VG or %PVS to make the size_requested an even modulus with the VGs physical extents by rounding down.  This makes the usage of %VG or %PVS idempotent when the calculated size_requested does not end on a physical extent boundary.

Fixes #29201

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lvol
