### PR TITLE
Ansible documentation: fix examples format

### DIFF
--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -104,28 +104,28 @@ author:
 '''
 
 EXAMPLES = r'''
-- name: return motd to registered var
+- name: Return motd to registered var
   command: cat /etc/motd
   register: mymotd
 
 # free-form (string) arguments, all arguments on one line
-- name: Run command if /path/to/database does not exist (without 'args').
+- name: Run command if /path/to/database does not exist (without 'args')
   command: /usr/bin/make_database.sh db_user db_name creates=/path/to/database
 
 # free-form (string) arguments, some arguments on separate lines with the 'args' keyword
 # 'args' is a task keyword, passed at the same level as the module
-- name: Run command if /path/to/database does not exist (with 'args' keyword).
+- name: Run command if /path/to/database does not exist (with 'args' keyword)
   command: /usr/bin/make_database.sh db_user db_name
   args:
     creates: /path/to/database
 
 # 'cmd' is module parameter
-- name: Run command if /path/to/database does not exist (with 'cmd' parameter).
+- name: Run command if /path/to/database does not exist (with 'cmd' parameter)
   command:
     cmd: /usr/bin/make_database.sh db_user db_name
     creates: /path/to/database
 
-- name: Change the working directory to somedir/ and run the command as db_owner if /path/to/database does not exist.
+- name: Change the working directory to somedir/ and run the command as db_owner if /path/to/database does not exist
   command: /usr/bin/make_database.sh db_user db_name
   become: yes
   become_user: db_owner
@@ -143,7 +143,7 @@ EXAMPLES = r'''
       - dbname with whitespace
     creates: /path/to/database
 
-- name: safely use templated variable to run command. Always use the quote filter to avoid injection issues.
+- name: Safely use templated variable to run command. Always use the quote filter to avoid injection issues
   command: cat {{ myfile|quote }}
   register: myoutput
 '''

--- a/lib/ansible/modules/commands/shell.py
+++ b/lib/ansible/modules/commands/shell.py
@@ -103,16 +103,16 @@ author:
 '''
 
 EXAMPLES = r'''
-- name: Execute the command in remote shell; stdout goes to the specified file on the remote.
+- name: Execute the command in remote shell; stdout goes to the specified file on the remote
   shell: somescript.sh >> somelog.txt
 
-- name: Change the working directory to somedir/ before executing the command.
+- name: Change the working directory to somedir/ before executing the command
   shell: somescript.sh >> somelog.txt
   args:
     chdir: somedir/
 
 # You can also use the 'args' form to provide the options.
-- name: This command will change the working directory to somedir/ and will only run when somedir/somelog.txt doesn't exist.
+- name: This command will change the working directory to somedir/ and will only run when somedir/somelog.txt doesn't exist
   shell: somescript.sh >> somelog.txt
   args:
     chdir: somedir/
@@ -153,7 +153,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 
 # Disabling warnings
-- name: Using curl to connect to a host via SOCKS proxy (unsupported in uri). Ordinarily this would throw a warning.
+- name: Using curl to connect to a host via SOCKS proxy (unsupported in uri). Ordinarily this would throw a warning
   shell: curl --socks5 localhost:9000 http://www.ansible.com
   args:
     warn: no

--- a/lib/ansible/modules/files/stat.py
+++ b/lib/ansible/modules/files/stat.py
@@ -73,7 +73,8 @@ author: Bruce Pennypacker (@bpennypacker)
 EXAMPLES = r'''
 # Obtain the stats of /etc/foo.conf, and check that the file still belongs
 # to 'root'. Fail otherwise.
-- stat:
+- name: Get stats
+  stat:
     path: /etc/foo.conf
   register: st
 - fail:
@@ -85,7 +86,8 @@ EXAMPLES = r'''
 # therefore, we must test whether it is defined.
 # Run this to understand the structure, the skipped ones do not pass the
 # check performed by 'when'
-- stat:
+- name: Get stats
+  stat:
     path: /path/to/something
   register: sym
 
@@ -108,20 +110,21 @@ EXAMPLES = r'''
 
 # Determine if a path exists and is a directory.  Note that we need to test
 # both that p.stat.isdir actually exists, and also that it's set to true.
-- stat:
+- name: Get stats
+  stat:
     path: /path/to/something
   register: p
 - debug:
     msg: "Path exists and is a directory"
   when: p.stat.isdir is defined and p.stat.isdir
 
-# Don't do checksum
-- stat:
+- name: Don't do checksum
+  stat:
     path: /path/to/myhugefile
     get_checksum: no
 
-# Use sha256 to calculate checksum
-- stat:
+- name: Use sha256 to calculate checksum
+  stat:
     path: /path/to/something
     checksum_algorithm: sha256
 '''

--- a/lib/ansible/modules/files/tempfile.py
+++ b/lib/ansible/modules/files/tempfile.py
@@ -52,18 +52,18 @@ author:
 '''
 
 EXAMPLES = """
-- name: create temporary build directory
+- name: Create temporary build directory
   tempfile:
     state: directory
     suffix: build
 
-- name: create temporary file
+- name: Create temporary file
   tempfile:
     state: file
     suffix: temp
   register: tempfile_1
 
-- name: use the registered var and the file module to remove the temporary file
+- name: Use the registered var and the file module to remove the temporary file
   file:
     path: "{{ tempfile_1.path }}"
     state: absent

--- a/lib/ansible/modules/inventory/group_by.py
+++ b/lib/ansible/modules/inventory/group_by.py
@@ -41,16 +41,16 @@ author:
 '''
 
 EXAMPLES = r'''
-# Create groups based on the machine architecture
-- group_by:
+- name: Create groups based on the machine architecture
+  group_by:
     key: machine_{{ ansible_machine }}
 
-# Create groups like 'virt_kvm_host'
-- group_by:
+- name: Create groups like virt_kvm_host
+  group_by:
     key: virt_{{ ansible_virtualization_type }}_{{ ansible_virtualization_role }}
 
-# Create nested groups
-- group_by:
+- name: Create nested groups
+  group_by:
     key: el{{ ansible_distribution_major_version }}-{{ ansible_architecture }}
     parents:
       - el{{ ansible_distribution_major_version }}

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -134,96 +134,98 @@ author:
 '''
 
 EXAMPLES = '''
-# Install (Bottle) python package.
-- pip:
+- name: Install Bottle python package
+  pip:
     name: bottle
 
-# Install (Bottle) python package on version 0.11.
-- pip:
+- name: Install Bottle python package on version 0.11
+  pip:
     name: bottle==0.11
 
-# Install (bottle) python package with version specifiers
-- pip:
+- name: Install (bottle) python package with version specifiers
+  pip:
     name: bottle>0.10,<0.20,!=0.11
 
-# Install multi python packages with version specifiers
-- pip:
+- name: Install multi python packages with version specifiers
+  pip:
     name:
       - django>1.11.0,<1.12.0
       - bottle>0.10,<0.20,!=0.11
 
-# Install python package using a proxy - it doesn't use the standard environment variables, please use the CAPITALIZED ones below
-- pip:
+# It doesn't use the standard environment variables, please use the CAPITALIZED ones below
+- name: Install python package using a proxy
+  pip:
     name: six
   environment:
     HTTP_PROXY: '127.0.0.1:8080'
     HTTPS_PROXY: '127.0.0.1:8080'
 
-# Install (MyApp) using one of the remote protocols (bzr+,hg+,git+,svn+). You do not have to supply '-e' option in extra_args.
-- pip:
+# You do not have to supply '-e' option in extra_args
+- name: Install MyApp using one of the remote protocols (bzr+,hg+,git+,svn+)
+  pip:
     name: svn+http://myrepo/svn/MyApp#egg=MyApp
 
-# Install MyApp using one of the remote protocols (bzr+,hg+,git+).
-- pip:
+- name: Install MyApp using one of the remote protocols (bzr+,hg+,git+)
+  pip:
     name: git+http://myrepo/app/MyApp
 
-# Install (MyApp) from local tarball
-- pip:
+- name: Install MyApp from local tarball
+  pip:
     name: file:///path/to/MyApp.tar.gz
 
-# Install (Bottle) into the specified (virtualenv), inheriting none of the globally installed modules
-- pip:
+- name: Install Bottle into the specified (virtualenv), inheriting none of the globally installed modules
+  pip:
     name: bottle
     virtualenv: /my_app/venv
 
-# Install (Bottle) into the specified (virtualenv), inheriting globally installed modules
-- pip:
+- name: Install Bottle into the specified (virtualenv), inheriting globally installed modules
+  pip:
     name: bottle
     virtualenv: /my_app/venv
     virtualenv_site_packages: yes
 
-# Install (Bottle) into the specified (virtualenv), using Python 2.7
-- pip:
+- name: Install Bottle into the specified (virtualenv), using Python 2.7
+  pip:
     name: bottle
     virtualenv: /my_app/venv
     virtualenv_command: virtualenv-2.7
 
-# Install (Bottle) within a user home directory.
-- pip:
+- name: Install Bottle within a user home directory
+  pip:
     name: bottle
     extra_args: --user
 
-# Install specified python requirements.
-- pip:
+- name: Install specified python requirements
+  pip:
     requirements: /my_app/requirements.txt
 
-# Install specified python requirements in indicated (virtualenv).
-- pip:
+- name: Install specified python requirements in indicated (virtualenv)
+  pip:
     requirements: /my_app/requirements.txt
     virtualenv: /my_app/venv
 
-# Install specified python requirements and custom Index URL.
-- pip:
+- name: Install specified python requirements and custom Index URL
+  pip:
     requirements: /my_app/requirements.txt
     extra_args: -i https://example.com/pypi/simple
 
-# Install specified python requirements offline from a local directory with downloaded packages.
-- pip:
+- name: Install specified python requirements offline from a local directory with downloaded packages
+  pip:
     requirements: /my_app/requirements.txt
     extra_args: "--no-index --find-links=file:///my_downloaded_packages_dir"
 
-# Install (Bottle) for Python 3.3 specifically,using the 'pip3.3' executable.
-- pip:
+- name: Install Bottle for Python 3.3 specifically,using the 'pip3.3' executable
+  pip:
     name: bottle
     executable: pip3.3
 
-# Install (Bottle), forcing reinstallation if it's already installed
-- pip:
+- name: Install Bottle, forcing reinstallation if it is already installed
+  pip:
     name: bottle
     state: forcereinstall
 
-# Install (Bottle) while ensuring the umask is 0022 (to ensure other users can use it)
-- pip:
+- name: Install Bottle while ensuring the umask is 0022 (to ensure other users can use it)
+  pip:
     name: bottle
     umask: "0022"
   become: True

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -236,7 +236,7 @@ EXAMPLES = '''
     pkg: foo
     state: build-dep
 
-- name: Install a .deb package from the internet.
+- name: Install a .deb package from the internet
   apt:
     deb: https://example.com/python-ppq_0.1-1_all.deb
 

--- a/lib/ansible/modules/packaging/os/apt_repository.py
+++ b/lib/ansible/modules/packaging/os/apt_repository.py
@@ -82,34 +82,33 @@ requirements:
 '''
 
 EXAMPLES = '''
-# Add specified repository into sources list.
-- apt_repository:
+- name: Add specified repository into sources list
+  apt_repository:
     repo: deb http://archive.canonical.com/ubuntu hardy partner
     state: present
 
-# Add specified repository into sources list using specified filename.
-- apt_repository:
+- name: Add specified repository into sources list using specified filename
+  apt_repository:
     repo: deb http://dl.google.com/linux/chrome/deb/ stable main
     state: present
     filename: google-chrome
 
-# Add source repository into sources list.
-- apt_repository:
+- name: Add source repository into sources list
+  apt_repository:
     repo: deb-src http://archive.canonical.com/ubuntu hardy partner
     state: present
 
-# Remove specified repository from sources list.
-- apt_repository:
+- name: Remove specified repository from sources list
+  apt_repository:
     repo: deb http://archive.canonical.com/ubuntu hardy partner
     state: absent
 
-# Add nginx stable repository from PPA and install its signing key.
-# On Ubuntu target:
-- apt_repository:
+- name: Add nginx stable repository from PPA and install its signing key on Ubuntu target
+  apt_repository:
     repo: ppa:nginx/stable
 
-# On Debian target
-- apt_repository:
+- name: Add nginx stable repository from PPA and install its signing key on Debian target
+  apt_repository:
     repo: 'ppa:nginx/stable'
     codename: trusty
 '''

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -221,45 +221,45 @@ author:
 '''
 
 EXAMPLES = '''
-- name: install the latest version of Apache
+- name: Install the latest version of Apache
   dnf:
     name: httpd
     state: latest
 
-- name: install the latest version of Apache and MariaDB
+- name: Install the latest version of Apache and MariaDB
   dnf:
     name:
       - httpd
       - mariadb-server
     state: latest
 
-- name: remove the Apache package
+- name: Remove the Apache package
   dnf:
     name: httpd
     state: absent
 
-- name: install the latest version of Apache from the testing repo
+- name: Install the latest version of Apache from the testing repo
   dnf:
     name: httpd
     enablerepo: testing
     state: present
 
-- name: upgrade all packages
+- name: Upgrade all packages
   dnf:
     name: "*"
     state: latest
 
-- name: install the nginx rpm from a remote repo
+- name: Install the nginx rpm from a remote repo
   dnf:
     name: 'http://nginx.org/packages/centos/6/noarch/RPMS/nginx-release-centos-6-0.el6.ngx.noarch.rpm'
     state: present
 
-- name: install nginx rpm from a local file
+- name: Install nginx rpm from a local file
   dnf:
     name: /usr/local/src/nginx-release-centos-6-0.el6.ngx.noarch.rpm
     state: present
 
-- name: install the 'Development tools' package group
+- name: Install the 'Development tools' package group
   dnf:
     name: '@Development tools'
     state: present
@@ -274,17 +274,17 @@ EXAMPLES = '''
     state: absent
     autoremove: no
 
-- name: install a modularity appstream with defined stream and profile
+- name: Install a modularity appstream with defined stream and profile
   dnf:
     name: '@postgresql:9.6/client'
     state: present
 
-- name: install a modularity appstream with defined stream
+- name: Install a modularity appstream with defined stream
   dnf:
     name: '@postgresql:9.6'
     state: present
 
-- name: install a modularity appstream with defined profile
+- name: Install a modularity appstream with defined profile
   dnf:
     name: '@postgresql/client'
     state: present

--- a/lib/ansible/modules/packaging/os/dpkg_selections.py
+++ b/lib/ansible/modules/packaging/os/dpkg_selections.py
@@ -36,8 +36,8 @@ notes:
     - This module won't cause any packages to be installed/removed/purged, use the C(apt) module for that.
 '''
 EXAMPLES = '''
-# Prevent python from being upgraded.
-- dpkg_selections:
+- name: Prevent python from being upgraded
+  dpkg_selections:
     name: python
     selection: hold
 '''

--- a/lib/ansible/modules/packaging/os/package.py
+++ b/lib/ansible/modules/packaging/os/package.py
@@ -49,18 +49,18 @@ notes:
     - For Windows targets, use the M(win_package) module instead.
 '''
 EXAMPLES = '''
-- name: install ntpdate
+- name: Install ntpdate
   package:
     name: ntpdate
     state: present
 
 # This uses a variable as this changes per distribution.
-- name: remove the apache package
+- name: Remove the apache package
   package:
     name: "{{ apache }}"
     state: absent
 
-- name: install the latest version of Apache and MariaDB
+- name: Install the latest version of Apache and MariaDB
   package:
     name:
       - httpd

--- a/lib/ansible/modules/packaging/os/rpm_key.py
+++ b/lib/ansible/modules/packaging/os/rpm_key.py
@@ -48,23 +48,23 @@ options:
 '''
 
 EXAMPLES = '''
-# Example action to import a key from a url
-- rpm_key:
+- name: Import a key from a url
+  rpm_key:
     state: present
     key: http://apt.sw.be/RPM-GPG-KEY.dag.txt
 
-# Example action to import a key from a file
-- rpm_key:
+- name: Import a key from a file
+  rpm_key:
     state: present
     key: /path/to/key.gpg
 
-# Example action to ensure a key is not present in the db
-- rpm_key:
+- name: Ensure a key is not present in the db
+  rpm_key:
     state: absent
     key: DEADB33F
 
-# Verify the key, using a fingerprint, before import
-- rpm_key:
+- name: Verify the key, using a fingerprint, before import
+  rpm_key:
     key: /path/to/RPM-GPG-KEY.dag.txt
     fingerprint: EBC6 E12C 62B1 C734 026B  2122 A20E 5214 6B8D 79E6
 '''

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -241,12 +241,12 @@ author:
 '''
 
 EXAMPLES = '''
-- name: install the latest version of Apache
+- name: Install the latest version of Apache
   yum:
     name: httpd
     state: latest
 
-- name: install a list of packages (suitable replacement for 2.11 loop deprecation warning)
+- name: Install a list of packages (suitable replacement for 2.11 loop deprecation warning)
   yum:
     name:
       - nginx
@@ -254,7 +254,7 @@ EXAMPLES = '''
       - postgresql-server
     state: present
 
-- name: install a list of packages with a list variable
+- name: Install a list of packages with a list variable
   yum:
     name: "{{ packages }}"
   vars:
@@ -262,54 +262,54 @@ EXAMPLES = '''
     - httpd
     - httpd-tools
 
-- name: remove the Apache package
+- name: Remove the Apache package
   yum:
     name: httpd
     state: absent
 
-- name: install the latest version of Apache from the testing repo
+- name: Install the latest version of Apache from the testing repo
   yum:
     name: httpd
     enablerepo: testing
     state: present
 
-- name: install one specific version of Apache
+- name: Install one specific version of Apache
   yum:
     name: httpd-2.2.29-1.4.amzn1
     state: present
 
-- name: upgrade all packages
+- name: Upgrade all packages
   yum:
     name: '*'
     state: latest
 
-- name: upgrade all packages, excluding kernel & foo related packages
+- name: Upgrade all packages, excluding kernel & foo related packages
   yum:
     name: '*'
     state: latest
     exclude: kernel*,foo*
 
-- name: install the nginx rpm from a remote repo
+- name: Install the nginx rpm from a remote repo
   yum:
     name: http://nginx.org/packages/centos/6/noarch/RPMS/nginx-release-centos-6-0.el6.ngx.noarch.rpm
     state: present
 
-- name: install nginx rpm from a local file
+- name: Install nginx rpm from a local file
   yum:
     name: /usr/local/src/nginx-release-centos-6-0.el6.ngx.noarch.rpm
     state: present
 
-- name: install the 'Development tools' package group
+- name: Install the 'Development tools' package group
   yum:
     name: "@Development tools"
     state: present
 
-- name: install the 'Gnome desktop' environment group
+- name: Install the 'Gnome desktop' environment group
   yum:
     name: "@^gnome-desktop-environment"
     state: present
 
-- name: List ansible packages and register result to print with debug later.
+- name: List ansible packages and register result to print with debug later
   yum:
     list: ansible
   register: result

--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -354,7 +354,7 @@ EXAMPLES = '''
     enabled: no
 
 # Handler showing how to clean yum metadata cache
-- name: yum-clean-metadata
+- name: Run yum-clean-metadata
   command: yum clean metadata
   args:
     warn: no

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -196,45 +196,44 @@ notes:
 '''
 
 EXAMPLES = '''
-# Example git checkout from Ansible Playbooks
-- git:
+- name: Git checkout
+  git:
     repo: 'https://foosball.example.org/path/to/repo.git'
     dest: /srv/checkout
     version: release-0.22
 
-# Example read-write git checkout from github
-- git:
+- name: Read-write git checkout from github
+  git:
     repo: git@github.com:mylogin/hello.git
     dest: /home/mylogin/hello
 
-# Example just ensuring the repo checkout exists
-- git:
+- name: Ensure the repo checkout exists
+  git:
     repo: 'https://foosball.example.org/path/to/repo.git'
     dest: /srv/checkout
     update: no
 
-# Example just get information about the repository whether or not it has
-# already been cloned locally.
-- git:
+- name: Get information about the repository whether or not it has already been cloned locally
+  git:
     repo: 'https://foosball.example.org/path/to/repo.git'
     dest: /srv/checkout
     clone: no
     update: no
 
-# Example checkout a github repo and use refspec to fetch all pull requests
-- git:
+- name: Checkout a github repo and use refspec to fetch all pull requests
+  git:
     repo: https://github.com/ansible/ansible-examples.git
     dest: /src/ansible-examples
     refspec: '+refs/pull/*:refs/heads/*'
 
-# Example Create git archive from repo
-- git:
+- name: Create git archive from repo
+  git:
     repo: https://github.com/ansible/ansible-examples.git
     dest: /src/ansible-examples
     archive: /tmp/ansible-examples.zip
 
-# Example clone a repo with separate git directory
-- git:
+- name: Clone a repo with separate git directory
+  git:
     repo: https://github.com/ansible/ansible-examples.git
     dest: /src/ansible-examples
     separate_git_dir: /src/ansible-examples.git

--- a/lib/ansible/modules/system/debconf.py
+++ b/lib/ansible/modules/system/debconf.py
@@ -68,7 +68,7 @@ EXAMPLES = r'''
     value: fr_FR.UTF-8
     vtype: select
 
-- name: set to generate locales
+- name: Set to generate locales
   debconf:
     name: locales
     question: locales/locales_to_be_generated

--- a/lib/ansible/modules/system/getent.py
+++ b/lib/ansible/modules/system/getent.py
@@ -51,42 +51,41 @@ author:
 '''
 
 EXAMPLES = '''
-# get root user info
-- getent:
+- name: Get root user info
+  getent:
     database: passwd
     key: root
 - debug:
     var: getent_passwd
 
-# get all groups
-- getent:
+- name: Get all groups
+  getent:
     database: group
     split: ':'
 - debug:
     var: getent_group
 
-# get all hosts, split by tab
-- getent:
+- name: Get all hosts, split by tab
+  getent:
     database: hosts
 - debug:
     var: getent_hosts
 
-# get http service info, no error if missing
-- getent:
+- name: Get http service info, no error if missing
+  getent:
     database: services
     key: http
     fail_key: False
 - debug:
     var: getent_services
 
-# get user password hash (requires sudo/root)
-- getent:
+- name: Get user password hash (requires sudo/root)
+  getent:
     database: shadow
     key: www-data
     split: ':'
 - debug:
     var: getent_shadow
-
 '''
 import traceback
 

--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -38,7 +38,8 @@ options:
 '''
 
 EXAMPLES = '''
-- hostname:
+- name: Set a hostname
+  hostname:
     name: web01
 '''
 

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -438,13 +438,13 @@ EXAMPLES = r'''
         - SYN
         - FIN
 
-- name: iptables flush filter
+- name: Iptables flush filter
   iptables:
     chain: "{{ item }}"
     flush: yes
   with_items:  [ 'INPUT', 'FORWARD', 'OUTPUT' ]
 
-- name: iptables flush nat
+- name: Iptables flush nat
   iptables:
     table: nat
     chain: '{{ item }}'

--- a/lib/ansible/modules/system/known_hosts.py
+++ b/lib/ansible/modules/system/known_hosts.py
@@ -59,7 +59,7 @@ author: "Matthew Vernon (@mcv21)"
 '''
 
 EXAMPLES = '''
-- name: tell the host about our servers it might want to ssh to
+- name: Tell the host about our servers it might want to ssh to
   known_hosts:
     path: /etc/ssh/ssh_known_hosts
     name: foo.com.invalid

--- a/lib/ansible/modules/system/ping.py
+++ b/lib/ansible/modules/system/ping.py
@@ -44,11 +44,11 @@ EXAMPLES = '''
 # Test we can logon to 'webservers' and execute python with json lib.
 # ansible webservers -m ping
 
-# Example from an Ansible Playbook
-- ping:
+- name: Try to connect to host, verify a usable python and return pong on success
+  ping:
 
-# Induce an exception to see what happens
-- ping:
+- name: Induce an exception to see what happens
+  ping:
     data: crash
 '''
 

--- a/lib/ansible/modules/system/service_facts.py
+++ b/lib/ansible/modules/system/service_facts.py
@@ -35,7 +35,7 @@ author:
 '''
 
 EXAMPLES = '''
-- name: populate service facts
+- name: Populate service facts
   service_facts:
 
 - debug:

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -95,39 +95,39 @@ EXAMPLES = '''
     state: started
     name: httpd
 
-- name: stop service cron on debian, if running
+- name: Stop service cron on debian, if running
   systemd:
     name: cron
     state: stopped
 
-- name: restart service cron on centos, in all cases, also issue daemon-reload to pick up config changes
+- name: Restart service cron on centos, in all cases, also issue daemon-reload to pick up config changes
   systemd:
     state: restarted
     daemon_reload: yes
     name: crond
 
-- name: reload service httpd, in all cases
+- name: Reload service httpd, in all cases
   systemd:
     name: httpd
     state: reloaded
 
-- name: enable service httpd and ensure it is not masked
+- name: Enable service httpd and ensure it is not masked
   systemd:
     name: httpd
     enabled: yes
     masked: no
 
-- name: enable a timer for dnf-automatic
+- name: Enable a timer for dnf-automatic
   systemd:
     name: dnf-automatic.timer
     state: started
     enabled: yes
 
-- name: just force systemd to reread configs (2.4 and above)
+- name: Just force systemd to reread configs (2.4 and above)
   systemd:
     daemon_reload: yes
 
-- name: just force systemd to re-execute itself (2.8 and above)
+- name: Just force systemd to re-execute itself (2.8 and above)
   systemd:
     daemon_reexec: yes
 '''

--- a/lib/ansible/modules/system/sysvinit.py
+++ b/lib/ansible/modules/system/sysvinit.py
@@ -71,13 +71,13 @@ requirements:
 '''
 
 EXAMPLES = '''
-- name: make sure apache2 is started
+- name: Make sure apache2 is started
   sysvinit:
       name: apache2
       state: started
       enabled: yes
 
-- name: make sure apache2 is started on runlevels 3 and 5
+- name: Make sure apache2 is started on runlevels 3 and 5
   sysvinit:
       name: apache2
       state: started


### PR DESCRIPTION
##### SUMMARY
https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#examples-block
```
Per playbook best practices, each example should include a name: line:
EXAMPLES = r'''
- name: Ensure foo is installed
  modulename:
    name: foo
    state: present
'''
The name: line should be capitalized and not include a trailing dot.
```

##### ISSUE TYPE
- Docs Pull Request
