### PR TITLE
 Don't attempt to decrypt host_vars with the name 'vault'

### DIFF
--- a/lib/ansible/plugins/vars/host_group_vars.py
+++ b/lib/ansible/plugins/vars/host_group_vars.py
@@ -106,6 +106,11 @@ class VarsModule(BaseVarsPlugin):
                                 self._display.warning("Found %s that is not a directory, skipping: %s" % (subdir, opath))
 
                     for found in found_files:
+                        # if the file is called 'vault' then there is a pretty good chance it's 
+                        # an encrypted vault so don't try and load the variables
+                        if os.path.basename(found) == "vault":
+                            break;
+
                         new_data = loader.load_from_file(found, cache=True, unsafe=True)
                         if new_data:  # ignore empty files
                             data = combine_vars(data, new_data)


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/awx/issues/223. Don't attempt to load  host_vars with the name of the file is 'vault' 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
host_group_vars

##### ADDITIONAL INFORMATION
 When following the best practice guide (https://docs.ansible.com/ansible/latest/user_guide/playbooks_best_practices.html#best-practices-for-variables-and-vaults) ansible-inventory will fail to parse the file..as it's encrypted. This causes AWX / Tower to fail when trying to import git repos that contain a group_vars/group_name/vars|vault combo


```paste below
Before: ERROR! Attempting to decrypt but no vault secrets found
-----
After: 
...
{
    "_meta": {
        "hostvars": {
....

```

