### PR TITLE
Handle ansible.builtins version in doc build

### DIFF
--- a/hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
+++ b/hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
@@ -337,6 +337,8 @@ def too_old(added):
     if not added:
         return False
     try:
+        if isinstance(added, string_types) and added.startswith('ansible.builtin'):
+            added = added.split(":")[1]
         added_tokens = str(added).split(".")
         readded = added_tokens[0] + "." + added_tokens[1]
         added_float = float(readded)


### PR DESCRIPTION
##### SUMMARY

This fix correctly builds docs by handling new version_added schema
via https://github.com/ansible/ansible/pull/69680

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
hacking/build_library/build_ansible/command_plugins/plugin_formatter.py
