### PR TITLE
Properly build collection resource path

### DIFF
--- a/changelogs/fragments/68361-correctly-build-path.yml
+++ b/changelogs/fragments/68361-correctly-build-path.yml
@@ -1,0 +1,4 @@
+bigfixes:
+- Collection Loader - Properly build the path to the collection resource,
+  using the python calculated package
+  (https://github.com/ansible/ansible/issues/68361)

--- a/changelogs/fragments/68361-correctly-build-path.yml
+++ b/changelogs/fragments/68361-correctly-build-path.yml
@@ -1,4 +1,4 @@
-bigfixes:
+bugfixes:
 - Collection Loader - Properly build the path to the collection resource,
   using the python calculated package
   (https://github.com/ansible/ansible/issues/68361)

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -663,7 +663,7 @@ class CollectionModuleInfo(ModuleInfo):
         # FIXME (nitz): need this in py2 for some reason TBD, but we shouldn't (get_data delegates
         # to wrong loader without it)
         pkg = import_module(self._package_name)
-        data = pkgutil.get_data(to_native(self._package_name), to_native(self._mod_name + '.py'))
+        data = pkgutil.get_data(to_native(pkg.__package__), to_native(self._mod_name + '.py'))
         return data
 
 


### PR DESCRIPTION
##### SUMMARY
Properly build collection resource path. Fixes #68361

This is not a backport, as this was fixed in devel with the rewrite of the collection loader for routing.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/module_common.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
