### PR TITLE
generator inventory plugin: remove "strict" from example

### DIFF
--- a/lib/ansible/plugins/inventory/generator.py
+++ b/lib/ansible/plugins/inventory/generator.py
@@ -41,7 +41,6 @@ EXAMPLES = '''
     # remember to enable this inventory plugin in the ansible.cfg before using
     # View the output using `ansible-inventory -i inventory.config --list`
     plugin: generator
-    strict: False
     hosts:
         name: "{{ operation }}_{{ application }}_{{ environment }}_runner"
         parents:


### PR DESCRIPTION
##### SUMMARY
This `strict` option appears to be unused. It's probably a copy-paste error from the `constructed` plugin.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
generator