### PR TITLE
pacman: Improve package state detection speed

### DIFF
--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -159,20 +159,17 @@ from ansible.module_utils.basic import AnsibleModule
 
 
 def get_version(pacman_output):
-    """Take pacman -Qi or pacman -Si output and get the Version"""
-    lines = pacman_output.split('\n')
-    for line in lines:
-        if line.startswith('Version '):
-            return line.split(':')[1].strip()
+    """Take pacman -Q or pacman -S output and get the Version"""
+    fields = pacman_output.split()
+    if len(fields) == 2:
+        return fields[1]
     return None
 
-
 def get_name(module, pacman_output):
-    """Take pacman -Qi or pacman -Si output and get the package name"""
-    lines = pacman_output.split('\n')
-    for line in lines:
-        if line.startswith('Name '):
-            return line.split(':')[1].strip()
+    """Take pacman -Q or pacman -S output and get the package name"""
+    fields = pacman_output.split()
+    if len(fields) == 2:
+        return fields[0]
     module.fail_json(msg="get_name: fail to retrieve package name from pacman output")
 
 
@@ -181,7 +178,7 @@ def query_package(module, pacman_path, name, state="present"):
     boolean to indicate if the package is up-to-date and a third boolean to indicate whether online information were available
     """
     if state == "present":
-        lcmd = "%s --query --info %s" % (pacman_path, name)
+        lcmd = "%s --query %s" % (pacman_path, name)
         lrc, lstdout, lstderr = module.run_command(lcmd, check_rc=False)
         if lrc != 0:
             # package is not installed locally
@@ -196,7 +193,7 @@ def query_package(module, pacman_path, name, state="present"):
         # get the version installed locally (if any)
         lversion = get_version(lstdout)
 
-        rcmd = "%s --sync --info %s" % (pacman_path, name)
+        rcmd = "%s --sync --print-format \"%%n %%v\" %s" % (pacman_path, name)
         rrc, rstdout, rstderr = module.run_command(rcmd, check_rc=False)
         # get the version in the repository
         rversion = get_version(rstdout)


### PR DESCRIPTION
Don't query for full details of a package. It is sufficient to query
the name and version. This also simplifies parsing the output.

##### SUMMARY
When using a large amount packages  the  pacman module takes very long to determine the version numbers, because it parses the `pacman -Qi` (full-detail) output.

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
pacman

##### ADDITIONAL INFORMATION
Instead of parsing `gcc -Qi gcc`:

```
Name            : gcc
Version         : 9.3.0-1
Description     : The GNU Compiler Collection - C and C++ frontends
Architecture    : x86_64
URL             : https://gcc.gnu.org
Licenses        : GPL  LGPL  FDL  custom
Groups          : base-devel
Provides        : gcc-multilib
Depends On      : gcc-libs=9.3.0-1  binutils>=2.28  libmpc
Optional Deps   : lib32-gcc-libs: for generating code for 32-bit ABI
Required By     : clang  ghc  varnish
Optional For    : xorg-xrdb
Conflicts With  : None
Replaces        : gcc-multilib
Installed Size  : 139.32 MiB
Packager        : Bart
Build Date      : Thu Mar 12 17:55:10 2020
Install Date    : Tue Mar 17 06:59:01 2020
Install Reason  : Explicitly installed
Install Script  : No
Validated By    : Signature
```
the module only has to parse `pacman -Q gcc`:

```
gcc 9.3.0-1
```

Profiling full parsing on my system (30 packages):
```
Tuesday 12 May 2020  16:47:48 +0200 (0:00:20.480)       0:00:20.496 *********** 
```
Speedup witch this commit:

```
Tuesday 12 May 2020  16:48:13 +0200 (0:00:14.484)       0:00:14.501 *********** 
```

That's about 30% performance improvement.
