### PR TITLE
2.9: Do not keep empty blocks after tag filtering (#69987)

### DIFF
--- a/changelogs/fragments/purge-empty-block.yml
+++ b/changelogs/fragments/purge-empty-block.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Do not keep empty blocks in PlayIterator after skipping tasks with tags.

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -371,7 +371,9 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
             tmp_list = []
             for task in target:
                 if isinstance(task, Block):
-                    tmp_list.append(evaluate_block(task))
+                    filtered_block = evaluate_block(task)
+                    if filtered_block.has_tasks():
+                        tmp_list.append(filtered_block)
                 elif (task.action == 'meta' or
                         (task.action == 'include' and task.evaluate_tags([], self._play.skip_tags, all_vars=all_vars)) or
                         task.evaluate_tags(self._play.only_tags, self._play.skip_tags, all_vars=all_vars)):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of https://github.com/ansible/ansible/pull/69987

(cherry picked from commit ac2046637510eed8e31ca0c88aebce3279f38070)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/playbook/block.py`