### PR TITLE
RHEL 8.2 CI

### DIFF
--- a/changelogs/fragments/ansible-test-rhel-82.yml
+++ b/changelogs/fragments/ansible-test-rhel-82.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ansible-test - Now includes testing support for RHEL 8.2

--- a/changelogs/fragments/dnf-4-2-18.yml
+++ b/changelogs/fragments/dnf-4-2-18.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - dnf - Unified error messages when trying to install a nonexistent package with newer dnf (4.2.18) vs older dnf (4.2.9)
+  - dnf - Unified error messages when trying to remove a wildcard name that is not currently installed, with newer dnf (4.2.18) vs older dnf (4.2.9)

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -335,7 +335,10 @@ class DnfModule(YumDnf):
         For unhandled dnf.exceptions.Error scenarios, there are certain error
         messages we want to filter in an install scenario. Do that here.
         """
-        if to_text("no package matched") in to_text(error):
+        if (
+            to_text("no package matched") in to_text(error) or
+            to_text("No match for argument:") in to_text(error)
+        ):
             return "No package {0} available.".format(spec)
 
         return error
@@ -346,7 +349,10 @@ class DnfModule(YumDnf):
         messages we want to ignore in a removal scenario as known benign
         failures. Do that here.
         """
-        if 'no package matched' in to_native(error):
+        if (
+            'no package matched' in to_native(error) or
+            'No match for argument:' in to_native(error)
+        ):
             return (False, "{0} is not installed".format(spec))
 
         # Return value is tuple of:

--- a/shippable.yml
+++ b/shippable.yml
@@ -30,7 +30,7 @@ matrix:
     - env: T=aix/7.2/1
     - env: T=osx/10.11/1
     - env: T=rhel/7.8/1
-    - env: T=rhel/8.1/1
+    - env: T=rhel/8.2/1
     - env: T=freebsd/11.1/1
     - env: T=freebsd/12.1/1
     - env: T=linux/centos6/1
@@ -47,7 +47,7 @@ matrix:
     - env: T=aix/7.2/2
     - env: T=osx/10.11/2
     - env: T=rhel/7.8/2
-    - env: T=rhel/8.1/2
+    - env: T=rhel/8.2/2
     - env: T=freebsd/11.1/2
     - env: T=freebsd/12.1/2
     - env: T=linux/centos6/2
@@ -64,7 +64,7 @@ matrix:
     - env: T=aix/7.2/3
     - env: T=osx/10.11/3
     - env: T=rhel/7.8/3
-    - env: T=rhel/8.1/3
+    - env: T=rhel/8.2/3
     - env: T=freebsd/11.1/3
     - env: T=freebsd/12.1/3
     - env: T=linux/centos6/3
@@ -81,7 +81,7 @@ matrix:
     - env: T=aix/7.2/4
     - env: T=osx/10.11/4
     - env: T=rhel/7.8/4
-    - env: T=rhel/8.1/4
+    - env: T=rhel/8.2/4
     - env: T=freebsd/11.1/4
     - env: T=freebsd/12.1/4
     - env: T=linux/centos6/4
@@ -98,7 +98,7 @@ matrix:
     - env: T=aix/7.2/5
     - env: T=osx/10.11/5
     - env: T=rhel/7.8/5
-    - env: T=rhel/8.1/5
+    - env: T=rhel/8.2/5
     - env: T=freebsd/11.1/5
     - env: T=freebsd/12.1/5
     - env: T=linux/centos6/5
@@ -118,7 +118,7 @@ matrix:
     - env: T=i/aix/7.2
     - env: T=i/osx/10.11
     - env: T=i/rhel/7.8
-    - env: T=i/rhel/8.1
+    - env: T=i/rhel/8.2
     - env: T=i/freebsd/11.1
     - env: T=i/freebsd/12.1
     - env: T=i/linux/centos6

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -699,3 +699,14 @@
           - "'vim-minimal' in rpm_output.stdout"
   when:
     - ansible_distribution == 'Fedora'
+
+- name: Remove wildcard package that isn't installed
+  dnf:
+    name: firefox*
+    state: absent
+  register: wildcard_absent
+
+- assert:
+    that:
+      - wildcard_absent is successful
+      - wildcard_absent is not changed

--- a/test/integration/targets/dnf/tasks/dnfinstallroot.yml
+++ b/test/integration/targets/dnf/tasks/dnfinstallroot.yml
@@ -11,7 +11,8 @@
 
 - name: Populate directory
   copy:
-    content: "{{ ansible_distribution_version }}\n"
+    # We need '8' for CentOS, but '8.x' for RHEL.
+    content: "{{ ansible_distribution_version|int if ansible_distribution != 'RedHat' else ansible_distribution_version }}\n"
     dest: "/{{ dnfroot.stdout }}/etc/dnf/vars/releasever"
 
 # This will drag in > 200 MB.

--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -21,15 +21,15 @@
 
 - include_tasks: dnf.yml
   when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('23', '>=')) or
-        (ansible_distribution == 'RedHat' and ansible_distribution_major_version is version('8', '>='))
+        (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
 
 - include_tasks: repo.yml
   when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('23', '>=')) or
-        (ansible_distribution == 'RedHat' and ansible_distribution_major_version is version('8', '>='))
+        (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
 
 - include_tasks: dnfinstallroot.yml
   when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('23', '>=')) or
-        (ansible_distribution == 'RedHat' and ansible_distribution_major_version is version('8', '>='))
+        (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
 
 # Attempting to install a different RHEL release in a tmpdir doesn't work (rhel8 beta)
 - include_tasks: dnfreleasever.yml
@@ -39,4 +39,4 @@
 
 - include_tasks: modularity.yml
   when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('29', '>=')) or
-        (ansible_distribution == 'RedHat' and ansible_distribution_major_version is version('8', '>='))
+        (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))

--- a/test/integration/targets/dnf/vars/CentOS.yml
+++ b/test/integration/targets/dnf/vars/CentOS.yml
@@ -1,0 +1,2 @@
+astream_name: '@php:7.2/minimal'
+astream_name_no_stream: '@php/minimal'

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -4,5 +4,6 @@ osx/10.11 python=2.7 python_dir=/usr/local/bin
 rhel/7.6 python=2.7
 rhel/7.8 python=2.7
 rhel/8.1 python=3.6
+rhel/8.2 python=3.6
 aix/7.2 python=2.7 httptester=disabled temp-unicode=disabled pip-check=disabled
 power/centos/7 python=2.7


### PR DESCRIPTION
##### SUMMARY

- Add RHEL 8.2 to CI instead of 8.1.
- Fix `dnf` module to work with newer DNF versions
- Enable `dnf` tests on CentOS; we will intentionally keep a stale CentOS 8 in CI to test against old DNF.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

CI