### PR TITLE
[2.9] ansible-test: don't trigger full CI run for changes to changelogs/ and docs/ in collections

### DIFF
--- a/changelogs/fragments/68550-ansible-test-docs-changelogs.yml
+++ b/changelogs/fragments/68550-ansible-test-docs-changelogs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-test change detection - Run only sanity tests on ``docs/`` and ``changelogs/`` in collections, to avoid triggering full CI runs of integration and unit tests when files in these directories change."

--- a/test/lib/ansible_test/_internal/classification.py
+++ b/test/lib/ansible_test/_internal/classification.py
@@ -644,6 +644,14 @@ class PathMapper:
         if result is not None:
             return result
 
+        minimal = {}
+
+        if path.startswith('changelogs/'):
+            return minimal
+
+        if path.startswith('docs/'):
+            return minimal
+
         return None
 
     def _classify_ansible(self, path):  # type: (str) -> t.Optional[t.Dict[str, str]]


### PR DESCRIPTION
##### SUMMARY
Backport of #68550 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test
