### PR TITLE
git: don't import get_module_path

### DIFF
--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -283,7 +283,7 @@ import shutil
 import tempfile
 from distutils.version import LooseVersion
 
-from ansible.module_utils.basic import AnsibleModule, get_module_path
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import b, string_types
 from ansible.module_utils._text import to_native, to_text
 


### PR DESCRIPTION
##### SUMMARY

The module don't use the `get_module_path()` function. No need to import
it.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

git