### PR TITLE
docs: Proposal: list playbook keywords with "Applies to" flags

### DIFF
--- a/docs/templates/playbooks_keywords.rst.j2
+++ b/docs/templates/playbooks_keywords.rst.j2
@@ -19,15 +19,16 @@ These are the keywords available on common playbook objects. Keywords are one of
    :local:
    :depth: 1
 
-{% for name in playbook_class_names %}
 
-{{ name }}
-{{ '-' * name|length }}
-.. glossary::
+{% for keyword in keywords | sort %}
+{{ keyword }}
+{{ '-' * keyword | length }}
 
-{% for attribute in pb_keywords[name]|sort %}
-    {{ attribute }}
-        {{ pb_keywords[name][attribute] |indent(8) }}
 
-{% endfor %}
+Applies to:{% for name in playbook_class_names %}  {% if keyword in pb_keywords[name] %}✓{% else %}✗{% endif %} {{ name }}{% endfor %}
+
+
+{{ keywords[keyword] }}
+
+
 {% endfor %}

--- a/hacking/build_library/build_ansible/command_plugins/dump_keywords.py
+++ b/hacking/build_library/build_ansible/command_plugins/dump_keywords.py
@@ -84,7 +84,13 @@ def extract_keywords(keyword_definitions):
 def generate_page(pb_keywords, template_dir):
     env = Environment(loader=FileSystemLoader(template_dir), trim_blocks=True,)
     template = env.get_template(TEMPLATE_FILE)
-    tempvars = {'pb_keywords': pb_keywords, 'playbook_class_names': PLAYBOOK_CLASS_NAMES}
+    tempvars = {
+        'pb_keywords': pb_keywords,
+        'playbook_class_names': PLAYBOOK_CLASS_NAMES,
+        'keywords': {keyword: pb_keywords[class_name][keyword]
+                     for class_name in PLAYBOOK_CLASS_NAMES
+                     for keyword in pb_keywords[class_name]},
+    }
 
     keyword_page = template.render(tempvars)
     if LooseVersion(jinja2.__version__) < LooseVersion('2.10'):


### PR DESCRIPTION
##### SUMMARY
The [playbook keywords reference](https://docs.ansible.com/ansible/devel/reference_appendices/playbooks_keywords.html) is currently organised by category, then applicable keywords.

I propose reorganising this, to list all keywords at the top level, each with an "Applies to" block. The PR shows a demonstrator. It isn't intended to as a polished, styled final design. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
The motivations for this proposed reorganisation are

- Make it easy to link to one canonical reference for a given keyword
- Make it easier to see what categories/levels a given keyword applies to
- Reduce repetition of keyword descriptions on the page

I hope the following table and screenshot illustrate the concept

<table>
<tr>
<th>Current organisation
<th>Proposed organisation
<tr>
<td>

**Play**

any_errors_fatal
&nbsp;&nbsp;    [description]

become
&nbsp;&nbsp;    [description]

...

**Role**

any_errors_fatal
&nbsp;&nbsp;    [description]

become
&nbsp;&nbsp;    [description]

...

<td>

**action**

Applies to: ✗ Play ✗ Role ✗ Block ✓ Task

[description]

**always**

Applies to: ✗ Play ✗ Role ✓ Block ✗ Task

[description]

...
</table>

![image](https://user-images.githubusercontent.com/174450/82602518-1dcd6600-9ba9-11ea-807b-0ea7f972e797.png)
