### PR TITLE
Add support for Parrot Linux, a Debian derivate

### DIFF
--- a/changelogs/fragments/distribution_support_parrot.yml
+++ b/changelogs/fragments/distribution_support_parrot.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- distribution - added distribution fact and hostname support for Parrot OS (https://github.com/ansible/ansible/pull/69158).

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -320,9 +320,12 @@ class DistributionFiles:
         elif 'SteamOS' in data:
             debian_facts['distribution'] = 'SteamOS'
             # nothing else to do, SteamOS gets correct info from python functions
-        elif path in ('/etc/lsb-release', '/etc/os-release') and 'Kali' in data:
-            # Kali does not provide /etc/lsb-release anymore
-            debian_facts['distribution'] = 'Kali'
+        elif path in ('/etc/lsb-release', '/etc/os-release') and ('Kali' in data or 'Parrot' in data):
+            if 'Kali' in data:
+                # Kali does not provide /etc/lsb-release anymore
+                debian_facts['distribution'] = 'Kali'
+            elif 'Parrot' in data:
+                debian_facts['distribution'] = 'Parrot'
             release = re.search('DISTRIB_RELEASE=(.*)', data)
             if release:
                 debian_facts['distribution_release'] = release.groups()[0]
@@ -471,7 +474,7 @@ class Distribution(object):
                                 'EulerOS', 'openEuler'],
                      'Debian': ['Debian', 'Ubuntu', 'Raspbian', 'Neon', 'KDE neon',
                                 'Linux Mint', 'SteamOS', 'Devuan', 'Kali', 'Cumulus Linux',
-                                'Pop!_OS', ],
+                                'Pop!_OS', 'Parrot'],
                      'Suse': ['SuSE', 'SLES', 'SLED', 'openSUSE', 'openSUSE Tumbleweed',
                               'SLES_SAP', 'SUSE_LINUX', 'openSUSE Leap'],
                      'Archlinux': ['Archlinux', 'Antergos', 'Manjaro'],

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -725,6 +725,12 @@ class KaliHostname(Hostname):
     strategy_class = DebianStrategy
 
 
+class ParrotHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Parrot'
+    strategy_class = DebianStrategy
+
+
 class UbuntuHostname(Hostname):
     platform = 'Linux'
     distribution = 'Ubuntu'

--- a/test/units/module_utils/facts/system/distribution/fixtures/parrot_4.8.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/parrot_4.8.json
@@ -1,0 +1,25 @@
+{
+    "name": "Parrot 4.8",
+    "input": {
+        "/etc/os-release": "PRETTY_NAME=\"Parrot GNU/Linux 4.8\"\nNAME=\"Parrot GNU/Linux\"\nID=parrot\nVERSION=\"4.8\"\nVERSION_ID=\"4.8\"\nID_LIKE=debian\nHOME_URL=\"https://www.parrotlinux.org/\"\nSUPPORT_URL=\"https://community.parrotlinux.org/\"\nBUG_REPORT_URL=\"https://nest.parrot.sh/\"\n",
+        "/etc/lsb-release": "DISTRIB_ID=Parrot\nDISTRIB_RELEASE=4.8\nDISTRIB_CODENAME=rolling\nDISTRIB_DESCRIPTION=\"Parrot 4.8\"\n",
+        "/usr/lib/os-release": "PRETTY_NAME=\"Parrot GNU/Linux 4.8\"\nNAME=\"Parrot GNU/Linux\"\nID=parrot\nVERSION=\"4.8\"\nVERSION_ID=\"4.8\"\nID_LIKE=debian\nHOME_URL=\"https://www.parrotlinux.org/\"\nSUPPORT_URL=\"https://community.parrotlinux.org/\"\nBUG_REPORT_URL=\"https://nest.parrot.sh/\"\n"
+    },
+    "platform.dist": ["parrot", "4.8", ""],
+    "distro": {
+        "codename": "rolling",
+        "id": "parrot",
+        "name": "Parrot GNU/Linux",
+        "version": "4.8",
+        "version_best": "4.8",
+        "os_release_info": {},
+        "lsb_release_info": {}
+    },
+    "result": {
+        "distribution": "Parrot",
+        "distribution_version": "4.8",
+        "distribution_release": "rolling",
+        "distribution_major_version": "4",
+        "os_family": "Debian"
+    }
+}


### PR DESCRIPTION
##### SUMMARY
This PR adds support for Parrot Linux, a Debian derivate quite similar to Kali Linux.
In particular, this fixes Parrot not being part of the Debian `os_family`, which causes various issues when working with Parrot Linux targets.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup

##### ADDITIONAL INFORMATION
I mostly copied everything relating to Kali and adjusted it for Parrot. Seems to work fine on my Parrot system, but may benefit from some more testing.