### PR TITLE
try to load unqualified plugins from whitelist

### DIFF
--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -8306,6 +8306,13 @@ plugin_routing:
       redirect: ansible.posix.timer
     foreman:
       redirect: theforeman.foreman.foreman
+    # 'collections' integration test entries, do not remove
+    formerly_core_callback:
+      redirect: testns.testcoll.usercallback
+    formerly_core_removed_callback:
+      redirect: testns.testcoll.removedcallback
+    formerly_core_missing_callback:
+      redirect: bogusns.boguscoll.boguscallback
   doc_fragments:
     a10:
       redirect: community.network.a10

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -138,6 +138,9 @@ class TaskQueueManager:
         else:
             raise AnsibleError("callback must be an instance of CallbackBase or the name of a callback plugin")
 
+        loaded_callbacks = set()
+
+        # first, load callbacks in the core distribution and configured callback paths
         for callback_plugin in callback_loader.all(class_only=True):
             callback_type = getattr(callback_plugin, 'CALLBACK_TYPE', '')
             callback_needs_whitelist = getattr(callback_plugin, 'CALLBACK_NEEDS_WHITELIST', False)
@@ -156,13 +159,21 @@ class TaskQueueManager:
                 continue
 
             callback_obj = callback_plugin()
+            loaded_callbacks.add(callback_name)  # mark as loaded so we skip in second pass
             callback_obj.set_options()
             self._callback_plugins.append(callback_obj)
 
-        for callback_plugin_name in (c for c in C.DEFAULT_CALLBACK_WHITELIST if AnsibleCollectionRef.is_valid_fqcr(c)):
+        # Second pass over everything in the whitelist we haven't already loaded, try to explicitly load. This will catch
+        # collection-hosted callbacks, as well as formerly-core callbacks that have been redirected to collections.
+        for callback_plugin_name in (c for c in C.DEFAULT_CALLBACK_WHITELIST if c not in loaded_callbacks):
             # TODO: need to extend/duplicate the stdout callback check here (and possible move this ahead of the old way
-            callback_obj = callback_loader.get(callback_plugin_name)
+            callback_obj, plugin_load_context = callback_loader.get_with_context(callback_plugin_name)
             if callback_obj:
+                loaded_as_name = callback_obj._redirected_names[-1]
+                if loaded_as_name in loaded_callbacks:
+                    display.warning("Skipping callback '%s', already loaded as '%s'." % (callback_plugin_name, loaded_as_name))
+                    continue
+                loaded_callbacks.add(loaded_as_name)
                 callback_obj.set_options()
                 self._callback_plugins.append(callback_obj)
             else:

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/meta/runtime.yml
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/meta/runtime.yml
@@ -2,6 +2,10 @@ plugin_routing:
   action:
     uses_redirected_action:
       redirect: testns.testcoll.subclassed_normal
+  callback:
+    removedcallback:
+      tombstone:
+        removal_date: '2020-01-01'
   connection:
     redirected_local:
       redirect: ansible.builtin.local

--- a/test/integration/targets/collections/noop.yml
+++ b/test/integration/targets/collections/noop.yml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - debug:

--- a/test/integration/targets/collections/runme.sh
+++ b/test/integration/targets/collections/runme.sh
@@ -21,7 +21,7 @@ ANSIBLE_CALLBACK_WHITELIST=formerly_core_missing_callback ansible localhost -m d
 # validate redirected + removed callback (fatal)
 ANSIBLE_CALLBACK_WHITELIST=formerly_core_removed_callback ansible localhost -m debug 2>&1 | grep -- "testns.testcoll.removedcallback has been removed"
 # validate warning on logical duplicate (FQ + unqualified that are the same)
-ANSIBLE_CALLBACK_WHITELIST=testns.testcoll.usercallback,formerly_core_callback ansible localhost -m debug 2>&1 | grep -- "Skipping callback 'formerly_core_callback', already loaded as 'testns.testcoll.usercallback'"
+ANSIBLE_CALLBACK_WHITELIST=testns.testcoll.usercallback,formerly_core_callback ansible localhost -m debug 2>&1 | grep -- "Skipping callback 'formerly_core_callback'"
 # ensure non existing callback does not crash ansible
 ANSIBLE_CALLBACK_WHITELIST=charlie.gomez.notme ansible localhost -m debug 2>&1 | grep -- "Skipping 'charlie.gomez.notme'"
 

--- a/test/integration/targets/collections/runme.sh
+++ b/test/integration/targets/collections/runme.sh
@@ -12,8 +12,18 @@ export ANSIBLE_HOST_PATTERN_MISMATCH=error
 ipath=../../$(basename "${INVENTORY_PATH:-../../inventory}")
 export INVENTORY_PATH="$ipath"
 
-# test callback
-ANSIBLE_CALLBACK_WHITELIST=testns.testcoll.usercallback ansible localhost -m ping | grep "usercallback says ok"
+# CALLBACK VALIDATION
+# validate FQ callbacks
+ANSIBLE_CALLBACK_WHITELIST=testns.testcoll.usercallback ansible localhost -m debug | grep "usercallback says ok"
+# validate redirected callback
+ANSIBLE_CALLBACK_WHITELIST=formerly_core_callback ansible localhost -m debug 2>&1 | grep -- "usercallback says ok"
+# validate missing redirected callback
+ANSIBLE_CALLBACK_WHITELIST=formerly_core_missing_callback ansible localhost -m debug 2>&1 | grep -- "Skipping 'formerly_core_missing_callback'"
+# validate redirected + removed callback (fatal)
+ANSIBLE_CALLBACK_WHITELIST=formerly_core_removed_callback ansible localhost -m debug 2>&1 | grep -- "testns.testcoll.removedcallback has been removed"
+# ensure non existing callback does not crash ansible
+ANSIBLE_CALLBACK_WHITELIST=charlie.gomez.notme ansible localhost -m debug 2>&1 | grep -- "Skipping 'charlie.gomez.notme'"
+
 
 # test documentation
 ansible-doc testns.testcoll.testmodule -vvv | grep -- "- normal_doc_frag"
@@ -85,5 +95,3 @@ fi
 
 ./vars_plugin_tests.sh
 
-# ensure non existing callback does not crash ansible
-ANSIBLE_CALLBACK_WHITELIST=charlie.gomez.notme ansible -m ping localhost

--- a/test/integration/targets/collections/runme.sh
+++ b/test/integration/targets/collections/runme.sh
@@ -12,8 +12,10 @@ ipath=../../$(basename "${INVENTORY_PATH:-../../inventory}")
 export INVENTORY_PATH="$ipath"
 
 echo "--- validating callbacks"
-# validate FQ callbacks
-ANSIBLE_CALLBACK_WHITELIST=testns.testcoll.usercallback ansible localhost -m debug | grep "usercallback says ok"
+# validate FQ callbacks in ansible-playbook
+ANSIBLE_CALLBACK_WHITELIST=testns.testcoll.usercallback ansible-playbook noop.yml | grep "usercallback says ok"
+# use adhoc for the rest of these tests, must force it to load other callbacks
+export ANSIBLE_LOAD_CALLBACK_PLUGINS=1
 # validate redirected callback
 ANSIBLE_CALLBACK_WHITELIST=formerly_core_callback ansible localhost -m debug 2>&1 | grep -- "usercallback says ok"
 # validate missing redirected callback
@@ -24,6 +26,9 @@ ANSIBLE_CALLBACK_WHITELIST=formerly_core_removed_callback ansible localhost -m d
 ANSIBLE_CALLBACK_WHITELIST=testns.testcoll.usercallback,formerly_core_callback ansible localhost -m debug 2>&1 | grep -- "Skipping callback 'formerly_core_callback'"
 # ensure non existing callback does not crash ansible
 ANSIBLE_CALLBACK_WHITELIST=charlie.gomez.notme ansible localhost -m debug 2>&1 | grep -- "Skipping 'charlie.gomez.notme'"
+unset ANSIBLE_LOAD_CALLBACK_PLUGINS
+# adhoc normally shouldn't load non-default plugins- let's be sure
+ANSIBLE_CALLBACK_WHITELIST=testns.testcoll.usercallback ansible localhost -m debug | grep -L "usercallback says ok"
 
 echo "--- validating docs"
 # test documentation

--- a/test/integration/targets/collections/runme.sh
+++ b/test/integration/targets/collections/runme.sh
@@ -21,6 +21,8 @@ ANSIBLE_CALLBACK_WHITELIST=formerly_core_callback ansible localhost -m debug 2>&
 ANSIBLE_CALLBACK_WHITELIST=formerly_core_missing_callback ansible localhost -m debug 2>&1 | grep -- "Skipping 'formerly_core_missing_callback'"
 # validate redirected + removed callback (fatal)
 ANSIBLE_CALLBACK_WHITELIST=formerly_core_removed_callback ansible localhost -m debug 2>&1 | grep -- "testns.testcoll.removedcallback has been removed"
+# validate warning on logical duplicate (FQ + unqualified that are the same)
+ANSIBLE_CALLBACK_WHITELIST=testns.testcoll.usercallback,formerly_core_callback ansible localhost -m debug 2>&1 | grep -- "Skipping callback 'formerly_core_callback', already loaded as 'testns.testcoll.usercallback'"
 # ensure non existing callback does not crash ansible
 ANSIBLE_CALLBACK_WHITELIST=charlie.gomez.notme ansible localhost -m debug 2>&1 | grep -- "Skipping 'charlie.gomez.notme'"
 

--- a/test/integration/targets/collections/runme.sh
+++ b/test/integration/targets/collections/runme.sh
@@ -28,7 +28,8 @@ ANSIBLE_CALLBACK_WHITELIST=testns.testcoll.usercallback,formerly_core_callback a
 ANSIBLE_CALLBACK_WHITELIST=charlie.gomez.notme ansible localhost -m debug 2>&1 | grep -- "Skipping 'charlie.gomez.notme'"
 unset ANSIBLE_LOAD_CALLBACK_PLUGINS
 # adhoc normally shouldn't load non-default plugins- let's be sure
-ANSIBLE_CALLBACK_WHITELIST=testns.testcoll.usercallback ansible localhost -m debug | grep -L "usercallback says ok"
+output=$(ANSIBLE_CALLBACK_WHITELIST=testns.testcoll.usercallback ansible localhost -m debug)
+if [[ "${output}" =~ "usercallback says ok" ]]; then echo fail; exit 1; fi
 
 echo "--- validating docs"
 # test documentation


### PR DESCRIPTION
##### SUMMARY
* necessary for backcompat loading of unqualified collectionized callback plugins redirected from <= 2.9 core
* also added de-duping from actual loaded name

fixes #69781 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
task_queue_manager.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
