### PR TITLE
Re-add documentation for yum "install_repoquery"

### DIFF
--- a/lib/ansible/modules/yum.py
+++ b/lib/ansible/modules/yum.py
@@ -204,6 +204,20 @@ options:
       - Has an effect only if I(download_only) is specified.
     type: str
     version_added: "2.8"
+  install_repoquery:
+    description:
+      - If repoquery is not available, install yum-utils. If the system is
+        registered to RHN or an RHN Satellite, repoquery allows for querying
+        all channels assigned to the system. It is also required to use the
+        'list' parameter.
+      - "NOTE: This will run and be logged as a separate yum transation which
+        takes place before any other installation or removal."
+      - "NOTE: This will use the system's default enabled repositories without
+        regard for disablerepo/enablerepo given to the module."
+    required: false
+    version_added: "1.5"
+    default: "yes"
+    type: bool
 notes:
   - When used with a `loop:` each package will be processed individually,
     it is much more efficient to pass the list directly to the `name` option.

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -180,12 +180,10 @@ lib/ansible/modules/package_facts.py validate-modules:doc-missing-type
 lib/ansible/modules/package_facts.py validate-modules:parameter-list-no-elements
 lib/ansible/modules/rpm_key.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/yum.py pylint:blacklisted-name
-lib/ansible/modules/yum.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/yum.py validate-modules:doc-missing-type
 lib/ansible/modules/yum.py validate-modules:parameter-invalid
 lib/ansible/modules/yum.py validate-modules:parameter-list-no-elements
 lib/ansible/modules/yum.py validate-modules:parameter-type-not-in-doc
-lib/ansible/modules/yum.py validate-modules:undocumented-parameter
 lib/ansible/modules/yum_repository.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/yum_repository.py validate-modules:doc-missing-type
 lib/ansible/modules/yum_repository.py validate-modules:parameter-list-no-elements


### PR DESCRIPTION
##### SUMMARY

Change:
- This was removed in 2014 in 122a7021bc0af.
- The option still exists and is enabled by default and can lead to user
  confusion when people aren't expecting packages (or updated
  dependencies for it) to get installed and they do.
- Add the option documentation back with a few notes to make it clear what
  is happening.

Test Plan:
N/A, no code change, just documentation

Tickets:
- Refs #69497

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
yum