### PR TITLE
connection plugins: try config, then play_context

### DIFF
--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -324,9 +324,11 @@ class Connection(ConnectionBase):
 
         ssh.set_missing_host_key_policy(MyAddPolicy(self._new_stdin, self))
 
+        conn_password = self.get_option('password') or self._play_context.password
+
         allow_agent = True
 
-        if self.get_option('password') is not None:
+        if conn_password is not None:
             allow_agent = False
 
         try:
@@ -344,7 +346,7 @@ class Connection(ConnectionBase):
                 allow_agent=allow_agent,
                 look_for_keys=self.get_option('look_for_keys'),
                 key_filename=key_filename,
-                password=self.get_option('password'),
+                password=conn_password,
                 timeout=self._play_context.timeout,
                 port=port,
                 **ssh_connect_kwargs

--- a/test/integration/targets/network_cli/aliases
+++ b/test/integration/targets/network_cli/aliases
@@ -1,0 +1,3 @@
+# Keeping incidental for efficiency, to avoid spinning up another VM
+shippable/vyos/incidental
+network/vyos

--- a/test/integration/targets/network_cli/passworded_user.yml
+++ b/test/integration/targets/network_cli/passworded_user.yml
@@ -1,0 +1,14 @@
+- hosts: vyos-1-1-8
+  gather_facts: false
+
+  tasks:
+    - name: Run whoami
+      vyos.vyos.vyos_command:
+        commands:
+          - whoami
+      register: whoami
+
+    - assert:
+        that:
+          - whoami is successful
+          - whoami.stdout_lines[0][0] == 'atester'

--- a/test/integration/targets/network_cli/runme.sh
+++ b/test/integration/targets/network_cli/runme.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -ux # no -e because we want to run teardown no matter waht
+export ANSIBLE_ROLES_PATH=../
+
+ansible-playbook setup.yml -i $INVENTORY_PATH "$@"
+
+# We need a nonempty file to override key with (empty file gives a
+# lovely "list index out of range" error)
+foo=`mktemp`
+echo hello > $foo
+
+ansible-playbook \
+    -i $INVENTORY_PATH \
+    -e ansible_user=atester \
+    -e ansible_password=testymctest \
+    -e ansible_ssh_private_key_file=$foo \
+    passworded_user.yml
+
+ansible-playbook teardown.yml -i $INVENTORY_PATH "$@"

--- a/test/integration/targets/network_cli/runme.sh
+++ b/test/integration/targets/network_cli/runme.sh
@@ -2,18 +2,18 @@
 set -ux # no -e because we want to run teardown no matter waht
 export ANSIBLE_ROLES_PATH=../
 
-ansible-playbook setup.yml -i $INVENTORY_PATH "$@"
+ansible-playbook setup.yml -i "$INVENTORY_PATH" "$@"
 
 # We need a nonempty file to override key with (empty file gives a
 # lovely "list index out of range" error)
-foo=`mktemp`
-echo hello > $foo
+foo=$(mktemp)
+echo hello > "$foo"
 
 ansible-playbook \
-    -i $INVENTORY_PATH \
+    -i "$INVENTORY_PATH" \
     -e ansible_user=atester \
     -e ansible_password=testymctest \
-    -e ansible_ssh_private_key_file=$foo \
+    -e ansible_ssh_private_key_file="$foo" \
     passworded_user.yml
 
-ansible-playbook teardown.yml -i $INVENTORY_PATH "$@"
+ansible-playbook teardown.yml -i "$INVENTORY_PATH" "$@"

--- a/test/integration/targets/network_cli/setup.yml
+++ b/test/integration/targets/network_cli/setup.yml
@@ -1,0 +1,14 @@
+- hosts: vyos-1-1-8
+  connection: ansible.netcommon.network_cli
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Create user with password
+      register: result
+      vyos.vyos.vyos_config:
+        lines:
+          - set system login user atester full-name "Ansible Tester"
+          - set system login user atester authentication plaintext-password testymctest
+          - set system login user jsmith level admin
+          - delete service ssh disable-password-authentication

--- a/test/integration/targets/network_cli/teardown.yml
+++ b/test/integration/targets/network_cli/teardown.yml
@@ -1,0 +1,14 @@
+- hosts: vyos-1-1-8
+  connection: ansible.netcommon.network_cli
+  become: true
+  gather_facts: false
+
+  tasks:
+    - name: Get rid of user (undo everything from setup.yml)
+      register: result
+      vyos.vyos.vyos_config:
+        lines:
+          - delete system login user atester full-name "Ansible Tester"
+          - delete system login user atester authentication plaintext-password testymctest
+          - delete system login user jsmith level admin
+          - set service ssh disable-password-authentication


### PR DESCRIPTION
##### SUMMARY

Change:
Rather than only using config, have base connection plugins fall back to
play_context.

Test Plan:
- Tested ansible-connection logic against an IOS device
- Tested -k against a VM
- CI

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

connection plugins