### PR TITLE
ansible-test: vcenter initialize group/vmware

### DIFF
--- a/test/integration/targets/incidental_vmware_prepare_tests/tasks/init_vcsim.yml
+++ b/test/integration/targets/incidental_vmware_prepare_tests/tasks/init_vcsim.yml
@@ -40,5 +40,9 @@
   vmware_guest:
     name: "{{ item.name }}"
     state: poweredoff
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
   with_items: "{{ virtual_machines + virtual_machines_in_cluster }}"
   register: poweroff_d1_c1_f0

--- a/test/lib/ansible_test/_internal/cloud/vcenter.py
+++ b/test/lib/ansible_test/_internal/cloud/vcenter.py
@@ -220,7 +220,7 @@ class VcenterEnvironment(CloudEnvironment):
             env_vars=env_vars,
             ansible_vars=ansible_vars,
             module_defaults={
-                'vmware_guest': {
+                'group/vmware': {
                     'hostname': ansible_vars['vcenter_hostname'],
                     'username': ansible_vars['vcenter_username'],
                     'password': ansible_vars['vcenter_password'],


### PR DESCRIPTION
##### SUMMARY

Ensure the vcenter provider initialize the `module_defaults` of all
the vmware modules, not just `vmware_guest`.
The VMware CI relies on this for the authentication of the different
VMware modules.

The commit adjust `incidental_vmware_prepare_tests/tasks/init_vcsim.yml`.
The test-suite uses a copy of `vmware_guest` that is not in the
`group/vmware` group. As a result, we need to manually pass the
authentification parameter.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

test/lib/ansible_test/_internal/cloud/vcenter.py
<!--- Write the short name of the module, plugin, task or feature below -->