### PR TITLE
[ansiballz] ensure that '' is not in sys.path

### DIFF
--- a/changelogs/fragments/69320-sys-path-cwd.yml
+++ b/changelogs/fragments/69320-sys-path-cwd.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansiballz - remove '' and '.' from sys.path to fix a permissions issue on OpenBSD with pipelining (#69320)

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -135,6 +135,7 @@ Noteworthy module changes
 * The parameter ``message`` in :ref:`grafana_dashboard <grafana_dashboard_module>` module is renamed to ``commit_message`` since ``message`` is used by Ansible Core engine internally.
 * The parameter ``message`` in :ref:`datadog_monitor <datadog_monitor_module>` module is renamed to ``notification_message`` since ``message`` is used by Ansible Core engine internally.
 * The parameter ``message`` in :ref:`bigpanda <bigpanda_module>` module is renamed to ``deployment_message`` since ``message`` is used by Ansible Core engine internally.
+* Ansible modules most no longer rely on being able to import Python modules from the remote user's home directory. Such dependencies will need to live elsewhere in the Python path.
 
 
 Plugins

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -135,7 +135,7 @@ Noteworthy module changes
 * The parameter ``message`` in :ref:`grafana_dashboard <grafana_dashboard_module>` module is renamed to ``commit_message`` since ``message`` is used by Ansible Core engine internally.
 * The parameter ``message`` in :ref:`datadog_monitor <datadog_monitor_module>` module is renamed to ``notification_message`` since ``message`` is used by Ansible Core engine internally.
 * The parameter ``message`` in :ref:`bigpanda <bigpanda_module>` module is renamed to ``deployment_message`` since ``message`` is used by Ansible Core engine internally.
-* Ansible modules most no longer rely on being able to import Python modules from the remote user's home directory. Such dependencies will need to live elsewhere in the Python path.
+* Ansible no longer looks for Python modules in the current working directory (typically the ``remote_user``'s home directory) when an Ansible module is run. This is to fix becoming an unprivileged user on OpenBSD and to mitigate any attack vector if the current working directory is writable by a malicious user. Install any Python modules needed to run the Ansible modules on the managed node in a system-wide location or in another directory which is in the ``remote_user``'s ``$PYTHONPATH`` and readable by the ``become_user``.
 
 
 Plugins

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -144,7 +144,7 @@ def _ansiballz_main():
         pass
 
     # Strip cwd from sys.path to avoid potential permissions issues
-    excludes = set(('', scriptdir))
+    excludes = set(('', '.', scriptdir))
     sys.path = [p for p in sys.path if p not in excludes]
 
     import base64

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -142,8 +142,10 @@ def _ansiballz_main():
         # OSX raises OSError if using abspath() in a directory we don't have
         # permission to read (realpath calls abspath)
         pass
-    if scriptdir is not None:
-        sys.path = [p for p in sys.path if p != scriptdir]
+
+    # Strip cwd from sys.path to avoid potential permissions issues
+    excludes = set(('', scriptdir))
+    sys.path = [p for p in sys.path if p not in excludes]
 
     import base64
     import runpy


### PR DESCRIPTION
##### SUMMARY

Change:
On OpenBSD when using pipelining, we do not set cwd which results in a
permissions fatal. Ensure that `''` - cwd - is not in `sys.path`.

Test Plan:
Tested against local OpenBSD VM

Tickets:
Fixes #69320

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

ansiballz