### PR TITLE
Remove Ansible.Service from routing

### DIFF
--- a/lib/ansible/config/routing.yml
+++ b/lib/ansible/config/routing.yml
@@ -7828,8 +7828,6 @@ plugin_routing:
       redirect: ansible.netcommon.restconf
     ismount:
       redirect: ansible.posix.ismount
-    Ansible.Service:
-      redirect: ansible.windows.Ansible.Service
     fortimanager:
       redirect: fortinet.fortios.fortimanager
     system:


### PR DESCRIPTION
##### SUMMARY
This was renamed to [SCManager](https://github.com/ansible-collections/ansible.windows/blob/master/plugins/module_utils/SCManager.cs) in `ansible.windows` but because it was never part of an Ansible release there is no reason to have a routing entry for this.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
routing.yml