### PR TITLE
Added missing parameter

### DIFF
--- a/changelogs/fragments/69160-add-missing-parameter.yaml
+++ b/changelogs/fragments/69160-add-missing-parameter.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- sysvinit - Add missing parameter ``module`` in call to ``daemonize()``.

--- a/lib/ansible/modules/system/sysvinit.py
+++ b/lib/ansible/modules/system/sysvinit.py
@@ -306,7 +306,7 @@ def main():
 
             # how to run
             if module.params['daemonize']:
-                (rc, out, err) = daemonize(cmd)
+                (rc, out, err) = daemonize(module, cmd)
             else:
                 (rc, out, err) = module.run_command(cmd)
             # FIXME: ERRORS


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The call to `daemonize()` in `sysvinit.py` was missing the `module` parameter included in the function definition in [`service.py`](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/service.py#L165).

This pull request simply adds that parameter, as `module` is used for error handling in `daemonize()`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`sysvinit.py`