### PR TITLE
Fixes plugin exception in syslog_json callback plugin

### DIFF
--- a/changelogs/fragments/syslogjson-callback-exception.yml
+++ b/changelogs/fragments/syslogjson-callback-exception.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - syslog_json callback - fix plugin exception when running (https://github.com/ansible-collections/community.general/issues/407).

--- a/lib/ansible/plugins/callback/syslog_json.py
+++ b/lib/ansible/plugins/callback/syslog_json.py
@@ -67,7 +67,9 @@ class CallbackModule(CallbackBase):
 
         super(CallbackModule, self).__init__()
 
-        self.set_options()
+    def set_options(self, task_keys=None, var_options=None, direct=None):
+
+        super(CallbackModule, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
 
         syslog_host = self.get_option("server")
         syslog_port = int(self.get_option("port"))


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible-collections/community.general/pull/408

<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible-collections/community.general/issues/407
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
syslog_json.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Debug is thrown to the syslog

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
May 24 19:28:29 debian ansible-command: task execution OK; host: localhost; message: {#012    "changed": false,#012    "foo": "VARIABLE IS NOT DEFINED!"#012}
May 24 19:28:29 debian ansible-command: task execution OK; host: localhost; message: {#012    "bar | bool": "VARIABLE IS NOT DEFINED!",#012    "changed": false#012}
May 24 19:28:30 debian ansible-command: task execution OK; host: localhost; message: {#012    "bar | bool | ternary('Eremutonto','Eremutontisimo')": "VARIABLE IS NOT DEFINED!",#012    "changed": false#012}
```
