### PR TITLE
[2.9] Update developing_modules_best_practices.rst

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
@@ -76,7 +76,7 @@ Importing and using shared code
 
     import traceback
 
-    from ansible.basic import missing_required_lib
+    from ansible.module_utils.basic import missing_required_lib
 
     LIB_IMP_ERR = None
     try:


### PR DESCRIPTION
##### SUMMARY

wrong module path for module_utils.basic in developing_modules_best_practices.rst

(cherry picked from commit ff98ecc4d0413f7b51dfb5210534b2c5b2ebdce1)


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
