### PR TITLE
properly define ModuleNotFoundError

### DIFF
--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -54,7 +54,8 @@ try:
     ModuleNotFoundError
 except NameError:
     # this was introduced in Python 3.6
-    ModuleNotFoundError = None
+    class ModuleNotFoundError(ImportError):
+        pass
 
 display = Display()
 


### PR DESCRIPTION
##### SUMMARY

you can't catch non-Exception exceptions on Python 3

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/loader.py


