### PR TITLE
Fix documentation for the assemble modules remote_src property.

### DIFF
--- a/changelogs/fragments/69845-doc-assemble-remote_src.yaml
+++ b/changelogs/fragments/69845-doc-assemble-remote_src.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - assemble module - fix documentation - the remote_src property specified a default value of no but it's actually yes.

--- a/lib/ansible/modules/assemble.py
+++ b/lib/ansible/modules/assemble.py
@@ -55,7 +55,7 @@ options:
     - If C(no), it will search for src at originating/master machine.
     - If C(yes), it will go to the remote/target machine for the src.
     type: bool
-    default: no
+    default: yes
     version_added: '1.4'
   regexp:
     description:
@@ -183,7 +183,7 @@ def main():
             delimiter=dict(type='str'),
             dest=dict(type='path', required=True),
             backup=dict(type='bool', default=False),
-            remote_src=dict(type='bool', default=False),
+            remote_src=dict(type='bool', default=True),
             regexp=dict(type='str'),
             ignore_hidden=dict(type='bool', default=False),
             validate=dict(type='str'),


### PR DESCRIPTION
##### SUMMARY
According to the documentation for the `assemble module`, the `remote_src` property has the default value `no`, but it's actually `yes` (https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/action/assemble.py#L96).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
assemble

##### ADDITIONAL INFORMATION
