### PR TITLE
Update gcp docs to add a link to the list of valid machine types

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_compute_instance.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_instance.py
@@ -749,7 +749,7 @@ metadata:
 machineType:
   description:
   - A reference to a machine type which defines VM kind. See https://cloud.google.com/compute/docs/machine-types
-  for a list of current valid machine types.
+    for a list of current valid machine types.
   returned: success
   type: str
 minCpuPlatform:

--- a/lib/ansible/modules/cloud/google/gcp_compute_instance.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_instance.py
@@ -748,7 +748,8 @@ metadata:
   type: dict
 machineType:
   description:
-  - A reference to a machine type which defines VM kind.
+  - A reference to a machine type which defines VM kind. See https://cloud.google.com/compute/docs/machine-types
+  for a list of current valid machine types.
   returned: success
   type: str
 minCpuPlatform:


### PR DESCRIPTION

##### SUMMARY
Nothing major, just a link off to the google cloud site (https://cloud.google.com/compute/docs/machine-types) that has the valid machine types required for gcp_compute_instance machineType field. 

Note: Due to changes for upcoming ansible release 2.10 I targeted this against stable. I'm guessing it _should_ go somewhere else for 2.10 but i'm not sure where these modules moved?


##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
gcp_compute_instance


