### PR TITLE
ansible-doc: properly handle suboptions

### DIFF
--- a/changelogs/fragments/69795-ansible-doc-suboptions.yml
+++ b/changelogs/fragments/69795-ansible-doc-suboptions.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "ansible-doc - improve suboptions formatting (https://github.com/ansible/ansible/pull/69795)."

--- a/test/integration/targets/ansible-doc/library/test_docs_suboptions.py
+++ b/test/integration/targets/ansible-doc/library/test_docs_suboptions.py
@@ -29,7 +29,7 @@ options:
                     a_suboption:
                         description: A sub-suboption.
                         type: str
-            a_first: 
+            a_first:
                 description: The first suboption.
                 type: str
 '''

--- a/test/integration/targets/ansible-doc/library/test_docs_suboptions.py
+++ b/test/integration/targets/ansible-doc/library/test_docs_suboptions.py
@@ -1,0 +1,70 @@
+#!/usr/bin/python
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: test_docs_suboptions
+short_description: Test module
+description:
+    - Test module
+author:
+    - Ansible Core Team
+options:
+    with_suboptions:
+        description:
+            - An option with suboptions.
+            - Use with care.
+        type: dict
+        suboptions:
+            z_last:
+                description: The last suboption.
+                type: str
+            m_middle:
+                description:
+                    - The suboption in the middle.
+                    - Has its own suboptions.
+                suboptions:
+                    a_suboption:
+                        description: A sub-suboption.
+                        type: str
+            a_first: 
+                description: The first suboption.
+                type: str
+'''
+
+EXAMPLES = '''
+'''
+
+RETURN = '''
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            test_docs_suboptions=dict(
+                type='dict',
+                options=dict(
+                    a_first=dict(type='str'),
+                    m_middle=dict(
+                        type='dict',
+                        options=dict(
+                            a_suboption=dict(type='str')
+                        ),
+                    ),
+                    z_last=dict(type='str'),
+                ),
+            ),
+        ),
+    )
+
+    module.exit_json()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/ansible-doc/runme.sh
+++ b/test/integration/targets/ansible-doc/runme.sh
@@ -12,6 +12,11 @@ current_out="$(ansible-doc --playbook-dir ./ testns.testcol.fakemodule)"
 expected_out="$(cat fakemodule.output)"
 test "$current_out" == "$expected_out"
 
+# test module docs from collection
+current_out="$(ansible-doc --playbook-dir ./ test_docs_suboptions)"
+expected_out="$(cat test_docs_suboptions.output)"
+test "$current_out" == "$expected_out"
+
 # test listing diff plugin types from collection
 for ptype in cache inventory lookup vars
 do

--- a/test/integration/targets/ansible-doc/test_docs_suboptions.output
+++ b/test/integration/targets/ansible-doc/test_docs_suboptions.output
@@ -1,0 +1,53 @@
+> TEST_DOCS_SUBOPTIONS    (/home/felix/projects/code/github-cloned/ansible/test/integration/targets/ansible-doc/library/test_docs_suboptions.py)
+
+        Test module
+
+  * This module is maintained by The Ansible Community
+OPTIONS (= is mandatory):
+
+- with_suboptions
+        An option with suboptions.
+        Use with care.
+        [Default: (null)]
+        type: dict
+
+        SUBOPTIONS:
+
+        - a_first
+            The first suboption.
+            [Default: (null)]
+            type: str
+
+        - m_middle
+            The suboption in the middle.
+            Has its own suboptions.
+            [Default: (null)]
+
+            SUBOPTIONS:
+
+            - a_suboption
+                A sub-suboption.
+                [Default: (null)]
+                type: str
+
+        - z_last
+            The last suboption.
+            [Default: (null)]
+            type: str
+
+
+AUTHOR: Ansible Core Team
+        METADATA:
+          status:
+          - preview
+          supported_by: community
+        
+
+EXAMPLES:
+
+
+
+
+RETURN VALUES:
+
+

--- a/test/integration/targets/ansible-doc/test_docs_suboptions.output
+++ b/test/integration/targets/ansible-doc/test_docs_suboptions.output
@@ -2,7 +2,6 @@
 
         Test module
 
-  * This module is maintained by The Ansible Community
 OPTIONS (= is mandatory):
 
 - with_suboptions
@@ -37,11 +36,6 @@ OPTIONS (= is mandatory):
 
 
 AUTHOR: Ansible Core Team
-        METADATA:
-          status:
-          - preview
-          supported_by: community
-        
 
 EXAMPLES:
 
@@ -49,5 +43,4 @@ EXAMPLES:
 
 
 RETURN VALUES:
-
 


### PR DESCRIPTION
##### SUMMARY
Right now, suboptions for module/plugin options are simply dumped as YAML (excerpt from `ansible-doc docker_container`):
```
- device_read_bps
        List of device path and read rate (bytes per second) from device.
        [Default: (null)]
        elements: dict
        suboptions:
          path:
            description:
            - Device path in the container.
            required: true
            type: str
          rate:
            description:
            - Device read limit in format `<number>[<unit>]'.
            - Number is a positive integer. Unit can be one of `B' (byte), `K' (kibibyte,
              1024B), `M' (mebibyte), `G' (gibibyte), `T' (tebibyte), or `P' (pebibyte).
            - Omitting the unit defaults to bytes.
            required: true
            type: str
        
        type: list
```
This PR adjusts it so they are pretty-printed like top-level options:
```
- device_read_bps
        List of device path and read rate (bytes per second) from device.
        [Default: (null)]
        elements: dict
        type: list

        SUBOPTIONS:

        = path
            Device path in the container.

            type: str

        = rate
            Device read limit in format `<number>[<unit>]'.
            Number is a positive integer. Unit can be one of `B' (byte), `K' (kibibyte, 1024B), `M' (mebibyte), `G'
            (gibibyte), `T' (tebibyte), or `P' (pebibyte).
            Omitting the unit defaults to bytes.

            type: str
```

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
ansible-doc
