### PR TITLE
Raise exception in objects.py when vault is not found

### DIFF
--- a/changelogs/fragments/69240-add-exception-when-vault-not-found.yaml
+++ b/changelogs/fragments/69240-add-exception-when-vault-not-found.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- objects - Raise an exception when ``vault`` is not found.

--- a/lib/ansible/parsing/yaml/objects.py
+++ b/lib/ansible/parsing/yaml/objects.py
@@ -102,8 +102,7 @@ class AnsibleVaultEncryptedUnicode(yaml.YAMLObject, AnsibleBaseYAMLObject):
     @property
     def data(self):
         if not self.vault:
-            # FIXME: raise exception?
-            return self._ciphertext
+            raise Exception("Error while accessing vault. Vault not found.")
         return to_text(self.vault.decrypt(self._ciphertext))
 
     @data.setter


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added an exception to the `data()` function in the class `AnsibleVaultEncryptedUnicode` in `objects.py`. This exception should be thrown when `vault` is not found.

Please suggest any changes if a different exception should be raised, or if the message should be changed.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`objects.py`