### PR TITLE
[stable-2.8] Default ansible-test provisioning to us-east-1.

### DIFF
--- a/test/runner/lib/core_ci.py
+++ b/test/runner/lib/core_ci.py
@@ -108,14 +108,7 @@ class AnsibleCoreCI(object):
                 region = args.remote_aws_region
                 # use a dedicated CI key when overriding the region selection
                 self.ci_key += '.%s' % args.remote_aws_region
-            elif is_shippable():
-                # split Shippable jobs across multiple regions to maximize use of launch credits
-                if self.platform == 'windows':
-                    region = 'us-east-2'
-                else:
-                    region = 'us-east-1'
             else:
-                # send all non-Shippable jobs to us-east-1 to reduce api key maintenance
                 region = 'us-east-1'
 
             self.path = "%s-%s" % (self.path, region)


### PR DESCRIPTION
##### SUMMARY

Previously windows instances on Shippable would be automatically directed to us-east-2.

Backport of https://github.com/ansible/ansible/pull/69248

(cherry picked from commit 1cf26896c50379c671e120985c4f1194f44d0205)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
