### PR TITLE
Add new comment attribute to template plugin

### DIFF
--- a/changelogs/fragments/69253-template-comment-attribute.yml
+++ b/changelogs/fragments/69253-template-comment-attribute.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - template - Add comment attributes (``comment_start_string`` and ``comment_end_string``)

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -37,7 +37,7 @@ class ActionModule(ActionBase):
         # Options type validation
         # stings
         for s_type in ('src', 'dest', 'state', 'newline_sequence', 'variable_start_string', 'variable_end_string', 'block_start_string',
-                       'block_end_string'):
+                       'block_end_string', 'comment_start_string', 'comment_end_string'):
             if s_type in self._task.args:
                 value = ensure_type(self._task.args[s_type], 'string')
                 if value is not None and not isinstance(value, string_types):
@@ -61,6 +61,8 @@ class ActionModule(ActionBase):
         variable_end_string = self._task.args.get('variable_end_string', None)
         block_start_string = self._task.args.get('block_start_string', None)
         block_end_string = self._task.args.get('block_end_string', None)
+        comment_start_string = self._task.args.get('comment_start_string', None)
+        comment_end_string = self._task.args.get('comment_end_string', None)
         output_encoding = self._task.args.get('output_encoding', 'utf-8') or 'utf-8'
 
         # Option `lstrip_blocks' was added in Jinja2 version 2.7.
@@ -140,6 +142,8 @@ class ActionModule(ActionBase):
                                                           block_end_string=block_end_string,
                                                           variable_start_string=variable_start_string,
                                                           variable_end_string=variable_end_string,
+                                                          comment_start_string=comment_start_string,
+                                                          comment_end_string=comment_end_string,
                                                           trim_blocks=trim_blocks,
                                                           lstrip_blocks=lstrip_blocks,
                                                           available_variables=temp_vars)
@@ -158,7 +162,7 @@ class ActionModule(ActionBase):
 
             # remove 'template only' options:
             for remove in ('newline_sequence', 'block_start_string', 'block_end_string', 'variable_start_string', 'variable_end_string',
-                           'trim_blocks', 'lstrip_blocks', 'output_encoding'):
+                           'comment_start_string', 'comment_end_string', 'trim_blocks', 'lstrip_blocks', 'output_encoding'):
                 new_task.args.pop(remove, None)
 
             local_tempdir = tempfile.mkdtemp(dir=C.DEFAULT_LOCAL_TMP)

--- a/lib/ansible/plugins/doc_fragments/template_common.py
+++ b/lib/ansible/plugins/doc_fragments/template_common.py
@@ -74,13 +74,13 @@ options:
     - The string marking the beginning of a comment statement.
     type: str
     default: '{#'
-    version_added: '2.9'
+    version_added: '2.10'
   comment_end_string:
     description:
     - The string marking the end of a comment statement.
     type: str
     default: '#}'
-    version_added: '2.9'
+    version_added: '2.10'
   trim_blocks:
     description:
     - Determine when newlines should be removed from blocks.

--- a/lib/ansible/plugins/doc_fragments/template_common.py
+++ b/lib/ansible/plugins/doc_fragments/template_common.py
@@ -69,6 +69,18 @@ options:
     type: str
     default: '}}'
     version_added: '2.4'
+  comment_start_string:
+    description:
+    - The string marking the beginning of a comment statement.
+    type: str
+    default: '{#'
+    version_added: '2.9'
+  comment_end_string:
+    description:
+    - The string marking the end of a comment statement.
+    type: str
+    default: '#}'
+    version_added: '2.9'
   trim_blocks:
     description:
     - Determine when newlines should be removed from blocks.

--- a/lib/ansible/plugins/doc_fragments/template_common.py
+++ b/lib/ansible/plugins/doc_fragments/template_common.py
@@ -73,13 +73,11 @@ options:
     description:
     - The string marking the beginning of a comment statement.
     type: str
-    default: '{#'
     version_added: '2.10'
   comment_end_string:
     description:
     - The string marking the end of a comment statement.
     type: str
-    default: '#}'
     version_added: '2.10'
   trim_blocks:
     description:

--- a/lib/ansible/plugins/doc_fragments/template_common.py
+++ b/lib/ansible/plugins/doc_fragments/template_common.py
@@ -73,12 +73,12 @@ options:
     description:
     - The string marking the beginning of a comment statement.
     type: str
-    version_added: '2.10'
+    version_added: '2.12'
   comment_end_string:
     description:
     - The string marking the end of a comment statement.
     type: str
-    version_added: '2.10'
+    version_added: '2.12'
   trim_blocks:
     description:
     - Determine when newlines should be removed from blocks.

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -50,7 +50,7 @@ DOCUMENTATION = """
         default: '{#'
         version_added: '2.9'
         type: str
-      variable_end_string:
+      comment_end_string:
         description: The string marking the end of a comment statement.
         default: '#}'
         version_added: '2.9'

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -45,6 +45,16 @@ DOCUMENTATION = """
         default: {}
         version_added: '2.3'
         type: dict
+      comment_start_string:
+        description: The string marking the beginning of a comment statement.
+        default: '{#'
+        version_added: '2.9'
+        type: str
+      variable_end_string:
+        description: The string marking the end of a comment statement.
+        default: '#}'
+        version_added: '2.9'
+        type: str
 """
 
 EXAMPLES = """
@@ -55,6 +65,10 @@ EXAMPLES = """
 - name: show templating results with different variable start and end string
   debug:
     msg: "{{ lookup('template', './some_template.j2', variable_start_string='[%', variable_end_string='%]') }}"
+
+- name: show templating results with different comment start and end string
+  debug:
+    msg: "{{ lookup('template', './some_template.j2', comment_start_string='[#', comment_end_string='#]') }}"
 """
 
 RETURN = """
@@ -94,6 +108,8 @@ class LookupModule(LookupBase):
         jinja2_native = self.get_option('jinja2_native')
         variable_start_string = self.get_option('variable_start_string')
         variable_end_string = self.get_option('variable_end_string')
+        comment_start_string = self.get_option('comment_start_string')
+        comment_end_string = self.get_option('comment_end_string')
 
         if USE_JINJA2_NATIVE and not jinja2_native:
             templar = self._templar.copy_with_new_env(environment_class=AnsibleEnvironment)
@@ -132,6 +148,8 @@ class LookupModule(LookupBase):
 
                 with templar.set_temporary_context(variable_start_string=variable_start_string,
                                                    variable_end_string=variable_end_string,
+                                                   comment_start_string=comment_start_string,
+                                                   comment_end_string=comment_end_string,
                                                    available_variables=vars, searchpath=searchpath):
                     res = templar.template(template_data, preserve_trailing_newlines=True,
                                            convert_data=convert_data_p, escape_backslashes=False)

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -47,11 +47,11 @@ DOCUMENTATION = """
         type: dict
       comment_start_string:
         description: The string marking the beginning of a comment statement.
-        version_added: '2.10'
+        version_added: '2.12'
         type: str
       comment_end_string:
         description: The string marking the end of a comment statement.
-        version_added: '2.10'
+        version_added: '2.12'
         type: str
 """
 

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -48,12 +48,12 @@ DOCUMENTATION = """
       comment_start_string:
         description: The string marking the beginning of a comment statement.
         default: '{#'
-        version_added: '2.9'
+        version_added: '2.10'
         type: str
       comment_end_string:
         description: The string marking the end of a comment statement.
         default: '#}'
-        version_added: '2.9'
+        version_added: '2.10'
         type: str
 """
 

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -47,12 +47,10 @@ DOCUMENTATION = """
         type: dict
       comment_start_string:
         description: The string marking the beginning of a comment statement.
-        default: '{#'
         version_added: '2.10'
         type: str
       comment_end_string:
         description: The string marking the end of a comment statement.
-        default: '#}'
         version_added: '2.10'
         type: str
 """

--- a/test/integration/targets/lookup_template/tasks/main.yml
+++ b/test/integration/targets/lookup_template/tasks/main.yml
@@ -17,3 +17,11 @@
 - assert:
     that:
       - "hello_world_string|trim == 'Hello world!'"
+
+- name: Test that we have a proper jinja search path in template lookup with different comment start and end string
+  set_fact:
+    hello_world_comment: "{{ lookup('template', 'hello_comment.txt', comment_start_string='[#', comment_end_string='#]') }}"
+
+- assert:
+    that:
+      - "hello_world_comment|trim == 'Hello world!'"

--- a/test/integration/targets/lookup_template/templates/hello_comment.txt
+++ b/test/integration/targets/lookup_template/templates/hello_comment.txt
@@ -1,0 +1,2 @@
+[# Comment #]
+Hello world!

--- a/test/integration/targets/template/files/custom_comment_string.expected
+++ b/test/integration/targets/template/files/custom_comment_string.expected
@@ -1,0 +1,2 @@
+Before
+After

--- a/test/integration/targets/template/tasks/main.yml
+++ b/test/integration/targets/template/tasks/main.yml
@@ -141,7 +141,7 @@
         - 'import_as_with_context_diff_result.stdout == ""'
         - "import_as_with_context_diff_result.rc == 0"
 
-# VERIFY comment_start_string
+# VERIFY comment_start_string and comment_end_string
 
 - name: Render a template with "comment_start_string" set to [#
   template:

--- a/test/integration/targets/template/tasks/main.yml
+++ b/test/integration/targets/template/tasks/main.yml
@@ -141,6 +141,26 @@
         - 'import_as_with_context_diff_result.stdout == ""'
         - "import_as_with_context_diff_result.rc == 0"
 
+# VERIFY comment_start_string
+
+- name: Render a template with "comment_start_string" set to [#
+  template:
+    src: custom_comment_string.j2
+    dest: "{{output_dir}}/custom_comment_string.templated"
+    comment_start_string: "[#"
+    comment_end_string: "#]"
+  register: custom_comment_string_result
+
+- name: Get checksum of known good custom_comment_string.expected
+  stat:
+    path: "{{role_path}}/files/custom_comment_string.expected"
+  register: custom_comment_string_good
+
+- name: Verify templated custom_comment_string matches known good using checksum
+  assert:
+    that:
+        - "custom_comment_string_result.checksum == custom_comment_string_good.stat.checksum"
+
 # VERIFY trim_blocks
 
 - name: Render a template with "trim_blocks" set to False

--- a/test/integration/targets/template/templates/custom_comment_string.j2
+++ b/test/integration/targets/template/templates/custom_comment_string.j2
@@ -1,0 +1,3 @@
+Before
+[# Test comment_start_string #]
+After


### PR DESCRIPTION
Add comment_start_string and comment_end_string attribute to template
plugin
Fixes #69254

##### SUMMARY
Implement comment_start_sting and comment_end_string for template action and lookup plugin.
In some situation, we need to change comment behaviour of template plugin, for an example macros in Zabbix is like {#MACRO}.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
template

##### ADDITIONAL INFORMATION

To use this change, you need to set comment_start_string and comment_end_string.

```paste below
- name: Render a template with "comment_start_string" set to [#
  template:
    src: template.xml.j2
    dest: template.xml
    comment_start_string: "[#"
    comment_end_string: "#]"
```
