### PR TITLE
VMware: Specify content library

### DIFF
--- a/changelogs/fragments/69855-vmware_content_deploy_template-specify_content_library_name.yml
+++ b/changelogs/fragments/69855-vmware_content_deploy_template-specify_content_library_name.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_content_deploy_template - added new field "content_library" to search template inside the specified content library.
+  - vmware_rest_client - Added a new definition get_library_item_from_content_library_name.

--- a/lib/ansible/module_utils/vmware_rest_client.py
+++ b/lib/ansible/module_utils/vmware_rest_client.py
@@ -265,6 +265,28 @@ class VmwareRestClient(object):
         item_id = item_ids[0] if item_ids else None
         return item_id
 
+    def get_library_item_from_content_library_name(self, name, content_library_name):
+        """
+        Returns the identifier of the library item with the given name in the specified
+        content library.
+        Args:
+            name (str): The name of item to look for
+            content_library_name (str): The name of the content library to search in
+        Returns:
+            str: The item ID or None if the item is not found
+        """
+        cl_find_spec = self.api_client.content.Library.FindSpec(
+            name=content_library_name)
+        cl_item_ids = self.api_client.content.Library.find(cl_find_spec)
+        cl_item_id = cl_item_ids[0] if cl_item_ids else None
+        if cl_item_id:
+            find_spec = Item.FindSpec(name=name, library_id=cl_item_id)
+            item_ids = self.api_client.content.library.Item.find(find_spec)
+            item_id = item_ids[0] if item_ids else None
+            return item_id
+        else:
+            return None
+
     def get_datacenter_by_name(self, datacenter_name):
         """
         Returns the identifier of a datacenter


### PR DESCRIPTION
1) specify the name of the content library from where the template needs to be picked.

SUMMARY
Added the functionality to be able to specify the name of the content library from where the template needs to be picked from. The existing functionality will prevail if the field content_library
is not specified.

ISSUE TYPE
Feature Pull Request

COMPONENT NAME
vmware_content_deploy_template.py

ADDITIONAL INFORMATION
Currently, if we have templates with the same name in multiple content libraries then the first template that matches the specified template name is returned. Being able to specify the content library name with the template name gives more control for choosing the template.

###### No change in the output if vm creation successful

###### If the template or the content library specified does not exist
fatal: [localhost -> localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "cluster": null,
            "content_library": "<content_library_name>",
            "datacenter": "<datacenter name>",
            "datastore": "<datastore_name>",
            "folder": "<folder_name>",
            "host": "<host_name>",
            "hostname": "<vcenter_name>",
            "name": "<virtual_machine_name>",
            "password": "<password>",
            "protocol": "https",
            "resource_pool": null,
            "state": "poweredon",
            "template": "<template_name>",
            "username": "<user_name>",
            "validate_certs": false
        }
    },
    "msg": "Failed to find the library Item <template_name> in content library <content_library_name>"
}