### PR TITLE
Modify wording to specify two ctl-d to end stdin input in ansible-vault

### DIFF
--- a/docs/docsite/rst/user_guide/vault.rst
+++ b/docs/docsite/rst/user_guide/vault.rst
@@ -241,7 +241,7 @@ To encrypt a string read from stdin and name it 'db_password':
 
 Result::
 
-    Reading plaintext input from stdin. (ctrl-d to end input)
+    Reading plaintext input from stdin. (ctrl-d to end input, twice if your content does not already have a new line)
     db_password: !vault |
               $ANSIBLE_VAULT;1.2;AES256;dev
               61323931353866666336306139373937316366366138656131323863373866376666353364373761
@@ -259,7 +259,7 @@ To be prompted for a string to encrypt, encrypt it, and give it the name 'new_us
 
 Output::
 
-    Reading plaintext input from stdin. (ctrl-d to end input)
+    Reading plaintext input from stdin. (ctrl-d to end input, twice if your content does not already have a new line)
 
 User enters 'hunter2' and hits ctrl-d.
 

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -312,7 +312,7 @@ class VaultCLI(CLI):
         # read from stdin
         if self.encrypt_string_read_stdin:
             if sys.stdout.isatty():
-                display.display("Reading plaintext input from stdin. (ctrl-d to end input)", stderr=True)
+                display.display("Reading plaintext input from stdin. (ctrl-d to end input, twice if your content does not already have a new line)", stderr=True)
 
             stdin_text = sys.stdin.read()
             if stdin_text == '':

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -312,7 +312,7 @@ class VaultCLI(CLI):
         # read from stdin
         if self.encrypt_string_read_stdin:
             if sys.stdout.isatty():
-                display.display("Reading plaintext input from stdin. (ctrl-d to end input, twice if your content does not already have a new line)", stderr=True)
+                display.display("Reading plaintext input from stdin. (ctrl-d to end input, twice if your content does not already have a newline)", stderr=True)
 
             stdin_text = sys.stdin.read()
             if stdin_text == '':


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
For ansible-vault encrypt_string you need to end the string with two ctl-d's. Now a newline, ctl-d. Updating the wording in the stdout message to indicate this.
Helps with #51860

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-vault

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
