### PR TITLE
galaxy: Handle empty roles and collections

### DIFF
--- a/changelogs/fragments/68186_collection_index_err.yml
+++ b/changelogs/fragments/68186_collection_index_err.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Handle empty roles and empty collections in requirements.yml in ansible-galaxy install command (https://github.com/ansible/ansible/issues/68186).

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -568,10 +568,10 @@ class GalaxyCLI(CLI):
                 raise AnsibleError("Expecting only 'roles' and/or 'collections' as base keys in the requirements "
                                    "file. Found: %s" % (to_native(", ".join(extra_keys))))
 
-            for role_req in file_requirements.get('roles', []):
+            for role_req in file_requirements.get('roles') or []:
                 requirements['roles'] += parse_role_req(role_req)
 
-            for collection_req in file_requirements.get('collections', []):
+            for collection_req in file_requirements.get('collections') or []:
                 if isinstance(collection_req, dict):
                     req_name = collection_req.get('name', None)
                     if req_name is None:

--- a/test/integration/targets/ansible-galaxy-collection/tasks/download.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/download.yml
@@ -4,7 +4,7 @@
     path: '{{ galaxy_dir }}/download'
     state: directory
 
-- name: download collection with multiple dependencides
+- name: download collection with multiple dependencies
   command: ansible-galaxy collection download parent_dep.parent_collection -s {{ fallaxy_galaxy_server }}
   register: download_collection
   args:
@@ -86,3 +86,22 @@
     - download_req_custom_path_actual.matched == 2
     - (download_req_custom_path_actual.files[0].path | basename) in ['requirements.yml', 'namespace1-name1-1.1.0-beta.1.tar.gz']
     - (download_req_custom_path_actual.files[1].path | basename) in ['requirements.yml', 'namespace1-name1-1.1.0-beta.1.tar.gz']
+
+# https://github.com/ansible/ansible/issues/68186
+- name: create test requirements file without roles and collections
+  copy:
+    content: |
+      collections:
+      roles:
+
+    dest: '{{ galaxy_dir }}/download/no_roles_no_collections.yml'
+
+- name: install collection with requirements
+  command: ansible-galaxy collection install -r '{{ galaxy_dir }}/download/no_roles_no_collections.yml'
+  register: install_no_requirements
+
+- name: assert install collection with no roles and no collections in requirements
+  assert:
+    that:
+      - '"Process install" in install_no_requirements.stdout'
+      - '"Starting collection" in install_no_requirements.stdout'


### PR DESCRIPTION
##### SUMMARY

Galaxy collection install command raised indexError,
when requirements.yml contains empty roles and collections.

This fix handles empty roles and/or empty collections.

Fixes: #68186

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/68186_collection_index_err.yml
lib/ansible/cli/galaxy.py
test/integration/targets/ansible-galaxy-collection/tasks/download.yml
