### PR TITLE
Fix name of utility "nologin"

### DIFF
--- a/docs/docsite/rst/user_guide/become.rst
+++ b/docs/docsite/rst/user_guide/become.rst
@@ -31,7 +31,7 @@ become_method
     (at play or task level) overrides the default method set in ansible.cfg, set to use any of the :ref:`become_plugins`.
 
 become_flags
-    (at play or task level) permit the use of specific flags for the tasks or role. One common use is to change the user to nobody when the shell is set to no login. Added in Ansible 2.2.
+    (at play or task level) permit the use of specific flags for the tasks or role. One common use is to change the user to nobody when the shell is set to nologin. Added in Ansible 2.2.
 
 For example, to manage a system service (which requires ``root`` privileges) when connected as a non-``root`` user, you can use the default value of ``become_user`` (``root``):
 


### PR DESCRIPTION
##### SUMMARY
This fixes the name of the utility `nologin`. In the example further down below it is spelled correctly.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr