### PR TITLE
Change example ControlPath to be short and unique

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -392,7 +392,7 @@
 # In those cases, a "too long for Unix domain socket" ssh error would occur.
 #
 # Example:
-# control_path = %(directory)s/%%h-%%r
+# control_path = %(directory)s/%%C
 #control_path =
 
 # Enabling pipelining reduces the number of SSH operations required to


### PR DESCRIPTION
##### SUMMARY
Using only %h and %r tokens break ansible for a few use cases. For example packer provisioning, where hostname is always 127.0.0.1

%C is a hash of local host, remote host, username and port.

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
Example Config

