### PR TITLE
Support configuration around conditional checking

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1953,4 +1953,15 @@ VERBOSE_TO_STDERR:
     - section: defaults
       key: verbose_to_stderr
   type: bool
+CHECK_CONDITIONAL_TEMPLATING:
+  name: Controls whether conditional statements are checked for jinja2 templating
+  default: True
+  description: If 'false', conditional statements including jinja2 templating will not generate a warning
+  type: boolean
+  env:
+    - name: ANSIBLE_CHECK_CONDITIONAL_TEMPLATING
+  ini:
+    - key: check_conditional_templating
+      section: defaults
+  version_added: "2.11"
 ...

--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -114,7 +114,7 @@ class Conditional:
         if isinstance(conditional, bool):
             return conditional
 
-        if templar.is_template(conditional):
+        if C.CHECK_CONDITIONAL_TEMPLATING and templar.is_template(conditional):
             display.warning('conditional statements should not include jinja2 '
                             'templating delimiters such as {{ }} or {%% %%}. '
                             'Found: %s' % conditional)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Enhances the work done by @sivel in #20312 to allow those with use cases for evaluating conditional statements before use without generating warning

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
conditional

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I like to use the `assert` module to verify required information has been provided before proceeding with certain tasks that are problematic to rollback in the middle of.  Rather than writing a single task per variable I want to check, I prefer to have a single task check a list of variables.  There are some variables that are conditionally used, so I want to skip asserting them if possible.  The following snippet is a generalized form I'm using: 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
- name: "Assert variables"
  assert:
    that:
      - lookup('vars', item.var) is defined
      - lookup('vars', item.var) | default()
    fail_msg: "{{ item.var }} must be defined and not empty"
    quiet: true
  when: item.when | default(true)
  with_items:
    - var: ex_a
    - var: ex_b

    - var: ex_c
      when: "{{ ex_c_enabled }}"
```

This does what I need but the loop description isn't exactly useful:
```shell
TASK [Assert variables] ***************************************
ok: [example] => (item={u'var': u'ex_a'})
ok: [example] => (item={u'var': u'ex_b'})
skipping: [example] => (item={u'var': u'ex_c', u'when': False}) 
```

If I alter this slightly:
```yaml
- name: "Assert variables"
  assert:
    that:
      - lookup('vars', item.var) is defined
      - lookup('vars', item.var) | default()
    fail_msg: "{{ item.var }} must be defined and not empty"
    quiet: true
  when: "{{ item.when | default(true) }}"
  with_items:
    - var: ex_a
    - var: ex_b

    - var: ex_c
      when: ex_c_enabled
```

I get something I like better but the warning is distracting and confusing when this is intended:
```shell
TASK [Assert variables] ***************************************
 [WARNING]: conditional statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ item.when | default(true) }}
ok: [example] => (item={u'var': u'ex_a'})
ok: [example] => (item={u'var': u'ex_b'})
skipping: [example] => (item={u'var': u'ex_c', u'when': u'ex_c_enabled | bool'}) 
```

With these changes, I get to choose to use a feature in a way the original author of #20312 couldn't predict.