### PR TITLE
Add an author exception for OpenStack Ansible SIG

### DIFF
--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -26,8 +26,9 @@ any_string_types = Any(*string_types)
 #   author: First Last (@name) [optional anything]
 #     "Ansible Core Team" - Used by the Bot
 #     "Michael DeHaan" - nop
+#     "OpenStack Ansible SIG" - OpenStack does not use GitHub
 #     "Name (!UNKNOWN)" - For the few untraceable authors
-author_line = re.compile(r'^\w.*(\(@([\w-]+)\)|!UNKNOWN)(?![\w.])|^Ansible Core Team$|^Michael DeHaan$')
+author_line = re.compile(r'^\w.*(\(@([\w-]+)\)|!UNKNOWN)(?![\w.])|^Ansible Core Team$|^Michael DeHaan$|^OpenStack Ansible SIG$')
 
 
 def _add_ansible_error_code(exception, error_code):


### PR DESCRIPTION
The current author line wants to match a github author id. But
some people, including the OpenStack project, do not use github,
and additionally do not claim individual ownership but instead
group ownership.

Since there are already a couple of hard-coded examples in the
regex, just add one more. Alternately we could come up with some
mechanism to indicate that the author is purposely not listing
a github id, but that seems a bit heavywight.