### PR TITLE
template - modify error message

### DIFF
--- a/changelogs/fragments/69519-template.yml
+++ b/changelogs/fragments/69519-template.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- template - Modify failure message since remote_src is not a valid parameter (https://github.com/ansible/ansible/issues/69519).

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -103,8 +103,8 @@ class ActionModule(ActionBase):
             # Get vault decrypted tmp file
             try:
                 tmp_source = self._loader.get_real_file(source)
-            except AnsibleFileNotFound as e:
-                raise AnsibleActionFail("could not find src=%s, %s" % (source, to_text(e)))
+            except AnsibleFileNotFound:
+                raise AnsibleActionFail("could not find src=%s" % source)
             b_tmp_source = to_bytes(tmp_source, errors='surrogate_or_strict')
 
             # template the source data locally & get ready to transfer


### PR DESCRIPTION
##### SUMMARY

'remote_src' is not a valid parameter for template module.
AnsibleFileNotFound error message suggests user to use it anyways.
This fix will remove this mis-leading message from failure message.

Fixes: #69519

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/69519-template.yml
lib/ansible/plugins/action/template.py
