### PR TITLE
ansible-doc: fix return value interpretation of PluginLoader.find_plugin_with_context()

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -327,7 +327,7 @@ class DocCLI(CLI):
     def _get_plugin_doc(plugin, plugin_type, loader, search_paths):
         # if the plugin lives in a non-python file (eg, win_X.ps1), require the corresponding python file for docs
         result = loader.find_plugin_with_context(plugin, mod_type='.py', ignore_deprecated=True, check_aliases=True)
-        if result is None:
+        if not result.resolved:
             raise PluginNotFound('%s was not found in %s' % (plugin, search_paths))
         plugin_name, filename = result.plugin_resolved_name, result.plugin_resolved_path
 


### PR DESCRIPTION
##### SUMMARY
While rebasing #69680 after the routing PR was merged, I used the return value of `PluginLoader.find_plugin_with_context()` wrongly (treat it as `None`/non-`None` instead of checking `result.resolved`). This causes `ERROR! module xxx missing documentation (or could not parse documentation): 'NoneType' object has no attribute 'startswith'` when `ansible-doc` is called for a non-existant module (or plugin).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/cli/doc.py
