### PR TITLE
ansible-galaxy - Fix role info when role is not installed

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -936,7 +936,17 @@ class GalaxyCLI(CLI):
                 role_info.update(install_info)
 
             if not context.CLIARGS['offline']:
-                remote_data = self.api.lookup_role_by_name(role, False)
+                remote_data = None
+                try:
+                    remote_data = self.api.lookup_role_by_name(role, False)
+                except AnsibleError as e:
+                    if e.http_code == 400 and 'Bad Request' in e.message:
+                        # Role does not exist in Ansible Galaxy
+                        data = u"- the role %s was not found" % role
+                        break
+
+                    raise AnsibleError("Unable to find info about '%s': %s" % (role, e))
+
                 if remote_data:
                     role_info.update(remote_data)
 

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -927,9 +927,6 @@ class GalaxyCLI(CLI):
 
             role_info = {'path': roles_path}
             gr = GalaxyRole(self.galaxy, self.api, role)
-            if not gr._exists:
-                data = u"- the role %s was not found" % role
-                break
 
             install_info = gr.install_info
             if install_info:
@@ -938,12 +935,14 @@ class GalaxyCLI(CLI):
                     del install_info['version']
                 role_info.update(install_info)
 
-            remote_data = False
             if not context.CLIARGS['offline']:
                 remote_data = self.api.lookup_role_by_name(role, False)
+                if remote_data:
+                    role_info.update(remote_data)
 
-            if remote_data:
-                role_info.update(remote_data)
+            elif context.CLIARGS['offline'] and not gr._exists:
+                data = u"- the role %s was not found" % role
+                break
 
             if gr.metadata:
                 role_info.update(gr.metadata)

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -244,9 +244,9 @@ f_ansible_galaxy_status \
 role_testdir=$(mktemp -d)
 pushd "${role_testdir}"
 
-    ansible-galaxy role info notaroll 2>&1 | tee out.txt || echo "expected failed"
+    ansible-galaxy role info notaroll | tee out.txt
 
-    grep 'Bad Request' out.txt
+    grep -- '- the role notaroll was not found' out.txt
 
 f_ansible_galaxy_status \
     "role info description offline"

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -226,15 +226,27 @@ rm -fr "${role_testdir}"
 
 # Galaxy role info tests
 
+# Get info about role that is not installed
+
+f_ansible_galaxy_status "role info"
+galaxy_testdir=$(mktemp -d)
+pushd "${galaxy_testdir}"
+    ansible-galaxy role info samdoran.fish | tee out.txt
+
+    [[ $(grep -c 'not found' out.txt ) -eq 0 ]]
+    [[ $(grep -c 'Role:.*samdoran\.fish' out.txt ) -eq 1 ]]
+
+popd # ${galaxy_testdir}
+
 f_ansible_galaxy_status \
     "role info non-existant role"
 
 role_testdir=$(mktemp -d)
 pushd "${role_testdir}"
 
-    ansible-galaxy role info notaroll | tee out.txt
+    ansible-galaxy role info notaroll 2>&1 | tee out.txt || echo "expected failed"
 
-    grep -- '- the role notaroll was not found' out.txt
+    grep 'Bad Request' out.txt
 
 f_ansible_galaxy_status \
     "role info description offline"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Only report the role not found if in offline mode, otherwise query the galaxy API to get role information.

Fixes #69867
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/cli/galaxy.py`