### PR TITLE
Add backward_sorted and backward_reverse_sorted ordering strategies

### DIFF
--- a/changelogs/fragments/69801-Add backward_sorted and backward_reverse_sorted ordering strategies.yml
+++ b/changelogs/fragments/69801-Add backward_sorted and backward_reverse_sorted ordering strategies.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add backward_sorted and backward_reverse_sorted ordering strategies

--- a/docs/docsite/keyword_desc.yml
+++ b/docs/docsite/keyword_desc.yml
@@ -49,7 +49,7 @@ module_defaults: Specifies default parameter values for modules.
 name: "Identifier. Can be used for documentation, in or tasks/handlers."
 no_log: Boolean that controls information disclosure.
 notify: "List of handlers to notify when the task returns a 'changed=True' status."
-order: Controls the sorting of hosts as they are used for executing the play. Possible values are inventory (default), sorted, reverse_sorted, reverse_inventory and shuffle.
+order: Controls the sorting of hosts as they are used for executing the play. Possible values are inventory (default), sorted, reverse_sorted, backward_sorted, backward_reverse_sorted, reverse_inventory and shuffle.
 poll: Sets the polling interval in seconds for async tasks (default 10s).
 port: Used to override the default port used in a connection.
 post_tasks: A list of tasks to execute after the :term:`tasks` section.

--- a/docs/docsite/rst/user_guide/playbooks_strategies.rst
+++ b/docs/docsite/rst/user_guide/playbooks_strategies.rst
@@ -155,6 +155,10 @@ sorted:
     Sorted alphabetically sorted by name
 reverse_sorted:
     Sorted by name in reverse alphabetical order
+backward_sorted:
+    Sorted by reversed name in alphabetical order
+backward_reverse_sorted:
+    Sorted by reversed name in reverse alphabetical order
 shuffle:
     Randomly ordered on each run
 

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -400,6 +400,10 @@ class InventoryManager(object):
             # sort hosts list if needed (should only happen when called from strategy)
             if order in ['sorted', 'reverse_sorted']:
                 hosts = sorted(self._hosts_patterns_cache[pattern_hash][:], key=attrgetter('name'), reverse=(order == 'reverse_sorted'))
+            elif order in ['backward_sorted', 'backward_reverse_sorted']:
+                hosts = sorted(self._hosts_patterns_cache[pattern_hash][:],
+                               key=lambda elem: attrgetter('name')(elem)[::-1],
+                               reverse=(order == 'backward_reverse_sorted'))
             elif order == 'reverse_inventory':
                 hosts = self._hosts_patterns_cache[pattern_hash][::-1]
             else:

--- a/test/integration/targets/order/inventory
+++ b/test/integration/targets/order/inventory
@@ -1,8 +1,8 @@
 [incremental]
-hostB
-hostA
-hostD
-hostC
+host-dc1-02
+host-dc2-01
+host-dc1-01
+host-dc2-02
 
 [incremental:vars]
 ansible_connection=local

--- a/test/integration/targets/order/runme.sh
+++ b/test/integration/targets/order/runme.sh
@@ -11,12 +11,14 @@ cleanup () {
     done
 }
 
-for EXTRA in '{"inputlist": ["hostB", "hostA", "hostD", "hostC"]}' \
-             '{"myorder": "inventory", "inputlist": ["hostB", "hostA", "hostD", "hostC"]}' \
-             '{"myorder": "sorted", "inputlist": ["hostA", "hostB", "hostC", "hostD"]}'  \
-             '{"myorder": "reverse_sorted", "inputlist": ["hostD", "hostC", "hostB", "hostA"]}' \
-             '{"myorder": "reverse_inventory", "inputlist": ["hostC", "hostD", "hostA", "hostB"]}' \
-             '{"myorder": "shuffle", "inputlist": ["hostC", "hostD", "hostA", "hostB"]}'
+for EXTRA in '{"inputlist": ["host-dc1-02", "host-dc2-01", "host-dc1-01", "host-dc2-02"]}' \
+             '{"myorder": "inventory", "inputlist": ["host-dc1-02", "host-dc2-01", "host-dc1-01", "host-dc2-02"]}' \
+             '{"myorder": "sorted", "inputlist": ["host-dc1-01", "host-dc1-02", "host-dc2-01", "host-dc2-02"]}'  \
+             '{"myorder": "reverse_sorted", "inputlist": ["host-dc2-02", "host-dc2-01", "host-dc1-02", "host-dc1-01"]}' \
+             '{"myorder": "backward_sorted", "inputlist": ["host-dc1-01", "host-dc2-01", "host-dc1-02", "host-dc2-02"]}'  \
+             '{"myorder": "backward_reverse_sorted", "inputlist": ["host-dc2-02", "host-dc1-02", "host-dc2-01", "host-dc1-01"]}' \
+             '{"myorder": "reverse_inventory", "inputlist": ["host-dc2-02", "host-dc1-01", "host-dc2-01", "host-dc1-02"]}' \
+             '{"myorder": "shuffle", "inputlist": ["host-dc2-02", "host-dc1-01", "host-dc2-01", "host-dc1-02"]}'
 do
     cleanup
     ansible-playbook order.yml --forks 1 -i inventory -e "$EXTRA" "$@"


### PR DESCRIPTION
##### SUMMARY
Add backward_sorted and backward_reverse_sorted ordering strategies.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Orders

##### ADDITIONAL INFORMATION
This ordering can be useful if you have hostnames like fw-dc1-01, fw-dc1-02, fw-dc2-01, fw-dc2-02.
With these orders you can run plays against 02 (backup) nods first then the 01 (primary) nodes.
