### PR TITLE
vmware: example should use FQCN

### DIFF
--- a/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
@@ -181,7 +181,7 @@ Depending upon the functionality provided by ESXi or vCenter, some modules can s
 Example should use the fully qualified collection name (FQCN)
 -------------------------------------------------------------
 
-For instance, you should use ``community.vmware.vmware_guest`` instead of just
+Use FQCN for examples within module documentation For instance, you should use ``community.vmware.vmware_guest`` instead of just
 ``vmware_guest``.
 
 This way, the examples don't depend on the `collections` directive of the

--- a/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
@@ -184,7 +184,7 @@ Example should use the fully qualified collection name (FQCN)
 Use FQCN for examples within module documentation For instance, you should use ``community.vmware.vmware_guest`` instead of just
 ``vmware_guest``.
 
-This way, the examples don't depend on the `collections` directive of the
+This way, the examples don't depend on the ``collections`` directive of the
 playbook.
 
 Functional tests

--- a/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/vmware_guidelines.rst
@@ -178,6 +178,15 @@ Depending upon the functionality provided by ESXi or vCenter, some modules can s
     if self.host is None:
         self.module.fail_json(msg="Failed to find host system.")
 
+Example should use the fully qualified collection name (FQCN)
+-------------------------------------------------------------
+
+For instance, you should use ``community.vmware.vmware_guest`` instead of just
+``vmware_guest``.
+
+This way, the examples don't depend on the `collections` directive of the
+playbook.
+
 Functional tests
 ----------------
 


### PR DESCRIPTION
##### SUMMARY

For instance, you should use `community.vmware.vmware_guest` instead of just
`vmware_guest`.

This way, the examples don't depend on the `collections` directive of the
playbook.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

vmware