### PR TITLE
Only show one deprecation warning if version and date are both defined.

### DIFF
--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -137,15 +137,15 @@ def list_deprecations(argument_spec, params, prefix=''):
                 sub_prefix = '%s["%s"]' % (prefix, arg_name)
             else:
                 sub_prefix = arg_name
-            if arg_opts.get('removed_in_version') is not None:
-                deprecations.append({
-                    'msg': "Param '%s' is deprecated. See the module docs for more information" % sub_prefix,
-                    'version': arg_opts.get('removed_in_version')
-                })
             if arg_opts.get('removed_at_date') is not None:
                 deprecations.append({
                     'msg': "Param '%s' is deprecated. See the module docs for more information" % sub_prefix,
                     'date': arg_opts.get('removed_at_date')
+                })
+            elif arg_opts.get('removed_in_version') is not None:
+                deprecations.append({
+                    'msg': "Param '%s' is deprecated. See the module docs for more information" % sub_prefix,
+                    'version': arg_opts.get('removed_in_version')
                 })
             # Check sub-argument spec
             sub_argument_spec = arg_opts.get('options')


### PR DESCRIPTION
##### SUMMARY
This prefers date to version on the basis that date will have been added
in 2.10, and version retained for 2.9 compatibility

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request?

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/common/parameters.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

For a collection looking to transition from (ansible) version-based deprecation to date-based deprecation, there is the issue of retaining deprecations if the modules are run under ansible 2.9. For example, in the netconf_config module in ansible.netcommon, if the versions are simply replaced with dates will show the following in devel:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
TASK [ansible.netcommon.netconf_config] *******************************************************************************
[DEPRECATION WARNING]: Param 'src' is deprecated. See the module docs for more information. This feature will be 
removed in a release after 2020-12-01. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
[DEPRECATION WARNING]: Param 'host' is deprecated. See the module docs for more information. This feature will be 
removed in a release after 2020-12-01. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
[DEPRECATION WARNING]: Param 'port' is deprecated. See the module docs for more information. This feature will be 
removed in a release after 2020-12-01. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
[DEPRECATION WARNING]: Param 'username' is deprecated. See the module docs for more information. This feature will be 
removed in a release after 2020-12-01. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
[DEPRECATION WARNING]: Param 'password' is deprecated. See the module docs for more information. This feature will be 
removed in a release after 2020-12-01. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
ok: [veos23]
```

But show no warnings in 2.9:
```
TASK [ansible.netcommon.netconf_config] *******************************************************************************
ok: [veos23]
```

Adding the date alongside the version restores the warnings in 2.9:
```
TASK [ansible.netcommon.netconf_config] *******************************************************************************
[DEPRECATION WARNING]: Param 'src' is deprecated. See the module docs for more information. This feature will be 
removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Param 'host' is deprecated. See the module docs for more information. This feature will be 
removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Param 'port' is deprecated. See the module docs for more information. This feature will be 
removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Param 'username' is deprecated. See the module docs for more information. This feature will be 
removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Param 'password' is deprecated. See the module docs for more information. This feature will be 
removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
ok: [veos23]
```

But presents a confusing set of double warnings in devel:
```
TASK [ansible.netcommon.netconf_config] *******************************************************************************
[DEPRECATION WARNING]: Param 'src' is deprecated. See the module docs for more information. This feature will be 
removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Param 'src' is deprecated. See the module docs for more information. This feature will be 
removed in a release after 2020-12-01. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
[DEPRECATION WARNING]: Param 'host' is deprecated. See the module docs for more information. This feature will be 
removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Param 'host' is deprecated. See the module docs for more information. This feature will be 
removed in a release after 2020-12-01. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
[DEPRECATION WARNING]: Param 'port' is deprecated. See the module docs for more information. This feature will be 
removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Param 'port' is deprecated. See the module docs for more information. This feature will be 
removed in a release after 2020-12-01. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
[DEPRECATION WARNING]: Param 'username' is deprecated. See the module docs for more information. This feature will be 
removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Param 'username' is deprecated. See the module docs for more information. This feature will be 
removed in a release after 2020-12-01. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
[DEPRECATION WARNING]: Param 'password' is deprecated. See the module docs for more information. This feature will be 
removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Param 'password' is deprecated. See the module docs for more information. This feature will be 
removed in a release after 2020-12-01. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
ok: [veos23]
```

This PR just swaps the order in which the deprecation triggers are checked so that the date is checked first, and then does not look at version if date is already set. With this patch, when both values are defined in the argspec, devel now only shows the date-based deprecations:

```
TASK [ansible.netcommon.netconf_config] *******************************************************************************
[DEPRECATION WARNING]: Param 'src' is deprecated. See the module docs for more information. This feature will be 
removed in a release after 2020-12-01. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
[DEPRECATION WARNING]: Param 'host' is deprecated. See the module docs for more information. This feature will be 
removed in a release after 2020-12-01. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
[DEPRECATION WARNING]: Param 'port' is deprecated. See the module docs for more information. This feature will be 
removed in a release after 2020-12-01. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
[DEPRECATION WARNING]: Param 'username' is deprecated. See the module docs for more information. This feature will be 
removed in a release after 2020-12-01. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
[DEPRECATION WARNING]: Param 'password' is deprecated. See the module docs for more information. This feature will be 
removed in a release after 2020-12-01. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
ok: [veos23]
```