### PR TITLE
[2.9] Typecast results before use in profile_tasks callback

### DIFF
--- a/changelogs/fragments/69563_profile_tasks.yml
+++ b/changelogs/fragments/69563_profile_tasks.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- profile_tasks - typecast results before using it (https://github.com/ansible/ansible/issues/69563).

--- a/lib/ansible/plugins/callback/profile_tasks.py
+++ b/lib/ansible/plugins/callback/profile_tasks.py
@@ -184,7 +184,7 @@ class CallbackModule(CallbackBase):
             )
 
         # Display the number of tasks specified or the default of 20
-        results = results[:self.task_output_limit]
+        results = list(results)[:self.task_output_limit]
 
         # Print the timings
         for uuid, result in results:


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible-collections/ansible.posix/pull/26


If user specifies sort_order to none, results are not converted to list.
This fix force this typecasting before using the results.

Fixes: ansible/ansible#69563

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/69563_profile_tasks.yml
lib/ansible/plugins/callback/profile_tasks.py
