### PR TITLE
'groups' is a list, update examples to suit

### DIFF
--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -269,7 +269,7 @@ EXAMPLES = r'''
   user:
     name: james
     shell: /bin/bash
-    groups: admins,developers
+    groups: [admins,developers]
     append: yes
 
 - name: Remove the user 'johnd'

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -328,7 +328,7 @@ groups:
   description: List of groups of which the user is a member
   returned: When C(groups) is not empty and C(state) is 'present'
   type: str
-  sample: 'chrony,apache'
+  sample: ['chrony','apache']
 home:
   description: "Path to user's home directory"
   returned: When C(state) is 'present'


### PR DESCRIPTION
##### SUMMARY
`groups` is documented as a list, the current example could be improved to show it as such.

Also, the current example raises a "Incorrect type. Expected "array"." warning from RedHat's VSCode YAML extension.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
user module

##### ADDITIONAL INFORMATION
n/a
