### PR TITLE
ansible-test local change detection: use --base-branch if specified

### DIFF
--- a/changelogs/fragments/69508-ansible-test-local-changes-detection.yml
+++ b/changelogs/fragments/69508-ansible-test-local-changes-detection.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- "ansible-test - honor ``--base-branch`` for local change detection (https://github.com/ansible/ansible/pull/69508)."
+- "ansible-test - for local change detection, allow to specify branch to compare to with ``--base-branch`` for all types of tests (https://github.com/ansible/ansible/pull/69508)."

--- a/changelogs/fragments/69508-ansible-test-local-changes-detection.yml
+++ b/changelogs/fragments/69508-ansible-test-local-changes-detection.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-test - honor ``--base-branch`` for local change detection (https://github.com/ansible/ansible/pull/69508)."

--- a/test/lib/ansible_test/_internal/ci/local.py
+++ b/test/lib/ansible_test/_internal/ci/local.py
@@ -203,9 +203,11 @@ class LocalChanges:
         # diff of all tracked files from fork point to working copy
         self.diff = self.git.get_diff([self.fork_point])
 
-    @staticmethod
-    def is_official_branch(name):  # type: (str) -> bool
+    def is_official_branch(self, name):  # type: (str) -> bool
         """Return True if the given branch name an official branch for development or releases."""
+        if self.args.base_branch:
+            return name == self.args.base_branch
+
         if name == 'devel':
             return True
 

--- a/test/lib/ansible_test/_internal/cli.py
+++ b/test/lib/ansible_test/_internal/cli.py
@@ -309,6 +309,9 @@ def parse_args():
     test.add_argument('--metadata',
                       help=argparse.SUPPRESS)
 
+    test.add_argument('--base-branch',
+                      help=argparse.SUPPRESS)
+
     add_changes(test, argparse)
     add_environments(test)
 
@@ -526,9 +529,6 @@ def parse_args():
                         metavar='VERSION',
                         choices=SUPPORTED_PYTHON_VERSIONS + ('default',),
                         help='python version: %s' % ', '.join(SUPPORTED_PYTHON_VERSIONS))
-
-    sanity.add_argument('--base-branch',
-                        help=argparse.SUPPRESS)
 
     sanity.add_argument('--enable-optional-errors',
                         action='store_true',

--- a/test/lib/ansible_test/_internal/cli.py
+++ b/test/lib/ansible_test/_internal/cli.py
@@ -310,7 +310,7 @@ def parse_args():
                       help=argparse.SUPPRESS)
 
     test.add_argument('--base-branch',
-                      help=argparse.SUPPRESS)
+                      help='base branch used for change detection')
 
     add_changes(test, argparse)
     add_environments(test)

--- a/test/lib/ansible_test/_internal/config.py
+++ b/test/lib/ansible_test/_internal/config.py
@@ -193,6 +193,7 @@ class TestConfig(EnvironmentConfig):
         self.unstaged = args.unstaged  # type: bool
         self.changed_from = args.changed_from  # type: str
         self.changed_path = args.changed_path  # type: t.List[str]
+        self.base_branch = args.base_branch  # type: str
 
         self.lint = args.lint if 'lint' in args else False  # type: bool
         self.junit = args.junit if 'junit' in args else False  # type: bool
@@ -241,7 +242,6 @@ class SanityConfig(TestConfig):
         self.list_tests = args.list_tests  # type: bool
         self.allow_disabled = args.allow_disabled  # type: bool
         self.enable_optional_errors = args.enable_optional_errors  # type: bool
-        self.base_branch = args.base_branch  # type: str
         self.info_stderr = self.lint
 
 


### PR DESCRIPTION
##### SUMMARY
The "official" base branch detection doesn't work in most collections, where the main branch is called `master` and not `devel`. This results in ansible-test to error with `ERROR: Unable to auto-detect fork branch and fork point.` if `--changed` is added, even if `--base-branch` is specified.

This PR uses the branch specified to `--base-branch` as the only "official" branch for change detection if `--base-branch` is specified.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test
