### PR TITLE
Supports multi-byte characters

### DIFF
--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -302,14 +302,11 @@ class Display(with_metaclass(Singleton, object)):
 
         msg = msg.strip()
         msglen = 0
-        if sys.version_info >= (3,) or isinstance(msg, unicode):
-            for c in msg:
-                if unicodedata.east_asian_width(c) in 'FWA':
-                    msglen += 2
-                else:
-                    msglen += 1
-        else:
-            msglen = len(msg)
+        for c in msg:
+            if ord(c) >= 0x100 and unicodedata.east_asian_width(c) in "FWA":
+                msglen += 2
+            else:
+                msglen += 1
         star_len = self.columns - msglen
         if star_len <= 3:
             star_len = 3

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -301,15 +301,12 @@ class Display(with_metaclass(Singleton, object)):
                 self.warning("somebody cleverly deleted cowsay or something during the PB run.  heh.")
 
         msg = msg.strip()
-        if isinstance(msg, unicode):
-            msglen = 0
-            for c in msg:
-                if unicodedata.east_asian_width(c) in "FWA":
-                    msglen += 2
-                else:
-                    msglen += 1
-        else:
-            msglen = len(msg)
+        msglen = 0
+        for c in msg:
+            if (sys.version_info >= (3,) or isinstance(msg, unicode)) and unicodedata.east_asian_width(c) in 'FWA':
+                msglen += 2
+            else:
+                msglen += 1
         star_len = self.columns - msglen
         if star_len <= 3:
             star_len = 3

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -303,7 +303,7 @@ class Display(with_metaclass(Singleton, object)):
         msg = msg.strip()
         msglen = 0
         for c in msg:
-            if ord(c) >= 0x100 and unicodedata.east_asian_width(c) in "FWA":
+            if ord(c) > 0xff and unicodedata.east_asian_width(c) in "FWA":
                 msglen += 2
             else:
                 msglen += 1

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -302,11 +302,14 @@ class Display(with_metaclass(Singleton, object)):
 
         msg = msg.strip()
         msglen = 0
-        for c in msg:
-            if (sys.version_info >= (3,) or isinstance(msg, unicode)) and unicodedata.east_asian_width(c) in 'FWA':
-                msglen += 2
-            else:
-                msglen += 1
+        if sys.version_info >= (3,) or isinstance(msg, unicode):
+            for c in msg:
+                if unicodedata.east_asian_width(c) in 'FWA':
+                    msglen += 2
+                else:
+                    msglen += 1
+        else:
+            msglen = len(msg)
         star_len = self.columns - msglen
         if star_len <= 3:
             star_len = 3

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -29,6 +29,7 @@ import subprocess
 import sys
 import textwrap
 import time
+import unicodedata
 
 from struct import unpack, pack
 from termios import TIOCGWINSZ
@@ -300,7 +301,16 @@ class Display(with_metaclass(Singleton, object)):
                 self.warning("somebody cleverly deleted cowsay or something during the PB run.  heh.")
 
         msg = msg.strip()
-        star_len = self.columns - len(msg)
+        if isinstance(msg, unicode):
+            msglen = 0
+            for c in msg:
+                if unicodedata.east_asian_width(c) in "FWA":
+                    msglen += 2
+                else:
+                    msglen += 1
+        else:
+            msglen = len(msg)
+        star_len = self.columns - msglen
         if star_len <= 3:
             star_len = 3
         stars = u"*" * star_len


### PR DESCRIPTION
##### SUMMARY
Fixed the problem that the display is broken when "name" contains multi-byte characters.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/utils/display.py

##### ADDITIONAL INFORMATION
If "name" contains multi-byte characters, the display when executed will be corrupted as follows.
```
TASK [common : 日本語] *****************
***
```

This patch is intended to fix the above issue and to do the following:
```
TASK [common : 日本語] *****************
```