### PR TITLE
basic: Add name of aliases in error message

### DIFF
--- a/changelogs/fragments/58752_argument_aliases.yml
+++ b/changelogs/fragments/58752_argument_aliases.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Added name of aliases in user error (https://github.com/ansible/ansible/issues/58752).

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1471,7 +1471,13 @@ class AnsibleModule(object):
             msg = "Unsupported parameters for (%s) module: %s" % (self._name, ', '.join(sorted(list(unsupported_parameters))))
             if self._options_context:
                 msg += " found in %s." % " -> ".join(self._options_context)
-            msg += " Supported parameters include: %s" % (', '.join(sorted(spec.keys())))
+            supported_parameters = list()
+            for key in sorted(spec.keys()):
+                if 'aliases' in spec[key] and spec[key]['aliases']:
+                    supported_parameters.append("%s (%s)" % (key, ', '.join(sorted(spec[key]['aliases']))))
+                else:
+                    supported_parameters.append(key)
+            msg += " Supported parameters include: %s" % (', '.join(supported_parameters))
             self.fail_json(msg=msg)
         if self.check_mode and not self.supports_check_mode:
             self.exit_json(skipped=True, msg="remote module (%s) does not support check mode" % self._name)

--- a/test/units/module_utils/basic/test_argument_spec.py
+++ b/test/units/module_utils/basic/test_argument_spec.py
@@ -84,6 +84,8 @@ INVALID_SPECS = (
     # unknown parameter
     ({'arg': {'type': 'int'}}, {'other': 'bad', '_ansible_module_name': 'ansible_unittest'},
      'Unsupported parameters for (ansible_unittest) module: other Supported parameters include: arg'),
+    ({'arg': {'type': 'int', 'aliases': ['argument']}}, {'other': 'bad', '_ansible_module_name': 'ansible_unittest'},
+     'Unsupported parameters for (ansible_unittest) module: other Supported parameters include: arg (argument)'),
     # parameter is required
     ({'arg': {'required': True}}, {}, 'missing required arguments: arg'),
 )


### PR DESCRIPTION
##### SUMMARY

With this patch, user will be notified with available aliases
of arg parameter.

Fixes: #58752

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/58752_argument_aliases.yml
