### PR TITLE
Add projection feature for registering vars

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -82,6 +82,7 @@ class Task(Base, Conditional, Taggable, CollectionSearch):
     _notify = FieldAttribute(isa='list')
     _poll = FieldAttribute(isa='int', default=C.DEFAULT_POLL_INTERVAL)
     _register = FieldAttribute(isa='string', static=True)
+    _projection = FieldAttribute(isa='string', static=True)
     _retries = FieldAttribute(isa='int', default=3)
     _until = FieldAttribute(isa='list', default=list)
 
@@ -313,6 +314,7 @@ class Task(Base, Conditional, Taggable, CollectionSearch):
         specially in the TaskExecutor class when evaluating loops.
         '''
         return value
+
 
     def _post_validate_environment(self, attr, value, templar):
         '''

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -315,7 +315,6 @@ class Task(Base, Conditional, Taggable, CollectionSearch):
         '''
         return value
 
-
     def _post_validate_environment(self, attr, value, templar):
         '''
         Override post validation of vars on the play, as we don't want to

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -730,6 +730,16 @@ class StrategyBase:
                 if 'invocation' in clean_copy:
                     del clean_copy['invocation']
 
+                if original_task.projection:
+                    if original_task.projection[0] != '.':
+                        raise AnsibleError('"projection" must be a raw jinja2 statement, starting with "." representing the result to process')
+                    template = '{{ _projection%s }}' % original_task.projection[1:]
+                    all_vars = self._variable_manager.get_vars(play=iterator._play, host=original_host, task=original_task,
+                                                               _hosts=self._hosts_cache, _hosts_all=self._hosts_cache_all)
+                    all_vars['_projection'] = clean_copy
+                    templar = Templar(loader=self._loader, variables=all_vars)
+                    clean_copy = templar.template(template)
+
                 for target_host in host_list:
                     self._variable_manager.set_nonpersistent_facts(target_host, {original_task.register: clean_copy})
 

--- a/test/units/plugins/strategy/test_strategy.py
+++ b/test/units/plugins/strategy/test_strategy.py
@@ -256,6 +256,7 @@ class TestStrategyBase(unittest.TestCase):
         mock_task.ignore_unreachable = False
         mock_task._uuid = uuid.uuid4()
         mock_task.loop = None
+        mock_task.projection = None
         mock_task.copy.return_value = mock_task
 
         mock_handler_task = Handler()


### PR DESCRIPTION
##### SUMMARY
This PoC PR introduces a new task keyword called `projection`, which allows you to pre-process module return results, before registering the variable.

This only operates on the final result, immediately before registering, _not_ per loop.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
```
lib/ansible/plugins/strategy/__init__.py
```
##### ADDITIONAL INFORMATION
```yaml
    - command: echo Hello, World!
      register: stdout
      projection: ..stdout

    - debug:
        var: stdout
```

```
TASK [command] *******************************************************************************************************************************************************************************************************************************
changed: [localhost] => {"changed": true, "cmd": ["echo", "Hello,", "World!"], "delta": "0:00:00.004779", "end": "2020-06-03 17:10:11.148424", "rc": 0, "start": "2020-06-03 17:10:11.143645", "stderr": "", "stderr_lines": [], "stdout": "Hello, World!", "stdout_lines": ["Hello, World!"]}

TASK [debug] *********************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "stdout": "Hello, World!"
}
```

The initial `.` in the projection is currently required, and represents the task result, all normal jinja follows.

A couple of other examples:

```yaml
projection: .['results']|flatten
projection: .
projection: .|type_debug
```