### PR TITLE
Add note in inventory guide saying group names follow variable name guidelines

### DIFF
--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -36,6 +36,7 @@ The most common formats are INI and YAML. A basic INI ``/etc/ansible/hosts`` mig
 
 The headings in brackets are group names, which are used in classifying hosts
 and deciding what hosts you are controlling at what times and for what purpose.
+Group names should follow the same guidelines as :ref:`valid_variable_names`.
 
 Here's that same basic inventory file in YAML format:
 


### PR DESCRIPTION
##### SUMMARY
Update docs for inventory groups to mention that group names should follow the same naming guidelines as variables: only letters, numbers, and underscore are allowed.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
intro_inventory.rst

##### ADDITIONAL INFORMATION
This was brought up because of [this SO question](https://stackoverflow.com/q/56332403/1354930) and the [associated answer](https://stackoverflow.com/a/56345970/1354930).

The warning for `TRANSFORM_INVALID_GROUP_CHARS` does not mention which characters are invalid, and I couldn't find anywhere else in the docs that said that group names are essentially variable names.