### PR TITLE
Fix include loading for handler runs

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -1005,7 +1005,17 @@ class StrategyBase:
         if len(included_files) > 0:
             for included_file in included_files:
                 try:
-                    new_blocks = self._load_included_file(included_file, iterator=iterator, is_handler=True)
+                    if included_file._is_role:
+                        ir = self._copy_included_file(included_file)
+                        # get_block_list returns (blocks, handlers)
+                        # and in this instance we only care about the handler
+                        # blocks
+                        (_, new_blocks) = ir.get_block_list(
+                                play=iterator._play,
+                                variable_manager=self._variable_manager,
+                                loader=self.loader)
+                    else:
+                        new_blocks = self._load_included_file(included_file, iterator=iterator, is_handler=True)
                     # for every task in each block brought in by the include, add the list
                     # of hosts which included the file to the notified_handlers dict
                     for block in new_blocks:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When using the free (or host_pinned) strategy if your playbook includes
a tasks, roles and handlers, an error can occur when handlers are run
and there are included files to process. In the free.py strategy[0], when
included files are run there is an additional check to see if the
included file is a role and to process that differently than if it's an
included file.

[0] https://github.com/ansible/ansible/blob/c8704573396e7480b3e1b33b2ddda2b6325d0d80/lib/ansible/plugins/strategy/free.py#L244-L254

Resolves #69457
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
