### PR TITLE
Add entries for missing network modules

### DIFF
--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -5436,6 +5436,8 @@ plugin_routing:
       redirect: check_point.mgmt.cp_mgmt_wildcard
     cp_mgmt_wildcard_facts:
       redirect: check_point.mgmt.cp_mgmt_wildcard_facts
+    eos_ospfv2:
+      redirect: arista.eos.eos_ospfv2
     eos_static_route:
       redirect: arista.eos.eos_static_route
     eos_acls:
@@ -5642,6 +5644,8 @@ plugin_routing:
       redirect: community.general.intersight_info
     intersight_rest_api:
       redirect: cisco.intersight.intersight_rest_api
+    ios_ospfv2:
+      redirect: cisco.ios.ios_ospfv2
     ios_l3_interfaces:
       redirect: cisco.ios.ios_l3_interfaces
     ios_lldp:
@@ -5702,6 +5706,8 @@ plugin_routing:
       redirect: cisco.ios.ios_acls
     ios_interfaces:
       redirect: cisco.ios.ios_interfaces
+    iosxr_ospfv2:
+      redirect: cisco.iosxr.iosxr_ospfv2
     iosxr_bgp:
       redirect: cisco.iosxr.iosxr_bgp
     iosxr_lldp_interfaces:
@@ -5856,6 +5862,8 @@ plugin_routing:
       redirect: cisco.nxos.nxos_bfd_interfaces
     nxos_ospf:
       redirect: cisco.nxos.nxos_ospf
+    nxos_ospfv2:
+      redirect: cisco.nxos.nxos_ospfv2
     nxos_system:
       redirect: cisco.nxos.nxos_system
     nxos_l3_interface:
@@ -5864,6 +5872,8 @@ plugin_routing:
       redirect: cisco.nxos.nxos_smu
     nxos_reboot:
       redirect: cisco.nxos.nxos_reboot
+    nxos_static_routes:
+      redirect: cisco.nxos.nxos_static_routes
     nxos_static_route:
       redirect: cisco.nxos.nxos_static_route
     nxos_acl_interfaces:
@@ -6492,6 +6502,12 @@ plugin_routing:
       redirect: openstack.cloud.volume_snapshot
     os_zone:
       redirect: openstack.cloud.dns_zone
+    junos_acls:
+      redirect: junipernetworks.junos.junos_acls
+    junos_acl_interfaces:
+      redirect: junipernetworks.junos.junos_acl_interfaces
+    junos_ospfv2:
+      redirect: junipernetworks.junos.junos_ospfv2
     junos_user:
       redirect: junipernetworks.junos.junos_user
     junos_l2_interface:
@@ -7502,6 +7518,8 @@ plugin_routing:
       redirect: openvswitch.openvswitch.openvswitch_db
     openvswitch_bridge:
       redirect: openvswitch.openvswitch.openvswitch_bridge
+    vyos_ospfv2:
+      redirect: vyos.vyos.vyos_ospfv2
     vyos_l3_interface:
       redirect: vyos.vyos.vyos_l3_interface
     vyos_banner:


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
Add entries for network modules that were added in respective collections after the "big split".

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible_builtin_runtime.yml