### PR TITLE
[2.8] Fix documentation of docker_host_info (it does not delete).

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_host_info.py
+++ b/lib/ansible/modules/cloud/docker/docker_host_info.py
@@ -37,7 +37,7 @@ options:
     default: no
   containers_filters:
     description:
-      - A dictionary of filter values used for selecting containers to delete.
+      - A dictionary of filter values used for selecting containers to list.
       - "For example, C(until: 24h)."
       - See L(the docker documentation,https://docs.docker.com/engine/reference/commandline/container_prune/#filtering)
         for more information on possible filters.
@@ -49,7 +49,7 @@ options:
     default: no
   images_filters:
     description:
-      - A dictionary of filter values used for selecting images to delete.
+      - A dictionary of filter values used for selecting images to list.
       - "For example, C(dangling: true)."
       - See L(the docker documentation,https://docs.docker.com/engine/reference/commandline/image_prune/#filtering)
         for more information on possible filters.
@@ -61,7 +61,7 @@ options:
     default: no
   networks_filters:
     description:
-      - A dictionary of filter values used for selecting networks to delete.
+      - A dictionary of filter values used for selecting networks to list.
       - See L(the docker documentation,https://docs.docker.com/engine/reference/commandline/network_prune/#filtering)
         for more information on possible filters.
     type: dict
@@ -72,7 +72,7 @@ options:
     default: no
   volumes_filters:
     description:
-      - A dictionary of filter values used for selecting volumes to delete.
+      - A dictionary of filter values used for selecting volumes to list.
       - See L(the docker documentation,https://docs.docker.com/engine/reference/commandline/volume_prune/#filtering)
         for more information on possible filters.
     type: dict


### PR DESCRIPTION
##### SUMMARY
Backport of ansible-collections/community.general#426 to stable-2.8.

CC @Yajo

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docker_host_info
