### PR TITLE
Fix fileglob plugin with non-existent subdirectory

### DIFF
--- a/changelogs/fragments/69451-fix-fileglob-nonexistent-subdirs.yaml
+++ b/changelogs/fragments/69451-fix-fileglob-nonexistent-subdirs.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+- Fix an issue with the ``fileglob`` plugin where passing a subdirectory of
+  non-existent directory would cause it to fail -
+  https://github.com/ansible/ansible/issues/69450

--- a/lib/ansible/plugins/lookup/fileglob.py
+++ b/lib/ansible/plugins/lookup/fileglob.py
@@ -72,8 +72,9 @@ class LookupModule(LookupBase):
                     found_paths.append(p)
 
             for dwimmed_path in found_paths:
-                globbed = glob.glob(to_bytes(os.path.join(dwimmed_path, term_file), errors='surrogate_or_strict'))
-                ret.extend(to_text(g, errors='surrogate_or_strict') for g in globbed if os.path.isfile(g))
-                if ret:
-                    break
+                if dwimmed_path:
+                    globbed = glob.glob(to_bytes(os.path.join(dwimmed_path, term_file), errors='surrogate_or_strict'))
+                    ret.extend(to_text(g, errors='surrogate_or_strict') for g in globbed if os.path.isfile(g))
+                    if ret:
+                        break
         return ret

--- a/test/integration/targets/fileglob/non_existent/play.yml
+++ b/test/integration/targets/fileglob/non_existent/play.yml
@@ -1,0 +1,6 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: fileglob should be empty
+      assert:
+        that: q("fileglob", seed) | length == 0

--- a/test/integration/targets/fileglob/runme.sh
+++ b/test/integration/targets/fileglob/runme.sh
@@ -7,3 +7,9 @@ for seed in play_adj play_adj_subdir somepath/play_adj_subsubdir in_role otherpa
 do
 	ansible-playbook find_levels/play.yml -e "seed='${seed}'" "$@"
 done
+
+# non-existent paths
+for seed in foo foo/bar foo/bar/baz
+do
+	ansible-playbook non_existent/play.yml -e "seed='${seed}'" "$@"
+done


### PR DESCRIPTION
Since Ansible 2.9.8, if the fileglob plugin is passed a path containing
a subdirectory of a non-existent directory, it will fail. For example:

lookup('fileglob', '/'): ok
lookup('fileglob', '/foo'): (non-existent): ok
lookup('fileglob', '/foo/bar'): (non-existent): FAIL

The exact error depends on Python 2 or 3, but here is the error on
Python 2:

    AttributeError: 'NoneType' object has no attribute 'endswith'

And on Python 3:

    TypeError: expected str, bytes or os.PathLike object, not NoneType

This change fixes the issue by skipping paths that are falsey before
passing them to os.path.join().

Fixes: #69450

Backport of https://github.com/ansible/ansible/pull/69451

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
