### PR TITLE
only show_vars when showing vars (#69365)

### DIFF
--- a/changelogs/fragments/69357_optimize_inventory_graph_wo_vars.yml
+++ b/changelogs/fragments/69357_optimize_inventory_graph_wo_vars.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - Avoid running subfunctions that are passed to show_vars function when it will be a noop.

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -263,9 +263,8 @@ class InventoryCLI(CLI):
     @staticmethod
     def _show_vars(dump, depth):
         result = []
-        if context.CLIARGS['show_vars']:
-            for (name, val) in sorted(dump.items()):
-                result.append(InventoryCLI._graph_name('{%s = %s}' % (name, val), depth))
+        for (name, val) in sorted(dump.items()):
+            result.append(InventoryCLI._graph_name('{%s = %s}' % (name, val), depth))
         return result
 
     @staticmethod
@@ -284,9 +283,11 @@ class InventoryCLI(CLI):
         if group.name != 'all':
             for host in sorted(group.hosts, key=attrgetter('name')):
                 result.append(self._graph_name(host.name, depth))
-                result.extend(self._show_vars(self._get_host_variables(host), depth + 1))
+                if context.CLIARGS['show_vars']:
+                    result.extend(self._show_vars(self._get_host_variables(host), depth + 1))
 
-        result.extend(self._show_vars(self._get_group_variables(group), depth))
+        if context.CLIARGS['show_vars']:
+            result.extend(self._show_vars(self._get_group_variables(group), depth))
 
         return result
 


### PR DESCRIPTION
* only show_vars when showing vars

avoid processing function params that can be very expensive
and might not be used at all in called function.

fixes #69357

* Update changelogs/fragments/69357_optimize_inventory_graph_wo_vars.yml

Co-authored-by: Sloane Hertel <shertel@redhat.com>
(cherry picked from commit f0b6f76bc61cbef5f45fcf8cfb39ca5767f074f6)


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-inventory

Backport of https://github.com/ansible/ansible/pull/69365
