### PR TITLE
[2.9] Check feature privilege status only if priv escalation is required 

### DIFF
--- a/changelogs/fragments/fix_nxos_terminal_plugin_order.yaml
+++ b/changelogs/fragments/fix_nxos_terminal_plugin_order.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Update terminal plugin to check feature privilege only when escalation is needed (https://github.com/ansible-collections/cisco.nxos/pull/61).

--- a/lib/ansible/plugins/terminal/nxos.py
+++ b/lib/ansible/plugins/terminal/nxos.py
@@ -57,8 +57,6 @@ class TerminalModule(TerminalBase):
 
         out = self._exec_cli_command('show privilege')
         out = to_text(out, errors='surrogate_then_replace').strip()
-        if 'Disabled' in out:
-            raise AnsibleConnectionFailure('Feature privilege is not enabled')
 
         # if already at privilege level 15 return
         if '15' in out:
@@ -66,6 +64,9 @@ class TerminalModule(TerminalBase):
 
         if self.validate_user_role():
             return
+
+        if 'Disabled' in out:
+            raise AnsibleConnectionFailure('Feature privilege is not enabled')
 
         cmd = {u'command': u'enable'}
         if passwd:


### PR DESCRIPTION
Check feature privilege status only if priv escalation is required

Reviewed-by: https://github.com/apps/ansible-zuul
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

Add changelog

Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
Backport of https://github.com/ansible-collections/cisco.nxos/pull/61

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
terminal/nxos.py