### PR TITLE
yum: avoid running non-yum modules via the action

### DIFF
--- a/changelogs/fragments/yum_backend_validation.yml
+++ b/changelogs/fragments/yum_backend_validation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- yum - yum tasks can no longer end up running non-yum modules

--- a/lib/ansible/plugins/action/yum.py
+++ b/lib/ansible/plugins/action/yum.py
@@ -22,6 +22,8 @@ from ansible.utils.display import Display
 
 display = Display()
 
+VALID_BACKENDS = frozenset(('yum', 'yum4', 'dnf'))
+
 
 class ActionModule(ActionBase):
 
@@ -56,15 +58,23 @@ class ActionModule(ActionBase):
             except Exception:
                 pass  # could not get it from template!
 
-        if module not in ["yum", "yum4", "dnf"]:
+        if module not in VALID_BACKENDS:
             facts = self._execute_module(module_name="setup", module_args=dict(filter="ansible_pkg_mgr", gather_subset="!all"), task_vars=task_vars)
             display.debug("Facts %s" % facts)
             module = facts.get("ansible_facts", {}).get("ansible_pkg_mgr", "auto")
             if (not self._task.delegate_to or self._task.delegate_facts) and module != 'auto':
                 result['ansible_facts'] = {'pkg_mgr': module}
 
-        if module != "auto":
+        if module not in VALID_BACKENDS:
+            result.update(
+                {
+                    'failed': True,
+                    'msg': ("Could not detect which major revision of yum is in use, which is required to determine module backend.",
+                            "You should manually specify use_backend to tell the module whether to use the yum (yum3) or dnf (yum4) backend})"),
+                }
+            )
 
+        else:
             if module == "yum4":
                 module = "dnf"
 
@@ -78,16 +88,6 @@ class ActionModule(ActionBase):
 
                 display.vvvv("Running %s as the backend for the yum action plugin" % module)
                 result.update(self._execute_module(module_name=module, module_args=new_module_args, task_vars=task_vars, wrap_async=self._task.async_val))
-                # Now fall through to cleanup
-        else:
-            result.update(
-                {
-                    'failed': True,
-                    'msg': ("Could not detect which major revision of yum is in use, which is required to determine module backend.",
-                            "You can manually specify use_backend to tell the module whether to use the yum (yum3) or dnf (yum4) backend})"),
-                }
-            )
-            # Now fall through to cleanup
 
         # Cleanup
         if not self._task.async_val:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If the system's detected package manager is not yum or dnf it should refuse to run without an explicit backend, instead of running the non-yum module.

Fixes #62362

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum