### PR TITLE
improve redis documentation to include an example with security

### DIFF
--- a/test/integration/targets/old_style_cache_plugins/plugins/cache/redis.py
+++ b/test/integration/targets/old_style_cache_plugins/plugins/cache/redis.py
@@ -15,7 +15,8 @@ DOCUMENTATION = '''
     options:
       _uri:
         description:
-          - A colon separated string of connection information for Redis.
+          - A colon separated string of connection information for Redis, which is host:port:db:password
+            For example (localhost:6379:0:changeme)
         required: True
         env:
           - name: ANSIBLE_CACHE_PLUGIN_CONNECTION


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Simple change to include an example for redis, had to do a decent amount of googling to be sure the uri with a password was as simple as it is. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cache/redis

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Just wanted to include a default example of a redis system in use with auth, wasn't obvious before (to me at least), didnt know if password was before or after the rest of the string or middle, etc.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
