### PR TITLE
Feature/ol 9305 add power states to tacp instance

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,6 @@
+[default]
+# human-readable stdout/stderr results display
+# Use the YAML callback plugin.
+stdout_callback = json
+# Use the stdout_callback when running ad-hoc commands.
+bin_ansible_callbacks = True

--- a/create_vm.yml
+++ b/create_vm.yml
@@ -12,11 +12,11 @@
       template: CentOS 7 - Jenkins - Lenovo Template
       storage_pool: Pool 1
       vcpu_cores: 1
-      memory_mb: 2048
+      memory: 2g
       disks:
         - size_gb: 20
       nics:
-        - name: NIC 1
+        - name: vNIC 0
           type: VNET
           network: OTA_VNET
     register: testout

--- a/create_vm.yml
+++ b/create_vm.yml
@@ -1,0 +1,26 @@
+---
+- name: test my new module
+  hosts: localhost
+  tasks:
+  - name: Create a VM on TACP
+    tacp_instance:
+      api_key: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJYYW5kZXIgTWFkc2VuIFR1ZSBBcHIgMjEgMTg6Mjg6MzAgVVRDIDIwMjAifQ.lMQzOVVozwPq38C43zJ83B8hDQKHeW9DESkmQx_cc3t22vBLRVVC2CAQIxIkVmKAYprrgkBWtXUJG8wz33q_cg
+      name: Test_VM
+      state: present
+      datacenter: OTA_TEST
+      mz: MZ 1
+      template: CentOS 7 - Jenkins - Lenovo Template
+      storage_pool: Pool 1
+      vcpu_cores: 1
+      memory_mb: 2048
+      disks:
+        - size_gb: 20
+      nics:
+        - name: NIC 1
+          type: VNET
+          network: OTA_VNET
+    register: testout
+
+  - name: Output
+    debug:
+      msg: '{{ testout }}'

--- a/lib/ansible/module_utils/tacp.py
+++ b/lib/ansible/module_utils/tacp.py
@@ -205,13 +205,15 @@ def api_response_to_dict(api_response):
         elif "message" in dir(api_response):
             message_str = api_response.message
         else:
-            attrs = [key for key in api_response.__dict__.keys() if not key.startswith("__") and key != "discriminator"]
+            attrs = [key for key in api_response.__dict__.keys(
+            ) if not key.startswith("__") and key != "discriminator"]
             api_dict = {}
             for attr in attrs:
                 val = str(api_response.__dict__[
                     attr]).replace('\n', '').replace('null', 'None')
                 extra_space_pattern = ",\\s{2,}"
-                api_dict[str(attr).lstrip("_")] = re.sub(extra_space_pattern, ", ", val)
+                api_dict[str(attr).lstrip("_")] = re.sub(
+                    extra_space_pattern, ", ", val)
             return api_dict
 
     message_str = message_str.replace('\n', '').replace('null', 'None')
@@ -230,12 +232,20 @@ def wait_for_action_to_complete(action_uuid, api_client):
         api_instance = tacp.ActionsApi(api_client)
         action_incomplete = True
 
-        while action_incomplete:
+        timeout = 30
+        time_spent = 0
+
+        while action_incomplete and time_spent < timeout:
             api_response = api_instance.get_action_using_get(action_uuid)
             if api_response.status == 'Completed':
                 action_incomplete = False
+                return True, None
             else:
                 sleep(1)
+                time_spent += 1
+
+        return False, "Action timed out."
+    return False, "Invalid action UUID, nothing to do."
 
 
 def delete_application(name, uuid, api_client):

--- a/lib/ansible/module_utils/tacp.py
+++ b/lib/ansible/module_utils/tacp.py
@@ -37,7 +37,7 @@ def get_component_fields_by_name(name, component,
     elif component == "application":
         api_instance = tacp.ApplicationsApi(api_client)
         try:
-            # View flash pools for an organization
+            # View applications for an organization
             api_response = api_instance.get_applications_using_get(
                 fields=fields)
         except ApiException as e:
@@ -45,7 +45,7 @@ def get_component_fields_by_name(name, component,
     elif component == "template":
         api_instance = tacp.TemplatesApi(api_client)
         try:
-            # View flash pools for an organization
+            # View templates for an organization
             api_response = api_instance.get_templates_using_get(
                 fields=fields)
         except ApiException as e:
@@ -53,7 +53,7 @@ def get_component_fields_by_name(name, component,
     elif component == "datacenter":
         api_instance = tacp.DatacentersApi(api_client)
         try:
-            # View flash pools for an organization
+            # View datacenters for an organization
             api_response = api_instance.get_datacenters_using_get(
                 fields=fields)
         except ApiException as e:
@@ -61,7 +61,7 @@ def get_component_fields_by_name(name, component,
     elif component == "migration_zone":
         api_instance = tacp.MigrationZonesApi(api_client)
         try:
-            # View flash pools for an organization
+            # View migration zones for an organization
             api_response = api_instance.get_migration_zones_using_get(
                 fields=fields)
         except ApiException as e:
@@ -69,7 +69,7 @@ def get_component_fields_by_name(name, component,
     elif component == "vlan":
         api_instance = tacp.VlansApi(api_client)
         try:
-            # View flash pools for an organization
+            # View VLAN networks for an organization
             api_response = api_instance.get_vlans_using_get(
                 fields=fields)
         except ApiException as e:
@@ -77,7 +77,7 @@ def get_component_fields_by_name(name, component,
     elif component == "vnet":
         api_instance = tacp.VnetsApi(api_client)
         try:
-            # View flash pools for an organization
+            # View VNET networks for an organization
             api_response = api_instance.get_vnets_using_get(
                 fields=fields)
         except ApiException as e:
@@ -132,13 +132,13 @@ def convert_memory_abbreviation_to_bytes(value):
     amount_in_bytes = amount
     if unit is None:
         amount_in_bytes = amount
-    elif unit in ['k', 'kb']:
+    elif unit in ['k', 'kb', 'K', 'KB']:
         amount_in_bytes = amount * 1024
-    elif unit in ['m', 'mb']:
+    elif unit in ['m', 'mb', 'M', 'MB']:
         amount_in_bytes = amount * 1024 * 1024
-    elif unit in ['g', 'gb']:
+    elif unit in ['g', 'gb', 'G', 'GB']:
         amount_in_bytes = amount * 1024 * 1024 * 1024
-    elif unit in ['t', 'tb']:
+    elif unit in ['t', 'tb', 'T', 'TB']:
         amount_in_bytes = amount * 1024 * 1024 * 1024 * 1024
 
     return amount_in_bytes

--- a/lib/ansible/module_utils/tacp.py
+++ b/lib/ansible/module_utils/tacp.py
@@ -111,7 +111,7 @@ def get_component_fields_by_name(name, component,
                         boot_order.append(boot_order_payload)
                     return boot_order
     return None
-    
+
 
 def convert_memory_abbreviation_to_bytes(value):
     """Validate memory argument. Returns the memory value in bytes."""
@@ -165,3 +165,19 @@ def is_valid_uuid(uuid_to_test, version=4):
         return False
 
     return str(uuid_obj) == uuid_to_test
+
+
+def api_response_to_dict(api_response):
+    if type(api_response) != ApiException:
+        message_str = api_response.message
+    else:
+        message_str = str(api_response)
+    message_str = message_str.replace('\n', '').replace('null', 'None')
+
+    http_text = 'HTTP response body: '
+    http_index = message_str.find(http_text)
+
+    message_str = message_str[http_index + len(http_text):]
+
+    message_dict = dict(json.loads(message_str))
+    return message_dict

--- a/lib/ansible/module_utils/tacp.py
+++ b/lib/ansible/module_utils/tacp.py
@@ -9,6 +9,7 @@ import tacp
 from tacp.rest import ApiException
 from uuid import UUID, uuid4
 
+
 def get_component_fields_by_name(name, component,
                                  api_client, fields=['name', 'uuid']):
     """
@@ -87,7 +88,7 @@ def get_component_fields_by_name(name, component,
         if fields == ['name', 'uuid']:
             for result in api_response:
                 if result.name == name:
-                     return result.uuid
+                    return result.uuid
         if 'bootOrder' in fields:
             for result in api_response:
                 if result.name == name:
@@ -110,13 +111,7 @@ def get_component_fields_by_name(name, component,
                         boot_order.append(boot_order_payload)
                     return boot_order
     return None
-
-
-def fail_with_reason(reason):
-        result['failed'] = True
-        result['failure_reason'] = reason
-        module.exit_json(**result)
-        return
+    
 
 def convert_memory_abbreviation_to_bytes(value):
     """Validate memory argument. Returns the memory value in bytes."""
@@ -142,6 +137,7 @@ def convert_memory_abbreviation_to_bytes(value):
         amount_in_bytes = amount * 1024 * 1024 * 1024 * 1024
 
     return amount_in_bytes
+
 
 def is_valid_uuid(uuid_to_test, version=4):
     """

--- a/lib/ansible/module_utils/tacp.py
+++ b/lib/ansible/module_utils/tacp.py
@@ -1,0 +1,171 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2020, Lenovo
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import json
+import re
+import tacp
+from tacp.rest import ApiException
+from uuid import UUID, uuid4
+
+def get_component_fields_by_name(name, component,
+                                 api_client, fields=['name', 'uuid']):
+    """
+    Returns the UUID of a named component if it exists in a given
+    ThinkAgile CP cloud, otherwise return None.
+
+    :param name The name of the component that may or may not exist yet
+    :type name str
+    :param component The type of component in question, must be one of
+    """
+
+    valid_components = ["storage_pool", "application",
+                        "template", "datacenter", "migration_zone",
+                        "vnet", "vlan"]
+
+    if component not in valid_components:
+        return "Invalid component"
+    if component == "storage_pool":
+        api_instance = tacp.FlashPoolsApi(api_client)
+        try:
+            # View flash pools for an organization
+            api_response = api_instance.get_flash_pools_using_get(
+                fields=fields)
+        except ApiException as e:
+            return "Exception when calling get_flash_pools_using_get: %s\n" % e
+    elif component == "application":
+        api_instance = tacp.ApplicationsApi(api_client)
+        try:
+            # View flash pools for an organization
+            api_response = api_instance.get_applications_using_get(
+                fields=fields)
+        except ApiException as e:
+            return "Exception when calling get_applications_using_get: %s\n" % e
+    elif component == "template":
+        api_instance = tacp.TemplatesApi(api_client)
+        try:
+            # View flash pools for an organization
+            api_response = api_instance.get_templates_using_get(
+                fields=fields)
+        except ApiException as e:
+            return "Exception when calling get_templates_using_get: %s\n" % e
+    elif component == "datacenter":
+        api_instance = tacp.DatacentersApi(api_client)
+        try:
+            # View flash pools for an organization
+            api_response = api_instance.get_datacenters_using_get(
+                fields=fields)
+        except ApiException as e:
+            return "Exception when calling get_datacenters_using_get: %s\n" % e
+    elif component == "migration_zone":
+        api_instance = tacp.MigrationZonesApi(api_client)
+        try:
+            # View flash pools for an organization
+            api_response = api_instance.get_migration_zones_using_get(
+                fields=fields)
+        except ApiException as e:
+            return "Exception when calling get_migration_zones_using_get: %s\n" % e
+    elif component == "vlan":
+        api_instance = tacp.VlansApi(api_client)
+        try:
+            # View flash pools for an organization
+            api_response = api_instance.get_vlans_using_get(
+                fields=fields)
+        except ApiException as e:
+            return "Exception when calling get_vlans_using_get: %s\n" % e
+    elif component == "vnet":
+        api_instance = tacp.VnetsApi(api_client)
+        try:
+            # View flash pools for an organization
+            api_response = api_instance.get_vnets_using_get(
+                fields=fields)
+        except ApiException as e:
+            return "Exception when calling get_vnets_using_get: %s\n" % e
+
+    if (api_response):
+        if fields == ['name', 'uuid']:
+            for result in api_response:
+                if result.name == name:
+                     return result.uuid
+        if 'bootOrder' in fields:
+            for result in api_response:
+                if result.name == name:
+                    boot_order = []
+                    for order_item in result.boot_order:
+                        str_dict = str(order_item).replace(
+                            "\n", "").replace("'", '"').replace("None", '""')
+
+                        json_dict = json.loads(str_dict)
+
+                        disk_uuid = json_dict['disk_uuid'] if json_dict['disk_uuid'] else None
+                        name = json_dict['name'] if json_dict['name'] else None
+                        order = json_dict['order'] if json_dict['order'] else None
+                        vnic_uuid = json_dict['vnic_uuid'] if json_dict['vnic_uuid'] else None
+
+                        boot_order_payload = tacp.ApiBootOrderPayload(disk_uuid=disk_uuid,
+                                                                      name=name,
+                                                                      order=order,
+                                                                      vnic_uuid=vnic_uuid)
+                        boot_order.append(boot_order_payload)
+                    return boot_order
+    return None
+
+
+def fail_with_reason(reason):
+        result['failed'] = True
+        result['failure_reason'] = reason
+        module.exit_json(**result)
+        return
+
+def convert_memory_abbreviation_to_bytes(value):
+    """Validate memory argument. Returns the memory value in bytes."""
+    MEMORY_RE = re.compile(
+        r"^(?P<amount>[0-9]+)(?P<unit>t|tb|g|gb|m|mb|k|kb)?$")
+
+    matches = MEMORY_RE.match(value.lower())
+    if matches is None:
+        raise ValueError(
+            '%s is not a valid value for memory amount' % value)
+    amount_str, unit = matches.groups()
+    amount = int(amount_str)
+    amount_in_bytes = amount
+    if unit is None:
+        amount_in_bytes = amount
+    elif unit in ['k', 'kb']:
+        amount_in_bytes = amount * 1024
+    elif unit in ['m', 'mb']:
+        amount_in_bytes = amount * 1024 * 1024
+    elif unit in ['g', 'gb']:
+        amount_in_bytes = amount * 1024 * 1024 * 1024
+    elif unit in ['t', 'tb']:
+        amount_in_bytes = amount * 1024 * 1024 * 1024 * 1024
+
+    return amount_in_bytes
+
+def is_valid_uuid(uuid_to_test, version=4):
+    """
+    Check if uuid_to_test is a valid UUID.
+
+    Parameters
+    ----------
+    uuid_to_test : str
+    version : {1, 2, 3, 4}
+
+    Returns
+    -------
+    `True` if uuid_to_test is a valid UUID, otherwise `False`.
+
+    Examples
+    --------
+    >>> is_valid_uuid('c9bf9e57-1685-4c89-bafb-ff5af830be8a')
+    True
+    >>> is_valid_uuid('c9bf9e58')
+    False
+    """
+    try:
+        uuid_obj = UUID(uuid_to_test, version=version)
+    except ValueError:
+        return False
+
+    return str(uuid_obj) == uuid_to_test

--- a/lib/ansible/module_utils/tacp.py
+++ b/lib/ansible/module_utils/tacp.py
@@ -23,7 +23,7 @@ def get_component_fields_by_name(name, component,
 
     valid_components = ["storage_pool", "application",
                         "template", "datacenter", "migration_zone",
-                        "vnet", "vlan"]
+                        "vnet", "vlan", "firewall_profile", "firewall_override"]
 
     if component not in valid_components:
         return "Invalid component"
@@ -83,6 +83,33 @@ def get_component_fields_by_name(name, component,
                 fields=fields)
         except ApiException as e:
             return "Exception when calling get_vnets_using_get: %s\n" % e
+    elif component == "firewall_profile":
+        api_instance = tacp.FirewallProfilesApi(api_client)
+        try:
+            # View Firewall profiles for an organization
+            api_response = api_instance.get_firewall_profiles_using_get(
+                fields=fields)
+        except ApiException as e:
+            return "Exception when calling get_firewall_profiles_using_get: %s\n" % e
+    elif component == "firewall_override":
+        # Need to get all datacenter UUIDs first 
+        api_instance = tacp.DatacentersApi(api_client)
+        try:
+            # View datacenters for an organization
+            datacenter_list = api_instance.get_datacenters_using_get(
+                fields=fields)
+        except ApiException as e:
+            return "Exception when calling get_datacenters_using_get: %s\n" % e
+
+        api_response = []
+        for datacenter in datacenter_list:
+            api_instance = tacp.DatacentersApi(api_client)
+            try:
+                # View Firewall profiles for an organization
+                api_response += api_instance.get_datacenter_firewall_overrides_using_get(
+                    uuid=datacenter.uuid, fields=fields)
+            except ApiException as e:
+                return "Exception when calling get_firewall_profiles_using_get"
 
     if (api_response):
         if fields == ['name', 'uuid']:

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -83,14 +83,14 @@ def run_module():
         name=dict(type='str', required=True),
         state=dict(type='str', default='present',
                    choices=['present', 'absent']),
-        datacenter=dict(type='str', required=True),
-        mz=dict(type='str', required=True),
-        storage_pool=dict(type='str', required=True),
-        template=dict(type='str', required=True),
-        vcpu_cores=dict(type='int', required=True),
-        memory=dict(type='str', required=True),
-        disks=dict(type='list', required=True),
-        nics=dict(type='list', required=True),
+        datacenter=dict(type='str', required=False),
+        mz=dict(type='str', required=False),
+        storage_pool=dict(type='str', required=False),
+        template=dict(type='str', required=False),
+        vcpu_cores=dict(type='int', required=False),
+        memory=dict(type='str', required=False),
+        disks=dict(type='list', required=False),
+        nics=dict(type='list', required=False),
         vtx_enabled=dict(type='bool', default=True, required=False),
         auto_recovery_enabled=dict(type='bool', default=True, required=False),
         description=dict(type='str', required=False),
@@ -124,150 +124,131 @@ def run_module():
         module.exit_json(**result)
 
     def fail_with_reason(reason):
-        result['failure_reason'] = reason
-        result['failed'] = True
-        module.exit_json(**result)
+        result['msg'] = reason
+        module.fail_json(**result)
 
     # manipulate or modify the state as needed (this is going to be the
     # part where your module will do what it needs to do)
 
-    # Return the inputs for debugging purposes
-    result['args'] = module.params
+    def validate_input(params):
+        pass
 
-    # Define configuration
-    configuration = tacp.Configuration()
-    configuration.host = "https://manage.cp.lenovo.com"
-    configuration.api_key_prefix['Authorization'] = 'Bearer'
-    configuration.api_key['Authorization'] = module.params['api_key']
-    api_client = tacp.ApiClient(configuration)
+    def generate_instance_params(module):
+        # VM does not exist yet, so we must create it
+        instance_params = {}
+        instance_params['instance_name'] = module.params['name']
 
-    instance_params = {}
-
-    # Check if VM instance with this name exists already
-    instance_uuid = get_component_fields_by_name(
-        module.params['name'], 'application', api_client)
-
-    if instance_uuid:
-        # VM does exist - so for now we need to just break without changing anything,
-        # but in the future this would mean we go to edit the existing VM with this name/uuid
-        # vm_exists = True
-        result['msg'] = "An application for this datacenter already exists with name %s" % module.params['name']
-        result['changed'] = False
-
-        module.exit_json(**result)
-
-    # VM does not exist yet, so we must create it
-    instance_params['instance_name'] = module.params['name']
-
-    # Check if storage pool exists, it must in order to continue
-    storage_pool_uuid = get_component_fields_by_name(
-        module.params['storage_pool'], 'storage_pool', api_client)
-    if storage_pool_uuid:
-        instance_params['storage_pool_uuid'] = storage_pool_uuid
-    else:
-        # Pool does not exist - must fail the task
-        reason = "Storage pool %s does not exist, cannot continue." % module.params[
-            'storage_pool']
-        fail_with_reason(reason)
-
-    # Check if datacenter exists, it must in order to continue
-    datacenter_uuid = get_component_fields_by_name(
-        module.params['datacenter'], 'datacenter', api_client)
-    if datacenter_uuid:
-        instance_params['datacenter_uuid'] = datacenter_uuid
-    else:
-        # Datacenter does not exist - must fail the task
-        reason = "Datacenter %s does not exist, cannot continue." % module.params[
-            'datacenter']
-        fail_with_reason(reason)
-
-    # Check if migration_zone exists, it must in order to continue
-    migration_zone_uuid = get_component_fields_by_name(
-        module.params['mz'], 'migration_zone', api_client)
-    if migration_zone_uuid:
-        instance_params['migration_zone_uuid'] = migration_zone_uuid
-    else:
-        # Migration zone does not exist - must fail the task
-        reason = "Migration Zone %s does not exist, cannot continue." % module.params[
-            'mz']
-        fail_with_reason(reason)
-
-    # Check if template exists, it must in order to continue
-    template_uuid = get_component_fields_by_name(
-        module.params['template'], 'template', api_client)
-    if template_uuid:
-        instance_params['template_uuid'] = template_uuid
-        boot_order = get_component_fields_by_name(
-            module.params['template'], 'template', api_client, fields=['name', 'uuid', 'bootOrder'])
-    else:
-        # Template does not exist - must fail the task
-        reason = "Template %s does not exist, cannot continue." % module.params[
-            'template']
-        fail_with_reason(reason)
-
-    network_payloads = []
-
-    for i, nic in enumerate(module.params['nics']):
-        if nic['type'].lower() == "vnet":
-            network_uuid = get_component_fields_by_name(
-                nic['network'], 'vnet', api_client)
-        elif nic['type'].lower() == "vlan":
-            network_uuid = get_component_fields_by_name(
-                nic['network'], 'vlan', api_client)
-
-        if 'mac_address' in nic.keys():
-            if nic['mac_address']:
-                automatic_mac_address = False
-                mac_address = nic['mac_address']
+        # Check if storage pool exists, it must in order to continue
+        storage_pool_uuid = get_component_fields_by_name(
+            module.params['storage_pool'], 'storage_pool', api_client)
+        if storage_pool_uuid:
+            instance_params['storage_pool_uuid'] = storage_pool_uuid
         else:
-            automatic_mac_address = True
-            mac_address = None
+            # Pool does not exist - must fail the task
+            reason = "Storage pool %s does not exist, cannot continue." % module.params[
+                'storage_pool']
+            fail_with_reason(reason)
 
-        if i == 0:
-            vnic_payloads = []
-            for boot_order_item in boot_order:
-                if boot_order_item.vnic_uuid:
-                    vnic_uuid = boot_order_item.vnic_uuid
-                    vnic_name = boot_order_item.name
-
+        # Check if datacenter exists, it must in order to continue
+        datacenter_uuid = get_component_fields_by_name(
+            module.params['datacenter'], 'datacenter', api_client)
+        if datacenter_uuid:
+            instance_params['datacenter_uuid'] = datacenter_uuid
         else:
-            # TODO - his will eventually need to be modified so that any
-            # boot order is possible for any extra NICs
+            # Datacenter does not exist - must fail the task
+            reason = "Datacenter %s does not exist, cannot continue." % module.params[
+                'datacenter']
+            fail_with_reason(reason)
 
-            vnic_uuid = str(uuid4())
-            vnic_boot_order = len(boot_order) + i
+        # Check if migration_zone exists, it must in order to continue
+        migration_zone_uuid = get_component_fields_by_name(
+            module.params['mz'], 'migration_zone', api_client)
+        if migration_zone_uuid:
+            instance_params['migration_zone_uuid'] = migration_zone_uuid
+        else:
+            # Migration zone does not exist - must fail the task
+            reason = "Migration Zone %s does not exist, cannot continue." % module.params[
+                'mz']
+            fail_with_reason(reason)
 
-            vnic_payload = tacp.ApiAddVnicPayload(
-                automatic_mac_address=automatic_mac_address,
+        # Check if template exists, it must in order to continue
+        template_uuid = get_component_fields_by_name(
+            module.params['template'], 'template', api_client)
+        if template_uuid:
+            instance_params['template_uuid'] = template_uuid
+            boot_order = get_component_fields_by_name(
+                module.params['template'], 'template', api_client, fields=['name', 'uuid', 'bootOrder'])
+        else:
+            # Template does not exist - must fail the task
+            reason = "Template %s does not exist, cannot continue." % module.params[
+                'template']
+            fail_with_reason(reason)
+
+        network_payloads = []
+
+        for i, nic in enumerate(module.params['nics']):
+            if nic['type'].lower() == "vnet":
+                network_uuid = get_component_fields_by_name(
+                    nic['network'], 'vnet', api_client)
+            elif nic['type'].lower() == "vlan":
+                network_uuid = get_component_fields_by_name(
+                    nic['network'], 'vlan', api_client)
+
+            if 'mac_address' in nic.keys():
+                if nic['mac_address']:
+                    automatic_mac_address = False
+                    mac_address = nic['mac_address']
+            else:
+                automatic_mac_address = True
+                mac_address = None
+
+            if i == 0:
+                vnic_payloads = []
+                for boot_order_item in boot_order:
+                    if boot_order_item.vnic_uuid:
+                        vnic_uuid = boot_order_item.vnic_uuid
+                        vnic_name = boot_order_item.name
+
+            else:
+                # TODO - his will eventually need to be modified so that any
+                # boot order is possible for any extra NICs
+
+                vnic_uuid = str(uuid4())
+                vnic_boot_order = len(boot_order) + i
+
+                vnic_payload = tacp.ApiAddVnicPayload(
+                    automatic_mac_address=automatic_mac_address,
+                    name=vnic_name,
+                    network_uuid=network_uuid,
+                    boot_order=vnic_boot_order,
+                    mac_address=mac_address
+                )
+                vnic_payloads.append(vnic_payload)
+
+            network_payload = tacp.ApiCreateOrEditApplicationNetworkOptionsPayload(
                 name=vnic_name,
+                automatic_mac_assignment=automatic_mac_address,
                 network_uuid=network_uuid,
-                boot_order=vnic_boot_order,
+                vnic_uuid=vnic_uuid,
                 mac_address=mac_address
             )
-            vnic_payloads.append(vnic_payload)
+            network_payloads.append(network_payload)
 
-        network_payload = tacp.ApiCreateOrEditApplicationNetworkOptionsPayload(
-            name=vnic_name,
-            automatic_mac_assignment=automatic_mac_address,
-            network_uuid=network_uuid,
-            vnic_uuid=vnic_uuid,
-            mac_address=mac_address
-        )
-        network_payloads.append(network_payload)
+            instance_params['boot_order'] = boot_order
+            instance_params['networks'] = network_payloads
+            instance_params['vnics'] = vnic_payloads
+            instance_params['vcpus'] = module.params['vcpu_cores']
+            instance_params['memory'] = convert_memory_abbreviation_to_bytes(
+                module.params['memory'])
+            instance_params['vm_mode'] = module.params['vm_mode'].capitalize()
+            instance_params['vtx_enabled'] = module.params['vtx_enabled']
+            instance_params['auto_recovery_enabled'] = module.params['auto_recovery_enabled']
+            instance_params['description'] = module.params['description']
 
-    instance_params['boot_order'] = boot_order
-    instance_params['networks'] = network_payloads
-    instance_params['vnics'] = vnic_payloads
-    instance_params['vcpus'] = module.params['vcpu_cores']
-    instance_params['memory'] = convert_memory_abbreviation_to_bytes(
-        module.params['memory'])
-    instance_params['vm_mode'] = module.params['vm_mode'].capitalize()
-    instance_params['vtx_enabled'] = module.params['vtx_enabled']
-    instance_params['auto_recovery_enabled'] = module.params['auto_recovery_enabled']
-    instance_params['description'] = module.params['description']
+            return instance_params
 
-    def create_instance(instance_params):
-        api_instance = tacp.ApplicationsApi(tacp.ApiClient(configuration))
+    def create_instance(instance_params, api_client):
+        api_instance = tacp.ApplicationsApi(api_client)
 
         # Need to create boot disk ahead of time and provide it in the
         # ApiCreateApplicationPayload parameters
@@ -288,30 +269,101 @@ def run_module():
             enable_automatic_recovery=instance_params['auto_recovery_enabled'],
             description=instance_params['description'])
 
-        result['api_request_body'] = str(body)
+        if module._verbosity >= 3:
+            result['api_request_body'] = str(body)
         try:
             # Create an application from a template
             api_response = api_instance.create_application_from_template_using_post(
                 body)
-            result['changed'] = True
-            result['failed'] = False
-            module.exit_json(**result)
-
+            if module._verbosity >= 3:
+                result['api_response'] = str(api_response)
         except ApiException as e:
 
             return "Exception when calling ApplicationsApi->create_application_from_template_using_post: %s\n" % e
 
-    create_instance_response = create_instance(instance_params)
+        wait_for_action_to_complete(api_response.action_uuid, api_client)
+        result['ansible_module_results'] = get_resource_by_uuid(
+            api_response.object_uuid, 'application', api_client)
+        result['changed'] = True
+        result['failed'] = False
+        module.exit_json(**result)
+
+    def delete_instance(name, api_client):
+        instance_uuid = get_component_fields_by_name(
+            module.params['name'], 'application', api_client)
+        api_instance = tacp.ApplicationsApi(api_client)
+        try:
+            # Delete an application
+            api_response = api_instance.delete_application_using_delete(
+                instance_uuid)
+            if module._verbosity >= 3:
+                result['api_response'] = str(api_response)
+        except ApiException as e:
+            response_dict = api_response_to_dict(e)
+            # result['msg'] = response_dict['message']
+            if "Error" in response_dict['message']:
+                result['changed'] = False
+                result['failed'] = True
+                fail_with_reason(response_dict['message'])
+
+        wait_for_action_to_complete(api_response.action_uuid, api_client)
+        result['changed'] = True
+        result['failed'] = False
+        module.exit_json(**result)
+
+    # Return the inputs for debugging purposes
+    result['args'] = module.params
+
+    # Define configuration
+    configuration = tacp.Configuration()
+    configuration.host = "https://manage.cp.lenovo.com"
+    configuration.api_key_prefix['Authorization'] = 'Bearer'
+    configuration.api_key['Authorization'] = module.params['api_key']
+    api_client = tacp.ApiClient(configuration)
+
+    instance_params = generate_instance_params(module)
+
+    instance_uuid = get_component_fields_by_name(
+        module.params['name'], 'application', api_client)
+    if instance_uuid:
+        vm_is_present = True
+    else:
+        vm_is_present = False
+
+    if module.params['state'] == 'present':
+        if vm_is_present:
+            result['changed'] = False
+            module.exit_json(**result)
+        else:
+            create_instance_response = create_instance(instance_params, api_client)
+    elif module.params['state'] == 'absent':
+        if vm_is_present:
+            delete_instance(module.params['name'], api_client)
+        else:
+            result['changed'] = False
+            module.exit_json(**result)
+    elif module.params['state'] == 'shutdown':
+        pass
+    elif module.params['state'] == 'stopped':
+        pass
+    elif module.params['state'] == 'paused':
+        pass
+    elif module.params['state'] == 'resumed':
+        pass
+
+    # Check if VM instance with this name exists already
+
+    if instance_uuid:
+        # VM does exist - so for now we need to just break without changing anything,
+        # but in the future this would mean we go to edit the existing VM with this name/uuid
+        # vm_exists = True
+        result['msg'] = "An application for this datacenter already exists with name %s" % module.params['name']
+        result['changed'] = False
+
+        module.exit_json(**result)
 
     result['create_instance_response'] = create_instance_response
 
-    # use whatever logic you need to determine whether or not this module
-    # made any modifications to your target
-    # if module.params['new']:
-    #     result['changed'] = True
-
-    # during the execution of the module, if there is an exception or a
-    # conditional state that effectively causes a failure, run
     # AnsibleModule.fail_json() to pass in the message and the result
 
     # in the event of a successful module execution, you will want to

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -93,7 +93,9 @@ def run_module():
         nics=dict(type='list', required=True),
         vtx_enabled=dict(type='bool', default=True, required=False),
         auto_recovery_enabled=dict(type='bool', default=True, required=False),
-        description=dict(type='str', required=False)
+        description=dict(type='str', required=False),
+        vm_mode=dict(type='str', default='Enhanced', choices=['enhanced', 'Enhanced',
+                                                              'compatibility', 'Compatibility'])
     )
 
     # seed the result dict in the object
@@ -219,7 +221,7 @@ def run_module():
 
             vnic_uuid = str(uuid4())
             vnic_boot_order = len(boot_order) + i
-            
+
             vnic_payload = tacp.ApiAddVnicPayload(
                 automatic_mac_address=automatic_mac_address,
                 name=nic['name'],
@@ -244,7 +246,7 @@ def run_module():
     instance_params['vcpus'] = module.params['vcpu_cores']
     instance_params['memory'] = convert_memory_abbreviation_to_bytes(
         module.params['memory'])
-    instance_params['vm_mode'] = "Enhanced"
+    instance_params['vm_mode'] = module.params['vm_mode'].capitalize()
     instance_params['vtx_enabled'] = module.params['vtx_enabled']
     instance_params['auto_recovery_enabled'] = module.params['auto_recovery_enabled']
     instance_params['description'] = module.params['description']

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -1,0 +1,377 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2020, Lenovo
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from uuid import UUID
+from ansible.module_utils.basic import AnsibleModule
+
+import tacp
+from tacp.rest import ApiException
+from pprint import pprint
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: tacp_instance
+
+short_description: This is my test module
+
+version_added: "2.9"
+
+description:
+    - "This is my longer description explaining my test module"
+
+options:
+    name:
+        description:
+            - This is the message to send to the test module
+        required: true
+    new:
+        description:
+            - Control to demo if the result of this module is changed or not
+        required: false
+
+extends_documentation_fragment:
+    - azure
+
+author:
+    - Your Name (@yourhandle)
+'''
+
+EXAMPLES = '''
+# Pass in a message
+- name: Test with a message
+  tacp_instance:
+    name: hello world
+
+# pass in a message and have changed true
+- name: Test with a message and changed output
+  tacp_instance:
+    name: hello world
+    new: true
+
+# fail the module
+- name: Test failure of the module
+  tacp_instance:
+    name: fail me
+'''
+
+RETURN = '''
+original_message:
+    description: The original name param that was passed in
+    type: str
+    returned: always
+message:
+    description: The output message that the test module generates
+    type: str
+    returned: always
+'''
+
+
+def run_module():
+    # define available arguments/parameters a user can pass to the module
+    module_args = dict(
+        api_key=dict(type='str', required=True),
+        name=dict(type='str', required=True),
+        state=dict(type='str', default='present',
+                   choices=['present', 'absent']),
+        datacenter=dict(type='str', required=True),
+        mz=dict(type='str', required=True),
+        storage_pool=dict(type='str', required=True),
+        template=dict(type='str', required=True),
+        vcpu_cores=dict(type='int', required=True),
+        memory_mb=dict(type='int', required=True),
+        disks=dict(type='list', required=True),
+        nics=dict(type='list', required=True)
+    )
+
+    # seed the result dict in the object
+    # we primarily care about changed and state
+    # change is if this module effectively modified the target
+    # state will include any data that you want your module to pass back
+    # for consumption, for example, in a subsequent task
+    result = dict(
+        changed=False,
+        args=[]
+    )
+
+    # the AnsibleModule object will be our abstraction working with Ansible
+    # this includes instantiation, a couple of common attr would be the
+    # args/params passed to the execution, as well as if the module
+    # supports check mode
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    # if the user is working with this module in only check mode we do not
+    # want to make any changes to the environment, just return the current
+    # state with no modifications
+    if module.check_mode:
+        module.exit_json(**result)
+
+    # manipulate or modify the state as needed (this is going to be the
+    # part where your module will do what it needs to do)
+
+    # Return the inputs for debugging purposes
+    result['args'] = module.params
+
+    # Define configuration
+    configuration = tacp.Configuration()
+    configuration.host = "https://manage.cp.lenovo.com"
+    configuration.api_key_prefix['Authorization'] = 'Bearer'
+    configuration.api_key['Authorization'] = module.params['api_key']
+    api_client = tacp.ApiClient(configuration)
+
+    def fail_with_reason(reason):
+        result['failed'] = True
+        result['failure_reason'] = reason
+        module.exit_json(**result)
+        return
+
+    def is_valid_uuid(uuid_to_test, version=4):
+        """
+        Check if uuid_to_test is a valid UUID.
+
+        Parameters
+        ----------
+        uuid_to_test : str
+        version : {1, 2, 3, 4}
+
+        Returns
+        -------
+        `True` if uuid_to_test is a valid UUID, otherwise `False`.
+
+        Examples
+        --------
+        >>> is_valid_uuid('c9bf9e57-1685-4c89-bafb-ff5af830be8a')
+        True
+        >>> is_valid_uuid('c9bf9e58')
+        False
+        """
+        try:
+            uuid_obj = UUID(uuid_to_test, version=version)
+        except ValueError:
+            return False
+
+        return str(uuid_obj) == uuid_to_test
+
+    def get_component_uuid_by_name(name, component, api_client):
+        """
+        Returns the UUID of a named component if it exists in a given 
+        ThinkAgile CP cloud, otherwise return None.
+
+        :param name The name of the component that may or may not exist yet
+        :type name str
+        :param component The type of component in question, must be one of 
+        """
+        fields = ['uuid']
+
+        valid_components = ["storage_pool", "application",
+                            "template", "datacenter", "migration_zone"]
+
+        if component not in valid_components:
+            return "Invalid component"
+        if component == "storage_pool":
+            api_instance = tacp.FlashPoolsApi(api_client)
+            try:
+                # View flash pools for an organization
+                api_response = api_instance.get_flash_pools_using_get(
+                    fields=fields)
+            except ApiException as e:
+                return "Exception when calling get_component_uuid_by_name: %s\n" % e
+        elif component == "application":
+            api_instance = tacp.ApplicationsApi(api_client)
+            try:
+                # View flash pools for an organization
+                api_response = api_instance.get_applications_using_get(
+                    fields=fields)
+            except ApiException as e:
+                return "Exception when calling get_component_uuid_by_name: %s\n" % e
+        elif component == "template":
+            api_instance = tacp.TemplatesApi(api_client)
+            try:
+                # View flash pools for an organization
+                api_response = api_instance.get_templates_using_get(
+                    fields=fields)
+            except ApiException as e:
+                return "Exception when calling get_component_uuid_by_name: %s\n" % e
+        elif component == "datacenter":
+            api_instance = tacp.DatacentersApi(api_client)
+            try:
+                # View flash pools for an organization
+                api_response = api_instance.get_datacenters_using_get(
+                    fields=fields)
+            except ApiException as e:
+                return "Exception when calling get_component_uuid_by_name: %s\n" % e
+        elif component == "migration_zone":
+            api_instance = tacp.MigrationZonesApi(api_client)
+            try:
+                # View flash pools for an organization
+                api_response = api_instance.get_migration_zones_using_get(
+                    fields=fields)
+            except ApiException as e:
+                return "Exception when calling get_component_uuid_by_name: %s\n" % e
+        elif component == "vlan":
+            api_instance = tacp.VlansApi(api_client)
+            try:
+                # View flash pools for an organization
+                api_response = api_instance.get_vlans_using_get(
+                    fields=fields)
+            except ApiException as e:
+                return "Exception when calling get_component_uuid_by_name: %s\n" % e
+        elif component == "vnet":
+            api_instance = tacp.VnetsApi(api_client)
+            try:
+                # View flash pools for an organization
+                api_response = api_instance.get_vnets_using_get(
+                    fields=fields)
+            except ApiException as e:
+                return "Exception when calling get_component_uuid_by_name: %s\n" % e
+
+        if (api_response):
+            if hasattr(api_response[0], 'uuid'):
+                return api_response[0].uuid
+        return None
+
+    instance_params = {}
+
+    # Check if VM instance with this name exists already
+    instance_uuid = get_component_uuid_by_name(
+        module.params['name'], 'application', api_client)
+    # if is_valid_uuid(instance_uuid):
+    #     # VM does exist - so for now we need to just break without changing anything,
+    #     # but in the future this would mean we go to edit the existing VM with this name/uuid
+    #     # vm_exists = True
+    #     module.exit_json(**result)
+    # else:
+    #     # VM does not exist yet, so we must create it
+    instance_params['instance_name'] = module.params['name']
+
+    # Check if storage pool exists, it must in order to continue
+    storage_pool_uuid = get_component_uuid_by_name(
+        module.params['storage_pool'], 'storage_pool', api_client)
+    if is_valid_uuid(storage_pool_uuid):
+        instance_params['storage_pool_uuid'] = storage_pool_uuid
+    else:
+        # Pool does not exist - must fail the task
+        pass
+
+    # Check if datacenter exists, it must in order to continue
+    datacenter_uuid = get_component_uuid_by_name(
+        module.params['datacenter'], 'datacenter', api_client)
+    if is_valid_uuid(datacenter_uuid):
+        instance_params['datacenter_uuid'] = datacenter_uuid
+    else:
+        # Datacenter does not exist - must fail the task
+        pass
+
+    # Check if migration_zone exists, it must in order to continue
+    migration_zone_uuid = get_component_uuid_by_name(
+        module.params['mz'], 'migration_zone', api_client)
+    if is_valid_uuid(migration_zone_uuid):
+        instance_params['migration_zone_uuid'] = migration_zone_uuid
+    else:
+        # Migration zone does not exist - must fail the task
+        pass
+
+    # Check if migration_zone exists, it must in order to continue
+    template_uuid = get_component_uuid_by_name(
+        module.params['template'], 'template', api_client)
+    if is_valid_uuid(template_uuid):
+        instance_params['template_uuid'] = template_uuid
+    else:
+        # Migration zone does not exist - must fail the task
+        pass
+
+    network_payloads = []
+    vnic_payloads = []
+    for nic in module.params['nics']:
+        if nic['type'].lower() == "vnet":
+            network_uuid = get_component_uuid_by_name(
+                nic['network'], 'vnet', api_client)
+        elif nic['type'].lower() == "vlan":
+            network_uuid = get_component_uuid_by_name(
+                nic['network'], 'vlan', api_client)
+
+        network_payload = tacp.ApiCreateOrEditApplicationNetworkOptionsPayload(
+            name=nic['network'],
+            automatic_mac_assignment=True,
+            network_uuid=network_uuid)
+        network_payloads.append(network_payload)
+
+        vnic_payload = tacp.ApiAddVnicPayload(
+            automatic_mac_address=True,
+            name=nic['name'],
+            network_uuid=network_uuid
+        )
+        vnic_payloads.append(vnic_payload)
+
+    instance_params['networks'] = network_payloads
+    instance_params['vnics'] = vnic_payloads
+    instance_params['vcpus'] = module.params['vcpu_cores']
+    # We will want to parse out the units on the memory provided to convert it to bytes,
+    # which this parameter requires
+    instance_params['memory'] = module.params['memory_mb'] * 1024 * 1024
+    instance_params['vm_mode'] = "Enhanced"
+
+    def create_instance(instance_params):
+        api_instance = tacp.ApplicationsApi(tacp.ApiClient(configuration))
+
+
+        # Need to create boot disk ahead of time and provide it in the
+        # ApiCreateApplicationPayload parameters
+
+
+        body = tacp.ApiCreateApplicationPayload(
+            name=instance_params['instance_name'],
+            datacenter_uuid=instance_params['datacenter_uuid'],
+            flash_pool_uuid=instance_params['storage_pool_uuid'],
+            migration_zone_uuid=instance_params['migration_zone_uuid'],
+            template_uuid=instance_params['template_uuid'],
+            vcpus=instance_params['vcpus'],
+            memory=instance_params['memory'],
+            vm_mode=instance_params['vm_mode'],
+            networks=instance_params['networks'],
+            vnics=instance_params['vnics'],
+            hardware_assisted_virtualization_enabled=True)
+
+        try:
+            # Create an application from a template
+            api_response = api_instance.create_application_from_template_using_post(
+                body)
+            return api_response
+
+        except ApiException as e:
+            return "Exception when calling ApplicationsApi->create_application_from_template_using_post: %s\n" % e
+
+    create_instance_response = create_instance(instance_params)
+
+    result['create_instance_response'] = create_instance_response
+    module.exit_json(**result)
+    # use whatever logic you need to determine whether or not this module
+    # made any modifications to your target
+    # if module.params['new']:
+    #     result['changed'] = True
+
+    # during the execution of the module, if there is an exception or a
+    # conditional state that effectively causes a failure, run
+    # AnsibleModule.fail_json() to pass in the message and the result
+
+    # in the event of a successful module execution, you will want to
+    # simple AnsibleModule.exit_json(), passing the key/value results
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -90,7 +90,10 @@ def run_module():
         vcpu_cores=dict(type='int', required=True),
         memory=dict(type='str', required=True),
         disks=dict(type='list', required=True),
-        nics=dict(type='list', required=True)
+        nics=dict(type='list', required=True),
+        vtx_enabled=dict(type='bool', default=True, required=False),
+        auto_recovery_enabled=dict(type='bool', default=True, required=False),
+        description=dict(type='str', required=False)
     )
 
     # seed the result dict in the object
@@ -242,6 +245,9 @@ def run_module():
     instance_params['memory'] = convert_memory_abbreviation_to_bytes(
         module.params['memory'])
     instance_params['vm_mode'] = "Enhanced"
+    instance_params['vtx_enabled'] = module.params['vtx_enabled']
+    instance_params['auto_recovery_enabled'] = module.params['auto_recovery_enabled']
+    instance_params['description'] = module.params['description']
 
     def create_instance(instance_params):
         api_instance = tacp.ApplicationsApi(tacp.ApiClient(configuration))
@@ -261,7 +267,10 @@ def run_module():
             networks=instance_params['networks'],
             vnics=instance_params['vnics'],
             boot_order=instance_params['boot_order'],
-            hardware_assisted_virtualization_enabled=True)
+            hardware_assisted_virtualization_enabled=instance_params['vtx_enabled'],
+            enable_automatic_recovery=instance_params['auto_recovery_enabled'],
+            description=instance_params['description'])
+
         result['api_request_body'] = str(body)
         try:
             # Create an application from a template

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -123,6 +123,11 @@ def run_module():
     if module.check_mode:
         module.exit_json(**result)
 
+    def fail_with_reason(reason):
+        result['failure_reason'] = reason
+        result['failed'] = True
+        module.exit_json(**result)
+
     # manipulate or modify the state as needed (this is going to be the
     # part where your module will do what it needs to do)
 
@@ -157,40 +162,49 @@ def run_module():
     # Check if storage pool exists, it must in order to continue
     storage_pool_uuid = get_component_fields_by_name(
         module.params['storage_pool'], 'storage_pool', api_client)
-    if is_valid_uuid(storage_pool_uuid):
+    if storage_pool_uuid:
         instance_params['storage_pool_uuid'] = storage_pool_uuid
     else:
         # Pool does not exist - must fail the task
-        pass
+        reason = "Storage pool %s does not exist, cannot continue." % module.params[
+            'storage_pool']
+        fail_with_reason(reason)
+        
 
     # Check if datacenter exists, it must in order to continue
     datacenter_uuid = get_component_fields_by_name(
         module.params['datacenter'], 'datacenter', api_client)
-    if is_valid_uuid(datacenter_uuid):
+    if datacenter_uuid:
         instance_params['datacenter_uuid'] = datacenter_uuid
     else:
         # Datacenter does not exist - must fail the task
-        pass
+        reason = "Datacenter %s does not exist, cannot continue." % module.params[
+            'datacenter']
+        fail_with_reason(reason)
 
     # Check if migration_zone exists, it must in order to continue
     migration_zone_uuid = get_component_fields_by_name(
         module.params['mz'], 'migration_zone', api_client)
-    if is_valid_uuid(migration_zone_uuid):
+    if migration_zone_uuid:
         instance_params['migration_zone_uuid'] = migration_zone_uuid
     else:
         # Migration zone does not exist - must fail the task
-        pass
+        reason = "Migration Zone %s does not exist, cannot continue." % module.params[
+            'mz']
+        fail_with_reason(reason)
 
-    # Check if migration_zone exists, it must in order to continue
+    # Check if template exists, it must in order to continue
     template_uuid = get_component_fields_by_name(
         module.params['template'], 'template', api_client)
-    if is_valid_uuid(template_uuid):
+    if template_uuid:
         instance_params['template_uuid'] = template_uuid
         boot_order = get_component_fields_by_name(
             module.params['template'], 'template', api_client, fields=['name', 'uuid', 'bootOrder'])
     else:
-        # Migration zone does not exist - must fail the task
-        pass
+        # Template does not exist - must fail the task
+        reason = "Template %s does not exist, cannot continue." % module.params[
+            'template']
+        fail_with_reason(reason)
 
     network_payloads = []
 

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -169,7 +169,6 @@ def run_module():
         reason = "Storage pool %s does not exist, cannot continue." % module.params[
             'storage_pool']
         fail_with_reason(reason)
-        
 
     # Check if datacenter exists, it must in order to continue
     datacenter_uuid = get_component_fields_by_name(
@@ -216,9 +215,10 @@ def run_module():
             network_uuid = get_component_fields_by_name(
                 nic['network'], 'vlan', api_client)
 
-        if nic['mac_address']:
-            automatic_mac_address = False
-            mac_address = nic['mac_address']
+        if 'mac_address' in nic.keys():
+            if nic['mac_address']:
+                automatic_mac_address = False
+                mac_address = nic['mac_address']
         else:
             automatic_mac_address = True
             mac_address = None

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -3,9 +3,9 @@
 # Copyright: (c) 2020, Lenovo
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from uuid import UUID, uuid4
 from ansible.module_utils.basic import AnsibleModule
-import re
+from ansible.module_utils.tacp import *
+
 import json
 import tacp
 import sys
@@ -40,10 +40,10 @@ options:
         required: false
 
 extends_documentation_fragment:
-    - azure
+    - tacp
 
 author:
-    - Your Name (@yourhandle)
+    - Xander Madsen (@xmadsen)
 '''
 
 EXAMPLES = '''
@@ -131,172 +131,12 @@ def run_module():
     configuration.api_key['Authorization'] = module.params['api_key']
     api_client = tacp.ApiClient(configuration)
 
-    def fail_with_reason(reason):
-        result['failed'] = True
-        result['failure_reason'] = reason
-        module.exit_json(**result)
-        return
-
-    def convert_memory_abbreviation_to_bytes(value):
-        """Validate memory argument. Returns the memory value in bytes."""
-        MEMORY_RE = re.compile(
-            r"^(?P<amount>[0-9]+)(?P<unit>t|tb|g|gb|m|mb|k|kb)?$")
-
-        matches = MEMORY_RE.match(value.lower())
-        if matches is None:
-            raise ValueError(
-                '%s is not a valid value for memory amount' % value)
-        amount_str, unit = matches.groups()
-        amount = int(amount_str)
-        amount_in_bytes = amount
-        if unit is None:
-            amount_in_bytes = amount
-        elif unit in ['k', 'kb']:
-            amount_in_bytes = amount * 1024
-        elif unit in ['m', 'mb']:
-            amount_in_bytes = amount * 1024 * 1024
-        elif unit in ['g', 'gb']:
-            amount_in_bytes = amount * 1024 * 1024 * 1024
-        elif unit in ['t', 'tb']:
-            amount_in_bytes = amount * 1024 * 1024 * 1024 * 1024
-
-        return amount_in_bytes
-
-    def is_valid_uuid(uuid_to_test, version=4):
-        """
-        Check if uuid_to_test is a valid UUID.
-
-        Parameters
-        ----------
-        uuid_to_test : str
-        version : {1, 2, 3, 4}
-
-        Returns
-        -------
-        `True` if uuid_to_test is a valid UUID, otherwise `False`.
-
-        Examples
-        --------
-        >>> is_valid_uuid('c9bf9e57-1685-4c89-bafb-ff5af830be8a')
-        True
-        >>> is_valid_uuid('c9bf9e58')
-        False
-        """
-        try:
-            uuid_obj = UUID(uuid_to_test, version=version)
-        except ValueError:
-            return False
-
-        return str(uuid_obj) == uuid_to_test
-
-    def get_component_fields_by_name(name, component, api_client, fields=['name', 'uuid']):
-        """
-        Returns the UUID of a named component if it exists in a given 
-        ThinkAgile CP cloud, otherwise return None.
-
-        :param name The name of the component that may or may not exist yet
-        :type name str
-        :param component The type of component in question, must be one of 
-        """
-
-        valid_components = ["storage_pool", "application",
-                            "template", "datacenter", "migration_zone",
-                            "vnet", "vlan"]
-
-        if component not in valid_components:
-            return "Invalid component"
-        if component == "storage_pool":
-            api_instance = tacp.FlashPoolsApi(api_client)
-            try:
-                # View flash pools for an organization
-                api_response = api_instance.get_flash_pools_using_get(
-                    fields=fields)
-            except ApiException as e:
-                return "Exception when calling get_flash_pools_using_get: %s\n" % e
-        elif component == "application":
-            api_instance = tacp.ApplicationsApi(api_client)
-            try:
-                # View flash pools for an organization
-                api_response = api_instance.get_applications_using_get(
-                    fields=fields)
-            except ApiException as e:
-                return "Exception when calling get_applications_using_get: %s\n" % e
-        elif component == "template":
-            api_instance = tacp.TemplatesApi(api_client)
-            try:
-                # View flash pools for an organization
-                api_response = api_instance.get_templates_using_get(
-                    fields=fields)
-            except ApiException as e:
-                return "Exception when calling get_templates_using_get: %s\n" % e
-        elif component == "datacenter":
-            api_instance = tacp.DatacentersApi(api_client)
-            try:
-                # View flash pools for an organization
-                api_response = api_instance.get_datacenters_using_get(
-                    fields=fields)
-            except ApiException as e:
-                return "Exception when calling get_datacenters_using_get: %s\n" % e
-        elif component == "migration_zone":
-            api_instance = tacp.MigrationZonesApi(api_client)
-            try:
-                # View flash pools for an organization
-                api_response = api_instance.get_migration_zones_using_get(
-                    fields=fields)
-            except ApiException as e:
-                return "Exception when calling get_migration_zones_using_get: %s\n" % e
-        elif component == "vlan":
-            api_instance = tacp.VlansApi(api_client)
-            try:
-                # View flash pools for an organization
-                api_response = api_instance.get_vlans_using_get(
-                    fields=fields)
-            except ApiException as e:
-                return "Exception when calling get_vlans_using_get: %s\n" % e
-        elif component == "vnet":
-            api_instance = tacp.VnetsApi(api_client)
-            try:
-                # View flash pools for an organization
-                api_response = api_instance.get_vnets_using_get(
-                    fields=fields)
-            except ApiException as e:
-                return "Exception when calling get_vnets_using_get: %s\n" % e
-
-        if (api_response):
-            if fields == ['name', 'uuid']:
-                for result in api_response:
-                    if result.name == name:
-                        return result.uuid                
-            if 'bootOrder' in fields:
-                for result in api_response:
-                    if result.name == name:
-                        boot_order = []
-                        for order_item in result.boot_order:
-                            str_dict = str(order_item).replace(
-                                "\n", "").replace("'", '"').replace("None", '""')
-
-                            json_dict = json.loads(str_dict)
-
-                            disk_uuid = json_dict['disk_uuid'] if json_dict['disk_uuid'] else None
-                            name = json_dict['name'] if json_dict['name'] else None
-                            order = json_dict['order'] if json_dict['order'] else None
-                            vnic_uuid = json_dict['vnic_uuid'] if json_dict['vnic_uuid'] else None
-                            boot_order_payload = tacp.ApiBootOrderPayload(disk_uuid=disk_uuid,
-                                                                        name=name,
-                                                                        order=order,
-                                                                        vnic_uuid=vnic_uuid)
-
-                            #sys.stdout.write(str(boot_order_payload) + '\n')
-                            boot_order.append(boot_order_payload)
-                        return boot_order
-        return None
-
     instance_params = {}
 
     # Check if VM instance with this name exists already
     instance_uuid = get_component_fields_by_name(
         module.params['name'], 'application', api_client)
-    result['instance_uuid'] = instance_uuid
+
     if instance_uuid:
         # VM does exist - so for now we need to just break without changing anything,
         # but in the future this would mean we go to edit the existing VM with this name/uuid
@@ -305,8 +145,8 @@ def run_module():
         result['changed'] = False
 
         module.exit_json(**result)
-    
-        # VM does not exist yet, so we must create it
+
+    # VM does not exist yet, so we must create it
     instance_params['instance_name'] = module.params['name']
 
     # Check if storage pool exists, it must in order to continue
@@ -357,6 +197,13 @@ def run_module():
             network_uuid = get_component_fields_by_name(
                 nic['network'], 'vlan', api_client)
 
+        if nic['mac_address']:
+            automatic_mac_address = False
+            mac_address = nic['mac_address']
+        else:
+            automatic_mac_address = True
+            mac_address = None
+
         if i == 0:
             vnic_payloads = []
             for boot_order_item in boot_order:
@@ -364,23 +211,27 @@ def run_module():
                     vnic_uuid = boot_order_item.vnic_uuid
 
         else:
-            vnic_uuid = str(uuid4())
             # TODO - his will eventually need to be modified so that any
             # boot order is possible for any extra NICs
+
+            vnic_uuid = str(uuid4())
             vnic_boot_order = len(boot_order) + i
+            
             vnic_payload = tacp.ApiAddVnicPayload(
-                automatic_mac_address=True,
+                automatic_mac_address=automatic_mac_address,
                 name=nic['name'],
                 network_uuid=network_uuid,
-                boot_order=vnic_boot_order
+                boot_order=vnic_boot_order,
+                mac_address=mac_address
             )
             vnic_payloads.append(vnic_payload)
 
         network_payload = tacp.ApiCreateOrEditApplicationNetworkOptionsPayload(
             name=nic['name'],
-            automatic_mac_assignment=True,
+            automatic_mac_assignment=automatic_mac_address,
             network_uuid=network_uuid,
             vnic_uuid=vnic_uuid,
+            mac_address=mac_address
         )
         network_payloads.append(network_payload)
 
@@ -421,11 +272,11 @@ def run_module():
             module.exit_json(**result)
 
         except ApiException as e:
-            
+
             return "Exception when calling ApplicationsApi->create_application_from_template_using_post: %s\n" % e
 
     create_instance_response = create_instance(instance_params)
-    
+
     result['create_instance_response'] = create_instance_response
 
     # use whatever logic you need to determine whether or not this module

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -226,7 +226,7 @@ def run_module():
         if i == 0:
             vnic_payloads = []
             for boot_order_item in boot_order:
-                if boot_order_item.name == nic['name'] and boot_order_item.vnic_uuid:
+                if boot_order_item.vnic_uuid:
                     vnic_uuid = boot_order_item.vnic_uuid
 
         else:

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -228,6 +228,7 @@ def run_module():
             for boot_order_item in boot_order:
                 if boot_order_item.vnic_uuid:
                     vnic_uuid = boot_order_item.vnic_uuid
+                    vnic_name = boot_order_item.name
 
         else:
             # TODO - his will eventually need to be modified so that any
@@ -238,7 +239,7 @@ def run_module():
 
             vnic_payload = tacp.ApiAddVnicPayload(
                 automatic_mac_address=automatic_mac_address,
-                name=nic['name'],
+                name=vnic_name,
                 network_uuid=network_uuid,
                 boot_order=vnic_boot_order,
                 mac_address=mac_address
@@ -246,7 +247,7 @@ def run_module():
             vnic_payloads.append(vnic_payload)
 
         network_payload = tacp.ApiCreateOrEditApplicationNetworkOptionsPayload(
-            name=nic['name'],
+            name=vnic_name,
             automatic_mac_assignment=automatic_mac_address,
             network_uuid=network_uuid,
             vnic_uuid=vnic_uuid,

--- a/lib/ansible/modules/tacp/tacp_instance.py
+++ b/lib/ansible/modules/tacp/tacp_instance.py
@@ -324,10 +324,8 @@ def run_module():
     def create_instance(instance_params):
         api_instance = tacp.ApplicationsApi(tacp.ApiClient(configuration))
 
-
         # Need to create boot disk ahead of time and provide it in the
         # ApiCreateApplicationPayload parameters
-
 
         body = tacp.ApiCreateApplicationPayload(
             name=instance_params['instance_name'],

--- a/lib/ansible/modules/tacp/tacp_network.py
+++ b/lib/ansible/modules/tacp/tacp_network.py
@@ -272,12 +272,13 @@ def run_module():
             location_uuid=network_params['location_uuid'],
             vlan_tag=network_params['vlan_tag']
         )
-
-        result['api_request_body'] = str(body)
+        if module._verbosity >= 3:
+            result['api_request_body'] = str(body)
         try:
             api_response = api_instance.create_vlan_using_post(
                 body)
-            result['api_response'] = str(api_response)
+            if module._verbosity >= 3:
+                result['api_response'] = str(api_response)
             result['msg'] = api_response.message
 
         except ApiException as e:
@@ -290,6 +291,8 @@ def run_module():
             pass
 
         wait_for_action_to_complete(api_response.action_uuid, api_client)
+        result['ansible_module_results'] = get_resource_by_uuid(
+            api_response.object_uuid, 'vlan', api_client)
         result['changed'] = True
         result['failed'] = False
         module.exit_json(**result)
@@ -385,11 +388,12 @@ def run_module():
             routing_service=routing_service,
             subnet_mask=network_params['subnet_mask']
         )
-
-        result['api_request_body'] = str(body)
+        if module._verbosity >= 3:
+            result['api_request_body'] = str(body)
         try:
             api_response = api_instance.create_vnet_using_post(body)
-            result['api_response'] = str(api_response)
+            if module._verbosity >= 3:
+                result['api_response'] = str(api_response)
             result['msg'] = api_response.message
 
         except ApiException as e:
@@ -405,6 +409,8 @@ def run_module():
                 module.exit_json(**result)
 
         wait_for_action_to_complete(api_response.action_uuid, api_client)
+        result['ansible_module_results'] = get_resource_by_uuid(
+            api_response.object_uuid, 'vnet', api_client)
         result['changed'] = True
         result['failed'] = False
         module.exit_json(**result)
@@ -417,10 +423,8 @@ def run_module():
             try:
                 # Delete a VNET
                 api_response = api_instance.delete_vlan_using_delete(vlan_uuid)
-                result['api_response'] = str(api_response)
-                result['changed'] = True
-                result['failed'] = False
-                module.exit_json(**result)
+                if module._verbosity >= 3:
+                    result['api_response'] = str(api_response)
             except ApiException as e:
                 response_dict = api_response_to_dict(e)
                # result['msg'] = response_dict['message']
@@ -428,6 +432,11 @@ def run_module():
                     result['changed'] = False
                     result['failed'] = True
                     fail_with_reason(response_dict['message'])
+
+            wait_for_action_to_complete(api_response.action_uuid, api_client)
+            result['changed'] = True
+            result['failed'] = False
+            module.exit_json(**result)
 
         elif network_type == 'VNET':
             vnet_uuid = get_component_fields_by_name(
@@ -444,7 +453,8 @@ def run_module():
             try:
                 # Delete a VNET
                 api_response = api_instance.delete_vnet_using_delete(vnet_uuid)
-                result['api_response'] = str(api_response)
+                if module._verbosity >= 3:
+                    result['api_response'] = str(api_response)
 
             except ApiException as e:
                 response_dict = api_response_to_dict(e)

--- a/lib/ansible/modules/tacp/tacp_network.py
+++ b/lib/ansible/modules/tacp/tacp_network.py
@@ -279,7 +279,6 @@ def run_module():
                 body)
             if module._verbosity >= 3:
                 result['api_response'] = str(api_response)
-            result['msg'] = api_response.message
 
         except ApiException as e:
             response_dict = api_response_to_dict(e)
@@ -394,7 +393,6 @@ def run_module():
             api_response = api_instance.create_vnet_using_post(body)
             if module._verbosity >= 3:
                 result['api_response'] = str(api_response)
-            result['msg'] = api_response.message
 
         except ApiException as e:
             response_dict = api_response_to_dict(e)

--- a/lib/ansible/modules/tacp/tacp_network.py
+++ b/lib/ansible/modules/tacp/tacp_network.py
@@ -143,6 +143,7 @@ def run_module():
         # Check if there is more than one site already
         # If there is only one, default to that one.
         # Otherwise require a site_name to be provided
+        required_params = []
         site_list = get_site_list()
         if len(site_list) != 1:
             required_params.append('site_name')
@@ -289,7 +290,9 @@ def run_module():
                 module.exit_json(**result)
             pass
 
-        wait_for_action_to_complete(api_response.action_uuid, api_client)
+        success, failure_reason = wait_for_action_to_complete(api_response.action_uuid, api_client)
+        if not success:
+            fail_with_reason(failure_reason)
         result['ansible_module_results'] = get_resource_by_uuid(
             api_response.object_uuid, 'vlan', api_client)
         result['changed'] = True
@@ -406,7 +409,9 @@ def run_module():
                 result['failed'] = False
                 module.exit_json(**result)
 
-        wait_for_action_to_complete(api_response.action_uuid, api_client)
+        success, failure_reason = wait_for_action_to_complete(api_response.action_uuid, api_client)
+        if not success:
+            fail_with_reason(failure_reason)
         result['ansible_module_results'] = get_resource_by_uuid(
             api_response.object_uuid, 'vnet', api_client)
         result['changed'] = True
@@ -431,7 +436,9 @@ def run_module():
                     result['failed'] = True
                     fail_with_reason(response_dict['message'])
 
-            wait_for_action_to_complete(api_response.action_uuid, api_client)
+            success, failure_reason = wait_for_action_to_complete(api_response.action_uuid, api_client)
+            if not success:
+                fail_with_reason(failure_reason)
             result['changed'] = True
             result['failed'] = False
             module.exit_json(**result)
@@ -463,7 +470,9 @@ def run_module():
                     result['failed'] = True
                     fail_with_reason(response_dict['message'])
 
-            wait_for_action_to_complete(api_response.action_uuid, api_client)
+            success, failure_reason = wait_for_action_to_complete(api_response.action_uuid, api_client)
+            if not success:
+                fail_with_reason(failure_reason)
             result['changed'] = True
             result['failed'] = False
             module.exit_json(**result)

--- a/lib/ansible/modules/tacp/tacp_network.py
+++ b/lib/ansible/modules/tacp/tacp_network.py
@@ -1,0 +1,395 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2020, Lenovo
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.tacp import *
+
+import json
+import tacp
+import sys
+from tacp.rest import ApiException
+from pprint import pprint
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: tacp_network
+
+short_description: This is my test module
+
+version_added: "2.9"
+
+description:
+    - "This is my longer description explaining my test module"
+
+options:
+    name:
+        description:
+            - This is the message to send to the test module
+        required: true
+    new:
+        description:
+            - Control to demo if the result of this module is changed or not
+        required: false
+
+extends_documentation_fragment:
+    - tacp
+
+author:
+    - Xander Madsen (@xmadsen)
+'''
+
+EXAMPLES = '''
+# Pass in a message
+- name: Test with a message
+  tacp_instance:
+    name: hello world
+
+# pass in a message and have changed true
+- name: Test with a message and changed output
+  tacp_instance:
+    name: hello world
+    new: true
+
+# fail the module
+- name: Test failure of the module
+  tacp_instance:
+    name: fail me
+'''
+
+RETURN = '''
+original_message:
+    description: The original name param that was passed in
+    type: str
+    returned: always
+message:
+    description: The output message that the test module generates
+    type: str
+    returned: always
+'''
+
+
+def run_module():
+    # define available arguments/parameters a user can pass to the module
+    module_args = dict(
+        api_key=dict(type='str', required=True),
+        name=dict(type='str', required=True),
+        state=dict(type='str', default='present',
+                   choices=['present', 'absent']),
+        network_type=dict(type='str', required=True, choices=[
+                          'VLAN', 'vlan', 'VNET', 'vnet']),
+        site_name=dict(type='str', required=False),
+        vlan_tag=dict(type='int', required=False),
+        firewall_override=dict(type='str', required=False),
+        firewall_profile=dict(type='str', required=False),
+        autodeploy_nfv=dict(type='bool', required=False, default=True),
+        network_address=dict(type='str', required=False),
+        subnet_mask=dict(type='str', required=False),
+        gateway=dict(type='str', required=False),
+        dhcp=dict(type='dict', required=False),
+        routing=dict(type='dict', required=False)
+    )
+
+    # seed the result dict in the object
+    # we primarily care about changed and state
+    # change is if this module effectively modified the target
+    # state will include any data that you want your module to pass back
+    # for consumption, for example, in a subsequent task
+    result = dict(
+        changed=False,
+        args=[]
+    )
+
+    # the AnsibleModule object will be our abstraction working with Ansible
+    # this includes instantiation, a couple of common attr would be the
+    # args/params passed to the execution, as well as if the module
+    # supports check mode
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    # if the user is working with this module in only check mode we do not
+    # want to make any changes to the environment, just return the current
+    # state with no modifications
+    if module.check_mode:
+        module.exit_json(**result)
+
+    def fail_with_reason(reason):
+        module.fail_json(**result, msg=reason)
+
+    def get_site_list():
+        api_instance = tacp.LocationsApi(api_client)
+        try:
+            # View sites for an organization
+            api_response = api_instance.get_locations_for_organization_using_get()
+        except ApiException as e:
+            return "Exception when calling get_locations_for_organization_using_get: %s\n" % e
+
+        if api_response:
+            return api_response
+        else:
+            return None
+
+    def inputs_are_valid(params):
+        # Check if there is more than one site already
+        # If there is only one, default to that one.
+        # Otherwise require a site_name to be provided
+        site_list = get_site_list()
+        if len(site_list) != 1:
+            required_params.append('site_name')
+        else:
+            network_params['location_uuid'] = site_list[0].uuid
+
+        inputs_valid = True
+        if params['network_type'].upper() == 'VLAN':
+            if params['state'] == 'present':
+                missing_params = []
+                required_params = ['name', 'vlan_tag']
+
+                for param in required_params:
+                    if not params[param]:
+                        missing_params.append(param)
+                        inputs_valid = False
+                return inputs_valid, missing_params
+
+        elif params['network_type'].upper() == 'VNET':
+            if params['state'] == 'present':
+                missing_params = []
+                required_params = ['network_address', 'subnet_mask', 'gateway',
+                                   'dhcp', 'routing']
+                for param in required_params:
+                    if not params[param]:
+                        missing_params.append(param)
+                        inputs_valid = False
+                return inputs_valid, missing_params
+
+    def create_vlan_network(network_params):
+        api_instance = tacp.VlansApi(tacp.ApiClient(configuration))
+
+        body = tacp.ApiVlanPropertiesPayload(
+            name=network_params['name'],
+            location_uuid=network_params['location_uuid'],
+            vlan_tag=network_params['vlan_tag']
+        )
+
+        result['api_request_body'] = str(body)
+        try:
+            api_response = api_instance.create_vlan_using_post(
+                body)
+
+            result['api_response_message'] = api_response.message
+            if "Creating VLAN" in api_response.message:
+                should_wait_for_creation = True
+
+        except ApiException as e:
+            response_dict = api_response_to_dict(e)
+            result['api_response_message'] = response_dict['message']
+            if "already exists" in response_dict['message']:
+                result['changed'] = False
+                result['failed'] = False
+                module.exit_json(**result)
+            pass
+        return
+
+    def create_vnet_network(network_params):
+        api_instance = tacp.VnetsApi(tacp.ApiClient(configuration))
+
+        # Package static bindings input as a list of ApiStaticBindingRulePayloads
+        static_binding_payloads = []
+        try:
+            for binding in network_params['dhcp']['static_bindings']:
+                params = ['hostname', 'ip_address', 'mac_address']
+                for param in params:
+                    if param not in binding.keys():
+                        binding[param] = None
+                payload = tacp.ApiStaticBindingRulePayload(
+                    hostname=binding['hostname'],
+                    ip_address=binding['ip_address'],
+                    mac_address=binding['mac_address'])
+                static_binding_payloads.append(payload)
+        except Exception:
+            # If there are no static_bindings we can just move on with an empty list
+            pass
+
+        # Create ApiVnetDhcpServicePayload from inputs and static binding list
+        dhcp_service = tacp.ApiVnetDhcpServicePayload(
+            domain_name=network_params['dhcp']['domain_name'],
+            start_ip_range=network_params['dhcp']['dhcp_start'],
+            end_ip_range=network_params['dhcp']['dhcp_end'],
+            lease_time=network_params['dhcp']['lease_time'],
+            primary_dns_server_ip_address=network_params['dhcp']['dns1'],
+            secondary_dns_server_ip_address=network_params['dhcp']['dns2'],
+            static_bindings=static_binding_payloads
+        )
+
+        params = ['address_mode', 'firewall_override', 'gateway',
+                  'ip_address', 'subnet_mask', 'type']
+        for param in params:
+            if param not in network_params['routing'].keys():
+                network_params['routing'][param] = None
+
+        routing_service = tacp.ApiVnetRoutingServicePayload(
+            address_mode=network_params['routing']['address_mode'],
+            firewall_override_uuid=network_params['routing']['firewall_override_uuid'],
+            gateway=network_params['routing']['gateway'],
+            ip_address=network_params['routing']['ip_address'],
+            network_uuid=network_params['routing']['network_uuid'],
+            subnet_mask=network_params['routing']['subnet_mask'],
+            type=network_params['routing']['type']
+        )
+
+        body = tacp.ApiCreateVnetPayload(
+            automatic_deployment=network_params['autodeploy_nfv'],
+            default_gateway=network_params['gateway'],
+            deploy_now=True,
+            dhcp_service=dhcp_service,
+            firewall_override_uuid=network_params['firewall_override_uuid'],
+            firewall_profile_uuid=network_params['firewall_profile_uuid'],
+            name=network_params['name'],
+            network_address=network_params['network_address'],
+            routing_service=routing_service,
+            subnet_mask=network_params['subnet_mask']
+        )
+
+        result['api_request_body'] = str(body)
+        try:
+            api_response = api_instance.create_vnet_using_post(body)
+
+            result['api_response_message'] = api_response.message
+            if "Creating" in api_response.message:
+                should_wait_for_creation = True
+            result['changed'] = True
+            result['failed'] = False
+            module.exit_json(**result)
+        except ApiException as e:
+            response_dict = api_response_to_dict(e)
+            result['api_response_message'] = response_dict['message']
+            if "Error" in response_dict['message']:
+                result['changed'] = False
+                result['failed'] = True
+                fail_with_reason(response_dict['message'])
+            elif "already exists" in response_dict['message']:
+                result['changed'] = False
+                result['failed'] = False
+                module.exit_json(**result)
+        return
+
+        module.exit_json(**result)
+    # manipulate or modify the state as needed (this is going to be the
+    # part where your module will do what it needs to do)
+
+    # Return the inputs for debugging purposes
+    result['args'] = module.params
+
+    # Define configuration
+    configuration = tacp.Configuration()
+    configuration.host = "https://manage.cp.lenovo.com"
+    configuration.api_key_prefix['Authorization'] = 'Bearer'
+    configuration.api_key['Authorization'] = module.params['api_key']
+    api_client = tacp.ApiClient(configuration)
+
+    network_params = {}
+
+    inputs_valid, missing_params = inputs_are_valid(module.params)
+    if not inputs_valid:
+        fail_with_reason("Invalid inputs - %s" % ', '.join(missing_params))
+
+    network_params['name'] = module.params['name']
+
+    if 'location_uuid' not in network_params.keys():
+        location_uuid = get_component_fields_by_name(
+            module.params['site_name'], 'location', api_client)
+        network_params['location_uuid'] = location_uuid
+
+    if module.params['network_type'].upper() == 'VNET':
+        base_params = ['autodeploy_nfv',
+                       'network_address', 'subnet_mask', 'gateway']
+
+        for param in base_params:
+            if param in module.params.keys():
+                network_params[param] = module.params[param]
+            else:
+                network_params[param] = None
+
+        if 'firewall_override' in module.params.keys():
+            network_params['firewall_override_uuid'] = get_component_fields_by_name(
+                module.params['firewall_override'], 'firewall_override', api_client)
+        else:
+            network_params['firewall_override_uuid'] = None
+
+        if 'firewall_profile' in module.params.keys():
+            network_params['firewall_profile_uuid'] = get_component_fields_by_name(
+                module.params['firewall_profile'], 'firewall_profile', api_client)
+        else:
+            network_params['firewall_profile_uuid'] = None
+
+        dhcp_params = ['dhcp_start', 'dhcp_end',
+                       'domain_name', 'lease_time', 'dns1', 'dns2',
+                       'static_bindings']
+        network_params['dhcp'] = {}
+        for param in dhcp_params:
+            if param in module.params['dhcp'].keys():
+                network_params['dhcp'][param] = module.params['dhcp'][param]
+            else:
+                network_params['dhcp'][param] = None
+
+        routing_params = ['network', 'type', 'address_mode', 'ip_address', 'subnet_mask',
+                          'gateway']
+        network_params['routing'] = {}
+        for param in routing_params:
+            if param in module.params['routing'].keys():
+                network_params['routing'][param] = module.params['routing'][param]
+            else:
+                network_params['routing'][param] = None
+        try:
+            if module.params['routing']['firewall_override']:
+                network_params['routing']['firewall_override_uuid'] = get_component_fields_by_name(
+                    network_params['routing']['firewall_override'],
+                    'firewall_override', api_client)
+        except Exception:
+            network_params['routing']['firewall_override_uuid'] = None
+
+        network_params['routing']['network_uuid'] = get_component_fields_by_name(
+            network_params['routing']['network'],
+            network_params['routing']['type'].lower(), api_client)
+
+    elif module.params['network_type'].upper() == 'VLAN':
+        if module.params['vlan_tag'] in range(1, 4095):
+            network_params['vlan_tag'] = module.params['vlan_tag']
+        else:
+            fail_with_reason(
+                "vlan_tag parameter is invalid - must be in range 1-4094")
+
+    if module.params['network_type'].upper() == 'VLAN':
+        create_vlan_network(network_params)
+    elif module.params['network_type'].upper() == 'VNET':
+        create_vnet_network(network_params)
+
+    # use whatever logic you need to determine whether or not this module
+    # made any modifications to your target
+    # if module.params['new']:
+    #     result['changed'] = True
+
+    # during the execution of the module, if there is an exception or a
+    # conditional state that effectively causes a failure, run
+    # AnsibleModule.fail_json() to pass in the message and the result
+
+    # in the event of a successful module execution, you will want to
+    # simple AnsibleModule.exit_json(), passing the key/value results
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change adds power state functionality to tacp_instance

- started
- stopped
- restarted
- shutdown
- force-restarted
- paused

This does remove the previous 'present' state.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tacp_instance

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
```yaml
---
- name: test my new module
  hosts: localhost
  tasks:
  - name: Create a VM on TACP
    tacp_instance:
      api_key: <API_KEY>
      name: Test_VM
      state: started
      datacenter: OTA_TEST
      mz: MZ 1
      template: CentOS 7 - Jenkins - Lenovo Template
      storage_pool: Pool 1
      vcpu_cores: 1
      memory: 2g
      disks:
        - size_gb: 20
      nics:
        - name: vNIC 0
          type: VNET
          network: OTA_VNET
    register: testout

  - name: Output
    debug:
      msg: '{{ testout }}'

  - name: Pause a VM on TACP
    tacp_instance:
      api_key: <API_KEY>
      name: Test_VM
      state: paused

  - name: Restart a VM on TACP
    tacp_instance:
      api_key: <API_KEY>
      name: Test_VM
      state: restarted

  - name: Stop a VM on TACP
    tacp_instance:
      api_key: <API_KEY>
      name: Test_VM
      state: stopped

  - name: Delete a VM on TACP
    tacp_instance:
      api_key: <API_KEY>
      name: Test_VM
      state: absent

  - name: Force-restart a VM on TACP
    tacp_instance:
      api_key: <API_KEY>
      name: Test_VM
      state: force-restarted
```
