### PR TITLE
fix delegated loading when path is not a directory

### DIFF
--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -228,7 +228,12 @@ class _AnsiblePathHookFinder:
             if PY3:
                 # create or consult our cached file finder for this path
                 if not self._file_finder:
-                    self._file_finder = _AnsiblePathHookFinder._filefinder_path_hook(self._pathctx)
+                    try:
+                        self._file_finder = _AnsiblePathHookFinder._filefinder_path_hook(self._pathctx)
+                    except ImportError:
+                        # FUTURE: log at a high logging level? This is normal for things like python36.zip on the path, but
+                        # might not be in some other situation...
+                        return None
 
                 spec = self._file_finder.find_spec(fullname)
                 if not spec:

--- a/test/units/utils/collection_loader/test_collection_loader.py
+++ b/test/units/utils/collection_loader/test_collection_loader.py
@@ -273,6 +273,15 @@ def test_path_hook_setup():
     assert repr(_AnsiblePathHookFinder(object(), '/bogus/path')) == "_AnsiblePathHookFinder(path='/bogus/path')"
 
 
+def test_path_hook_importerror():
+    # ensure that AnsiblePathHookFinder.find_module swallows ImportError from path hook delegation on Py3, eg if the delegated
+    # path hook gets passed a file on sys.path (python36.zip)
+    reset_collections_loader_state()
+    path_to_a_file = os.path.join(default_test_collection_paths[0], 'ansible_collections/testns/testcoll/plugins/action/my_action.py')
+    # it's a bug if the following pops an ImportError...
+    assert _AnsiblePathHookFinder(_AnsibleCollectionFinder(), path_to_a_file).find_module('foo.bar.my_action') is None
+
+
 def test_new_or_existing_module():
     module_name = 'blar.test.module'
     pkg_name = module_name.rpartition('.')[0]


### PR DESCRIPTION
##### SUMMARY
* find_module can't pop ImportError- we need to just translate to `None` since this is a normal condition with files on sys.path (eg `/usr/lib/python36.zip`)
* added test

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
_collection_finder.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
