### PR TITLE
Updated CLI help for 'ansible-galaxy' for 'collection' subcommand

### DIFF
--- a/changelogs/fragments/69458-updated-galaxy-cli-help.yaml
+++ b/changelogs/fragments/69458-updated-galaxy-cli-help.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - On giving an invalid subcommand to ansible-galaxy, the help would be shown only for role subcommand (collection subcommand help is not shown). With this change, the entire help for ansible-galaxy (same as ansible-galaxy --help) is displayed along with the help for role subcommand. 

--- a/changelogs/fragments/69458-updated-galaxy-cli-help.yaml
+++ b/changelogs/fragments/69458-updated-galaxy-cli-help.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - ansible-galaxy - On giving an invalid subcommand to ansible-galaxy, the help would be shown only for role subcommand (collection subcommand help is not shown). With this change, the entire help for ansible-galaxy (same as ansible-galaxy --help) is displayed along with the help for role subcommand. (https://github.com/ansible/ansible/issues/69009)
+  - "ansible-galaxy- On giving an invalid subcommand to ansible-galaxy, the help would be shown only for role subcommand (collection subcommand help is not shown). With this change, the entire help for ansible-galaxy (same as ansible-galaxy --help) is displayed along with the help for role subcommand. (https://github.com/ansible/ansible/issues/69009)"

--- a/changelogs/fragments/69458-updated-galaxy-cli-help.yaml
+++ b/changelogs/fragments/69458-updated-galaxy-cli-help.yaml
@@ -1,2 +1,3 @@
+---
 bugfixes:
-  - ansible-galaxy - On giving an invalid subcommand to ansible-galaxy, the help would be shown only for role subcommand (collection subcommand help is not shown). With this change, the entire help for ansible-galaxy (same as ansible-galaxy --help) is displayed along with the help for role subcommand. 
+  - ansible-galaxy - On giving an invalid subcommand to ansible-galaxy, the help would be shown only for role subcommand (collection subcommand help is not shown). With this change, the entire help for ansible-galaxy (same as ansible-galaxy --help) is displayed along with the help for role subcommand. (https://github.com/ansible/ansible/issues/69009)

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -371,7 +371,12 @@ class CLI(with_metaclass(ABCMeta, object)):
         if HAS_ARGCOMPLETE:
             argcomplete.autocomplete(self.parser)
 
-        options = self.parser.parse_args(self.args[1:])
+        try:
+            options = self.parser.parse_args(self.args[1:])
+        except SystemExit as e:
+            if(e.code != 0):
+                self.parser.exit(status=2, message=" \n%s " % self.parser.format_help())
+            raise
         options = self.post_process_args(options)
         context._init_global_context(options)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
On giving an invalid subcommand to ansible-galaxy, the argparse help output for ansible-galaxy (the same as running `ansible-galaxy --help`) is also displayed along with the error displayed by argparse.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #69009 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-galaxy
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Before this change giving an invalid subcommand to ansible-galaxy would result in:
```
(venv) ganeshb@LAPTOP-QANFFN26:~/Documents/ansible$ ansible-galaxy doesnotexist
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development.
This is a rapidly changing source of code and can become unstable at any point.
usage: ansible-galaxy role [-h] ROLE_ACTION ...
ansible-galaxy role: error: argument ROLE_ACTION: invalid choice: 'doesnotexist' (choose from 'init', 'remove', 'delete', 'list', 'search', 'import', 'setup', 'login', 'info', 'install')
```
Here the help shown does not include help for collection subcommand. This might lead to some confusion. After the change, the output is:
```
(venv) ganeshb@LAPTOP-QANFFN26:~/Documents/ansible$ ansible-galaxy doesnotexist                                                                                                            
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. 
This is a rapidly changing source of code and can become unstable at any point.                                                                                                            
usage: ansible-galaxy role [-h] ROLE_ACTION ...                                                                                                                                            
ansible-galaxy role: error: argument ROLE_ACTION: invalid choice: 'doesnotexist' (choose from 'init', 'remove', 'delete', 'list', 'search', 'import', 'setup', 'login', 'info', 'install') 
                                                                                                                                                                                           
usage: ansible-galaxy [-h] [--version] [-v] TYPE ...                                                                                                                                       
                                                                                                                                                                                           
Perform various Role and Collection related operations.                                                                                                                                    
                                                                                                                                                                                           
positional arguments:                                                                                                                                                                      
  TYPE                                                                                                                                                                                     
    collection   Manage an Ansible Galaxy collection.                                                                                                                                      
    role         Manage an Ansible Galaxy role.                                                                                                                                            
                                                                                                                                                                                           
optional arguments:                                                                                                                                                                        
  --version      show program's version number, config file location,                                                                                                                      
                 configured module search path, module location, executable                                                                                                                
                 location and exit                                                                                                                                                         
  -h, --help     show this help message and exit                                                                                                                                           
  -v, --verbose  verbose mode (-vvv for more, -vvvv to enable connection                                                                                                                   
                 debugging)                                                                                                                                                                
```
Here the additional help is also displayed. This makes it much more clearer. I have attached the sanity test output here. 
[test.txt](https://github.com/ansible/ansible/files/4616956/test.txt)
tldr of tests:

```
ERROR: The 2 sanity test(s) listed below (out of 54) failed. See error output above for details.
pylint
rstcheck
```
The reason for their failure is not due to this particular change.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->


