### PR TITLE
yum - fix bug where enablerepo is not honored when disablerepo all (#…

### DIFF
--- a/changelogs/fragments/66549-enablerepo-not-honored-when-used-with-disablerepo-all.yml
+++ b/changelogs/fragments/66549-enablerepo-not-honored-when-used-with-disablerepo-all.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - yum - fix bug that caused ``enablerepo`` to not be honored when used with disablerepo all wildcard/glob (https://github.com/ansible/ansible/issues/66549)

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -434,11 +434,11 @@ class YumModule(YumDnf):
         # another copy seems to be running
         return True
 
-    def _enablerepos_with_error_checking(self, yumbase):
-        # NOTE: This seems unintuitive, but it mirrors yum's CLI bahavior
+    def _enablerepos_with_error_checking(self):
+        # NOTE: This seems unintuitive, but it mirrors yum's CLI behavior
         if len(self.enablerepo) == 1:
             try:
-                yumbase.repos.enableRepo(self.enablerepo[0])
+                self.yum_base.repos.enableRepo(self.enablerepo[0])
             except yum.Errors.YumBaseError as e:
                 if u'repository not found' in to_text(e):
                     self.module.fail_json(msg="Repository %s not found." % self.enablerepo[0])
@@ -447,7 +447,7 @@ class YumModule(YumDnf):
         else:
             for rid in self.enablerepo:
                 try:
-                    yumbase.repos.enableRepo(rid)
+                    self.yum_base.repos.enableRepo(rid)
                 except yum.Errors.YumBaseError as e:
                     if u'repository not found' in to_text(e):
                         self.module.warn("Repository %s not found." % rid)
@@ -491,10 +491,11 @@ class YumModule(YumDnf):
             self.yum_base.conf
 
             try:
-                self._enablerepos_with_error_checking(self._yum_base)
-
                 for rid in self.disablerepo:
                     self.yum_base.repos.disableRepo(rid)
+
+                self._enablerepos_with_error_checking()
+
             except Exception as e:
                 self.module.fail_json(msg="Failure talking to yum: %s" % to_native(e))
 

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -112,6 +112,25 @@
         - "yum_result is not changed"
   when: ansible_distribution == 'CentOS'
 
+# This test case is unfortunately distro specific because we have to specify
+# repo names which are not the same across Fedora/RHEL/CentOS for base/updates
+- name: install sos again with disable all and enable select repo(s)
+  yum:
+    name: sos
+    state: present
+    enablerepo:
+      - "base"
+      - "updates"
+    disablerepo: "*"
+  register: yum_result
+  when: ansible_distribution == 'CentOS'
+- name: verify no change on fourth install with missing repo enablerepo (yum)
+  assert:
+    that:
+        - "yum_result is success"
+        - "yum_result is not changed"
+  when: ansible_distribution == 'CentOS'
+
 - name: install sos again with only missing repo enablerepo
   yum:
     name: sos


### PR DESCRIPTION
…66557)

Fixes #66549
Fixes #70081

Backport of #66557

(This is a backport of the above which never made it back into 2.8)

The inefficiency improvement
https://github.com/ansible/ansible/pull/63713 introduced a bug where
`enablerepo` was not being honored if combined with
`disablerepo="*"`. This fixes that issue.

Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
yum