### PR TITLE
Revert "Fix missing persistent connection messages (#68496)" (#69147)

### DIFF
--- a/changelogs/fragments/b5a0475a-revert-persistent-connection-messages.yml
+++ b/changelogs/fragments/b5a0475a-revert-persistent-connection-messages.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Revert 5f6427b1fc7449a5c42212013d3f628665701c3d as it breaks netconf connection"

--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -147,8 +147,6 @@ class ConnectionProcess(object):
                     resp = self.srv.handle_request(data)
                     signal.alarm(0)
 
-                    display_messages(self.connection)
-
                     if log_messages:
                         display.display("jsonrpc response: %s" % resp, log_only=True)
 
@@ -198,7 +196,9 @@ class ConnectionProcess(object):
                     self.sock.close()
                 if self.connection:
                     self.connection.close()
-                    display_messages(self.connection)
+                    if self.connection.get_option("persistent_log_messages"):
+                        for _level, message in self.connection.pop_messages():
+                            display.display(message, log_only=True)
             except Exception:
                 pass
             finally:
@@ -333,24 +333,6 @@ def main():
         sys.stdout.write(json.dumps(result, cls=AnsibleJSONEncoder))
 
     sys.exit(rc)
-
-
-def display_messages(connection):
-    # This should be handled elsewhere, but if this is the last task, nothing will
-    # come back to collect the messages. So now each task will dump its own messages
-    # to stdout before logging the response message. This may make some other
-    # pop_messages calls redundant.
-    for level, message in connection.pop_messages():
-        if connection.get_option('persistent_log_messages') and level == "log":
-            display.display(message, log_only=True)
-        else:
-            # These should be keyed by valid method names, but
-            # fail gracefully just in case.
-            display_method = getattr(display, level, None)
-            if display_method:
-                display_method(message)
-            else:
-                display.display((level, message))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This reverts commit 5f6427b1fc7449a5c42212013d3f628665701c3d.
as it breaks netconf connection. This will be a temporary measure
for unlocking CI until a proper fix is shipped.

Fixes #69065

Backport of https://github.com/ansible/ansible/pull/69147

(cherry picked from commit 9217aeeac1fadbbfd89714cb987bba08e2f41003)
Signed-off-by: Daniel Mellado <dmellado@redhat.com>
