### PR TITLE
fix `ansible-test units` to work(ish) under podman

### DIFF
--- a/changelogs/fragments/ansible-test-podman-units.yml
+++ b/changelogs/fragments/ansible-test-podman-units.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - fixed ``units`` command with ``--docker`` to (mostly) work under podman

--- a/test/lib/ansible_test/_internal/delegation.py
+++ b/test/lib/ansible_test/_internal/delegation.py
@@ -350,8 +350,12 @@ def delegate_docker(args, exclude, require, integration_targets):
 
                 networks = get_docker_networks(args, test_id)
 
-                for network in networks:
-                    docker_network_disconnect(args, test_id, network)
+                if networks is not None:
+                    for network in networks:
+                        docker_network_disconnect(args, test_id, network)
+                else:
+                    display.warning('Network disconnection is not supported (this is normal under podman). '
+                                    'Tests will not be isolated from the network. Network-related tests may misbehave.')
 
                 cmd += ['--requirements-mode', 'skip']
 

--- a/test/lib/ansible_test/_internal/docker_util.py
+++ b/test/lib/ansible_test/_internal/docker_util.py
@@ -78,8 +78,11 @@ def get_docker_networks(args, container_id):
     :rtype: list[str]
     """
     results = docker_inspect(args, container_id)
-    networks = sorted(results[0]['NetworkSettings']['Networks'])
-    return networks
+    # podman doesn't return Networks- just silently return None if it's missing...
+    networks = results[0]['NetworkSettings'].get('Networks')
+    if networks is None:
+        return None
+    return sorted(networks)
 
 
 def docker_pull(args, image):


### PR DESCRIPTION
##### SUMMARY
* ignore the missing `Networks` key, issue a warning that network disconnection won't function

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test

##### ADDITIONAL INFORMATION
