### PR TITLE
enable collections module_utils subpkg tests

### DIFF
--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/uses_leaf_mu_module_import_from.py
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/uses_leaf_mu_module_import_from.py
@@ -6,17 +6,17 @@ import json
 import sys
 
 from ansible_collections.testns.testcoll.plugins.module_utils import leaf, secondary
-# FIXME: these don't work yet under collections
-# from ansible_collections.testns.testcoll.plugins.module_utils.subpkg import submod
-# from ansible_collections.testns.testcoll.plugins.module_utils.subpkg_with_init import thingtocall as spwi_thingtocall
+from ansible_collections.testns.testcoll.plugins.module_utils.subpkg import submod
+from ansible_collections.testns.testcoll.plugins.module_utils.subpkg_with_init import thingtocall as spwi_thingtocall
 
 
 def main():
     mu_result = leaf.thingtocall()
     mu2_result = secondary.thingtocall()
-#    mu3_result = submod.thingtocall()
-#    mu4_result = spwi_thingtocall()
-    print(json.dumps(dict(changed=False, source='user', mu_result=mu_result, mu2_result=mu2_result)))
+    mu3_result = submod.thingtocall()
+    mu4_result = spwi_thingtocall()
+    print(json.dumps(dict(changed=False, source='user', mu_result=mu_result, mu2_result=mu2_result,
+                          mu3_result=mu3_result, mu4_result=mu4_result)))
 
     sys.exit()
 

--- a/test/integration/targets/collections/posix.yml
+++ b/test/integration/targets/collections/posix.yml
@@ -89,6 +89,8 @@
       - flat_out.mu_result == 'thingtocall in leaf'
       - from_out.mu_result == 'thingtocall in leaf'
       - from_out.mu2_result == 'thingtocall in secondary'
+      - from_out.mu3_result == 'thingtocall in subpkg.submod'
+      - from_out.mu4_result == 'thingtocall in subpkg_with_init'
       - from_nested_func.mu_result == 'hello from nested_same'
       - from_nested_module.mu_result == 'hello from nested_same'
 


### PR DESCRIPTION
##### SUMMARY
* fixed by collection loader rewrite, just needed to be reenabled

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
collections module_utils tests

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
