### PR TITLE
To fix the issue where loopback address wasn't populated as expected via ios_l3_interfaces module 

### DIFF
--- a/changelogs/fragments/45_ios_l3_loopback_issue.yaml
+++ b/changelogs/fragments/45_ios_l3_loopback_issue.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - To fix ios_l3_interfaces Loopback issue (https://github.com/ansible-collections/cisco.ios/pull/45)

--- a/lib/ansible/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
+++ b/lib/ansible/module_utils/network/ios/config/l3_interfaces/l3_interfaces.py
@@ -15,7 +15,7 @@ __metaclass__ = type
 from ansible.module_utils.network.common.cfg.base import ConfigBase
 from ansible.module_utils.network.common.utils import to_list
 from ansible.module_utils.network.ios.facts.facts import Facts
-from ansible.module_utils.network.ios.utils.utils import dict_to_set
+from ansible.module_utils.network.ios.utils.utils import dict_to_set, normalize_interface
 from ansible.module_utils.network.ios.utils.utils import remove_command_from_config_list, add_command_to_config_list
 from ansible.module_utils.network.ios.utils.utils import filter_dict_having_none_value, remove_duplicate_interface
 from ansible.module_utils.network.ios.utils.utils import validate_n_expand_ipv4, validate_ipv6
@@ -80,7 +80,12 @@ class L3_Interfaces(ConfigBase):
         :returns: the commands necessary to migrate the current configuration
                   to the desired configuration
         """
-        want = self._module.params['config']
+        config = self._module.params.get("config")
+        want = []
+        if config:
+            for each in config:
+                each.update({"name": normalize_interface(each["name"])})
+                want.append(each)
         have = existing_l3_interfaces_facts
         resp = self.set_state(want, have)
         return to_list(resp)

--- a/test/integration/targets/ios_l3_interfaces/tests/cli/_remove_config.yaml
+++ b/test/integration/targets/ios_l3_interfaces/tests/cli/_remove_config.yaml
@@ -4,6 +4,8 @@
     config: "{{ lines }}"
   vars:
     lines: |
+      interface Loopback 999
+      no ip address
       interface GigabitEthernet 0/1
       no ip address
       no ipv6 address

--- a/test/integration/targets/ios_l3_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/ios_l3_interfaces/tests/cli/merged.yaml
@@ -8,6 +8,9 @@
     - name: Merge provided configuration with device configuration
       ios_l3_interfaces: &merged
         config:
+          - name: Loopback999
+            ipv4:
+              - address: 192.0.2.1/24
           - name: GigabitEthernet0/1
             ipv4:
             - address: dhcp

--- a/test/integration/targets/ios_l3_interfaces/vars/main.yaml
+++ b/test/integration/targets/ios_l3_interfaces/vars/main.yaml
@@ -10,6 +10,8 @@ merged:
     - name: GigabitEthernet0/2
 
   commands:
+    - "interface loopback999"
+    - "ip address 192.0.2.1 255.255.255.0"
     - "interface GigabitEthernet0/1"
     - "ip address dhcp client-id GigabitEthernet 0/0 hostname test.com"
     - "interface GigabitEthernet0/2"
@@ -19,7 +21,9 @@ merged:
 
   after:
     - name: loopback888
-    - name: loopback999
+    - ipv4:
+        - address: 192.0.2.1 255.255.255.0
+      name: loopback999
     - ipv4:
       - address: dhcp
       name: GigabitEthernet0/0


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible-collections/cisco.ios/pull/45

<!--- Describe the change below, including rationale and design decisions -->
To fix the issue where loopback address wasn't populated as expected via ios_l3_interfaces module, PR is merged in IOS collection, ref: https://github.com/ansible-collections/cisco.ios/pull/45
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_l3_interfaces
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
