### PR TITLE
Handle non-ascii paths during role installation

### DIFF
--- a/changelogs/fragments/69133-role-install-non-ascii.yml
+++ b/changelogs/fragments/69133-role-install-non-ascii.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- Role Installation - Ensure that a role containing files with non-ascii characters can be installed
+  (https://github.com/ansible/ansible/issues/69133)

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -327,13 +327,15 @@ class GalaxyRole(object):
                             # bits that might be in the file for security purposes
                             # and drop any containing directory, as mentioned above
                             if member.isreg() or member.issym():
-                                parts = member.name.replace(archive_parent_dir, "", 1).split(os.sep)
-                                final_parts = []
-                                for part in parts:
-                                    if part != '..' and '~' not in part and '$' not in part:
-                                        final_parts.append(part)
-                                member.name = os.path.join(*final_parts)
-                                role_tar_file.extract(member, self.path)
+                                n_member_name = to_native(member.name)
+                                n_archive_parent_dir = to_native(archive_parent_dir)
+                                n_parts = n_member_name.replace(n_archive_parent_dir, "", 1).split(os.sep)
+                                n_final_parts = []
+                                for n_part in n_parts:
+                                    if n_part != '..' and '~' not in n_part and '$' not in n_part:
+                                        n_final_parts.append(n_part)
+                                member.name = os.path.join(*n_final_parts)
+                                role_tar_file.extract(member, to_native(self.path))
 
                         # write out the install info file for later use
                         self._write_galaxy_install_info()

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -212,6 +212,20 @@ pushd "${role_testdir}"
 popd # ${role_testdir}
 rm -rf "${role_testdir}"
 
+f_ansible_galaxy_status \
+    "Test role with non-ascii characters"
+
+role_testdir=$(mktemp -d)
+pushd "${role_testdir}"
+
+    mkdir nonascii
+    ansible-galaxy role init --init-path ./nonascii nonascii
+    touch nonascii/ÅÑŚÌβŁÈ.txt
+    tar czvf nonascii.tar.gz nonascii
+    ansible-galaxy role install -p ./roles nonascii.tar.gz
+
+popd # ${role_testdir}
+rm -rf "${role_testdir}"
 
 #################################
 # ansible-galaxy collection tests


### PR DESCRIPTION
##### SUMMARY
Handle non-ascii paths during role installation. Fixes #69133

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/galaxy/role.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
