### PR TITLE
[2.9] Bugfix of 67377: postgresql_set converts value to uppercase if "mb" or "gb" or "tb" is in the value string (#67418)

### DIFF
--- a/changelogs/fragments/67418-postgresql_set_converts_value_to_uppercase.yml
+++ b/changelogs/fragments/67418-postgresql_set_converts_value_to_uppercase.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgresql_set - fix converting value to uppercase (https://github.com/ansible/ansible/issues/67377).

--- a/lib/ansible/modules/database/postgresql/postgresql_set.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_set.py
@@ -300,7 +300,7 @@ def main():
     # Allow to pass values like 1mb instead of 1MB, etc:
     if value:
         for unit in POSSIBLE_SIZE_UNITS:
-            if unit in value:
+            if value[:-2].isdigit() and unit in value[-2:]:
                 value = value.upper()
 
     if value and reset:

--- a/test/integration/targets/postgresql/tasks/postgresql_set.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_set.yml
@@ -69,7 +69,7 @@
     postgresql_set:
       <<: *pg_parameters
       name: work_mem
-      value: 12MB
+      value: 12mb
     register: set_wm
 
   - assert:
@@ -281,3 +281,24 @@
       - set_aut.changed == false
       - set_aut.restart_required == false
       - set_aut.value.value == 'off'
+
+  #################
+  # Bugfix of 67377
+  - name: archive command with mb
+    <<: *task_parameters
+    postgresql_set:
+      <<: *pg_parameters
+      name: archive_command
+      value: 'test ! -f /mnt/postgres/mb/%f && cp %p /mnt/postgres/mb/%f'
+
+  # Check:
+  - name: check value
+    <<: *task_parameters
+    postgresql_query:
+      <<: *pg_parameters
+      query: select reset_val from pg_settings where name = 'archive_command'
+    register: result
+
+  - assert:
+      that:
+      - result.query_result.0.reset_val == "test ! -f /mnt/postgres/mb/%f && cp %p /mnt/postgres/mb/%f"


### PR DESCRIPTION
(cherry picked from commit 59bcc9f739d40c35ec1f471dbd7f30934bccfd94)

##### SUMMARY
Bugfix of 67377: postgresql_set converts value to uppercase if "mb" or "gb" or "tb" is in the value string
backport of #67418  

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```lib/ansible/modules/database/postgresql/postgresql_set.py```
