### PR TITLE
Add missing options for GRE interface

### DIFF
--- a/lib/ansible/module_utils/network/junos/config/interfaces/interfaces.py
+++ b/lib/ansible/module_utils/network/junos/config/interfaces/interfaces.py
@@ -216,16 +216,32 @@ class Interfaces(ConfigBase):
             build_child_xml_node(intf, 'name', config['name'])
 
             intf_fields = ['description']
-            if not config['name'].startswith('lo'):
+            if not any(
+                [
+                    config['name'].startswith('gr'),
+                    config['name'].startswith('lo'),
+                ]
+            ):
                 intf_fields.append('speed')
 
-            if not any([config['name'].startswith('fxp'), config['name'].startswith('lo')]):
+            if not any(
+                [
+                    config['name'].startswith('gr'),
+                    config['name'].startswith('fxp'),
+                    config['name'].startswith('lo')
+                ]
+            ):
                 intf_fields.append('mtu')
 
             for field in intf_fields:
                 build_child_xml_node(intf, field, None, {'delete': 'delete'})
 
-            if not config['name'].startswith('lo'):
+            if not any(
+                    [
+                        config['name'].startswith('gr'),
+                        config['name'].startswith('lo')
+                    ]
+            ):
                 build_child_xml_node(intf, 'link-mode', None, {'delete': 'delete'})
 
             build_child_xml_node(intf, 'disable', None, {'delete': 'delete'})

--- a/test/integration/targets/junos_interfaces/tests/netconf/_remove_config.yaml
+++ b/test/integration/targets/junos_interfaces/tests/netconf/_remove_config.yaml
@@ -8,6 +8,7 @@
       - delete interfaces ge-0/0/1
       - delete interfaces ge-0/0/2
       - delete interfaces ge-0/0/3
+      - delete interfaces gr-0/0/0
       - delete interfaces lo0
 
 - debug:

--- a/test/integration/targets/junos_interfaces/tests/netconf/deleted.yaml
+++ b/test/integration/targets/junos_interfaces/tests/netconf/deleted.yaml
@@ -29,6 +29,11 @@
             hold_time:
               up: 3000
               down: 3200
+          - name: gr-0/0/0
+            description: "Configured by Ansible - Interface 3"
+            hold_time:
+              up: 2400
+              down: 2600
         state: merged
       register: result
 
@@ -37,6 +42,7 @@
         config:
         - name: ge-0/0/1
         - name: ge-0/0/2
+        - name: gr-0/0/0
         state: deleted
       register: result
 

--- a/test/integration/targets/junos_interfaces/tests/netconf/merged.yaml
+++ b/test/integration/targets/junos_interfaces/tests/netconf/merged.yaml
@@ -6,8 +6,14 @@
 
 - set_fact:
     expected_merged_output:
-      - name: ge-0/0/1
+      - name: gr-0/0/0
         description: "Configured by Ansible - Interface 1"
+        enabled: true
+        hold_time:
+          down: 2600
+          up: 2400
+      - name: ge-0/0/1
+        description: "Configured by Ansible - Interface 2"
         mtu: 1024
         speed: 100m
         enabled: false
@@ -16,7 +22,7 @@
           up: 2000
           down: 2200
       - name: ge-0/0/2
-        description: "Configured by Ansible - Interface 2"
+        description: "Configured by Ansible - Interface 3"
         mtu: 2048
         speed: 10m
         enabled: true
@@ -30,8 +36,13 @@
     - name: Merge the provided configuration with the exisiting running configuration
       junos_interfaces: &merged
         config:
-          - name: ge-0/0/1
+          - name: gr-0/0/0
             description: "Configured by Ansible - Interface 1"
+            hold_time:
+              up: 2400
+              down: 2600
+          - name: ge-0/0/1
+            description: "Configured by Ansible - Interface 2"
             mtu: 1024
             speed: 100m
             enabled: False
@@ -40,7 +51,7 @@
               up: 2000
               down: 2200
           - name: ge-0/0/2
-            description: "Configured by Ansible - Interface 2"
+            description: "Configured by Ansible - Interface 3"
             mtu: 2048
             speed: 10m
             hold_time:


### PR DESCRIPTION
This commit adds some missing options related to gre interfaces on
junos_interfaces module.

Cherry-picked from https://github.com/ansible-collections/junipernetworks.junos/pull/37
Fixes: https://github.com/ansible-collections/junipernetworks.junos/issues/36

Signed-off-by: Daniel Mellado <dmellado@redhat.com>


Backport of https://github.com/ansible-collections/junipernetworks.junos/pull/37
