### PR TITLE
Strip no log values from module response keys

### DIFF
--- a/changelogs/fragments/68400-strip-no-log-values-from-keys.yml
+++ b/changelogs/fragments/68400-strip-no-log-values-from-keys.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Strip no log values from module response keys (https://github.com/ansible/ansible/issues/68400)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -410,8 +410,9 @@ def remove_values(value, no_log_strings):
         old_data, new_data = deferred_removals.popleft()
         if isinstance(new_data, Mapping):
             for old_key, old_elem in old_data.items():
+                new_key = _remove_values_conditions(old_key, no_log_strings, deferred_removals)
                 new_elem = _remove_values_conditions(old_elem, no_log_strings, deferred_removals)
-                new_data[old_key] = new_elem
+                new_data[new_key] = new_elem
         else:
             for elem in old_data:
                 new_elem = _remove_values_conditions(elem, no_log_strings, deferred_removals)

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -544,6 +544,18 @@
     that:
       - result.json.json[0] == 'JSON Test Pattern pass1'
 
+- name: Make request that includes password in JSON keys
+  uri:
+    url: "https://{{ httpbin_host}}/get?key-password=value-password"
+    user: admin
+    password: password
+  register: sanitize_keys
+
+- name: assert that keys were sanitized
+  assert:
+    that:
+      - sanitize_keys.json.args['key-********'] == 'value-********'
+
 - name: Create a testing file
   copy:
     content: "content"

--- a/test/units/module_utils/basic/test_no_log.py
+++ b/test/units/module_utils/basic/test_no_log.py
@@ -105,12 +105,17 @@ class TestRemoveValues(unittest.TestCase):
                 'three': [
                     OMIT, 'musketeers', None, {
                         'ping': OMIT,
-                        'base': [
+                        OMIT: [
                             OMIT, 'raquets'
                         ]
                     }
                 ]
             }
+        ),
+        (
+            {'key-password': 'value-password'},
+            frozenset(['password']),
+            {'key-********': 'value-********'},
         ),
         (
             'This sentence has an enigma wrapped in a mystery inside of a secret. - mr mystery',


### PR DESCRIPTION
##### SUMMARY
Strip no log values from module response keys. Fixes #68400

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
