### PR TITLE
Enable logging for dnf module using setup_loggers() API

### DIFF
--- a/changelogs/fragments/dnf-setup_loggers.yml
+++ b/changelogs/fragments/dnf-setup_loggers.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - dnf - enable logging using setup_loggers() API in dnf-4.2.17-6 or later

--- a/changelogs/fragments/dnf_setup_loggers.yml
+++ b/changelogs/fragments/dnf_setup_loggers.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - dnf - enable logging using setup_loggers() API in dnf-4.2.17-6 or later

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -610,6 +610,12 @@ class DnfModule(YumDnf):
         base = dnf.Base()
         self._configure_base(base, conf_file, disable_gpg_check, installroot)
         try:
+            # this method has been supported in dnf-4.2.17-6 or later
+            # https://bugzilla.redhat.com/show_bug.cgi?id=1788212
+            base.setup_loggers()
+        except AttributeError:
+            pass
+        try:
             base.init_plugins(set(self.disable_plugin), set(self.enable_plugin))
             base.pre_configure_plugins()
         except AttributeError:

--- a/test/integration/targets/dnf/tasks/logging.yml
+++ b/test/integration/targets/dnf/tasks/logging.yml
@@ -1,0 +1,45 @@
+# Verify logging function is enabled in the dnf module.
+#  The following tasks has been supported in dnf-4.2.17-6 or later
+#  Note: https://bugzilla.redhat.com/show_bug.cgi?id=1788212
+- name: Install latest version python3-dnf
+  dnf:
+    name: python3-dnf
+    state: latest
+  register: dnf_result
+
+- name: Verify python3-dnf installed
+  assert:
+    that:
+      - "dnf_result.rc == 0"
+
+- name: Get python3-dnf version
+  shell: "dnf info python3-dnf | awk '/^Version/ { print $3 }'"
+  register: py3_dnf_version
+
+- name: Check logging enabled
+  block:
+    - name: remove logfiles if exist
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop: "{{ dnf_log_files }}"
+
+    - name: Install sos package
+      dnf:
+        name: sos
+        state: present
+      register: dnf_result
+
+    - name: Get status of logfiles
+      stat:
+        path: "{{ item }}"
+      loop: "{{ dnf_log_files }}"
+      register: stats
+
+    - name: Verify logfile exists
+      assert:
+        that:
+          - "item.stat.exists"
+      loop: "{{ stats.results }}"
+  when:
+    - 'py3_dnf_version.stdout is version("4.2.17", ">=")'

--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -40,3 +40,7 @@
 - include_tasks: modularity.yml
   when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('29', '>=')) or
         (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
+
+- include_tasks: logging.yml
+  when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('31', '>=')) or
+        (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))

--- a/test/integration/targets/dnf/vars/main.yml
+++ b/test/integration/targets/dnf/vars/main.yml
@@ -1,0 +1,4 @@
+dnf_log_files:
+    - /var/log/dnf.log
+    - /var/log/dnf.rpm.log
+    - /var/log/dnf.librepo.log


### PR DESCRIPTION
##### SUMMARY
Enable logging(/var/log/dnf.log,dnf.rpm.log,dnf.librepo.log) for dnf module using setup_loggers() API. This API has been supported in dnf-4.2.17-6 or later.

- Fixed issue #28061
- https://bugzilla.redhat.com/show_bug.cgi?id=1788212

##### ISSUE TYPE
- ~Bugfix  Pull Request~
- Feature

##### COMPONENT NAME
- modules/packaging/os/dnf.py

##### ADDITIONAL INFORMATION
None