### PR TITLE
[2.9] Prevent Ansible 2.9 to choke on collections using deprecation by date or collection_name for deprecation calls

### DIFF
--- a/changelogs/fragments/69935-2.10-deprecation-support.yml
+++ b/changelogs/fragments/69935-2.10-deprecation-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+ - ``Display.deprecated()``, ``AnsibleModule.deprecate()`` and ``Ansible.Basic.Deprecate()`` now also accept the deprecation-by-date parameters and collection name parameters from Ansible 2.10. This prevents collections plugins and modules from Ansible 2.10 conforming collections to crash with newer versions of Ansible 2.9.

--- a/changelogs/fragments/69935-2.10-deprecation-support.yml
+++ b/changelogs/fragments/69935-2.10-deprecation-support.yml
@@ -1,2 +1,2 @@
 minor_changes:
- - "``Display.deprecated()``, ``AnsibleModule.deprecate()`` and ``Ansible.Basic.Deprecate()`` now also accept the deprecation-by-date parameters and collection name parameters from Ansible 2.10. This prevents collections plugins and modules from Ansible 2.10 conforming collections to crash with newer versions of Ansible 2.9."
+ - "``Display.deprecated()``, ``AnsibleModule.deprecate()`` and ``Ansible.Basic.Deprecate()`` now also accept the deprecation-by-date parameters and collection name parameters from Ansible 2.10, so plugins and modules in collections that conform to Ansible 2.10 will run with newer versions of Ansible 2.9."

--- a/changelogs/fragments/69935-2.10-deprecation-support.yml
+++ b/changelogs/fragments/69935-2.10-deprecation-support.yml
@@ -1,2 +1,2 @@
 minor_changes:
- - ``Display.deprecated()``, ``AnsibleModule.deprecate()`` and ``Ansible.Basic.Deprecate()`` now also accept the deprecation-by-date parameters and collection name parameters from Ansible 2.10. This prevents collections plugins and modules from Ansible 2.10 conforming collections to crash with newer versions of Ansible 2.9.
+ - "``Display.deprecated()``, ``AnsibleModule.deprecate()`` and ``Ansible.Basic.Deprecate()`` now also accept the deprecation-by-date parameters and collection name parameters from Ansible 2.10. This prevents collections plugins and modules from Ansible 2.10 conforming collections to crash with newer versions of Ansible 2.9."

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -752,7 +752,10 @@ class AnsibleModule(object):
         else:
             raise TypeError("warn requires a string not a %s" % type(warning))
 
-    def deprecate(self, msg, version=None):
+    def deprecate(self, msg, version=None, date=None, collection_name=None):
+        # `date` and `collection_name` are Ansible 2.10 parameters. We accept and ignore them,
+        # to avoid modules/plugins from 2.10 conformant collections to break with new enough
+        # versions of Ansible 2.9.
         if isinstance(msg, string_types):
             self._deprecations.append({
                 'msg': msg,
@@ -1438,7 +1441,7 @@ class AnsibleModule(object):
             if deprecation['name'] in param.keys():
                 self._deprecations.append(
                     {'msg': "Alias '%s' is deprecated. See the module docs for more information" % deprecation['name'],
-                     'version': deprecation['version']})
+                     'version': deprecation.get('version')})
         return alias_results
 
     def _handle_no_log_values(self, spec=None, param=None):

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -134,7 +134,7 @@ def list_deprecations(argument_spec, params, prefix=''):
                 sub_prefix = '%s["%s"]' % (prefix, arg_name)
             else:
                 sub_prefix = arg_name
-            if arg_opts.get('removed_in_version') is not None:
+            if arg_opts.get('removed_in_version') is not None or arg_opts.get('removed_at_date') is not None:
                 deprecations.append({
                     'msg': "Param '%s' is deprecated. See the module docs for more information" % sub_prefix,
                     'version': arg_opts.get('removed_in_version')

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -246,8 +246,7 @@ namespace Ansible.Basic
 
         public void Deprecate(string message, string version)
         {
-            deprecations.Add(new Dictionary<string, string>() { { "msg", message }, { "version", version } });
-            LogEvent(String.Format("[DEPRECATION WARNING] {0} {1}", message, version));
+            Deprecate(message, version, null);
         }
 
         public void Deprecate(string message, string version, string collectionName)
@@ -264,8 +263,7 @@ namespace Ansible.Basic
             // This function is only available for Ansible 2.10. We still accept and ignore it,
             // to avoid modules/plugins from 2.10 conformant collections to break with new enough
             // versions of Ansible 2.9.
-            deprecations.Add(new Dictionary<string, string>() { { "msg", message }, { "version", null } });
-            LogEvent(String.Format("[DEPRECATION WARNING] {0} {1}", message, null));
+            Deprecate(message, date, null);
         }
 
         public void Deprecate(string message, DateTime date, string collectionName)

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -242,10 +242,22 @@ namespace Ansible.Basic
                 LogEvent(String.Format("[DEBUG] {0}", message));
         }
 
-        public void Deprecate(string message, string version)
+        public void Deprecate(string message, string version, string collectionName = null)
         {
+            // `collectionName` is a Ansible 2.10 parameter. We accept and ignore it,
+            // to avoid modules/plugins from 2.10 conformant collections to break with
+            // new enough versions of Ansible 2.9.
             deprecations.Add(new Dictionary<string, string>() { { "msg", message }, { "version", version } });
             LogEvent(String.Format("[DEPRECATION WARNING] {0} {1}", message, version));
+        }
+
+        public void Deprecate(string message, DateTime date, string collectionName = null)
+        {
+            // This function is only available for Ansible 2.10. We still accept and ignore it,
+            // to avoid modules/plugins from 2.10 conformant collections to break with new enough
+            // versions of Ansible 2.9.
+            deprecations.Add(new Dictionary<string, string>() { { "msg", message }, { "version", null } });
+            LogEvent(String.Format("[DEPRECATION WARNING] {0} {1}", message, null));
         }
 
         public void ExitJson()

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -738,8 +738,8 @@ namespace Ansible.Basic
                 if (removedInVersion != null && parameters.Contains(k))
                     Deprecate(String.Format("Param '{0}' is deprecated. See the module docs for more information", k), removedInVersion.ToString());
 
-                object removedInVersion = v["removed_at_date"];
-                if (removedInVersion != null && parameters.Contains(k))
+                object removedAtDate = v["removed_at_date"];
+                if (removedAtDate != null && parameters.Contains(k))
                     Deprecate(String.Format("Param '{0}' is deprecated. See the module docs for more information", k), (string)null);
             }
         }

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -83,7 +83,7 @@ namespace Ansible.Basic
             { "no_log", new List<object>() { false, typeof(bool) } },
             { "options", new List<object>() { typeof(Hashtable), typeof(Hashtable) } },
             { "removed_in_version", new List<object>() { null, typeof(string) } },
-            { "removed_at_date", new List<object>() { null, typeof(string) } },  // Ansible 2.10 compatibility
+            { "removed_at_date", new List<object>() { null, typeof(DateTime) } },  // Ansible 2.10 compatibility
             { "removed_from_collection", new List<object>() { null, typeof(string) } },  // Ansible 2.10 compatibility
             { "required", new List<object>() { false, typeof(bool) } },
             { "required_by", new List<object>() { typeof(Hashtable), typeof(Hashtable) } },

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -249,8 +249,12 @@ class Display(with_metaclass(Singleton, object)):
             else:
                 self.display("<%s> %s" % (host, msg), color=C.COLOR_VERBOSE, stderr=to_stderr)
 
-    def deprecated(self, msg, version=None, removed=False):
+    def deprecated(self, msg, version=None, removed=False, date=None, collection_name=None):
         ''' used to print out a deprecation message.'''
+
+        # `date` and `collection_name` are Ansible 2.10 parameters. We accept and ignore them,
+        # to avoid modules/plugins from 2.10 conformant collections to break with new enough
+        # versions of Ansible 2.9.
 
         if not removed and not C.DEPRECATION_WARNINGS:
             return

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -1623,9 +1623,9 @@ class ModuleValidator(Validator):
             # See if current version => deprecated.removed_in, ie, should be docs only
             if isinstance(doc_info['ANSIBLE_METADATA']['value'], ast.Dict) and 'removed' in ast.literal_eval(doc_info['ANSIBLE_METADATA']['value'])['status']:
                 end_of_deprecation_should_be_removed_only = True
-            elif docs and 'deprecated' in docs and docs['deprecated'] is not None:
+            elif docs and 'deprecated' in docs and docs['deprecated'] is not None and 'removed_in' in docs['deprecated']:
                 try:
-                    removed_in = StrictVersion(str(docs.get('deprecated')['removed_in']))
+                    removed_in = StrictVersion(str(docs['deprecated']['removed_in']))
                 except ValueError:
                     end_of_deprecation_should_be_removed_only = False
                 else:

--- a/test/units/module_utils/basic/test_deprecate_warn.py
+++ b/test/units/module_utils/basic/test_deprecate_warn.py
@@ -23,9 +23,12 @@ def test_warn(am, capfd):
 def test_deprecate(am, capfd):
     am.deprecate('deprecation1')
     am.deprecate('deprecation2', '2.3')
+    am.deprecate('deprecation3', '2.5', collection_name='foo.bar')  # Ansible 2.10 compatibility
+    am.deprecate('deprecation4', date='2020-01-01')  # Ansible 2.10 compatibility
+    am.deprecate('deprecation5', date='2020-01-01', collection_name='foo.bar')  # Ansible 2.10 compatibility
 
     with pytest.raises(SystemExit):
-        am.exit_json(deprecations=['deprecation3', ('deprecation4', '2.4')])
+        am.exit_json(deprecations=['deprecation6', ('deprecation7', '2.4')])
 
     out, err = capfd.readouterr()
     output = json.loads(out)
@@ -33,8 +36,11 @@ def test_deprecate(am, capfd):
     assert output['deprecations'] == [
         {u'msg': u'deprecation1', u'version': None},
         {u'msg': u'deprecation2', u'version': '2.3'},
-        {u'msg': u'deprecation3', u'version': None},
-        {u'msg': u'deprecation4', u'version': '2.4'},
+        {u'msg': u'deprecation3', u'version': '2.5'},
+        {u'msg': u'deprecation4', u'version': None},
+        {u'msg': u'deprecation5', u'version': None},
+        {u'msg': u'deprecation6', u'version': None},
+        {u'msg': u'deprecation7', u'version': '2.4'},
     ]
 
 

--- a/test/units/module_utils/common/parameters/test_list_deprecations.py
+++ b/test/units/module_utils/common/parameters/test_list_deprecations.py
@@ -25,11 +25,14 @@ def test_list_deprecations():
         'old': {'type': 'str', 'removed_in_version': '2.5'},
         'foo': {'type': 'dict', 'options': {'old': {'type': 'str', 'removed_in_version': 1.0}}},
         'bar': {'type': 'list', 'elements': 'dict', 'options': {'old': {'type': 'str', 'removed_in_version': '2.10'}}},
+        # Ansible 2.10 compatibility:
+        'compat': {'type': 'str', 'removed_at_date': '2020-01-01', 'removed_from_collection': 'foo.bar'},
     }
 
     params = {
         'name': 'rod',
         'old': 'option',
+        'old2': 'option2',
         'foo': {'old': 'value'},
         'bar': [{'old': 'value'}, {}],
     }


### PR DESCRIPTION
##### SUMMARY
Needed to avoid #69926 making collections stop working with Ansible 2.9.

The changes are minimal to prevent modules/plugins using these parameters from crashing.

The only change I'm not sure about is adding the overload `public void Deprecate(string message, DateTime date, string collectionName = null)` in lib/ansible/module_utils/csharp/Ansible.Basic.cs.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py
lib/ansible/module_utils/csharp/Ansible.Basic.cs
lib/ansible/utils/display.py
