### PR TITLE
[backport][2.9] ec2_group: Ensure group-based rule targets have consistent data formats

### DIFF
--- a/test/integration/targets/ec2_group/tasks/main.yml
+++ b/test/integration/targets/ec2_group/tasks/main.yml
@@ -519,6 +519,7 @@
       assert:
         that:
           - result.changed
+          - result.warning is not defined
           - result.ip_permissions|length == 2
           - result.ip_permissions[0].user_id_group_pairs or
             result.ip_permissions[1].user_id_group_pairs
@@ -626,6 +627,7 @@
         that:
            - 'result.changed'
            - 'result.group_id.startswith("sg-")'
+           - result.warning is not defined
 
     # ============================================================
     - name: test adding a range of ports and ports given as strings (expected changed=true) (CHECK MODE)

--- a/test/integration/targets/ec2_group/tasks/multi_nested_target.yml
+++ b/test/integration/targets/ec2_group/tasks/multi_nested_target.yml
@@ -220,6 +220,7 @@
   - assert:
       that:
         - result.changed
+        - result.warning is not defined
         - 'result.ip_permissions[0].ip_ranges | length == 3 or result.ip_permissions[1].ip_ranges | length == 3'
         - 'result.ip_permissions[0].ipv6_ranges | length == 3 or result.ip_permissions[1].ipv6_ranges | length == 3'
 

--- a/test/integration/targets/ec2_group/tasks/rule_group_create.yml
+++ b/test/integration/targets/ec2_group/tasks/rule_group_create.yml
@@ -51,6 +51,10 @@
         - 60
         - 80
 
+    - assert:
+        that:
+          - result.warning is not defined
+
     - name: Create a group with only the default rule
       ec2_group:
         name: '{{ec2_group_name}}-auto-create-1'
@@ -87,6 +91,10 @@
         state: present
       register: result
 
+    - assert:
+        that:
+          - result.warning is not defined
+
     - name: Create a 4th group
       ec2_group:
         name: '{{ec2_group_name}}-auto-create-4'
@@ -112,6 +120,10 @@
           group_name: '{{ec2_group_name}}-auto-create-4'
         <<: *aws_connection_info
         state: present
+
+    - assert:
+        that:
+          - result.warning is not defined
 
   always:
     - name: tidy up egress rule test security group


### PR DESCRIPTION
##### SUMMARY
Ensure group-based rule targets have consistent data formats throughout the module.
Backport of https://github.com/ansible-collections/amazon.aws/pull/33

##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_group.py

##### ADDITIONAL INFORMATION
ansible/ansible#68729
ansible/ansible#68217
ansible/ansible#66852
ansible/ansible#66641