### PR TITLE
Backport to fix ios_l2_interfaces facts parsing issue

### DIFF
--- a/changelogs/fragments/59_ios_l2_interfaces_facts_parsing_issue.yaml
+++ b/changelogs/fragments/59_ios_l2_interfaces_facts_parsing_issue.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - To fix ios_l2_interfaces facts parsing issue (https://github.com/ansible-collections/cisco.ios/pull/59)

--- a/lib/ansible/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py
+++ b/lib/ansible/module_utils/network/ios/facts/l2_interfaces/l2_interfaces.py
@@ -92,7 +92,7 @@ class L2_InterfacesFacts(object):
                 config["access"] = {"vlan": int(has_access)}
 
             trunk = dict()
-            trunk["encapsulation"] = utils.parse_conf_arg(conf, 'encapsulation')
+            trunk["encapsulation"] = utils.parse_conf_arg(conf, 'switchport trunk encapsulation')
             native_vlan = utils.parse_conf_arg(conf, 'native vlan')
             if native_vlan:
                 trunk["native_vlan"] = int(native_vlan)


### PR DESCRIPTION
Depends-on: #70253

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport to fix ios_l2_interfaces facts parsing issue.
Backport of https://github.com/ansible-collections/cisco.ios/pull/59
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_l2_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
