### PR TITLE
Doc: playbook keywords are reserved names too

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/user_guide/playbooks_variables.rst
@@ -18,7 +18,7 @@ Once you understand the concepts and examples on this page, read about :ref:`Ans
 Creating valid variable names
 =============================
 
-Not all strings are valid Ansible variable names. A variable name must start with a letter, and can only include letters, numbers, and underscores. `Python keywords`_ are not valid variable names.
+Not all strings are valid Ansible variable names. A variable name must start with a letter, and can only include letters, numbers, and underscores. `Python keywords`_ and :ref:`playbook keywords<playbook_keywords>` are not valid variable names.
 
 .. table::
    :class: documentation-table
@@ -27,6 +27,8 @@ Not all strings are valid Ansible variable names. A variable name must start wit
     Valid variable names   Not valid
    ====================== ====================================================================
    ``foo``                ``*foo``, `Python keywords`_ such as ``async`` and ``lambda``
+
+   ``foo_env``            :ref:`playbook keywords<playbook_keywords>` such as ``environment``
 
    ``foo_port``           ``foo-port``, ``foo port``, ``foo.port``
 


### PR DESCRIPTION
##### SUMMARY
Mention that playbook keywords are reserved too.

Related: #20567.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
doc

##### ADDITIONAL INFORMATION
Screenshot:

![Screenshot_2020-05-18_16-30-56](https://user-images.githubusercontent.com/1356830/82231270-72a87c80-991c-11ea-8a5a-4eecdade24b0.png)
