### PR TITLE
[dnf] Make behavior/errors compatible for new DNF

### DIFF
--- a/changelogs/fragments/dnf-4-2-18.yml
+++ b/changelogs/fragments/dnf-4-2-18.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - dnf - Unified error messages when trying to install a nonexistent package with newer dnf vs older dnf
+  - dnf - Unified error messages when trying to remove a wildcard name that is not currently installed, with newer dnf vs older dnf

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -335,7 +335,10 @@ class DnfModule(YumDnf):
         For unhandled dnf.exceptions.Error scenarios, there are certain error
         messages we want to filter in an install scenario. Do that here.
         """
-        if to_text("no package matched") in to_text(error):
+        if (
+            to_text("no package matched") in to_text(error) or
+            to_text("No match for argument:") in to_text(error)
+        ):
             return "No package {0} available.".format(spec)
 
         return error
@@ -346,7 +349,10 @@ class DnfModule(YumDnf):
         messages we want to ignore in a removal scenario as known benign
         failures. Do that here.
         """
-        if 'no package matched' in to_native(error):
+        if (
+            'no package matched' in to_native(error) or
+            'No match for argument:' in to_native(error)
+        ):
             return (False, "{0} is not installed".format(spec))
 
         # Return value is tuple of:

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -699,3 +699,8 @@
           - "'vim-minimal' in rpm_output.stdout"
   when:
     - ansible_distribution == 'Fedora'
+
+- name: Remove wildcard package that isn't installed
+  dnf:
+    name: firefox*
+    state: absent

--- a/test/integration/targets/dnf/tasks/dnfinstallroot.yml
+++ b/test/integration/targets/dnf/tasks/dnfinstallroot.yml
@@ -11,7 +11,8 @@
 
 - name: Populate directory
   copy:
-    content: "{{ ansible_distribution_version }}\n"
+    # We need '8' for CentOS, but '8.x' for RHEL.
+    content: "{{ ansible_distribution_version|int if ansible_distribution != 'RedHat' else ansible_distribution_version }}\n"
     dest: "/{{ dnfroot.stdout }}/etc/dnf/vars/releasever"
 
 # This will drag in > 200 MB.

--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -21,15 +21,15 @@
 
 - include_tasks: dnf.yml
   when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('23', '>=')) or
-        (ansible_distribution == 'RedHat' and ansible_distribution_major_version is version('8', '>='))
+        (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
 
 - include_tasks: repo.yml
   when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('23', '>=')) or
-        (ansible_distribution == 'RedHat' and ansible_distribution_major_version is version('8', '>='))
+        (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
 
 - include_tasks: dnfinstallroot.yml
   when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('23', '>=')) or
-        (ansible_distribution == 'RedHat' and ansible_distribution_major_version is version('8', '>='))
+        (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
 
 # Attempting to install a different RHEL release in a tmpdir doesn't work (rhel8 beta)
 - include_tasks: dnfreleasever.yml
@@ -39,4 +39,4 @@
 
 - include_tasks: modularity.yml
   when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('29', '>=')) or
-        (ansible_distribution == 'RedHat' and ansible_distribution_major_version is version('8', '>='))
+        (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))

--- a/test/integration/targets/dnf/vars/CentOS.yml
+++ b/test/integration/targets/dnf/vars/CentOS.yml
@@ -1,0 +1,2 @@
+astream_name: '@php:7.2/minimal'
+astream_name_no_stream: '@php/minimal'


### PR DESCRIPTION
##### SUMMARY

Change:
Extend the logic for custom error handling in the dnf module, so that on
newer DNF (such as DNF that ships with modern Fedora 31 container
images, and ships with RHEL 8.2) we report errors consistently with
older DNF.

Test Plan:
Ran dnf integration tests against an old Fedora 31 container image and a
brand new Fedora 32 container image; tess passed on both.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

dnf