### PR TITLE
restore jsonfile cache plugin

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -7016,8 +7016,6 @@ files:
     migrated_to: community.general
   lib/ansible/plugins/become/sesu.py:
     migrated_to: community.general
-  lib/ansible/plugins/cache/jsonfile.py:
-    migrated_to: community.general
   lib/ansible/plugins/cache/memcached.py:
     migrated_to: community.general
   lib/ansible/plugins/cache/pickle.py:

--- a/lib/ansible/config/routing.yml
+++ b/lib/ansible/config/routing.yml
@@ -8183,8 +8183,6 @@ plugin_routing:
     enable:
       redirect: ansible.netcommon.enable
   cache:
-    jsonfile:
-      redirect: community.general.jsonfile
     memcached:
       redirect: community.general.memcached
     pickle:

--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -1,0 +1,63 @@
+# (c) 2014, Brian Coca, Josh Drake, et al
+# (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    cache: jsonfile
+    short_description: JSON formatted files.
+    description:
+        - This cache uses JSON formatted, per host, files saved to the filesystem.
+    version_added: "1.9"
+    author: Ansible Core (@ansible-core)
+    options:
+      _uri:
+        required: True
+        description:
+          - Path in which the cache plugin will save the JSON files
+        env:
+          - name: ANSIBLE_CACHE_PLUGIN_CONNECTION
+        ini:
+          - key: fact_caching_connection
+            section: defaults
+      _prefix:
+        description: User defined prefix to use when creating the JSON files
+        env:
+          - name: ANSIBLE_CACHE_PLUGIN_PREFIX
+        ini:
+          - key: fact_caching_prefix
+            section: defaults
+      _timeout:
+        default: 86400
+        description: Expiration timeout for the cache plugin data
+        env:
+          - name: ANSIBLE_CACHE_PLUGIN_TIMEOUT
+        ini:
+          - key: fact_caching_timeout
+            section: defaults
+        type: integer
+'''
+
+import codecs
+import json
+
+from ansible.parsing.ajson import AnsibleJSONEncoder, AnsibleJSONDecoder
+from ansible.plugins.cache import BaseFileCacheModule
+
+
+class CacheModule(BaseFileCacheModule):
+    """
+    A caching module backed by json files.
+    """
+
+    def _load(self, filepath):
+        # Valid JSON is always UTF-8 encoded.
+        with codecs.open(filepath, 'r', encoding='utf-8') as f:
+            return json.load(f, cls=AnsibleJSONDecoder)
+
+    def _dump(self, value, filepath):
+        with codecs.open(filepath, 'w', encoding='utf-8') as f:
+            f.write(json.dumps(value, cls=AnsibleJSONEncoder, sort_keys=True, indent=4))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Restore the `jsonfile` cache plugin (previously moved to community.general)- it's needed by a core feature of ansible-runner (https://github.com/ansible/ansible-runner/issues/450), and there was support from the core team for it as well.

Before this is merged, we should also create a corresponding PR to remove it from `community.general`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
jsonfile.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
