### PR TITLE
[2.9] plugin_formatter: sys.exit does not take a file argument

### DIFF
--- a/hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
+++ b/hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
@@ -678,9 +678,9 @@ def validate_options(options):
     ''' validate option parser options '''
 
     if not options.module_dir:
-        sys.exit("--module-dir is required", file=sys.stderr)
+        sys.exit("--module-dir is required")
     if not os.path.exists(options.module_dir):
-        sys.exit("--module-dir does not exist: %s" % options.module_dir, file=sys.stderr)
+        sys.exit("--module-dir does not exist: %s" % options.module_dir)
     if not options.template_dir:
         sys.exit("--template-dir must be specified")
 


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/68016


Cleanup of leftover from bcdfdc0cc33155598edfd4752db85c6358b17864.

sys.exit does not take any named argument.

(cherry picked from commit cdad594b1690a8354a7ee6dee75a6123fb13203b)


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
