### PR TITLE
2.9: Ensure --version works with non-ascii project path (#66624)

### DIFF
--- a/changelogs/fragments/66617-version-unicode-fix.yml
+++ b/changelogs/fragments/66617-version-unicode-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Ensure that ``--version`` works with non-ascii ansible project paths (https://github.com/ansible/ansible/issues/66617)

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -231,7 +231,7 @@ def find_ini_config_file(warnings=None):
             if os.path.exists(cwd_cfg):
                 warn_cmd_public = True
         else:
-            potential_paths.append(cwd_cfg)
+            potential_paths.append(to_text(cwd_cfg, errors='surrogate_or_strict'))
     except OSError:
         # If we can't access cwd, we'll simply skip it as a possible config source
         pass

--- a/test/integration/targets/unicode/křížek-ansible-project/ansible.cfg
+++ b/test/integration/targets/unicode/křížek-ansible-project/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+library=~/.ansible/plugins/modules:/usr/share/ansible/plugins/modules:.

--- a/test/integration/targets/unicode/runme.sh
+++ b/test/integration/targets/unicode/runme.sh
@@ -5,3 +5,9 @@ set -eux
 ansible-playbook unicode.yml -i inventory -v -e 'extra_var=café' "$@"
 # Test the start-at-task flag #9571
 ANSIBLE_HOST_PATTERN_MISMATCH=warning ansible-playbook unicode.yml -i inventory -v --start-at-task '*¶' -e 'start_at_task=True' "$@"
+
+# Test --version works with non-ascii ansible project paths #66617
+# Unset these so values from the project dir are used
+unset ANSIBLE_CONFIG
+unset ANSIBLE_LIBRARY
+pushd křížek-ansible-project && ansible --version; popd


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #66624 

(cherry picked from commit 3606dcfe652ab45a8c7e4dedd5e2a64edd820ef5)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/config/manager.py`