### PR TITLE
Fix issue with nxos privilege check

### DIFF
--- a/lib/ansible/plugins/terminal/nxos.py
+++ b/lib/ansible/plugins/terminal/nxos.py
@@ -57,12 +57,13 @@ class TerminalModule(TerminalBase):
 
         out = self._exec_cli_command('show privilege')
         out = to_text(out, errors='surrogate_then_replace').strip()
-        if 'Disabled' in out:
-            raise AnsibleConnectionFailure('Feature privilege is not enabled')
 
         # if already at privilege level 15 return
         if '15' in out:
             return
+
+        if 'Disabled' in out:
+            raise AnsibleConnectionFailure('Feature privilege is not enabled')
 
         if self.validate_user_role():
             return


### PR DESCRIPTION
##### SUMMARY
On a nexus 9k switch where user used by ansible has the following privileges and feature privilege is disabled:

```
SWITCH# show privilege 
User name: ansible
Current privilege level: 15
Feature privilege: Disabled
```
Code stops and drops error that `Feature privilege` is not enabled:

```
The full traceback is:
Traceback (most recent call last):
  File "/home/markwell-ch/.ansible/tmp/ansible-local-144096g9r7d80t/ansible-tmp-1589982208.2762504-144188-109827282841191/AnsiballZ_nxos_config.py", line 102, in <module>
    _ansiballz_main()
  File "/home/markwell-ch/.ansible/tmp/ansible-local-144096g9r7d80t/ansible-tmp-1589982208.2762504-144188-109827282841191/AnsiballZ_nxos_config.py", line 94, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/markwell-ch/.ansible/tmp/ansible-local-144096g9r7d80t/ansible-tmp-1589982208.2762504-144188-109827282841191/AnsiballZ_nxos_config.py", line 40, in invoke_module
    runpy.run_module(mod_name='ansible.modules.network.nxos.nxos_config', init_globals=None, run_name='__main__', alter_sys=True)
  File "/usr/lib/python3.8/runpy.py", line 206, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib/python3.8/runpy.py", line 96, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/lib/python3.8/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_nxos_config_payload_qd42b41n/ansible_nxos_config_payload.zip/ansible/modules/network/nxos/nxos_config.py", line 535, in <module>
  File "/tmp/ansible_nxos_config_payload_qd42b41n/ansible_nxos_config_payload.zip/ansible/modules/network/nxos/nxos_config.py", line 419, in main
  File "/tmp/ansible_nxos_config_payload_qd42b41n/ansible_nxos_config_payload.zip/ansible/module_utils/network/nxos/nxos.py", line 130, in get_connection
  File "/tmp/ansible_nxos_config_payload_qd42b41n/ansible_nxos_config_payload.zip/ansible/module_utils/connection.py", line 185, in __rpc__
ansible.module_utils.connection.ConnectionError: Feature privilege is not enabled

```

Fix the order of if statements for checking `show privilege` status . The check if privilege is already 15 needs to be the first.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
plugins/terminal/nxos.py