### PR TITLE
Add galaxy collection info subcommand

### DIFF
--- a/changelogs/fragments/70080-galaxy-collection-info.yml
+++ b/changelogs/fragments/70080-galaxy-collection-info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Added 'ansible-galaxy collection info' subcommand to print metadata about an installed collection.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -718,7 +718,11 @@ class GalaxyCLI(CLI):
 
         Note: This mimics the `role info` output.
         """
-        collection_info = collection.collection_info(collection.b_path, fallback_metadata=True)['manifest_file']['collection_info']
+        info = collection.collection_info(collection.b_path, fallback_metadata=True)
+        if 'manifest_file' in info:
+            collection_info = info['manifest_file']['collection_info']
+        else:
+            return
 
         # Add the installation path to the metadata
         collection_info['install_path'] = to_text(collection.b_path)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -718,7 +718,7 @@ class GalaxyCLI(CLI):
 
         Note: This mimics the `role info` output.
         """
-        collection_info = collection.collection_info(collection.b_path)['manifest_file']['collection_info']
+        collection_info = collection.collection_info(collection.b_path, fallback_metadata=True)['manifest_file']['collection_info']
 
         # Add the installation path to the metadata
         collection_info['install_path'] = to_text(collection.b_path)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -721,6 +721,9 @@ class GalaxyCLI(CLI):
         artifact_info = collection.artifact_info(collection.b_path)
         collection_info = artifact_info['manifest_file']['collection_info']
 
+        # Add the installation path to the metadata
+        collection_info['install_path'] = to_text(collection.b_path)
+
         text = [u"", u"Collection: %s" % to_text(collection)]
         for k in sorted(collection_info.keys()):
             if isinstance(collection_info[k], dict):

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -726,8 +726,8 @@ class GalaxyCLI(CLI):
         text = [u"", u"Collection: %s" % to_text(collection)]
         for k in sorted(collection_info.keys()):
             if isinstance(collection_info[k], dict):
+                text.append(u"\t%s:" % (k))
                 for key in sorted(collection_info[k].keys()):
-                    text.append(u"\t%s:" % (k))
                     text.append(u"\t\t%s: %s" % (key, collection_info[k][key]))
             else:
                 text.append(u"\t%s: %s" % (k, collection_info[k]))

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -718,8 +718,7 @@ class GalaxyCLI(CLI):
 
         Note: This mimics the `role info` output.
         """
-        artifact_info = collection.artifact_info(collection.b_path)
-        collection_info = artifact_info['manifest_file']['collection_info']
+        collection_info = collection.collection_info(collection.b_path)['manifest_file']['collection_info']
 
         # Add the installation path to the metadata
         collection_info['install_path'] = to_text(collection.b_path)

--- a/test/integration/targets/ansible-galaxy-collection/tasks/info.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/info.yml
@@ -1,0 +1,57 @@
+---
+- include_vars:
+    file: info.yml
+
+- name: Create directories for fake installed collections
+  file:
+     path: "{{ item }}"
+     state: directory
+  loop:
+     - "{{ galaxy_dir }}/ansible_collections/fake_namespace/fake_name1"
+     - "{{ galaxy_dir }}/ansible_collections/fake_namespace/fake_name2"
+     - "{{ galaxy_dir }}/ansible_collections/fake_namespace/fake_name3"
+
+- name: "Create MANIFEST.json for {{ collection1 }}"
+  copy:
+     content: "{{ info_collection1_manifest }}"
+     dest: "{{ galaxy_dir }}/ansible_collections/fake_namespace/fake_name1/MANIFEST.json"
+
+- name: "Create galaxy.yml for {{ collection2 }}"
+  copy:
+     content: "{{ info_collection2_galaxy }}"
+     dest: "{{ galaxy_dir }}/ansible_collections/fake_namespace/fake_name2/galaxy.yml"
+
+- name: Get info on collection with MANIFEST.json
+  command: "ansible-galaxy collection info {{ info_collection1 }}"
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
+  register: collection1_output
+
+- name: Get info on collection with galaxy.yml
+  command: "ansible-galaxy collection info {{ info_collection2 }}"
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
+  register: collection2_output
+
+- name: Get info on collection with neither MANIFEST.json nor galaxy.yml
+  command: "ansible-galaxy collection info {{ info_collection3 }}"
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
+  register: collection3_output
+
+- name: Assert collection output
+  assert:
+    that:
+      - '"Collection: {{ info_collection1 }}" in collection1_output.stdout'
+      - '"version: 1.0.0" in collection1_output.stdout'
+      - '"namespace: fake_namespace" in collection1_output.stdout'
+      - '"name: fake_name1" in collection1_output.stdout'
+      - '"install_path:" in collection1_output.stdout'
+
+      - '"Collection: {{ info_collection2 }}" in collection2_output.stdout'
+      - '"version: 1.0.0" in collection2_output.stdout'
+      - '"namespace: fake_namespace" in collection2_output.stdout'
+      - '"name: fake_name2" in collection2_output.stdout'
+      - '"install_path:" in collection2_output.stdout'
+
+      - '"does not have a galaxy.yml or a MANIFEST.json" in collection3_output.stderr'

--- a/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
@@ -205,3 +205,6 @@
     apply:
       environment:
         ANSIBLE_CONFIG: '{{ galaxy_dir }}/ansible.cfg'
+
+- name: run ansible-galaxy collection info tests
+  include_tasks: info.yml

--- a/test/integration/targets/ansible-galaxy-collection/vars/info.yml
+++ b/test/integration/targets/ansible-galaxy-collection/vars/info.yml
@@ -1,0 +1,19 @@
+info_collection1: fake_namespace.fake_name1
+info_collection1_manifest: '{
+"collection_info": {
+  "namespace": "fake_namespace",
+  "name": "fake_name1",
+  "version": "1.0.0",
+  "dependencies": {},
+}}'
+info_collection2: fake_namespace.fake_name2
+info_collection2_galaxy: "
+namespace: fake_namespace\n
+name: fake_name2\n
+version: 1.0.0\n
+dependencies:\n
+authors:\n
+  - Ansible\n
+readme: README.md\n
+"
+info_collection3: fake_namespace.fake_name3


### PR DESCRIPTION
##### SUMMARY
New galaxy collection subcommand 'info' to display metadata of an installed collection.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-galaxy

##### ADDITIONAL INFORMATION

Example output for a normal install via ansible-galaxy:

```
% ansible-galaxy collection info sample.utils

Collection: sample.utils
	authors: ['Sample User' <author@sample.com>']
	description: Personal utilities collection
	documentation: http://github.com/Shrews/sample-collection
	homepage: http://github.com/Shrews/sample-collection
	install_path: /Users/shrews/.ansible/collections/ansible_collections/sample/utils
	issues: http://github.com/Shrews/sample-collection/issues
	license: ['GPL-2.0-or-later']
	license_file: None
	name: utils
	namespace: sample
	readme: README.md
	repository: http://github.com/Shrews/sample-collection
	tags: []
	version: 1.0.0
```

And for a collection installed via git (i.e., no MANIFEST.json):

```
Collection: community.general
	authors: ['Ansible (https://github.com/ansible)']
	dependencies:
		ansible.netcommon: >=0.0.2
		ansible.posix: >=0.1.0
		community.kubernetes: >=0.1.0
		google.cloud: >=0.0.9
	description: None
	documentation: https://github.com/ansible-collection-migration/community.general/tree/master/docs
	homepage: https://github.com/ansible-collections/community.general
	install_path: /Users/shrews/.ansible/collections/ansible_collections/community/general
	issues: https://github.com/ansible-collections/community.general/issues
	license: []
	license_file: COPYING
	name: general
	namespace: community
	readme: README.md
	repository: https://github.com/ansible-collections/community.general
	tags: []
	version: 0.2.0
```