### PR TITLE
file: module should warn in check_mode when path and owner/group don't exist

### DIFF
--- a/changelogs/fragments/69640-file_must_fail_when_path_and_owner_or_group_dont_exist.yml
+++ b/changelogs/fragments/69640-file_must_fail_when_path_and_owner_or_group_dont_exist.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- file - the module must fail in check_mode when path and owner/group don't exist (https://github.com/ansible/ansible/issues/67307).

--- a/changelogs/fragments/69640-file_must_fail_when_path_and_owner_or_group_dont_exist.yml
+++ b/changelogs/fragments/69640-file_must_fail_when_path_and_owner_or_group_dont_exist.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- file - the module must fail in check_mode when path and owner/group don't exist (https://github.com/ansible/ansible/issues/67307).

--- a/changelogs/fragments/69640-file_should_warn_when_path_and_owner_or_group_dont_exist.yml
+++ b/changelogs/fragments/69640-file_should_warn_when_path_and_owner_or_group_dont_exist.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- file - the module should warn in check_mode when path an owner/group don't exist (https://github.com/ansible/ansible/issues/67307).

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -710,7 +710,7 @@ def ensure_symlink(path, src, follow, force, timestamps):
     diff = initial_diff(path, 'link', prev_state)
     changed = False
 
-    if prev_state == 'absent':
+    if prev_state in ('hard', 'file', 'directory', 'absent'):
         changed = True
     elif prev_state == 'link':
         b_old_src = os.readlink(b_path)
@@ -718,22 +718,6 @@ def ensure_symlink(path, src, follow, force, timestamps):
             diff['before']['src'] = to_native(b_old_src, errors='strict')
             diff['after']['src'] = src
             changed = True
-    elif prev_state == 'hard':
-        changed = True
-        if not force:
-            raise AnsibleModuleError(results={'msg': 'Cannot link because a hard link exists at destination',
-                                              'dest': path, 'src': src})
-    elif prev_state == 'file':
-        changed = True
-        if not force:
-            raise AnsibleModuleError(results={'msg': 'Cannot link because a file exists at destination',
-                                              'dest': path, 'src': src})
-    elif prev_state == 'directory':
-        changed = True
-        if os.path.exists(b_path):
-            if not force:
-                raise AnsibleModuleError(results={'msg': 'Cannot link because a file exists at destination',
-                                                  'dest': path, 'src': src})
     else:
         raise AnsibleModuleError(results={'msg': 'unexpected position reached', 'dest': path, 'src': src})
 

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -881,7 +881,7 @@ def check_group_exists(module, group):
         try:
             getgrnam(group).gr_gid
         except KeyError:
-            module.fail_json(msg='failed to look up group %s. Create group up to this point in real play' % group)
+            module.warn('failed to look up group %s. Create group up to this point in real play' % group)
 
 
 def main():

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -862,12 +862,12 @@ def check_owner_exists(module, owner):
         try:
             getpwuid(uid).pw_name
         except KeyError:
-            module.fail_json(msg='failed to look up user with uid %s' % uid)
+            module.warn('failed to look up user with uid %s. Create user up to this point in real play' % uid)
     except ValueError:
         try:
             getpwnam(owner).pw_uid
         except KeyError:
-            module.fail_json(msg='failed to look up user %s' % owner)
+            module.warn('failed to look up user %s. Create user up to this point in real play' % owner)
 
 
 def check_group_exists(module, group):
@@ -876,12 +876,12 @@ def check_group_exists(module, group):
         try:
             getgrgid(gid).gr_name
         except KeyError:
-            module.fail_json(msg='failed to look up group with gid %s' % gid)
+            module.warn('failed to look up group with gid %s. Create group up to this point in real play' % gid)
     except ValueError:
         try:
             getgrnam(group).gr_gid
         except KeyError:
-            module.fail_json(msg='failed to look up group %s' % group)
+            module.fail_json(msg='failed to look up group %s. Create group up to this point in real play' % group)
 
 
 def main():

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -919,7 +919,7 @@ def main():
     path = params['path']
     src = params['src']
 
-    if state != 'absent' and module.check_mode:
+    if module.check_mode and state != 'absent':
         file_args = module.load_file_common_arguments(module.params)
         if file_args['owner']:
             check_owner_exists(module, file_args['owner'])

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -919,7 +919,7 @@ def main():
     path = params['path']
     src = params['src']
 
-    if state != 'absent':
+    if state != 'absent' and module.check_mode:
         file_args = module.load_file_common_arguments(module.params)
         if file_args['owner']:
             check_owner_exists(module, file_args['owner'])

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -124,6 +124,16 @@
       - "file_attributes_result_4 is not changed"
   when: file_attributes_result_4 is changed
 
+- name: create user
+  user:
+    name: test1
+    uid: 1234
+
+- name: create group
+  group:
+    name: test1
+    gid: 1234
+
 - name: change ownership and group
   file: path={{output_dir}}/baz.txt owner=1234 group=1234
 
@@ -310,6 +320,11 @@
   assert:
     that:
       - "file9_result.uid != 1234"
+
+- name: create user
+  user:
+    name: test2
+    uid: 1235
 
 - name: change the ownership of a directory with recurse=yes
   file: path={{output_dir}}/foobar owner=1235 recurse=yes
@@ -519,6 +534,53 @@
   assert:
     that:
     - result.mode == '0444'
+
+# https://github.com/ansible/ansible/issues/67307
+# Test the module fails in check_mode when directory and owner/group do not exist
+- name: owner does not exist in check_mode
+  file:
+    path: /nonexistent
+    owner: nonexistent
+  check_mode: yes
+  ignore_errors: yes
+  register: owner_no_exist
+
+- name: owner does not exist in check_mode, using uid
+  file:
+    path: /nonexistent
+    owner: 1111111
+  check_mode: yes
+  ignore_errors: yes
+  register: owner_uid_no_exist
+
+- name: group does not exist in check_mode
+  file:
+    path: /nonexistent
+    state: directory
+    group: nonexistent
+  check_mode: yes
+  ignore_errors: yes
+  register: group_no_exist
+
+- name: group does not exist in check_mode, using gid
+  file:
+    path: /nonexistent
+    state: directory
+    group: 1111111
+  check_mode: yes
+  ignore_errors: yes
+  register: group_gid_no_exist
+
+- assert:
+    that:
+    - owner_no_exist is failed
+    - owner_no_exist.msg is search('failed to look up user')
+    - owner_uid_no_exist is failed
+    - owner_uid_no_exist is search('failed to look up user with uid')
+    - group_no_exist is failed
+    - group_no_exist.msg is search('failed to look up group')
+    - group_gid_no_exist is failed
+    - group_gid_no_exist.msg is search('failed to look up group with gid')
 
 # https://github.com/ansible/ansible/issues/50943
 # Need to use /tmp as nobody can't access output_dir at all

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -537,42 +537,49 @@
 
 # https://github.com/ansible/ansible/issues/67307
 # Test the module fails in check_mode when directory and owner/group do not exist
+# I don't use state=touch here intentionally to fail and catch warnings
 - name: owner does not exist in check_mode
   file:
-    path: '{{ output_dir }}/nonexistent'
+    path: '/tmp/nonexistent'
     owner: nonexistent
   check_mode: yes
   register: owner_no_exist
+  ignore_errors: yes
 
+# I don't use state=touch here intentionally to fail and catch warnings
 - name: owner does not exist in check_mode, using uid
   file:
-    path: '{{ output_dir }}/nonexistent'
+    path: '/tmp/nonexistent'
     owner: '1111111'
+    state: touch
   check_mode: yes
+  ignore_errors: yes
   register: owner_uid_no_exist
 
+# I don't use state=touch here intentionally to fail and catch warnings
 - name: group does not exist in check_mode
   file:
-    path: '{{ output_dir }}/nonexistent'
-    state: directory
+    path: '/tmp/nonexistent'
     group: nonexistent
   check_mode: yes
   register: group_no_exist
+  ignore_errors: yes
 
+# I don't use state=touch here intentionally to fail and catch warnings
 - name: group does not exist in check_mode, using gid
   file:
-    path: '{{ output_dir }}/nonexistent'
-    state: directory
+    path: '/tmp/nonexistent'
     group: '1111111'
   check_mode: yes
   register: group_gid_no_exist
+  ignore_errors: yes
 
 - assert:
     that:
-    - owner_no_exist.msg is search('failed to look up user')
-    - owner_uid_no_exist.msg is search('failed to look up user with uid')
-    - group_no_exist.msg is search('failed to look up group')
-    - group_gid_no_exist.msg is search('failed to look up group with gid')
+    - owner_no_exist.warnings[0] is search('failed to look up user')
+    - owner_uid_no_exist.warnings[0] is search('failed to look up user with uid')
+    - group_no_exist.warnings[0] is search('failed to look up group')
+    - group_gid_no_exist.warnings[0] is search('failed to look up group with gid')
 
 # https://github.com/ansible/ansible/issues/50943
 # Need to use /tmp as nobody can't access output_dir at all

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -550,7 +550,6 @@
     path: /nonexistent
     owner: 1111111
   check_mode: yes
-  ignore_errors: yes
   register: owner_uid_no_exist
 
 - name: group does not exist in check_mode
@@ -559,7 +558,6 @@
     state: directory
     group: nonexistent
   check_mode: yes
-  ignore_errors: yes
   register: group_no_exist
 
 - name: group does not exist in check_mode, using gid
@@ -568,18 +566,13 @@
     state: directory
     group: 1111111
   check_mode: yes
-  ignore_errors: yes
   register: group_gid_no_exist
 
 - assert:
     that:
-    - owner_no_exist is failed
     - owner_no_exist.msg is search('failed to look up user')
-    - owner_uid_no_exist is failed
     - owner_uid_no_exist is search('failed to look up user with uid')
-    - group_no_exist is failed
     - group_no_exist.msg is search('failed to look up group')
-    - group_gid_no_exist is failed
     - group_gid_no_exist.msg is search('failed to look up group with gid')
 
 # https://github.com/ansible/ansible/issues/50943

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -546,6 +546,19 @@
   register: owner_no_exist
   ignore_errors: yes
 
+- name: create owner
+  user:
+    name: nonexistent
+
+# I don't use state=touch here intentionally to fail and catch warnings
+- name: owner exist in check_mode
+  file:
+    path: '/tmp/nonexistent'
+    owner: nonexistent
+  check_mode: yes
+  register: owner_exists
+  ignore_errors: yes
+
 # I don't use state=touch here intentionally to fail and catch warnings
 - name: owner does not exist in check_mode, using uid
   file:
@@ -556,6 +569,21 @@
   ignore_errors: yes
   register: owner_uid_no_exist
 
+- name: create owner using uid
+  user:
+    name: test_uid
+    uid: 1111111
+
+# I don't use state=touch here intentionally to fail and catch warnings
+- name: owner exists in check_mode, using uid
+  file:
+    path: '/tmp/nonexistent'
+    owner: '1111111'
+    state: touch
+  check_mode: yes
+  ignore_errors: yes
+  register: owner_uid_exists
+
 # I don't use state=touch here intentionally to fail and catch warnings
 - name: group does not exist in check_mode
   file:
@@ -563,6 +591,19 @@
     group: nonexistent
   check_mode: yes
   register: group_no_exist
+  ignore_errors: yes
+
+- name: create group
+  group:
+    name: nonexistent1
+
+# I don't use state=touch here intentionally to fail and catch warnings
+- name: group exists in check_mode
+  file:
+    path: '/tmp/nonexistent'
+    group: nonexistent1
+  check_mode: yes
+  register: group_exists
   ignore_errors: yes
 
 # I don't use state=touch here intentionally to fail and catch warnings
@@ -574,12 +615,30 @@
   register: group_gid_no_exist
   ignore_errors: yes
 
+- name: create group with gid
+  group:
+    name: test_gid
+    gid: 1111112
+
+# I don't use state=touch here intentionally to fail and catch warnings
+- name: group exists in check_mode, using gid
+  file:
+    path: '/tmp/nonexistent'
+    group: '1111112'
+  check_mode: yes
+  register: group_gid_exists
+  ignore_errors: yes
+
 - assert:
     that:
     - owner_no_exist.warnings[0] is search('failed to look up user')
     - owner_uid_no_exist.warnings[0] is search('failed to look up user with uid')
     - group_no_exist.warnings[0] is search('failed to look up group')
     - group_gid_no_exist.warnings[0] is search('failed to look up group with gid')
+    - owner_exists.warnings is not defined
+    - owner_uid_exists.warnings is not defined
+    - group_exists.warnings is not defined
+    - group_gid_exists.warnings is not defined
 
 # https://github.com/ansible/ansible/issues/50943
 # Need to use /tmp as nobody can't access output_dir at all

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -539,22 +539,21 @@
 # Test the module fails in check_mode when directory and owner/group do not exist
 - name: owner does not exist in check_mode
   file:
-    path: /nonexistent
+    path: '{{ output_dir }}/nonexistent'
     owner: nonexistent
   check_mode: yes
-  ignore_errors: yes
   register: owner_no_exist
 
 - name: owner does not exist in check_mode, using uid
   file:
-    path: /nonexistent
+    path: '{{ output_dir }}/nonexistent'
     owner: 1111111
   check_mode: yes
   register: owner_uid_no_exist
 
 - name: group does not exist in check_mode
   file:
-    path: /nonexistent
+    path: '{{ output_dir }}/nonexistent'
     state: directory
     group: nonexistent
   check_mode: yes
@@ -562,7 +561,7 @@
 
 - name: group does not exist in check_mode, using gid
   file:
-    path: /nonexistent
+    path: '{{ output_dir }}/nonexistent'
     state: directory
     group: 1111111
   check_mode: yes

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -547,7 +547,7 @@
 - name: owner does not exist in check_mode, using uid
   file:
     path: '{{ output_dir }}/nonexistent'
-    owner: 1111111
+    owner: '1111111'
   check_mode: yes
   register: owner_uid_no_exist
 
@@ -563,7 +563,7 @@
   file:
     path: '{{ output_dir }}/nonexistent'
     state: directory
-    group: 1111111
+    group: '1111111'
   check_mode: yes
   register: group_gid_no_exist
 

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -563,8 +563,7 @@
 - name: owner does not exist in check_mode, using uid
   file:
     path: '/tmp/nonexistent'
-    owner: '1111111'
-    state: touch
+    owner: '111111'
   check_mode: yes
   ignore_errors: yes
   register: owner_uid_no_exist
@@ -572,13 +571,13 @@
 - name: create owner using uid
   user:
     name: test_uid
-    uid: 1111111
+    uid: 111111
 
 # I don't use state=touch here intentionally to fail and catch warnings
 - name: owner exists in check_mode, using uid
   file:
     path: '/tmp/nonexistent'
-    owner: '1111111'
+    owner: '111111'
     state: touch
   check_mode: yes
   ignore_errors: yes
@@ -588,7 +587,7 @@
 - name: group does not exist in check_mode
   file:
     path: '/tmp/nonexistent'
-    group: nonexistent
+    group: nonexistent1
   check_mode: yes
   register: group_no_exist
   ignore_errors: yes
@@ -610,7 +609,7 @@
 - name: group does not exist in check_mode, using gid
   file:
     path: '/tmp/nonexistent'
-    group: '1111111'
+    group: '111112'
   check_mode: yes
   register: group_gid_no_exist
   ignore_errors: yes
@@ -618,13 +617,13 @@
 - name: create group with gid
   group:
     name: test_gid
-    gid: 1111112
+    gid: 111112
 
 # I don't use state=touch here intentionally to fail and catch warnings
 - name: group exists in check_mode, using gid
   file:
     path: '/tmp/nonexistent'
-    group: '1111112'
+    group: '111112'
   check_mode: yes
   register: group_gid_exists
   ignore_errors: yes

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -571,7 +571,7 @@
 - assert:
     that:
     - owner_no_exist.msg is search('failed to look up user')
-    - owner_uid_no_exist is search('failed to look up user with uid')
+    - owner_uid_no_exist.msg is search('failed to look up user with uid')
     - group_no_exist.msg is search('failed to look up group')
     - group_gid_no_exist.msg is search('failed to look up group with gid')
 


### PR DESCRIPTION
##### SUMMARY 
Fixes: #67307
Copied from https://github.com/ansible/ansible/pull/67995

This PR doesn't solve the issue but the issue reports wrong behavior.
See my comment under the description.

When we run file module in check_mode and owner/group doesn't exist at the same time,
it returns True but if we run the module in the actual mode it fails (and it's expected). See examples in the issue.

Ideally, the misleading behavior should be fixed but not to break current pipelines, at least, users should be warned that their systems are not matched the real conditions.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
```file.py```
