### PR TITLE
do not return the body even if it failed

### DIFF
--- a/changelogs/fragments/21003-uri-return-content.yml
+++ b/changelogs/fragments/21003-uri-return-content.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- uri - Don't return the body even if it failed
+  (https://github.com/ansible/ansible/issues/21003)

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -75,7 +75,7 @@ options:
   return_content:
     description:
       - Whether or not to return the body of the response as a "content" key in
-        the dictionary result.
+        the dictionary result no matter it succeeded or failed.
       - Independently of this option, if the reported Content-type is "application/json", then the JSON is
         always loaded into a key called C(json) in the dictionary results.
     type: bool
@@ -739,7 +739,10 @@ def main():
 
     if resp['status'] not in status_code:
         uresp['msg'] = 'Status code was %s and not %s: %s' % (resp['status'], status_code, uresp.get('msg', ''))
-        module.fail_json(content=u_content, **uresp)
+        if return_content:
+            module.fail_json(content=u_content, **uresp)
+        else:
+            module.fail_json(**uresp)
     elif return_content:
         module.exit_json(content=u_content, **uresp)
     else:

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -595,3 +595,6 @@
 
 - name: Check unexpected failures
   import_tasks: unexpected-failures.yml
+
+- name: Check return-content
+  import_tasks: return-content.yml

--- a/test/integration/targets/uri/tasks/return-content.yml
+++ b/test/integration/targets/uri/tasks/return-content.yml
@@ -15,6 +15,7 @@
     url: http://does/not/exist
     return_content: yes
   register: result
+  ignore_errors: true
 
 - name: Assert content exists when return_content is yes and request fails
   assert:
@@ -39,6 +40,7 @@
     url: http://does/not/exist
     return_content: no
   register: result
+  ignore_errors: true
 
 - name: Assert content does not exist when return_content is no and request fails
   assert:

--- a/test/integration/targets/uri/tasks/return-content.yml
+++ b/test/integration/targets/uri/tasks/return-content.yml
@@ -1,0 +1,47 @@
+- name: Test when return_content is yes
+  uri:
+    url: https://{{ httpbin_host }}/get
+    return_content: yes
+  register: result
+
+- name: Assert content exists when return_content is yes and request succeeds
+  assert:
+    that:
+      - result is successful
+      - "'content' in result"
+
+- name: Test when return_content is yes
+  uri:
+    url: http://does/not/exist
+    return_content: yes
+  register: result
+
+- name: Assert content exists when return_content is yes and request fails
+  assert:
+    that:
+      - result is failed
+      - "'content' in result"
+
+- name: Test when return_content is no
+  uri:
+    url: https://{{ httpbin_host }}/get
+    return_content: no
+  register: result
+
+- name: Assert content does not exist when return_content is no and request succeeds
+  assert:
+    that:
+      - result is successful
+      - "'content' not in result"
+
+- name: Test when return_content is no
+  uri:
+    url: http://does/not/exist
+    return_content: no
+  register: result
+
+- name: Assert content does not exist when return_content is no and request fails
+  assert:
+    that:
+      - result is failed
+      - "'content' not in result"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The parameter 'return_content' did not work when the request failed.
So I add a condition make the output information simple.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #21003
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
uri
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
[loop_control](https://docs.ansible.com/ansible/latest/user_guide/playbooks_loops.html#loop-control) can only limit the item displayed output, not returned content.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
failed: [x.x.x.x -> 127.0.0.1] (item=xxx/xxx/xxx) => {"cache_control": "private", "changed": false, "connection": "close", "content": "<!DOCTYPE html>\r\n<html>\r\n    <head>\r\n        <title>Runtime Error</title>\r\n        <meta name=\"viewport\" content=\"width=device-width\" />\r\n        <style>\r\n         body {font-family:\"Verdana\";font-weight:normal;font-size: .7em;color:black;} \r\n         p {font-family:\"Verdana\";font-weight:normal;color:black;margin-top: -5px}\r\n         b {font-family:\"Verdana\";font-weight:bold;color:black;margin-top: -5px}\r\n         H1 { font-family:\"Verdana\";font-weight:normal;font-size:18pt;color:red }\r\n         H2 { font-family:\"Verdana\";font-weight:normal;font-size:14pt;color:maroon }\r\n         pre {font-family:\"Consolas\",\"Lucida Console\",Monospace;font-size:11pt;margin:0;padding:0.5em;line-height:14pt}\r\n         .marker {font-weight: bold; color: black;text-decoration: none;}\r\n         .version {color: gray;}\r\n         .error {margin-bottom: 10px;}\r\n         .expandable { text-decoration:underline; font-weight:bold; color:navy; cursor:hand; }\r\n         @media screen and (max-width: 639px) {\r\n          pre { width: 440px; overflow: auto; white-space: pre-wrap; word-wrap: break-word; }\r\n         }\r\n         @media screen and (max-width: 479px) {\r\n          pre { width: 280px; }\r\n         }\r\n        </style>\r\n    </head>\r\n\r\n    <body bgcolor=\"white\">\r\n\r\n            <span><H1>Server Error in '/xxx' Application.<hr width=100% size=1 color=silver></H1>\r\n\r\n            <h2> <i>Runtime Error</i> </h2></span>\r\n\r\n            <font face=\"Arial, Helvetica, Geneva, SunSans-Regular, sans-serif \">\r\n\r\n            <b> Description: </b>An application error occurred on the server. The current custom error settings for this application prevent the details of the application error from being viewed remotely (for security reasons). It could, however, be viewed by browsers running on the local server machine.\r\n            <br><br>\r\n\r\n            <b>Details:</b> To enable the details of this specific error message to be viewable on remote machines, please create a &lt;customErrors&gt; tag within a &quot;web.config&quot; configuration file located in the root directory of the current web application. This &lt;customErrors&gt; tag should then have its &quot;mode&quot; attribute set to &quot;Off&quot;.<br><br>\r\n\r\n            <table width=100% bgcolor=\"#ffffcc\">\r\n               <tr>\r\n                  <td>\r\n                      <code><pre>\r\n\r\n&lt;!-- Web.Config Configuration File --&gt;\r\n\r\n&lt;configuration&gt;\r\n    &lt;system.web&gt;\r\n        &lt;customErrors mode=&quot;Off&quot;/&gt;\r\n    &lt;/system.web&gt;\r\n&lt;/configuration&gt;</pre></code>\r\n\r\n                  </td>\r\n               </tr>\r\n            </table>\r\n\r\n            <br>\r\n\r\n            <b>Notes:</b> The current error page you are seeing can be replaced by a custom error page by modifying the &quot;defaultRedirect&quot; attribute of the application&#39;s &lt;customErrors&gt; configuration tag to point to a custom error page URL.<br><br>\r\n\r\n            <table width=100% bgcolor=\"#ffffcc\">\r\n               <tr>\r\n                  <td>\r\n                      <code><pre>\r\n\r\n&lt;!-- Web.Config Configuration File --&gt;\r\n\r\n&lt;configuration&gt;\r\n    &lt;system.web&gt;\r\n        &lt;customErrors mode=&quot;RemoteOnly&quot; defaultRedirect=&quot;mycustompage.htm&quot;/&gt;\r\n    &lt;/system.web&gt;\r\n&lt;/configuration&gt;</pre></code>\r\n\r\n                  </td>\r\n               </tr>\r\n            </table>\r\n\r\n            <br>\r\n\r\n    </body>\r\n</html>\r\n", "content_length": "3431", "content_type": "text/html; charset=utf-8", "date": "Tue, 26 May 2020 16:27:51 GMT", "item": "xxx/xxx/xxx", "msg": "Status code was 500 and not [200, 302]: HTTP Error 500: Internal Server Error", "redirected": false, "server": "Microsoft-IIS/10.0", "status": 500, "url": "https://x.x.x.x:xxx/xxx/xxx", "x_aspnet_version": "4.0.30319", "x_powered_by": "ASP.NET"}
```
After
```
failed: [x.x.x.x -> 127.0.0.1] (item=xxx/xxx/xxx) => {"cache_control": "private", "changed": false, "connection": "close", "content_length": "3431", "content_type": "text/html; charset=utf-8", "date": "Tue, 26 May 2020 16:53:06 GMT", "item": "xxx/xxx/xxx", "msg": "Status code was 500 and not [200, 302]: HTTP Error 500: Internal Server Error", "redirected": false, "server": "Microsoft-IIS/10.0", "status": 500, "url": "https://x.x.x.x:xxx/xxx/xxx", "x_aspnet_version": "4.0.30319", "x_powered_by": "ASP.NET"}
```
