### PR TITLE
provide encryption salt as a native str type

### DIFF
--- a/changelogs/fragments/encryption-salt-as-native-str.yml
+++ b/changelogs/fragments/encryption-salt-as-native-str.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - transform a salt into the native str type to prevent passing unicode to the underlying encryption module

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -80,6 +80,7 @@ class BaseHash(object):
         else:
             return to_native(to_text(salt, encoding='ascii', errors='strict'))
 
+
 class CryptHash(BaseHash):
     def __init__(self, algorithm):
         super(CryptHash, self).__init__(algorithm)

--- a/test/units/utils/test_encrypt.py
+++ b/test/units/utils/test_encrypt.py
@@ -20,6 +20,7 @@ import sys
 import pytest
 
 from ansible.errors import AnsibleError, AnsibleFilterError
+from ansible.module_utils.six import PY3, binary_type, text_type
 from ansible.plugins.filter.core import get_encrypted_password
 from ansible.utils import encrypt
 
@@ -163,3 +164,19 @@ def test_random_salt():
     assert len(res) == 8
     for res_char in res:
         assert res_char in expected_salt_candidate_chars
+
+
+def test_clean_salt_no_passlib():
+    with passlib_off():
+        if PY3:
+            salt = encrypt.BaseHash('md5_crypt')._clean_salt('123', has_raw_salt=False)
+            assert isinstance(salt, text_type)
+
+            salt = encrypt.BaseHash('md5_crypt')._clean_salt(b'123', has_raw_salt=False)
+            assert isinstance(salt, text_type)
+        else:
+            salt = encrypt.BaseHash('md5_crypt')._clean_salt('123', has_raw_salt=False)
+            assert isinstance(salt, binary_type)
+
+            salt = encrypt.BaseHash('md5_crypt')._clean_salt(u'123', has_raw_salt=False)
+            assert isinstance(salt, binary_type)


### PR DESCRIPTION
##### SUMMARY
Some implementations of crypt (like CFFI based) don't accept unicode string in salt and this results in exceptions like:
 ```
fatal: [host1]: FAILED! =>
  msg: 'Unexpected templating type error occurred on ({{ ''secretpassword'' | password_hash(''md5'') }}): initializer for ctype ''char *'' must be a str or list or tuple, not unicode'
```
This update provide salt in native string type to the underlying crypt/passlib module

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/utils/encrypt.py