### PR TITLE
Clarify blockinfile docs for insertafter/insertbefore

### DIFF
--- a/changelogs/fragments/69396-blockinfile-docs.yaml
+++ b/changelogs/fragments/69396-blockinfile-docs.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- blockinfile - Update module documentation to clarify insertbefore/insertafter usage.

--- a/lib/ansible/modules/blockinfile.py
+++ b/lib/ansible/modules/blockinfile.py
@@ -35,7 +35,7 @@ options:
   marker:
     description:
     - The marker line template.
-    - C({mark}) will be replaced with the values C(in marker_begin) (default="BEGIN") and C(marker_end) (default="END").
+    - C({mark}) will be replaced with the values in C(marker_begin) (default="BEGIN") and C(marker_end) (default="END").
     - Using a custom marker without the C({mark}) variable may result in the block being repeatedly inserted on subsequent playbook runs.
     type: str
     default: '# {mark} ANSIBLE MANAGED BLOCK'
@@ -48,7 +48,7 @@ options:
     aliases: [ content ]
   insertafter:
     description:
-    - If specified, the block will be inserted after the last match of specified regular expression.
+    - If specified and no begin/ending C(marker) lines are found, the block will be inserted after the last match of specified regular expression.
     - A special value is available; C(EOF) for inserting the block at the end of the file.
     - If specified regular expression has no matches, C(EOF) will be used instead.
     type: str
@@ -56,7 +56,7 @@ options:
     default: EOF
   insertbefore:
     description:
-    - If specified, the block will be inserted before the last match of specified regular expression.
+    - If specified and no begin/ending C(marker) lines are found, the block will be inserted before the last match of specified regular expression.
     - A special value is available; C(BOF) for inserting the block at the beginning of the file.
     - If specified regular expression has no matches, the block will be inserted at the end of the file.
     type: str


### PR DESCRIPTION
##### SUMMARY

It's not clear from the docs that these options take effect
only when no marker lines are found in the document.
##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

lib/ansible/modules/files/blockinfile.py

##### ADDITIONAL INFORMATION

I've seen more than one issue with a misunderstanding of how these options work with blockinfile. E.g., Issues: #21176, #69372
