### PR TITLE
[2.9] Remove unused and invalid import from FRR cliconf plugin

### DIFF
--- a/changelogs/fragments/67790_frr_remove_unused_import.yaml
+++ b/changelogs/fragments/67790_frr_remove_unused_import.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Remove unused and invalid import from FRR cliconf plugin (https://github.com/ansible/ansible/pull/67790).

--- a/lib/ansible/plugins/cliconf/frr.py
+++ b/lib/ansible/plugins/cliconf/frr.py
@@ -38,7 +38,6 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.common._collections_compat import Mapping
 from ansible.module_utils.network.common.config import NetworkConfig, dumps
 from ansible.module_utils.network.common.utils import to_list
-from ansible.module_utils.basic import get_timestamp
 from ansible.plugins.cliconf import CliconfBase, enable_mode
 
 


### PR DESCRIPTION
Signed-off-by: Paul Belanger <pabelanger@redhat.com>
(cherry picked from commit 357ae7ec0ef006553fcc9e4831d13d4eccb0f8a8)

Add changelog

Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/67790

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
cliconf/frr.py