### PR TITLE
[WIP] [2.9] various ansible-test backports

### DIFF
--- a/changelogs/fragments/ansible-test-delegation-inventory.yml
+++ b/changelogs/fragments/ansible-test-delegation-inventory.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now correctly includes inventory files ignored by git when running tests with the ``--docker`` option

--- a/changelogs/fragments/ansible-test-paramiko-constraint.yml
+++ b/changelogs/fragments/ansible-test-paramiko-constraint.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test - Remove out-of-date constraint on installing paramiko versions 2.5.0 or later in tests.

--- a/changelogs/fragments/ps-argspec-type.yaml
+++ b/changelogs/fragments/ps-argspec-type.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- validate-modules - Fix hang when inspecting module with a delegate args spec type

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -14,7 +14,6 @@ pycrypto >= 2.6 # Need features found in 2.6 and greater
 ncclient >= 0.5.2 # Need features added in 0.5.2 and greater
 idna < 2.6, >= 2.5 # linode requires idna < 2.9, >= 2.5, requests requires idna < 2.6, but cryptography will cause the latest version to be installed instead
 paramiko < 2.4.0 ; python_version < '2.7' # paramiko 2.4.0 drops support for python 2.6
-paramiko < 2.5.0 ; python_version >= '2.7' # paramiko 2.5.0 requires cryptography 2.5.0+
 pytest < 3.3.0 ; python_version < '2.7' # pytest 3.3.0 drops support for python 2.6
 pytest < 5.0.0 ; python_version == '2.7' # pytest 5.0.0 and later will no longer support python 2.7
 pytest-forked < 1.0.2 ; python_version < '2.7' # pytest-forked 1.0.2 and later require python 2.7 or later

--- a/test/lib/ansible_test/_internal/integration/__init__.py
+++ b/test/lib/ansible_test/_internal/integration/__init__.py
@@ -170,8 +170,9 @@ def delegate_inventory(args, inventory_path_src):  # type: (IntegrationConfig, s
             working_path = ''
 
         inventory_path = os.path.join(working_path, get_inventory_relative_path(args))
+        inventory_tuple = inventory_path_src, inventory_path
 
-        if os.path.isfile(inventory_path_src) and os.path.relpath(inventory_path_src, data_context().content.root) != inventory_path:
+        if os.path.isfile(inventory_path_src) and inventory_tuple not in files:
             originals = [item for item in files if item[1] == inventory_path]
 
             if originals:
@@ -182,7 +183,7 @@ def delegate_inventory(args, inventory_path_src):  # type: (IntegrationConfig, s
             else:
                 display.notice('Sourcing inventory file "%s" from "%s".' % (inventory_path, inventory_path_src))
 
-            files.append((inventory_path_src, inventory_path))
+            files.append(inventory_tuple)
 
     data_context().register_payload_callback(inventory_callback)
 


### PR DESCRIPTION
##### SUMMARY
Backports of:
- #66509
- ~~#66738 (backport in #69403)~~
- #67979
- ~~#68345 (backport in #69404)~~
- ~~#68352 (backport in #69405)~~
- ~~#68372 (backport in #69406)~~
- ~~#68385~~
- #68386
- ~~#68298 (backport in #69407)~~
- ~~#68519 (backport in #69409)~~
- ~~#68550 (backport in #69408)~~

(Almost all of them could be cherry-picked without human intervention, except https://github.com/ansible/ansible/pull/68519/files#diff-b9b20e655483710b9822ab04700358c6L137 which failed because `os.sep` was there instead of `os.path.sep`.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test
