### PR TITLE
[yum] Make package removal confirmation strict

### DIFF
--- a/lib/ansible/modules/yum.py
+++ b/lib/ansible/modules/yum.py
@@ -1159,7 +1159,7 @@ class YumModule(YumDnf):
                 if pkg.startswith('@'):
                     installed = self.is_group_env_installed(pkg)
                 else:
-                    installed = self.is_installed(repoq, pkg)
+                    installed = self.is_installed(repoq, pkg, is_pkg=True)
 
                 if installed:
                     # Return a message so it's obvious to the user why yum failed

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -838,3 +838,31 @@
   # actually honored and those releases are EOL'd so we have no expectation they
   # will ever be fixed
   when: not ((ansible_distribution == "Fedora") and (ansible_distribution_major_version|int < 26))
+
+- name: Check that packages with Provides are handled correctly in state=absent
+  block:
+    - name: Install test packages
+      yum:
+        name:
+          - https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/yum/test-package-that-provides-toaster-1.3.3.7-1.el7.noarch.rpm
+          - https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/yum/toaster-1.2.3.4-1.el7.noarch.rpm
+      register: install
+
+    - name: Remove toaster
+      yum:
+        name: toaster
+        state: absent
+      register: remove
+
+    - name: rpm -qa
+      command: rpm -qa
+      register: rpmqa
+
+    - assert:
+        that:
+          - install is successful
+          - install is changed
+          - remove is successful
+          - remove is changed
+          - "'toaster-1.2.3.4' not in rpmqa.stdout"
+          - "'test-package-that-provides-toaster' in rpmqa.stdout"


### PR DESCRIPTION
##### SUMMARY

Change:
After removing packages, the yum module does a final check to ensure the
packages are really uninstalled. The check would include packages that
were RPM `Provides:` values of another package.

This means that, for example, if a third-party kernel RPM spec had
`Provides: kernel` in it, removing the stock kernel would be successful
but the check to see if it was really removed would fail and cause
Ansible to report a failure.

Test Plan:
Tested on local CentOS 7 VM with kernel from elrepo which is known to
`Provides: kernel`.

Tickets:
Fixes #69237
Refs #35672
Refs #40723

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

yum

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
