### PR TITLE
Fix up schema for collection deprecation

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2063,7 +2063,7 @@ class AnsibleModule(object):
                         self.deprecate(d[0], version=d[1])
                     elif isinstance(d, Mapping):
                         self.deprecate(d['msg'], version=d.get('version'), date=d.get('date'),
-                                       collection_name=d.get('date'))
+                                       collection_name=d.get('collection_name'))
                     else:
                         self.deprecate(d)  # pylint: disable=ansible-deprecated-no-version
             else:

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1529,7 +1529,7 @@ def url_argument_spec():
     return dict(
         url=dict(type='str'),
         force=dict(type='bool', default=False, aliases=['thirsty'],
-                   deprecated_aliases=[dict(name='thirsty', version='2.13', collection='ansible.builtin')]),
+                   deprecated_aliases=[dict(name='thirsty', version='2.13', collection_name='ansible.builtin')]),
         http_agent=dict(type='str', default='ansible-httpget'),
         use_proxy=dict(type='bool', default=True),
         validate_certs=dict(type='bool', default=True),

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -182,12 +182,12 @@ def argument_spec_schema(for_collection):
                 {
                     Required('name'): Any(*string_types),
                     Required('date'): date(),
-                    Required('collection'): collection_name,
+                    Required('collection_name'): collection_name,
                 },
                 {
                     Required('name'): Any(*string_types),
                     Required('version'): version(for_collection),
-                    Required('collection'): collection_name,
+                    Required('collection_name'): collection_name,
                 },
             )]),
         }


### PR DESCRIPTION
##### SUMMARY
Fix up schema to use `collection_name` which is what the arg spec is coded to use. Bugfix for change added in https://github.com/ansible/ansible/pull/69926.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
validate-modules