### PR TITLE
Add SLES to user_guide/playbook_conditionals.yml

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_conditionals.rst
+++ b/docs/docsite/rst/user_guide/playbooks_conditionals.rst
@@ -369,6 +369,7 @@ Possible values (sample, not complete list)::
     OracleLinux
     RedHat
     Slackware
+    SLES
     SMGL
     SUSE
     Ubuntu


### PR DESCRIPTION
##### SUMMARY
In the ansible_facts['distribution'] section, the list of common examples includes SUSE which I believes refers to openSUSE.
I suggest that we add SLES, which is what Suse Linux Enterprise Server is being reported as.
Not a major change, just a suggestion to help out users.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr