### PR TITLE
plugin_formatter - Properly exit when invoked with incorrect parameters

### DIFF
--- a/changelogs/fragments/69312-plugin-formatter-typeerror.yaml
+++ b/changelogs/fragments/69312-plugin-formatter-typeerror.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- plugin_formatter - Properly exit when invoked with incorrect parameters
+  (https://github.com/ansible/ansible/issues/69312)

--- a/hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
+++ b/hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
@@ -678,9 +678,9 @@ def validate_options(options):
     ''' validate option parser options '''
 
     if not options.module_dir:
-        sys.exit("--module-dir is required", file=sys.stderr)
+        sys.exit("--module-dir is required")
     if not os.path.exists(options.module_dir):
-        sys.exit("--module-dir does not exist: %s" % options.module_dir, file=sys.stderr)
+        sys.exit("--module-dir does not exist: %s" % options.module_dir)
     if not options.template_dir:
         sys.exit("--template-dir must be specified")
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #69312

Properly exit when invoked with incorrect parameters.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

plugin_formatter.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

See issue #69312.
