### PR TITLE
add defensive conversions to display methods, tests

### DIFF
--- a/changelogs/fragments/display_defensive_conversions.yml
+++ b/changelogs/fragments/display_defensive_conversions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - display - defensively convert incoming strings to text to prevent behavior changes from increased verbosity

--- a/test/units/utils/display/test_display.py
+++ b/test/units/utils/display/test_display.py
@@ -5,8 +5,13 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+import pytest
 
+from ansible.errors import AnsibleError
 from ansible.utils.display import Display
+
+nonascii_text = u'\u00c5\u00d1\u015a\u00cc\u03b2\u0141\u00c8'
+nonascii_utf8_bytes = nonascii_text.encode('utf-8')
 
 
 def test_display_basic_message(capsys, mocker):
@@ -18,3 +23,38 @@ def test_display_basic_message(capsys, mocker):
     out, err = capsys.readouterr()
     assert out == 'Some displayed message\n'
     assert err == ''
+
+
+# ensure that display methods won't barf on bad string inputs (note we're not validating output yet)
+def test_display_defensive_strings():
+    d = Display()
+    d.display(nonascii_text)
+    d.display(nonascii_utf8_bytes)
+
+
+def test_warning_defensive_strings():
+    d = Display()
+    for formatted in [False, True]:
+        d.warning(nonascii_text, formatted=formatted)
+        d.warning(nonascii_utf8_bytes, formatted=formatted)
+
+
+def test_deprecated_defensive_strings():
+    d = Display()
+    with pytest.raises(AnsibleError):
+        d.deprecated(nonascii_text, nonascii_utf8_bytes, removed=True)
+    with pytest.raises(AnsibleError):
+        d.deprecated(nonascii_utf8_bytes, nonascii_text, removed=True)
+
+
+def test_banner_defensive_strings():
+    d = Display()
+    for cows in [False, True]:
+        d.banner(nonascii_text, cows=cows)
+        d.banner(nonascii_utf8_bytes, cows=cows)
+
+
+def test_debug_defensive_strings():
+    d = Display()
+    d.debug(nonascii_text, nonascii_utf8_bytes)
+    d.debug(nonascii_utf8_bytes, nonascii_text)

--- a/test/units/utils/display/test_warning.py
+++ b/test/units/utils/display/test_warning.py
@@ -24,6 +24,7 @@ def test_warning(capsys, mocker, warning_message):
     mocker.patch('ansible.utils.color.parsecolor', return_value=u'1;35')  # value for 'bright purple'
 
     d = Display()
+    d._warns = {}
     d.warning(warning_message)
     out, err = capsys.readouterr()
     assert d._warns == {expected_warning_message: 1}
@@ -36,6 +37,7 @@ def test_warning_no_color(capsys, mocker, warning_message):
     mocker.patch('ansible.utils.color.ANSIBLE_COLOR', False)
 
     d = Display()
+    d._warns = {}
     d.warning(warning_message)
     out, err = capsys.readouterr()
     assert d._warns == {expected_warning_message: 1}


### PR DESCRIPTION
##### SUMMARY
* prevent display/debug/verbose messages from causing new failures (eg by increasing verbosity to a level that tries to render a bytes-ish message string)
* defensive early convert messages and other strings to text
* adds basic regression tests with mixed bytes/text non-ASCII inputs (that fail without the changes)


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/utils/display.py

##### ADDITIONAL INFORMATION
(this was after a painful debug session where running with `-vvv` caused a new failure deep in a place where the resultant exception was lost because of an implicit bytes via `ascii` encoding in a display method that expected text)