### PR TITLE
lineinfile - Use ANSIBLE_REMOTE_TMP for temporary file

### DIFF
--- a/changelogs/fragments/lineinfile-use-module-tempdir.yaml
+++ b/changelogs/fragments/lineinfile-use-module-tempdir.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - lineinfile - use ``module.tmpdir`` to allow configuration of the remote temp directory (https://github.com/ansible/ansible/issues/68218)

--- a/lib/ansible/modules/lineinfile.py
+++ b/lib/ansible/modules/lineinfile.py
@@ -213,7 +213,7 @@ from ansible.module_utils._text import to_bytes, to_native
 
 def write_changes(module, b_lines, dest):
 
-    tmpfd, tmpfile = tempfile.mkstemp()
+    tmpfd, tmpfile = tempfile.mkstemp(dir=module.tmpdir)
     with os.fdopen(tmpfd, 'wb') as f:
         f.writelines(b_lines)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Honor `ANSIBLE_REMOTE_TMP` set by the shell plugin when creating a temporary file.

Fixes #68218 
Fixes #24082
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/lineinfile.py`