### PR TITLE
intersight_info and intersight_facts routed to cisco.intersight

### DIFF
--- a/lib/ansible/config/routing.yml
+++ b/lib/ansible/config/routing.yml
@@ -2790,8 +2790,6 @@ plugin_routing:
       redirect: community.general.hponcfg
     imc_rest:
       redirect: community.general.imc_rest
-    intersight_info:
-      redirect: community.general.intersight_info
     ipmi_boot:
       redirect: community.general.ipmi_boot
     ipmi_power:
@@ -5631,7 +5629,9 @@ plugin_routing:
     asa_command:
       redirect: cisco.asa.asa_command
     intersight_facts:
-      redirect: cisco.intersight.intersight_facts
+      redirect: cisco.intersight.intersight_info
+    intersight_info:
+      redirect: community.general.intersight_info
     intersight_rest_api:
       redirect: cisco.intersight.intersight_rest_api
     ios_l3_interfaces:


### PR DESCRIPTION
##### SUMMARY
intersight_info and intersight_facts routed to cisco.intersight.intersight_info
facts was renamed info, so no plans to have intersight_facts in cisco.intersight collection
##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
cisco.intersight collection routing

##### ADDITIONAL INFORMATION
n/a
