### PR TITLE
os_subnet allocation pool empty fix

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_subnet.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnet.py
@@ -7,9 +7,11 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
+
 
 DOCUMENTATION = '''
 ---


### PR DESCRIPTION
##### SUMMARY

Below scenarios addressed:

1. When updating subnet information, module was expecting pre-existing allocation pools for a subnet. It was failing due to no existing allocation pools for a subnet.

2. When updating subnet informaion with existing allocation pools, module was overriding existing allocation pools.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
os_subnet

##### ADDITIONAL INFORMATION
Scenario 1 error

```
File "/tmp/ansible_os_subnet_payload_c243hzpf/ansible_os_subnet_payload.zip/ansible/modules/os_subnet.py", line 372, in <module>
File "/tmp/ansible_os_subnet_payload_c243hzpf/ansible_os_subnet_payload.zip/ansible/modules/os_subnet.py", line 338, in main
File "/tmp/ansible_os_subnet_payload_c243hzpf/ansible_os_subnet_payload.zip/ansible/modules/os_subnet.py", line 187, in _needs_update
IndexError: list index out of range
```