### PR TITLE
[WIP] ansible-test: allow version_added tests for collections

### DIFF
--- a/test/lib/ansible_test/_internal/cli/commands/sanity.py
+++ b/test/lib/ansible_test/_internal/cli/commands/sanity.py
@@ -16,10 +16,6 @@ from ...target import (
     walk_sanity_targets,
 )
 
-from ...data import (
-    data_context,
-)
-
 from ..environments import (
     CompositeActionCompletionFinder,
     ControllerMode,
@@ -81,16 +77,20 @@ def do_sanity(
         help='enable optional errors',
     )
 
-    if data_context().content.is_ansible:
-        sanity.add_argument(
-            '--keep-git',
-            action='store_true',
-            help='transfer git related files to the remote host/container',
-        )
-    else:
-        sanity.set_defaults(
-            keep_git=False,
-        )
+    sanity.add_argument(
+        '--collection-version_added',
+        metavar='VERSION',
+        nargs='?',
+        default=None,
+        const='auto',
+        help='Enable version_added checks for collections. Optionally specify expected value to compare to',
+    )
+
+    sanity.add_argument(
+        '--keep-git',
+        action='store_true',
+        help='transfer git related files to the remote host/container',
+    )
 
     sanity.add_argument(
         '--lint',

--- a/test/lib/ansible_test/_internal/commands/sanity/validate_modules.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/validate_modules.py
@@ -117,19 +117,31 @@ class ValidateModulesTest(SanitySingleVersion):
             '--arg-spec',
         ]
 
+        needs_base_branch = False
         if data_context().content.collection:
             cmd.extend(['--collection', data_context().content.collection.directory])
+            if args.collection_version_added and args.collection_version_added != 'auto':
+                cmd.extend(['--collection-version_added', args.collection_version_added])
+                needs_base_branch = True
 
             try:
                 collection_detail = get_collection_detail(args, python)
 
                 if collection_detail.version:
                     cmd.extend(['--collection-version', collection_detail.version])
+                    if args.collection_version_added == 'auto':
+                        cmd.extend(['--collection-version_added', collection_detail.version])
+                        needs_base_branch = True
                 else:
                     display.warning('Skipping validate-modules collection version checks since no collection version was found.')
+                    if args.collection_version_added == 'auto':
+                        display.warning('Skipping validate-modules collection version_added checks since no collection version was found.')
             except CollectionDetailError as ex:
                 display.warning('Skipping validate-modules collection version checks since collection detail loading failed: %s' % ex.reason)
         else:
+            needs_base_branch = True
+
+        if needs_base_branch:
             base_branch = args.base_branch or get_ci_provider().get_base_branch()
 
             if base_branch:

--- a/test/lib/ansible_test/_internal/config.py
+++ b/test/lib/ansible_test/_internal/config.py
@@ -250,6 +250,7 @@ class SanityConfig(TestConfig):
         self.list_tests = args.list_tests  # type: bool
         self.allow_disabled = args.allow_disabled  # type: bool
         self.enable_optional_errors = args.enable_optional_errors  # type: bool
+        self.collection_version_added = args.collection_version_added  # type: str
         self.keep_git = args.keep_git  # type: bool
         self.prime_venvs = args.prime_venvs  # type: bool
 


### PR DESCRIPTION
##### SUMMARY
IMO this is necessary for proper module documentation.

This is a WIP since it builds on top of #66920 for some collection-related data handling. I've tested it manually with `community.crypto`, and it works as expected.

There is now a new option, `--collection-version_added`, which uses the collection's version by default (extracted from `galaxy.yml` resp. `MANIFEST.json`), or an explicit value like `1.0.0` when the form `--collection-version_added 1.0.0` is used. This allows collections to chose their own strategy on what kind of values `version_added` should get.

For this to work, both `--base-branch` and `--docker-keep-git` have to be specified (the latter only when running with `--docker`), like this:
```
ansible-test sanity --docker --docker-keep-git -v --collection-version_added 1.0.0 --base-branch master --test validate-modules
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test
