### PR TITLE
make plugins loader Python 3.5 compatible again

### DIFF
--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -49,6 +49,11 @@ try:
     imp = None
 except ImportError:
     import imp
+
+try:
+    ModuleNotFoundError
+except NameError:
+    # this was introduced in Python 3.6
     ModuleNotFoundError = None
 
 display = Display()


### PR DESCRIPTION
##### SUMMARY

ModuleNotFoundError was only introduced in Python 3.6, so chaining the
fallback to None to the importlib.util import (that exists in 3.5) results
in code that does not work on 3.5 as ModuleNotFoundError is undefined.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/loader.py


##### ADDITIONAL INFORMATION

alternative to https://github.com/ansible/ansible/pull/69737