### PR TITLE
ansible-doc man formatter: fail with better error message when description isn't there

### DIFF
--- a/changelogs/fragments/70046-ansible-doc-description-crash.yml
+++ b/changelogs/fragments/70046-ansible-doc-description-crash.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- "ansible-doc - avoid crash in man page formatter when ``description`` is missing for a (sub-)option or a return value or its ``contains`` (https://github.com/ansible/ansible/pull/70046)."
+- "ansible-doc - improve error message in text formatter when ``description`` is missing for a (sub-)option or a return value or its ``contains`` (https://github.com/ansible/ansible/pull/70046)."

--- a/changelogs/fragments/70046-ansible-doc-description-crash.yml
+++ b/changelogs/fragments/70046-ansible-doc-description-crash.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-doc - avoid crash in man page formatter when ``description`` is missing for a (sub-)option or a return value or its ``contains`` (https://github.com/ansible/ansible/pull/70046)."

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -526,16 +526,17 @@ class DocCLI(CLI):
 
             text.append("%s%s %s" % (base_indent, opt_leadin, o))
 
-            if isinstance(opt['description'], list):
-                for entry_idx, entry in enumerate(opt['description'], 1):
-                    if not isinstance(entry, string_types):
-                        raise AnsibleError("Expected string in description of %s at index %s, got %s" % (o, entry_idx, type(entry)))
-                    text.append(textwrap.fill(DocCLI.tty_ify(entry), limit, initial_indent=opt_indent, subsequent_indent=opt_indent))
-            else:
-                if not isinstance(opt['description'], string_types):
-                    raise AnsibleError("Expected string in description of %s, got %s" % (o, type(opt['description'])))
-                text.append(textwrap.fill(DocCLI.tty_ify(opt['description']), limit, initial_indent=opt_indent, subsequent_indent=opt_indent))
-            del opt['description']
+            if 'description' in opt:
+                if isinstance(opt['description'], list):
+                    for entry_idx, entry in enumerate(opt['description'], 1):
+                        if not isinstance(entry, string_types):
+                            raise AnsibleError("Expected string in description of %s at index %s, got %s" % (o, entry_idx, type(entry)))
+                        text.append(textwrap.fill(DocCLI.tty_ify(entry), limit, initial_indent=opt_indent, subsequent_indent=opt_indent))
+                else:
+                    if not isinstance(opt['description'], string_types):
+                        raise AnsibleError("Expected string in description of %s, got %s" % (o, type(opt['description'])))
+                    text.append(textwrap.fill(DocCLI.tty_ify(opt['description']), limit, initial_indent=opt_indent, subsequent_indent=opt_indent))
+                del opt['description']
 
             aliases = ''
             if 'aliases' in opt:

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -526,17 +526,18 @@ class DocCLI(CLI):
 
             text.append("%s%s %s" % (base_indent, opt_leadin, o))
 
-            if 'description' in opt:
-                if isinstance(opt['description'], list):
-                    for entry_idx, entry in enumerate(opt['description'], 1):
-                        if not isinstance(entry, string_types):
-                            raise AnsibleError("Expected string in description of %s at index %s, got %s" % (o, entry_idx, type(entry)))
-                        text.append(textwrap.fill(DocCLI.tty_ify(entry), limit, initial_indent=opt_indent, subsequent_indent=opt_indent))
-                else:
-                    if not isinstance(opt['description'], string_types):
-                        raise AnsibleError("Expected string in description of %s, got %s" % (o, type(opt['description'])))
-                    text.append(textwrap.fill(DocCLI.tty_ify(opt['description']), limit, initial_indent=opt_indent, subsequent_indent=opt_indent))
-                del opt['description']
+            if 'description' not in opt:
+                raise AnsibleError("All (sub-)options and return values must have a 'description' field")
+            if isinstance(opt['description'], list):
+                for entry_idx, entry in enumerate(opt['description'], 1):
+                    if not isinstance(entry, string_types):
+                        raise AnsibleError("Expected string in description of %s at index %s, got %s" % (o, entry_idx, type(entry)))
+                    text.append(textwrap.fill(DocCLI.tty_ify(entry), limit, initial_indent=opt_indent, subsequent_indent=opt_indent))
+            else:
+                if not isinstance(opt['description'], string_types):
+                    raise AnsibleError("Expected string in description of %s, got %s" % (o, type(opt['description'])))
+                text.append(textwrap.fill(DocCLI.tty_ify(opt['description']), limit, initial_indent=opt_indent, subsequent_indent=opt_indent))
+            del opt['description']
 
             aliases = ''
             if 'aliases' in opt:

--- a/test/integration/targets/ansible-doc/library/test_docs_missing_description.py
+++ b/test/integration/targets/ansible-doc/library/test_docs_missing_description.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: test_docs_returns
+short_description: Test module
+description:
+    - Test module
+author:
+    - Ansible Core Team
+options:
+    test:
+        type: str
+'''
+
+EXAMPLES = '''
+'''
+
+RETURN = '''
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            test=dict(type='str'),
+        ),
+    )
+
+    module.exit_json()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/ansible-doc/test.yml
+++ b/test/integration/targets/ansible-doc/test.yml
@@ -3,6 +3,18 @@
   environment:
     ANSIBLE_LIBRARY: "{{ playbook_dir }}/library"
   tasks:
+    - name: module with missing description return docs
+      command: ansible-doc test_docs_missing_description
+      register: result
+      ignore_errors: true
+
+    - assert:
+        that:
+          - result is failed
+          - |
+            "ERROR! Unable to retrieve documentation from 'test_docs_missing_description' due to: All (sub-)options and return values must have a 'description' field"
+            in result.stderr
+
     - name: module with suboptions
       command: ansible-doc test_docs_suboptions
       register: result


### PR DESCRIPTION
##### SUMMARY
~~Prevent ansible-doc man formatter to crash for options which do not have `description`.~~
Improve error message for ansible-doc text formatter for options which do not have `description`.

This happens for example for the `community.general.nosh` module's return value docs: https://github.com/ansible-collections/community.general/blob/2aa84f07f11dfe2cfdfa22ef2f4da09d71ae2a1b/plugins/modules/system/nosh.py#L134-L269

~~While IMO this is a bug in the module that needs to be fixed, it is annoying that ansible-doc stops working for this module. Since ansible-doc should be lenient in what it accepts, I propose this bugfix.~~

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-doc
