### PR TITLE
Add custom globals to the environment, and not per template

### DIFF
--- a/changelogs/fragments/69278-early-customize-jinja2.yml
+++ b/changelogs/fragments/69278-early-customize-jinja2.yml
@@ -1,0 +1,5 @@
+minor_changes:
+- Templating - Add globals to the jinja2 environment at ``Templar``
+  instantiation, instead of customizing the template object.
+  Only customize the template object, to disable lookups.
+  (https://github.com/ansible/ansible/pull/69278)

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -469,6 +469,15 @@ class Templar:
             loader=FileSystemLoader(self._basedir),
         )
 
+        # jinja2 global is inconsistent across versions, this normalizes them
+        self.environment.globals['dict'] = dict
+
+        # Custom globals
+        self.environment.globals['lookup'] = self._lookup
+        self.environment.globals['query'] = self.environment.globals['q'] = self._query_lookup
+        self.environment.globals['now'] = self._now_datetime
+        self.environment.globals['finalize'] = self._finalize
+
         # the current rendering context under which the templar class is working
         self.cur_context = None
 
@@ -882,18 +891,8 @@ class Templar:
                 else:
                     return data
 
-            # jinja2 global is inconsistent across versions, this normalizes them
-            t.globals['dict'] = dict
-
             if disable_lookups:
                 t.globals['query'] = t.globals['q'] = t.globals['lookup'] = self._fail_lookup
-            else:
-                t.globals['lookup'] = self._lookup
-                t.globals['query'] = t.globals['q'] = self._query_lookup
-
-            t.globals['now'] = self._now_datetime
-
-            t.globals['finalize'] = self._finalize
 
             jvars = AnsibleJ2Vars(self, t.globals)
 


### PR DESCRIPTION
##### SUMMARY
Add custom globals to the environment, and not per template

This produces an environment, that is more similar to what is used when calling `templar.template`.  `lookups` are disable on the template if necessary.

This makes an `environmentfilter` filter more powerful, as it now has access to our custom globals.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```
lib/ansible/template/__init__.py
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
