### PR TITLE
Add path for yum on IBM i to PKG_MGRS

### DIFF
--- a/changelogs/fragments/69484-add-path-to-yum-for-ibmi.yml
+++ b/changelogs/fragments/69484-add-path-to-yum-for-ibmi.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - setup - properly detect yum package manager for IBM i.

--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -37,6 +37,7 @@ PKG_MGRS = [{'path': '/usr/bin/yum', 'name': 'yum'},
             {'path': '/usr/sbin/sorcery', 'name': 'sorcery'},
             {'path': '/usr/bin/rpm-ostree', 'name': 'atomic_container'},
             {'path': '/usr/bin/installp', 'name': 'installp'},
+            {'path': '/QOpenSys/pkgs/bin/yum', 'name': 'yum'},
             ]
 
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
On IBM i, yum is installed under the `/QOpenSys/pkgs` prefix, see:
https://bitbucket.org/ibmi/opensource/src/master/docs/yum/#markdown-header-must-know-usage-notes-read-this-after-you-install
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
setup

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before
```
-bash-4.2$ ansible -m setup -a "filter=ansible_pkg_mgr" test-iinthecloud-ibmi72-ppc64_be-1
test-iinthecloud-ibmi72-ppc64_be-1 | SUCCESS => {
    "ansible_facts": {
        "ansible_pkg_mgr": "unknown"
    },
    "changed": false
}
-bash-4.2$
```

after
```
-bash-4.2$ ansible -m setup -a "filter=ansible_pkg_mgr" test-iinthecloud-ibmi72-ppc64_be-1
test-iinthecloud-ibmi72-ppc64_be-1 | SUCCESS => {
    "ansible_facts": {
        "ansible_pkg_mgr": "yum"
    },
    "changed": false
}
-bash-4.2$
```
