### PR TITLE
headless apt-get install python-apt

### DIFF
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1057,7 +1057,9 @@ def main():
                 module.warn("Updating cache and auto-installing missing dependency: %s" % PYTHON_APT)
                 module.run_command(['apt-get', 'update'], check_rc=True)
 
-            module.run_command(['apt-get', 'install', '--no-install-recommends', PYTHON_APT, '-y', '-q'], check_rc=True)
+            options = [expand_dpkg_options(module.params.get('dpkg_options')), '--no-install-recommends', '--yes', '--quiet']
+            module.run_command(['apt-get', 'install', PYTHON_APT] + options, check_rc=True)
+
             global apt, apt_pkg
             import apt
             import apt.debfile


### PR DESCRIPTION
##### SUMMARY
The initial apt-get install python3-apt was missing the dpkg_options
This can cause the operation to hang if python-apt drags in dependencies
which desire user interaction.

Fixes #63134

Signed-off-by: David Tulloh <git-david@tulloh.id.au>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
modules/packaging/os/apt

##### ADDITIONAL INFORMATION
Could not craft a nice concise integration test to excite the bug.
Passes existing integration tests.