### PR TITLE
Add validity check for [Driver][IPAddress] else use docker-machine ip command.

### DIFF
--- a/changelogs/fragments/412-docker-machine-add-ip-fallback.yaml
+++ b/changelogs/fragments/412-docker-machine-add-ip-fallback.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - docker_machine - fallback to ip subcommand output if IPAddress is missing (https://github.com/ansible-collections/community.general/issues/412).


### PR DESCRIPTION
##### SUMMARY
This PR addresses an issue observed initially by @benroose whereby the `docker-machine inspect <machine name>` command output unexpectedly lacks an `IPAddress` value but the IP address was/is available via the `docker-machine ip <machine name>` command.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_machine

##### ADDITIONAL INFORMATION
Backport of https://github.com/ansible-collections/community.general/pull/412.