### PR TITLE
Stop mutating the input when formatting module docs

### DIFF
--- a/changelogs/fragments/70060-remove-input-mutation-from-man-formatter.yml
+++ b/changelogs/fragments/70060-remove-input-mutation-from-man-formatter.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- ansible-doc - remove input mutation from the man page formatting process to
+  avoid problems when YAML anchors are used
+  (https://github.com/ansible/ansible/pull/70060).

--- a/test/integration/targets/ansible-doc/library/test_docs_yaml_anchors.py
+++ b/test/integration/targets/ansible-doc/library/test_docs_yaml_anchors.py
@@ -1,0 +1,71 @@
+#!/usr/bin/python
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: test_docs_yaml_anchors
+short_description: Test module with YAML anchors in docs
+description:
+    - Test module
+author:
+    - Ansible Core Team
+options:
+  at_the_top: &toplevel_anchor
+    description:
+        - Short desc
+    default: some string
+    type: str
+
+  last_one: *toplevel_anchor
+
+  egress:
+    description:
+        - Egress firewall rules
+    type: list
+    elements: dict
+    suboptions: &sub_anchor
+        port:
+            description:
+                - Rule port
+            type: int
+            required: true
+
+  ingress:
+    description:
+        - Ingress firewall rules
+    type: list
+    elements: dict
+    suboptions: *sub_anchor
+'''
+
+EXAMPLES = '''
+'''
+
+RETURN = '''
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            at_the_top=dict(type='str', default='some string'),
+            last_one=dict(type='str', default='some string'),
+            egress=dict(type='list', elements='dict', options=dict(
+                port=dict(type='int', required=True),
+            )),
+            ingress=dict(type='list', elements='dict', options=dict(
+                port=dict(type='int', required=True),
+            )),
+        ),
+    )
+
+    module.exit_json()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/ansible-doc/test.yml
+++ b/test/integration/targets/ansible-doc/test.yml
@@ -124,3 +124,14 @@
           - '"Reason: Updated module released with more functionality" in result.stdout'
           - '"Will be removed in a release after 2022-06-01" in result.stdout'
           - '"Alternatives: new_module" in result.stdout'
+
+    - name: documented module with YAML anchors
+      command: ansible-doc test_docs_yaml_anchors
+      register: result
+    - set_fact:
+        actual_output: >-
+          {{ result.stdout | regex_replace('^(> [A-Z_]+ +\().+library/([a-z_]+.py)\)$', '\1library/\2)', multiline=true) }}
+        expected_output: "{{ lookup('file', 'test_docs_yaml_anchors.output') }}"
+    - assert:
+        that:
+          - actual_output == expected_output

--- a/test/integration/targets/ansible-doc/test_docs_yaml_anchors.output
+++ b/test/integration/targets/ansible-doc/test_docs_yaml_anchors.output
@@ -1,0 +1,49 @@
+> TEST_DOCS_YAML_ANCHORS    (library/test_docs_yaml_anchors.py)
+
+        Test module
+
+OPTIONS (= is mandatory):
+
+- at_the_top
+        Short desc
+        [Default: some string]
+        type: str
+
+- egress
+        Egress firewall rules
+        [Default: (null)]
+        elements: dict
+        type: list
+
+        SUBOPTIONS:
+
+        = port
+            Rule port
+
+            type: int
+
+- ingress
+        Ingress firewall rules
+        [Default: (null)]
+        elements: dict
+        type: list
+
+        SUBOPTIONS:
+
+        = port
+            Rule port
+
+            type: int
+
+- last_one
+        Short desc
+        [Default: some string]
+        type: str
+
+
+AUTHOR: Ansible Core Team
+
+EXAMPLES:
+
+
+


### PR DESCRIPTION
##### SUMMARY

Up until this commit, the man formatter kept track of what parts of the documentation were already processed by removing them from the input data. And while this behavior works in the majority of cases, the process breaks when the YAML loader reuses the same underlying data for different parts of the document.

One situation where this happens is when the module author uses YAML anchors to "copy" parts of the documentation in order to remove duplication.

This commit tries to rectify this situation by removing the mutation altogether and instead relies on filtering in order not to produce duplicated entries. Fields that require special treatment are placed in the `customized_output_fields` list and are skipped when rendering the remaining documentation fields.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-docs

##### ADDITIONAL INFORMATION

Sample module that demonstrates the issue:

```
#!/usr/bin/python
from __future__ import absolute_import, division, print_function
__metaclass__ = type


DOCUMENTATION = '''
---
module: sample
short_description: Test module with YAML anchors in docs
description:
    - Test module
author:
    - Ansible Core Team
options:
  at_the_top: &toplevel_anchor
    description:
        - Short desc
    default: some string
    type: str

  last_one: *toplevel_anchor
'''

EXAMPLES = '''
'''

RETURN = '''
'''


from ansible.module_utils.basic import AnsibleModule


def main():
    module = AnsibleModule(argument_spec={})
    module.exit_json()


if __name__ == '__main__':
    main()
```

Output from the `ansible-doc -t module sample.py` command before the applied patch:
```
ERROR! Unable to retrieve documentation from 'sample' due to: 'description'
```


Output from the `ansible-doc -t module sample.py` command after the patch is applied:
```
> SAMPLE    (/home/tadej/tmp/library/sample.py)

        Test module

OPTIONS (= is mandatory):

- at_the_top
        Short desc
        [Default: some string]
        type: str

- last_one
        Short desc
        [Default: some string]
        type: str


AUTHOR: Ansible Core Team

EXAMPLES:



```


##### NOTES

This is an alternative approach at fixing the same issue as in #70045

/cc @felixfontein 