### PR TITLE
ansible-test: make work if collection is completely .gitignore'd

### DIFF
--- a/changelogs/fragments/69341-ansible-test-collection-gitignore.yml
+++ b/changelogs/fragments/69341-ansible-test-collection-gitignore.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-test - will no longer run no tests in a collection which is completely ``.gitignore``ed (https://github.com/ansible/ansible/issues/68499)."

--- a/changelogs/fragments/69341-ansible-test-collection-gitignore.yml
+++ b/changelogs/fragments/69341-ansible-test-collection-gitignore.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- "ansible-test - will no longer run no tests in a collection which is completely ``.gitignore``ed (https://github.com/ansible/ansible/issues/68499)."
+- "ansible-test - will no longer run no tests in a collection which is completely covered by ``.gitignore`` (https://github.com/ansible/ansible/issues/68499)."

--- a/test/lib/ansible_test/_internal/data.py
+++ b/test/lib/ansible_test/_internal/data.py
@@ -109,14 +109,14 @@ class DataContext:
                                 walk,  # type: bool
                                 ):  # type: (...) -> ContentLayout
         """Create a content layout using the given providers and root path."""
-        layout_provider = find_path_provider(LayoutProvider, layout_providers, root, walk)
+        layout_provider = find_path_provider(LayoutProvider, layout_providers, root, walk=walk)
 
         try:
             # Begin the search for the source provider at the layout provider root.
             # This intentionally ignores version control within subdirectories of the layout root, a condition which was previously an error.
             # Doing so allows support for older git versions for which it is difficult to distinguish between a super project and a sub project.
             # It also provides a better user experience, since the solution for the user would effectively be the same -- to remove the nested version control.
-            source_provider = find_path_provider(SourceProvider, source_providers, layout_provider.root, walk)
+            source_provider = find_path_provider(SourceProvider, source_providers, layout_provider.root, walk=walk, check_paths=True)
         except ProviderNotFoundForPath:
             source_provider = UnversionedSource(layout_provider.root)
 
@@ -143,7 +143,7 @@ class DataContext:
             return tuple((os.path.join(self.content.root, path), path) for path in self.content.all_files())
 
         try:
-            source_provider = find_path_provider(SourceProvider, self.__source_providers, ANSIBLE_SOURCE_ROOT, False)
+            source_provider = find_path_provider(SourceProvider, self.__source_providers, ANSIBLE_SOURCE_ROOT, walk=False)
         except ProviderNotFoundForPath:
             source_provider = UnversionedSource(ANSIBLE_SOURCE_ROOT)
 

--- a/test/lib/ansible_test/_internal/provider/__init__.py
+++ b/test/lib/ansible_test/_internal/provider/__init__.py
@@ -29,6 +29,7 @@ def find_path_provider(provider_type,  # type: t.Type[TPathProvider],
                        provider_classes,  # type:  t.List[t.Type[TPathProvider]]
                        path,  # type: str
                        walk,  # type: bool
+                       check_paths=False,  # type: bool
                        ):  # type: (...) -> TPathProvider
     """Return the first found path provider of the given type for the given path."""
     sequences = sorted(set(pc.sequence for pc in provider_classes if pc.sequence > 0))
@@ -40,7 +41,12 @@ def find_path_provider(provider_type,  # type: t.Type[TPathProvider],
         while True:
             for provider_class in tier_classes:
                 if provider_class.is_content_root(candidate_path):
-                    return provider_class(candidate_path)
+                    provider = provider_class(candidate_path)
+                    if check_paths:
+                        if provider.get_paths(path):
+                            return provider
+                    else:
+                        return provider
 
             if not walk:
                 break


### PR DESCRIPTION
##### SUMMARY
Fixes #68499. It prevents ansible-test to do nothing (no target found) when running it in a collection that is completely `.gitignored`.

Common use-cases are galaxy-installed collections in a subtree somewhere in a git repository, f.ex. `~/projects` is a git repo, `~/projects/ansible/ansible_collections` is `.gitignored`, and collection is installed at `~/projects/ansible/ansible_collections/foo/bar`. If `ansible-test` is run inside `foo.bar`, it used to print `WARNING: All targets skipped.` and do nothing. With this PR, it runs as expected (by end-users which don't realize that the whole collection is in `.gitignore`).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test
