### PR TITLE
constructed inventory plugin: correct example

### DIFF
--- a/lib/ansible/plugins/inventory/constructed.py
+++ b/lib/ansible/plugins/inventory/constructed.py
@@ -45,7 +45,7 @@ EXAMPLES = r'''
         private_only: not (public_dns_name is defined or ip_address is defined)
 
         # complex group membership
-        multi_group: (group_names|intersection(['alpha', 'beta', 'omega']))|length >= 2
+        multi_group: (group_names | intersect(['alpha', 'beta', 'omega'])) | length >= 2
 
     keyed_groups:
         # this creates a group per distro (distro_CentOS, distro_Debian) and assigns the hosts that have matching values to it,


### PR DESCRIPTION
##### SUMMARY
There is no "intersection" filter. It's "intersect". Also, remove superfluous parentheses.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr
