### PR TITLE
Fix docs return formatting.

### DIFF
--- a/lib/ansible/modules/package_facts.py
+++ b/lib/ansible/modules/package_facts.py
@@ -116,7 +116,7 @@ ansible_facts:
             ...
           }
         }
-      sample_rpm:
+        # Sample rpm
         {
           "packages": {
             "kernel": [
@@ -183,7 +183,7 @@ ansible_facts:
             ],
           }
         }
-      sample_deb:
+        # Sample deb
         {
           "packages": {
             "libbz2-1.0": [

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -177,7 +177,6 @@ lib/ansible/modules/dpkg_selections.py validate-modules:doc-required-mismatch
 lib/ansible/modules/package_facts.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/package_facts.py validate-modules:doc-missing-type
 lib/ansible/modules/package_facts.py validate-modules:parameter-list-no-elements
-lib/ansible/modules/package_facts.py validate-modules:return-syntax-error
 lib/ansible/modules/rpm_key.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/yum.py pylint:blacklisted-name
 lib/ansible/modules/yum.py validate-modules:doc-default-does-not-match-spec


### PR DESCRIPTION
This gets rid of the unknown field names in the return data.
It allows the plugin return docs to format under the new docs pipeline.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
* modules/package_facts.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
