### PR TITLE
Fixes documentation for SSH pipelining

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -202,8 +202,6 @@ DOCUMENTATION = '''
             - name: ANSIBLE_PIPELINING
             - name: ANSIBLE_SSH_PIPELINING
           ini:
-            #- section: defaults
-            #   key: pipelining
             - section: ssh_connection
               key: pipelining
           type: boolean

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -200,12 +200,12 @@ DOCUMENTATION = '''
               which is why this feature is disabled by default.
           env:
             - name: ANSIBLE_PIPELINING
-            #- name: ANSIBLE_SSH_PIPELINING
+            - name: ANSIBLE_SSH_PIPELINING
           ini:
-            - section: defaults
+            # - section: defaults
+            #   key: pipelining
+            - section: ssh_connection
               key: pipelining
-            #- section: ssh_connection
-            #  key: pipelining
           type: boolean
           vars:
             - name: ansible_pipelining

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -202,7 +202,7 @@ DOCUMENTATION = '''
             - name: ANSIBLE_PIPELINING
             - name: ANSIBLE_SSH_PIPELINING
           ini:
-            # - section: defaults
+            #- section: defaults
             #   key: pipelining
             - section: ssh_connection
               key: pipelining


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #69905
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ssh.py plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Documentation is incorrect under ssh.py plugin:

Before:
```ini
[defaults]
pipelining = true
```
after:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```ini
[ssh_connection]
pipelining = true
```

Also the env variable ANSIBLE_SSH_PIPELINING was commented and it working together with ANSIBLE_PIPELINING

Personally I would remove all the comments sections to avoid confusion, but I have kept for now.
