### PR TITLE
blockinfile - fix line ending regression

### DIFF
--- a/changelogs/fragments/blockinfile-line-ending-fix.yaml
+++ b/changelogs/fragments/blockinfile-line-ending-fix.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >
+    blockinfile - fix regression that results in incorrect block in file when the
+    block to be inserted does not end in a line separator (https://github.com/ansible/ansible/pull/69734)

--- a/lib/ansible/modules/blockinfile.py
+++ b/lib/ansible/modules/blockinfile.py
@@ -272,6 +272,8 @@ def main():
         # Escape sequences like '\n' need to be handled in Ansible 1.x
         if module.ansible_version.startswith('1.'):
             block = re.sub('', block, '')
+        if not block.endswith(b(os.linesep)):
+            block += b(os.linesep)
         blocklines = [marker0] + block.splitlines(True) + [marker1]
     else:
         blocklines = []

--- a/test/integration/targets/blockinfile/tasks/main.yml
+++ b/test/integration/targets/blockinfile/tasks/main.yml
@@ -137,3 +137,35 @@
       - 'blockinfile_test2 is changed'
       - 'blockinfile_test2.msg == "Block inserted"'
       - 'blockinfile_test2_grep.stdout == "6"'
+
+
+- name: Add block without trailing line separator
+  blockinfile:
+    path: "{{ output_dir_test }}/chomped_block_test.txt"
+    create: yes
+    content: |-
+      one
+      two
+      three
+  register: chomptest1
+
+- name: Add block without trailing line separator again
+  blockinfile:
+    path: "{{ output_dir_test }}/chomped_block_test.txt"
+    content: |-
+      one
+      two
+      three
+  register: chomptest2
+
+- name: Check output file
+  stat:
+    path: "{{ output_dir_test }}/chomped_block_test.txt"
+  register: chomptest_file
+
+- name: Ensure chomptest results are correct
+  assert:
+    that:
+      - chomptest1 is changed
+      - chomptest2 is not changed
+      - chomptest_file.stat.checksum == '50d49f528a5f7147c7029ed6220c326b1ee2c4ae'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
PR #66461 introduced a regression that resulted in an incorrect block in the file if the block to be inserted did not end with a line separator. This was causing some other tests in our CI to fail and probably would badly break things for others.

Fix this bug by ensuring the block has a line separator at the end and add tests to cover this scenario.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/blockinfile.py`