### PR TITLE
auto_assign_ip for ecs_task module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_task.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_task.py
@@ -14,7 +14,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: ecs_task
-short_description: run, start or stop a task in ecs
+short_description: Run, start or stop a task in ecs
 description:
     - Creates or deletes instances of task definitions.
 version_added: "2.0"
@@ -23,43 +23,82 @@ requirements: [ json, botocore, boto3 ]
 options:
     operation:
         description:
-            - Which task operation to execute
+            - Which task operation to execute.
         required: True
         choices: ['run', 'start', 'stop']
+        type: str
     cluster:
         description:
-            - The name of the cluster to run the task on
+            - The name of the cluster to run the task on.
         required: False
+        type: str
     task_definition:
         description:
-            - The task definition to start or run
+            - The task definition to start or run.
         required: False
+        type: str
     overrides:
         description:
-            - A dictionary of values to pass to the new instances
+            - A dictionary of values to pass to the new instances.
         required: False
+        type: dict
     count:
         description:
-            - How many new instances to start
+            - How many new instances to start.
         required: False
+        type: int
     task:
         description:
-            - The task to stop
+            - The task to stop.
         required: False
+        type: str
     container_instances:
         description:
-            - The list of container instances on which to deploy the task
+            - The list of container instances on which to deploy the task.
         required: False
+        type: list
+        elements: str
     started_by:
         description:
-            - A value showing who or what started the task (for informational purposes)
+            - A value showing who or what started the task (for informational purposes).
         required: False
+        type: str
     network_configuration:
         description:
-          - network configuration of the service. Only applicable for task definitions created with C(awsvpc) I(network_mode).
-          - I(network_configuration) has two keys, I(subnets), a list of subnet IDs to which the task is attached and I(security_groups),
-            a list of group names or group IDs for the task
-        version_added: 2.6
+            - Network configuration of the service. Only applicable for task definitions created with I(network_mode=awsvpc) I(network_mode).
+            - assign_public_ip requires botocore >= 1.8.4
+        suboptions:
+          subnets:
+            description:
+              - A list of subnet IDs to associate with the task.
+            version_added: 2.6
+            type: list
+            elements: str
+          security_groups:
+            description:
+              - A list of security group names or group IDs to associate with the task
+            version_added: 2.6
+            type: list
+            elements: str
+          assign_public_ip:
+            description:
+              - Whether the task's elastic network interface receives a public IP address.
+              - This option requires botocore >= 1.8.4.
+            version_added: 2.9
+            type: bool         
+    launch_type:
+        description:
+          - The launch type on which to run your service.
+        required: false
+        version_added: 2.8
+        choices: ["EC2", "FARGATE"]
+        type: str
+    tags:
+        type: dict
+        description:
+          - Tags that will be added to ecs tasks on start and run
+        required: false
+        version_added: "2.10"
 extends_documentation_fragment:
     - aws
     - ec2
@@ -75,26 +114,45 @@ EXAMPLES = '''
     count: 1
     started_by: ansible_user
   register: task_output
-
 # Simple example of start task
-
 - name: Start a task
   ecs_task:
       operation: start
       cluster: console-sample-app-static-cluster
       task_definition: console-sample-app-static-taskdef
       task: "arn:aws:ecs:us-west-2:172139249013:task/3f8353d1-29a8-4689-bbf6-ad79937ffe8a"
+      tags:
+        resourceName: a_task_for_ansible_to_run
+        type: long_running_task
+        network: internal
+        version: 1.4
       container_instances:
       - arn:aws:ecs:us-west-2:172139249013:container-instance/79c23f22-876c-438a-bddf-55c98a3538a8
       started_by: ansible_user
       network_configuration:
+        assign_public_ip: no
         subnets:
         - subnet-abcd1234
         security_groups:
         - sg-aaaa1111
         - my_security_group
   register: task_output
-
+- name: RUN a task on Fargate
+  ecs_task:
+      operation: run
+      cluster: console-sample-app-static-cluster
+      task_definition: console-sample-app-static-taskdef
+      task: "arn:aws:ecs:us-west-2:172139249013:task/3f8353d1-29a8-4689-bbf6-ad79937ffe8a"
+      started_by: ansible_user
+      launch_type: FARGATE
+      network_configuration:
+        assign_public_ip: yes
+        subnets:
+        - subnet-abcd1234
+        security_groups:
+        - sg-aaaa1111
+        - my_security_group
+  register: task_output
 - name: Stop a task
   ecs_task:
       operation: stop
@@ -104,71 +162,78 @@ EXAMPLES = '''
 '''
 RETURN = '''
 task:
-    description: details about the tast that was started
+    description: details about the task that was started
     returned: success
     type: complex
     contains:
         taskArn:
             description: The Amazon Resource Name (ARN) that identifies the task.
             returned: always
-            type: string
+            type: str
         clusterArn:
             description: The Amazon Resource Name (ARN) of the of the cluster that hosts the task.
             returned: only when details is true
-            type: string
+            type: str
         taskDefinitionArn:
             description: The Amazon Resource Name (ARN) of the task definition.
             returned: only when details is true
-            type: string
+            type: str
         containerInstanceArn:
             description: The Amazon Resource Name (ARN) of the container running the task.
             returned: only when details is true
-            type: string
+            type: str
         overrides:
             description: The container overrides set for this task.
             returned: only when details is true
-            type: list of complex
+            type: list
+            elements: dict
         lastStatus:
             description: The last recorded status of the task.
             returned: only when details is true
-            type: string
+            type: str
         desiredStatus:
             description: The desired status of the task.
             returned: only when details is true
-            type: string
+            type: str
         containers:
             description: The container details.
             returned: only when details is true
-            type: list of complex
+            type: list
+            elements: dict
         startedBy:
             description: The used who started the task.
             returned: only when details is true
-            type: string
+            type: str
         stoppedReason:
             description: The reason why the task was stopped.
             returned: only when details is true
-            type: string
+            type: str
         createdAt:
             description: The timestamp of when the task was created.
             returned: only when details is true
-            type: string
+            type: str
         startedAt:
             description: The timestamp of when the task was started.
             returned: only when details is true
-            type: string
+            type: str
         stoppedAt:
             description: The timestamp of when the task was stopped.
             returned: only when details is true
-            type: string
+            type: str
+        launchType:
+            description: The launch type on which to run your task.
+            returned: always
+            type: str
 '''
 
 from ansible.module_utils.aws.core import AnsibleAWSModule
-from ansible.module_utils.ec2 import ec2_argument_spec, get_ec2_security_group_ids_from_names
+from ansible.module_utils.basic import missing_required_lib
+from ansible.module_utils.ec2 import get_ec2_security_group_ids_from_names, ansible_dict_to_boto3_tag_list
 
 try:
     import botocore
 except ImportError:
-    pass  # handled by AnsibleAWSModule
+    pass  # caught by AnsibleAWSModule
 
 
 class EcsExecManager:
@@ -194,6 +259,14 @@ class EcsExecManager:
                 except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                     self.module.fail_json_aws(e, msg="Couldn't look up security groups")
             result['securityGroups'] = groups
+        if network_config['assign_public_ip'] is not None:
+            if self.module.botocore_at_least('1.8.4'):
+                if network_config['assign_public_ip'] is True:
+                    result['assignPublicIp'] = "ENABLED"
+                else:
+                    result['assignPublicIp'] = "DISABLED"
+            else:
+                self.module.fail_json(msg='botocore needs to be version 1.8.4 or higher to use assign_public_ip in network_configuration')
         return dict(awsvpcConfiguration=result)
 
     def list_tasks(self, cluster_name, service_name, status):
@@ -208,13 +281,19 @@ class EcsExecManager:
                     return c
         return None
 
-    def run_task(self, cluster, task_definition, overrides, count, startedBy):
+    def run_task(self, cluster, task_definition, overrides, count, startedBy, launch_type, tags):
         if overrides is None:
             overrides = dict()
         params = dict(cluster=cluster, taskDefinition=task_definition,
                       overrides=overrides, count=count, startedBy=startedBy)
         if self.module.params['network_configuration']:
             params['networkConfiguration'] = self.format_network_configuration(self.module.params['network_configuration'])
+        if launch_type:
+            params['launchType'] = launch_type
+        if tags:
+            params['tags'] = ansible_dict_to_boto3_tag_list(tags, 'key', 'value')
+
+            # TODO: need to check if long arn format enabled.
         try:
             response = self.ecs.run_task(**params)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
@@ -222,7 +301,7 @@ class EcsExecManager:
         # include tasks and failures
         return response['tasks']
 
-    def start_task(self, cluster, task_definition, overrides, container_instances, startedBy):
+    def start_task(self, cluster, task_definition, overrides, container_instances, startedBy, tags):
         args = dict()
         if cluster:
             args['cluster'] = cluster
@@ -236,6 +315,8 @@ class EcsExecManager:
             args['startedBy'] = startedBy
         if self.module.params['network_configuration']:
             args['networkConfiguration'] = self.format_network_configuration(self.module.params['network_configuration'])
+        if tags:
+            args['tags'] = ansible_dict_to_boto3_tag_list(tags, 'key', 'value')
         try:
             response = self.ecs.start_task(**args)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
@@ -247,6 +328,24 @@ class EcsExecManager:
         response = self.ecs.stop_task(cluster=cluster, task=task)
         return response['task']
 
+    def ecs_api_handles_launch_type(self):
+        from distutils.version import LooseVersion
+        # There doesn't seem to be a nice way to inspect botocore to look
+        # for attributes (and networkConfiguration is not an explicit argument
+        # to e.g. ecs.run_task, it's just passed as a keyword argument)
+        return LooseVersion(botocore.__version__) >= LooseVersion('1.8.4')
+
+    def ecs_task_long_format_enabled(self):
+        account_support = self.ecs.list_account_settings(name='taskLongArnFormat', effectiveSettings=True)
+        return account_support['settings'][0]['value'] == 'enabled'
+
+    def ecs_api_handles_tags(self):
+        from distutils.version import LooseVersion
+        # There doesn't seem to be a nice way to inspect botocore to look
+        # for attributes (and networkConfiguration is not an explicit argument
+        # to e.g. ecs.run_task, it's just passed as a keyword argument)
+        return LooseVersion(botocore.__version__) >= LooseVersion('1.12.46')
+
     def ecs_api_handles_network_configuration(self):
         from distutils.version import LooseVersion
         # There doesn't seem to be a nice way to inspect botocore to look
@@ -256,8 +355,7 @@ class EcsExecManager:
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         operation=dict(required=True, choices=['run', 'start', 'stop']),
         cluster=dict(required=False, type='str'),  # R S P
         task_definition=dict(required=False, type='str'),  # R* S*
@@ -266,10 +364,18 @@ def main():
         task=dict(required=False, type='str'),  # P*
         container_instances=dict(required=False, type='list'),  # S*
         started_by=dict(required=False, type='str'),  # R S
-        network_configuration=dict(required=False, type='dict')
-    ))
+        network_configuration=dict(required=False, type='dict', options=dict(
+            subnets=dict(type='list', elements='str'),
+            security_groups=dict(type='list', elements='str'),
+            assign_public_ip=dict(type='bool')
+        )),
+        network_configuration=dict(required=False, type='dict'),
+        launch_type=dict(required=False, choices=['EC2', 'FARGATE']),
+        tags=dict(required=False, type='dict')
+    )
 
-    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True,
+                              required_if=[('launch_type', 'FARGATE', ['network_configuration'])])
 
     # Validate Inputs
     if module.params['operation'] == 'run':
@@ -295,8 +401,19 @@ def main():
         status_type = "STOPPED"
 
     service_mgr = EcsExecManager(module)
+
     if module.params['network_configuration'] and not service_mgr.ecs_api_handles_network_configuration():
         module.fail_json(msg='botocore needs to be version 1.7.44 or higher to use network configuration')
+
+    if module.params['launch_type'] and not service_mgr.ecs_api_handles_launch_type():
+        module.fail_json(msg='botocore needs to be version 1.8.4 or higher to use launch type')
+
+    if module.params['tags']:
+        if not service_mgr.ecs_api_handles_tags():
+            module.fail_json(msg=missing_required_lib("botocore >= 1.12.46", reason="to use tags"))
+        if not service_mgr.ecs_task_long_format_enabled():
+            module.fail_json(msg="Cannot set task tags: long format task arns are required to set tags")
+
     existing = service_mgr.list_tasks(module.params['cluster'], task_to_list, status_type)
 
     results = dict(changed=False)
@@ -311,7 +428,10 @@ def main():
                     module.params['task_definition'],
                     module.params['overrides'],
                     module.params['count'],
-                    module.params['started_by'])
+                    module.params['started_by'],
+                    module.params['launch_type'],
+                    module.params['tags'],
+                )
             results['changed'] = True
 
     elif module.params['operation'] == 'start':
@@ -325,7 +445,8 @@ def main():
                     module.params['task_definition'],
                     module.params['overrides'],
                     module.params['container_instances'],
-                    module.params['started_by']
+                    module.params['started_by'],
+                    module.params['tags'],
                 )
             results['changed'] = True
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding auto_assign_ip that require at the time of running task on fargate and also documentation of the same
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue --> 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
auto_assign_ip for ecs_task
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
BEFORE
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "aws_access_key": null,
            "aws_secret_key": null,
            "cluster": "mycluster",
            "container_instances": null,
            "count": 1,
            "debug_botocore_endpoint_logs": false,
            "ec2_url": null,
            "launch_type": "FARGATE",
            "network_configuration": {
                "assign_public_ip": true,
                "security_groups": [
                    "sg-02689d2aa94ae63d8"
                ],
                "subnets": [
                    "subnet-082122607afb7c53f",
                    "subnet-029decbb82f1c1ec9"
                ]
            },
            "operation": "run",
            "overrides": null,
            "profile": null,
            "region": "us-east-1",
            "security_token": null,
            "started_by": "ansible_user",
            "task": null,
            "task_definition": "rushi",
            "validate_certs": true
        }
    },
    "task": [
        {
            "attachments": [
                {
                    "details": [
                        {
                            "name": "subnetId",
                            "value": "subnet-029decbb82f1c1ec9"
                        }
                    ],
                    "id": "157f3176-9dfe-45f1-925c-7164fd9acc3d",
                    "status": "PRECREATED",
                    "type": "ElasticNetworkInterface"
                }
            ],
            "availabilityZone": "us-east-1b",
            "clusterArn": "arn:aws:ecs:us-east-1:255378380220:cluster/mycluster",
            "containers": [
                {
                    "containerArn": "arn:aws:ecs:us-east-1:255378380220:container/96901b34-8230-4cc2-84bc-43242a120091",
                    "cpu": "0",
                    "image": "pengbai/docker-supermario:latest",
                    "lastStatus": "PENDING",
                    "name": "rushi-mario",
                    "networkInterfaces": [],
                    "taskArn": "arn:aws:ecs:us-east-1:255378380220:task/3ec6568d-ff5d-4537-8b1a-5d5ed4dbd11f"
                }
            ],
            "cpu": "1024",
            "createdAt": "2020-05-10T18:27:35.478000+05:30",
            "desiredStatus": "RUNNING",
            "group": "family:rushi",
            "lastStatus": "PROVISIONING",
            "launchType": "FARGATE",
            "memory": "2048",
            "overrides": {
                "containerOverrides": [
                    {
                        "name": "rushi-mario"
                    }
                ],
                "inferenceAcceleratorOverrides": []
            },
            "platformVersion": "1.3.0",
            "startedBy": "ansible_user",
            "tags": [],
            "taskArn": "arn:aws:ecs:us-east-1:255378380220:task/3ec6568d-ff5d-4537-8b1a-5d5ed4dbd11f",
            "taskDefinitionArn": "arn:aws:ecs:us-east-1:255378380220:task-definition/rushi:18",
            "version": 1
        }
    ]
}
FROM above module there is a error when pulling image from docker for fargate 
If you're running your task using an Amazon Elastic Compute Cloud (Amazon EC2) launch type and your container instance is in a public subnet, confirm that the instance has a public IP address. Or, if you're running a task using the Fargate launch type in a public subnet, choose ENABLED for Auto-assign public IP when you launch the task. This allows your task to have outbound network access to pull an image.

AFTER
successfully deploy task and run without STOP error
![Screenshot from 2020-05-11 09-46-51](https://user-images.githubusercontent.com/50708898/81523782-88420300-936c-11ea-80cb-2a82b27a92a0.png)
![Screenshot from 2020-05-11 09-53-50](https://user-images.githubusercontent.com/50708898/81524023-5f6e3d80-936d-11ea-9742-325b4ab1402d.png)


```
