### PR TITLE
Remove left hand side slicing

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -854,7 +854,7 @@ class GalaxyCLI(CLI):
             else:
                 in_templates_dir = rel_root_dir == 'templates'
 
-            dirs[:] = [d for d in dirs if not any(r.match(d) for r in skeleton_ignore_re)]
+            dirs = [d for d in dirs if not any(r.match(d) for r in skeleton_ignore_re)]
 
             for f in files:
                 filename, ext = os.path.splitext(f)

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -381,27 +381,27 @@ class InventoryManager(object):
             if pattern_hash not in self._hosts_patterns_cache:
 
                 patterns = split_host_pattern(pattern)
-                hosts[:] = self._evaluate_patterns(patterns)
+                hosts = self._evaluate_patterns(patterns)
 
                 # mainly useful for hostvars[host] access
                 if not ignore_limits and self._subset:
                     # exclude hosts not in a subset, if defined
                     subset_uuids = set(s._uuid for s in self._evaluate_patterns(self._subset))
-                    hosts[:] = [h for h in hosts if h._uuid in subset_uuids]
+                    hosts = [h for h in hosts if h._uuid in subset_uuids]
 
                 if not ignore_restrictions and self._restriction:
                     # exclude hosts mentioned in any restriction (ex: failed hosts)
-                    hosts[:] = [h for h in hosts if h.name in self._restriction]
+                    hosts = [h for h in hosts if h.name in self._restriction]
 
                 self._hosts_patterns_cache[pattern_hash] = deduplicate_list(hosts)
 
             # sort hosts list if needed (should only happen when called from strategy)
             if order in ['sorted', 'reverse_sorted']:
-                hosts[:] = sorted(self._hosts_patterns_cache[pattern_hash][:], key=attrgetter('name'), reverse=(order == 'reverse_sorted'))
+                hosts = sorted(self._hosts_patterns_cache[pattern_hash][:], key=attrgetter('name'), reverse=(order == 'reverse_sorted'))
             elif order == 'reverse_inventory':
-                hosts[:] = self._hosts_patterns_cache[pattern_hash][::-1]
+                hosts = self._hosts_patterns_cache[pattern_hash][::-1]
             else:
-                hosts[:] = self._hosts_patterns_cache[pattern_hash][:]
+                hosts = self._hosts_patterns_cache[pattern_hash][:]
                 if order == 'shuffle':
                     shuffle(hosts)
                 elif order not in [None, 'inventory']:

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -414,7 +414,6 @@ def main():
                     if files or dirs:
                         depth += 1
                     if depth > params['depth']:
-                        del(dirs[:])
                         continue
                 looked = looked + len(files) + len(dirs)
                 for fsobj in (files + dirs):

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -508,8 +508,8 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
         # Due to where _extend_value may run for some attributes
         # it is possible to end up with Sentinel in the list of values
         # ensure we strip them
-        value[:] = [v for v in value if v is not Sentinel]
-        new_value[:] = [v for v in new_value if v is not Sentinel]
+        value = [v for v in value if v is not Sentinel]
+        new_value = [v for v in new_value if v is not Sentinel]
 
         if prepend:
             combined = new_value + value

--- a/lib/ansible/utils/version.py
+++ b/lib/ansible/utils/version.py
@@ -172,7 +172,7 @@ class SemanticVersion(Version):
             else:
                 if idx < extra_idx:
                     extra_idx = idx
-        version[:] = version[:extra_idx]
+        version = version[:extra_idx]
 
         if version and set(type(v) for v in version) != set((int,)):
             raise ValueError("Non integer values in %r" % loose_version)
@@ -180,7 +180,7 @@ class SemanticVersion(Version):
         # Extra is everything to the right of the core version
         extra = re.search('[+-].+$', loose_version.vstring)
 
-        version[:] = version + [0] * (3 - len(version))
+        version = version + [0] * (3 - len(version))
         return SemanticVersion(
             '%s%s' % (
                 '.'.join(str(v) for v in version),

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -2104,7 +2104,7 @@ def run():
 
     args = parser.parse_args()
 
-    args.modules[:] = [m.rstrip('/') for m in args.modules]
+    args.modules = [m.rstrip('/') for m in args.modules]
 
     reporter = Reporter()
     git_cache = GitCache(args.base_branch)

--- a/test/sanity/code-smell/docs-build.py
+++ b/test/sanity/code-smell/docs-build.py
@@ -113,6 +113,7 @@ def simplify_stdout(value):
             notice += ' (%d previous rendering line(s) omitted)' % (len(rendering) - 1)
 
         keep.append(notice)
+        # Could change to rendering.clear() if we do not support python2
         rendering[:] = []
 
     for line in lines:

--- a/test/support/integration/plugins/module_utils/ec2.py
+++ b/test/support/integration/plugins/module_utils/ec2.py
@@ -547,7 +547,7 @@ def get_ec2_security_group_ids_from_names(sec_group_list, ec2_connection, vpc_id
     if len(unmatched) > 0:
         # If we have unmatched names that look like an ID, assume they are
         import re
-        sec_group_id_list[:] = [sg for sg in unmatched if re.match('sg-[a-fA-F0-9]+$', sg)]
+        sec_group_id_list = [sg for sg in unmatched if re.match('sg-[a-fA-F0-9]+$', sg)]
         still_unmatched = [sg for sg in unmatched if not re.match('sg-[a-fA-F0-9]+$', sg)]
         if len(still_unmatched) > 0:
             raise ValueError("The following group names are not valid: %s" % ', '.join(still_unmatched))


### PR DESCRIPTION
Left hand side slicing is confusing and slower but maybe more memory
efficient in some circumstances.  There is one case where it adds to
code safety: when it's used to substitute a different list in place of a
slice of the original list and the original list could have been bound
to a different variable in some other code.  (The most likely case of
this is when it's a global variable and some other code might import
that variable name).

Because of the confusion factor we think it should only be used for the
safety case or where it's been benchmarked and shown to have some sort
of documentatble improvement.  At the moment, only one piece of code
falls into those categories so this PR removes all the other instances
of left hand side slicing.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
@mattclay I can't remember if the docs build sanity test would only be run on python3.  If that's the case, we can use `render.clear()` in that test instead of `render[:] = []`.  (Also, I know we're talking about changing the website build test in some sort of major way so I'm not too bothered by this continuing to have the left hand side slice notation for now.