### PR TITLE
[2.9] Fix docs issues in aws_s3_bucket_info and ec2_vpc_vpn

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_s3_bucket_info.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3_bucket_info.py
@@ -47,7 +47,7 @@ buckets:
   description: "List of buckets"
   returned: always
   sample:
-    - creation_date: 2017-07-06 15:05:12 +00:00
+    - creation_date: '2017-07-06 15:05:12 +00:00'
       name: my_bucket
   type: list
 '''

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_vpn.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_vpn.py
@@ -270,7 +270,7 @@ vgw_telemetry:
     vgw_telemetry: [{
                      'outside_ip_address': 'string',
                      'status': 'up',
-                     'last_status_change': datetime(2015, 1, 1),
+                     'last_status_change': 'datetime(2015, 1, 1)',
                      'status_message': 'string',
                      'accepted_route_count': 123
                     }]

--- a/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
@@ -82,7 +82,7 @@ snapshot:
   type: dict
   sample:
     auto_minor_version_upgrade: true
-    cache_cluster_create_time: 2017-02-01T17:43:58.261000+00:00
+    cache_cluster_create_time: '2017-02-01T17:43:58.261000+00:00'
     cache_cluster_id: test-please-delete
     cache_node_type: cache.m1.small
     cache_parameter_group_name: default.redis3.2
@@ -90,7 +90,7 @@ snapshot:
     engine: redis
     engine_version: 3.2.4
     node_snapshots:
-      cache_node_create_time: 2017-02-01T17:43:58.261000+00:00
+      cache_node_create_time: '2017-02-01T17:43:58.261000+00:00'
       cache_node_id: 0001
       cache_size:
     num_cache_nodes: 1

--- a/lib/ansible/modules/cloud/amazon/elb_classic_lb_info.py
+++ b/lib/ansible/modules/cloud/amazon/elb_classic_lb_info.py
@@ -101,7 +101,7 @@ elbs:
         backend_server_description: []
         canonical_hosted_zone_name: test-lb-XXXXXXXXXXXX.us-east-1.elb.amazonaws.com
         canonical_hosted_zone_name_id: XXXXXXXXXXXXXX
-        created_time: 2017-08-23T18:25:03.280000+00:00
+        created_time: '2017-08-23T18:25:03.280000+00:00'
         dns_name: test-lb-XXXXXXXXXXXX.us-east-1.elb.amazonaws.com
         health_check:
           healthy_threshold: 10

--- a/lib/ansible/modules/cloud/amazon/sts_assume_role.py
+++ b/lib/ansible/modules/cloud/amazon/sts_assume_role.py
@@ -66,7 +66,7 @@ sts_creds:
     type: dict
     sample:
       access_key: XXXXXXXXXXXXXXXXXXXX
-      expiration: 2017-11-11T11:11:11+00:00
+      expiration: '2017-11-11T11:11:11+00:00'
       secret_key: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
       session_token: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 sts_user:


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible-collections/community.aws/pull/47

Fixes the docs that broke ansible-doc (see #69031).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
aws_s3_bucket_info
ec2_vpc_vpn
