### PR TITLE
__eq__ should be redefined if __hash__ is defined.

### DIFF
--- a/lib/ansible/module_utils/common/collections.py
+++ b/lib/ansible/module_utils/common/collections.py
@@ -28,6 +28,15 @@ class ImmutableDict(Hashable, Mapping):
     def __hash__(self):
         return hash(frozenset(self.items()))
 
+    def __eq__(self, other):
+        try:
+            if self.__hash__() == hash(other):
+                return True
+        except TypeError:
+            pass
+
+        return False
+
     def __repr__(self):
         return 'ImmutableDict({0})'.format(repr(self._store))
 


### PR DESCRIPTION

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
This is really minor.  At the moment we do not do any equality testing with ImmutableDicts.  But it completes the API so there's no surprises if someone adds an equality test at some point in the future.