### PR TITLE
elb_application_ld docs: add http-header example

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -208,6 +208,16 @@ EXAMPLES = '''
             Actions:
               - TargetGroupName: test-target-group
                 Type: forward
+          - Conditions:
+              - Field: http-header
+                HttpHeaderConfig:
+                  HttpHeaderName: X-Forwarded-Port
+                  Values:
+                    - "4321"
+            Priority: '2'
+            Actions:
+              - TargetGroupName: test-target-group
+                Type: forward                
     state: present
 
 # Remove an ELB


### PR DESCRIPTION
##### SUMMARY

Add and example to the `elb_application_lb` module covering the `http-header` rule creation.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

elb_application_ld

##### ADDITIONAL INFORMATION

The `listeners` key values of the `elb_application_lb` module rely heavily on the examples. This extends the existing examples with a `http-header` rule.

I personally struggled with existing Ansible & AWS docs to get this (eventually straight-forward) config right, so this addition will hopefully help anyone struggling with the AWS docs and API spec.