### PR TITLE
default callback plugin: Add default 'show_per_host_start' value'

### DIFF
--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -57,7 +57,8 @@ COMPAT_OPTIONS = (('display_skipped_hosts', C.DISPLAY_SKIPPED_HOSTS),
                   ('display_ok_hosts', True),
                   ('show_custom_stats', C.SHOW_CUSTOM_STATS),
                   ('display_failed_stderr', False),
-                  ('check_mode_markers', False),)
+                  ('check_mode_markers', False),
+                  ('show_per_host_start', False),)
 
 
 class CallbackModule(CallbackBase):
@@ -253,7 +254,7 @@ class CallbackModule(CallbackBase):
         self._task_start(task, prefix='RUNNING HANDLER')
 
     def v2_runner_on_start(self, host, task):
-        if self.get_option('show_per_host_start'):
+        if self.show_per_host_start:
             self._display.display(" [started %s on %s]" % (task, host), color=C.COLOR_OK)
 
     def v2_playbook_on_play_start(self, play):


### PR DESCRIPTION
Fixes #69954

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

default callback plugin: Add default 'show_per_host_start' value' 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
default callback plugin
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
