### PR TITLE
Convert to using Display.prompt instead of raw stdin

### DIFF
--- a/changelogs/fragments/69464-ansible-vault-display-prompt.yml
+++ b/changelogs/fragments/69464-ansible-vault-display-prompt.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - ansible-vault - Alter behavior of ``encrypt_string`` to work more intutativly (ending input on Enter and masking input) (https://github.com/ansible/ansible/issues/51860)
+minor_changes:
+  - ansible-vault ``encrypt_string`` no longer supports prompted multi-line input see docs for new methods to send multi line content.

--- a/docs/docsite/rst/user_guide/vault.rst
+++ b/docs/docsite/rst/user_guide/vault.rst
@@ -218,7 +218,6 @@ To encrypt the string 'letmein' read from stdin, add the vault ID 'test' using t
 
 The command above creates this output::
 
-    Reading plaintext input to encrypt:
     db_password: !vault |
               $ANSIBLE_VAULT;1.2;AES256;dev
               61323931353866666336306139373937316366366138656131323863373866376666353364373761
@@ -244,6 +243,7 @@ Type the string to encrypt (for example, 'hunter2'), hit ctrl-d or Enter.
 .. warning::
 
    Pressing Enter will no longer allow for multiple lines, multiline text must be passed via stdin.
+   See next example.
 
 The sequence above creates this output::
 
@@ -255,10 +255,31 @@ The sequence above creates this output::
               3866363862363335620a376466656164383032633338306162326639643635663936623939666238
               3161
 
+<<<<<<< HEAD
 You can add the output from any of the examples above to any playbook, variables file, or role for future use. Encrypted variables are larger than plain-text variables, but they protect your sensitive content while leaving the rest of the playbook, variables file, or role in plain text so you can easily read it.
 
 Viewing encrypted variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=======
+To encrypt a multi line string (such as an ssh-key) and give it the name of 'my_ssh_key':
+
+.. code-block:: bash
+
+    cat ssh-key.id_rsa | ansible-vault encrypt_string --stdin-name 'my_ssh_key'
+
+Result::
+
+    my_ssh_key: !vault |
+              $ANSIBLE_VAULT;1.1;AES256
+              34353865613238323233356533633562653233626166636430386534306239373963353438356562
+              6333353964316238313165363432633065646135383835640a623866626635336238313365393637
+              31623537323935393564346332366266303038653430666162636262313066393130663634333061
+              ...
+              30386537626265376364623237333065383264316434386334373262343662353065333730303233
+              306333333939646332316137373365313432
+
+See also :ref:`single_encrypted_variable`
+>>>>>>> Adding changelog and multi-line example
 
 You can view the original value of an encrypted variable using the debug module. You must pass the password that was used to encrypt the variable. For example, if you stored the variable created by the last example above in a file called 'vars.yml', you could view the unencrypted value of that variable like this:
 

--- a/docs/docsite/rst/user_guide/vault.rst
+++ b/docs/docsite/rst/user_guide/vault.rst
@@ -255,12 +255,6 @@ The sequence above creates this output::
               3866363862363335620a376466656164383032633338306162326639643635663936623939666238
               3161
 
-<<<<<<< HEAD
-You can add the output from any of the examples above to any playbook, variables file, or role for future use. Encrypted variables are larger than plain-text variables, but they protect your sensitive content while leaving the rest of the playbook, variables file, or role in plain text so you can easily read it.
-
-Viewing encrypted variables
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-=======
 To encrypt a multi line string (such as an ssh-key) and give it the name of 'my_ssh_key':
 
 .. code-block:: bash
@@ -279,7 +273,11 @@ Result::
               306333333939646332316137373365313432
 
 See also :ref:`single_encrypted_variable`
->>>>>>> Adding changelog and multi-line example
+
+You can add the output from any of the examples above to any playbook, variables file, or role for future use. Encrypted variables are larger than plain-text variables, but they protect your sensitive content while leaving the rest of the playbook, variables file, or role in plain text so you can easily read it.
+
+Viewing encrypted variables
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can view the original value of an encrypted variable using the debug module. You must pass the password that was used to encrypt the variable. For example, if you stored the variable created by the last example above in a file called 'vars.yml', you could view the unencrypted value of that variable like this:
 

--- a/docs/docsite/rst/user_guide/vault.rst
+++ b/docs/docsite/rst/user_guide/vault.rst
@@ -218,7 +218,7 @@ To encrypt the string 'letmein' read from stdin, add the vault ID 'test' using t
 
 The command above creates this output::
 
-    Reading plaintext input from stdin. (ctrl-d to end input)
+    Reading plaintext input to encrypt:
     db_password: !vault |
               $ANSIBLE_VAULT;1.2;AES256;dev
               61323931353866666336306139373937316366366138656131323863373866376666353364373761
@@ -237,13 +237,13 @@ The command above triggers this prompt:
 
 .. code-block:: text
 
-    Reading plaintext input from stdin. (ctrl-d to end input)
+    Reading plaintext input to encrypt:
 
-Type the string to encrypt (for example, 'hunter2'), hit ctrl-d, and wait.
+Type the string to encrypt (for example, 'hunter2'), hit ctrl-d or Enter.
 
 .. warning::
 
-   Do not press ``Enter`` after supplying the string to encrypt. That will add a newline to the encrypted value.
+   Pressing Enter will no longer allow for multiple lines, multiline text must be passed via stdin.
 
 The sequence above creates this output::
 

--- a/test/units/module_utils/basic/test_argument_spec.py
+++ b/test/units/module_utils/basic/test_argument_spec.py
@@ -167,6 +167,10 @@ def options_argspec_list():
             mutually_exclusive=[
                 ['bam', 'bam1'],
             ],
+            mutually_exclusive_if=[
+                ['foo', 'hello', ['bam2']],
+                ['foo', 'bam2', ['bam']]
+            ],
             required_if=[
                 ['foo', 'hello', ['bam']],
                 ['foo', 'bam2', ['bam2']]
@@ -503,6 +507,9 @@ class TestComplexOptions:
         # required_if fails
         ({'foobar': [{"foo": "hello", "bar": "bad"}]},
          'foo is hello but all of the following are missing: bam found in foobar'),
+        # mutually_exclusive_if fails
+        ({'foobar': [{"foo": "hello", "bam2": "bad"}]},
+         'foo is hello so the following fields can not be set: bam2'),
         # Missing required_one_of option
         ({'foobar': [{"foo": "test"}]},
          'one of the following is required: bar, bam found in foobar'),
@@ -527,6 +534,9 @@ class TestComplexOptions:
         # required_if fails
         ({'foobar': {"foo": "hello", "bar": "bad"}},
          'foo is hello but all of the following are missing: bam found in foobar'),
+        # mutually_exclusive_if fails
+        ({'foobar': {"foo": "hello", "bam2": "bad"}},
+         'foo is hello so the following fields can not be set: bam2'),
         # Missing required_one_of option
         ({'foobar': {"foo": "test"}},
          'one of the following is required: bar, bam found in foobar'),
@@ -541,7 +551,7 @@ class TestComplexOptions:
     @pytest.mark.parametrize('stdin, expected', OPTIONS_PARAMS_DICT, indirect=['stdin'])
     def test_options_type_dict(self, stdin, options_argspec_dict, expected):
         """Test that a basic creation with required and required_if works"""
-        # should test ok, tests basic foo requirement and required_if
+        # should test ok, tests basic foo requirement, required_if and mutually_exclusive_if
         am = basic.AnsibleModule(**options_argspec_dict)
 
         assert isinstance(am.params['foobar'], dict)
@@ -550,7 +560,7 @@ class TestComplexOptions:
     @pytest.mark.parametrize('stdin, expected', OPTIONS_PARAMS_LIST, indirect=['stdin'])
     def test_options_type_list(self, stdin, options_argspec_list, expected):
         """Test that a basic creation with required and required_if works"""
-        # should test ok, tests basic foo requirement and required_if
+        # should test ok, tests basic foo requirement, required_if and mutually_esclusive_if
         am = basic.AnsibleModule(**options_argspec_list)
 
         assert isinstance(am.params['foobar'], list)

--- a/test/units/module_utils/basic/test_argument_spec.py
+++ b/test/units/module_utils/basic/test_argument_spec.py
@@ -167,10 +167,6 @@ def options_argspec_list():
             mutually_exclusive=[
                 ['bam', 'bam1'],
             ],
-            mutually_exclusive_if=[
-                ['foo', 'hello', ['bam2']],
-                ['foo', 'bam2', ['bam']]
-            ],
             required_if=[
                 ['foo', 'hello', ['bam']],
                 ['foo', 'bam2', ['bam2']]
@@ -507,9 +503,6 @@ class TestComplexOptions:
         # required_if fails
         ({'foobar': [{"foo": "hello", "bar": "bad"}]},
          'foo is hello but all of the following are missing: bam found in foobar'),
-        # mutually_exclusive_if fails
-        ({'foobar': [{"foo": "hello", "bam2": "bad"}]},
-         'foo is hello so the following fields can not be set: bam2'),
         # Missing required_one_of option
         ({'foobar': [{"foo": "test"}]},
          'one of the following is required: bar, bam found in foobar'),
@@ -534,9 +527,6 @@ class TestComplexOptions:
         # required_if fails
         ({'foobar': {"foo": "hello", "bar": "bad"}},
          'foo is hello but all of the following are missing: bam found in foobar'),
-        # mutually_exclusive_if fails
-        ({'foobar': {"foo": "hello", "bam2": "bad"}},
-         'foo is hello so the following fields can not be set: bam2'),
         # Missing required_one_of option
         ({'foobar': {"foo": "test"}},
          'one of the following is required: bar, bam found in foobar'),
@@ -551,7 +541,7 @@ class TestComplexOptions:
     @pytest.mark.parametrize('stdin, expected', OPTIONS_PARAMS_DICT, indirect=['stdin'])
     def test_options_type_dict(self, stdin, options_argspec_dict, expected):
         """Test that a basic creation with required and required_if works"""
-        # should test ok, tests basic foo requirement, required_if and mutually_exclusive_if
+        # should test ok, tests basic foo requirement and required_if
         am = basic.AnsibleModule(**options_argspec_dict)
 
         assert isinstance(am.params['foobar'], dict)
@@ -560,7 +550,7 @@ class TestComplexOptions:
     @pytest.mark.parametrize('stdin, expected', OPTIONS_PARAMS_LIST, indirect=['stdin'])
     def test_options_type_list(self, stdin, options_argspec_list, expected):
         """Test that a basic creation with required and required_if works"""
-        # should test ok, tests basic foo requirement, required_if and mutually_esclusive_if
+        # should test ok, tests basic foo requirement and required_if
         am = basic.AnsibleModule(**options_argspec_list)
 
         assert isinstance(am.params['foobar'], list)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Another solution for #51860. This one uses Display.prompt method which has a more natural flow than the double ctl-d when reading from stdin.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-vault

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
