### PR TITLE
[ansible-test] Remove /run/nologin from containers

### DIFF
--- a/test/lib/ansible_test/_data/setup/docker.sh
+++ b/test/lib/ansible_test/_data/setup/docker.sh
@@ -12,3 +12,6 @@ alias ls='ls --color=auto'
 export PS1='\[\e]0;\u@\h: \w\a\]\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
 cd ~/ansible/
 EOF
+
+# Required for SSHing into some containers
+rm -f /run/nologin


### PR DESCRIPTION
##### SUMMARY

Change:
Some containers have /run/nologin files created by systemd which prevent
us from being able to SSH into them in tests.

Ensure this file gets deleted once the container is up and running well
enough to run this setup script.

Test Plan:
`ansible-test shell --docker fedora31`



<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test