### PR TITLE
only ever catch ImportError

### DIFF
--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -50,12 +50,6 @@ try:
 except ImportError:
     import imp
 
-try:
-    ModuleNotFoundError
-except NameError:
-    # this was introduced in Python 3.6
-    ModuleNotFoundError = None
-
 display = Display()
 
 _tombstones = None
@@ -493,7 +487,7 @@ class PluginLoader:
             # FIXME: there must be cheaper/safer way to do this
             try:
                 pkg = import_module(acr.n_python_package_name)
-            except (ImportError, ModuleNotFoundError):
+            except ImportError:
                 return plugin_load_context.nope('Python package {0} not found'.format(acr.n_python_package_name))
 
         pkg_path = os.path.dirname(pkg.__file__)


### PR DESCRIPTION
##### SUMMARY

ModuleNotFoundError is a subclass of ImportError but only exists in
Python 3.6 or newer. Instead of doing hacks to be able to catch that on
older Pythons, just always only catch ImportError, which will also catch
ModuleNotFoundError on Python 3.6 or later

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/loader.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->


