### PR TITLE
[stable-2.9] Properly handle unicode in safe_eval (#68576)

### DIFF
--- a/changelogs/fragments/66943-handle-unicode-in-safe_eval.yml
+++ b/changelogs/fragments/66943-handle-unicode-in-safe_eval.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Properly handle unicode in ``safe_eval``. (https://github.com/ansible/ansible/issues/66943)

--- a/lib/ansible/module_utils/common/text/converters.py
+++ b/lib/ansible/module_utils/common/text/converters.py
@@ -61,7 +61,7 @@ def container_to_bytes(d, encoding='utf-8', errors='surrogate_or_strict'):
 
 
 def container_to_text(d, encoding='utf-8', errors='surrogate_or_strict'):
-    """Recursively convert dict keys and values to byte str
+    """Recursively convert dict keys and values to text str
 
     Specialized for json return because this only handles, lists, tuples,
     and dict container types (the containers that the json module returns)

--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -22,7 +22,9 @@ import ast
 import sys
 
 from ansible import constants as C
-from ansible.module_utils.six import string_types
+from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import container_to_text
+from ansible.module_utils.six import string_types, PY2
 from ansible.module_utils.six.moves import builtins
 from ansible.plugins.loader import filter_loader, test_loader
 
@@ -139,11 +141,15 @@ def safe_eval(expr, locals=None, include_exceptions=False):
     try:
         parsed_tree = ast.parse(expr, mode='eval')
         cnv.visit(parsed_tree)
-        compiled = compile(parsed_tree, expr, 'eval')
+        compiled = compile(parsed_tree, to_native(expr), 'eval')
         # Note: passing our own globals and locals here constrains what
         # callables (and other identifiers) are recognized.  this is in
         # addition to the filtering of builtins done in CleansingNodeVisitor
         result = eval(compiled, OUR_GLOBALS, dict(locals))
+        if PY2:
+            # On Python 2 u"{'key': 'value'}" is evaluated to {'key': 'value'},
+            # ensure it is converted to {u'key': u'value'}.
+            result = container_to_text(result)
 
         if include_exceptions:
             return (result, None)

--- a/test/integration/targets/lookups/runme.sh
+++ b/test/integration/targets/lookups/runme.sh
@@ -13,3 +13,6 @@ ANSIBLE_ROLES_PATH=../ ansible-playbook lookups.yml "$@"
 ansible-playbook template_lookup_vaulted.yml --vault-password-file test_vault_pass "$@"
 
 ansible-playbook -i template_deepcopy/hosts template_deepcopy/playbook.yml "$@"
+
+# https://github.com/ansible/ansible/issues/66943
+ansible-playbook template_lookup_safe_eval_unicode/playbook.yml "$@"

--- a/test/integration/targets/lookups/template_lookup_safe_eval_unicode/playbook.yml
+++ b/test/integration/targets/lookups/template_lookup_safe_eval_unicode/playbook.yml
@@ -1,0 +1,8 @@
+- hosts: localhost
+  gather_facts: no
+  vars:
+    original_dict: "{{ lookup('template', 'template.json.j2') }}"
+    copy_dict: {}
+  tasks:
+    - set_fact:
+        copy_dict: "{{ copy_dict | combine(original_dict) }}"

--- a/test/integration/targets/lookups/template_lookup_safe_eval_unicode/template.json.j2
+++ b/test/integration/targets/lookups/template_lookup_safe_eval_unicode/template.json.j2
@@ -1,0 +1,4 @@
+{
+  "key1": "ascii_value",
+  "key2": "unicode_value_křížek",
+}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #68576
(cherry picked from commit ecd986006ededd3ecfd4fb6704d7a68b3bfba5e1)

This is not a direct backport since `to_native()` has moved in `devel` and we won't backport that change. I had to make some minor changes to the import in `safe_eval.py`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/common/text/converters.py`
`lib/ansible/template/safe_eval.py`