### PR TITLE
Discover Flatcar Linux properly for hostname

### DIFF
--- a/changelogs/fragments/69516_flatcar_distribution.yml
+++ b/changelogs/fragments/69516_flatcar_distribution.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Added support for Flatcar Container Linux in distribution and hostname modules. (https://github.com/ansible/ansible/pull/69627)

--- a/hacking/tests/gen_distribution_version_testcase.py
+++ b/hacking/tests/gen_distribution_version_testcase.py
@@ -37,6 +37,7 @@ filelist = [
     '/etc/altlinux-release',
     '/etc/os-release',
     '/etc/coreos/update.conf',
+    '/etc/flatcar/update.conf',
     '/usr/lib/os-release',
 ]
 

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -71,6 +71,7 @@ class DistributionFiles:
         {'path': '/etc/sourcemage-release', 'name': 'SMGL'},
         {'path': '/usr/lib/os-release', 'name': 'ClearLinux'},
         {'path': '/etc/coreos/update.conf', 'name': 'Coreos'},
+        {'path': '/etc/flatcar/update.conf', 'name': 'Flatcar'},
         {'path': '/etc/os-release', 'name': 'NA'},
     )
 
@@ -402,6 +403,21 @@ class DistributionFiles:
 
         return True, coreos_facts
 
+    def parse_distribution_file_Flatcar(self, name, data, path, collected_facts):
+        flatcar_facts = {}
+        distro = get_distribution()
+
+        if distro.lower() == 'flatcar':
+            if not data:
+                return False, flatcar_facts
+            release = re.search("^GROUP=(.*)", data)
+            if release:
+                flatcar_facts['distribution_release'] = release.group(1).strip('"')
+        else:
+            return False, flatcar_facts
+
+        return True, flatcar_facts
+
     def parse_distribution_file_ClearLinux(self, name, data, path, collected_facts):
         clear_facts = {}
         if "clearlinux" not in name.lower():
@@ -453,6 +469,7 @@ class Distribution(object):
         {'path': '/etc/sourcemage-release', 'name': 'SMGL'},
         {'path': '/usr/lib/os-release', 'name': 'ClearLinux'},
         {'path': '/etc/coreos/update.conf', 'name': 'Coreos'},
+        {'path': '/etc/flatcar/update.conf', 'name': 'Flatcar'},
         {'path': '/etc/os-release', 'name': 'NA'},
     )
 

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -677,6 +677,12 @@ class CoreosHostname(Hostname):
     strategy_class = SystemdStrategy
 
 
+class FlatcarHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Flatcar'
+    strategy_class = SystemdStrategy
+
+
 class ScientificHostname(Hostname):
     platform = 'Linux'
     distribution = 'Scientific'

--- a/test/units/module_utils/basic/test_platform_distribution.py
+++ b/test/units/module_utils/basic/test_platform_distribution.py
@@ -70,6 +70,9 @@ class TestGetDistribution:
         with patch('ansible.module_utils.distro.id', return_value="debian"):
             assert get_distribution() == "Debian"
 
+        with patch('ansible.module_utils.distro.id', return_value="flatcar"):
+            assert get_distribution() == "Flatcar"
+
         with patch('ansible.module_utils.distro.id', return_value="linuxmint"):
             assert get_distribution() == "Linuxmint"
 

--- a/test/units/module_utils/common/test_sys_info.py
+++ b/test/units/module_utils/common/test_sys_info.py
@@ -59,6 +59,9 @@ class TestGetDistribution:
         with patch('ansible.module_utils.distro.id', return_value="debian"):
             assert get_distribution() == "Debian"
 
+        with patch('ansible.module_utils.distro.id', return_value="flatcar"):
+            assert get_distribution() == "Flatcar"
+
         with patch('ansible.module_utils.distro.id', return_value="linuxmint"):
             assert get_distribution() == "Linuxmint"
 

--- a/test/units/module_utils/facts/system/distribution/fixtures/flatcar_2492.0.0.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/flatcar_2492.0.0.json
@@ -1,0 +1,24 @@
+{
+    "name": "Flatcar Container Linux",
+    "input": {
+        "/usr/lib/os-release": "NAME=\"Flatcar Container Linux by Kinvolk\"\nID=flatcar\nID_LIKE=coreos\nVERSION=2492.0.0\nVERSION_ID=2492.0.0\nBUILD_ID=2020-04-28-2210\nPRETTY_NAME=\"Flatcar Container Linux by Kinvolk 2492.0.0 (Rhyolite)\"\nANSI_COLOR=\"38;5;75\"\nHOME_URL=\"https://flatcar-linux.org/\"\nBUG_REPORT_URL=\"https://issues.flatcar-linux.org\"",
+        "/etc/lsb-release": "DISTRIB_ID=\"Flatcar Container Linux by Kinvolk\"\nDISTRIB_RELEASE=2492.0.0\nDISTRIB_CODENAME=\"Rhyolite\"\nDISTRIB_DESCRIPTION=\"Flatcar Container Linux by Kinvolk 2492.0.0 (Rhyolite)\""
+    },
+    "platform.dist": ["", "", ""],
+    "distro": {
+        "codename": "Rhyolite",
+        "id": "flatcar",
+        "id_like": "coreos",
+        "name": "Flatcar",
+        "version": "2492.0.0",
+        "version_best": "2492.0.0",
+        "os_release_info": {},
+        "lsb_release_info": {}
+    },
+    "platform.release": "",
+    "result": {
+        "distribution": "Flatcar",
+        "distribution_major_version": "2492",
+        "distribution_version": "2492.0.0"
+    }
+}


### PR DESCRIPTION
##### SUMMARY

To avoid issues with Flatcar Container Linux being unable to be found,
detect Flatcar distro name especially for hostname, just like CoreOS
Container Linux was supported.

Fixes https://github.com/ansible/ansible/issues/69516

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module
