### PR TITLE
fix regression which disabled force_valid_group_names (#68851)

### DIFF
--- a/changelogs/fragments/68851-force_valid_group_names-ignored.yml
+++ b/changelogs/fragments/68851-force_valid_group_names-ignored.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - constructed - Fix regression introduced in https://github.com/ansible/ansible/pull/60912 which caused group name sanitization to always run regardless of the force_valid_group_names setting

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -372,7 +372,7 @@ class Constructable(object):
             self.templar.available_variables = variables
             for group_name in groups:
                 conditional = "{%% if %s %%} True {%% else %%} False {%% endif %%}" % groups[group_name]
-                group_name = original_safe(group_name, force=True)
+                group_name = original_safe(group_name)
                 try:
                     result = boolean(self.templar.template(conditional))
                 except Exception as e:


### PR DESCRIPTION
##### SUMMARY
Do not force sanitization when constructing inventory. This fixes a regression introduced in https://github.com/ansible/ansible/pull/60912 which breaks 'force_valid_group_names'.

Fixes #68851

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
constructed

##### ADDITIONAL INFORMATION
Before:
```
ansible-inventory -i inventory/internal_services/inventory.gcp.yml --graph
[WARNING]: Invalid characters were found in group names and automatically replaced, use -vvvv to see details
@all:
  |--@bastion:
  |  |--just-passing-through
  |--@etcd:
  |  |--etcd-1
  |--@kube_master:
  |  |--master-1
  |--@kube_node:
  |  |--node-1
  |--@ungrouped:
```

After:
```
ansible-inventory -i inventory/internal_services/inventory.gcp.yml --graph
[WARNING]: Invalid characters were found in group names but not replaced, use -vvvv to see details
@all:
  |--@bastion:
  |  |--just-passing-through
  |--@etcd:
  |  |--etcd-1
  |--@kube-master:
  |  |--master-1
  |--@kube-node:
  |  |--node-1
  |--@ungrouped:
```
