### PR TITLE
[2.9] Fix/archive empty file

### DIFF
--- a/changelogs/fragments/64895-fix-archive-empty-file.yml
+++ b/changelogs/fragments/64895-fix-archive-empty-file.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - archive - fix issue with empty file exclusion from archive

--- a/lib/ansible/modules/files/archive.py
+++ b/lib/ansible/modules/files/archive.py
@@ -414,16 +414,15 @@ def main():
                                     n_fullpath = to_native(b_fullpath, errors='surrogate_or_strict', encoding='ascii')
                                     n_arcname = to_native(b_match_root.sub(b'', b_fullpath), errors='surrogate_or_strict')
 
-                                    if not filecmp.cmp(b_fullpath, b_dest):
-                                        try:
-                                            if fmt == 'zip':
-                                                arcfile.write(n_fullpath, n_arcname)
-                                            else:
-                                                arcfile.add(n_fullpath, n_arcname, recursive=False)
+                                    try:
+                                        if fmt == 'zip':
+                                            arcfile.write(n_fullpath, n_arcname)
+                                        else:
+                                            arcfile.add(n_fullpath, n_arcname, recursive=False)
 
-                                            b_successes.append(b_fullpath)
-                                        except Exception as e:
-                                            errors.append('Adding %s: %s' % (to_native(b_path), to_native(e)))
+                                        b_successes.append(b_fullpath)
+                                    except Exception as e:
+                                        errors.append('Adding %s: %s' % (to_native(b_path), to_native(e)))
                         else:
                             path = to_native(b_path, errors='surrogate_or_strict', encoding='ascii')
                             arcname = to_native(b_match_root.sub(b'', b_path), errors='surrogate_or_strict')

--- a/test/integration/targets/archive/tasks/main.yml
+++ b/test/integration/targets/archive/tasks/main.yml
@@ -68,11 +68,12 @@
   when: ansible_python_version.split('.')[0] == '2'
   register: backports_lzma_pip
 
-- name: prep our file
+- name: prep our files
   copy: src={{ item }} dest={{output_dir}}/{{ item }}
   with_items:
     - foo.txt
     - bar.txt
+    - empty.txt
 
 - name: archive using gz
   archive:
@@ -86,12 +87,12 @@
 - name: verify that the files archived
   file: path={{output_dir}}/archive_01.gz state=file
 
-- name: check if gz file exists
+- name: check if gz file exists and includes all text files
   assert:
     that:
       - "{{ archive_gz_result_01.changed }}"
       - "{{ 'archived' in archive_gz_result_01 }}"
-      - "{{ archive_gz_result_01['archived'] | length }} == 2"
+      - "{{ archive_gz_result_01['archived'] | length }} == 3"
 
 - name: archive using zip
   archive:
@@ -110,7 +111,7 @@
     that:
       - "{{ archive_zip_result_01.changed }}"
       - "{{ 'archived' in archive_zip_result_01 }}"
-      - "{{ archive_zip_result_01['archived'] | length }} == 2"
+      - "{{ archive_zip_result_01['archived'] | length }} == 3"
 
 - name: archive using bz2
   archive:
@@ -129,7 +130,7 @@
     that:
       - "{{ archive_bz2_result_01.changed }}"
       - "{{ 'archived' in archive_bz2_result_01 }}"
-      - "{{ archive_bz2_result_01['archived'] | length }} == 2"
+      - "{{ archive_bz2_result_01['archived'] | length }} == 3"
 
 - name: archive using xz
   archive:
@@ -148,7 +149,7 @@
     that:
       - "{{ archive_xz_result_01.changed }}"
       - "{{ 'archived' in archive_xz_result_01 }}"
-      - "{{ archive_xz_result_01['archived'] | length }} == 2"
+      - "{{ archive_xz_result_01['archived'] | length }} == 3"
 
 - name: archive and set mode to 0600
   archive:
@@ -171,7 +172,7 @@
       - "archive_02_gz_stat.changed == False "
       - "archive_02_gz_stat.stat.mode == '0600'"
       - "'archived' in archive_bz2_result_02"
-      - "{{ archive_bz2_result_02['archived']| length}} == 2"
+      - "{{ archive_bz2_result_02['archived']| length}} == 3"
 
 - name: remove our gz
   file: path="{{ output_dir }}/archive_02.gz" state=absent
@@ -196,7 +197,7 @@
       - "archive_02_zip_stat.changed == False"
       - "archive_02_zip_stat.stat.mode == '0600'"
       - "'archived' in archive_zip_result_02"
-      - "{{ archive_zip_result_02['archived']| length}} == 2"
+      - "{{ archive_zip_result_02['archived']| length}} == 3"
 
 - name: remove our zip
   file: path="{{ output_dir }}/archive_02.zip" state=absent
@@ -221,7 +222,7 @@
       - "archive_02_bz2_stat.changed == False"
       - "archive_02_bz2_stat.stat.mode == '0600'"
       - "'archived' in archive_bz2_result_02"
-      - "{{ archive_bz2_result_02['archived']| length}} == 2"
+      - "{{ archive_bz2_result_02['archived']| length}} == 3"
 
 - name: remove our bz2
   file: path="{{ output_dir }}/archive_02.bz2" state=absent
@@ -245,7 +246,7 @@
       - "archive_02_xz_stat.changed == False"
       - "archive_02_xz_stat.stat.mode == '0600'"
       - "'archived' in archive_xz_result_02"
-      - "{{ archive_xz_result_02['archived']| length}} == 2"
+      - "{{ archive_xz_result_02['archived']| length}} == 3"
 
 - name: remove our xz
   file: path="{{ output_dir }}/archive_02.xz" state=absent


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/64895


* Remove call to filecompare to fix issue with empty file exclusion from archive

* Add empty file

(cherry picked from commit 277dd54d45dd32a93a3448da4a7a696f4d905479)

This is backported from #64895. I omit the first chunk (removal of extra space) in commit 277dd54d45dd32a93a3448da4a7a696f4d905479 as that sentence is not in 2.8 branch.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`archive` module

##### ADDITIONAL INFORMATION