### PR TITLE
add changelog categories, update CVE fragments to use security_fix category

### DIFF
--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -7,7 +7,9 @@ new_plugins_after_name: removed_features
 sections:
 - ['major_changes', 'Major Changes']
 - ['minor_changes', 'Minor Changes']
+- ['breaking_changes', 'Breaking Changes / Porting Guide']
 - ['deprecated_features', 'Deprecated Features']
 - ['removed_features', 'Removed Features (previously deprecated)']
+- ['security_fixes', 'Security Fixes']
 - ['bugfixes', 'Bugfixes']
 - ['known_issues', 'Known Issues']

--- a/changelogs/fragments/62237-keep-unsafe-context.yml
+++ b/changelogs/fragments/62237-keep-unsafe-context.yml
@@ -1,4 +1,4 @@
-bugfixes:
+security_fixes:
 - >
   **security issue** - TaskExecutor - Ensure we don't erase unsafe context in TaskExecutor.run on bytes.
   Only present in 2.9.0beta1

--- a/changelogs/fragments/ansible-test-cloud-secrets.yml
+++ b/changelogs/fragments/ansible-test-cloud-secrets.yml
@@ -1,3 +1,3 @@
-bugfixes:
+security_fixes:
     - >
         **security issue** - Redact cloud plugin secrets in ansible-test when running integration tests using cloud plugins. Only present in 2.9.0b1.

--- a/changelogs/fragments/dont-template-cli-passwords.yml
+++ b/changelogs/fragments/dont-template-cli-passwords.yml
@@ -1,4 +1,4 @@
-bugfixes:
+security_fixes:
 - >
   **security issue** - Convert CLI provided passwords to text initially, to
   prevent unsafe context being lost when converting from bytes->text during

--- a/changelogs/fragments/fetch_no_slurp.yml
+++ b/changelogs/fragments/fetch_no_slurp.yml
@@ -1,2 +1,2 @@
-bugfixes:
+security_fixes:
     - In fetch action, avoid using slurp return to set up dest, also ensure no dir traversal CVE-2020-1735.

--- a/changelogs/fragments/galaxy-install-tar-path-traversal.yaml
+++ b/changelogs/fragments/galaxy-install-tar-path-traversal.yaml
@@ -1,2 +1,2 @@
-bugfixes:
+security_fixes:
 - ansible-galaxy - Error when install finds a tar with a file that will be extracted outside the collection install directory - CVE-2020-10691

--- a/changelogs/fragments/no-log-sub-options-invalid-parameter.yaml
+++ b/changelogs/fragments/no-log-sub-options-invalid-parameter.yaml
@@ -1,2 +1,2 @@
-bugfixes:
+security_fixes:
   - '**security issue** - properly hide parameters marked with ``no_log`` in suboptions when invalid parameters are passed to the module (CVE-2019-14858)'

--- a/changelogs/fragments/remote_mkdir_fix.yml
+++ b/changelogs/fragments/remote_mkdir_fix.yml
@@ -1,2 +1,2 @@
-bugfixes:
+security_fixes:
     - Ensure we get an error when creating a remote tmp if it already exists. CVE-2020-1733

--- a/changelogs/fragments/subversion_password.yaml
+++ b/changelogs/fragments/subversion_password.yaml
@@ -1,4 +1,4 @@
-bugfixes:
+security_fixes:
 - >
   **security issue** - The ``subversion`` module provided the password
   via the svn command line option ``--password`` and can be retrieved

--- a/changelogs/fragments/vault_tmp_race_fix.yml
+++ b/changelogs/fragments/vault_tmp_race_fix.yml
@@ -1,2 +1,2 @@
-bugfixes:
+security_fixes:
     - "**security_issue** - create temporary vault file with strict permissions when editing and prevent race condition (CVE-2020-1740)"

--- a/changelogs/fragments/win-unzip-check-extraction-path.yml
+++ b/changelogs/fragments/win-unzip-check-extraction-path.yml
@@ -1,4 +1,4 @@
-bugfixes:
+security_fixes:
   - >
     **security issue** win_unzip - normalize paths in archive to ensure extracted
     files do not escape from the target directory (CVE-2020-1737)


### PR DESCRIPTION
##### SUMMARY
Related to #69313.
Updates ansible-base changelog config to match [categories supported by antsibull-changelog](https://github.com/ansible-community/antsibull-changelog/blob/master/antsibull_changelog/config.py#L357-L364).
Calls out existing CVE changelog fragments and other fragments marked "security" as `security_fix` instead of `bugfix`. 

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
changelogs on docs.ansible.com
