### PR TITLE
Fix testcase for old sshpass

### DIFF
--- a/test/integration/targets/connection_ssh/runme.sh
+++ b/test/integration/targets/connection_ssh/runme.sh
@@ -36,7 +36,7 @@ if command -v sshpass > /dev/null; then
             -e ansible_password=foo \
             -e ansible_user=definitelynotroot \
 	    -i test_connection.inventory \
-            ssh-pipelining | grep 'customized password prompts'
+            ssh-pipelining 2>&1 | grep 'customized password prompts'
         ret=$?
         [[ $ret -eq 0 ]] || exit $ret
     fi


### PR DESCRIPTION
##### SUMMARY

Change:
When `sshpass` doesn't have a `-P` option, we test that we get the right
error back from Ansible. This error goes to stderr, not stdout. Fix the
check by 2>&1 before grepping for the error text.

Test Plan:
CI

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

tests