### PR TITLE
ansible-test validate-modules: don't allow arbitrary lists and dicts for 'default', 'sample' and 'example'

### DIFF
--- a/changelogs/fragments/69287-ansible-test-validate-default-sample-example.yml
+++ b/changelogs/fragments/69287-ansible-test-validate-default-sample-example.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "ansible-test - improve module validation so that ``default``, ``sample`` and ``example`` contain JSON values and not arbitrary YAML values, like ``datetime`` objects or dictionaries with non-string keys."

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -152,8 +152,7 @@ json_value = Schema(Any(
     int,
     float,
     [Self],
-    *list({str_type: Self} for str_type in string_types),
-    *string_types
+    *(list({str_type: Self} for str_type in string_types) + list(string_types))
 ))
 
 

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -147,6 +147,16 @@ def ansible_module_kwargs_schema():
     return Schema(schema)
 
 
+json_value = Schema(Any(
+    None,
+    int,
+    float,
+    [Self],
+    *list({str_type: Self} for str_type in string_types),
+    *string_types
+))
+
+
 suboption_schema = Schema(
     {
         Required('description'): Any(list_string_types, *string_types),
@@ -154,7 +164,7 @@ suboption_schema = Schema(
         'choices': list,
         'aliases': Any(list_string_types),
         'version_added': Any(float, *string_types),
-        'default': Any(None, float, int, bool, list, dict, *string_types),
+        'default': json_value,
         # Note: Types are strings, not literal bools, such as True or False
         'type': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
         # in case of type='list' elements define type of individual item in list
@@ -176,7 +186,7 @@ option_schema = Schema(
         'choices': list,
         'aliases': Any(list_string_types),
         'version_added': Any(float, *string_types),
-        'default': Any(None, float, int, bool, list, dict, *string_types),
+        'default': json_value,
         'suboptions': Any(None, *list_dict_suboption_schema),
         # Note: Types are strings, not literal bools, such as True or False
         'type': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
@@ -211,8 +221,8 @@ return_contains_schema = Any(
                 'returned': Any(*string_types),  # only returned on top level
                 Required('type'): Any('bool', 'complex', 'dict', 'float', 'int', 'list', 'str'),
                 'version_added': Any(float, *string_types),
-                'sample': Any(None, list, dict, int, float, *string_types),
-                'example': Any(None, list, dict, int, float, *string_types),
+                'sample': json_value,
+                'example': json_value,
                 'contains': Any(None, *list({str_type: Self} for str_type in string_types)),
                 # in case of type='list' elements define type of individual item in list
                 'elements': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
@@ -236,8 +246,8 @@ return_schema = Any(
                     Required('returned'): Any(*string_types),
                     Required('type'): Any('bool', 'complex', 'dict', 'float', 'int', 'list', 'str'),
                     'version_added': Any(float, *string_types),
-                    'sample': Any(None, list, dict, int, float, *string_types),
-                    'example': Any(None, list, dict, int, float, *string_types),
+                    'sample': json_value,
+                    'example': json_value,
                     'contains': Any(None, *list_dict_return_contains_schema),
                     # in case of type='list' elements define type of individual item in list
                     'elements': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),


### PR DESCRIPTION
##### SUMMARY
This improves validation to prevent problems which caused #69031.

(The remaining problems of this type in stable-2.9 are fixed in #69221 and #69166. The problems in collections I know about have already been fixed.)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test
