### PR TITLE
iptables: Fixed get_chain_policy API

### DIFF
--- a/changelogs/fragments/68612_iptables.yml
+++ b/changelogs/fragments/68612_iptables.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- iptables - fixed get_chain_policy API (https://github.com/ansible/ansible/issues/68612).

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -328,7 +328,9 @@ options:
       - Set the policy for the chain to the given target.
       - Only built-in chains can have policies.
       - This parameter requires the C(chain) parameter.
-      - Ignores all other parameters.
+      - If you specify this parameter, all other parameters will be ignored.
+      - This parameter is used to set default policy for the given C(chain).
+        Do not confuse this with C(jump) parameter.
     type: str
     choices: [ ACCEPT, DROP, QUEUE, RETURN ]
     version_added: "2.2"
@@ -410,6 +412,7 @@ EXAMPLES = r'''
     action: insert
     rule_num: 5
 
+# Think twice before running following task as this may lock target system
 - name: Set the policy for the INPUT chain to DROP
   iptables:
     chain: INPUT
@@ -636,7 +639,7 @@ def set_chain_policy(iptables_path, module, params):
 
 
 def get_chain_policy(iptables_path, module, params):
-    cmd = push_arguments(iptables_path, '-L', params)
+    cmd = push_arguments(iptables_path, '-L', params, make_rule=False)
     rc, out, _ = module.run_command(cmd, check_rc=True)
     chain_header = out.split("\n")[0]
     result = re.search(r'\(policy ([A-Z]+)\)', chain_header)


### PR DESCRIPTION
##### SUMMARY

While getting policy name in get_chain_policy API,
module does not require any additional parameters except chain
Enabling flag in get_chain_policy API call fixes this.

Fixes: #68612

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/68612_iptables.yml
lib/ansible/modules/system/iptables.py
