### PR TITLE
[2.9] Added missing parameter

### DIFF
--- a/changelogs/fragments/69160-add-missing-parameter.yaml
+++ b/changelogs/fragments/69160-add-missing-parameter.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- sysvinit - Add missing parameter ``module`` in call to ``daemonize()``.

--- a/lib/ansible/modules/system/sysvinit.py
+++ b/lib/ansible/modules/system/sysvinit.py
@@ -306,7 +306,7 @@ def main():
 
             # how to run
             if module.params['daemonize']:
-                (rc, out, err) = daemonize(cmd)
+                (rc, out, err) = daemonize(module, cmd)
             else:
                 (rc, out, err) = module.run_command(cmd)
             # FIXME: ERRORS


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/69160


The call to daemonize() in sysvinit.py was missing the module parameter
included in the function definition in service.py.

This pull request simply adds that parameter, as the module is
used for error handling in daemonize().

(cherry picked from commit 339c4422502addfee78c2f8a8461cdd9002c48b1)


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/69160-add-missing-parameter.yaml
lib/ansible/modules/system/sysvinit.py
