### PR TITLE
Fix support for Kali Linux detection

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -320,7 +320,8 @@ class DistributionFiles:
         elif 'SteamOS' in data:
             debian_facts['distribution'] = 'SteamOS'
             # nothing else to do, SteamOS gets correct info from python functions
-        elif path == '/etc/lsb-release' and 'Kali' in data:
+        elif (path == '/etc/lsb-release' or path == '/etc/os-release') and 'Kali' in data:
+            # Kali does not provide /etc/lsb-release anymore
             debian_facts['distribution'] = 'Kali'
             release = re.search('DISTRIB_RELEASE=(.*)', data)
             if release:

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -320,7 +320,7 @@ class DistributionFiles:
         elif 'SteamOS' in data:
             debian_facts['distribution'] = 'SteamOS'
             # nothing else to do, SteamOS gets correct info from python functions
-        elif (path == '/etc/lsb-release' or path == '/etc/os-release') and 'Kali' in data:
+        elif path in ('/etc/lsb-release', '/etc/os-release') and 'Kali' in data:
             # Kali does not provide /etc/lsb-release anymore
             debian_facts['distribution'] = 'Kali'
             release = re.search('DISTRIB_RELEASE=(.*)', data)

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -991,6 +991,40 @@ TESTSETS = [
         }
     },
     {
+        'name': 'Kali 2020.2',
+        'input': {
+            '/etc/os-release': ("PRETTY_NAME=\"Kali GNU/Linux Rolling\"\nNAME=\"Kali GNU/Linux\"\nID=kali\nVERSION=\"2020.2\"\n"
+                                "VERSION_ID=\"2020.2\"\nVERSION_CODENAME=\"kali-rolling\"\nID_LIKE=debian\nANSI_COLOR=\"1;31\"\n"
+                                "HOME_URL=\"https://www.kali.org/\"\nSUPPORT_URL=\"https://forums.kali.org/\"\n"
+                                "BUG_REPORT_URL=\"https://bugs.kali.org/\""),
+            '/usr/lib/os-release': ("PRETTY_NAME=\"Kali GNU/Linux Rolling\"\nNAME=\"Kali GNU/Linux\"\nID=kali\nVERSION=\"2020.2\"\n"
+                                "VERSION_ID=\"2020.2\"\nVERSION_CODENAME=\"kali-rolling\"\nID_LIKE=debian\nANSI_COLOR=\"1;31\"\n"
+                                "HOME_URL=\"https://www.kali.org/\"\nSUPPORT_URL=\"https://forums.kali.org/\"\n"
+                                "BUG_REPORT_URL=\"https://bugs.kali.org/\"")
+        },
+        'platform.dist': [
+            'kali',
+            '2020.2',
+            ''
+        ],
+        'distro': {
+            'codename': 'kali-rolling',
+            'id': 'kali',
+            'name': 'Kali GNU/Linux Rolling',
+            'version': '2020.2',
+            'version_best': '2020.2',
+            'os_release_info': {},
+            'lsb_release_info': {},
+        },
+        'result': {
+            'distribution': 'Kali',
+            'distribution_version': '2020.2',
+            'distribution_release': 'kali-rolling',
+            'distribution_major_version': '2020',
+            'os_family': 'Debian'
+        }
+    },
+    {
         "platform.dist": [
             "neon",
             "16.04",


### PR DESCRIPTION
##### SUMMARY
Kali Linux is a Debian derivative. Support was added by #50331

It recently [stopped providing](https://gitlab.com/kalilinux/packages/base-files/-/commit/f43e0f2c46619e1dc517a3a14928377baa281f3d) /etc/lsb-release and now it is not recognized anymore as a Debian derivative by Ansible.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
facts module, distribution file

##### ADDITIONAL INFORMATION
The current detection works fine on Kali 2020.1 giving us the following facts:
```json
"ansible_distribution": "Kali",
"ansible_distribution_file_parsed": true,
"ansible_distribution_file_path": "/etc/lsb-release",
"ansible_distribution_file_variety": "Debian",
"ansible_distribution_major_version": "2020",
"ansible_distribution_release": "kali-rolling",
"ansible_distribution_version": "2020.1",
"ansible_os_family": "Debian",
```

The files are:
```console
root@redacted:~# cat /etc/lsb-release 
DISTRIB_ID=Kali
DISTRIB_RELEASE=kali-rolling
DISTRIB_CODENAME=kali-rolling
DISTRIB_DESCRIPTION="Kali GNU/Linux Rolling"
root@redacted:~# cat /etc/os-release 
PRETTY_NAME="Kali GNU/Linux Rolling"
NAME="Kali GNU/Linux"
ID=kali
VERSION="2020.1"
VERSION_ID="2020.1"
VERSION_CODENAME="kali-rolling"
ID_LIKE=debian
ANSI_COLOR="1;31"
HOME_URL="https://www.kali.org/"
SUPPORT_URL="https://forums.kali.org/"
BUG_REPORT_URL="https://bugs.kali.org/"
```

But starting from 2020.2, the facts we obtain are:
```json
"ansible_distribution": "Kali GNU/Linux",
"ansible_distribution_file_parsed": true,
"ansible_distribution_file_path": "/etc/os-release",
"ansible_distribution_file_variety": "NA",
"ansible_distribution_major_version": "2020",
"ansible_distribution_release": "kali-rolling",
"ansible_distribution_version": "2020.2",
"ansible_os_family": "Kali GNU/Linux",
```
Notice the difference in ansible_distribution, ansible_distribution_file_variety and ansible_os_family

Now the files are:
```console
root@redacted:~# cat /etc/lsb-release
cat: /etc/lsb-release: No such file or directory
root@redacted:~# cat /etc/os-release
PRETTY_NAME="Kali GNU/Linux Rolling"
NAME="Kali GNU/Linux"
ID=kali
VERSION="2020.2"
VERSION_ID="2020.2"
VERSION_CODENAME="kali-rolling"
ID_LIKE=debian
ANSI_COLOR="1;31"
HOME_URL="https://www.kali.org/"
SUPPORT_URL="https://forums.kali.org/"
BUG_REPORT_URL="https://bugs.kali.org/"
```

With this patch, the facts are back to as previously:
```json
"ansible_distribution": "Kali",
"ansible_distribution_file_parsed": true,
"ansible_distribution_file_path": "/etc/os-release",
"ansible_distribution_file_variety": "Debian",
"ansible_distribution_major_version": "2020",
"ansible_distribution_release": "kali-rolling",
"ansible_distribution_version": "2020.2",
"ansible_os_family": "Debian",
```