### PR TITLE
distribution: Added support for openEuler OS

### DIFF
--- a/changelogs/fragments/openeuler_distribution_support.yml
+++ b/changelogs/fragments/openeuler_distribution_support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Added openEuler OS in RedHat OS Family.

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -467,7 +467,8 @@ class Distribution(object):
     # keep keys in sync with Conditionals page of docs
     OS_FAMILY_MAP = {'RedHat': ['RedHat', 'Fedora', 'CentOS', 'Scientific', 'SLC',
                                 'Ascendos', 'CloudLinux', 'PSBM', 'OracleLinux', 'OVS',
-                                'OEL', 'Amazon', 'Virtuozzo', 'XenServer', 'Alibaba', 'EulerOS'],
+                                'OEL', 'Amazon', 'Virtuozzo', 'XenServer', 'Alibaba',
+                                'EulerOS', 'openEuler'],
                      'Debian': ['Debian', 'Ubuntu', 'Raspbian', 'Neon', 'KDE neon',
                                 'Linux Mint', 'SteamOS', 'Devuan', 'Kali', 'Cumulus Linux',
                                 'Pop!_OS', ],

--- a/test/units/module_utils/facts/system/distribution/fixtures/openeuler_20.03.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/openeuler_20.03.json
@@ -1,0 +1,28 @@
+{
+    "platform.dist": [
+        "openeuler",
+        "20.03",
+        "LTS"
+    ],
+    "input": {
+        "/etc/os-release": "NAME=\"openEuler\"\nVERSION=\"20.03 (LTS)\"\nID=\"openEuler\"\nVERSION_ID=\"20.03\"\nPRETTY_NAME=\"openEuler 20.03 (LTS)\"\nANSI_COLOR=\"0;31\"\n\n",
+        "/etc/system-release": "openEuler release 20.03 (LTS)\n"
+    },
+    "result": {
+        "distribution_release": "LTS",
+        "distribution": "openEuler",
+        "distribution_major_version": "20",
+        "os_family": "RedHat",
+        "distribution_version": "20.03"
+    },
+    "name": "openEuler 20.03",
+    "distro": {
+        "codename": "LTS",
+        "version": "20.03",
+        "id": "openeuler",
+        "version_best": "20.03",
+        "name": "openEuler",
+        "os_release_info": {},
+        "lsb_release_info": {}
+    }
+}


### PR DESCRIPTION
##### SUMMARY

Detect os_family for openEuler OS as 'RedHat', instead of 'openEuler'.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/openeuler_distribution_support.yml
lib/ansible/module_utils/facts/system/distribution.py
test/units/module_utils/test_distribution_version.py
