### PR TITLE
document return values of file module

### DIFF
--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -209,7 +209,16 @@ EXAMPLES = r'''
 
 '''
 RETURN = r'''
-
+dest:
+    description: Destination file/path, equal to the path argument
+    returned: state=touch, state=hard, state=link
+    type: str
+    sample: /path/to/file.txt
+path:
+    description: Destination file/path, equal to the path argument
+    returned: state=absent, state=directory, state=file
+    type: str
+    sample: /path/to/file.txt
 '''
 
 import errno
@@ -611,7 +620,7 @@ def ensure_directory(path, follow, recurse, timestamps):
     if prev_state == 'absent':
         # Create directory and assign permissions to it
         if module.check_mode:
-            return {'changed': True, 'diff': diff}
+            return {'path': path, 'changed': True, 'diff': diff}
         curpath = ''
 
         try:

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -210,7 +210,7 @@ EXAMPLES = r'''
 '''
 RETURN = r'''
 dest:
-    description: Destination file/path, equal to the path argument
+    description: Destination file/path, equal to the value passed to I(path)
     returned: state=touch, state=hard, state=link
     type: str
     sample: /path/to/file.txt

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -215,7 +215,7 @@ dest:
     type: str
     sample: /path/to/file.txt
 path:
-    description: Destination file/path, equal to the path argument
+    description: Destination file/path, equal to the value passed to I(path)
     returned: state=absent, state=directory, state=file
     type: str
     sample: /path/to/file.txt


### PR DESCRIPTION
##### SUMMARY
Fixes #55898 

This documents the return values (`path` vs `dest`) for the `file` module.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

file

##### ADDITIONAL INFORMATION

It turns out the `file` module has pretty inconsistent return values.

I documented when it returns `path` vs `dest`.
I also added one of those to the code, because in check mode it might not return it, but it should.

Note that I haven't tested this. How can I generate the docs locally to test that my yaml is all right?

I didn't document the `diff` value, which is returned, but is pretty inconsistent. Same with things like `guid`, which only are returned sometimes. Honestly it's a lot of work to figure all that out. Let's just start with these two fields.

I believe the module should be changed to have it sometimes return both `path` and `dest`, so that there is one which is always returned, always the same.
