### PR TITLE
only show_vars when showing vars

### DIFF
--- a/changelogs/fragments/69357_optimize_inventory_graph_wo_vars.yml
+++ b/changelogs/fragments/69357_optimize_inventory_graph_wo_vars.yml
@@ -1,2 +1,2 @@
-bugfix:
+bugfixes:
     - Avoid running subfunctions that are passed to show_vars function when it will be a noop.

--- a/changelogs/fragments/69357_optimize_inventory_graph_wo_vars.yml
+++ b/changelogs/fragments/69357_optimize_inventory_graph_wo_vars.yml
@@ -1,0 +1,2 @@
+bugfix:
+    - Avoid running subfunctions that are passed to show_vars function when it will be a noop.

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -240,9 +240,8 @@ class InventoryCLI(CLI):
     @staticmethod
     def _show_vars(dump, depth):
         result = []
-        if context.CLIARGS['show_vars']:
-            for (name, val) in sorted(dump.items()):
-                result.append(InventoryCLI._graph_name('{%s = %s}' % (name, val), depth))
+        for (name, val) in sorted(dump.items()):
+            result.append(InventoryCLI._graph_name('{%s = %s}' % (name, val), depth))
         return result
 
     @staticmethod
@@ -261,9 +260,11 @@ class InventoryCLI(CLI):
         if group.name != 'all':
             for host in sorted(group.hosts, key=attrgetter('name')):
                 result.append(self._graph_name(host.name, depth))
-                result.extend(self._show_vars(self._get_host_variables(host), depth + 1))
+                if context.CLIARGS['show_vars']:
+                    result.extend(self._show_vars(self._get_host_variables(host), depth + 1))
 
-        result.extend(self._show_vars(self._get_group_variables(group), depth))
+        if context.CLIARGS['show_vars']:
+            result.extend(self._show_vars(self._get_group_variables(group), depth))
 
         return result
 


### PR DESCRIPTION
avoid processing function params that can be very expensive
and might not be used at all in called function.

fixes #69357


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-inventory