### PR TITLE
Add is_uuid filter plugin

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -287,7 +287,7 @@ def is_uuid(a, version=None):
     ''' check if input is uuid '''
 
     if not isinstance(a, string_types):
-        raise AnsibleFilterError("|is_uuid expects string type, got %s instead." % type(a))
+        raise AnsibleFilterError("|is_uuid expects string, got %s instead." % type(a))
 
     vers = ['1', '2', '3', '4', '5', 1, 2, 3, 4, 5]
     if version and version in vers:

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -284,7 +284,7 @@ def to_uuid(string, namespace=UUID_NAMESPACE_ANSIBLE):
 
 
 def is_uuid(a, version=None):
-    ''' check if input is uuid '''
+    '''check if input is uuid'''
 
     if not isinstance(a, string_types):
         raise AnsibleFilterError("|is_uuid expects string, got %s instead." % type(a))

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -283,6 +283,31 @@ def to_uuid(string, namespace=UUID_NAMESPACE_ANSIBLE):
     return to_text(uuid.uuid5(uuid_namespace, to_native(string, errors='surrogate_or_strict')))
 
 
+def is_uuid(a, version=None):
+    ''' check if input is uuid '''
+
+    if not isinstance(a, string_types):
+        raise AnsibleFilterError("|is_uuid expects string type, got %s instead." % type(a))
+
+    vers = ['1', '2', '3', '4', '5', 1, 2, 3, 4, 5]
+    if version and version in vers:
+        v = str(version)
+    else:
+        v = '[1-5]'  # support all version by default
+
+    re_uuid = re.compile(
+            '^[a-f0-9]{8}-' +
+            '[a-f0-9]{4}-' +
+            v + '[a-f0-9]{3}-' +
+            '[89ab][a-f0-9]{3}-' +
+            '[a-f0-9]{12}$'
+            )
+
+    re.IGNORECASE
+    match = re_uuid.match(a)
+    return bool(match)
+
+
 def mandatory(a, msg=None):
     from jinja2.runtime import Undefined
 
@@ -576,6 +601,7 @@ class FilterModule(object):
 
             # uuid
             'to_uuid': to_uuid,
+            'is_uuid': is_uuid,
 
             # json
             'to_json': to_json,

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -295,15 +295,12 @@ def is_uuid(a, version=None):
     else:
         v = '[1-5]'  # support all version by default
 
-    re_uuid = re.compile(
-            '^[a-f0-9]{8}-' +
-            '[a-f0-9]{4}-' +
-            v + '[a-f0-9]{3}-' +
-            '[89ab][a-f0-9]{3}-' +
-            '[a-f0-9]{12}$'
-            )
+    re_uuid = re.compile('^[a-f0-9]{8}-' +
+                         '[a-f0-9]{4}-' +
+                         v + '[a-f0-9]{3}-' +
+                         '[89ab][a-f0-9]{3}-' +
+                         '[a-f0-9]{12}$')
 
-    re.IGNORECASE
     match = re_uuid.match(a)
     return bool(match)
 

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -427,6 +427,19 @@
       - to_uuid_1 is failed
       - '"Invalid value" in to_uuid_1.msg'
 
+- name: Verify is_uuid
+  assert:
+    that:
+      - '"0d03a178-da0f-5b51-934e-cda9c76578c3"|is_uuid == True'
+      - '"0d03a178-da0f-5b51-934e-cda9c76578c3"|is_uuid(version=5) == True'
+      - '"0d03a178-da0f-5b51-934e-cda9c76578c3"|is_uuid(version=4) == False'
+      - '"0d03a178-da0f-5b51-934e-cda9c76578c3"|is_uuid(version=3) == False'
+      - '"0d03a178-da0f-5b51-934e-cda9c76578c3"|is_uuid(version=2) == False'
+      - '"0d03a178-da0f-5b51-934e-cda9c76578c3"|is_uuid(version=1) == False'
+      - '"0d03a178-da0f-5b51-934e-cda9c76578c"|is_uuid == False' # missing char
+      - '"b0d03a178-da0f-5b51-934e-cda9c76578c"|is_uuid == False' # extra char beg
+      - '"0d03a178-da0f-5b51-934e-cda9c76578c3b"|is_uuid == False' # extra char end
+
 - name: Verify mandatory throws on undefined variable
   set_fact:
     foo: '{{hey|mandatory}}'


### PR DESCRIPTION
##### SUMMARY
Added a plugin_filter named `is_uuid` that returns boolean result based on input. By default, it will search for any UUID version, but can be modified with the version argument.

I believe, currently, the only way to validate a uuid is with regex.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
is_uuid

##### ADDITIONAL INFORMATION
Test Playbook
```
---
- name: test
  connection: local
  hosts: localhost
  vars:
    test: 'this is a test'
    test_ex_a: '79e65761-39ad-51d0-8840-311f08b99374cha'
    test_ex_b: '179e65761-39ad-51d0-8840-311f08b993741'
  tasks:
    - name: prep
      set_fact:
        valid_uuid: "{{ test | to_uuid }}"
        invalid_uuid: "{{ test | to_uuid | replace('-', '') }}"

    - name: invalid
      debug:
        msg: "{{ test_ex_a | is_uuid }}
              {{ test_ex_b | is_uuid }}"

    - name: valid
      debug:
        msg: "{{ valid_uuid | is_uuid }}"

    - name: valid 1
      debug:
        msg: "{{ valid_uuid | is_uuid(version=1) }}"

    - name: valid 2
      debug:
        msg: "{{ valid_uuid | is_uuid(version=2) }}"

    - name: valid 3
      debug:
        msg: "{{ valid_uuid | is_uuid(version=3) }}"

    - name: valid 4
      debug:
        msg: "{{ valid_uuid | is_uuid(version=4) }}"

    - name: valid 5
      debug:
        msg: "{{ valid_uuid | is_uuid(version=5) }}"

    - name: invalid
      debug:
        msg: "{{ invalid_uuid | is_uuid }}"

    - name: Verify is_uuid
      assert:
        that:
          - '"0d03a178-da0f-5b51-934e-cda9c76578c3"|is_uuid == True'
          - '"0d03a178-da0f-5b51-934e-cda9c76578c3"|is_uuid(version=5) == True'
          - '"0d03a178-da0f-5b51-934e-cda9c76578c3"|is_uuid(version=4) == False'
          - '"0d03a178-da0f-5b51-934e-cda9c76578c3"|is_uuid(version=3) == False'
          - '"0d03a178-da0f-5b51-934e-cda9c76578c3"|is_uuid(version=2) == False'
          - '"0d03a178-da0f-5b51-934e-cda9c76578c3"|is_uuid(version=1) == False'
          - '"0d03a178-da0f-5b51-934e-cda9c76578c"|is_uuid == False' # missing char
          - '"b0d03a178-da0f-5b51-934e-cda9c76578c"|is_uuid == False' # extra char beg
          - '"0d03a178-da0f-5b51-934e-cda9c76578c3b"|is_uuid == False' # extra char end
```
```
# ansible-playbook TEST.yml
[WARNING]: You are running the development version of Ansible. You should only run Ansible from
"devel" if you are modifying the Ansible engine, or trying out features under development. This is
a rapidly changing source of code and can become unstable at any point.
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit
localhost does not match 'all'

PLAY [test] ****************************************************************************************

TASK [Gathering Facts] *****************************************************************************
ok: [localhost]

TASK [prep] ****************************************************************************************
ok: [localhost]

TASK [invalid] *************************************************************************************
ok: [localhost] => {
    "msg": "False False"
}

TASK [valid] ***************************************************************************************
ok: [localhost] => {
    "msg": true
}

TASK [valid 1] *************************************************************************************
ok: [localhost] => {
    "msg": false
}

TASK [valid 2] *************************************************************************************
ok: [localhost] => {
    "msg": false
}

TASK [valid 3] *************************************************************************************
ok: [localhost] => {
    "msg": false
}

TASK [valid 4] *************************************************************************************
ok: [localhost] => {
    "msg": false
}

TASK [valid 5] *************************************************************************************
ok: [localhost] => {
    "msg": true
}

TASK [invalid] *************************************************************************************
ok: [localhost] => {
    "msg": false
}

TASK [Verify is_uuid] ******************************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

PLAY RECAP *****************************************************************************************
localhost                  : ok=11   changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

```