### PR TITLE
[2.9] zabbix_template: fixed zabbix no longer returning macros as part of the template

### DIFF
--- a/changelogs/fragments/66996-zabbix-template.yaml
+++ b/changelogs/fragments/66996-zabbix-template.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- zabbix_template - no longer fails with KeyError when there are no macros present in existing template (see https://github.com/ansible-collections/community.zabbix/issues/19)

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_template.py
@@ -417,6 +417,9 @@ class Template(object):
                     changed = True
                     break
 
+        if 'macros' not in existing_template['zabbix_export']['templates'][0]:
+            existing_template['zabbix_export']['templates'][0]['macros'] = []
+
         if template_macros is not None:
             existing_macros = existing_template['zabbix_export']['templates'][0]['macros']
             if template_macros != existing_macros:


### PR DESCRIPTION
##### SUMMARY
Backport of #66996
Fixes ansible-collections/community.zabbix#19

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zabbix_template