### PR TITLE
[2.9] ansible-test: make pylint deprecation plugin not choke on tagged versions

### DIFF
--- a/changelogs/fragments/69851-ansible-test-pylint-versions.yml
+++ b/changelogs/fragments/69851-ansible-test-pylint-versions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-test pylint sanity test - do not crash when ``version`` specified to ``AnsibleModule.deprecate()`` or ``Display.deprecated()`` contains string components, f.ex. tagged version numbers for Ansible 2.10."

--- a/test/lib/ansible_test/_data/sanity/pylint/plugins/deprecated.py
+++ b/test/lib/ansible_test/_data/sanity/pylint/plugins/deprecated.py
@@ -87,6 +87,11 @@ class AnsibleDeprecatedChecker(BaseChecker):
                         self.add_message('ansible-deprecated-version', node=node, args=(version,))
                 except ValueError:
                     self.add_message('ansible-invalid-deprecated-version', node=node, args=(version,))
+                except TypeError:
+                    # This happens if version starts with string components, and LooseVersion
+                    # comparison tries to compare int with str. This can happen for tagged
+                    # versions from Ansible 2.10.
+                    pass
         except AttributeError:
             # Not the type of node we are interested in
             pass


### PR DESCRIPTION
##### SUMMARY
Ignores `TypeError`s raised when `LooseVersion`s starting with `str` components are compared to ones starting with `int` components. This happens if a tagged collection version like `community.general:1.0.0` is compared to the Ansible version `2.9`.

CC @nitzmahone @mattclay

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test
