### PR TITLE
Reset ALL connection settings for next loop iteration

### DIFF
--- a/changelogs/fragments/58787-become-loop-prompt.yaml
+++ b/changelogs/fragments/58787-become-loop-prompt.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Clear all connection related settings for the next loop iteration (https://github.com/ansible/ansible/issues/58787)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -414,6 +414,8 @@ class TaskExecutor:
             results.append(res)
             del task_vars[loop_var]
 
+            # needed for winrm/pspr before clearing the connection
+            self._connection.close()
             # clear the connection for the next iteration that may have different options set
             self._connection = None
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -414,19 +414,8 @@ class TaskExecutor:
             results.append(res)
             del task_vars[loop_var]
 
-            # clear 'connection related' plugin variables for next iteration
-            if self._connection:
-                clear_plugins = {
-                    'connection': self._connection._load_name,
-                    'shell': self._connection._shell._load_name
-                }
-                if self._connection.become:
-                    clear_plugins['become'] = self._connection.become._load_name
-
-                for plugin_type, plugin_name in iteritems(clear_plugins):
-                    for var in C.config.get_plugin_vars(plugin_type, plugin_name):
-                        if var in task_vars and var not in self._job_vars:
-                            del task_vars[var]
+            # clear the connection for the next iteration that may have different options set
+            self._connection = None
 
         self._task.no_log = no_log
 

--- a/lib/ansible/plugins/become/sudo.py
+++ b/lib/ansible/plugins/become/sudo.py
@@ -96,6 +96,8 @@ class BecomeModule(BecomeBase):
             if flags:  # this could be simplified, but kept as is for now for backwards string matching
                 flags = flags.replace('-n', '')
             prompt = '-p "%s"' % (self.prompt)
+        else:
+            self.prompt = ''
 
         user = self.get_option('become_user') or ''
         if user:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The original purpose of the change was to fix Become's
prompt not being reset for the next loop iteration which
this change fixes but also forces the connection/become/...
objects to be re-created which is simpler and more robust
than the original solution.

Co-authored-by: Brian Coca <bcoca@users.noreply.github.com>

Fixes #58787
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/executor/task_executor.py`
