### PR TITLE
module_utils: require X_OK when checking cwd sanity

### DIFF
--- a/changelogs/fragments/69201-fix-cwd-sanity-requirements.yml
+++ b/changelogs/fragments/69201-fix-cwd-sanity-requirements.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- module_utils - When checking that it is possible to cd in current working
+  directory before running a module, ansible now also checks that the directory
+  is searchable (+x).

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1932,7 +1932,7 @@ class AnsibleModule(object):
     def _set_cwd(self):
         try:
             cwd = os.getcwd()
-            if not os.access(cwd, os.F_OK | os.R_OK):
+            if not os.access(cwd, os.F_OK | os.R_OK | os.X_OK):
                 raise Exception()
             return cwd
         except Exception:
@@ -1940,7 +1940,7 @@ class AnsibleModule(object):
             # Try and move to a neutral location to prevent errors
             for cwd in [self.tmpdir, os.path.expandvars('$HOME'), tempfile.gettempdir()]:
                 try:
-                    if os.access(cwd, os.F_OK | os.R_OK):
+                    if os.access(cwd, os.F_OK | os.R_OK | os.X_OK):
                         os.chdir(cwd)
                         return cwd
                 except Exception:


### PR DESCRIPTION
##### SUMMARY

Every time an Ansible module is run, it checks that it is running from a
"sane" working directory, a.k.a where it has the permission to be. This
is because when running commands, it might temporarily change its
working directory, then later restore pop the cwd to the previous one.

Therefore, if the module is not run from a working directory where it
has the permission to be, the module will execute fine, but then fail
when trying to restore to the previous directory.

Up until now the way this cwd "sanity" was checked was by checking for
the F_OK and R_OK permissions, which respectively check that the
directory exists and is readable. However, this is actually not
sufficient to check whether you can cwd to it! You also need to check
for X_OK, which for directories mean that the directory is searchable.

See for example:

```
>>> cwd = os.getcwd()
>>> cwd
'/root'
>>> os.access(cwd, os.F_OK | os.R_OK)
True
>>> os.access(cwd, os.F_OK | os.R_OK | os.X_OK)
False
>>> os.chdir(cwd)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
PermissionError: [Errno 13] Permission denied: '/root'
```

Basically, this means that Ansible will fail every time you run a
"become" command from a directory with the mode o+r-x.

This commit fixes this issue by adding a requirement for X_OK when
checking the sanity of the current working directory.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

module_utils