### PR TITLE
Fix ansible-test pip filter on Fedora 32.

### DIFF
--- a/test/lib/ansible_test/_data/quiet_pip.py
+++ b/test/lib/ansible_test/_data/quiet_pip.py
@@ -10,7 +10,7 @@ import warnings
 BUILTIN_FILTERER_FILTER = logging.Filterer.filter
 
 LOGGING_MESSAGE_FILTER = re.compile("^("
-                                    "WARNING: Running pip install with root privileges is generally not a good idea. .*|"  # custom Fedora patch [1]
+                                    ".*Running pip install with root privileges is generally not a good idea.*|"  # custom Fedora patch [1]
                                     "DEPRECATION: Python 2.7 will reach the end of its life .*|"  # pip 19.2.3
                                     "Ignoring .*: markers .* don't match your environment|"
                                     "Requirement already satisfied.*"


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test pip filter on Fedora 32.

The original version works on CentOS 8 but not Fedora 32.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
