### PR TITLE
Add fail_on_autoremove option to apt module to avoid unintended package removals.

### DIFF
--- a/changelogs/fragments/70056-add-a-param-to-apt-module-to-avoid-unintended-uninstalls.yml
+++ b/changelogs/fragments/70056-add-a-param-to-apt-module-to-avoid-unintended-uninstalls.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - apt - add 'no_remove' param to apt module to avoid unintended package removals (https://github.com/ansible/ansible/issues/63231)

--- a/changelogs/fragments/70056-add-a-param-to-apt-module-to-avoid-unintended-uninstalls.yml
+++ b/changelogs/fragments/70056-add-a-param-to-apt-module-to-avoid-unintended-uninstalls.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - apt - add 'no_remove' param to apt module to avoid unintended package removals (https://github.com/ansible/ansible/issues/63231)
+  - apt - add ``fail_on_autoremove`` param to apt module to avoid unintended package removals (https://github.com/ansible/ansible/issues/63231)

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -968,7 +968,7 @@ def upgrade(m, mode="yes", force=False, default_release=None,
                             "to have APTITUDE in path or use 'force_apt_get=True'")
     apt_cmd_path = m.get_bin_path(apt_cmd, required=True)
 
-    cmd = '%s -y %s %s %s %s %s %s' % (apt_cmd_path, dpkg_options, force_yes, no_remove, allow_unauthenticated, check_arg, upgrade_command)
+    cmd = '%s -y %s %s %s %s %s %s' % (apt_cmd_path, dpkg_options, force_yes, fail_on_autoremove, allow_unauthenticated, check_arg, upgrade_command)
 
     if default_release:
         cmd += " -t '%s'" % (default_release,)

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -689,7 +689,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
             cmd = "%s -y %s %s %s %s %s %s build-dep %s" % (APT_GET_CMD, dpkg_options, only_upgrade, fixed, force_yes, fail_on_autoremove, check_arg, packages)
         else:
             cmd = "%s -y %s %s %s %s %s %s %s install %s" % \
-                  (APT_GET_CMD, dpkg_options, only_upgrade, fixed, force_yes, autoremove, no_remove, check_arg, packages)
+                  (APT_GET_CMD, dpkg_options, only_upgrade, fixed, force_yes, autoremove, fail_on_autoremove, check_arg, packages)
 
         if default_release:
             cmd += " -t '%s'" % (default_release,)

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -627,7 +627,7 @@ def mark_installed_manually(m, packages):
 def install(m, pkgspec, cache, upgrade=False, default_release=None,
             install_recommends=None, force=False,
             dpkg_options=expand_dpkg_options(DPKG_OPTIONS),
-            build_dep=False, fixed=False, autoremove=False, no_remove=False, only_upgrade=False,
+            build_dep=False, fixed=False, autoremove=False, fail_on_autoremove=False, only_upgrade=False,
             allow_unauthenticated=False):
     pkg_list = []
     packages = ""

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -667,9 +667,9 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
             fixed = ''
 
         if build_dep:
-            cmd = "%s -y %s %s %s %s %s build-dep %s" % (APT_GET_CMD, dpkg_options, only_upgrade, fixed, force_yes, check_arg, packages)
+            cmd = "%s -y --no-remove %s %s %s %s %s build-dep %s" % (APT_GET_CMD, dpkg_options, only_upgrade, fixed, force_yes, check_arg, packages)
         else:
-            cmd = "%s -y %s %s %s %s %s %s install %s" % (APT_GET_CMD, dpkg_options, only_upgrade, fixed, force_yes, autoremove, check_arg, packages)
+            cmd = "%s -y --no-remove %s %s %s %s %s %s install %s" % (APT_GET_CMD, dpkg_options, only_upgrade, fixed, force_yes, autoremove, check_arg, packages)
 
         if default_release:
             cmd += " -t '%s'" % (default_release,)
@@ -942,8 +942,8 @@ def upgrade(m, mode="yes", force=False, default_release=None,
                             "to have APTITUDE in path or use 'force_apt_get=True'")
     apt_cmd_path = m.get_bin_path(apt_cmd, required=True)
 
-    cmd = '%s -y %s %s %s %s %s' % (apt_cmd_path, dpkg_options, force_yes, allow_unauthenticated,
-                                    check_arg, upgrade_command)
+    cmd = '%s -y --no-remove %s %s %s %s %s' % (apt_cmd_path, dpkg_options, force_yes, allow_unauthenticated,
+                                                check_arg, upgrade_command)
 
     if default_release:
         cmd += " -t '%s'" % (default_release,)

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1055,7 +1055,7 @@ def main():
             dpkg_options=dict(type='str', default=DPKG_OPTIONS),
             autoremove=dict(type='bool', default=False),
             autoclean=dict(type='bool', default=False),
-            no_remove=dict(type='bool', aliases=['no-remove']),
+            no_remove=dict(type='bool', default=False, aliases=['no-remove']),
             policy_rc_d=dict(type='int', default=None),
             only_upgrade=dict(type='bool', default=False),
             force_apt_get=dict(type='bool', default=False),
@@ -1183,8 +1183,7 @@ def main():
             install_deb(module, p['deb'], cache,
                         install_recommends=install_recommends,
                         allow_unauthenticated=allow_unauthenticated,
-                        no_remove=no_remove,
-                        force=force_yes, dpkg_options=p['dpkg_options'])
+                        force=force_yes, no_remove=no_remove, dpkg_options=p['dpkg_options'])
 
         unfiltered_packages = p['package'] or ()
         packages = [package.strip() for package in unfiltered_packages if package != '*']

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -943,8 +943,7 @@ def upgrade(m, mode="yes", force=False, default_release=None,
                             "to have APTITUDE in path or use 'force_apt_get=True'")
     apt_cmd_path = m.get_bin_path(apt_cmd, required=True)
 
-    cmd = '%s -y --no-remove %s %s %s %s %s' % (apt_cmd_path, dpkg_options, force_yes, allow_unauthenticated,
-                                                check_arg, upgrade_command)
+    cmd = '%s -y %s %s %s %s %s' % (apt_cmd_path, dpkg_options, force_yes, allow_unauthenticated, check_arg, upgrade_command)
 
     if default_release:
         cmd += " -t '%s'" % (default_release,)

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -672,7 +672,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
             autoremove = ''
 
         if no_remove:
-            no_remove = '--auto-remove'
+            no_remove = '--no-remove'
         else:
             no_remove = ''
 

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -781,7 +781,7 @@ def install_deb(m, debs, cache, force, fail_on_autoremove, install_recommends, a
     if deps_to_install:
         (success, retvals) = install(m=m, pkgspec=deps_to_install, cache=cache,
                                      install_recommends=install_recommends,
-                                     fail_on_autoremove = fail_on_autoremove,
+                                     fail_on_autoremove=fail_on_autoremove,
                                      allow_unauthenticated=allow_unauthenticated,
                                      dpkg_options=expand_dpkg_options(dpkg_options))
         if not success:
@@ -911,7 +911,7 @@ def cleanup(m, purge=False, force=False, operation=None,
 
 def upgrade(m, mode="yes", force=False, default_release=None,
             use_apt_get=False,
-            dpkg_options=expand_dpkg_options(DPKG_OPTIONS), autoremove=False, fail_on_autoremove =False,
+            dpkg_options=expand_dpkg_options(DPKG_OPTIONS), autoremove=False, fail_on_autoremove=False,
             allow_unauthenticated=False,
             ):
 

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1110,7 +1110,7 @@ def main():
     allow_unauthenticated = p['allow_unauthenticated']
     dpkg_options = expand_dpkg_options(p['dpkg_options'])
     autoremove = p['autoremove']
-    no_remove = p['no_remove']
+    fail_on_autoremove = p['fail_on_autoremove']
     autoclean = p['autoclean']
 
     # Get the cache object

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1054,7 +1054,7 @@ def main():
             dpkg_options=dict(type='str', default=DPKG_OPTIONS),
             autoremove=dict(type='bool', default=False),
             autoclean=dict(type='bool', default=False),
-            no_remove=dict(type='bool', default=False, aliases=['no-remove']),
+            fail_on_autoremove=dict(type='bool', default=False),
             policy_rc_d=dict(type='int', default=None),
             only_upgrade=dict(type='bool', default=False),
             force_apt_get=dict(type='bool', default=False),

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -686,7 +686,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
             fixed = ''
 
         if build_dep:
-            cmd = "%s -y %s %s %s %s %s %s build-dep %s" % (APT_GET_CMD, dpkg_options, only_upgrade, fixed, force_yes, no_remove, check_arg, packages)
+            cmd = "%s -y %s %s %s %s %s %s build-dep %s" % (APT_GET_CMD, dpkg_options, only_upgrade, fixed, force_yes, fail_on_autoremove, check_arg, packages)
         else:
             cmd = "%s -y %s %s %s %s %s %s %s install %s" % \
                   (APT_GET_CMD, dpkg_options, only_upgrade, fixed, force_yes, autoremove, no_remove, check_arg, packages)

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1230,7 +1230,7 @@ def main():
                 build_dep=state_builddep,
                 fixed=state_fixed,
                 autoremove=autoremove,
-                no_remove=no_remove,
+                fail_on_autoremove=fail_on_autoremove,
                 only_upgrade=p['only_upgrade'],
                 allow_unauthenticated=allow_unauthenticated
             )

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -781,7 +781,7 @@ def install_deb(m, debs, cache, force, fail_on_autoremove, install_recommends, a
     if deps_to_install:
         (success, retvals) = install(m=m, pkgspec=deps_to_install, cache=cache,
                                      install_recommends=install_recommends,
-                                     no_remove=no_remove,
+                                     fail_on_autoremove = fail_on_autoremove,
                                      allow_unauthenticated=allow_unauthenticated,
                                      dpkg_options=expand_dpkg_options(dpkg_options))
         if not success:

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -953,10 +953,10 @@ def upgrade(m, mode="yes", force=False, default_release=None,
     else:
         force_yes = ''
 
-    if no_remove:
-        no_remove = '--no-remove'
+    if fail_on_autoremove:
+        fail_on_autoremove = '--no-remove'
     else:
-        no_remove = ''
+        fail_on_autoremove = ''
 
     allow_unauthenticated = '--allow-unauthenticated' if allow_unauthenticated else ''
 

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1172,7 +1172,7 @@ def main():
         force_yes = p['force']
 
         if p['upgrade']:
-            upgrade(module, p['upgrade'], force_yes, p['default_release'], use_apt_get, dpkg_options, autoremove, no_remove, allow_unauthenticated)
+            upgrade(module, p['upgrade'], force_yes, p['default_release'], use_apt_get, dpkg_options, autoremove, fail_on_autoremove, allow_unauthenticated)
 
         if p['deb']:
             if p['state'] != 'present':

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1192,7 +1192,7 @@ def main():
         if latest and all_installed:
             if packages:
                 module.fail_json(msg='unable to install additional packages when upgrading all installed packages')
-            upgrade(module, 'yes', force_yes, p['default_release'], use_apt_get, dpkg_options, autoremove, no_remove, allow_unauthenticated)
+            upgrade(module, 'yes', force_yes, p['default_release'], use_apt_get, dpkg_options, autoremove, fail_on_autoremove, allow_unauthenticated)
 
         if packages:
             for package in packages:

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1182,7 +1182,7 @@ def main():
             install_deb(module, p['deb'], cache,
                         install_recommends=install_recommends,
                         allow_unauthenticated=allow_unauthenticated,
-                        force=force_yes, no_remove=no_remove, dpkg_options=p['dpkg_options'])
+                        force=force_yes, fail_on_autoremove=fail_on_autoremove, dpkg_options=p['dpkg_options'])
 
         unfiltered_packages = p['package'] or ()
         packages = [package.strip() for package in unfiltered_packages if package != '*']

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -670,10 +670,10 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         else:
             autoremove = ''
 
-        if no_remove:
-            no_remove = '--no-remove'
+        if fail_on_autoremove:
+            fail_on_autoremove = '--no-remove'
         else:
-            no_remove = ''
+            fail_on_autoremove = ''
 
         if only_upgrade:
             only_upgrade = '--only-upgrade'

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -911,7 +911,7 @@ def cleanup(m, purge=False, force=False, operation=None,
 
 def upgrade(m, mode="yes", force=False, default_release=None,
             use_apt_get=False,
-            dpkg_options=expand_dpkg_options(DPKG_OPTIONS), autoremove=False, no_remove=False,
+            dpkg_options=expand_dpkg_options(DPKG_OPTIONS), autoremove=False, fail_on_autoremove =False,
             allow_unauthenticated=False,
             ):
 

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -202,9 +202,9 @@ EXAMPLES = '''
     default_release: squeeze-backports
     update_cache: yes
 
-- name: Install foo with ensuring no packages will be removed.
+- name: Install zfsutils-linux with ensuring conflicted packages (e.g. zfs-fuse) will not be removed.
   apt:
-    name: foo
+    name: zfsutils-linux
     state: latest
     fail_on_autoremove: yes
 

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -140,7 +140,6 @@ options:
       - 'Corresponds to the C(--no-remove) option for I(apt).'
       - 'If C(yes), it is ensured that no packages will be removed or the task will fail.'
       - 'C(no_remove) is only supported with state except I(absent)'
-    aliases: ['no-remove']
     type: bool
     default: 'no'
     version_added: "2.11"

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -137,9 +137,9 @@ options:
     version_added: "2.1"
   fail_on_autoremove:
     description:
-      - 'Corresponds to the C(--no-remove) option for I(apt).'
+      - 'Corresponds to the C(--no-remove) option for C(apt).'
       - 'If C(yes), it is ensured that no packages will be removed or the task will fail.'
-      - 'C(fail_on_autoremove) is only supported with state except I(absent)'
+      - 'C(fail_on_autoremove) is only supported with state except C(absent)'
     type: bool
     default: 'no'
     version_added: "2.11"

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1173,7 +1173,7 @@ def main():
         force_yes = p['force']
 
         if p['upgrade']:
-            upgrade(module, p['upgrade'], force_yes, p['default_release'], use_apt_get, dpkg_options, autoremove, allow_unauthenticated)
+            upgrade(module, p['upgrade'], force_yes, p['default_release'], use_apt_get, dpkg_options, autoremove, no_remove, allow_unauthenticated)
 
         if p['deb']:
             if p['state'] != 'present':
@@ -1193,7 +1193,7 @@ def main():
         if latest and all_installed:
             if packages:
                 module.fail_json(msg='unable to install additional packages when upgrading all installed packages')
-            upgrade(module, 'yes', force_yes, p['default_release'], use_apt_get, dpkg_options, no_remove, autoremove, allow_unauthenticated)
+            upgrade(module, 'yes', force_yes, p['default_release'], use_apt_get, dpkg_options, autoremove, no_remove, allow_unauthenticated)
 
         if packages:
             for package in packages:

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -739,7 +739,7 @@ def get_field_of_deb(m, deb_file, field="Version"):
     return to_native(stdout).strip('\n')
 
 
-def install_deb(m, debs, cache, force, no_remove, install_recommends, allow_unauthenticated, dpkg_options):
+def install_deb(m, debs, cache, force, fail_on_autoremove, install_recommends, allow_unauthenticated, dpkg_options):
     changed = False
     deps_to_install = []
     pkgs_to_install = []

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -206,7 +206,7 @@ EXAMPLES = '''
   apt:
     name: foo
     state: latest
-    no_remove: yes
+    fail_on_autoremove: yes
 
 - name: Install latest version of "openjdk-6-jdk" ignoring "install-recommends"
   apt:

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -135,11 +135,11 @@ options:
     type: bool
     default: 'no'
     version_added: "2.1"
-  no_remove:
+  fail_on_autoremove:
     description:
       - 'Corresponds to the C(--no-remove) option for I(apt).'
       - 'If C(yes), it is ensured that no packages will be removed or the task will fail.'
-      - 'C(no_remove) is only supported with state except I(absent)'
+      - 'C(fail_on_autoremove) is only supported with state except I(absent)'
     type: bool
     default: 'no'
     version_added: "2.11"

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -669,7 +669,8 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         if build_dep:
             cmd = "%s -y --no-remove %s %s %s %s %s build-dep %s" % (APT_GET_CMD, dpkg_options, only_upgrade, fixed, force_yes, check_arg, packages)
         else:
-            cmd = "%s -y --no-remove %s %s %s %s %s %s install %s" % (APT_GET_CMD, dpkg_options, only_upgrade, fixed, force_yes, autoremove, check_arg, packages)
+            cmd = "%s -y --no-remove %s %s %s %s %s %s install %s" % \
+                  (APT_GET_CMD, dpkg_options, only_upgrade, fixed, force_yes, autoremove, check_arg, packages)
 
         if default_release:
             cmd += " -t '%s'" % (default_release,)

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -143,7 +143,7 @@ options:
     aliases: ['no-remove']
     type: bool
     default: 'no'
-    version_added: "2.10"
+    version_added: "2.11"
   force_apt_get:
     description:
       - Force usage of apt-get instead of aptitude
@@ -203,7 +203,7 @@ EXAMPLES = '''
     default_release: squeeze-backports
     update_cache: yes
 
-- name: Install foo, but if there are some packages to be removed, this task will fail.
+- name: Install foo with ensuring no packages will be removed.
   apt:
     name: foo
     state: latest

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -202,8 +202,8 @@
 - name: verify failure of installing hello-traditional, because it is required to remove hello to install.
   assert:
     that:
-    - apt_result is failed
-    - '"Packages need to be removed but remove is disabled." in apt_result.msg'
+      - apt_result is failed
+      - '"Packages need to be removed but remove is disabled." in apt_result.msg'
 
 - name: uninstall hello with apt
   apt: pkg=hello state=absent purge=yes update_cache=no

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -212,7 +212,11 @@
       - '"Packages need to be removed but remove is disabled." in apt_result.msg'
 
 - name: uninstall hello with apt
-  apt: pkg=hello state=absent purge=yes update_cache=no
+  apt: 
+    pkg: hello
+    state: absent
+    purge: yes
+    update_cache: no
 
 - name: install deb file
   apt: deb="/var/cache/apt/archives/hello_{{ hello_version.stdout }}_{{ hello_architecture.stdout }}.deb"

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -179,6 +179,35 @@
 - name: uninstall hello with apt
   apt: pkg=hello state=absent purge=yes
 
+# INSTALL WITHOUT REMOVALS
+- name: Install hello, that conflicts with hello-traditional
+  apt: pkg=hello state=present update_cache=no
+
+- name: check hello
+  shell: dpkg-query -l hello
+  failed_when: False
+  register: dpkg_result
+
+- name: verify installation of hello
+  assert:
+    that:
+        - "apt_result.changed"
+        - "dpkg_result.rc == 0"
+
+- name: Try installing hello-traditional, that conflicts with hello
+  apt: pkg=hello-traditional state=present no_remove=yes
+  ignore_errors: yes
+  register: apt_result
+
+- name: verify failure of installing hello-traditional, because it is required to remove hello to install.
+  assert:
+    that:
+    - apt_result is failed
+    - '"Packages need to be removed but remove is disabled." in apt_result.msg'
+
+- name: uninstall hello with apt
+  apt: pkg=hello state=absent purge=yes update_cache=no
+
 - name: install deb file
   apt: deb="/var/cache/apt/archives/hello_{{ hello_version.stdout }}_{{ hello_architecture.stdout }}.deb"
   register: apt_initial

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -198,7 +198,10 @@
         - "dpkg_result.rc == 0"
 
 - name: Try installing hello-traditional, that conflicts with hello
-  apt: pkg=hello-traditional state=present no_remove=yes
+  apt: 
+    pkg: hello-traditional
+    state: present
+    fail_on_autoremove: yes
   ignore_errors: yes
   register: apt_result
 

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -181,7 +181,10 @@
 
 # INSTALL WITHOUT REMOVALS
 - name: Install hello, that conflicts with hello-traditional
-  apt: pkg=hello state=present update_cache=no
+  apt: 
+    pkg: hello
+    state: present
+    update_cache: no
 
 - name: check hello
   shell: dpkg-query -l hello

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -188,7 +188,6 @@
 
 - name: check hello
   shell: dpkg-query -l hello
-  failed_when: False
   register: dpkg_result
 
 - name: verify installation of hello


### PR DESCRIPTION
##### SUMMARY
Fixes #63231

As described in https://github.com/ansible/ansible/issues/63231, apt module removes the existing packages which conflict with the package to install (without no warnings or error), and breaks the system.

In this PR, `--no-remove` will be passed to apt-get command to avoid this issue.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

apt
