### PR TITLE
ansible-doc: avoid problems with YAML anchors when formatting man page

### DIFF
--- a/changelogs/fragments/70045-ansible-doc-yaml-anchors.yml
+++ b/changelogs/fragments/70045-ansible-doc-yaml-anchors.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-doc - improve man page formatting to avoid problems when YAML anchors are used (https://github.com/ansible/ansible/pull/70045)."

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -513,7 +513,8 @@ class DocCLI(CLI):
     def add_fields(text, fields, limit, opt_indent, return_values=False, base_indent=''):
 
         for o in sorted(fields):
-            opt = fields[o]
+            # Create a copy so we don't modify the original (in case YAML anchors have been used)
+            opt = dict(fields[o])
 
             required = opt.pop('required', False)
             if not isinstance(required, bool):
@@ -562,7 +563,8 @@ class DocCLI(CLI):
             conf = {}
             for config in ('env', 'ini', 'yaml', 'vars', 'keywords'):
                 if config in opt and opt[config]:
-                    conf[config] = opt.pop(config)
+                    # Create a copy so we don't modify the original (in case YAML anchors have been used)
+                    conf[config] = [dict(item) for item in opt.pop(config)]
                     for ignore in DocCLI.IGNORE:
                         for item in conf[config]:
                             if ignore in item:
@@ -593,6 +595,8 @@ class DocCLI(CLI):
 
     @staticmethod
     def get_man_text(doc):
+        # Create a copy so we don't modify the original
+        doc = dict(doc)
 
         DocCLI.IGNORE = DocCLI.IGNORE + (context.CLIARGS['type'],)
         opt_indent = "        "


### PR DESCRIPTION
##### SUMMARY
When YAML anchors are used to share documentation between different options, this can lead to crashes of ansible-doc since it actively removes elements from entries.

This is also a problem in 2.9, but has become a bigger problem since now suboptions and return values (and their contains) are all processed.

Fixes this by creating copies of the dicts.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-doc
