### PR TITLE
fix delegation vars usage (debug still shows inventory_hostname

### DIFF
--- a/changelogs/fragments/discovery_delegation_fix.yml
+++ b/changelogs/fragments/discovery_delegation_fix.yml
@@ -1,0 +1,3 @@
+bugfixes:
+    - interpreter discovery will now use correct vars (from delegated host) when in delegate_to task.
+    - discovery will NOT update incorrect host anymore when in delegate_to task.

--- a/changelogs/fragments/ensure_discovery_delegate.yml
+++ b/changelogs/fragments/ensure_discovery_delegate.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ensure we pass on interpreter discovery values to delegated host.

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -992,16 +992,19 @@ class TaskExecutor:
 
         task_keys = self._task.dump_attrs()
 
-        # set options with 'templated vars' specific to this plugin and dependant ones
+        # set options with 'templated vars' specific to this plugin and dependent ones
         self._connection.set_options(task_keys=task_keys, var_options=options)
         varnames.extend(self._set_plugin_options('shell', variables, templar, task_keys))
 
         if self._connection.become is not None:
+            if self._play_context.become_pass:
+                # FIXME: eventually remove from task and play_context, here for backwards compat
+                # keep out of play objects to avoid accidental disclosure, only become plugin should have
+                # The become pass is already in the play_context if given on
+                # the CLI (-K). Make the plugin aware of it in this case.
+                task_keys['become_pass'] = self._play_context.become_pass
 
             varnames.extend(self._set_plugin_options('become', variables, templar, task_keys))
-            # FIXME: eventually remove from task and play_context, here for backwards compat
-            # keep out of play objects to avoid accidental disclosure, only become plugin should have
-            task_keys['become_pass'] = self._connection.become.get_option('become_pass')
 
             # FOR BACKWARDS COMPAT:
             for option in ('become_user', 'become_flags', 'become_exe', 'become_pass'):

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -23,8 +23,8 @@ import os
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleParserError, AnsibleUndefinedVariable, AnsibleAssertionError
-from ansible.module_utils.six import iteritems, string_types
 from ansible.module_utils._text import to_native
+from ansible.module_utils.six import iteritems, string_types
 from ansible.parsing.mod_args import ModuleArgsParser
 from ansible.parsing.yaml.objects import AnsibleBaseYAMLObject, AnsibleMapping
 from ansible.plugins.loader import lookup_loader

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -157,8 +157,14 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         Handles the loading and templating of the module code through the
         modify_module() function.
         '''
+
         if task_vars is None:
-            task_vars = dict()
+            use_vars = dict()
+
+        if self._task.delegate_to:
+            use_vars = task_vars.get('ansible_delegated_vars')[self._task.delegate_to]
+        else:
+            use_vars = task_vars
 
         # Search module path(s) for named module.
         for mod_type in self._connection.module_implementation_preferences:
@@ -202,7 +208,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         for dummy in (1, 2):
             try:
                 (module_data, module_style, module_shebang) = modify_module(module_name, module_path, module_args, self._templar,
-                                                                            task_vars=task_vars,
+                                                                            task_vars=use_vars,
                                                                             module_compression=self._play_context.module_compression,
                                                                             async_timeout=self._task.async_val,
                                                                             environment=final_environment,
@@ -213,17 +219,22 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                     action=self,
                     interpreter_name=idre.interpreter_name,
                     discovery_mode=idre.discovery_mode,
-                    task_vars=task_vars))
+                    task_vars=use_vars))
 
                 # update the local task_vars with the discovered interpreter (which might be None);
                 # we'll propagate back to the controller in the task result
                 discovered_key = 'discovered_interpreter_%s' % idre.interpreter_name
-                # store in local task_vars facts collection for the retry and any other usages in this worker
-                if task_vars.get('ansible_facts') is None:
-                    task_vars['ansible_facts'] = {}
-                task_vars['ansible_facts'][discovered_key] = self._discovered_interpreter
-                # preserve this so _execute_module can propagate back to controller as a fact
-                self._discovered_interpreter_key = discovered_key
+
+                # TODO: this condition prevents 'wrong host' from being updated
+                # but in future we would want to be able to update 'delegated host facts'
+                # irrespective of task settings
+                if not self._task.delegate_to or self._task.delegate_facts:
+                    # store in local task_vars facts collection for the retry and any other usages in this worker
+                    if use_vars.get('ansible_facts') is None:
+                        task_vars['ansible_facts'] = {}
+                    task_vars['ansible_facts'][discovered_key] = self._discovered_interpreter
+                    # preserve this so _execute_module can propagate back to controller as a fact
+                    self._discovered_interpreter_key = discovered_key
 
         return (module_style, module_shebang, module_data, module_path)
 

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -235,6 +235,11 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                     task_vars['ansible_facts'][discovered_key] = self._discovered_interpreter
                     # preserve this so _execute_module can propagate back to controller as a fact
                     self._discovered_interpreter_key = discovered_key
+                else:
+                    task_vars['ansible_delegated_vars'][self._task.delegate_to]
+                    if task_vars['ansible_delegated_vars'][self._task.delegate_to].get('ansible_facts') is None:
+                        task_vars['ansible_delegated_vars'][self._task.delegate_to]['ansible_facts'] = {}
+                    task_vars['ansible_delegated_vars'][self._task.delegate_to]['ansible_facts'][discovered_key] = self._discovered_interpreter
 
         return (module_style, module_shebang, module_data, module_path)
 

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -538,6 +538,7 @@ class VariableManager:
             has_loop = False
             items = [None]
 
+        # since host can change per loop, we keep dict per host name resolved
         delegated_host_vars = dict()
         item_var = getattr(task.loop_control, 'loop_var', 'item')
         cache_items = False
@@ -554,27 +555,12 @@ class VariableManager:
                 raise AnsibleError(message="Undefined delegate_to host for task:", obj=task._ds)
             if not isinstance(delegated_host_name, string_types):
                 raise AnsibleError(message="the field 'delegate_to' has an invalid type (%s), and could not be"
-                                           " converted to a string type." % type(delegated_host_name),
-                                   obj=task._ds)
+                                           " converted to a string type." % type(delegated_host_name), obj=task._ds)
+
             if delegated_host_name in delegated_host_vars:
                 # no need to repeat ourselves, as the delegate_to value
                 # does not appear to be tied to the loop item variable
                 continue
-
-            # a dictionary of variables to use if we have to create a new host below
-            # we set the default port based on the default transport here, to make sure
-            # we use the proper default for windows
-            new_port = C.DEFAULT_REMOTE_PORT
-            if C.DEFAULT_TRANSPORT == 'winrm':
-                new_port = 5986
-
-            new_delegated_host_vars = dict(
-                ansible_delegated_host=delegated_host_name,
-                ansible_host=delegated_host_name,  # not redundant as other sources can change ansible_host
-                ansible_port=new_port,
-                ansible_user=C.DEFAULT_REMOTE_USER,
-                ansible_connection=C.DEFAULT_TRANSPORT,
-            )
 
             # now try to find the delegated-to host in inventory, or failing that,
             # create a new host on the fly so we can fetch variables for it
@@ -584,21 +570,16 @@ class VariableManager:
                 # try looking it up based on the address field, and finally
                 # fall back to creating a host on the fly to use for the var lookup
                 if delegated_host is None:
-                    if delegated_host_name in C.LOCALHOST:
-                        delegated_host = self._inventory.localhost
+                    for h in self._inventory.get_hosts(ignore_limits=True, ignore_restrictions=True):
+                        # check if the address matches, or if both the delegated_to host
+                        # and the current host are in the list of localhost aliases
+                        if h.address == delegated_host_name:
+                            delegated_host = h
+                            break
                     else:
-                        for h in self._inventory.get_hosts(ignore_limits=True, ignore_restrictions=True):
-                            # check if the address matches, or if both the delegated_to host
-                            # and the current host are in the list of localhost aliases
-                            if h.address == delegated_host_name:
-                                delegated_host = h
-                                break
-                        else:
-                            delegated_host = Host(name=delegated_host_name)
-                            delegated_host.vars = combine_vars(delegated_host.vars, new_delegated_host_vars)
+                        delegated_host = Host(name=delegated_host_name)
             else:
                 delegated_host = Host(name=delegated_host_name)
-                delegated_host.vars = combine_vars(delegated_host.vars, new_delegated_host_vars)
 
             # now we go fetch the vars for the delegated-to host and save them in our
             # master dictionary of variables to be used later in the TaskExecutor/PlayContext

--- a/test/integration/targets/cli/aliases
+++ b/test/integration/targets/cli/aliases
@@ -1,2 +1,5 @@
+destructive
+needs/root
+needs/ssh
 needs/target/setup_pexpect
 shippable/posix/group3

--- a/test/integration/targets/cli/setup.yml
+++ b/test/integration/targets/cli/setup.yml
@@ -1,4 +1,42 @@
 - hosts: localhost
-  gather_facts: no
+  gather_facts: yes
   roles:
     - setup_pexpect
+
+  tasks:
+    - name: Test ansible-playbook and ansible with -K
+      block:
+        - name: Create user to connect as
+          user:
+            name: cliuser1
+            shell: /bin/bash
+            groups: wheel
+            append: yes
+            password: "{{ 'secretpassword' | password_hash('sha512', 'mysecretsalt') }}"
+        - name: Create user to become
+          user:
+            name: cliuser2
+            shell: /bin/bash
+            password: "{{ 'secretpassword' | password_hash('sha512', 'mysecretsalt') }}"
+        # Sometimes this file doesn't get removed, and we need it gone to ssh
+        - name: Remove /run/nologin
+          file:
+            path: /run/nologin
+            state: absent
+        # Make Ansible run Python to run Ansible
+        - name: Run the test
+          shell: python test_k_and_K.py {{ ansible_python_interpreter }}
+      always:
+        - name: Remove users
+          user:
+            name: "{{ item }}"
+            state: absent
+          with_items:
+            - cliuser1
+            - cliuser2
+      # For now, we don't test this everywhere, because `user` works differently
+      # on some platforms, as does sudo/sudoers. On Fedora, we can just add
+      # the user to 'wheel' and things magically work.
+      # TODO: In theory, we should test this with all the different 'become'
+      # plugins in base.
+      when: ansible_distribution == 'Fedora'

--- a/test/integration/targets/cli/test_k_and_K.py
+++ b/test/integration/targets/cli/test_k_and_K.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import sys
+
+import pexpect
+
+os.environ['ANSIBLE_NOCOLOR'] = '1'
+
+out = pexpect.run(
+    'ansible -c ssh -i localhost, -u cliuser1 -e ansible_python_interpreter={0} '
+    '-m command -a whoami -Kkb --become-user cliuser2 localhost'.format(sys.argv[1]),
+    events={
+        'SSH password:': 'secretpassword\n',
+        'BECOME password': 'secretpassword\n',
+    },
+    timeout=10
+)
+
+print(out)
+
+assert b'cliuser2' in out

--- a/test/integration/targets/delegate_to/delegate_vars_hanldling.yml
+++ b/test/integration/targets/delegate_to/delegate_vars_hanldling.yml
@@ -1,0 +1,58 @@
+- name: setup delegated hsot
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - add_host:
+        name: delegatetome
+        ansible_host: 127.0.0.4
+
+- name: ensure we dont use orig host vars if delegated one does not define them
+  hosts: testhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: force current host to use winrm
+      set_fact:
+        ansible_connection: winrm
+
+    - name: this should fail (missing winrm or unreachable)
+      ping:
+      ignore_errors: true
+      ignore_unreachable: true
+      register: orig
+
+    - name: ensure prev failed
+      assert:
+        that:
+            - orig is failed or orig is unreachable
+
+    - name: this will only fail if we take orig host ansible_connection instead of defaults
+      ping:
+      delegate_to: delegatetome
+
+
+- name: ensure plugin specific vars are properly used
+  hosts: testhost
+  gather_facts: false
+  tasks:
+    - name: set unusable ssh args
+      set_fact:
+         ansible_host: 127.0.0.1
+         ansible_connection: ssh
+         ansible_ssh_common_args: 'MEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE'
+         ansible_connection_timeout: 5
+
+    - name: fail to ping with bad args
+      ping:
+      register: bad_args_ping
+      ignore_unreachable: true
+
+    - debug: var=bad_args_ping
+    - name: ensure prev failed
+      assert:
+        that:
+            - bad_args_ping is failed or bad_args_ping is unreachable
+
+    - name: this should work by ignoring the bad ags for orig host
+      ping:
+      delegate_to: delegatetome

--- a/test/integration/targets/delegate_to/discovery_applied.yml
+++ b/test/integration/targets/delegate_to/discovery_applied.yml
@@ -1,0 +1,8 @@
+- hosts: testhost
+  gather_facts: no
+  tasks:
+  - command: ls
+    delegate_to: "{{ item }}"
+    with_items:
+    - localhost
+    - "{{ inventory_hostname }}"

--- a/test/integration/targets/delegate_to/inventory_interpreters
+++ b/test/integration/targets/delegate_to/inventory_interpreters
@@ -1,0 +1,5 @@
+testhost ansible_python_interpreter=firstpython
+testhost2 ansible_python_interpreter=secondpython
+
+[all:vars]
+ansible_connection=local

--- a/test/integration/targets/delegate_to/library/detect_interpreter.py
+++ b/test/integration/targets/delegate_to/library/detect_interpreter.py
@@ -1,0 +1,18 @@
+#!/usr/bin/python
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(argument_spec={})
+    module.exit_json(**dict(found=sys.executable))
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/delegate_to/runme.sh
+++ b/test/integration/targets/delegate_to/runme.sh
@@ -69,3 +69,4 @@ ln -s python firstpython
 ln -s python secondpython
 )
 ansible-playbook verify_interpreter.yml -i inventory_interpreters -v "$@"
+ansible-playbook discovery_applied.yml -i inventory -v "$@"

--- a/test/integration/targets/delegate_to/runme.sh
+++ b/test/integration/targets/delegate_to/runme.sh
@@ -58,3 +58,14 @@ ansible-playbook test_delegate_to_loop_caching.yml -i inventory -v "$@"
 
 # ensure we are using correct settings when delegating
 ANSIBLE_TIMEOUT=3 ansible-playbook delegate_vars_hanldling.yml -i inventory -v "$@"
+
+
+# test ansible_x_interpreter
+# python
+source virtualenv.sh
+(
+cd "${OUTPUT_DIR}"/venv/bin
+ln -s python firstpython
+ln -s python secondpython
+)
+ansible-playbook verify_interpreter.yml -i inventory_interpreters -v "$@"

--- a/test/integration/targets/delegate_to/runme.sh
+++ b/test/integration/targets/delegate_to/runme.sh
@@ -55,3 +55,6 @@ ansible-playbook delegate_and_nolog.yml -i inventory -v "$@"
 ansible-playbook delegate_facts_block.yml -i inventory -v "$@"
 
 ansible-playbook test_delegate_to_loop_caching.yml -i inventory -v "$@"
+
+# ensure we are using correct settings when delegating
+ANSIBLE_TIMEOUT=3 ansible-playbook delegate_vars_hanldling.yml -i inventory -v "$@"

--- a/test/integration/targets/delegate_to/verify_interpreter.yml
+++ b/test/integration/targets/delegate_to/verify_interpreter.yml
@@ -1,0 +1,47 @@
+- name: ensure they are different
+  hosts: localhost
+  tasks:
+    - name: dont game me
+      assert:
+        msg: 'expected different values but got ((hostvars["testhost"]["ansible_python_interpreter"]}} and {{hostvars["testhost2"]["ansible_python_interpreter"]}}'
+        that:
+           - hostvars["testhost"]["ansible_python_interpreter"] != hostvars["testhost2"]["ansible_python_interpreter"]
+
+- name: no delegation
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: detect interpreter used by each host
+      detect_interpreter:
+      register: baseline
+
+    - name: verify it
+      assert:
+        msg: 'expected {{ansible_python_interpreter}} but got {{baseline.found|basename}}'
+        that:
+           - baseline.found|basename == ansible_python_interpreter
+
+- name: actual test
+  hosts: testhost
+  gather_facts: false
+  tasks:
+    - name: original host
+      detect_interpreter:
+      register: found
+
+    - name: verify it orig host
+      assert:
+        msg: 'expected {{ansible_python_interpreter}} but got {{found.found|basename}}'
+        that:
+           - found.found|basename == ansible_python_interpreter
+
+    - name: delegated host
+      detect_interpreter:
+      register: found2
+      delegate_to: testhost2
+
+    - name: verify it delegated
+      assert:
+        msg: 'expected {{hostvars["testhost2"]["ansible_python_interpreter"]}} but got {{found2.found|basename}}'
+        that:
+           - found2.found|basename == hostvars["testhost2"]["ansible_python_interpreter"]

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -116,6 +116,7 @@ class TestActionBase(unittest.TestCase):
         mock_task = MagicMock()
         mock_task.action = "copy"
         mock_task.async_val = 0
+        mock_task.delegate_to = None
 
         # create a mock connection, so we don't actually try and connect to things
         mock_connection = MagicMock()


### PR DESCRIPTION
* fix delegation vars usage and reporting

 - just pass delegated host vars + task vars to plugins
   and avoid poluting with original host vars
 - updated tests

(cherry picked from commit 2165f9ac40cf212891b11a75bd9b9b2f4f0b8dc3)
fixes #69853

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
engine

#### ADITIONAL INFO

This contains the original fix, 2nd part that original missed (discovery) and a fix to bug introduced by original (why 3 commits)

Backport of https://github.com/ansible/ansible/pull/69244
