### PR TITLE
Use a custom build container on Shippable.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -151,6 +151,11 @@ branches:
     - "revert-*-*"
 
 build:
+  pre_ci_boot:
+    image_name: quay.io/ansible/shippable-build-container
+    image_tag: 6.10.4.0
+    pull: true
+    options: --privileged=true --net=bridge
   ci:
     - test/utils/shippable/timing.sh test/utils/shippable/shippable.sh $T
 

--- a/test/utils/shippable/shippable.sh
+++ b/test/utils/shippable/shippable.sh
@@ -13,7 +13,7 @@ docker images ansible/ansible
 docker images quay.io/ansible/*
 docker ps
 
-for container in $(docker ps --format '{{.Image}} {{.ID}}' | grep -v '^drydock/' | sed 's/^.* //'); do
+for container in $(docker ps --format '{{.Image}} {{.ID}}' | grep -v -e '^drydock/' -e '^quay.io/ansible/shippable-build-container:' | sed 's/^.* //'); do
     docker rm -f "${container}" || true  # ignore errors
 done
 


### PR DESCRIPTION
##### SUMMARY

Use a custom build container on Shippable.

This supports key generation before git_sync, to avoid issues with pre-migration PRs.

If the node pool is switched to another version, a matching build container should be built and used.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

shippable.yml
