### PR TITLE
Add tests for ignore functionality of collection build

### DIFF
--- a/test/integration/targets/ansible-galaxy-collection/tasks/build.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/build.yml
@@ -51,3 +51,26 @@
     that:
     - '"use --force to re-create the collection artifact" in build_existing_no_force.stderr'
     - '"Created collection for ansible_test.my_collection" in build_existing_force.stdout'
+
+- name: build collection containing ignored files
+  command: ansible-galaxy collection build
+  args:
+    chdir: '{{ galaxy_dir }}/scratch/ansible_test/ignore'
+
+- name: list the created tar contents
+  command: tar -tf {{ galaxy_dir }}/scratch/ansible_test/ignore/ansible_test-ignore-1.0.0.tar.gz
+  args:
+    warn: false
+  register: tar_output
+
+- name: assert ignored files are not present in the archive
+  assert:
+    that:
+    - item not in tar_output.stdout_lines
+  loop: '{{ collection_ignored_files }}'
+
+- name: assert ignored directories are not present in the archive
+  assert:
+    that:
+    - item not in tar_output.stdout_lines
+  loop: '{{ collection_ignored_directories }}'

--- a/test/integration/targets/ansible-galaxy-collection/tasks/init.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/init.yml
@@ -42,3 +42,34 @@
     - (init_custom_path_actual.files | map(attribute='path') | list)[0] | basename in ['docs', 'plugins', 'roles']
     - (init_custom_path_actual.files | map(attribute='path') | list)[1] | basename in ['docs', 'plugins', 'roles']
     - (init_custom_path_actual.files | map(attribute='path') | list)[2] | basename in ['docs', 'plugins', 'roles']
+
+- name: create collection for ignored files and folders
+  command: ansible-galaxy collection init ansible_test.ignore
+  args:
+    chdir: '{{ galaxy_dir }}/scratch'
+
+- name: create list of ignored files
+  set_fact:
+    collection_ignored_files:
+    - plugins/compiled.pyc
+    - something.retry
+    - .git
+
+- name: plant ignored files into the ansible_test.ignore collection
+  copy:
+    dest: '{{ galaxy_dir }}/scratch/ansible_test/ignore/{{ item }}'
+    content: '{{ item }}'
+  loop: '{{ collection_ignored_files }}'
+
+- name: create list of ignored directories
+  set_fact:
+    collection_ignored_directories:
+    - docs/.git
+    - plugins/doc_fragments/__pycache__
+    - .svn
+
+- name: plant ignored folders into the ansible_test.ignore collection
+  file:
+    path: '{{ galaxy_dir }}/scratch/ansible_test/ignore/{{ item }}'
+    state: directory
+  loop: '{{ collection_ignored_directories }}'


### PR DESCRIPTION
In order to test this piece of functionality, we create a dedicated collection that contains files that should be ignored when building the collection tarball.

After the collection is built, we make sure the produced tarball does not contain any files that should be ignored.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-galaxy collection build