### PR TITLE
[2.9] Fix system default dict generation in nxos_interfaces

### DIFF
--- a/changelogs/fragments/fix_nxos_interfaces_enabled.yaml
+++ b/changelogs/fragments/fix_nxos_interfaces_enabled.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix nxos_interfaces enabled not working properly because of broken system default dict generation (https://github.com/ansible-collections/cisco.nxos/pull/56).

--- a/lib/ansible/module_utils/network/nxos/facts/interfaces/interfaces.py
+++ b/lib/ansible/module_utils/network/nxos/facts/interfaces/interfaces.py
@@ -49,7 +49,9 @@ class InterfacesFacts(object):
         objs = []
         if not data:
             data = connection.get("show running-config all | incl 'system default switchport'")
-            data += connection.get('show running-config | section ^interface')
+            data += "\n" + connection.get(
+                "show running-config | section ^interface"
+            )
 
         # Collect device defaults & per-intf defaults
         self.render_system_defaults(data)

--- a/test/integration/targets/nxos_interfaces/tests/cli/merged.yaml
+++ b/test/integration/targets/nxos_interfaces/tests/cli/merged.yaml
@@ -2,7 +2,10 @@
 - debug:
     msg: "Start nxos_interfaces merged integration tests connection={{ ansible_connection }}"
 
-- set_fact: test_int1="{{ nxos_int1 }}"
+- set_fact: 
+    test_int1: "{{ nxos_int1 }}"
+    test_int2: "{{ nxos_int2 }}"
+
 - set_fact: enabled=true
   when: platform is not search('N3[5KL]|N[56]K|titanium')
 
@@ -10,6 +13,7 @@
   cli_config: &cleanup
     config: |
       default interface {{ test_int1 }}
+      default interface {{ test_int2 }}
 
 - block:
   - name: Merged
@@ -51,6 +55,31 @@
       that:
         - "result.changed == false"
         - "result.commands|length == 0"
+
+  - name: "Populate {{ test_int2 }}"
+    nxos_config:
+      lines:
+        - "description Test"
+        - "switchport"
+        - "no shutdown"
+      parents: "interface {{ test_int2 }}"
+
+  - name: Update interface state
+    nxos_interfaces:
+      config:
+        - name: "{{ test_int2 }}"
+          enabled: False
+          mode: layer2
+          description: Test
+      state: merged
+    register: result
+
+  - assert:
+      that:
+        - "'interface {{ test_int2 }}' in result.commands"
+        - "'shutdown' in result.commands"
+        - result.changed == True
+        - result.commands|length == 2
 
   always:
   - name: teardown


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible-collections/cisco.nxos/pull/56

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/network/nxos/facts/interfaces/interfaces.py