### PR TITLE
Since we decided to keep the toml inventory plugin in ansible-base and support it, make it work out of the box.

### DIFF
--- a/changelogs/fragments/require-toml.yml
+++ b/changelogs/fragments/require-toml.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - Require the `toml` python library as the toml inventory plugin is now a supported offering.

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -173,11 +173,7 @@ class InventoryCLI(CLI):
             from ansible.parsing.yaml.dumper import AnsibleDumper
             results = yaml.dump(stuff, Dumper=AnsibleDumper, default_flow_style=False)
         elif context.CLIARGS['toml']:
-            from ansible.plugins.inventory.toml import toml_dumps, HAS_TOML
-            if not HAS_TOML:
-                raise AnsibleError(
-                    'The python "toml" library is required when using the TOML output format'
-                )
+            from ansible.plugins.inventory.toml import toml_dumps
             results = toml_dumps(stuff)
         else:
             import json

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -15,8 +15,6 @@ DOCUMENTATION = '''
     description:
         - TOML based inventory format
         - File MUST have a valid '.toml' file extension
-    notes:
-        - Requires the 'toml' python library
 '''
 
 EXAMPLES = '''
@@ -94,6 +92,8 @@ import os
 
 from functools import partial
 
+import toml
+
 from ansible.errors import AnsibleFileNotFound, AnsibleParserError
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.common._collections_compat import MutableMapping, MutableSequence
@@ -102,11 +102,6 @@ from ansible.parsing.yaml.objects import AnsibleSequence, AnsibleUnicode
 from ansible.plugins.inventory import BaseFileInventoryPlugin
 from ansible.utils.display import Display
 
-try:
-    import toml
-    HAS_TOML = True
-except ImportError:
-    HAS_TOML = False
 
 display = Display()
 
@@ -231,11 +226,6 @@ class InventoryModule(BaseFileInventoryPlugin):
 
     def parse(self, inventory, loader, path, cache=True):
         ''' parses the inventory file '''
-        if not HAS_TOML:
-            raise AnsibleParserError(
-                'The TOML inventory plugin requires the python "toml" library'
-            )
-
         display.warning(WARNING_MSG)
 
         super(InventoryModule, self).parse(inventory, loader, path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@
 jinja2
 PyYAML
 cryptography
+toml


### PR DESCRIPTION


##### SUMMARY
It was decided to support the toml inventory plugin rather than push it outside of ansible-base.  So make sure that it works out of the box.
 
https://github.com/ansible-community/collection_migration/issues/261

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
I removed the HAS_TOML code in a second commit.  If we think that we should keep that (for people who are running from git and won't automatically pick up the new dependency) then we can omit that commit.

\cc @thaumos @sivel @relrod