### PR TITLE
Execute dscl with elevated privilege on osx 10.14 targets

### DIFF
--- a/changelogs/fragments/69674-dscl_execute_with_sudo.yml
+++ b/changelogs/fragments/69674-dscl_execute_with_sudo.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "user module - The user module was unable to create users on darwin targets (10.14+) due to insufficient permission. This fix addresses this issue by executing dscl with sudo (https://github.com/ansible/ansible/pull/69674)"

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -2076,7 +2076,7 @@ class DarwinUser(User):
             self.fields.append(('hidden', 'IsHidden'))
 
     def _get_dscl(self):
-        return [self.module.get_bin_path('dscl', True), self.dscl_directory]
+        return ["sudo", self.module.get_bin_path('dscl', True), self.dscl_directory]
 
     def _list_user_groups(self):
         cmd = self._get_dscl()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The user module fails to create users on darwin targets (osx 10.14+) due to `DS Error: -14120 (eDSPermissionError)`.  This happens when `become: yes` is not used for the task. This fix addresses this issue by executing `dscl` under sudo.

Fixes #69607
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
m:user
