### PR TITLE
Add new option for YUM4/DNF repositories

### DIFF
--- a/changelogs/fragments/70042-dnf-repository-hotfixes.yml
+++ b/changelogs/fragments/70042-dnf-repository-hotfixes.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - yum_repository - added boolean option module_hotfixes which allows to enable functionality for dnf.

--- a/lib/ansible/modules/yum_repository.py
+++ b/lib/ansible/modules/yum_repository.py
@@ -109,6 +109,12 @@ options:
     description:
       - A URL pointing to the ASCII-armored GPG key file for the repository.
       - It can also be a list of multiple URLs.
+  module_hotfixes:
+    description:
+      - Disable module RPM filtering and make all RPMs from the repository
+        available. The default is C(None).
+    version_added: '2.11'
+    type: bool
   http_caching:
     description:
       - Determines how upstream HTTP caches are instructed to handle any HTTP
@@ -409,6 +415,7 @@ class YumRepo(object):
         'gpgcakey',
         'gpgcheck',
         'gpgkey',
+        'module_hotfixes',
         'http_caching',
         'include',
         'includepkgs',
@@ -554,6 +561,7 @@ def main():
         gpgcakey=dict(),
         gpgcheck=dict(type='bool'),
         gpgkey=dict(type='list'),
+        module_hotfixes=dict(type='bool'),
         http_caching=dict(choices=['all', 'packages', 'none']),
         include=dict(),
         includepkgs=dict(type='list'),

--- a/test/integration/targets/yum_repository/tasks/main.yml
+++ b/test/integration/targets/yum_repository/tasks/main.yml
@@ -114,6 +114,7 @@
         file: "{{ yum_repository_test_repo.name ~ 2 }}"
         ip_resolve: 4
         keepalive: no
+        module_hotfixes: no
       register: test_repo_add1
 
     - name: check that options are correctly getting written to the repo file
@@ -124,6 +125,7 @@
           - "'enablegroups = 0' in repo_file_contents"
           - "'ip_resolve = 4' in repo_file_contents"
           - "'keepalive = 0' in repo_file_contents"
+          - "'module_hotfixes = 0' in repo_file_contents"
       vars:
         repo_file: "{{ '/etc/yum.repos.d/' ~ yum_repository_test_repo.name ~ '2.repo' }}"
         repo_file_contents: "{{ lookup('file', repo_file) }}"
@@ -138,6 +140,7 @@
         file: "{{ yum_repository_test_repo.name ~ 2 }}"
         ip_resolve: 4
         keepalive: no
+        module_hotfixes: no
       register: test_repo_add2
 
     - name: check Idempotant


### PR DESCRIPTION
##### SUMMARY
YUM4/DNF introduce a new option in repo files called `module_hotfixes` which is used in the wild by upstream MariaDB on their CentOS 8/RHEL 8 packages.
 
##### ISSUE TYPE
* Feature Pull Request

##### COMPONENT NAME
yum_repository

##### ADDITIONAL INFORMATION
Documentation reference: https://dnf.readthedocs.io/en/stable/conf_ref.html

**module_hotfixes**

`boolean`

Set this to True to disable module RPM filtering and make all RPMs from the repository available. The default is False. This allows user to create a repository with cherry-picked hotfixes that are included in a package set on a modular system.

This is rebased copy of #67027 as I don't really know how to continue work on someones PR...