### PR TITLE
Enhance documentation around add_host bypassing the play host loop

### DIFF
--- a/lib/ansible/modules/add_host.py
+++ b/lib/ansible/modules/add_host.py
@@ -34,7 +34,8 @@ options:
     aliases: [ group, groupname ]
 notes:
 - This module bypasses the play host loop and only runs once for all the hosts in the play, if you need it
-  to iterate use a with-loop construct.
+  to iterate use a C(loop) construct. If you need to dynamically add all hosts targeted by a playbook for
+  later use, the C(group_by) module is potentially a better choice.
 - The alias C(host) of the parameter C(name) is only available on Ansible 2.4 and newer.
 - Since Ansible 2.4, the C(inventory_dir) variable is now set to C(None) instead of the 'global inventory source',
   because you can now have multiple sources.  An example was added that shows how to partially restore the previous behaviour.
@@ -80,4 +81,10 @@ EXAMPLES = r'''
   add_host:
     hostname: charlie
     inventory_dir: '{{ inventory_dir }}'
+
+- name: Add all hosts running this playbook to the done group
+  add_host:
+    name: '{{ item }}'
+    groups: done
+  loop: "{{ ansible_play_hosts }}"
 '''

--- a/lib/ansible/modules/group_by.py
+++ b/lib/ansible/modules/group_by.py
@@ -54,4 +54,8 @@ EXAMPLES = r'''
     key: el{{ ansible_distribution_major_version }}-{{ ansible_architecture }}
     parents:
       - el{{ ansible_distribution_major_version }}
+
+# Add all active hosts to a static group
+- group_by:
+    key: done
 '''


### PR DESCRIPTION
##### SUMMARY

A very common problem with `add_host` is that it bypasses the play host
loop and only activates for the first host in a play. While this is
documented, there is no example on how to "fix" that. The issue
tracker is filled by issues around this, most of them without an
example of solution: #2963, #6912, #7488, #9931, #9931, #23815
and #29729.

In #7499, there was a good explanation and it mentions that `group_by`
may be a better choice, but it was not merged at the time. In this
change, I am adding a word about `group_by` being a better choice in
some cases and I add two examples, one with `add_host` and one with
`group_by`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`add_host`