### PR TITLE
Redirect inventory script links

### DIFF
--- a/changelogs/fragments/69139_inventory_doc_fix.yml
+++ b/changelogs/fragments/69139_inventory_doc_fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Updated inventory script location for infoblox, ec2 and other after collection migration (https://github.com/ansible/ansible/issues/69139).

--- a/docs/docsite/rst/scenario_guides/guide_azure.rst
+++ b/docs/docsite/rst/scenario_guides/guide_azure.rst
@@ -286,14 +286,15 @@ Dynamic Inventory Script
 
 If you are not familiar with Ansible's dynamic inventory scripts, check out :ref:`Intro to Dynamic Inventory <intro_dynamic_inventory>`.
 
-The Azure Resource Manager inventory script is called  `azure_rm.py  <https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/azure_rm.py>`_. It authenticates with the Azure API exactly the same as the
+The Azure Resource Manager inventory script is called  `azure_rm.py  <https://raw.githubusercontent.com/ansible-collections/community.general/master/scripts/inventory/azure_rm.py>`_. It authenticates with the Azure API exactly the same as the
 Azure modules, which means you will either define the same environment variables described above in `Using Environment Variables`_,
 create a ``$HOME/.azure/credentials`` file (also described above in `Storing in a File`_), or pass command line parameters. To see available command
 line options execute the following:
 
 .. code-block:: bash
 
-    $ ./ansible/contrib/inventory/azure_rm.py --help
+    $ wget https://raw.githubusercontent.com/ansible-collections/community.general/master/scripts/inventory/azure_rm.py
+    $ ./azure_rm.py --help
 
 As with all dynamic inventory scripts, the script can be executed directly, passed as a parameter to the ansible command,
 or passed directly to ansible-playbook using the -i option. No matter how it is executed the script produces JSON representing
@@ -395,8 +396,9 @@ If you don't need the powerstate, you can improve performance by turning off pow
 
 * AZURE_INCLUDE_POWERSTATE=no
 
-A sample azure_rm.ini file is included along with the inventory script in contrib/inventory. An .ini
-file will contain the following:
+A sample azure_rm.ini file is included along with the inventory script in
+`here <https://raw.githubusercontent.com/ansible-collections/community.general/master/scripts/inventory/azure_rm.ini>`_.
+An .ini file will contain the following:
 
 .. code-block:: ini
 
@@ -429,6 +431,9 @@ Here are some examples using the inventory script:
 
 .. code-block:: bash
 
+    # Download inventory script
+    $ wget https://raw.githubusercontent.com/ansible-collections/community.general/master/scripts/inventory/azure_rm.py
+
     # Execute /bin/uname on all instances in the Testing resource group
     $ ansible -i azure_rm.py Testing -m shell -a "/bin/uname -a"
 
@@ -439,10 +444,10 @@ Here are some examples using the inventory script:
     $ ansible -i azure_rm.py linux -m ping
 
     # Use the inventory script to print instance specific information
-    $ ./ansible/contrib/inventory/azure_rm.py --host my_instance_host_name --resource-groups=Testing --pretty
+    $ ./azure_rm.py --host my_instance_host_name --resource-groups=Testing --pretty
 
     # Use the inventory script with ansible-playbook
-    $ ansible-playbook -i ./ansible/contrib/inventory/azure_rm.py test_playbook.yml
+    $ ansible-playbook -i ./azure_rm.py test_playbook.yml
 
 Here is a simple playbook to exercise the Azure inventory script:
 
@@ -453,13 +458,14 @@ Here is a simple playbook to exercise the Azure inventory script:
       connection: local
       gather_facts: no
       tasks:
-        - debug: msg="{{ inventory_hostname }} has powerstate {{ powerstate }}"
+        - debug:
+            msg: "{{ inventory_hostname }} has powerstate {{ powerstate }}"
 
 You can execute the playbook with something like:
 
 .. code-block:: bash
 
-    $ ansible-playbook -i ./ansible/contrib/inventory/azure_rm.py test_azure_inventory.yml
+    $ ansible-playbook -i ./azure_rm.py test_azure_inventory.yml
 
 
 Disabling certificate validation on Azure endpoints

--- a/docs/docsite/rst/scenario_guides/guide_docker.rst
+++ b/docs/docsite/rst/scenario_guides/guide_docker.rst
@@ -190,7 +190,7 @@ examples to get you started:
     DOCKER_DEFAULT_IP=192.0.2.5 ./docker.py --pretty
 
     # Run as input to a playbook:
-    ansible-playbook -i ~/projects/ansible/contrib/inventory/docker.py docker_inventory_test.yml
+    ansible-playbook -i ./docker.py docker_inventory_test.yml
 
     # Simple playbook to invoke with the above example:
 
@@ -198,12 +198,13 @@ examples to get you started:
           hosts: all
           gather_facts: no
           tasks:
-            - debug: msg="Container - {{ inventory_hostname }}"
+            - debug:
+                msg: "Container - {{ inventory_hostname }}"
 
 Configuration
 .............
 You can control the behavior of the inventory script by defining environment variables, or
-creating a docker.yml file (sample provided in ansible/contrib/inventory). The order of precedence is the docker.yml
+creating a docker.yml file (sample provided in https://raw.githubusercontent.com/ansible-collections/community.general/master/scripts/inventory/docker.py). The order of precedence is the docker.yml
 file and then environment variables.
 
 

--- a/docs/docsite/rst/scenario_guides/guide_infoblox.rst
+++ b/docs/docsite/rst/scenario_guides/guide_infoblox.rst
@@ -248,9 +248,9 @@ Dynamic inventory script
 
 You can use the Infoblox dynamic inventory script to import your network node inventory with Infoblox NIOS. To gather the inventory from Infoblox, you need two files:
 
-- `infoblox.yaml <https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/infoblox.yaml>`_ - A file that specifies the NIOS provider arguments and optional filters.
+- `infoblox.yaml <https://raw.githubusercontent.com/ansible-collections/community.general/master/scripts/inventory/infoblox.yaml>`_ - A file that specifies the NIOS provider arguments and optional filters.
 
-- `infoblox.py <https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/infoblox.py>`_ - The python script that retrieves the NIOS inventory.
+- `infoblox.py <https://raw.githubusercontent.com/ansible-collections/community.general/master/scripts/inventory/infoblox.py>`_ - The python script that retrieves the NIOS inventory.
 
 To use the Infoblox dynamic inventory script:
 

--- a/docs/docsite/rst/scenario_guides/guide_packet.rst
+++ b/docs/docsite/rst/scenario_guides/guide_packet.rst
@@ -126,7 +126,7 @@ More Complex Playbooks
 In this example, we'll create a CoreOS cluster with `user data <https://support.packet.com/kb/articles/user-data>`_.
 
 
-The CoreOS cluster will use `etcd <https://coreos.com/etcd/>`_ for discovery of other servers in the cluster. Before provisioning your servers, you'll need to generate a discovery token for your cluster:
+The CoreOS cluster will use `etcd <https://etcd.io/>`_ for discovery of other servers in the cluster. Before provisioning your servers, you'll need to generate a discovery token for your cluster:
 
 .. code-block:: bash
 
@@ -206,9 +206,11 @@ Once you create a couple of devices, you might appreciate the dynamic inventory 
 Dynamic Inventory Script
 ========================
 
-The dynamic inventory script queries the Packet API for a list of hosts, and exposes it to Ansible so you can easily identify and act on Packet devices. You can find it in Ansible's git repo at `contrib/inventory/packet_net.py <https://github.com/ansible/ansible/blob/devel/contrib/inventory/packet_net.py>`_.
+The dynamic inventory script queries the Packet API for a list of hosts, and exposes it to Ansible so you can easily identify and act on Packet devices.
 
-The inventory script is configurable via a `ini file <https://github.com/ansible/ansible/blob/devel/contrib/inventory/packet_net.ini>`_.
+You can find it in Ansible Community General Collection's git repo at `scripts/inventory/packet_net.py <https://raw.githubusercontent.com/ansible-collections/community.general/master/scripts/inventory/packet_net.py>`_.
+
+The inventory script is configurable via a `ini file <https://raw.githubusercontent.com/ansible-collections/community.general/master/scripts/inventory/packet_net.ini>`_.
 
 If you want to use the inventory script, you must first export your Packet API token to a PACKET_API_TOKEN environment variable.
 
@@ -216,9 +218,9 @@ You can either copy the inventory and ini config out from the cloned git repo, o
 
 .. code-block:: bash
 
-    $ wget https://github.com/ansible/ansible/raw/devel/contrib/inventory/packet_net.py
+    $ wget https://raw.githubusercontent.com/ansible-collections/community.general/master/scripts/inventory/packet_net.py
     $ chmod +x packet_net.py
-    $ wget https://github.com/ansible/ansible/raw/devel/contrib/inventory/packet_net.ini
+    $ wget https://raw.githubusercontent.com/ansible-collections/community.general/master/scripts/inventory/packet_net.ini
 
 In order to understand what the inventory script gives to Ansible you can run:
 

--- a/docs/docsite/rst/user_guide/intro_dynamic_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_dynamic_inventory.rst
@@ -132,7 +132,8 @@ You can test the script by itself to make sure your config is correct:
 
 .. code-block:: bash
 
-    cd contrib/inventory
+    cd /etc/ansible/
+    wget https://raw.githubusercontent.com/ansible-collections/community.aws/master/scripts/inventory/ec2.py
     ./ec2.py --list
 
 After a few moments, you should see your entire EC2 inventory across all regions in JSON.
@@ -252,7 +253,8 @@ To see the complete list of variables available for an instance, run the script 
 
 .. code-block:: bash
 
-    cd contrib/inventory
+    cd /etc/ansible
+    wget https://raw.githubusercontent.com/ansible-collections/community.aws/master/scripts/inventory/ec2.py
     ./ec2.py --host ec2-12-12-12-12.compute-1.amazonaws.com
 
 Note that the AWS inventory script will cache results to avoid repeated API calls, and this cache setting is configurable in ec2.ini.  To


### PR DESCRIPTION
##### SUMMARY

With inventory script migrated to their respective collection,
redirect links in documentation to their respective collection
location.

Fixes: #69139

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/69139_inventory_doc_fix.yml
docs/docsite/rst/scenario_guides/guide_azure.rst
docs/docsite/rst/scenario_guides/guide_docker.rst
docs/docsite/rst/scenario_guides/guide_infoblox.rst
docs/docsite/rst/scenario_guides/guide_packet.rst
docs/docsite/rst/user_guide/intro_dynamic_inventory.rst
