### PR TITLE
Ansible.Basic - Added generic fragment merger for module options

### DIFF
--- a/changelogs/fragments/ansible-basic-util-fragment.yaml
+++ b/changelogs/fragments/ansible-basic-util-fragment.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Ansible.Basic - Added the ability to specify multiple fragments to load in a generic way for modules that use a module_util with fragment options

--- a/docs/docsite/rst/dev_guide/developing_modules_general_windows.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general_windows.rst
@@ -209,10 +209,11 @@ options set:
 - ``aliases``: A list of aliases for the module option
 - ``choices``: A list of valid values for the module option, if ``type=list`` then each list value is validated against the choices and not the list itself
 - ``default``: The default value for the module option if not set
-- ``deprecated_aliases``: A list of hashtables that define aliases that are deprecated and the versions they will be removed in. Each entry must contain the keys ``name`` and ``version``
+- ``deprecated_aliases``: A list of hashtables that define aliases that are deprecated and the versions they will be removed in. Each entry must contain the key ``name`` with either ``version`` or ``date``
 - ``elements``: When ``type=list``, this sets the type of each list value, the values are the same as ``type``
 - ``no_log``: Will sanitise the input value before being returned in the ``module_invocation`` return value
 - ``removed_in_version``: States when a deprecated module option is to be removed, a warning is displayed to the end user if set
+- ``removed_at_date``: States the date when a deprecated module option will be removed, a warning is displayed to the end user if set
 - ``required``: Will fail when the module option is not set
 - ``type``: The type of the module option, if not set then it defaults to ``str``. The valid types are;
     * ``bool``: A boolean value
@@ -386,6 +387,126 @@ at the end of the file. For example
 .. code-block:: powershell
 
     Export-ModuleMember -Function Invoke-CustomUtil, Get-CustomInfo
+
+
+Exposing shared module options
+++++++++++++++++++++++++++++++
+
+PowerShell module utils can easily expose common module options that a module can use when building its argument spec.
+This allows common features to be stored and maintained in one location and have those features used by multiple
+modules with minimal effort. Any new features or bugifxes added to one of these utils are then automatically used by
+the various modules that call that util.
+
+An example of this would be to have a module util that handles authentication and communication against an API This
+util can be used by multiple modules to expose a common set of module options like the API endpoint, username,
+password, timeout, cert validation, etc, without having to add those options to each module spec.
+
+The standard convention for a module util that has a shared argument spec would have
+
+- A ``Get-<namespace.name.util name>Spec`` function that outputs the common spec for a module
+    * It is highly recommended to make this function name be unique to the module to avoid any conflicts with other utils that can be loaded
+    * The format of the output spec is a Hashtable in the same format as the ``$spec`` used for normal modules
+- A function that takes in an ``AnsibleModule`` object called under the ``-Module`` parameter which it can use to get the shared options
+
+Because these options can be shared across various module it is highly recommended to keep the module option names and
+aliases in the shared spec as specific as they can be. For example do not have a util option called ``password``,
+rather you should prefix it with a unique name like ``acme_password``.
+
+.. warning::
+    Failure to have a unique option name or alias can prevent the util being used by module that also use those names or
+    aliases for its own options.
+
+The following is an example module util called ``ServiceAuth.psm1`` in a collection that implements a common way for
+modules to authentication with a service.
+
+.. code-block:: powershell
+
+    Invoke-MyServiceResource {
+        [CmdletBinding()]
+        param (
+            [Parameter(Mandatory=$true)]
+            [ValidateScript({ $_.GetType().FullName -eq 'Ansible.Basic.AnsibleModule' })]
+            $Module,
+
+            [Parameter(Mandatory=$true)]
+            [String]
+            $ResourceId
+
+            [String]
+            $State = 'present'
+        )
+
+        # Process the common module options known to the util
+        $params = @{
+            ServerUri = $Module.Params.my_service_url
+        }
+        if ($Module.Params.my_service_username) {
+            $params.Credential = Get-MyServiceCredential
+        }
+
+        if ($State -eq 'absent') {
+            Remove-MyService @params -ResourceId $ResourceId
+        } else {
+            New-MyService @params -ResourceId $ResourceId
+        }
+    }
+
+    Get-MyNamespaceMyCollectionServiceAuthSpec {
+        # Output the util spec
+        @{
+            options = @{
+                my_service_url = @{ type = 'str'; required = $true }
+                my_service_username = @{ type = 'str' }
+                my_service_password = @{ type = 'str'; no_log = $true }
+            }
+
+            required_together = @(
+                ,@('my_service_username', 'my_service_password')
+            )
+        }
+    }
+
+    $exportMembers = @{
+        Function = 'Get-MyNamespaceMyCollectionServiceAuthSpec', 'Invoke-MyServiceResource'
+    }
+    Export-ModuleMember @exportMembers
+
+
+For a module to take advantage of this common argument spec it can be set out like
+
+.. code-block:: powershell
+
+    #!powershell
+
+    # Include the module util ServiceAuth.psm1 from the my_namespace.my_collection collection
+    #AnsibleRequires -PowerShell ansible_collections.my_namespace.my_collection.plugins.module_utils.ServiceAuth
+
+    # Create the module spec like normal
+    $spec = @{
+        options = @{
+            resource_id = @{ type = 'str'; required = $true }
+            state = @{ type = 'str'; choices = 'absent', 'present' }
+        }
+    }
+
+    # Create the module from the module spec but also include the util spec to merge into our own.
+    $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec, @(Get-MyNamespaceMyCollectionServiceAuthSpec))
+
+    # Call the ServiceAuth module util and pass in the module object so it can access the module options.
+    Invoke-MyServiceResource -Module $module -ResourceId $module.Params.resource_id -State $module.params.state
+
+    $module.ExitJson()
+
+
+.. note::
+    Options defined in the module spec will always have precedence over a util spec. Any list values under the same key
+    in a util spec will be appended to the module spec for that same key. Dictionary values will add any keys that are
+    missing from the module spec and merge any values that are lists or dictionaries. This is similar to how the doc
+    fragment plugins work when extending module documentation.
+
+To document these shared util options for a module, create a doc fragment plugin that documents the options implemented
+by the module util and extend the module docs for every module that implements the util to include that fragment in
+its docs.
 
 
 Windows playbook module testing

--- a/test/integration/targets/ansible-test-docker/ansible_collections/ns/col/plugins/modules/win_util_args.ps1
+++ b/test/integration/targets/ansible-test-docker/ansible_collections/ns/col/plugins/modules/win_util_args.ps1
@@ -11,8 +11,6 @@ $spec = @{
       my_opt = @{ type = "str"; required = $true }
     }
 }
-$util_spec = Get-PSUtilSpec
-$spec.options += $util_spec.options
 
-$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec, @(Get-PSUtilSpec))
 $module.ExitJson()

--- a/test/integration/targets/module_utils_Ansible.ModuleUtils.WebRequest/library/web_request_test.ps1
+++ b/test/integration/targets/module_utils_Ansible.ModuleUtils.WebRequest/library/web_request_test.ps1
@@ -423,9 +423,8 @@ $tests = [Ordered]@{
             }
             mutually_exclusive = @(,@('url', 'test'))
         }
-        $spec = Merge-WebRequestSpec -ModuleSpec $spec
 
-        $testModule = [Ansible.Basic.AnsibleModule]::Create(@(), $spec)
+        $testModule = [Ansible.Basic.AnsibleModule]::Create(@(), $spec, @(Get-AnsibleWebRequestSpec))
         $r = Get-AnsibleWebRequest -Url $testModule.Params.url -Module $testModule
 
         $actual = Invoke-WithWebRequest -Module $testModule -Request $r -Script {

--- a/test/support/windows-integration/plugins/modules/win_get_url.ps1
+++ b/test/support/windows-integration/plugins/modules/win_get_url.ps1
@@ -40,9 +40,7 @@ $spec = @{
     )
     supports_check_mode = $true
 }
-$spec = Merge-WebRequestSpec -ModuleSpec $spec
-
-$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec, @(Get-AnsibleWebRequestSpec))
 
 $url = $module.Params.url
 $dest = $module.Params.dest
@@ -274,4 +272,3 @@ if ((-not $module.Result.ContainsKey("checksum_dest")) -and (Test-Path -LiteralP
 }
 
 $module.ExitJson()
-


### PR DESCRIPTION
##### SUMMARY
As more functionality eventually merges out of ansible/ansible to a collection we need to make it easier to develop module_utils that can expose module options in a generic fashion.

The method currently in place for `Ansible.ModuleUtils.WebRequest` is not generic enough and requires the caller to know the module util implements a function that will merge it's spec with the fragments spec. What this PR proposes is a common way of specifying a fragment spec in a util and combine that with the modules spec in a common way. This is done by passing in an array of fragment specs to `[Ansible.Basic.AnsibleModule]::Create($args, $spec, @($fragmentSpec1, $fragmentSpec2, ...))`.

With this new method we gain the following benefits

* A module util that implements a shared fragment spec only need to expose it as a variable, the format of this spec is exactly the same as a module spec
* A module util does not need to reimplement a merging function to merge the modules spec with the utils spec or require the module to do so
* Enforces a common behaviour where module specs will override a util spec similar to how doc fragments work

While this PR does remove `Merge-WebRequestSpec` from `Ansible.ModuleUtils.WebRequest`, this was only added with https://github.com/ansible/ansible/pull/66325 and has not made it to a release yet. There are no breaking changes with existing releases by removing this function. Although we will have to fix `ansible.windows` that call this function to use the newer standard proposed (they have not been released yet).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Ansible.Basic.cs