### PR TITLE
cyberark appears to have renamed their collection

### DIFF
--- a/lib/ansible/config/routing.yml
+++ b/lib/ansible/config/routing.yml
@@ -6774,9 +6774,9 @@ plugin_routing:
     skydive_node:
       redirect: skydive.skydive.skydive_node
     cyberark_authentication:
-      redirect: cyberark.bizdev.cyberark_authentication
+      redirect: cyberark.pas.cyberark_authentication
     cyberark_user:
-      redirect: cyberark.bizdev.cyberark_user
+      redirect: cyberark.pas.cyberark_user
     gcp_appengine_firewall_rule:
       redirect: google.cloud.gcp_appengine_firewall_rule
     gcp_appengine_firewall_rule_info:


### PR DESCRIPTION
Trying to build docs for Ansible-2.10 and ran into error #69475
in ansible-doc.  To work around that I need to get a newer cyberark
collection which fixes the issues.  Unfortunately, it looks like the
cyberark team has renamed their collection from bizdev to pas is not
responding to issues on github.  I'm putting in this PR for them to
get this updated before 2.10 so that things will work out of the box when
2.10.0 is released.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
routing.yml

##### ADDITIONAL INFORMATION
@gundalow