### PR TITLE
[stable-2.9] Fix galaxy publish sha256 value format. (#67942)

### DIFF
--- a/changelogs/fragments/67942-fix-galaxy-multipart.yml
+++ b/changelogs/fragments/67942-fix-galaxy-multipart.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- ansible-galaxy - Fix ``multipart/form-data`` body to include extra CRLF
+  (https://github.com/ansible/ansible/pull/67942)

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -435,6 +435,7 @@ class GalaxyAPI:
         form = [
             part_boundary,
             b"Content-Disposition: form-data; name=\"sha256\"",
+            b"",
             to_bytes(secure_hash_s(data, hash_func=hashlib.sha256), errors='surrogate_or_strict'),
             part_boundary,
             b"Content-Disposition: file; name=\"file\"; filename=\"%s\"" % b_file_name,


### PR DESCRIPTION
* Fix galaxy publish sha256 value format.

The multipart/form content used for the body
of the POST to /api/automation-hub/v3/collections
was missing a newline before the line with the value
of the sha256.

automation-hub/galaxy/django skips the field entirely in
that case and automation-hub code will use None for default
to indicate that no sha256 is provided (an available option).

Fixes ansible/galaxy-dev#246

* Add changelog fragment

Co-authored-by: Matt Martz <matt@sivel.net>
(cherry picked from commit cd8dd4a)


Co-authored-by: Adrian Likins <alikins@redhat.com>

Backport of https://github.com/ansible/ansible/pull/67942
