### PR TITLE
Fix error parsing Cisco IOS interface (suggested patch)

### DIFF
--- a/changelogs/fragments/69280-fix-cisco-parsing-ios-interface.yaml
+++ b/changelogs/fragments/69280-fix-cisco-parsing-ios-interface.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- parse_cli - Fix error parsing Cisco IOS interface using ``start_block`` and ``end_block`` parameters.

--- a/test/support/network-integration/collections/ansible_collections/ansible/netcommon/plugins/filter/network.py
+++ b/test/support/network-integration/collections/ansible_collections/ansible/netcommon/plugins/filter/network.py
@@ -131,6 +131,7 @@ def parse_cli(output, tmpl):
                     if lines:
                         lines.append(line)
                         blocks.append("\n".join(lines))
+                        lines = None
                     block_started = False
 
                 elif block_started:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Suggest patch from/closes #69277.

Set `lines = None` if `match_end = end_block.match(line)`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`parse_cli`
