### PR TITLE
Support `removed_at_date` in ansible-doc (#70002)

### DIFF
--- a/changelogs/fragments/ansible-doc-remove_at_date.yaml
+++ b/changelogs/fragments/ansible-doc-remove_at_date.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-doc - Allow and give precedence to `removed_at_date` for deprecated modules. 

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -611,9 +611,14 @@ class DocCLI(CLI):
         if 'deprecated' in doc and doc['deprecated'] is not None and len(doc['deprecated']) > 0:
             text.append("DEPRECATED: \n")
             if isinstance(doc['deprecated'], dict):
-                if 'version' in doc['deprecated'] and 'removed_in' not in doc['deprecated']:
-                    doc['deprecated']['removed_in'] = doc['deprecated']['version']
-                text.append("\tReason: %(why)s\n\tWill be removed in: Ansible %(removed_in)s\n\tAlternatives: %(alternative)s" % doc.pop('deprecated'))
+                if 'removed_at_date' in doc['deprecated']:
+                    text.append(
+                        "\tReason: %(why)s\n\tWill be removed in a release after %(removed_at_date)s\n\tAlternatives: %(alternative)s" % doc.pop('deprecated')
+                    )
+                else:
+                    if 'version' in doc['deprecated'] and 'removed_in' not in doc['deprecated']:
+                        doc['deprecated']['removed_in'] = doc['deprecated']['version']
+                    text.append("\tReason: %(why)s\n\tWill be removed in: Ansible %(removed_in)s\n\tAlternatives: %(alternative)s" % doc.pop('deprecated'))
             else:
                 text.append("%s" % doc.pop('deprecated'))
             text.append("\n")

--- a/test/integration/targets/ansible-doc/library/test_docs_removed_precedence.py
+++ b/test/integration/targets/ansible-doc/library/test_docs_removed_precedence.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: test_docs_removed_precedence
+short_description: Test module
+description:
+    - Test module
+author:
+    - Ansible Core Team
+deprecated:
+  alternative: new_module
+  why: Updated module released with more functionality
+  removed_at_date: '2022-06-01'
+  removed_in: '2.14'
+'''
+
+EXAMPLES = '''
+'''
+
+RETURN = '''
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(),
+    )
+
+    module.exit_json()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/ansible-doc/test.yml
+++ b/test/integration/targets/ansible-doc/test.yml
@@ -103,3 +103,14 @@
     - assert:
         that:
           - '"[WARNING]: module test_no_docs_removed_status has been removed" in result.stderr'
+
+    - name: deprecated module with both removed date and version (date should get precedence)
+      command: ansible-doc test_docs_removed_precedence
+      register: result
+
+    - assert:
+        that:
+          - '"DEPRECATED" in result.stdout'
+          - '"Reason: Updated module released with more functionality" in result.stdout'
+          - '"Will be removed in a release after 2022-06-01" in result.stdout'
+          - '"Alternatives: new_module" in result.stdout'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
stable-2.9: Support `removed_at_date` in ansible-doc #70002

- ansible-doc and sanity --test=ansible-doc fails if `deprecated` dict in doc string doesn't have a `removed_in` or `version` but instead has `removed_at_date`.
- This changes adds support for `removed_at_date` and gives precedence to it.

```
> NXOS_ACL    (/Users/nchakrab/.ansible/collections/ansible_collections/cisco/nxos/plugins/modules/nxos_acl.py)

        Manages access list entries for ACLs.

DEPRECATED:

        Reason: Updated modules released with more functionality
        Will be removed in a release after 2022-06-01
        Alternatives: nxos_acls
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
cli/doc.py