### PR TITLE
ovirt_disk: add warning when uploading wrong format

### DIFF
--- a/changelogs/fragments/69153-ovirt_disk-add-warning-when-uploading-wrong-format.yml
+++ b/changelogs/fragments/69153-ovirt_disk-add-warning-when-uploading-wrong-format.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "ovirt_disk: add warning when uploading wrong format"

--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -58,6 +58,7 @@ options:
                if you want to upload the disk even if the disk with C(id) or C(name) exists,
                then please use C(force) I(true). If you will use C(force) I(false), which
                is default, then the disk image won't be uploaded."
+            - "Note that to upload iso the C(format) should be 'raw'"
         version_added: "2.3"
     size:
         description:
@@ -73,6 +74,7 @@ options:
         description:
             - Specify format of the disk.
             - Note that this option isn't idempotent as it's not currently possible to change format of the disk via API.
+        default: 'cow'
         choices: ['raw', 'cow']
     content_type:
         description:
@@ -740,6 +742,8 @@ def main():
 
             # Upload disk image in case it's new disk or force parameter is passed:
             if module.params['upload_image_path'] and (is_new_disk or module.params['force']):
+                if module.params['format'] == 'cow' and module.params['content_type'] == 'iso':
+                    module.warn("To upload an ISO image 'format' parameter needs to be set to 'raw'.")
                 uploaded = upload_disk_image(connection, module)
                 ret['changed'] = ret['changed'] or uploaded
             # Download disk image in case it's file don't exist or force parameter is passed:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -1707,7 +1707,6 @@ lib/ansible/modules/cloud/ovirt/ovirt_datacenter_info.py validate-modules:doc-mi
 lib/ansible/modules/cloud/ovirt/ovirt_disk.py future-import-boilerplate
 lib/ansible/modules/cloud/ovirt/ovirt_disk.py metaclass-boilerplate
 lib/ansible/modules/cloud/ovirt/ovirt_disk.py validate-modules:undocumented-parameter
-lib/ansible/modules/cloud/ovirt/ovirt_disk.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/cloud/ovirt/ovirt_disk.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/cloud/ovirt/ovirt_disk.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/cloud/ovirt/ovirt_disk.py validate-modules:doc-missing-type


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ovirt_disk: add warning when uploading wrong format
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Backport of https://github.com/oVirt/ovirt-ansible-collection/pull/22
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
