### PR TITLE
Disable failing azure_rm_dnszone test.

### DIFF
--- a/test/integration/targets/azure_rm_dnszone/aliases
+++ b/test/integration/targets/azure_rm_dnszone/aliases
@@ -4,3 +4,4 @@ destructive
 azure_rm_dnszone_info
 azure_rm_dnsrecordset
 azure_rm_dnsrecordset_info
+disabled


### PR DESCRIPTION
##### SUMMARY

Disable failing azure_rm_dnszone test.

The module requires updates to work with the current Azure API.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

azure_rm_dnszone

##### ADDITIONAL INFORMATION

Failure: https://app.shippable.com/github/ansible/ansible/runs/165892/104/tests

> Creation of private DNS zones using this API is no longer allowed. Please use privatednszones resource instead of dnszones resource. Refer to https://aka.ms/privatednsmigration for details.