### PR TITLE
 Update testing collections to mention ansible-base versions

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -531,7 +531,7 @@ The build process for docs.ansible.com will know where to find the module docs.
 Testing collections
 ===================
 
-The main tool for testing collections is ``ansible-test``, Ansible's testing tool described in :ref:`developing_testing`. You can run several compile and sanity checks, as well as run unit and integration tests for plugins using ``ansible-test``.
+The main tool for testing collections is ``ansible-test``, Ansible's testing tool described in :ref:`developing_testing`. You can run several compile and sanity checks, as well as run unit and integration tests for plugins using ``ansible-test``. When you test collections, test against the ansible-base version(s) you are targeting.
 
 You must always execute ``ansible-test`` from the root directory of a collection. You can run ``ansible-test`` in Docker containers without installing any special requirements. The Ansible team uses this approach in Shippable both in the ansible/ansible GitHub repository and in the large community collections such as `community.general <https://github.com/ansible-collections/community.general/>`_ and `community.network <https://github.com/ansible-collections/community.network/>`_. The examples below demonstrate running tests in Docker containers.
 

--- a/docs/docsite/rst/dev_guide/testing.rst
+++ b/docs/docsite/rst/dev_guide/testing.rst
@@ -4,7 +4,7 @@
 Testing Ansible
 ***************
 
-.. contents:: Topics
+.. contents::
    :local:
 
 
@@ -17,7 +17,7 @@ Ansible users who understand how to write playbooks and roles should be able to 
 
 Read on to learn how Ansible is tested, how to test your contributions locally, and how to extend testing capabilities.
 
-If you want to learn on how testing collections, you should read :ref:`testing_collections`
+If you want to learn about testing collections, read :ref:`testing_collections`
 
 
 
@@ -184,7 +184,7 @@ Example::
 
 If the PR does not resolve the issue, or if you see any failures from the unit/integration tests, just include that output instead:
 
-   | This doesn't work for me.
+   | This change causes errors for me.
    |
    | When I ran this Ubuntu 16.04 it failed with the following:
    |


### PR DESCRIPTION
##### SUMMARY
Adds a warning that collections developers should test against specific ansible-base version(s). Can we add more detail? How can devs find out which version(s) they are testing against? 

Related to [Ansible Core IRC meeting May 29, 2020](https://meetbot.fedoraproject.org/sresults/?group_id=ansible-meeting&type=channel)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com