### PR TITLE
[stable-2.9] Remove obsolete vcenter setup from ansible-test.

### DIFF
--- a/changelogs/fragments/ansible-test-obsolete-vcenter-proivisioning.yml
+++ b/changelogs/fragments/ansible-test-obsolete-vcenter-proivisioning.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - ansible-test - Remove obsolete support for provisioning remote vCenter instances. The supporting services are no longer available.

--- a/test/lib/ansible_test/_internal/cloud/vcenter.py
+++ b/test/lib/ansible_test/_internal/cloud/vcenter.py
@@ -13,7 +13,6 @@ from . import (
 from ..util import (
     find_executable,
     display,
-    is_shippable,
     ConfigParser,
 )
 
@@ -23,10 +22,6 @@ from ..docker_util import (
     docker_inspect,
     docker_pull,
     get_docker_container_id,
-)
-
-from ..core_ci import (
-    AnsibleCoreCI,
 )
 
 
@@ -47,12 +42,9 @@ class VcenterProvider(CloudProvider):
             self.image = 'quay.io/ansible/vcenter-test-container:1.7.0'
         self.container_name = ''
 
-        # VMware tests can be run on govcsim or baremetal, either BYO with a static config
-        # file or hosted in worldstream.  Using an env var value of 'worldstream' with appropriate
-        # CI credentials will deploy a dynamic baremetal environment. The simulator is the default
-        # if no other config if provided.
+        # VMware tests can be run on govcsim or BYO with a static config file.
+        # The simulator is the default if no config is provided.
         self.vmware_test_platform = os.environ.get('VMWARE_TEST_PLATFORM', '')
-        self.aci = None
         self.insecure = False
         self.proxy = None
 
@@ -78,14 +70,6 @@ class VcenterProvider(CloudProvider):
             if os.path.isfile(self.config_static_path):
                 return
 
-            aci = self._create_ansible_core_ci()
-
-            if os.path.isfile(aci.ci_key):
-                return
-
-            if is_shippable():
-                return
-
             super(VcenterProvider, self).filter(targets, exclude)
 
     def setup(self):
@@ -95,8 +79,6 @@ class VcenterProvider(CloudProvider):
         self._set_cloud_config('vmware_test_platform', self.vmware_test_platform)
         if self.vmware_test_platform == 'govcsim':
             self._setup_dynamic_simulator()
-        elif self.vmware_test_platform == 'worldstream':
-            self._setup_dynamic_baremetal()
         elif self._use_static_config():
             self._set_cloud_config('vmware_test_platform', 'static')
             self._setup_static()
@@ -107,18 +89,13 @@ class VcenterProvider(CloudProvider):
         """Get any additional options needed when delegating tests to a docker container.
         :rtype: list[str]
         """
-        if self.managed and self.vmware_test_platform != 'worldstream':
+        if self.managed:
             return ['--link', self.DOCKER_SIMULATOR_NAME]
 
         return []
 
     def cleanup(self):
         """Clean up the cloud resource and any temporary configuration files after tests complete."""
-        if self.vmware_test_platform == 'worldstream':
-
-            if self.aci:
-                self.aci.stop()
-
         if self.container_name:
             docker_rm(self.args, self.container_name)
 
@@ -180,35 +157,6 @@ class VcenterProvider(CloudProvider):
         ipaddress = results[0]['NetworkSettings']['IPAddress']
         return ipaddress
 
-    def _setup_dynamic_baremetal(self):
-        """Request Esxi credentials through the Ansible Core CI service."""
-        display.info('Provisioning %s cloud environment.' % self.platform,
-                     verbosity=1)
-
-        config = self._read_config_template()
-
-        aci = self._create_ansible_core_ci()
-
-        if not self.args.explain:
-            self.aci = aci
-            aci.start()
-            aci.wait(iterations=160)
-
-            data = aci.get().response_json.get('data')
-            for key, value in data.items():
-                if key.endswith('PASSWORD'):
-                    display.sensitive.add(value)
-            config = self._populate_config_template(config, data)
-            self._write_config(config)
-
-    def _create_ansible_core_ci(self):
-        """
-        :rtype: AnsibleCoreCI
-        """
-        return AnsibleCoreCI(self.args, 'vmware', 'vmware',
-                             persist=False, stage=self.args.remote_stage,
-                             provider='vmware')
-
     def _setup_static(self):
         parser = ConfigParser({
             'vcenter_port': '443',
@@ -234,7 +182,7 @@ class VcenterEnvironment(CloudEnvironment):
         if not vmware_test_platform:
             vmware_test_platform = self._get_cloud_config('vmware_test_platform')
 
-        if vmware_test_platform in ('worldstream', 'static'):
+        if vmware_test_platform == 'static':
             parser = ConfigParser()
             parser.read(self.config_path)
 

--- a/test/lib/ansible_test/_internal/core_ci.py
+++ b/test/lib/ansible_test/_internal/core_ci.py
@@ -92,9 +92,6 @@ class AnsibleCoreCI:
             parallels=(
                 'osx',
             ),
-            vmware=(
-                'vmware'
-            ),
         )
 
         if provider:
@@ -147,10 +144,6 @@ class AnsibleCoreCI:
 
             self.ssh_key = SshKey(args)
             self.port = None
-        elif self.provider == 'vmware':
-            self.ssh_key = SshKey(args)
-            self.endpoints = ['https://access.ws.testing.ansible.com']
-            self.max_threshold = 1
 
         else:
             raise ApplicationError('Unsupported platform: %s' % platform)
@@ -321,7 +314,7 @@ class AnsibleCoreCI:
                     password=con.get('password'),
                     response_json=response_json,
                 )
-            else:  # 'vcenter' resp does not have a 'connection' key
+            else:
                 self.connection = InstanceConnection(
                     running=status == 'running',
                     response_json=response_json,


### PR DESCRIPTION
##### SUMMARY

[stable-2.9] Remove obsolete vcenter setup from ansible-test.

Backport of https://github.com/ansible/ansible/pull/69186

(cherry picked from commit a050d892d83bc4a763f9de0c34bb37bb12a64107)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
