### PR TITLE
[WIP] Deduplicate some logic in DataLoader#path_dwim

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -184,15 +184,7 @@ class DataLoader:
         '''
 
         given = unquote(given)
-        given = to_text(given, errors='surrogate_or_strict')
-
-        if given.startswith(to_text(os.path.sep)) or given.startswith(u'~'):
-            path = given
-        else:
-            basedir = to_text(self._basedir, errors='surrogate_or_strict')
-            path = os.path.join(basedir, given)
-
-        return unfrackpath(path, follow=False)
+        return unfrackpath(given, follow=False, basedir=self._basedir)
 
     def _is_role(self, path):
         ''' imperfect role detection, roles are still valid w/o tasks|meta/main.yml|yaml|etc '''


### PR DESCRIPTION
##### SUMMARY

Change:
unfrackpath takes an optional basedir. Since we end up calling that
anyway, just pass the basedir along, and let it prepend it if necessary,
rather than duplicating that logic here.

Also nuke the to_text call since ultimately unfrackpath will convert it
to bytes before manipulating it anyway.

Test Plan:
Dataloader unit tests, and CI.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

dataloader