### PR TITLE
Removed redundant conditional in paramiko_ssh.py

### DIFF
--- a/changelogs/fragments/69164-remove-redundant-conditional.yaml
+++ b/changelogs/fragments/69164-remove-redundant-conditional.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- paramiko_ssh - Removed redundant conditional statement in ``_parse_proxy_command`` that always evaluated to True.

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -255,7 +255,7 @@ class Connection(ConnectionBase):
             getattr(self._play_context, 'ssh_common_args', '') or '',
             getattr(self._play_context, 'ssh_args', '') or '',
         ]
-        
+
         args = self._split_ssh_args(' '.join(ssh_args))
         for i, arg in enumerate(args):
             if arg.lower() == 'proxycommand':

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -255,21 +255,21 @@ class Connection(ConnectionBase):
             getattr(self._play_context, 'ssh_common_args', '') or '',
             getattr(self._play_context, 'ssh_args', '') or '',
         ]
-        if ssh_args is not None:
-            args = self._split_ssh_args(' '.join(ssh_args))
-            for i, arg in enumerate(args):
-                if arg.lower() == 'proxycommand':
-                    # _split_ssh_args split ProxyCommand from the command itself
-                    proxy_command = args[i + 1]
-                else:
-                    # ProxyCommand and the command itself are a single string
-                    match = SETTINGS_REGEX.match(arg)
-                    if match:
-                        if match.group(1).lower() == 'proxycommand':
-                            proxy_command = match.group(2)
+        
+        args = self._split_ssh_args(' '.join(ssh_args))
+        for i, arg in enumerate(args):
+            if arg.lower() == 'proxycommand':
+                # _split_ssh_args split ProxyCommand from the command itself
+                proxy_command = args[i + 1]
+            else:
+                # ProxyCommand and the command itself are a single string
+                match = SETTINGS_REGEX.match(arg)
+                if match:
+                    if match.group(1).lower() == 'proxycommand':
+                        proxy_command = match.group(2)
 
-                if proxy_command:
-                    break
+            if proxy_command:
+                break
 
         proxy_command = proxy_command or self.get_option('proxy_command')
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`paramiko_ssh.py` contained an `if` statement that always evaluated to `True` in the `_parse_proxy_command()` method.

This PR removes that redundant check.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`paramiko_ssh`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I believe this conditional was originally created because it was believes that a list containing ['','',''] would be considered `None`.
