### PR TITLE
Make connection plugins use password from config

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -1010,6 +1010,18 @@ class TaskExecutor:
 
         task_keys = self._task.dump_attrs()
 
+        if self._play_context.password:
+            # The connection password is threaded through the play_context for
+            # now. This is something we ultimately want to avoid, but the first
+            # step is to get connection plugins pulling the password through the
+            # config system instead of directly accessing play_context.
+            #
+            # This needs to be set as a *variable* here because plugins use
+            # different option names (e.g. ssh "password" vs psrp
+            # "remote_password") but they all seem to take ansible_password as a
+            # variable to set it.
+            options['ansible_password'] = self._play_context.password
+
         # set options with 'templated vars' specific to this plugin and dependent ones
         self._connection.set_options(task_keys=task_keys, var_options=options)
         varnames.extend(self._set_plugin_options('shell', variables, templar, task_keys))

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -1015,12 +1015,7 @@ class TaskExecutor:
             # now. This is something we ultimately want to avoid, but the first
             # step is to get connection plugins pulling the password through the
             # config system instead of directly accessing play_context.
-            #
-            # This needs to be set as a *variable* here because plugins use
-            # different option names (e.g. ssh "password" vs psrp
-            # "remote_password") but they all seem to take ansible_password as a
-            # variable to set it.
-            options['ansible_password'] = self._play_context.password
+            task_keys['password'] = self._play_context.password
 
         # set options with 'templated vars' specific to this plugin and dependent ones
         self._connection.set_options(task_keys=task_keys, var_options=options)

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -326,7 +326,7 @@ class Connection(ConnectionBase):
 
         allow_agent = True
 
-        if self._play_context.password is not None:
+        if self.get_option('password') is not None:
             allow_agent = False
 
         try:
@@ -344,7 +344,7 @@ class Connection(ConnectionBase):
                 allow_agent=allow_agent,
                 look_for_keys=self.get_option('look_for_keys'),
                 key_filename=key_filename,
-                password=self._play_context.password,
+                password=self.get_option('password'),
                 timeout=self._play_context.timeout,
                 port=port,
                 **ssh_connect_kwargs

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -39,6 +39,7 @@ options:
     - name: ansible_password
     - name: ansible_winrm_pass
     - name: ansible_winrm_password
+    aliases: [ password ]
   port:
     description:
     - The port for PSRP to connect on the remote target.


### PR DESCRIPTION
##### SUMMARY

Change:
Rather than connection plugins directly accessing play_context and pulling
the password from there, have them pull it from the config system, and
have TaskExecutor store it there for now.

Internally, it still routes through play_context for now, but this is
the first step away from that.

Test Plan:
- Local test with `ansible -c ssh`
- grep -R play_context.pass lib/ansible/plugins/connection/
- CI



<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

connection, task_executor