### PR TITLE
add wheel dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # packages.  Thus, this should be the loosest set possible (only required
 # packages, not optional ones, and with the widest range of versions that could
 # be suitable)
+wheel
 jinja2
 PyYAML
 cryptography


### PR DESCRIPTION
##### SUMMARY
Add wheel dependency to requirements.txt

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
development environment

##### ADDITIONAL INFORMATION
On new virtual environment (Python3) I getting an error. I believe it's reproducible.
```
  error: invalid command 'bdist_wheel'
  
  ----------------------------------------
  Failed building wheel for PyYAML
  Running setup.py clean for PyYAML

```
