### PR TITLE
fix get_data on case_insensitive fs

### DIFF
--- a/changelogs/fragments/case_insensitive_fix.yml
+++ b/changelogs/fragments/case_insensitive_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - collection loader - fix file/module/class confusion issues on case-insensitive filesystems

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -648,7 +648,7 @@ class CollectionModuleInfo(ModuleInfo):
             self._package_name = '.'.join(path.split('/'))
             try:
                 self.get_source()
-            except FileNotFoundError:
+            except IOError:
                 pass
             else:
                 self.path = os.path.join(path, self._mod_name) + '.py'

--- a/lib/ansible/utils/collection_loader.py
+++ b/lib/ansible/utils/collection_loader.py
@@ -6,7 +6,6 @@ __metaclass__ = type
 
 import os
 import os.path
-import pkgutil
 import re
 import sys
 
@@ -14,7 +13,7 @@ from types import ModuleType
 
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.six import iteritems, string_types, with_metaclass
-from ansible.utils.path import cs_isfile
+from ansible.utils.path import cs_open
 from ansible.utils.singleton import Singleton
 
 # HACK: keep Python 2.6 controller tests happy in CI until they're properly split
@@ -270,9 +269,7 @@ class AnsibleCollectionLoader(with_metaclass(Singleton, object)):
         return os.path.join(path, ns_path_add)
 
     def get_data(self, filename):
-        if not cs_isfile(filename):
-            raise IOError('could not find {0}'.format(filename))
-        with open(filename, 'rb') as fd:
+        with cs_open(filename, 'rb') as fd:
             return fd.read()
 
 

--- a/lib/ansible/utils/collection_loader.py
+++ b/lib/ansible/utils/collection_loader.py
@@ -14,6 +14,7 @@ from types import ModuleType
 
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.six import iteritems, string_types, with_metaclass
+from ansible.utils.path import cs_isfile
 from ansible.utils.singleton import Singleton
 
 # HACK: keep Python 2.6 controller tests happy in CI until they're properly split
@@ -269,6 +270,8 @@ class AnsibleCollectionLoader(with_metaclass(Singleton, object)):
         return os.path.join(path, ns_path_add)
 
     def get_data(self, filename):
+        if not cs_isfile(filename):
+            raise IOError('could not find {0}'.format(filename))
         with open(filename, 'rb') as fd:
             return fd.read()
 

--- a/test/units/utils/test_path.py
+++ b/test/units/utils/test_path.py
@@ -6,7 +6,8 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import os
-from ansible.utils.path import cs_exists, cs_isdir, cs_isfile
+import pytest
+from ansible.utils.path import cs_exists, cs_isdir, cs_isfile, cs_open
 
 
 def iter_parent_paths(path):
@@ -17,6 +18,15 @@ def iter_parent_paths(path):
             break
         else:
             yield parent
+
+
+def test_cs_open():
+    with open(__file__) as fd:
+        with cs_open(__file__) as csfd:
+            assert fd.read() == csfd.read()
+
+    with pytest.raises(IOError):
+        cs_open(__file__.upper())
 
 
 def test_cs_isfile():

--- a/test/units/utils/test_path.py
+++ b/test/units/utils/test_path.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# (c) 2020 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import os
+from ansible.utils.path import cs_exists, cs_isdir, cs_isfile
+
+
+def iter_parent_paths(path):
+    parent = path
+    while True:
+        parent, leaf = os.path.split(parent)
+        if not parent or not leaf:
+            break
+        else:
+            yield parent
+
+
+def test_cs_isfile():
+    assert cs_isfile(__file__)
+    for p in iter_parent_paths(__file__):
+        assert not cs_isfile(p)
+    assert not cs_isfile(__file__.upper())
+
+
+def test_cs_isdir():
+    assert not cs_isdir(__file__)
+    for p in iter_parent_paths(__file__):
+        assert cs_isdir(p)
+        if p != p.upper():
+            assert not cs_isdir(p.upper())
+
+
+def test_cs_exists():
+    assert cs_exists(__file__)
+    assert not cs_exists(__file__.upper())
+    for p in iter_parent_paths(__file__):
+        assert cs_exists(p)
+        if p != p.upper():
+            assert not cs_exists(p.upper())


### PR DESCRIPTION
##### SUMMARY
* implement case-sensitive-forcing versions of various os.path methods for OSX that just pass through on case-sensitive systems.
* fixes #69350 
* supersedes #67817

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
util/path.py
collection_loader.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
