### PR TITLE
ansible-galaxy - remove warning during collection install

### DIFF
--- a/changelogs/fragments/ansible-galaxy-install-manifest-warning.yaml
+++ b/changelogs/fragments/ansible-galaxy-install-manifest-warning.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >
+    ansible-galaxy - hide warning during collection installation if other installed collections
+    do not contain a ``MANIFEST.json`` (https://github.com/ansible/ansible/issues/67490)

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -605,7 +605,7 @@ def install_collections(collections, output_path, apis, validate_certs, ignore_e
     :param force: Re-install a collection if it has already been installed.
     :param force_deps: Re-install a collection as well as its dependencies if they have already been installed.
     """
-    existing_collections = find_existing_collections(output_path)
+    existing_collections = find_existing_collections(output_path, fallback_metadata=True)
 
     with _tempdir() as b_temp_path:
         display.display("Process install dependency map")


### PR DESCRIPTION
##### SUMMARY
If existing installed collections do not contain a `MANIFEST.json`, which is common for collections under development that were not installed from Ansible Galaxy, fall back to inspecting `galaxy.yml` rather than displaying a warning.

A warning will still be displayed in neither a `MANIFEST.json` nor `galaxy.yml` are present.

Related to https://github.com/ansible/ansible/issues/67490#issuecomment-624339897

I thought that #68925 addressed the install issue as well, but evidently I was mistaken.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/galaxy/collection.py`


