### PR TITLE
make apt errors more transparent

### DIFF
--- a/changelogs/fragments/70099-make-apt-errors-more-transparent.yaml
+++ b/changelogs/fragments/70099-make-apt-errors-more-transparent.yaml
@@ -1,2 +1,2 @@
-minor_changes:
+bugfixes:
   - apt - include exception message from apt python library in error output

--- a/changelogs/fragments/70099-make-apt-errors-more-transparent.yaml
+++ b/changelogs/fragments/70099-make-apt-errors-more-transparent.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - apt - include exception message from apt python library in error output

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1219,10 +1219,10 @@ def main():
         elif p['state'] == 'absent':
             remove(module, packages, cache, p['purge'], force=force_yes, dpkg_options=dpkg_options, autoremove=autoremove)
 
-    except apt.cache.LockFailedException:
-        module.fail_json(msg="Failed to lock apt for exclusive operation")
-    except apt.cache.FetchFailedException:
-        module.fail_json(msg="Could not fetch updated apt files")
+    except apt.cache.LockFailedException as lockFailedException:
+        module.fail_json(msg="Failed to lock apt for exclusive operation: %s" % lockFailedException)
+    except apt.cache.FetchFailedException as fetchFailedException:
+        module.fail_json(msg="Could not fetch updated apt files: %s" % fetchFailedException)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
While debugging a problem with apt on my remote host I found out that the apt module is voiding some upstream error messages from the python apt module. The changes in this PR helped me locally to debug the issue and I think they should be default in ansible.
There is no harm in seeing these errors if they occur and as I said it helps to debug stuff.