### PR TITLE
Address linting errors in default callback

### DIFF
--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -89,7 +89,7 @@ class CallbackModule(CallbackBase):
                 value = self.get_option(option)
             except (AttributeError, KeyError):
                 self._display.deprecated("'%s' is subclassing DefaultCallback without the corresponding doc_fragment." % self._load_name,
-                                   version='2.14')
+                                         version='2.14', collection_name='ansible.builtin')
                 value = constant
             setattr(self, option, value)
 


### PR DESCRIPTION
##### SUMMARY
Address linting errors in default callback

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/callback/default.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
