### PR TITLE
Remove "keywords" field in DOCUMENTATION.

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -27,9 +27,6 @@ DOCUMENTATION = """
             - name: ansible_winrm_host
         type: str
       remote_user:
-        keywords:
-          - name: user
-          - name: remote_user
         description:
             - The user to log in as to the Windows machine
         vars:
@@ -51,8 +48,6 @@ DOCUMENTATION = """
           - name: ansible_port
           - name: ansible_winrm_port
         default: 5986
-        keywords:
-          - name: port
         type: integer
       scheme:
         description:


### PR DESCRIPTION
This doesn't seem to be used by config although it came in with the
config PR.  It's not displayed in docs.  Removing it as this is the only
place where it's present.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
Motivation for this is I'm creating a schema for the DOCUMENTATION and the fewer outliers and special cases the schema has, the better it will be for everyone wanting to use the data.