### PR TITLE
Fix win_psmodule and win_psrepository tests - 2.9

### DIFF
--- a/changelogs/fragments/win_psmodule-repo-tls.yaml
+++ b/changelogs/fragments/win_psmodule-repo-tls.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+- win_psmodule - Fix TLS 1.2 compatibility with PSGallery.
+- win_psrepository - Fix TLS 1.2 compatibility with PSGallery.
+- win_psrepository - Fix ``Ignore`` error when trying to retrieve the list of registered repositories

--- a/test/integration/targets/win_psrepository/tasks/main.yml
+++ b/test/integration/targets/win_psrepository/tasks/main.yml
@@ -5,7 +5,7 @@
 
 ---
 - name: unregister the repository
-  win_shell: Unregister-PSRepository {{ repository_name | quote }} -ErrorAction Ignore
+  win_shell: Unregister-PSRepository {{ repository_name | quote }} -ErrorAction SilentlyContinue
 
 - block:
   - name: run all tests
@@ -13,4 +13,4 @@
 
   always:
   - name: ensure test repo is unregistered
-    win_shell: Unregister-PSRepository {{ repository_name | quote }} -ErrorAction Ignore
+    win_shell: Unregister-PSRepository {{ repository_name | quote }} -ErrorAction SilentlyContinue

--- a/test/integration/targets/win_psrepository/tasks/tests.yml
+++ b/test/integration/targets/win_psrepository/tasks/tests.yml
@@ -161,7 +161,7 @@
   register: removing_repository_check
 
 - name: get result of remove repository - check mode
-  win_shell: '(Get-PSRepository -Name {{ repository_name | quote }} -ErrorAction Ignore | Measure-Object).Count'
+  win_shell: '(Get-PSRepository -Name {{ repository_name | quote }} -ErrorAction SilentlyContinue | Measure-Object).Count'
   changed_when: false
   register: result_removing_repository_check
 
@@ -178,7 +178,7 @@
   register: removing_repository
 
 - name: get result of remove repository
-  win_shell: '(Get-PSRepository -Name {{ repository_name | quote }} -ErrorAction Ignore | Measure-Object).Count'
+  win_shell: '(Get-PSRepository -Name {{ repository_name | quote }} -ErrorAction SilentlyContinue | Measure-Object).Count'
   changed_when: false
   register: result_removing_repository
 


### PR DESCRIPTION
##### SUMMARY
Subset backport of change in `community.windows` https://github.com/ansible-collections/community.windows/pull/86.

Fixes TLS 1.2 issues with PSGallery and the use of `-ErrorAction Ignore` when trying to detect if resource is present.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_psmodule
win_psrepository