### PR TITLE
Strategy Plugin Support Custom Options

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -103,9 +103,9 @@ DEFAULT_PASSWORD_CHARS = to_text(ascii_letters + digits + ".,:-_", errors='stric
 DEFAULT_REMOTE_PASS = None
 DEFAULT_SUBSET = None
 # FIXME: expand to other plugins, but never doc fragments
-CONFIGURABLE_PLUGINS = ('become', 'cache', 'callback', 'cliconf', 'connection', 'httpapi', 'inventory', 'lookup', 'netconf', 'shell', 'vars')
+CONFIGURABLE_PLUGINS = ('become', 'cache', 'callback', 'cliconf', 'connection', 'httpapi', 'inventory', 'lookup', 'netconf', 'shell', 'strategy', 'vars')
 # NOTE: always update the docs/docsite/Makefile to match
-DOCUMENTABLE_PLUGINS = CONFIGURABLE_PLUGINS + ('module', 'strategy')
+DOCUMENTABLE_PLUGINS = CONFIGURABLE_PLUGINS + ('module',)
 IGNORE_FILES = ("COPYING", "CONTRIBUTING", "LICENSE", "README", "VERSION", "GUIDELINES")  # ignore during module search
 INTERNAL_RESULT_KEYS = ('add_host', 'add_group')
 LOCALHOST = ('127.0.0.1', 'localhost', '::1')

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -46,7 +46,7 @@ from ansible.playbook.handler import Handler
 from ansible.playbook.helpers import load_list_of_blocks
 from ansible.playbook.included_file import IncludedFile
 from ansible.playbook.task_include import TaskInclude
-from ansible.plugins import loader as plugin_loader
+from ansible.plugins import loader as plugin_loader, AnsiblePlugin
 from ansible.template import Templar
 from ansible.utils.display import Display
 from ansible.utils.vars import combine_vars
@@ -161,7 +161,7 @@ def debug_closure(func):
     return inner
 
 
-class StrategyBase:
+class StrategyBase(AnsiblePlugin):
 
     '''
     This is the base class for strategy plugins, which contains some common
@@ -174,6 +174,7 @@ class StrategyBase:
     ALLOW_BASE_THROTTLING = True
 
     def __init__(self, tqm):
+        super(StrategyBase, self).__init__()
         self._tqm = tqm
         self._inventory = tqm.get_inventory()
         self._workers = tqm._workers

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -37,7 +37,7 @@ DOCUMENTATION = '''
                   Ansible will not start a play for a host unless the play can be finished without interruption
                   by tasks for another host, i.e. the number of hosts with an active play does not exceed the
                   number of forks.
-                - Ansible will not wait for other hosts to finish the current task before queuing the next task
+                  Ansible will not wait for other hosts to finish the current task before queuing the next task
                   for a host that has finished.  Once a host is done with the play, it opens it's slot to a new
                   host that was waiting to start.
             default: False

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -34,7 +34,7 @@ DOCUMENTATION = '''
             description:
                 - Executes tasks on each host without interruption.
                 - Task execution is as fast as possible per host in batch as defined by C(serial) (default all).
-                  Ansible will not start a play for a host unless the play can be finished without interruption 
+                  Ansible will not start a play for a host unless the play can be finished without interruption
                   by tasks for another host, i.e. the number of hosts with an active play does not exceed the
                   number of forks.
                 - Ansible will not wait for other hosts to finish the current task before queuing the next task

--- a/lib/ansible/plugins/strategy/host_pinned.py
+++ b/lib/ansible/plugins/strategy/host_pinned.py
@@ -41,5 +41,8 @@ display = Display()
 class StrategyModule(FreeStrategyModule):
 
     def __init__(self, tqm):
+        # DEPRECATED: Ansible Strategy plugins now allow custom options.  The free strategy implements
+        #   this setting as an option that can be defined either through environment variable or
+        #   ansible.cfg `[default] host_pinned = True` setting.
         super(StrategyModule, self).__init__(tqm)
-        self._host_pinned = True
+        self.set_option("host_pinned", True)

--- a/test/integration/targets/blocks/runme.sh
+++ b/test/integration/targets/blocks/runme.sh
@@ -24,7 +24,7 @@ env python -c \
 # cleanup the output log again, to make sure the test is clean
 rm -f block_test.out block_test_wo_colors.out
 # run test with host_pinned strategy and again count the completions
-ansible-playbook -vv main.yml -i ../../inventory -e test_strategy=host_pinned | tee block_test.out
+ANSIBLE_HOST_PINNED=true ansible-playbook -vv main.yml -i ../../inventory -e test_strategy=free | tee block_test.out
 env python -c \
     'import sys, re; sys.stdout.write(re.sub("\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]", "", sys.stdin.read()))' \
     <block_test.out >block_test_wo_colors.out


### PR DESCRIPTION
Signed-off-by: Kevin J. Smith <kevin.j.smith2@cerner.com>

##### SUMMARY
Added custom options to strategy by inheriting ansible.plugins.AnsiblePlugin and adding host_pinned as an option to free to deprecate host_pinned.

Fixes #69668

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Strategy Plugin Support Custom Options through Inheriting AnsiblePlugin

##### ADDITIONAL INFORMATION
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See changes made to ansible.plugins.strategy.free that now obsoletes ansible.plugins.strategy.host_pinned

See how host_pinned can be used through env:
test/integration/targets/blocks/runme.sh:L27
