### PR TITLE
Revert "2.9: native types: literal_eval all the things (#68938) (#69044)"

### DIFF
--- a/lib/ansible/template/native_helpers.py
+++ b/lib/ansible/template/native_helpers.py
@@ -13,9 +13,6 @@ import types
 from jinja2._compat import text_type
 
 from jinja2.runtime import StrictUndefined
-
-from ansible.module_utils.common.text.converters import container_to_text
-from ansible.module_utils.six import PY2
 from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
 
 
@@ -51,6 +48,10 @@ def ansible_native_concat(nodes):
             # See https://github.com/ansible/ansible/issues/52158
             # We do that only here because it is taken care of by text_type() in the else block below already.
             str(out)
+
+        # short circuit literal_eval when possible
+        if not isinstance(out, list):
+            return out
     else:
         if isinstance(nodes, types.GeneratorType):
             nodes = chain(head, nodes)
@@ -59,10 +60,6 @@ def ansible_native_concat(nodes):
         out = u''.join([text_type(v) for v in nodes])
 
     try:
-        out = literal_eval(out)
-        if PY2:
-            # ensure bytes are not returned back into Ansible from templating
-            out = container_to_text(out)
-        return out
+        return literal_eval(out)
     except (ValueError, SyntaxError, MemoryError):
         return out

--- a/test/integration/targets/inventory_aws_conformance/runme.sh
+++ b/test/integration/targets/inventory_aws_conformance/runme.sh
@@ -83,7 +83,7 @@ compose:
   ec2_kernel: kernel_id | default("")
   ec2_monitored:  monitoring['state'] in ['enabled', 'pending']
   ec2_monitoring_state: monitoring['state']
-  ec2_account_id: owner_id | string | regex_replace('^(.*)$', '"\\1"')  # work around the fact that the string filter is not reliable on native jinja
+  ec2_account_id: owner_id
   ec2_placement: placement['availability_zone']
   ec2_ramdisk: ramdisk_id | default("")
   ec2_reason: state_transition_reason
@@ -95,7 +95,7 @@ compose:
   ec2_sourceDestCheck: source_dest_check | lower | string  # butchered snake_case case not a typo.
 
   # vars that just need ec2_ prefix
-  ec2_ami_launch_index: ami_launch_index | string | regex_replace('^(.*)$', '"\\1"')  # see ec2_account_id for why this needs to be quoted
+  ec2_ami_launch_index: ami_launch_index | string
   ec2_architecture: architecture
   ec2_client_token: client_token
   ec2_ebs_optimized: ebs_optimized

--- a/test/integration/targets/jinja2_native_types/filter_plugins/native_plugins.py
+++ b/test/integration/targets/jinja2_native_types/filter_plugins/native_plugins.py
@@ -1,0 +1,8 @@
+from ansible.module_utils._text import to_text
+
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'to_text': to_text,
+        }

--- a/test/integration/targets/jinja2_native_types/test_casting.yml
+++ b/test/integration/targets/jinja2_native_types/test_casting.yml
@@ -1,9 +1,9 @@
 - name: cast things to other things
   set_fact:
-      int_to_str: "'{{ i_two }}'"
+      int_to_str: "{{ i_two|to_text }}"
       str_to_int: "{{ s_two|int }}"
-      dict_to_str: "'{{ dict_one }}'"
-      list_to_str: "'{{ list_one }}'"
+      dict_to_str: "{{ dict_one|to_text }}"
+      list_to_str: "{{ list_one|to_text }}"
       int_to_bool: "{{ i_one|bool }}"
       str_true_to_bool: "{{ s_true|bool }}"
       str_false_to_bool: "{{ s_false|bool }}"

--- a/test/integration/targets/jinja2_native_types/test_concatentation.yml
+++ b/test/integration/targets/jinja2_native_types/test_concatentation.yml
@@ -18,7 +18,7 @@
 
 - name: concatenate int and string
   set_fact:
-      string_sum: "'{{ [i_one, s_two]|join('') }}'"
+      string_sum: "{{ [(i_one|to_text), s_two]|join('') }}"
 
 - assert:
     that:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -5973,6 +5973,8 @@ test/integration/targets/inventory_kubevirt_conformance/inventory_diff.py future
 test/integration/targets/inventory_kubevirt_conformance/inventory_diff.py metaclass-boilerplate
 test/integration/targets/inventory_kubevirt_conformance/server.py future-import-boilerplate
 test/integration/targets/inventory_kubevirt_conformance/server.py metaclass-boilerplate
+test/integration/targets/jinja2_native_types/filter_plugins/native_plugins.py future-import-boilerplate
+test/integration/targets/jinja2_native_types/filter_plugins/native_plugins.py metaclass-boilerplate
 test/integration/targets/lambda_policy/files/mini_http_lambda.py future-import-boilerplate
 test/integration/targets/lambda_policy/files/mini_http_lambda.py metaclass-boilerplate
 test/integration/targets/lookup_properties/lookup-8859-15.ini no-smart-quotes


### PR DESCRIPTION
##### SUMMARY

This change was causing a traceback for a Tower test case.

This reverts commit 70b4ce5efdff05bdfd6cc520260a6af974a3cf61.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible
