### PR TITLE
changing $HOME to $HOSTNAME in Synopsis

### DIFF
--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -22,7 +22,7 @@ description:
      - The C(command) module takes the command name followed by a list of space-delimited arguments.
      - The given command will be executed on all selected nodes.
      - The command(s) will not be
-       processed through the shell, so variables like C($HOME) and operations
+       processed through the shell, so variables like C($HOSTNAME) and operations
        like C("*"), C("<"), C(">"), C("|"), C(";") and C("&") will not work.
        Use the M(shell) module if you need these features.
      - To create C(command) tasks that are easier to read than the ones using space-delimited


### PR DESCRIPTION
##### SUMMARY
I see $HOME variable does work with command module, $HOSTNAME does not work as it set by shell.
Hence changing $HOME with $HOSTNAME in the Synopsis of command module documentation page.
<!--- Your description here -->


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
Command module documentation 

##### ADDITIONAL INFORMATION

```
# ansible  mynode.example.com -m command -a 'echo $HOME' -u ec2-user -i inventory 
mynode.example.com | CHANGED | rc=0 >>
/home/ec2-user

# ansible  mynode.example.com -m command -a 'echo $HOSTNAME' -u ec2-user -i inventory 
mynode.example.com | CHANGED | rc=0 >>
$HOSTNAME
```
