### PR TITLE
Turn on linkchecker in sphinx for documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,10 @@ epub:
 webdocs:
 	(cd docs/docsite/; CPUS=$(CPUS) $(MAKE) docs)
 
+.PHONY: linkcheckdocs
+linkcheckdocs:
+	(cd docs/docsite/; CPUS=$(CPUS) $(MAKE) linkcheckdocs)
+
 .PHONY: generate_rst
 generate_rst: lib/ansible/cli/*.py
 	mkdir -p ./docs/man/man1/ ; \

--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -46,6 +46,8 @@ htmldocs: generate_rst
 singlehtmldocs: generate_rst
 	CPUS=$(CPUS) $(MAKE) -f Makefile.sphinx singlehtml
 
+linkcheckdocs: generate_rst
+		CPUS=$(CPUS) $(MAKE) -f Makefile.sphinx linkcheck
 webdocs: docs
 
 #TODO: leaving htmlout removal for those having older versions, should eventually be removed also

--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -48,6 +48,7 @@ singlehtmldocs: generate_rst
 
 linkcheckdocs: generate_rst
 		CPUS=$(CPUS) $(MAKE) -f Makefile.sphinx linkcheck
+		
 webdocs: docs
 
 #TODO: leaving htmlout removal for those having older versions, should eventually be removed also

--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -283,3 +283,10 @@ intersphinx_mapping = {'python': ('https://docs.python.org/2/', (None, '../pytho
                        'ansible_2_6': ('https://docs.ansible.com/ansible/2.6/', (None, '../ansible_2_6.inv')),
                        'ansible_2_5': ('https://docs.ansible.com/ansible/2.5/', (None, '../ansible_2_5.inv')),
                        }
+
+# linckchecker settings
+linkcheck_ignore = [
+    r'http://irc\.freenode\.net',
+    ]
+
+linkcheck_anchors = False

--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -288,5 +288,5 @@ intersphinx_mapping = {'python': ('https://docs.python.org/2/', (None, '../pytho
 linkcheck_ignore = [
     r'http://irc\.freenode\.net',
 ]
-
+linkcheck_workers = 25
 # linkcheck_anchors = False

--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -287,6 +287,6 @@ intersphinx_mapping = {'python': ('https://docs.python.org/2/', (None, '../pytho
 # linckchecker settings
 linkcheck_ignore = [
     r'http://irc\.freenode\.net',
-    ]
+]
 
 # linkcheck_anchors = False

--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -289,4 +289,4 @@ linkcheck_ignore = [
     r'http://irc\.freenode\.net',
     ]
 
-linkcheck_anchors = False
+# linkcheck_anchors = False


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Sphinx has a built-in ability to check for broken links.  This PR enables that so you can run `make linkcheckdocs'
The output goes to docs/docsite/_build/linkcheck/output.txt.



<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs.ansible.com
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
