### PR TITLE
Make Python path warning say what it means to say

### DIFF
--- a/lib/ansible/executor/interpreter_discovery.py
+++ b/lib/ansible/executor/interpreter_discovery.py
@@ -156,7 +156,7 @@ def discover_interpreter(action, interpreter_name, discovery_mode, task_vars):
     if not is_silent:
         action._discovery_warnings \
             .append(u"Platform {0} on host {1} is using the discovered Python interpreter at {2}, but future installation of "
-                    u"another Python interpreter could change this. See {3} "
+                    u"another Python interpreter could change the meaning of that path. See {3} "
                     u"for more information."
                     .format(platform_type, host, found_interpreters[0],
                             get_versioned_doclink('reference_appendices/interpreter_discovery.html')))

--- a/test/units/executor/test_interpreter_discovery.py
+++ b/test/units/executor/test_interpreter_discovery.py
@@ -70,7 +70,7 @@ def test_discovery_interpreter_non_linux():
     assert len(mock_action.method_calls) == 2
     assert mock_action.method_calls[1][0] == '_discovery_warnings.append'
     assert u'Platform darwin on host host-fóöbär is using the discovered Python interpreter at /usr/bin/python, ' \
-           u'but future installation of another Python interpreter could change this' \
+           u'but future installation of another Python interpreter could change the meaning of that path' \
            in mock_action.method_calls[1][1][0]
 
 


### PR DESCRIPTION
##### SUMMARY
The way the old warning message was worded, it effectively meant
"future installation of another Python interpreter could change the
fact that we're using /usr/bin/python" (which isn't actually true).
Reword it so that it means "we're using the Python in /usr/bin/python,
and future OS upgrades could change what Python that is".

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
executor

##### ADDITIONAL INFORMATION
This is simply an attempt to improve a warning message printed out by `ansible-playbook`.  The new wording I came up with is more accurate (I think), but it's maybe a bit clumsy, so further improvement is welcome.