### PR TITLE
[2.9] constructed inventory plugin: correct example

### DIFF
--- a/changelogs/fragments/69165_constructed.yml
+++ b/changelogs/fragments/69165_constructed.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Fixed 'intersect' filter spelling in constructed inventory plugin example.

--- a/lib/ansible/plugins/inventory/constructed.py
+++ b/lib/ansible/plugins/inventory/constructed.py
@@ -45,7 +45,7 @@ EXAMPLES = r'''
         private_only: not (public_dns_name is defined or ip_address is defined)
 
         # complex group membership
-        multi_group: (group_names|intersection(['alpha', 'beta', 'omega']))|length >= 2
+        multi_group: (group_names | intersect(['alpha', 'beta', 'omega'])) | length >= 2
 
     keyed_groups:
         # this creates a group per distro (distro_CentOS, distro_Debian) and assigns the hosts that have matching values to it,


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/69165


Fixed 'intersect' filter name in constructed inventory plugin example.

(cherry picked from commit 91d02e1c1fb16ac0fbb079334f9d3c239e57034a)


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/69165_constructed.yml
lib/ansible/plugins/inventory/constructed.py
