### PR TITLE
Fix version_added test

### DIFF
--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -2024,7 +2024,7 @@ class ModuleValidator(Validator):
         try:
             mod_version_added = self.StrictVersion()
             mod_version_added.parse(
-                str(existing_doc.get('version_added', '0.0'))
+                self._extract_version_from_tag_for_msg(str(existing_doc.get('version_added', '0.0')))
             )
         except ValueError:
             mod_version_added = self.StrictVersion('0.0')
@@ -2071,7 +2071,7 @@ class ModuleValidator(Validator):
             try:
                 version_added = self.StrictVersion()
                 version_added.parse(
-                    str(details.get('version_added', '0.0'))
+                    self._extract_version_from_tag_for_msg(str(details.get('version_added', '0.0')))
                 )
             except ValueError:
                 # already reported during schema validation

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -2062,7 +2062,7 @@ class ModuleValidator(Validator):
                     self.reporter.error(
                         path=self.object_path,
                         code='option-incorrect-version-added',
-                        msg=('version_added for new option (%s) should '
+                        msg=('version_added for existing option (%s) should '
                              'be %r. Currently %r' %
                              (option, existing_version, current_version))
                     )


### PR DESCRIPTION
##### SUMMARY
Fixes the version_added test for ansible/ansible (ensures that new options/plugins have the correct `version_added` value, and that it is not changed for existing ones). I forgot to untag a version number in #69680 before converting it to `StrictVersion`.

(While testing I also noticed that the error message says "new option" also for existing options.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
