### PR TITLE
ovirt_host_network: fix save

### DIFF
--- a/changelogs/fragments/69142-ovirt_host_network-fix-save.yml
+++ b/changelogs/fragments/69142-ovirt_host_network-fix-save.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "ovirt_host_network: fix save of network configuration"

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_network.py
@@ -467,7 +467,7 @@ def main():
                     ) for network in networks
                 ] if networks else None,
             )
-            if engine_supported(connection, '4.3'):
+            if engine_supported(connection, '4.4'):
                 setup_params['commit_on_success'] = module.params['save']
             elif module.params['save']:
                 setup_params['post_action'] = host_networks_module._action_save_configuration


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/oVirt/ovirt-ansible-collection/pull/33

<!--- Describe the change below, including rationale and design decisions -->
Was not able to save network config. Should be fixed in 4.4.
https://github.com/ansible/ansible/issues/67810
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
