### PR TITLE
Remove exit code from traps in tests

### DIFF
--- a/test/integration/targets/incidental_inventory_docker_swarm/runme.sh
+++ b/test/integration/targets/incidental_inventory_docker_swarm/runme.sh
@@ -8,7 +8,6 @@ cleanup() {
     echo "Cleanup"
     ansible-playbook playbooks/swarm_cleanup.yml
     echo "Done"
-    exit 0
 }
 
 trap cleanup INT TERM EXIT


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Having the trap exit with a specific code will override the exit code that caused the trap to run, which could mask errors.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/incidental_inventory_docker_swarm`
`test/integration/targets/incidental_inventory_vmware_vm_inventory`