### PR TITLE
Change find_mount_point() to always return string

### DIFF
--- a/changelogs/fragments/70053-fix-special-handling-selinux-python3.yml
+++ b/changelogs/fragments/70053-fix-special-handling-selinux-python3.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Basic module utils - Change find_mount_point() to always return string to fix special filesystem handling of SELinux in Python 3

--- a/changelogs/fragments/70053-fix-special-handling-selinux-python3.yml
+++ b/changelogs/fragments/70053-fix-special-handling-selinux-python3.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Basic module utils - Change find_mount_point() to always return string to fix special filesystem handling of SELinux in Python 3
+  - Basic module utils - change find_mount_point() to always return string to fix special filesystem handling of SELinux in Python 3 (https://github.com/ansible/ansible/issues/68500).

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -863,16 +863,10 @@ class AnsibleModule(object):
         return (uid, gid)
 
     def find_mount_point(self, path):
-        path_is_bytes = False
-        if isinstance(path, binary_type):
-            path_is_bytes = True
-
-        b_path = os.path.realpath(to_bytes(os.path.expanduser(os.path.expandvars(path)), errors='surrogate_or_strict'))
+        b_path = os.path.realpath(to_bytes(os.path.expanduser(os.path.expandvars(path)),
+                                           errors='surrogate_or_strict'))
         while not os.path.ismount(b_path):
             b_path = os.path.dirname(b_path)
-
-        if path_is_bytes:
-            return b_path
 
         return to_text(b_path, errors='surrogate_or_strict')
 


### PR DESCRIPTION
##### SUMMARY
In `module_utils/basic.py` the function `is_special_selinux_path()` looks for the mount point that is the parent of the supplied path. It does this by passing the path to `find_mount_point()`, and that function honors the input type of the path parameter - so if a byte array `(b'path')` is passed to it then a byte array will be returned. 
The potential matches reported by `/proc/mounts` are all strings. In Python 3 comparing a string to a byte array always evaluates to `False`, so the path is never matched to the mount that it belongs to. Python 2 essentially ignores the distinction between byte arrays and strings. 
So, the best approach, when `find_mount_point()` function always returns string value. It satisfies both Python 2 and Python 3 environments.

This PR fixes #68500

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils/basic.py
