### PR TITLE
Addressed FIXME's in hurd.py (Extracted functionality and exit early)

### DIFF
--- a/changelogs/fragments/69226-hurd-extract-functionality.yaml
+++ b/changelogs/fragments/69226-hurd-extract-functionality.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- hurd - Address FIXMEs. Extract functionality and exit early.

--- a/lib/ansible/module_utils/facts/network/hurd.py
+++ b/lib/ansible/module_utils/facts/network/hurd.py
@@ -29,26 +29,6 @@ class HurdPfinetNetwork(Network):
     platform = 'GNU'
     _socket_dir = '/servers/socket/'
 
-    def populate(self, collected_facts=None):
-        network_facts = {}
-
-        fsysopts_path = self.module.get_bin_path('fsysopts')
-        if fsysopts_path is None:
-            return network_facts
-
-        socket_path = None
-
-        for l in ('inet', 'inet6'):
-            link = os.path.join(self._socket_dir, l)
-            if os.path.exists(link):
-                socket_path = link
-                break
-
-        if not socket_path:
-            return network_facts
-
-        return assign_network_facts(network_facts, fsysopts_path, socket_path)
-
     def assign_network_facts(self, network_facts, fsysopts_path, socket_path):
         rc, out, err = self.module.run_command([fsysopts_path, '-L', socket_path])
         # FIXME: build up a interfaces datastructure, then assign into network_facts
@@ -80,6 +60,26 @@ class HurdPfinetNetwork(Network):
                         'prefix': prefix,
                     })
         return network_facts
+
+    def populate(self, collected_facts=None):
+        network_facts = {}
+
+        fsysopts_path = self.module.get_bin_path('fsysopts')
+        if fsysopts_path is None:
+            return network_facts
+
+        socket_path = None
+
+        for l in ('inet', 'inet6'):
+            link = os.path.join(self._socket_dir, l)
+            if os.path.exists(link):
+                socket_path = link
+                break
+
+        if not socket_path:
+            return network_facts
+
+        return assign_network_facts(network_facts, fsysopts_path, socket_path)
 
 
 class HurdNetworkCollector(NetworkCollector):

--- a/lib/ansible/module_utils/facts/network/hurd.py
+++ b/lib/ansible/module_utils/facts/network/hurd.py
@@ -76,7 +76,7 @@ class HurdPfinetNetwork(Network):
                 socket_path = link
                 break
 
-        if not socket_path:
+        if socket_path is None:
             return network_facts
 
         return self.assign_network_facts(network_facts, fsysopts_path, socket_path)

--- a/lib/ansible/module_utils/facts/network/hurd.py
+++ b/lib/ansible/module_utils/facts/network/hurd.py
@@ -44,40 +44,41 @@ class HurdPfinetNetwork(Network):
                 socket_path = link
                 break
 
-        # FIXME: extract to method
-        # FIXME: exit early on falsey socket_path and un-indent whole block
+        if not socket_path:
+            return network_facts
 
-        if socket_path:
-            rc, out, err = self.module.run_command([fsysopts_path, '-L', socket_path])
-            # FIXME: build up a interfaces datastructure, then assign into network_facts
-            network_facts['interfaces'] = []
-            for i in out.split():
-                if '=' in i and i.startswith('--'):
-                    k, v = i.split('=', 1)
-                    # remove '--'
-                    k = k[2:]
-                    if k == 'interface':
-                        # remove /dev/ from /dev/eth0
-                        v = v[5:]
-                        network_facts['interfaces'].append(v)
-                        network_facts[v] = {
-                            'active': True,
-                            'device': v,
-                            'ipv4': {},
-                            'ipv6': [],
-                        }
-                        current_if = v
-                    elif k == 'address':
-                        network_facts[current_if]['ipv4']['address'] = v
-                    elif k == 'netmask':
-                        network_facts[current_if]['ipv4']['netmask'] = v
-                    elif k == 'address6':
-                        address, prefix = v.split('/')
-                        network_facts[current_if]['ipv6'].append({
-                            'address': address,
-                            'prefix': prefix,
-                        })
+        return assign_network_facts(network_facts, fsysopts_path, socket_path)
 
+    def assign_network_facts(self, network_facts, fsysopts_path, socket_path):
+        rc, out, err = self.module.run_command([fsysopts_path, '-L', socket_path])
+        # FIXME: build up a interfaces datastructure, then assign into network_facts
+        network_facts['interfaces'] = []
+        for i in out.split():
+            if '=' in i and i.startswith('--'):
+                k, v = i.split('=', 1)
+                # remove '--'
+                k = k[2:]
+                if k == 'interface':
+                    # remove /dev/ from /dev/eth0
+                    v = v[5:]
+                    network_facts['interfaces'].append(v)
+                    network_facts[v] = {
+                        'active': True,
+                        'device': v,
+                        'ipv4': {},
+                        'ipv6': [],
+                    }
+                    current_if = v
+                elif k == 'address':
+                    network_facts[current_if]['ipv4']['address'] = v
+                elif k == 'netmask':
+                    network_facts[current_if]['ipv4']['netmask'] = v
+                elif k == 'address6':
+                    address, prefix = v.split('/')
+                    network_facts[current_if]['ipv6'].append({
+                        'address': address,
+                        'prefix': prefix,
+                    })
         return network_facts
 
 

--- a/lib/ansible/module_utils/facts/network/hurd.py
+++ b/lib/ansible/module_utils/facts/network/hurd.py
@@ -79,7 +79,7 @@ class HurdPfinetNetwork(Network):
         if not socket_path:
             return network_facts
 
-        return assign_network_facts(network_facts, fsysopts_path, socket_path)
+        return self.assign_network_facts(network_facts, fsysopts_path, socket_path)
 
 
 class HurdNetworkCollector(NetworkCollector):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`hurd.py` had multiple FIXME's that have not been fixed. This PR extracts functionality from `populate()` and creates a new function `assign_network_facts()`.

The conditional logic is also revamped so that we can un-indent.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`hurd.py`
