### PR TITLE
use get() method to access items in dict type of variable

### DIFF
--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -143,7 +143,7 @@ class PlaybookExecutor:
                     templar = Templar(loader=self._loader, variables=all_vars)
                     play.post_validate(templar)
 
-                    if context.CLIARGS['syntax']:
+                    if context.CLIARGS.get('syntax'):
                         continue
 
                     if self._tqm is None:
@@ -238,7 +238,7 @@ class PlaybookExecutor:
             display.display("No issues encountered")
             return result
 
-        if context.CLIARGS['start_at_task'] and not self._tqm._start_at_done:
+        if context.CLIARGS.get('start_at_task') and not self._tqm._start_at_done:
             display.error(
                 "No matching task \"%s\" found."
                 " Note: --start-at-task can only follow static includes."


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Trying to create and run playbook with using PlaybookExecutor class without setting 'syntax' and 'start_at_task' option, it will be failed to run while accessing those keys in context.CLIARGS.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
