### PR TITLE
ansible-test ansible-doc sanity test: also run with --json parameter

### DIFF
--- a/changelogs/fragments/69288-ansible-test-ansible-doc-json.yml
+++ b/changelogs/fragments/69288-ansible-test-ansible-doc-json.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "ansible-test - also run the ``ansible-doc`` sanity test with ``--json`` to ensure that the documentation does not contain something that cannot be exported as JSON (https://github.com/ansible/ansible/issues/69238)."

--- a/test/lib/ansible_test/_internal/sanity/ansible_doc.py
+++ b/test/lib/ansible_test/_internal/sanity/ansible_doc.py
@@ -103,32 +103,36 @@ class AnsibleDocTest(SanitySingleVersion):
         error_messages = []
 
         for doc_type in sorted(doc_targets):
-            cmd = ['ansible-doc', '-t', doc_type] + sorted(doc_targets[doc_type])
+            for format in [None, '--json']:
+                cmd = ['ansible-doc', '-t', doc_type]
+                if format is not None:
+                    cmd.append(format)
+                cmd.extend(sorted(doc_targets[doc_type]))
 
-            try:
-                with coverage_context(args):
-                    stdout, stderr = intercept_command(args, cmd, target_name='ansible-doc', env=env, capture=True, python_version=python_version)
+                try:
+                    with coverage_context(args):
+                        stdout, stderr = intercept_command(args, cmd, target_name='ansible-doc', env=env, capture=True, python_version=python_version)
 
-                status = 0
-            except SubprocessError as ex:
-                stdout = ex.stdout
-                stderr = ex.stderr
-                status = ex.status
+                    status = 0
+                except SubprocessError as ex:
+                    stdout = ex.stdout
+                    stderr = ex.stderr
+                    status = ex.status
 
-            if status:
-                summary = u'%s' % SubprocessError(cmd=cmd, status=status, stderr=stderr)
-                return SanityFailure(self.name, summary=summary)
+                if status:
+                    summary = u'%s' % SubprocessError(cmd=cmd, status=status, stderr=stderr)
+                    return SanityFailure(self.name, summary=summary)
 
-            if stdout:
-                display.info(stdout.strip(), verbosity=3)
+                if stdout:
+                    display.info(stdout.strip(), verbosity=3)
 
-            if stderr:
-                # ignore removed module/plugin warnings
-                stderr = re.sub(r'\[WARNING\]: [^ ]+ [^ ]+ has been removed\n', '', stderr).strip()
+                if stderr:
+                    # ignore removed module/plugin warnings
+                    stderr = re.sub(r'\[WARNING\]: [^ ]+ [^ ]+ has been removed\n', '', stderr).strip()
 
-            if stderr:
-                summary = u'Output on stderr from ansible-doc is considered an error.\n\n%s' % SubprocessError(cmd, stderr=stderr)
-                return SanityFailure(self.name, summary=summary)
+                if stderr:
+                    summary = u'Output on stderr from ansible-doc is considered an error.\n\n%s' % SubprocessError(cmd, stderr=stderr)
+                    return SanityFailure(self.name, summary=summary)
 
         if args.explain:
             return SanitySuccess(self.name)

--- a/test/lib/ansible_test/_internal/sanity/ansible_doc.py
+++ b/test/lib/ansible_test/_internal/sanity/ansible_doc.py
@@ -103,10 +103,10 @@ class AnsibleDocTest(SanitySingleVersion):
         error_messages = []
 
         for doc_type in sorted(doc_targets):
-            for format in [None, '--json']:
+            for format_option in [None, '--json']:
                 cmd = ['ansible-doc', '-t', doc_type]
-                if format is not None:
-                    cmd.append(format)
+                if format_option is not None:
+                    cmd.append(format_option)
                 cmd.extend(sorted(doc_targets[doc_type]))
 
                 try:


### PR DESCRIPTION
##### SUMMARY
Makes sure `ansible-doc` is also run with `--json` parameter. This catches modules/plugins whose documentation contains values which are not JSON, resp. (after the changes in #68600) cannot be exported.

Fixes #69238.

For community.aws with ansible-collections/community.aws@dedf734b21def6c1968869f8ac57cf59a20ee18f reversed, the output looks like:
```
Run command: ansible-doc -t connection community.aws.aws_ssm
Run command: ansible-doc -t connection --json community.aws.aws_ssm
Run command: ansible-doc -t module community.aws.aws_acm community.aws.aws_acm_info community.aws.aws_api_gateway community.aws.aws_application_scaling_p ...
Run command: ansible-doc -t module --json community.aws.aws_acm community.aws.aws_acm_info community.aws.aws_api_gateway community.aws.aws_application_sc ...
ERROR: Command "ansible-doc -t module --json community.aws.aws_acm community.aws.aws_acm_info community.aws.aws_api_gateway community.aws.aws_application_scaling_policy community.aws.aws_batch_compute_environment community.aws.aws_batch_job_definition community.aws.aws_batch_job_queue community.aws.aws_codebuild community.aws.aws_codecommit community.aws.aws_codepipeline community.aws.aws_config_aggregation_authorization community.aws.aws_config_aggregator community.aws.aws_config_delivery_channel community.aws.aws_config_recorder community.aws.aws_config_rule community.aws.aws_direct_connect_connection community.aws.aws_direct_connect_gateway community.aws.aws_direct_connect_link_aggregation_group community.aws.aws_direct_connect_virtual_interface community.aws.aws_eks_cluster community.aws.aws_elasticbeanstalk_app community.aws.aws_glue_connection community.aws.aws_glue_job community.aws.aws_inspector_target community.aws.aws_kms community.aws.aws_kms_info community.aws.aws_region_info community.aws.aws_s3_bucket_info community.aws.aws_s3_cors community.aws.aws_secret community.aws.aws_ses_identity community.aws.aws_ses_identity_policy community.aws.aws_ses_rule_set community.aws.aws_sgw_info community.aws.aws_ssm_parameter_store community.aws.aws_step_functions_state_machine community.aws.aws_step_functions_state_machine_execution community.aws.aws_waf_condition community.aws.aws_waf_info community.aws.aws_waf_rule community.aws.aws_waf_web_acl community.aws.cloudformation_exports_info community.aws.cloudformation_stack_set community.aws.cloudfront_distribution community.aws.cloudfront_info community.aws.cloudfront_invalidation community.aws.cloudfront_origin_access_identity community.aws.cloudtrail community.aws.cloudwatchevent_rule community.aws.cloudwatchlogs_log_group community.aws.cloudwatchlogs_log_group_info community.aws.cloudwatchlogs_log_group_metric_filter community.aws.data_pipeline community.aws.dms_endpoint community.aws.dms_replication_subnet_group community.aws.dynamodb_table community.aws.dynamodb_ttl community.aws.ec2_ami_copy community.aws.ec2_asg community.aws.ec2_asg_info community.aws.ec2_asg_lifecycle_hook community.aws.ec2_customer_gateway community.aws.ec2_customer_gateway_info community.aws.ec2_eip community.aws.ec2_eip_info community.aws.ec2_elb community.aws.ec2_elb_info community.aws.ec2_instance community.aws.ec2_instance_info community.aws.ec2_launch_template community.aws.ec2_lc community.aws.ec2_lc_find community.aws.ec2_lc_info community.aws.ec2_metric_alarm community.aws.ec2_placement_group community.aws.ec2_placement_group_info community.aws.ec2_scaling_policy community.aws.ec2_snapshot_copy community.aws.ec2_transit_gateway community.aws.ec2_transit_gateway_info community.aws.ec2_vpc_egress_igw community.aws.ec2_vpc_endpoint community.aws.ec2_vpc_endpoint_info community.aws.ec2_vpc_igw community.aws.ec2_vpc_igw_info community.aws.ec2_vpc_nacl community.aws.ec2_vpc_nacl_info community.aws.ec2_vpc_nat_gateway community.aws.ec2_vpc_nat_gateway_info community.aws.ec2_vpc_peer community.aws.ec2_vpc_peering_info community.aws.ec2_vpc_route_table community.aws.ec2_vpc_route_table_info community.aws.ec2_vpc_vgw community.aws.ec2_vpc_vgw_info community.aws.ec2_vpc_vpn community.aws.ec2_vpc_vpn_info community.aws.ec2_win_password community.aws.ecs_attribute community.aws.ecs_cluster community.aws.ecs_ecr community.aws.ecs_service community.aws.ecs_service_info community.aws.ecs_tag community.aws.ecs_task community.aws.ecs_taskdefinition community.aws.ecs_taskdefinition_info community.aws.efs community.aws.efs_info community.aws.elasticache community.aws.elasticache_info community.aws.elasticache_parameter_group community.aws.elasticache_snapshot community.aws.elasticache_subnet_group community.aws.elb_application_lb community.aws.elb_application_lb_info community.aws.elb_classic_lb community.aws.elb_classic_lb_info community.aws.elb_instance community.aws.elb_network_lb community.aws.elb_target community.aws.elb_target_group community.aws.elb_target_group_info community.aws.elb_target_info community.aws.execute_lambda community.aws.iam community.aws.iam_cert community.aws.iam_group community.aws.iam_managed_policy community.aws.iam_mfa_device_info community.aws.iam_password_policy community.aws.iam_policy community.aws.iam_policy_info community.aws.iam_role community.aws.iam_role_info community.aws.iam_saml_federation community.aws.iam_server_certificate_info community.aws.iam_user community.aws.iam_user_info community.aws.kinesis_stream community.aws.lambda community.aws.lambda_alias community.aws.lambda_event community.aws.lambda_facts community.aws.lambda_info community.aws.lambda_policy community.aws.lightsail community.aws.rds community.aws.rds_instance community.aws.rds_instance_info community.aws.rds_param_group community.aws.rds_snapshot community.aws.rds_snapshot_info community.aws.rds_subnet_group community.aws.redshift community.aws.redshift_cross_region_snapshots community.aws.redshift_info community.aws.redshift_subnet_group community.aws.route53 community.aws.route53_health_check community.aws.route53_info community.aws.route53_zone community.aws.s3_bucket_notification community.aws.s3_lifecycle community.aws.s3_logging community.aws.s3_sync community.aws.s3_website community.aws.sns community.aws.sns_topic community.aws.sqs_queue community.aws.sts_assume_role community.aws.sts_session_token" returned exit status 1.
>>> Standard Error
ERROR! We could not convert all the documentation into JSON as there was a conversion issue: '<' not supported between instances of 'int' and 'str'
ERROR: The 1 sanity test(s) listed below (out of 1) failed. See error output above for details.
ansible-doc
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test
