### PR TITLE
2.8: Remove deprecation for TRANSFORM_INVALID_GROUP_CHARS (#66650)

### DIFF
--- a/changelogs/fragments/61889-change-transform_invalid_group_chars-default.yml
+++ b/changelogs/fragments/61889-change-transform_invalid_group_chars-default.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Remove the deprecation message for the ``TRANSFORM_INVALID_GROUP_CHARS`` setting. (https://github.com/ansible/ansible/issues/61889)

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -47,12 +47,6 @@ def to_safe_group_name(name, replacer="_", force=False, silent=False):
                     warn = True
                     warn = 'Invalid characters were found in group names but not replaced, use -vvvv to see details'
 
-                # remove this message after 2.10 AND changing the default to 'always'
-                group_chars_setting, group_chars_origin = C.config.get_config_value_and_origin('TRANSFORM_INVALID_GROUP_CHARS')
-                if group_chars_origin == 'default':
-                    display.deprecated('The TRANSFORM_INVALID_GROUP_CHARS settings is set to allow bad characters in group names by default,'
-                                       ' this will change, but still be user configurable on deprecation', version='2.10')
-
     if warn:
         display.warning(warn)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of https://github.com/ansible/ansible/pull/66650

(cherry picked from commit 6086ea62ee5e47f3071410b302a10392d6e2437a)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/inventory/group.py`
