### PR TITLE
Support simple (fnmatch) wildcarding for tags

### DIFF
--- a/changelogs/fragments/wildcard-tags.yml
+++ b/changelogs/fragments/wildcard-tags.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Tags now support simple (non-regex) wildcards, using python fnmatch.

--- a/test/integration/targets/tags/runme.sh
+++ b/test/integration/targets/tags/runme.sh
@@ -47,3 +47,6 @@ export LC_ALL=en_US.UTF-8
 # Run templated tags
 [ "$("${COMMAND[@]}" --tags tag3 | grep -F Task_with | xargs)" = \
 "Task_with_always_tag TAGS: [always] Task_with_templated_tags TAGS: [tag3]" ]
+
+# Test wildcard tags
+ansible-playbook -i ../../inventory test_wildcard_tags.yml -t 'test*' --skip-tags 'nope*'

--- a/test/integration/targets/tags/test_wildcard_tags.yml
+++ b/test/integration/targets/tags/test_wildcard_tags.yml
@@ -1,0 +1,50 @@
+---
+- name: verify tags work as expected (called with -t test* --skip-tags nope*)
+  hosts: testhost
+  gather_facts: False
+  tasks:
+    - debug: msg="This should NOT run"
+      register: one
+    - debug: msg="This should run"
+      register: two
+      tags:
+      - test1
+      - foo
+    - debug: msg="This should NOT run"
+      register: three
+      tags:
+      - monkey
+      - bartest1
+      - nopebye
+    - debug: msg="This should run"
+      register: four
+      tags:
+      - testhaha
+    - debug: msg="This should NOT run"
+      register: five
+      tags:
+      - nope
+      - nope:testnope
+    - debug: msg="This should run"
+      register: six
+      tags:
+      - haha
+      - what
+      - test494
+      - bye
+    - debug: msg="This has nope3 AND test8 - and should NOT run"
+      register: seven
+      tags:
+      - nope3
+      - test8
+    - assert:
+        that:
+          - one is not defined
+          - two is defined
+          - three is not defined
+          - four is defined
+          - five is not defined
+          - six is defined
+          - seven is not defined
+      tags:
+        - always


### PR DESCRIPTION
# NOTE

This needs discussion. I'm not suggesting we merge this, just writing up what an implementation could look like. It might be a horrible idea.

-----

Change:
We've seen a number of requests recently for a more expressive way
of matching on tags. This might be a step in that direction (or might
not, who knows).

This is what a simple implementation might look like using fnmatch
(using full-on regex could be confusing to unsuspecting users, fnmatch
seems a bit more sane).

Test Plan:
Added integration tests, could likely stand to add a few more.

Tickets:
Fixes #70036

Signed-off-by: Rick Elrod <rick@elrod.me>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
tags
