### PR TITLE
Update directory_mode description and add example

### DIFF
--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -81,6 +81,7 @@ options:
     - When doing a recursive copy set the mode for the directories.
     - If this is not set we will use the system defaults.
     - The mode is only set on directories which are newly created, and will not affect those that already existed.
+    - Requires a quoted or octal number(with a leading zero) similar to the "mode" option.
     type: raw
     version_added: '1.5'
   remote_src:
@@ -163,6 +164,14 @@ EXAMPLES = r'''
     group: root
     mode: '0644'
     backup: yes
+    
+- name: Recursively copy and assign 755 permissions to all contents(directories and files) from "etc" directory into "path" directory 
+  copy:
+    src: /mine/
+    dest: /path/ 
+    owner: root
+    group: root
+    directory_mode: 0755
 
 - name: Copy a new "sudoers" file into place, after passing validation with visudo
   copy:

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -171,7 +171,7 @@ EXAMPLES = r'''
     dest: /path/
     owner: root
     group: root
-    directory_mode: 0755
+    directory_mode: '0755'
 
 - name: Copy a new "sudoers" file into place, after passing validation with visudo
   copy:

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -165,7 +165,7 @@ EXAMPLES = r'''
     mode: '0644'
     backup: yes
 
-- name: Recursively copy and assign 755 permissions to all contents(directories and files) from "etc" directory into "path" directory
+- name: Recursively copy and assign 755 permissions to all contents(directories and files) from "mine" directory into "path" directory
   copy:
     src: /mine/
     dest: /path/

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -164,11 +164,11 @@ EXAMPLES = r'''
     group: root
     mode: '0644'
     backup: yes
-    
-- name: Recursively copy and assign 755 permissions to all contents(directories and files) from "etc" directory into "path" directory 
+
+- name: Recursively copy and assign 755 permissions to all contents(directories and files) from "etc" directory into "path" directory
   copy:
     src: /mine/
-    dest: /path/ 
+    dest: /path/
     owner: root
     group: root
     directory_mode: 0755


### PR DESCRIPTION
##### SUMMARY
Add additional description of "directory_mode" option, along with an example of its use.
##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
The description of the "directory_mode" option currently reads as if it is a flag that should be set using "True" or "yes".  Some confusion on my part in addition to (I believe)incorrect use in an [SO post](https://stackoverflow.com/questions/35488433/ansible-copy-a-directory-content-to-another-directory) prompted an update of the documentation for this command.


##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
copy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
When attempting to use the following task to copy several files, the permissions on the files were left as '0001'(an unusable state - default for the test system I believe).
```- name: Recursively copy all files and directories from example1 into example2
      copy:
        src: /example1/
        dest: /example2/
        owner: root
        group: root
        directory_mode: yes #or True
        mode: 0755
```
Passing the directory_mode option an octal resolved the issue: 
```- name: Recursively copy all files and directories from example1 into example2
      copy:
        src: /example1/
        dest: /example2/
        owner: root
        group: root
        directory_mode: 0755
        mode: 0755
```


