### PR TITLE
fix sys.modules cleanup and blacklist behavior

### DIFF
--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -493,7 +493,10 @@ class _AnsibleCollectionPkgLoader(_AnsibleCollectionPkgLoaderBase):
 
         if collection_name == 'ansible.builtin':
             # ansible.builtin is a synthetic collection, get its routing config from the Ansible distro
-            raw_routing = pkgutil.get_data('ansible.config', 'ansible_builtin_runtime.yml')
+            ansible_pkg_path = os.path.dirname(import_module('ansible').__file__)
+            metadata_path = os.path.join(ansible_pkg_path, 'config/ansible_builtin_runtime.yml')
+            with open(to_bytes(metadata_path), 'rb') as fd:
+                raw_routing = fd.read()
         else:
             b_routing_meta_path = to_bytes(os.path.join(module.__path__[0], 'meta/runtime.yml'))
             if os.path.isfile(b_routing_meta_path):

--- a/test/lib/ansible_test/_data/sanity/import/importer.py
+++ b/test/lib/ansible_test/_data/sanity/import/importer.py
@@ -75,10 +75,9 @@ def main():
 
         collection_loader = _AnsibleCollectionFinder(paths=[collection_root])
         collection_loader._install()  # pylint: disable=protected-access
-        nuke_modules = list(m for m in sys.modules if m.partition('.')[0] == 'ansible')
 
-        for m in nuke_modules:
-            sys.modules.pop(m)
+        # remove all modules under the ansible package
+        list(map(sys.modules.pop, (m for m in sys.modules if m.partition('.')[0] == 'ansible')))
 
     else:
         # do not support collection loading when not testing a collection

--- a/test/lib/ansible_test/_data/sanity/import/importer.py
+++ b/test/lib/ansible_test/_data/sanity/import/importer.py
@@ -22,7 +22,7 @@ def main():
 
     ansible_path = os.path.dirname(os.path.dirname(ansible.__file__))
     temp_path = os.environ['SANITY_TEMP_PATH'] + os.path.sep
-    external_python = os.environ.get('SANITY_EXTERNAL_PYTHON')
+    external_python = os.environ.get('SANITY_EXTERNAL_PYTHON') or sys.executable
     collection_full_name = os.environ.get('SANITY_COLLECTION_FULL_NAME')
     collection_root = os.environ.get('ANSIBLE_COLLECTIONS_PATHS')
 
@@ -43,7 +43,6 @@ def main():
     if collection_full_name:
         # allow importing code from collections when testing a collection
         from ansible.module_utils.common.text.converters import to_bytes, to_text, to_native
-        from ansible.utils.collection_loader import AnsibleCollectionConfig
         from ansible.utils.collection_loader._collection_finder import _AnsibleCollectionFinder
         from ansible.utils.collection_loader import _collection_finder
 
@@ -77,7 +76,9 @@ def main():
         collection_loader = _AnsibleCollectionFinder(paths=[collection_root])
         collection_loader._install()  # pylint: disable=protected-access
         nuke_modules = list(m for m in sys.modules if m.partition('.')[0] == 'ansible')
-        map(sys.modules.pop, nuke_modules)
+
+        for m in nuke_modules:
+            sys.modules.pop(m)
 
     else:
         # do not support collection loading when not testing a collection
@@ -374,6 +375,7 @@ def main():
         blacklist = ImportBlacklist(path, name)
 
         sys.meta_path.insert(0, blacklist)
+        sys.path_importer_cache.clear()
 
         try:
             yield
@@ -383,6 +385,8 @@ def main():
 
             while blacklist in sys.meta_path:
                 sys.meta_path.remove(blacklist)
+
+            sys.path_importer_cache.clear()
 
     @contextlib.contextmanager
     def monitor_sys_modules(path, messages):

--- a/test/lib/ansible_test/_data/sanity/import/importer.py
+++ b/test/lib/ansible_test/_data/sanity/import/importer.py
@@ -77,7 +77,7 @@ def main():
         collection_loader._install()  # pylint: disable=protected-access
 
         # remove all modules under the ansible package
-        list(map(sys.modules.pop, (m for m in sys.modules if m.partition('.')[0] == 'ansible')))
+        list(map(sys.modules.pop, [m for m in sys.modules if m.partition('.')[0] == 'ansible']))
 
     else:
         # do not support collection loading when not testing a collection


### PR DESCRIPTION
##### SUMMARY
* fix map-as-generator py2/py3 issue
* clear path_importer_cache between runs

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
importer.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
