### PR TITLE
Updated requirements file to include 'make' and 'sphinx' version

### DIFF
--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -2,7 +2,8 @@
 jinja2
 PyYAML
 rstcheck
-sphinx
+sphinx==2.1.2 
 sphinx-notfound-page
 Pygments >= 2.4.0
 straight.plugin # Needed for hacking/build-ansible.py which is the backend build script
+make


### PR DESCRIPTION
Summary:

Fixes #69814 , and includes the following updates:
- Added entry to 'make' [Earlier we assumed make is already installed (which may not be true for new contributors)]
- Added sphinx version 2.1.2


