### PR TITLE
Regex groupdict alone

### DIFF
--- a/changelogs/fragments/64474-regex-groupdict.yaml
+++ b/changelogs/fragments/64474-regex-groupdict.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+- Return named capture groups as a dict from the ``regex_search_groupdict`` and
+  ``regex_findall_groupdict`` filters. This makes ugly list comprehensions much
+  simpler by allowing it to be boiled to a single ``regex_findall_groupdict``.

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1396,12 +1396,23 @@ To search a string with a regex, use the "regex_search" filter::
     # case insensitive search in multiline mode
     {{ 'foo\nBAR' | regex_search("^bar", multiline=True, ignorecase=True) }}
 
+.. versionadded:: 2.10
+
+    # find the username and uid of a user in a passwd-formatted line,
+    # returned as a dictionary
+    {{ 'user:x:1000:1000:John Doe:/home/user:/bin/bash' | regex_search_groupdict('^(?P<id>[^:]*):[^:]*:(?P<uid>[^:]*)') }}
+
 
 To search for all occurrences of regex matches, use the "regex_findall" filter::
 
     # Return a list of all IPv4 addresses in the string
     {{ 'Some DNS servers are 8.8.8.8 and 8.8.4.4' | regex_findall('\\b(?:[0-9]{1,3}\\.){3}[0-9]{1,3}\\b') }}
 
+.. versionadded:: 2.10
+
+    # find list of username, uid, and gid for each user in a passwd-formatted
+    # file, returned as a list of dictionaries
+    {{ lookup('file', '/etc/passwd') | regex_findall_groupdict('^(?P<id>[^:]*):[^:]*:(?P<uid>[^:]*):(?P<gid>[^:]*)', multiline=True) }}
 
 To replace text in a string with regex, use the "regex_replace" filter::
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -142,6 +142,18 @@ def regex_findall(value, regex, multiline=False, ignorecase=False):
     return re.findall(regex, value, flags)
 
 
+def regex_findall_groupdict(value, regex, multiline=False, ignorecase=False):
+    ''' Perform re.findall and return the list of named matches (dicts) '''
+    flags = 0
+    if ignorecase:
+        flags |= re.I
+    if multiline:
+        flags |= re.M
+
+    r = re.compile(regex, flags)
+    return [m.groupdict() for m in r.finditer(value)]
+
+
 def regex_search(value, regex, *args, **kwargs):
     ''' Perform re.search and return the list of matches or a backref '''
 
@@ -171,6 +183,22 @@ def regex_search(value, regex, *args, **kwargs):
             for item in groups:
                 items.append(match.group(item))
             return items
+
+
+def regex_search_groupdict(value, regex, multiline=False, ignorecase=False):
+    ''' Perform re.search and return the named matches as a dict '''
+
+    flags = 0
+    if ignorecase:
+        flags |= re.I
+    if multiline:
+        flags |= re.M
+
+    match = re.search(regex, value, flags)
+    if match:
+        return match.groupdict()
+    else:
+        return dict()
 
 
 def ternary(value, true_val, false_val, none_val=None):
@@ -629,7 +657,9 @@ class FilterModule(object):
             'regex_replace': regex_replace,
             'regex_escape': regex_escape,
             'regex_search': regex_search,
+            'regex_search_groupdict': regex_search_groupdict,
             'regex_findall': regex_findall,
+            'regex_findall_groupdict': regex_findall_groupdict,
 
             # ? : ;
             'ternary': ternary,

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -256,6 +256,7 @@
     multi_line: "{{ 'hello\nworld' | regex_search('^world', multiline=true) }}"
     named_groups: "{{ 'goodbye' | regex_search('(?P<first>good)(?P<second>bye)', '\\g<second>', '\\g<first>') }}"
     numbered_groups: "{{ 'goodbye' | regex_search('(good)(bye)', '\\2', '\\1') }}"
+    groupdict: "{{ 'user:x:1000:1000:John Doe:/home/user:/bin/bash' | regex_search_groupdict('^(?P<id>[^:]*):[^:]*:(?P<uid>[^:]*)') }}"
 
 - name: regex_search unknown argument (failure expected)
   set_fact:
@@ -273,6 +274,18 @@
       - named_groups == ['bye', 'good']
       - numbered_groups == ['bye', 'good']
       - failure is failed
+      - "groupdict == {'id': 'user', 'uid': '1000'}"
+
+- name: regex_findall check
+  set_fact:
+    findall_groupdict: "{{ passwd_content | regex_findall_groupdict('^(?P<id>[^:]*):[^:]*:(?P<uid>[^:]*):(?P<gid>[^:]*)[\\n]?', multiline=True) }}"
+  failed_when:
+    - findall_groupdict | selectattr('uid', '==', '1000') | map(attribute='id') | list != ['user'] or
+      findall_groupdict | selectattr('id', '==', 'root') | map(attribute='uid') | list != ['0']
+  vars:
+    passwd_content: |
+      root:x:0:0:root:/root:/bin/bash
+      user:x:1000:1000:John Doe:/home/user:/bin/bash
 
 - name: Verify to_bool
   assert:

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -280,9 +280,15 @@
   set_fact:
     findall_groupdict: "{{ passwd_content | regex_findall_groupdict('^(?P<id>[^:]*):[^:]*:(?P<uid>[^:]*):(?P<gid>[^:]*)[\\n]?', multiline=True) }}"
   failed_when:
-    - findall_groupdict | selectattr('uid', '==', '1000') | map(attribute='id') | list != ['user'] or
-      findall_groupdict | selectattr('id', '==', 'root') | map(attribute='uid') | list != ['0']
+    - findall_groupdict != passwd_parsed
   vars:
+    passwd_parsed:
+      - id: root
+        uid: "0"
+        gid: "0"
+      - id: user
+        uid: "1000"
+        gid: "1000"
     passwd_content: |
       root:x:0:0:root:/root:/bin/bash
       user:x:1000:1000:John Doe:/home/user:/bin/bash


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
separate-filter version of https://github.com/ansible/ansible/pull/64474
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Return named capture groups as a dict from the regex_search and regex_findall filters.

This makes ugly list comprehensions much simpler by allowing it to be boiled to a single regex_findall.

(an example of a complicated case: https://github.com/MindPointGroup/RHEL7-STIG/blob/d0b128cef334374257a7f85d1fcb25b0653f64e0/tasks/parse_etc_passwd.yml#L10-L28 )

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
core filter plugins

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
