### PR TITLE
Support recursive fileglob lookups

### DIFF
--- a/changelogs/fragments/69368-recursive-fileglob.yaml
+++ b/changelogs/fragments/69368-recursive-fileglob.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - fileglob lookup plugin - add recursive option


### PR DESCRIPTION
##### SUMMARY
Python 3.5 or above supports a 'recursive' flag to `glob.glob`. We should expose this to users of the `fileglob` lookup plugin.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
fileglob lookup plugin