### PR TITLE
Fix Include_vars example

### DIFF
--- a/lib/ansible/modules/include_vars.py
+++ b/lib/ansible/modules/include_vars.py
@@ -95,12 +95,15 @@ EXAMPLES = r'''
   when: x == 0
 
 - name: Load a variable file based on the OS type, or a default if not found. Using free-form to specify the file.
-  include_vars: "{{ lookup('first_found', possible_files) }}"
+  include_vars: "{{ lookup('first_found', params) }}"
   vars:
-    possible_files:
-      - "{{ ansible_distribution }}.yaml"
-      - "{{ ansible_os_family }}.yaml"
-      - default.yaml
+    params:
+      files:
+        - '{{ansible_distribution}}.yaml'
+        - '{{ansible_os_family}}.yaml'
+        - default.yaml
+      paths:
+        - 'vars'
 
 - name: Bare include (free-form)
   include_vars: myvars.yaml

--- a/lib/ansible/plugins/lookup/first_found.py
+++ b/lib/ansible/plugins/lookup/first_found.py
@@ -88,7 +88,7 @@ EXAMPLES = """
   vars:
     params:
       files:
-        - '{{ansible_os_distribution}}.yml'
+        - '{{ansible_distribution}}.yml'
         - '{{ansible_os_family}}.yml'
         - default.yml
       paths:


### PR DESCRIPTION
##### SUMMARY
 - Change invalid var from `ansible_os_distribution` to `ansible_distribution`
 - Fix example in `lookup_vars` so that it correctly checks vars folder

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
 - include_vars
 - first_found
