### PR TITLE
Separate the galaxy lib from the cli

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -424,6 +424,8 @@ class GalaxyCLI(CLI):
         server_def = [('url', True), ('username', False), ('password', False), ('token', False),
                       ('auth_url', False)]
 
+        validate_certs = not context.CLIARGS['ignore_certs']
+
         config_servers = []
 
         # Need to filter out empty strings or non truthy values as an empty server list env var is equal to [''].
@@ -453,10 +455,12 @@ class GalaxyCLI(CLI):
                     if auth_url:
                         server_options['token'] = KeycloakToken(access_token=token_val,
                                                                 auth_url=auth_url,
-                                                                validate_certs=not context.CLIARGS['ignore_certs'])
+                                                                validate_certs=validate_certs)
                     else:
                         # The galaxy v1 / github / django / 'Token'
                         server_options['token'] = GalaxyToken(token=token_val)
+
+            server_options['validate_certs'] = validate_certs
 
             config_servers.append(GalaxyAPI(self.galaxy, server_key, **server_options))
 
@@ -469,13 +473,15 @@ class GalaxyCLI(CLI):
             if config_server:
                 self.api_servers.append(config_server)
             else:
-                self.api_servers.append(GalaxyAPI(self.galaxy, 'cmd_arg', cmd_server, token=cmd_token))
+                self.api_servers.append(GalaxyAPI(self.galaxy, 'cmd_arg', cmd_server, token=cmd_token,
+                                                  validate_certs=validate_certs))
         else:
             self.api_servers = config_servers
 
         # Default to C.GALAXY_SERVER if no servers were defined
         if len(self.api_servers) == 0:
-            self.api_servers.append(GalaxyAPI(self.galaxy, 'default', C.GALAXY_SERVER, token=cmd_token))
+            self.api_servers.append(GalaxyAPI(self.galaxy, 'default', C.GALAXY_SERVER, token=cmd_token,
+                                              validate_certs=validate_certs))
 
         context.CLIARGS['func']()
 
@@ -583,7 +589,10 @@ class GalaxyCLI(CLI):
                         # Try and match up the requirement source with our list of Galaxy API servers defined in the
                         # config, otherwise create a server with that URL without any auth.
                         req_source = next(iter([a for a in self.api_servers if req_source in [a.name, a.api_server]]),
-                                          GalaxyAPI(self.galaxy, "explicit_requirement_%s" % req_name, req_source))
+                                          GalaxyAPI(self.galaxy,
+                                                    "explicit_requirement_%s" % req_name,
+                                                    req_source,
+                                                    validate_certs=not context.CLIARGS['ignore_certs']))
 
                     requirements['collections'].append((req_name, req_version, req_source))
                 else:

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -12,7 +12,6 @@ import tarfile
 import uuid
 import time
 
-from ansible import context
 from ansible.errors import AnsibleError
 from ansible.galaxy.user_agent import user_agent
 from ansible.module_utils.six import string_types
@@ -169,14 +168,14 @@ class CollectionVersionMetadata:
 class GalaxyAPI:
     """ This class is meant to be used as a API client for an Ansible Galaxy server """
 
-    def __init__(self, galaxy, name, url, username=None, password=None, token=None):
+    def __init__(self, galaxy, name, url, username=None, password=None, token=None, validate_certs=True):
         self.galaxy = galaxy
         self.name = name
         self.username = username
         self.password = password
         self.token = token
         self.api_server = url
-        self.validate_certs = not context.CLIARGS['ignore_certs']
+        self.validate_certs = validate_certs
         self._available_api_versions = {}
 
         display.debug('Validate TLS certificates for %s: %s' % (self.api_server, self.validate_certs))
@@ -526,7 +525,7 @@ class GalaxyAPI:
 
         :param namespace: The collection namespace.
         :param name: The collection name.
-        :param version: Optional version of the collection to get the information for.
+        :param version: Version of the collection to get the information for.
         :return: CollectionVersionMetadata about the collection at the version requested.
         """
         api_path = self.available_api_versions.get('v3', self.available_api_versions.get('v2'))


### PR DESCRIPTION
The galaxy lib knew about the cli args in context.  This shouldn't be
the case as it makes it hard to use the lib in other contexts.  Moved
the context knowledge into cli/galaxy.py.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
This was a refactor that I needed for the original docs PR.  I'm pulling that apart and pushing much of the functionality into the ansibulled script.  I didn't want this fix to get lost, though.