### PR TITLE
Don't wrap lines by default

### DIFF
--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -273,7 +273,7 @@ class Display(with_metaclass(Singleton, object)):
 
     def warning(self, msg, formatted=False):
 
-        if not formatted:
+        if formatted:
             new_msg = "[WARNING]: %s" % msg
             wrapped = textwrap.wrap(new_msg, self.columns)
             new_msg = "\n".join(wrapped) + "\n"
@@ -323,7 +323,7 @@ class Display(with_metaclass(Singleton, object)):
         (out, err) = cmd.communicate()
         self.display(u"%s\n" % to_text(out), color=color)
 
-    def error(self, msg, wrap_text=True):
+    def error(self, msg, wrap_text=False):
         if wrap_text:
             new_msg = u"\n[ERROR]: %s" % msg
             wrapped = textwrap.wrap(new_msg, self.columns)


### PR DESCRIPTION
##### SUMMARY
Don't wrap lines by default,  as this is done by user terminals and prevents output parsing, fixes #69258

This is an alternative to #69259.

Fixes #69258

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
`lib/ansible/utils/display.py`
