### PR TITLE
Fix missing quoting for remote_tmp in second mkdir of shell module. Issue #69577

### DIFF
--- a/changelogs/fragments/69578-shell-remote_tmp-quoting.yaml
+++ b/changelogs/fragments/69578-shell-remote_tmp-quoting.yaml
@@ -1,2 +1,2 @@
-bug_fixes:
+bugfixes:
   - shell - Fix quoting of mkdir command in creation of remote_tmp in order to allow spaces and other special characters.

--- a/changelogs/fragments/69578-shell-remote_tmp-quoting.yaml
+++ b/changelogs/fragments/69578-shell-remote_tmp-quoting.yaml
@@ -1,0 +1,2 @@
+bug_fixes:
+  - shell - Fix quoting of mkdir command in creation of remote_tmp in order to allow spaces and other special characters.

--- a/changelogs/fragments/69578-shell-remote_tmp-quoting.yaml
+++ b/changelogs/fragments/69578-shell-remote_tmp-quoting.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - shell - Fix quoting of mkdir command in creation of remote_tmp in order to allow spaces and other special characters (https://github.com/ansible/ansible/issues/69577).
+  - shell - fix quoting of mkdir command in creation of remote_tmp in order to allow spaces and other special characters (https://github.com/ansible/ansible/issues/69577).

--- a/changelogs/fragments/69578-shell-remote_tmp-quoting.yaml
+++ b/changelogs/fragments/69578-shell-remote_tmp-quoting.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - shell - Fix quoting of mkdir command in creation of remote_tmp in order to allow spaces and other special characters.
+  - shell - Fix quoting of mkdir command in creation of remote_tmp in order to allow spaces and other special characters (https://github.com/ansible/ansible/issues/69577).

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -157,7 +157,7 @@ class ShellBase(AnsiblePlugin):
 
         # use mkdir -p to ensure parents exist, but mkdir fullpath to ensure last one is created by us
         cmd = 'mkdir -p %s echo %s %s' % (self._SHELL_SUB_LEFT, basetmpdir, self._SHELL_SUB_RIGHT)
-        cmd += '%s mkdir %s' % (self._SHELL_AND, basetmp)
+        cmd += '%s mkdir %s echo %s %s' % (self._SHELL_AND, self._SHELL_SUB_LEFT, basetmp, self._SHELL_SUB_RIGHT)
         cmd += ' %s echo %s=%s echo %s %s' % (self._SHELL_AND, basefile, self._SHELL_SUB_LEFT, basetmp, self._SHELL_SUB_RIGHT)
 
         # change the umask in a subshell to achieve the desired mode

--- a/test/integration/targets/config/runme.sh
+++ b/test/integration/targets/config/runme.sh
@@ -8,3 +8,8 @@ ANSIBLE_TIMEOUT= ansible -m ping testhost -i ../../inventory "$@"
 
 # env var is wrong type, this should be a fatal error pointing at the setting
 ANSIBLE_TIMEOUT='lola' ansible -m ping testhost -i ../../inventory "$@" 2>&1|grep 'Invalid type for configuration option setting: DEFAULT_TIMEOUT'
+
+# https://github.com/ansible/ansible/issues/69577                                                         
+ANSIBLE_REMOTE_TMP="~/.ansible/directory_with_no_space"  ansible -m ping testhost -i ../../inventory "$@" 
+                                                                                                          
+ANSIBLE_REMOTE_TMP="~/.ansible/directory with space"  ansible -m ping testhost -i ../../inventory "$@"

--- a/test/integration/targets/config/runme.sh
+++ b/test/integration/targets/config/runme.sh
@@ -10,6 +10,6 @@ ANSIBLE_TIMEOUT= ansible -m ping testhost -i ../../inventory "$@"
 ANSIBLE_TIMEOUT='lola' ansible -m ping testhost -i ../../inventory "$@" 2>&1|grep 'Invalid type for configuration option setting: DEFAULT_TIMEOUT'
 
 # https://github.com/ansible/ansible/issues/69577                                                         
-ANSIBLE_REMOTE_TMP="~/.ansible/directory_with_no_space"  ansible -m ping testhost -i ../../inventory "$@" 
+ANSIBLE_REMOTE_TMP="$HOME/.ansible/directory_with_no_space"  ansible -m ping testhost -i ../../inventory "$@" 
                                                                                                           
-ANSIBLE_REMOTE_TMP="~/.ansible/directory with space"  ansible -m ping testhost -i ../../inventory "$@"
+ANSIBLE_REMOTE_TMP="$HOME/.ansible/directory with space"  ansible -m ping testhost -i ../../inventory "$@"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix a quoting issue when making remote_tmp directory.

Fixes #69577 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
shell module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
# BEFORE CHANGE
Brians-Mac-mini:Pluralsight-GettingStartedWithAnsible briankohles$ ansible -m copy -a "src=master.gitconfig dest=~/.gitconfig" -vvv  localhost
WARNING: Executing a script that is loading libcrypto in an unsafe way. This will fail in a future version of macOS. Set the LIBRESSL_REDIRECT_STUB_ABORT=1 in the environment to force this into an error.
ansible 2.9.9
  config file = /Volumes/Data_2TB/Users/briankohles/.ansible.cfg
  configured module search path = [u'/Volumes/Data_2TB/Users/briankohles/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Volumes/Data_2TB/Users/briankohles/Library/Python/2.7/lib/python/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.16 (default, Feb 29 2020, 01:55:37) [GCC 4.2.1 Compatible Apple LLVM 11.0.3 (clang-1103.0.29.20) (-macos10.15-objc-
Using /Volumes/Data_2TB/Users/briankohles/.ansible.cfg as config file
host_list declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
[WARNING]: No inventory was parsed, only implicit localhost is available
META: ran handlers
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: briankohles
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Volumes/blank disk/.ansible/tmp `"&& mkdir /Volumes/blank disk/.ansible/tmp/ansible-tmp-1589750443.59-14727-54537596592985 && echo ansible-tmp-1589750443.59-14727-54537596592985="` echo /Volumes/blank disk/.ansible/tmp/ansible-tmp-1589750443.59-14727-54537596592985 `" ) && sleep 0'
localhost | UNREACHABLE! => {
    "changed": false,
    "msg": "Failed to create temporary directory.In some cases, you may have been able to authenticate and did not have permissions on the target directory. Consider changing the remote tmp path in ansible.cfg to a path rooted in \"/tmp\", for more error information use -vvv. Failed command was: ( umask 77 && mkdir -p \"` echo /Volumes/blank disk/.ansible/tmp `\"&& mkdir /Volumes/blank disk/.ansible/tmp/ansible-tmp-1589750443.59-14727-54537596592985 && echo ansible-tmp-1589750443.59-14727-54537596592985=\"` echo /Volumes/blank disk/.ansible/tmp/ansible-tmp-1589750443.59-14727-54537596592985 `\" ), exited with result 1",
    "unreachable": true
}

# AFTER CHANGE
Brians-Mac-mini:Pluralsight-GettingStartedWithAnsible briankohles$ ansible -m shell -a "hostname" -vvvv  localhost
WARNING: Executing a script that is loading libcrypto in an unsafe way. This will fail in a future version of macOS. Set the LIBRESSL_REDIRECT_STUB_ABORT=1 in the environment to force this into an error.
ansible 2.9.9
  config file = /Volumes/Data_2TB/Users/briankohles/.ansible.cfg
  configured module search path = [u'/Volumes/Data_2TB/Users/briankohles/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Volumes/Data_2TB/Users/briankohles/Library/Python/2.7/lib/python/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.16 (default, Feb 29 2020, 01:55:37) [GCC 4.2.1 Compatible Apple LLVM 11.0.3 (clang-1103.0.29.20) (-macos10.15-objc-
Using /Volumes/Data_2TB/Users/briankohles/.ansible.cfg as config file
setting up inventory plugins
host_list declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
[WARNING]: No inventory was parsed, only implicit localhost is available
Loading callback plugin minimal of type stdout, v2.0 from /Volumes/Data_2TB/Users/briankohles/Library/Python/2.7/lib/python/site-packages/ansible/plugins/callback/minimal.pyc
META: ran handlers
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: briankohles
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Volumes/blank disk/.ansible/tmp `"&& mkdir "/Volumes/blank disk/.ansible/tmp/ansible-tmp-1589751100.41-15193-112980309242535" && echo ansible-tmp-1589751100.41-15193-112980309242535="` echo /Volumes/blank disk/.ansible/tmp/ansible-tmp-1589751100.41-15193-112980309242535 `" ) && sleep 0'
Using module file /Volumes/Data_2TB/Users/briankohles/Library/Python/2.7/lib/python/site-packages/ansible/modules/commands/command.py
<127.0.0.1> PUT /Volumes/Data_2TB/Users/briankohles/.ansible/tmp/ansible-local-15173VcrxwG/tmpbzekpB TO /Volumes/blank disk/.ansible/tmp/ansible-tmp-1589751100.41-15193-112980309242535/AnsiballZ_command.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x '"'"'/Volumes/blank disk/.ansible/tmp/ansible-tmp-1589751100.41-15193-112980309242535/'"'"' '"'"'/Volumes/blank disk/.ansible/tmp/ansible-tmp-1589751100.41-15193-112980309242535/AnsiballZ_command.py'"'"' && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python '"'"'/Volumes/blank disk/.ansible/tmp/ansible-tmp-1589751100.41-15193-112980309242535/AnsiballZ_command.py'"'"' && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r '"'"'/Volumes/blank disk/.ansible/tmp/ansible-tmp-1589751100.41-15193-112980309242535/'"'"' > /dev/null 2>&1 && sleep 0'
localhost | CHANGED | rc=0 >>
Brians-Mac-mini.local
META: ran handlers
META: ran handlers
```
