### PR TITLE
[2.9] Backport Fix nxos_facts for VDC with no interface

### DIFF
--- a/changelogs/fragments/fix_nxos_facts_with_vdc.yaml
+++ b/changelogs/fragments/fix_nxos_facts_with_vdc.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix nxos_facts with VDC having no interfaces (https://github.com/ansible-collections/cisco.nxos/pull/68).

--- a/lib/ansible/module_utils/network/nxos/facts/legacy/base.py
+++ b/lib/ansible/module_utils/network/nxos/facts/legacy/base.py
@@ -252,7 +252,12 @@ class Interfaces(FactsBase):
 
     def populate_structured_interfaces(self, data):
         interfaces = dict()
-        for item in data['TABLE_interface']['ROW_interface']:
+        data = data["TABLE_interface"]["ROW_interface"]
+
+        if isinstance(data, dict):
+            data = [data]
+
+        for item in data:
             name = item['interface']
 
             intf = dict()
@@ -604,8 +609,12 @@ class Legacy(FactsBase):
 
     def parse_structured_interfaces(self, data):
         objects = list()
-        for item in data['TABLE_interface']['ROW_interface']:
-            objects.append(item['interface'])
+        data = data["TABLE_interface"]["ROW_interface"]
+        if isinstance(data, dict):
+            objects.append(data["interface"])
+        elif isinstance(data, list):
+            for item in data:
+                objects.append(item["interface"])
         return objects
 
     def parse_structured_vlans(self, data):


### PR DESCRIPTION
Fix for vdc with no interface in N7K (https://github.com/ansible-collections/cisco.nxos/pull/68)

Fix for vdc with no interface in N7K

Reviewed-by: Nilashish Chakraborty <nilashishchakraborty8@gmail.com>
             https://github.com/NilashishC
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

Add changelog

##### SUMMARY
Backport of https://github.com/ansible-collections/cisco.nxos/pull/68

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
nxos/facts/legacy/base.py