### PR TITLE
correct the roadmap with the new date for 2.10 beta

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_10.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_10.rst
@@ -16,7 +16,7 @@ PRs must be raised well in advance of the dates below to have a chance of being 
 .. note:: There is no Alpha phase in 2.10.
 .. note:: Dates subject to change.
 
-- 2020-06-12 Beta 1 **Feature freeze**
+- 2020-06-16 Beta 1 **Feature freeze**
   No new functionality (including modules/plugins) to any code
 
 - 2020-07-14 Release Candidate 1


### PR DESCRIPTION
##### SUMMARY
We never branch or release on Fridays, but somehow a Friday date crept into the 2.10 roadmap. Update it with the likely actual beta date for 2.10. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com 
2.10 roadmap
