### PR TITLE
Fix SemanticVersion comparison

### DIFF
--- a/lib/ansible/utils/version.py
+++ b/lib/ansible/utils/version.py
@@ -72,14 +72,14 @@ class _Alpha:
 
         raise ValueError
 
-    def __gt__(self, other):
-        return not self.__lt__(other)
-
     def __le__(self, other):
         return self.__lt__(other) or self.__eq__(other)
 
+    def __gt__(self, other):
+        return not self.__le__(other)
+
     def __ge__(self, other):
-        return self.__gt__(other) or self.__eq__(other)
+        return not self.__lt__(other)
 
 
 class _Numeric:
@@ -115,14 +115,14 @@ class _Numeric:
 
         raise ValueError
 
-    def __gt__(self, other):
-        return not self.__lt__(other)
-
     def __le__(self, other):
         return self.__lt__(other) or self.__eq__(other)
 
+    def __gt__(self, other):
+        return not self.__le__(other)
+
     def __ge__(self, other):
-        return self.__gt__(other) or self.__eq__(other)
+        return not self.__lt__(other)
 
 
 class SemanticVersion(Version):

--- a/test/units/utils/test_version.py
+++ b/test/units/utils/test_version.py
@@ -268,24 +268,28 @@ def test_alpha():
     assert _Alpha('b') >= _Alpha('a')
     assert _Alpha('b') >= _Alpha('b')
 
+    # The following 3*6 tests check that all comparison operators perform
+    # as expected. DO NOT remove any of them, or reformulate them (to remove
+    # the explicit `not`)!
+
     assert _Alpha('a') == _Alpha('a')
-    assert not _Alpha('a') != _Alpha('a')
-    assert not _Alpha('a') < _Alpha('a')
+    assert not _Alpha('a') != _Alpha('a')  # pylint: disable=unneeded-not
+    assert not _Alpha('a') < _Alpha('a')  # pylint: disable=unneeded-not
     assert _Alpha('a') <= _Alpha('a')
-    assert not _Alpha('a') > _Alpha('a')
+    assert not _Alpha('a') > _Alpha('a')  # pylint: disable=unneeded-not
     assert _Alpha('a') >= _Alpha('a')
 
-    assert not _Alpha('a') == _Alpha('b')
+    assert not _Alpha('a') == _Alpha('b')  # pylint: disable=unneeded-not
     assert _Alpha('a') != _Alpha('b')
     assert _Alpha('a') < _Alpha('b')
     assert _Alpha('a') <= _Alpha('b')
-    assert not _Alpha('a') > _Alpha('b')
-    assert not _Alpha('a') >= _Alpha('b')
+    assert not _Alpha('a') > _Alpha('b')  # pylint: disable=unneeded-not
+    assert not _Alpha('a') >= _Alpha('b')  # pylint: disable=unneeded-not
 
-    assert not _Alpha('b') == _Alpha('a')
+    assert not _Alpha('b') == _Alpha('a')  # pylint: disable=unneeded-not
     assert _Alpha('b') != _Alpha('a')
-    assert not _Alpha('b') < _Alpha('a')
-    assert not _Alpha('b') <= _Alpha('a')
+    assert not _Alpha('b') < _Alpha('a')  # pylint: disable=unneeded-not
+    assert not _Alpha('b') <= _Alpha('a')  # pylint: disable=unneeded-not
     assert _Alpha('b') > _Alpha('a')
     assert _Alpha('b') >= _Alpha('a')
 
@@ -305,23 +309,27 @@ def test_numeric():
     assert _Numeric(2) >= _Numeric(1)
     assert _Numeric(2) >= _Numeric(2)
 
+    # The following 3*6 tests check that all comparison operators perform
+    # as expected. DO NOT remove any of them, or reformulate them (to remove
+    # the explicit `not`)!
+
     assert _Numeric(1) == _Numeric(1)
-    assert not _Numeric(1) != _Numeric(1)
-    assert not _Numeric(1) < _Numeric(1)
+    assert not _Numeric(1) != _Numeric(1)  # pylint: disable=unneeded-not
+    assert not _Numeric(1) < _Numeric(1)  # pylint: disable=unneeded-not
     assert _Numeric(1) <= _Numeric(1)
-    assert not _Numeric(1) > _Numeric(1)
+    assert not _Numeric(1) > _Numeric(1)  # pylint: disable=unneeded-not
     assert _Numeric(1) >= _Numeric(1)
 
-    assert not _Numeric(1) == _Numeric(2)
+    assert not _Numeric(1) == _Numeric(2)  # pylint: disable=unneeded-not
     assert _Numeric(1) != _Numeric(2)
     assert _Numeric(1) < _Numeric(2)
     assert _Numeric(1) <= _Numeric(2)
-    assert not _Numeric(1) > _Numeric(2)
-    assert not _Numeric(1) >= _Numeric(2)
+    assert not _Numeric(1) > _Numeric(2)  # pylint: disable=unneeded-not
+    assert not _Numeric(1) >= _Numeric(2)  # pylint: disable=unneeded-not
 
-    assert not _Numeric(2) == _Numeric(1)
+    assert not _Numeric(2) == _Numeric(1)  # pylint: disable=unneeded-not
     assert _Numeric(2) != _Numeric(1)
-    assert not _Numeric(2) < _Numeric(1)
-    assert not _Numeric(2) <= _Numeric(1)
+    assert not _Numeric(2) < _Numeric(1)  # pylint: disable=unneeded-not
+    assert not _Numeric(2) <= _Numeric(1)  # pylint: disable=unneeded-not
     assert _Numeric(2) > _Numeric(1)
     assert _Numeric(2) >= _Numeric(1)

--- a/test/units/utils/test_version.py
+++ b/test/units/utils/test_version.py
@@ -268,6 +268,27 @@ def test_alpha():
     assert _Alpha('b') >= _Alpha('a')
     assert _Alpha('b') >= _Alpha('b')
 
+    assert _Alpha('a') == _Alpha('a')
+    assert not _Alpha('a') != _Alpha('a')
+    assert not _Alpha('a') < _Alpha('a')
+    assert _Alpha('a') <= _Alpha('a')
+    assert not _Alpha('a') > _Alpha('a')
+    assert _Alpha('a') >= _Alpha('a')
+
+    assert not _Alpha('a') == _Alpha('b')
+    assert _Alpha('a') != _Alpha('b')
+    assert _Alpha('a') < _Alpha('b')
+    assert _Alpha('a') <= _Alpha('b')
+    assert not _Alpha('a') > _Alpha('b')
+    assert not _Alpha('a') >= _Alpha('b')
+
+    assert not _Alpha('b') == _Alpha('a')
+    assert _Alpha('b') != _Alpha('a')
+    assert not _Alpha('b') < _Alpha('a')
+    assert not _Alpha('b') <= _Alpha('a')
+    assert _Alpha('b') > _Alpha('a')
+    assert _Alpha('b') >= _Alpha('a')
+
 
 def test_numeric():
     assert _Numeric(1) == _Numeric(1)
@@ -283,3 +304,24 @@ def test_numeric():
     assert _Numeric(1) <= _Numeric(2)
     assert _Numeric(2) >= _Numeric(1)
     assert _Numeric(2) >= _Numeric(2)
+
+    assert _Numeric(1) == _Numeric(1)
+    assert not _Numeric(1) != _Numeric(1)
+    assert not _Numeric(1) < _Numeric(1)
+    assert _Numeric(1) <= _Numeric(1)
+    assert not _Numeric(1) > _Numeric(1)
+    assert _Numeric(1) >= _Numeric(1)
+
+    assert not _Numeric(1) == _Numeric(2)
+    assert _Numeric(1) != _Numeric(2)
+    assert _Numeric(1) < _Numeric(2)
+    assert _Numeric(1) <= _Numeric(2)
+    assert not _Numeric(1) > _Numeric(2)
+    assert not _Numeric(1) >= _Numeric(2)
+
+    assert not _Numeric(2) == _Numeric(1)
+    assert _Numeric(2) != _Numeric(1)
+    assert not _Numeric(2) < _Numeric(1)
+    assert not _Numeric(2) <= _Numeric(1)
+    assert _Numeric(2) > _Numeric(1)
+    assert _Numeric(2) >= _Numeric(1)


### PR DESCRIPTION
##### SUMMARY
Fixes logic errors comparisons for `_Numeric` and `_Alpha` components of `SemanticVersion`. `>` is not the logical negation of `<`, but of `<=`.

This has almost no impact, since the main comparison is only relying on `<` and `==` (for tuple comparison). This potentially affects prerelease comparison, though. (Depending on how exactly Python is implementing `>` for tuples; from reading [this](https://docs.python.org/3/reference/expressions.html#value-comparisons) it could depend on the Python implementation used.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/utils/version.py
