### PR TITLE
Fix broken validate-modules

### DIFF
--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -2094,7 +2094,7 @@ class ModuleValidator(Validator):
                                 msg=('The deprecation version for a module must be added in this collection')
                             )
                         else:
-                            removed_in = self.StrictVersion(str(version))
+                            removed_in = self._create_strict_version(str(version))
 
                     except ValueError:
                         # ignore and hope we previouslly reported
@@ -2102,7 +2102,7 @@ class ModuleValidator(Validator):
 
                     if removed_in:
                         if not self.collection:
-                            strict_ansible_version = self.StrictVersion('.'.join(ansible_version.split('.')[:2]))
+                            strict_ansible_version = self._create_strict_version('.'.join(ansible_version.split('.')[:2]))
                             end_of_deprecation_should_be_removed_only = strict_ansible_version >= removed_in
                         elif self.collection_version:
                             strict_ansible_version = self.collection_version


### PR DESCRIPTION
##### SUMMARY
#69454 unfortunately broke validate-modules: `self.StrictVersion()` should have been `self._create_strict_version()`.

The current version crashes with collections (see for example https://app.shippable.com/github/ansible-collections/community.general/runs/1909/2/console).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
validate-modules
