### PR TITLE
[stable-2.9] Don't pass tenant_id for remote group in os_security_group_rule

### DIFF
--- a/changelogs/fragments/69726-os-security-group-rule-fix.yml
+++ b/changelogs/fragments/69726-os-security-group-rule-fix.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- Fix the issue when OS secgroup rule couldn't be imported from
+  a different tenant https://github.com/ansible/ansible/issues/69673

--- a/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
@@ -321,6 +321,7 @@ def main():
         secgroup = cloud.get_security_group(security_group, filters=filters)
 
         if remote_group:
+            filters.pop('tenant_id')
             remotegroup = cloud.get_security_group(remote_group,
                                                    filters=filters)
         else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #69673 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
os_security_group_rule.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Fixes bug in Openstack module of security group rules management.
This is fix in collection for 2.10: https://review.opendev.org/#/c/730422/
This PR is porting it to 2.9

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
