### PR TITLE
Improved ansible-galaxy cli STDOUT messages for collections

### DIFF
--- a/changelogs/fragments/ansible-galaxy-stdout.yml
+++ b/changelogs/fragments/ansible-galaxy-stdout.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ansible-galaxy - Change the output verbosity level of the download message from 3 to 0 (https://github.com/ansible/ansible/issues/70010)
+  - ansible-galaxy - Add installation successful message

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -251,6 +251,8 @@ class CollectionRequirement:
         else:
             self.install_scm(b_collection_path)
 
+        display.display("%s (%s) was installed successfully" % (to_text(self), self.latest_version))
+
     def install_artifact(self, b_collection_path, b_temp_path):
 
         try:
@@ -604,6 +606,7 @@ def download_collections(collections, output_path, apis, validate_certs, no_deps
                 display.display("Downloading collection '%s' to '%s'" % (name, dest_path))
                 b_temp_download_path = requirement.download(b_temp_path)
                 shutil.move(b_temp_download_path, to_bytes(dest_path, errors='surrogate_or_strict'))
+                display.display("%s (%s) was downloaded successfully" % (name, requirement.latest_version))
 
             requirements_path = os.path.join(output_path, 'requirements.yml')
             display.display("Writing requirements.yml file of downloaded collections to '%s'" % requirements_path)
@@ -1366,7 +1369,7 @@ def _download_file(url, b_path, expected_hash, validate_certs, headers=None):
     b_file_ext = to_bytes(urlsplit[1], errors='surrogate_or_strict')
     b_file_path = tempfile.NamedTemporaryFile(dir=b_path, prefix=b_file_name, suffix=b_file_ext, delete=False).name
 
-    display.vvv("Downloading %s to %s" % (url, to_text(b_path)))
+    display.display("Downloading %s to %s" % (url, to_text(b_path)))
     # Galaxy redirs downloads to S3 which reject the request if an Authorization header is attached so don't redir that
     resp = open_url(to_native(url, errors='surrogate_or_strict'), validate_certs=validate_certs, headers=headers,
                     unredirected_headers=['Authorization'], http_agent=user_agent())

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/scm_dependency_deduplication.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/scm_dependency_deduplication.yml
@@ -4,14 +4,16 @@
 
 - assert:
     that:
-      - command.stdout_lines | length == 7
+      - command.stdout_lines | length == 9
       - command.stdout_lines[0] == "Starting galaxy collection install process"
       - command.stdout_lines[1] == "Process install dependency map"
       - command.stdout_lines[2] == "Starting collection install process"
       - "'namespace_1.collection_1' in command.stdout_lines[3]"
       - "'namespace_1.collection_1' in command.stdout_lines[4]"
-      - "'namespace_2.collection_2' in command.stdout_lines[5]"
+      - "'namespace_1.collection_1' in command.stdout_lines[5]"
       - "'namespace_2.collection_2' in command.stdout_lines[6]"
+      - "'namespace_2.collection_2' in command.stdout_lines[7]"
+      - "'namespace_2.collection_2' in command.stdout_lines[8]"
 
 - name: list installed collections
   command: 'ansible-galaxy collection list'
@@ -28,14 +30,16 @@
 
 - assert:
     that:
-      - command.stdout_lines | length == 7
+      - command.stdout_lines | length == 9
       - command.stdout_lines[0] == "Starting galaxy collection install process"
       - command.stdout_lines[1] == "Process install dependency map"
       - command.stdout_lines[2] == "Starting collection install process"
       - "'namespace_1.collection_1' in command.stdout_lines[3]"
       - "'namespace_1.collection_1' in command.stdout_lines[4]"
-      - "'namespace_2.collection_2' in command.stdout_lines[5]"
+      - "'namespace_1.collection_1' in command.stdout_lines[5]"
       - "'namespace_2.collection_2' in command.stdout_lines[6]"
+      - "'namespace_2.collection_2' in command.stdout_lines[7]"
+      - "'namespace_2.collection_2' in command.stdout_lines[8]"
 
 - name: list installed collections
   command: 'ansible-galaxy collection list'

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -648,9 +648,10 @@ def test_install_collection(collection_artifact, monkeypatch):
     assert stat.S_IMODE(os.stat(os.path.join(collection_path, b'README.md')).st_mode) == 0o0644
     assert stat.S_IMODE(os.stat(os.path.join(collection_path, b'runme.sh')).st_mode) == 0o0755
 
-    assert mock_display.call_count == 1
+    assert mock_display.call_count == 2
     assert mock_display.mock_calls[0][1][0] == "Installing 'ansible_namespace.collection:0.1.0' to '%s'" \
         % to_text(collection_path)
+    assert mock_display.mock_calls[1][1][0] == "ansible_namespace.collection (0.1.0) was installed successfully"
 
 
 def test_install_collection_with_download(galaxy_server, collection_artifact, monkeypatch):
@@ -683,9 +684,10 @@ def test_install_collection_with_download(galaxy_server, collection_artifact, mo
     assert actual_files == [b'FILES.json', b'MANIFEST.json', b'README.md', b'docs', b'playbooks', b'plugins', b'roles',
                             b'runme.sh']
 
-    assert mock_display.call_count == 1
+    assert mock_display.call_count == 2
     assert mock_display.mock_calls[0][1][0] == "Installing 'ansible_namespace.collection:0.1.0' to '%s'" \
         % to_text(collection_path)
+    assert mock_display.mock_calls[1][1][0] == "ansible_namespace.collection (0.1.0) was installed successfully"
 
     assert mock_download.call_count == 1
     assert mock_download.mock_calls[0][1][0] == 'https://downloadme.com'
@@ -721,7 +723,7 @@ def test_install_collections_from_tar(collection_artifact, monkeypatch):
 
     # Filter out the progress cursor display calls.
     display_msgs = [m[1][0] for m in mock_display.mock_calls if 'newline' not in m[2] and len(m[1]) == 1]
-    assert len(display_msgs) == 3
+    assert len(display_msgs) == 4
     assert display_msgs[0] == "Process install dependency map"
     assert display_msgs[1] == "Starting collection install process"
     assert display_msgs[2] == "Installing 'ansible_namespace.collection:0.1.0' to '%s'" % to_text(collection_path)
@@ -807,7 +809,8 @@ def test_install_collection_with_circular_dependency(collection_artifact, monkey
 
     # Filter out the progress cursor display calls.
     display_msgs = [m[1][0] for m in mock_display.mock_calls if 'newline' not in m[2] and len(m[1]) == 1]
-    assert len(display_msgs) == 3
+    assert len(display_msgs) == 4
     assert display_msgs[0] == "Process install dependency map"
     assert display_msgs[1] == "Starting collection install process"
     assert display_msgs[2] == "Installing 'ansible_namespace.collection:0.1.0' to '%s'" % to_text(collection_path)
+    assert display_msgs[3] == "ansible_namespace.collection (0.1.0) was installed successfully"


### PR DESCRIPTION
### SUMMARY
Improved ansible-galaxy cli STDOUT messages for collections.

- Fix issue #70010
- Add installation successful message
- This feature targets "collection" sub-command and does not affect "role" sub-command

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- ansible-galaxy (collections)

##### ADDITIONAL INFORMATION
##### Before:
```
$ ansible-galaxy collection install netapp.azure                     
Starting galaxy collection install process
Process install dependency map
Starting collection install process
Installing 'netapp.azure:20.6.0' to '/home/foo/work/testing/ansible/collections/ansible_collections/netapp/azure'

$ ansible-galaxy collection download netapp.azure
Starting collection download process to '/home/foo/work/testing/ansible/collections'
Downloading collection 'netapp.azure' to '/home/foo/work/testing/ansible/collections/netapp-azure-20.6.0.tar.gz'
Writing requirements.yml file of downloaded collections to '/home/foo/work/testing/ansible/collections/requirements.yml'
```
##### After:
```
$ ansible-galaxy collection install netapp.azure                
Starting galaxy collection install process
Process install dependency map
Starting collection install process
Installing 'netapp.azure:20.6.0' to '/home/foo/work/testing/ansible/collections/ansible_collections/netapp/azure'
Downloading https://galaxy.ansible.com/download/netapp-azure-20.6.0.tar.gz to /home/foo/.ansible/tmp/ansible-local-41431qt1o1ehp/tmp5ttxfihl
netapp.azure (20.6.0) was installed successfully

$ ansible-galaxy collection download netapp.azure
Starting collection download process to '/home/foo/work/testing/ansible/collections'
Downloading collection 'netapp.azure' to '/home/foo/work/testing/ansible/collections/netapp-azure-20.6.0.tar.gz'
Downloading https://galaxy.ansible.com/download/netapp-azure-20.6.0.tar.gz to /home/foo/.ansible/tmp/ansible-local-83636fd5ug3me/tmpey9gvwgv
Writing requirements.yml file of downloaded collections to '/home/foo/work/testing/ansible/collections/requirements.yml'
netapp.azure (20.6.0) was downloaded successfully
```