### PR TITLE
Pin Docker version at 19.03

### DIFF
--- a/test/integration/targets/incidental_setup_docker/tasks/Suse.yml
+++ b/test/integration/targets/incidental_setup_docker/tasks/Suse.yml
@@ -1,4 +1,4 @@
-- name: Install docker 17
+- name: Install docker
   zypper:
     name: "{{ docker_packages }}"
     force: yes

--- a/test/integration/targets/incidental_setup_docker/vars/Debian.yml
+++ b/test/integration/targets/incidental_setup_docker/vars/Debian.yml
@@ -1,3 +1,7 @@
+docker_packages:
+  - docker-ce=5:19.03.0*
+  - docker-ce-cli=5:19.03.0*
+
 docker_prereq_packages:
   - apt-transport-https
   - ca-certificates

--- a/test/integration/targets/incidental_setup_docker/vars/Fedora.yml
+++ b/test/integration/targets/incidental_setup_docker/vars/Fedora.yml
@@ -1,4 +1,5 @@
 docker_prereq_packages: []
 
 docker_packages:
-  - docker-ce
+  - docker-ce-19.03.1
+  - docker-ce-cli-19.03.1

--- a/test/integration/targets/incidental_setup_docker/vars/RedHat-7.yml
+++ b/test/integration/targets/incidental_setup_docker/vars/RedHat-7.yml
@@ -4,5 +4,9 @@ docker_prereq_packages:
   - lvm2
   - libseccomp
 
+docker_packages:
+  - docker-ce-19.03.1
+  - docker-ce-cli-19.03.1
+
 docker_pip_extra_packages:
   - requests==2.6.0

--- a/test/integration/targets/incidental_setup_docker/vars/Suse.yml
+++ b/test/integration/targets/incidental_setup_docker/vars/Suse.yml
@@ -1,2 +1,2 @@
 docker_packages:
-  - docker>=17
+  - docker=19.03.1_ce


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This was done for RHEL 8 only before. Due to a recent Docker bug (https://github.com/docker/cli/issues/2533), all our Docker related tests in CI are failing. Pin the Docker version to prevent spontaneous failures in the future.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/incidental_setup_docker`