### PR TITLE
Add FQCN mappings for network facts modules

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1322,16 +1322,27 @@ CONNECTION_FACTS_MODULES:
   name: Map of connections to fact modules
   default:
     asa: asa_facts
+    cisco.asa.asa: cisco.asa.asa_facts
     eos: eos_facts
+    arista.eos.eos: arista.eos.eos_facts
     frr: frr_facts
+    frr.frr.frr: frr.frr.frr_facts
     ios: ios_facts
+    cisco.ios.ios: cisco.ios.ios_facts
     iosxr: iosxr_facts
+    cisco.iosxr.iosxr: cisco.iosxr.iosxr_facts
     junos: junos_facts
+    junipernetworks.junos.junos: junipernetworks.junos.junos_facts
     nxos: nxos_facts
+    cisco.nxos.nxos: cisco.nxos.nxos_facts
     vyos: vyos_facts
+    vyos.vyos.vyos: vyos.vyos.vyos_facts
     exos: exos_facts
+    extreme.exos.exos: extreme.exos.exos_facts
     slxos: slxos_facts
+    extreme.slxos.slxos: extreme.slxos.slxos_facts
     voss: voss_facts
+    extreme.voss.voss: extreme.voss.voss_facts
     ironware: ironware_facts
   description: "Which modules to run during a play's fact gathering stage based on connection"
   env: [{name: ANSIBLE_CONNECTION_FACTS_MODULES}]

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1344,6 +1344,7 @@ CONNECTION_FACTS_MODULES:
     voss: voss_facts
     extreme.voss.voss: extreme.voss.voss_facts
     ironware: ironware_facts
+    community.network.ironware: community.network.ironware_facts
   description: "Which modules to run during a play's fact gathering stage based on connection"
   env: [{name: ANSIBLE_CONNECTION_FACTS_MODULES}]
   ini:


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- gather_facts for network platforms doesn't work if the `network_os` is in `namespace.collection.network_os` format.
- This PR explicitly adds those mappings in base.yml.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
config/base.yml