### PR TITLE
ios_static_route module IndexError when using EEM / route profiling

### DIFF
--- a/lib/ansible/modules/network/ios/ios_static_route.py
+++ b/lib/ansible/modules/network/ios/ios_static_route.py
@@ -195,12 +195,24 @@ def map_config_to_obj(module):
     for line in out.splitlines():
         splitted_line = findall(r'[^"\s]\S*|".+?"', line)  # Split by whitespace but do not split quotes, needed for name parameter
 
+
+        # Exit the iteration if the first two words in the match are different than ip route
+        # (eg: EEM applet 'action 1.3 cli command "ip route 10.1.1.1 255.255.255.255 192.168.1.1"')
+        match_conditions = (splitted_line[0] != 'ip', splitted_line[1] != 'route')
+
+        if all(match_conditions):
+            continue
+
         if splitted_line[2] == 'vrf':
             route = {'vrf': splitted_line[3]}
             del splitted_line[:4]  # Removes the words ip route vrf vrf_name
         else:
             route = {}
             del splitted_line[:2]  # Removes the words ip route
+
+        # Edge case to handle: ip route profile command.
+        if len(splitted_line) <= 1:
+            continue
 
         prefix = splitted_line[0]
         mask = splitted_line[1]

--- a/test/units/modules/network/ios/fixtures/ios_static_route_config.cfg
+++ b/test/units/modules/network/ios/fixtures/ios_static_route_config.cfg
@@ -1,0 +1,6 @@
+ip route vrf INTERNET 10.1.1.1 255.255.255.255 192.168.1.2 tag 100
+ip route profile
+action 1.2 cli command "no ip route profile"
+action 1.3 cli command "ip route profile"
+ip route 192.168.1.0 255.255.255.0 GigabitEthernet0/0 200
+ip route vrf DATA 192.168.1.128 255.255.255.128 GigabitEthernet0/0 10.1.1.1 200 tag 200 name "Some Remote Server" track 1

--- a/test/units/modules/network/ios/test_ios_static_route.py
+++ b/test/units/modules/network/ios/test_ios_static_route.py
@@ -1,0 +1,106 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from units.compat.mock import patch
+from ansible.modules.network.ios import ios_static_route
+from units.modules.utils import set_module_args
+from .ios_module import TestIosModule, load_fixture
+
+
+class TestIosStaticRouteModule(TestIosModule):
+
+    module = ios_static_route
+
+    def setUp(self):
+        super(TestIosStaticRouteModule, self).setUp()
+
+        self.mock_get_config = patch('ansible.modules.network.ios.ios_static_route.get_config')
+        self.get_config = self.mock_get_config.start()
+
+        self.mock_load_config = patch('ansible.modules.network.ios.ios_static_route.load_config')
+        self.load_config = self.mock_load_config.start()
+
+    def tearDown(self):
+        super(TestIosStaticRouteModule, self).tearDown()
+        self.mock_get_config.stop()
+        self.mock_load_config.stop()
+
+    def load_fixtures(self, commands=None):
+        self.get_config.return_value = load_fixture('ios_static_route_config.cfg').strip()
+        self.load_config.return_value = dict(diff=None, session='session')
+
+    def test_ios_static_route_idempotent(self):
+        set_module_args(dict(
+            prefix='10.1.1.1',
+            mask='255.255.255.255',
+            next_hop='192.168.1.2',
+            tag=100,
+            vrf='INTERNET',
+            state='present'
+        ))
+        commands = []
+        self.execute_module(changed=False, commands=commands)
+
+    def test_ios_static_route_config(self):
+        set_module_args(dict(
+            prefix='12.11.0.0',
+            mask='255.255.0.0',
+            next_hop='10.1.1.1',
+            tag=100,
+            vrf='DATA_VRF',
+            admin_distance=150,
+            interface='GigabitEthernet0/0',
+            name='Web Server Static',
+            state='present'
+        ))
+        commands = [
+            'ip route vrf DATA_VRF 12.11.0.0 255.255.0.0 GigabitEthernet0/0 10.1.1.1 150 tag 100 name "Web Server Static"'
+        ]
+        self.execute_module(changed=True, commands=commands)
+
+    def test_ios_static_route_not_remove(self):
+        set_module_args(dict(
+            prefix='192.168.1.128',
+            mask='255.255.255.128',
+            next_hop='10.1.1.1',
+            tag=100,
+            vrf='DATA',
+            track=1,
+            interface='GigabitEthernet0/0',
+            name='Some Remote Server',
+            state='absent'
+        ))
+        commands = []
+        self.execute_module(changed=False, commands=commands)
+
+    def test_ios_static_route_remove(self):
+        set_module_args(dict(
+            prefix='192.168.1.128',
+            mask='255.255.255.128',
+            next_hop='10.1.1.1',
+            tag=200,
+            vrf='DATA',
+            track=1,
+            admin_distance=200,
+            interface='GigabitEthernet0/0',
+            name='Some Remote Server',
+            state='absent'
+        ))
+        commands = ['no ip route vrf DATA 192.168.1.128 255.255.255.128 GigabitEthernet0/0 10.1.1.1 200 tag 200 name "Some Remote Server" track 1']
+        self.execute_module(changed=True, commands=commands)

--- a/test/units/modules/network/ios/test_ios_static_route.py
+++ b/test/units/modules/network/ios/test_ios_static_route.py
@@ -65,12 +65,12 @@ class TestIosStaticRouteModule(TestIosModule):
             tag=100,
             vrf='DATA_VRF',
             admin_distance=150,
-            interface='GigabitEthernet0/0',
+            interface='GigabitEthernet0/1',
             name='Web Server Static',
             state='present'
         ))
         commands = [
-            'ip route vrf DATA_VRF 12.11.0.0 255.255.0.0 GigabitEthernet0/0 10.1.1.1 150 tag 100 name "Web Server Static"'
+            'ip route vrf DATA_VRF 12.11.0.0 255.255.0.0 GigabitEthernet0/1 10.1.1.1 150 tag 100 name "Web Server Static"'
         ]
         self.execute_module(changed=True, commands=commands)
 


### PR DESCRIPTION
##### SUMMARY
The IOS Static Route module currently uses a regular expression to match all outputs from the ```show running-config | include ip route``` command.

It expects the output to be exclusively composed of IP static routes.

However,  it is possible to have configuration lines prefixed with "ip route" which are not actual IP static routes:

[IP Route Profiling](https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/iproute_pi/command/iri-cr-book/iri-cr-a1.html#wp1551900326)

```
ip route profile
```

EEM Applets

```
action 1.2 cli command "no ip route profile"
action 1.3 cli command "ip route profile"
```

The above examples lead to IndexError exception when trying to extract the static route prefix and mask here:

[ios_static_route.py](https://github.com/ansible/ansible/blob/stable-2.9/lib/ansible/modules/network/ios/ios_static_route.py#L206)

This pull request aims at fixing these edge cases.

Furthermore, unit tests and fixtures for ios_static_route module are added as part of this PR.

Thanks

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

ios_static_route

##### ADDITIONAL INFORMATION

PyTest results:

```
pytest -r a -s -v   --fulltrace --color yes test/units/modules/network/ios/test_ios_static_route.py
=============================================== test session starts ===============================================
platform darwin -- Python 3.8.2, pytest-5.4.2, py-1.8.1, pluggy-0.13.1 -- /Users/sebastianpouplin/.pyenv/versions/3.8.2/envs/ansible_venv/bin/python3.8
cachedir: .pytest_cache
rootdir: /Users/sebastianpouplin/Dropbox/Dev_Projects/ansible_source/ansible
plugins: mock-3.1.0, forked-1.1.3, xdist-1.32.0
collected 4 items

test/units/modules/network/ios/test_ios_static_route.py::TestIosStaticRouteModule::test_ios_static_route_config PASSED
test/units/modules/network/ios/test_ios_static_route.py::TestIosStaticRouteModule::test_ios_static_route_idempotent PASSED
test/units/modules/network/ios/test_ios_static_route.py::TestIosStaticRouteModule::test_ios_static_route_not_remove PASSED
test/units/modules/network/ios/test_ios_static_route.py::TestIosStaticRouteModule::test_ios_static_route_remove PASSED

================================================ 4 passed in 0.05s ================================================
```


