### PR TITLE
ansible-galaxy - fix collection installation with trailing slashes

### DIFF
--- a/test/units/cli/galaxy/test_collection_extract_tar.py
+++ b/test/units/cli/galaxy/test_collection_extract_tar.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible.errors import AnsibleError
+from ansible.galaxy.collection import _extract_tar_dir
+
+
+@pytest.fixture
+def fake_tar_obj(mocker):
+    m_tarfile = mocker.Mock()
+    m_tarfile.type = mocker.Mock(return_value=b'99')
+    m_tarfile.SYMTYPE = mocker.Mock(return_value=b'22')
+
+    return m_tarfile
+
+
+def test_extract_tar_bad_member(mocker):
+    m_tarfile = mocker.Mock()
+    m_tarfile.getmember = mocker.Mock(side_effect=KeyError)
+
+    with pytest.raises(AnsibleError, match='Unable to extract'):
+        _extract_tar_dir(m_tarfile, '/some/dir', b'/some/dest')
+
+    assert m_tarfile.getmember.call_count == 2
+
+
+def test_extract_tar_dir_exists(mocker, fake_tar_obj):
+    mocker.patch('os.makedirs', return_value=None)
+    m_makedir = mocker.patch('os.mkdir', return_value=None)
+    mocker.patch('os.path.isdir', return_value=True)
+
+    _extract_tar_dir(fake_tar_obj, '/some/dir', b'/some/dest')
+
+    assert not m_makedir.called
+
+
+def test_extract_tar_dir_does_not_exist(mocker, fake_tar_obj):
+    mocker.patch('os.makedirs', return_value=None)
+    m_makedir = mocker.patch('os.mkdir', return_value=None)
+    mocker.patch('os.path.isdir', return_value=False)
+
+    _extract_tar_dir(fake_tar_obj, '/some/dir', b'/some/dest')
+
+    assert m_makedir.called
+    assert m_makedir.call_args[0] == (b'/some/dir', 0o0755)

--- a/test/units/cli/galaxy/test_collection_extract_tar.py
+++ b/test/units/cli/galaxy/test_collection_extract_tar.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 # Copyright (c) 2020 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
@@ -21,7 +20,17 @@ def fake_tar_obj(mocker):
     return m_tarfile
 
 
-def test_extract_tar_bad_member(mocker):
+def test_extract_tar_member_trailing_sep(mocker):
+    m_tarfile = mocker.Mock()
+    m_tarfile.getmember = mocker.Mock(side_effect=KeyError)
+
+    with pytest.raises(AnsibleError, match='Unable to extract'):
+        _extract_tar_dir(m_tarfile, '/some/dir/', b'/some/dest')
+
+    assert m_tarfile.getmember.call_count == 1
+
+
+def test_extract_tar_member_no_trailing_sep(mocker):
     m_tarfile = mocker.Mock()
     m_tarfile.getmember = mocker.Mock(side_effect=KeyError)
 


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

If we fail to find a member when extracting a directory, try adding a trailing slash to the member name. In certain cases, the member in the tarfile will contain a trailing slash but the file name in FILES.json will never contain the trailing slash.

If unable to find the member, handle the KeyError and print a nicer error.

Also check if a directory exists before creating it since it may have been extracted from the archive.

Fixes #70009
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/galaxy/collection.py`
##### ADDITIONAL INFORMATION

Not sure we need a changelog since this was just added yesterday.

I'm open to suggestions for tests on this. It would be much easier to write unit tests rather than integration tests since I'm not sure how to create tar file where some members contain a trailing slash. If unit tests are ok, I'll work on adding those.
