### PR TITLE
Pin docker-ce-cli version in tests

### DIFF
--- a/test/integration/targets/incidental_setup_docker/vars/RedHat-8.yml
+++ b/test/integration/targets/incidental_setup_docker/vars/RedHat-8.yml
@@ -7,3 +7,4 @@ docker_prereq_packages:
 # Docker CE > 3:18.09.1 requires containerd.io >= 1.2.2-3 which is unavaible at this time
 docker_packages:
   - docker-ce-3:18.09.1
+  - docker-ce-cli-1:18.09.1


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Installing `docker-ce` has a dependency of `docker-ce-cli`. If the version of _that_ package is not specified, it install the latest version. The latest version of `docker-ce-cli` has a bug (https://github.com/docker/cli/issues/2533) that results in our tests failing.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/incidental_setup_docker`

##### ADDITIONAL INFORMATION
This is a subset of changes made in community.general https://github.com/ansible-collections/community.general/pull/366/files#diff-bb48e3b88f37ec540f9d6d128f8c80ecR10. Those changes should probably be applied to the `stable-2.9` branch, but further discussion on that topic is needed.