### PR TITLE
version_added source tracing for ansible-doc/ansible-test, version number validation for validate-modules

### DIFF
--- a/changelogs/fragments/ansible-doc-version_added-collection.yml
+++ b/changelogs/fragments/ansible-doc-version_added-collection.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "ansible-doc - now indicates if an option is added by a doc fragment from another collection by prepending the collection name, or ``ansible.builtin`` for ansible-base, to the version number."

--- a/changelogs/fragments/ansible-test-version-validation.yml
+++ b/changelogs/fragments/ansible-test-version-validation.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "ansible-test - ``validate-modules`` now validates all version numbers in documentation and argument spec. Version numbers for collections are checked for being valid semantic versioning version number strings."

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -397,7 +397,7 @@ class ConsoleCLI(CLI, cmd.Cmd):
 
     def module_args(self, module_name):
         in_path = module_loader.find_plugin(module_name)
-        oc, a, _, _ = plugin_docs.get_docstring(in_path, fragment_loader)
+        oc, a, _, _ = plugin_docs.get_docstring(in_path, fragment_loader, is_module=True)
         return list(oc['options'].keys())
 
     def run(self):

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -31,7 +31,7 @@ from ansible.plugins.loader import action_loader, fragment_loader
 from ansible.utils.collection_loader import AnsibleCollectionConfig
 from ansible.utils.collection_loader._collection_finder import _get_collection_name_from_path
 from ansible.utils.display import Display
-from ansible.utils.plugin_docs import BLACKLIST, get_docstring, get_versioned_doclink
+from ansible.utils.plugin_docs import BLACKLIST, untag_version_added, get_docstring, get_versioned_doclink
 
 display = Display()
 
@@ -321,11 +321,17 @@ class DocCLI(CLI):
     @staticmethod
     def _get_plugin_doc(plugin, loader, search_paths):
         # if the plugin lives in a non-python file (eg, win_X.ps1), require the corresponding python file for docs
-        filename = loader.find_plugin(plugin, mod_type='.py', ignore_deprecated=True, check_aliases=True)
-        if filename is None:
+        result = loader.find_plugin_with_context(plugin, mod_type='.py', ignore_deprecated=True, check_aliases=True)
+        if result is None:
             raise PluginNotFound('%s was not found in %s' % (plugin, search_paths))
+        plugin_name, filename = result.plugin_resolved_name, result.plugin_resolved_path
 
-        doc, plainexamples, returndocs, metadata = get_docstring(filename, fragment_loader, verbose=(context.CLIARGS['verbosity'] > 0))
+        collection_name = 'ansible.builtin'
+        if plugin_name.startswith('ansible_collections.'):
+            collection_name = '.'.join(plugin_name.split('.')[1:3])
+
+        doc, plainexamples, returndocs, metadata = get_docstring(
+            filename, fragment_loader, verbose=(context.CLIARGS['verbosity'] > 0), collection_name=collection_name)
 
         # If the plugin existed but did not have a DOCUMENTATION element and was not removed, it's
         # an error
@@ -346,6 +352,7 @@ class DocCLI(CLI):
             raise ValueError('%s did not contain a DOCUMENTATION attribute' % plugin)
 
         doc['filename'] = filename
+        untag_version_added(doc, '%s:' % (collection_name, ))
         return doc, plainexamples, returndocs, metadata
 
     @staticmethod

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -31,7 +31,7 @@ from ansible.plugins.loader import action_loader, fragment_loader
 from ansible.utils.collection_loader import AnsibleCollectionConfig
 from ansible.utils.collection_loader._collection_finder import _get_collection_name_from_path
 from ansible.utils.display import Display
-from ansible.utils.plugin_docs import BLACKLIST, untag_version_added, get_docstring, get_versioned_doclink
+from ansible.utils.plugin_docs import BLACKLIST, untag_versions, get_docstring, get_versioned_doclink
 
 display = Display()
 
@@ -218,7 +218,7 @@ class DocCLI(CLI):
             plugin_docs = {}
             for plugin in context.CLIARGS['args']:
                 try:
-                    doc, plainexamples, returndocs, metadata = DocCLI._get_plugin_doc(plugin, loader, search_paths)
+                    doc, plainexamples, returndocs, metadata = DocCLI._get_plugin_doc(plugin, plugin_type, loader, search_paths)
                 except PluginNotFound:
                     display.warning("%s %s not found in:\n%s\n" % (plugin_type, plugin, search_paths))
                     continue
@@ -281,8 +281,13 @@ class DocCLI(CLI):
         if filename is None:
             raise AnsibleError("unable to load {0} plugin named {1} ".format(plugin_type, plugin_name))
 
+        collection_name = 'ansible.builtin'
+        if plugin_name.startswith('ansible_collections.'):
+            collection_name = '.'.join(plugin_name.split('.')[1:3])
+
         try:
-            doc, __, __, metadata = get_docstring(filename, fragment_loader, verbose=(context.CLIARGS['verbosity'] > 0))
+            doc, __, __, metadata = get_docstring(filename, fragment_loader, verbose=(context.CLIARGS['verbosity'] > 0),
+                                                  collection_name=collection_name, is_module=(plugin_type == 'module'))
         except Exception:
             display.vvv(traceback.format_exc())
             raise AnsibleError(
@@ -319,7 +324,7 @@ class DocCLI(CLI):
         return clean_ns
 
     @staticmethod
-    def _get_plugin_doc(plugin, loader, search_paths):
+    def _get_plugin_doc(plugin, plugin_type, loader, search_paths):
         # if the plugin lives in a non-python file (eg, win_X.ps1), require the corresponding python file for docs
         result = loader.find_plugin_with_context(plugin, mod_type='.py', ignore_deprecated=True, check_aliases=True)
         if result is None:
@@ -331,7 +336,8 @@ class DocCLI(CLI):
             collection_name = '.'.join(plugin_name.split('.')[1:3])
 
         doc, plainexamples, returndocs, metadata = get_docstring(
-            filename, fragment_loader, verbose=(context.CLIARGS['verbosity'] > 0), collection_name=collection_name)
+            filename, fragment_loader, verbose=(context.CLIARGS['verbosity'] > 0),
+            collection_name=collection_name, is_module=(plugin_type == 'module'))
 
         # If the plugin existed but did not have a DOCUMENTATION element and was not removed, it's
         # an error
@@ -352,7 +358,7 @@ class DocCLI(CLI):
             raise ValueError('%s did not contain a DOCUMENTATION attribute' % plugin)
 
         doc['filename'] = filename
-        untag_version_added(doc, '%s:' % (collection_name, ))
+        untag_versions(doc, '%s:' % (collection_name, ), is_module=(plugin_type == 'module'))
         return doc, plainexamples, returndocs, metadata
 
     @staticmethod

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -374,7 +374,7 @@ class PluginLoader:
             if type_name in C.CONFIGURABLE_PLUGINS:
                 dstring = AnsibleLoader(getattr(module, 'DOCUMENTATION', ''), file_name=path).get_single_data()
                 if dstring:
-                    add_fragments(dstring, path, fragment_loader=fragment_loader)
+                    add_fragments(dstring, path, fragment_loader=fragment_loader, is_module=(type_name == 'module'))
 
                 if dstring and 'options' in dstring and isinstance(dstring['options'], dict):
                     C.config.initialize_plugin_configuration_definitions(type_name, name, dstring['options'])

--- a/lib/ansible/utils/plugin_docs.py
+++ b/lib/ansible/utils/plugin_docs.py
@@ -40,7 +40,7 @@ def merge_fragment(target, source):
         target[key] = value
 
 
-def tag_version_added(fragment, prefix):
+def tag_versions(fragment, prefix, is_module):
     def tag(option, prefix, recursive=True):
         if 'version_added' in option:
             option['version_added'] = '%s%s' % (prefix, option['version_added'])
@@ -55,7 +55,7 @@ def tag_version_added(fragment, prefix):
             tag(option, prefix)
 
 
-def untag_version_added(fragment, prefix):
+def untag_versions(fragment, prefix, is_module):
     def untag(option, prefix, recursive=True):
         if isinstance(option.get('version_added'), string_types) and to_native(option['version_added']).startswith(prefix):
             option['version_added'] = option['version_added'][len(prefix):]
@@ -70,7 +70,7 @@ def untag_version_added(fragment, prefix):
             untag(option, prefix)
 
 
-def add_fragments(doc, filename, fragment_loader):
+def add_fragments(doc, filename, fragment_loader, is_module=False):
 
     fragments = doc.pop('extends_documentation_fragment', [])
 
@@ -114,7 +114,7 @@ def add_fragments(doc, filename, fragment_loader):
         real_fragment_name = getattr(fragment_class, '_load_name')
         if real_fragment_name.startswith('ansible_collections.'):
             real_collection_name = '.'.join(real_fragment_name.split('.')[1:3])
-        tag_version_added(fragment, '%s:' % (real_collection_name, ))
+        tag_versions(fragment, '%s:' % (real_collection_name, ), is_module=is_module)
 
         if 'notes' in fragment:
             notes = fragment.pop('notes')
@@ -152,7 +152,7 @@ def add_fragments(doc, filename, fragment_loader):
         raise AnsibleError('unknown doc_fragment(s) in file {0}: {1}'.format(filename, to_native(', '.join(unknown_fragments))))
 
 
-def get_docstring(filename, fragment_loader, verbose=False, ignore_errors=False, collection_name=None):
+def get_docstring(filename, fragment_loader, verbose=False, ignore_errors=False, collection_name=None, is_module=False):
     """
     DOCUMENTATION can be extended using documentation fragments loaded by the PluginLoader from the doc_fragments plugins.
     """
@@ -162,10 +162,10 @@ def get_docstring(filename, fragment_loader, verbose=False, ignore_errors=False,
     if data.get('doc', False):
         # tag version_added
         if collection_name is not None:
-            tag_version_added(data['doc'], '%s:' % (collection_name, ))
+            tag_versions(data['doc'], '%s:' % (collection_name, ), is_module=is_module)
 
         # add fragments to documentation
-        add_fragments(data['doc'], filename, fragment_loader=fragment_loader)
+        add_fragments(data['doc'], filename, fragment_loader=fragment_loader, is_module=is_module)
 
     return data['doc'], data['plainexamples'], data['returndocs'], data['metadata']
 

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -41,10 +41,10 @@ import yaml
 from ansible import __version__ as ansible_version
 from ansible.executor.module_common import REPLACER_WINDOWS
 from ansible.module_utils.common._collections_compat import Mapping
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils._text import to_bytes, to_native
 from ansible.plugins.loader import fragment_loader
 from ansible.utils.collection_loader._collection_finder import _AnsibleCollectionFinder
-from ansible.utils.plugin_docs import BLACKLIST, add_fragments, get_docstring
+from ansible.utils.plugin_docs import BLACKLIST, tag_version_added, add_fragments, get_docstring
 from ansible.utils.version import SemanticVersion
 
 from .module_args import AnsibleModuleImportError, AnsibleModuleNotInitialized, get_argument_spec
@@ -258,9 +258,12 @@ class ModuleValidator(Validator):
         self.StrictVersion = StrictVersion
 
         self.collection = collection
+        self.collection_name = 'ansible.builtin'
         if self.collection:
             self.Version = SemanticVersion
             self.StrictVersion = SemanticVersion
+            collection_namespace_path, collection_name = os.path.split(self.collection)
+            self.collection_name = '%s.%s' % (os.path.basename(collection_namespace_path), collection_name)
         self.routing = routing
         self.collection_version = None
         if collection_version is not None:
@@ -873,6 +876,8 @@ class ModuleValidator(Validator):
         for error in errors:
             path = [str(p) for p in error.path]
 
+            local_error_code = getattr(error, 'ansible_error_code', error_code)
+
             if isinstance(error.data, dict):
                 error_message = humanize_error(error.data, error)
             else:
@@ -885,9 +890,27 @@ class ModuleValidator(Validator):
 
             self.reporter.error(
                 path=self.object_path,
-                code=error_code,
+                code=local_error_code,
                 msg='%s: %s' % (combined_path, error_message)
             )
+
+    @staticmethod
+    def _split_tagged_version(version_str):
+        if not isinstance(version_str, string_types):
+            raise ValueError('Tagged version must be string')
+        version_str = to_native(version_str)
+        if ':' not in version_str:
+            raise ValueError('Tagged version must have ":"')
+        return version_str.split(':', 1)
+
+    @staticmethod
+    def _extract_version_from_tag_for_msg(version_str):
+        if not isinstance(version_str, string_types):
+            return version_str
+        version_str = to_native(version_str)
+        if ':' not in version_str:
+            return version_str
+        return version_str.split(':', 1)[1]
 
     def _validate_docs(self):
         doc_info = self._get_docs()
@@ -964,6 +987,8 @@ class ModuleValidator(Validator):
                     doc_info['DOCUMENTATION']['lineno'],
                     self.name, 'DOCUMENTATION'
                 )
+                if doc:
+                    tag_version_added(doc, '%s:' % (self.collection_name, ))
                 for error in errors:
                     self.reporter.error(
                         path=self.object_path,
@@ -1021,7 +1046,7 @@ class ModuleValidator(Validator):
                             doc,
                             doc_schema(
                                 os.readlink(self.object_path).split('.')[0],
-                                version_added=not bool(self.collection),
+                                for_collection=bool(self.collection),
                                 deprecated_module=deprecated,
                             ),
                             'DOCUMENTATION',
@@ -1033,7 +1058,7 @@ class ModuleValidator(Validator):
                             doc,
                             doc_schema(
                                 self.object_name.split('.')[0],
-                                version_added=not bool(self.collection),
+                                for_collection=bool(self.collection),
                                 deprecated_module=deprecated,
                             ),
                             'DOCUMENTATION',
@@ -1083,7 +1108,8 @@ class ModuleValidator(Validator):
                 data, errors, traces = parse_yaml(doc_info['RETURN']['value'],
                                                   doc_info['RETURN']['lineno'],
                                                   self.name, 'RETURN')
-                self._validate_docs_schema(data, return_schema, 'RETURN', 'return-syntax-error')
+                self._validate_docs_schema(data, return_schema(for_collection=bool(self.collection)),
+                                           'RETURN', 'return-syntax-error')
 
                 for error in errors:
                     self.reporter.error(
@@ -1140,23 +1166,26 @@ class ModuleValidator(Validator):
     def _check_version_added(self, doc, existing_doc):
         version_added_raw = doc.get('version_added')
         try:
-            version_added = self.StrictVersion(str(doc.get('version_added', '0.0') or '0.0'))
+            version_added = self.StrictVersion(self._extract_version_from_tag_for_msg(str(doc.get('version_added', '0.0') or '0.0')))
         except ValueError:
             version_added = doc.get('version_added', '0.0')
-            if self._is_new_module() or version_added != 'historical':
-                self.reporter.error(
-                    path=self.object_path,
-                    code='module-invalid-version-added',
-                    msg='version_added is not a valid version number: %r' % version_added
-                )
+            if self._is_new_module() or version_added != 'ansible.builtin:historical':
+                # already reported during schema validation, except:
+                if version_added == 'ansible.builtin:historical':
+                    self.reporter.error(
+                        path=self.object_path,
+                        code='module-invalid-version-added',
+                        msg='version_added is not a valid version number: %r' % 'historical'
+                    )
                 return
 
         if existing_doc and str(version_added_raw) != str(existing_doc.get('version_added')):
             self.reporter.error(
                 path=self.object_path,
                 code='module-incorrect-version-added',
-                msg='version_added should be %r. Currently %r' % (existing_doc.get('version_added'),
-                                                                  version_added_raw)
+                msg='version_added should be %r. Currently %r' % (
+                    self._extract_version_from_tag_for_msg(existing_doc.get('version_added')),
+                    self._extract_version_from_tag_for_msg(version_added_raw))
             )
 
         if not self._is_new_module():
@@ -1170,7 +1199,8 @@ class ModuleValidator(Validator):
             self.reporter.error(
                 path=self.object_path,
                 code='module-incorrect-version-added',
-                msg='version_added should be %r. Currently %r' % (should_be, version_added_raw)
+                msg='version_added should be %r. Currently %r' % (
+                    should_be, self._extract_version_from_tag_for_msg(version_added_raw))
             )
 
     def _validate_ansible_module_call(self, docs):
@@ -1195,7 +1225,8 @@ class ModuleValidator(Validator):
             )
             return
 
-        self._validate_docs_schema(kwargs, ansible_module_kwargs_schema(), 'AnsibleModule', 'invalid-ansiblemodule-schema')
+        self._validate_docs_schema(kwargs, ansible_module_kwargs_schema(for_collection=bool(self.collection)),
+                                   'AnsibleModule', 'invalid-ansiblemodule-schema')
 
         self._validate_argument_spec(docs, spec, kwargs)
 
@@ -1535,16 +1566,8 @@ class ModuleValidator(Validator):
                                 msg=msg,
                             )
                     except ValueError:
-                        msg = "Argument '%s' in argument_spec" % arg
-                        if context:
-                            msg += " found in %s" % " -> ".join(context)
-                        msg += " has an invalid removed_in_version '%s'," % removed_in_version
-                        msg += " i.e. %s" % version_parser_error
-                        self.reporter.error(
-                            path=self.object_path,
-                            code=code_prefix + '-invalid-version',
-                            msg=msg,
-                        )
+                        # Has been caught in schema validation
+                        pass
 
                 if deprecated_aliases is not None:
                     for deprecated_alias in deprecated_aliases:
@@ -1563,17 +1586,8 @@ class ModuleValidator(Validator):
                                         msg=msg,
                                     )
                             except ValueError:
-                                msg = "Argument '%s' in argument_spec" % arg
-                                if context:
-                                    msg += " found in %s" % " -> ".join(context)
-                                msg += " has aliases '%s' with removal in invalid version '%s'," % (
-                                    deprecated_alias['name'], deprecated_alias['version'])
-                                msg += " i.e. %s" % version_parser_error
-                                self.reporter.error(
-                                    path=self.object_path,
-                                    code=code_prefix + '-invalid-version',
-                                    msg=msg,
-                                )
+                                # Has been caught in schema validation
+                                pass
 
             aliases = data.get('aliases', [])
             if arg in aliases:
@@ -1952,7 +1966,8 @@ class ModuleValidator(Validator):
 
         with CaptureStd():
             try:
-                existing_doc, dummy_examples, dummy_return, existing_metadata = get_docstring(self.base_module, fragment_loader, verbose=True)
+                existing_doc, dummy_examples, dummy_return, existing_metadata = get_docstring(
+                    self.base_module, fragment_loader, verbose=True, collection_name=self.collection_name)
                 existing_options = existing_doc.get('options', {}) or {}
             except AssertionError:
                 fragment = doc['extends_documentation_fragment']
@@ -2005,6 +2020,7 @@ class ModuleValidator(Validator):
                 continue
 
             if any(name in existing_options for name in names):
+                # The option already existed. Make sure version_added didn't change.
                 for name in names:
                     existing_version = existing_options.get(name, {}).get('version_added')
                     if existing_version:
@@ -2026,19 +2042,7 @@ class ModuleValidator(Validator):
                     str(details.get('version_added', '0.0'))
                 )
             except ValueError:
-                version_added = details.get('version_added', '0.0')
-                self.reporter.error(
-                    path=self.object_path,
-                    code='module-invalid-version-added-number',
-                    msg=('version_added for new option (%s) '
-                         'is not a valid version number: %r' %
-                         (option, version_added))
-                )
-                continue
-            except Exception:
-                # If there is any other exception it should have been caught
-                # in schema validation, so we won't duplicate errors by
-                # listing it again
+                # already reported during schema validation
                 continue
 
             if (strict_ansible_version != mod_version_added and

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -44,7 +44,7 @@ from ansible.module_utils.common._collections_compat import Mapping
 from ansible.module_utils._text import to_bytes, to_native
 from ansible.plugins.loader import fragment_loader
 from ansible.utils.collection_loader._collection_finder import _AnsibleCollectionFinder
-from ansible.utils.plugin_docs import BLACKLIST, tag_version_added, add_fragments, get_docstring
+from ansible.utils.plugin_docs import BLACKLIST, tag_versions, add_fragments, get_docstring
 from ansible.utils.version import SemanticVersion
 
 from .module_args import AnsibleModuleImportError, AnsibleModuleNotInitialized, get_argument_spec
@@ -988,7 +988,7 @@ class ModuleValidator(Validator):
                     self.name, 'DOCUMENTATION'
                 )
                 if doc:
-                    tag_version_added(doc, '%s:' % (self.collection_name, ))
+                    tag_versions(doc, '%s:' % (self.collection_name, ), is_module=True)
                 for error in errors:
                     self.reporter.error(
                         path=self.object_path,
@@ -1004,7 +1004,8 @@ class ModuleValidator(Validator):
                     missing_fragment = False
                     with CaptureStd():
                         try:
-                            get_docstring(self.path, fragment_loader, verbose=True)
+                            get_docstring(self.path, fragment_loader, verbose=True,
+                                          collection_name=self.collection_name, is_module=True)
                         except AssertionError:
                             fragment = doc['extends_documentation_fragment']
                             self.reporter.error(
@@ -1025,7 +1026,7 @@ class ModuleValidator(Validator):
                             )
 
                     if not missing_fragment:
-                        add_fragments(doc, self.object_path, fragment_loader=fragment_loader)
+                        add_fragments(doc, self.object_path, fragment_loader=fragment_loader, is_module=True)
 
                     if 'options' in doc and doc['options'] is None:
                         self.reporter.error(
@@ -1438,7 +1439,7 @@ class ModuleValidator(Validator):
 
         try:
             if not context:
-                add_fragments(docs, self.object_path, fragment_loader=fragment_loader)
+                add_fragments(docs, self.object_path, fragment_loader=fragment_loader, is_module=True)
         except Exception:
             # Cannot merge fragments
             return
@@ -1967,7 +1968,7 @@ class ModuleValidator(Validator):
         with CaptureStd():
             try:
                 existing_doc, dummy_examples, dummy_return, existing_metadata = get_docstring(
-                    self.base_module, fragment_loader, verbose=True, collection_name=self.collection_name)
+                    self.base_module, fragment_loader, verbose=True, collection_name=self.collection_name, is_module=True)
                 existing_options = existing_doc.get('options', {}) or {}
             except AssertionError:
                 fragment = doc['extends_documentation_fragment']

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -9,9 +9,13 @@ __metaclass__ = type
 import datetime
 import re
 
+from functools import partial
+
 from voluptuous import ALLOW_EXTRA, PREVENT_EXTRA, All, Any, Invalid, Length, Required, Schema, Self, ValueInvalid
 from ansible.module_utils.six import string_types
 from ansible.module_utils.common.collections import is_iterable
+from ansible.utils.version import SemanticVersion
+from distutils.version import StrictVersion
 
 from .utils import parse_isodate
 
@@ -26,6 +30,60 @@ any_string_types = Any(*string_types)
 #     "Michael DeHaan" - nop
 #     "Name (!UNKNOWN)" - For the few untraceable authors
 author_line = re.compile(r'^\w.*(\(@([\w-]+)\)|!UNKNOWN)(?![\w.])|^Ansible Core Team$|^Michael DeHaan$')
+
+
+def _add_ansible_error_code(exception, error_code):
+    setattr(exception, 'ansible_error_code', error_code)
+    return exception
+
+
+def semantic_version(v, error_code=None):
+    if not isinstance(v, string_types):
+        raise _add_ansible_error_code(Invalid('Semantic version must be a string'), error_code or 'collection-invalid-version')
+    try:
+        SemanticVersion(v)
+    except ValueError as e:
+        raise _add_ansible_error_code(Invalid(str(e)), error_code or 'collection-invalid-version')
+    return v
+
+
+def ansible_version(v, error_code=None):
+    # Assumes argument is a string or float
+    if 'historical' == v:
+        return v
+    try:
+        StrictVersion(str(v))
+    except ValueError as e:
+        raise _add_ansible_error_code(Invalid(str(e)), error_code or 'ansible-invalid-version')
+    return v
+
+
+TAGGED_VERSION_RE = re.compile('^([^.]+.[^.]+):(.*)$')
+
+
+def tagged_version(v, error_code=None):
+    if not isinstance(v, string_types):
+        # Should never happen to versions tagged by code
+        raise Invalid('Tagged version must be a string')
+    m = TAGGED_VERSION_RE.match(v)
+    if not m:
+        # Should never happen to versions tagged by code
+        raise Invalid('Tagged version does not match format')
+    collection = m.group(1)
+    version = m.group(2)
+    if collection != 'ansible.builtin':
+        semantic_version(version, error_code=error_code)
+    else:
+        ansible_version(version, error_code=error_code)
+    return v
+
+
+def version(for_collection=False, tagged='never', error_code=None):
+    if tagged == 'always':
+        return Any(partial(tagged_version, error_code=error_code))
+    if for_collection:
+        return Any(partial(semantic_version, error_code=error_code))
+    return All(Any(float, *string_types), partial(ansible_version, error_code=error_code))
 
 
 def is_callable(v):
@@ -109,7 +167,7 @@ def isodate(v):
     return v
 
 
-def argument_spec_schema():
+def argument_spec_schema(for_collection):
     any_string_types = Any(*string_types)
     schema = {
         any_string_types: {
@@ -125,7 +183,7 @@ def argument_spec_schema():
             'no_log': bool,
             'aliases': Any(list_string_types, tuple(list_string_types)),
             'apply_defaults': bool,
-            'removed_in_version': Any(float, *string_types),
+            'removed_in_version': version(for_collection),
             'removed_at_date': Any(isodate),
             'options': Self,
             'deprecated_aliases': Any([Any(
@@ -135,7 +193,7 @@ def argument_spec_schema():
                 },
                 {
                     Required('name'): Any(*string_types),
-                    Required('version'): Any(float, *string_types),
+                    Required('version'): version(for_collection),
                 },
             )]),
         }
@@ -150,9 +208,9 @@ def argument_spec_schema():
     return Schema(schemas)
 
 
-def ansible_module_kwargs_schema():
+def ansible_module_kwargs_schema(for_collection):
     schema = {
-        'argument_spec': argument_spec_schema(),
+        'argument_spec': argument_spec_schema(for_collection),
         'bypass_checks': bool,
         'no_log': bool,
         'check_invalid_arguments': Any(None, bool),
@@ -172,48 +230,49 @@ json_value = Schema(Any(
 ))
 
 
-suboption_schema = Schema(
-    {
-        Required('description'): Any(list_string_types, *string_types),
-        'required': bool,
-        'choices': list,
-        'aliases': Any(list_string_types),
-        'version_added': Any(float, *string_types),
-        'default': json_value,
-        # Note: Types are strings, not literal bools, such as True or False
-        'type': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
-        # in case of type='list' elements define type of individual item in list
-        'elements': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
-        # Recursive suboptions
-        'suboptions': Any(None, *list({str_type: Self} for str_type in string_types)),
-    },
-    extra=PREVENT_EXTRA
-)
+def list_dict_option_schema(for_collection):
+    suboption_schema = Schema(
+        {
+            Required('description'): Any(list_string_types, *string_types),
+            'required': bool,
+            'choices': list,
+            'aliases': Any(list_string_types),
+            'version_added': version(for_collection, tagged='always', error_code='option-invalid-version-added'),
+            'default': json_value,
+            # Note: Types are strings, not literal bools, such as True or False
+            'type': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
+            # in case of type='list' elements define type of individual item in list
+            'elements': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
+            # Recursive suboptions
+            'suboptions': Any(None, *list({str_type: Self} for str_type in string_types)),
+        },
+        extra=PREVENT_EXTRA
+    )
 
-# This generates list of dicts with keys from string_types and suboption_schema value
-# for example in Python 3: {str: suboption_schema}
-list_dict_suboption_schema = [{str_type: suboption_schema} for str_type in string_types]
+    # This generates list of dicts with keys from string_types and suboption_schema value
+    # for example in Python 3: {str: suboption_schema}
+    list_dict_suboption_schema = [{str_type: suboption_schema} for str_type in string_types]
 
-option_schema = Schema(
-    {
-        Required('description'): Any(list_string_types, *string_types),
-        'required': bool,
-        'choices': list,
-        'aliases': Any(list_string_types),
-        'version_added': Any(float, *string_types),
-        'default': json_value,
-        'suboptions': Any(None, *list_dict_suboption_schema),
-        # Note: Types are strings, not literal bools, such as True or False
-        'type': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
-        # in case of type='list' elements define type of individual item in list
-        'elements': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
-    },
-    extra=PREVENT_EXTRA
-)
+    option_schema = Schema(
+        {
+            Required('description'): Any(list_string_types, *string_types),
+            'required': bool,
+            'choices': list,
+            'aliases': Any(list_string_types),
+            'version_added': version(for_collection, tagged='always', error_code='option-invalid-version-added'),
+            'default': json_value,
+            'suboptions': Any(None, *list_dict_suboption_schema),
+            # Note: Types are strings, not literal bools, such as True or False
+            'type': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
+            # in case of type='list' elements define type of individual item in list
+            'elements': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
+        },
+        extra=PREVENT_EXTRA
+    )
 
-# This generates list of dicts with keys from string_types and option_schema value
-# for example in Python 3: {str: option_schema}
-list_dict_option_schema = [{str_type: option_schema} for str_type in string_types]
+    # This generates list of dicts with keys from string_types and option_schema value
+    # for example in Python 3: {str: option_schema}
+    return [{str_type: option_schema} for str_type in string_types]
 
 
 def return_contains(v):
@@ -228,66 +287,71 @@ def return_contains(v):
     return v
 
 
-return_contains_schema = Any(
-    All(
-        Schema(
-            {
-                Required('description'): Any(list_string_types, *string_types),
-                'returned': Any(*string_types),  # only returned on top level
-                Required('type'): Any('bool', 'complex', 'dict', 'float', 'int', 'list', 'str'),
-                'version_added': Any(float, *string_types),
-                'sample': json_value,
-                'example': json_value,
-                'contains': Any(None, *list({str_type: Self} for str_type in string_types)),
-                # in case of type='list' elements define type of individual item in list
-                'elements': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
-            }
-        ),
-        Schema(return_contains)
-    ),
-    Schema(type(None)),
-)
-
-# This generates list of dicts with keys from string_types and return_contains_schema value
-# for example in Python 3: {str: return_contains_schema}
-list_dict_return_contains_schema = [{str_type: return_contains_schema} for str_type in string_types]
-
-return_schema = Any(
-    All(
-        Schema(
-            {
-                any_string_types: {
+def return_schema(for_collection):
+    return_contains_schema = Any(
+        All(
+            Schema(
+                {
                     Required('description'): Any(list_string_types, *string_types),
-                    Required('returned'): Any(*string_types),
+                    'returned': Any(*string_types),  # only returned on top level
                     Required('type'): Any('bool', 'complex', 'dict', 'float', 'int', 'list', 'str'),
-                    'version_added': Any(float, *string_types),
+                    'version_added': version(for_collection, error_code='return-invalid-version-added'),
                     'sample': json_value,
                     'example': json_value,
-                    'contains': Any(None, *list_dict_return_contains_schema),
+                    'contains': Any(None, *list({str_type: Self} for str_type in string_types)),
                     # in case of type='list' elements define type of individual item in list
                     'elements': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
                 }
-            }
+            ),
+            Schema(return_contains)
         ),
-        Schema({any_string_types: return_contains})
-    ),
-    Schema(type(None)),
-)
+        Schema(type(None)),
+    )
+
+    # This generates list of dicts with keys from string_types and return_contains_schema value
+    # for example in Python 3: {str: return_contains_schema}
+    list_dict_return_contains_schema = [{str_type: return_contains_schema} for str_type in string_types]
+
+    return Any(
+        All(
+            Schema(
+                {
+                    any_string_types: {
+                        Required('description'): Any(list_string_types, *string_types),
+                        Required('returned'): Any(*string_types),
+                        Required('type'): Any('bool', 'complex', 'dict', 'float', 'int', 'list', 'str'),
+                        'version_added': version(for_collection, error_code='return-invalid-version-added'),
+                        'sample': json_value,
+                        'example': json_value,
+                        'contains': Any(None, *list_dict_return_contains_schema),
+                        # in case of type='list' elements define type of individual item in list
+                        'elements': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
+                    }
+                }
+            ),
+            Schema({any_string_types: return_contains})
+        ),
+        Schema(type(None)),
+    )
 
 
-deprecation_schema = Schema(
-    {
-        # Only list branches that are deprecated or may have docs stubs in
-        # Deprecation cycle changed at 2.4 (though not retroactively)
-        # 2.3 -> removed_in: "2.5" + n for docs stub
-        # 2.4 -> removed_in: "2.8" + n for docs stub
-        Required('removed_in'): Any("2.2", "2.3", "2.4", "2.5", "2.6", "2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14"),
-        Required('why'): Any(*string_types),
-        Required('alternative'): Any(*string_types),
-        'removed': Any(True),
-    },
-    extra=PREVENT_EXTRA
-)
+def deprecation_schema(for_collection):
+    removed_in_version = Any("2.2", "2.3", "2.4", "2.5", "2.6", "2.8", "2.9", "2.10", "2.11", "2.12", "2.13", "2.14")
+    if for_collection:
+        removed_in_version = version(for_collection)
+    return Schema(
+        {
+            # Only list branches that are deprecated or may have docs stubs in
+            # Deprecation cycle changed at 2.4 (though not retroactively)
+            # 2.3 -> removed_in: "2.5" + n for docs stub
+            # 2.4 -> removed_in: "2.8" + n for docs stub
+            Required('removed_in'): removed_in_version,
+            Required('why'): Any(*string_types),
+            Required('alternative'): Any(*string_types),
+            'removed': Any(True),
+        },
+        extra=PREVENT_EXTRA
+    )
 
 
 def author(value):
@@ -301,7 +365,7 @@ def author(value):
             raise Invalid("Invalid author")
 
 
-def doc_schema(module_name, version_added=True, deprecated_module=False):
+def doc_schema(module_name, for_collection=False, deprecated_module=False):
 
     if module_name.startswith('_'):
         module_name = module_name[1:]
@@ -315,19 +379,21 @@ def doc_schema(module_name, version_added=True, deprecated_module=False):
         'seealso': Any(None, seealso_schema),
         'requirements': list_string_types,
         'todo': Any(None, list_string_types, *string_types),
-        'options': Any(None, *list_dict_option_schema),
+        'options': Any(None, *list_dict_option_schema(for_collection)),
         'extends_documentation_fragment': Any(list_string_types, *string_types)
     }
 
-    if version_added:
-        doc_schema_dict[Required('version_added')] = Any(float, *string_types)
-    else:
+    if for_collection:
         # Optional
-        doc_schema_dict['version_added'] = Any(float, *string_types)
+        doc_schema_dict['version_added'] = version(
+            for_collection=True, tagged='always', error_code='module-invalid-version-added')
+    else:
+        doc_schema_dict[Required('version_added')] = version(
+            for_collection=False, tagged='always', error_code='module-invalid-version-added')
 
     if deprecated_module:
         deprecation_required_scheme = {
-            Required('deprecated'): Any(deprecation_schema),
+            Required('deprecated'): Any(deprecation_schema(for_collection)),
         }
 
         doc_schema_dict.update(deprecation_required_scheme)


### PR DESCRIPTION
##### SUMMARY
This is an extension of a subset of #69291 that does not need additional ansible-test infrastructure.

1) This PR adds "version tagging" for version_added:
    a) Every `version_added` version number in a changelog fragment is prefixed with `namespace.collection:` (with `ansible.builtin:` for ansible-base), so it is known where the `version_added` comes from and to which collection (or ansible-base) it refers.
    b) `ansible-doc` strips the current collection name (resp. `ansible.builtin` for ansible-base) from `version_added`, so that the source is only shown for `version_added` coming from doc fragments from *other* collections.
    c) See https://github.com/ansible/community/wiki/Version-numbers-for-documentation-deprecation-removal-in-the-collection-world for some background.
2) This PR also modifies ansible-test that it behaves well w.r.t. these tags.
    a) It receives `version_added` with these tags for doc fragments, so some change is needed.
    b) I also added a general validation of version numbers: deprecation version numbers must be valid `StrictVersion`s (for ansible-base) or `SemanticVersion`s (for collections); `verison_added` must be a valid `StrictVersion` or `SemanticVersion` depending on where the version number is from.
3) To avoid introducing new error codes for existing errors (invalid `version_added` version, invalid semantic versioning collection deprecation version, etc.), I added a mechanism to allow schema validation to override the error code used when validating something with that schema. (Search for `ansible_error_code` in this PR.)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/cli/doc.py
lib/ansible/utils/plugin_docs.py
test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
