### PR TITLE
Freeze pycodestyle in ansible-test.

### DIFF
--- a/changelogs/fragments/ansible-test-pycodestyle-freeze.yml
+++ b/changelogs/fragments/ansible-test-pycodestyle-freeze.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test now uses ``pycodestyle`` frozen at version 2.6.0 for consistent test results.

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -51,3 +51,6 @@ mccabe == 0.6.1
 pylint == 2.3.1
 typed-ast == 1.4.0  # 1.4.0 is required to compile on Python 3.8
 wrapt == 1.11.1
+
+# freeze pycodestyle for consistent test results
+pycodestyle == 2.6.0


### PR DESCRIPTION
##### SUMMARY

Freeze pycodestyle in ansible-test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

https://github.com/ansible/ansible/pull/69530 was a good reminder that pinning a specific version of pycodestyle is required to get consistent results.
