### PR TITLE
ansible-test: do not accept empty string as valid version number

### DIFF
--- a/test/lib/ansible_test/_data/sanity/pylint/plugins/deprecated.py
+++ b/test/lib/ansible_test/_data/sanity/pylint/plugins/deprecated.py
@@ -205,6 +205,8 @@ class AnsibleDeprecatedChecker(BaseChecker):
         if collection == 'ansible.builtin':
             # Ansible-base
             try:
+                if not version_no:
+                    raise ValueError('Version string should not be empty')
                 loose_version = LooseVersion(str(version_no))
                 if ANSIBLE_VERSION >= loose_version:
                     self.add_message('ansible-deprecated-version', node=node, args=(version,))
@@ -213,6 +215,8 @@ class AnsibleDeprecatedChecker(BaseChecker):
         else:
             # Collections
             try:
+                if not version_no:
+                    raise ValueError('Version string should not be empty')
                 semantic_version = SemanticVersion(version_no)
                 if collection == self.collection_name and self.collection_version is not None:
                     if self.collection_version >= semantic_version:

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -40,6 +40,10 @@ def _add_ansible_error_code(exception, error_code):
 def semantic_version(v, error_code=None):
     if not isinstance(v, string_types):
         raise _add_ansible_error_code(Invalid('Semantic version must be a string'), error_code or 'collection-invalid-version')
+    if not v:
+        raise _add_ansible_error_code(
+            Invalid('Empty string is not a valid semantic version'),
+            error_code or 'collection-invalid-version')
     try:
         SemanticVersion(v)
     except ValueError as e:


### PR DESCRIPTION
##### SUMMARY
Both StrictVersion, LooseVersion and SemanticVersion all accept an empty string as a valid version number.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test
