### PR TITLE
Get test data file directly in rebalance script

### DIFF
--- a/hacking/shippable/rebalance.py
+++ b/hacking/shippable/rebalance.py
@@ -7,9 +7,14 @@
 """
 CLI tool that analyses a Shippable run's test result and re-balances the test targets into new groups.
 
-Before running this script you must run download.py like
+Before running this script you must run download.py like:
 
-./download.py https://app.shippable.com/github/<team>/<repo>/runs/<run_num> --test-results --job-number x --job-number y
+    ./download.py https://app.shippable.com/github/<team>/<repo>/runs/<run_num> --test-results --job-number x --job-number y
+
+Or to get all job results from a run:
+
+    ./download.py https://app.shippable.com/github/<team>/<repo>/runs/<run_num> --test-results --all
+
 
 Set the dir <team>/<repo>/<run_num> as the value of '-p/--test-path' for this script.
 """

--- a/hacking/shippable/rebalance.py
+++ b/hacking/shippable/rebalance.py
@@ -91,7 +91,6 @@ def get_raw_test_targets(args, test_path):
                 continue
 
             info = json.loads(test['contents'])
-            targets = info.get('targets')
 
             targets = info.get('targets')
             if isinstance(targets, dict):

--- a/hacking/shippable/rebalance.py
+++ b/hacking/shippable/rebalance.py
@@ -86,15 +86,18 @@ def get_raw_test_targets(args, test_path):
                 continue
 
             info = json.loads(test['contents'])
+            targets = info.get('targets')
 
-            for target_name, target_info in info.get('targets', {}).items():
-                target_runtime = int(target_info.get('run_time_seconds', 0))
+            targets = info.get('targets')
+            if isinstance(targets, dict):
+                for target_name, target_info in info.get('targets', {}).items():
+                    target_runtime = int(target_info.get('run_time_seconds', 0))
 
-                # If that target already is found and has a higher runtime than the current one, ignore this entry.
-                if target_times.get(target_name, 0) > target_runtime:
-                    continue
+                    # If that target already is found and has a higher runtime than the current one, ignore this entry.
+                    if target_times.get(target_name, 0) > target_runtime:
+                        continue
 
-                target_times[target_name] = target_runtime
+                    target_times[target_name] = target_runtime
 
     return dict([(k, v) for k, v in sorted(target_times.items(), key=lambda i: i[1], reverse=True)])
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The value of `['contents']['targets']` is not always a dict. Here is an example of the data that is causing a stack trace because it is a list and has no `.items()` attribute.

```json
{
    "contents": "{\"targets\":
        [\"connection_windows_ssh\",
        \"connection_psrp\",
        \"win_become\",
        \"win_script\",
        \"win_fetch\",
        \"win_async_wrapper\",
        \"module_utils_Ansible.ModuleUtils.CommandUtil\",
        \"module_utils_Ansible.ModuleUtils.Backup\",
        \"module_utils_Ansible.Service\",
        \"windows-minimal\",
        \"module_utils_Ansible.Basic\",
        \"module_utils_Ansible.Process\",
        \"collections\",
        \"module_utils_Ansible.ModuleUtils.WebRequest\",
        \"connection_winrm\",
        \"module_utils_Ansible.ModuleUtils.CamelConversion\",
        \"win_module_utils\",
        \"binary_modules_winrm\",
        \"module_utils_Ansible.ModuleUtils.ArgvParser\",
        \"module_utils_Ansible.ModuleUtils.FileUtil\",
        \"module_utils_Ansible.ModuleUtils.SID\",
        \"win_exec_wrapper\",
        \"windows-paths\",
        \"module_utils_Ansible.Become\",
        \"win_raw\",
        \"module_utils_Ansible.ModuleUtils.AddType\",
        \"module_utils_Ansible.Privilege\",
        \"module_utils_Ansible.ModuleUtils.Legacy\",
        \"module_utils_Ansible.AccessToken\",
        \"module_utils_Ansible.ModuleUtils.LinkUtil\",
        \"module_utils_Ansible.ModuleUtils.PrivilegeUtil\",
        \"collections_relative_imports\"]
...
}
```

**Steps to reproduce:**

```
> python -VV
Python 3.8.2 (default, May 12 2020, 12:11:39)
[Clang 11.0.3 (clang-1103.0.32.59)]

> python3 download.py https://app.shippable.com/github/ansible/ansible/runs/168526 --test-results --job-number 13

> python3 rebalance.py -p ansible/ansible/168526 5
```

**Expected Results:**

Prints out rebalanced groups.

**Actual Results:**
```
Traceback (most recent call last):
  File "rebalance.py", line 181, in <module>
    main()
  File "rebalance.py", line 35, in main
    rebalance(args)
  File "rebalance.py", line 117, in rebalance
    target_times = get_raw_test_targets(args, test_path)
  File "rebalance.py", line 90, in get_raw_test_targets
    for target_name, target_info in info.get('targets', {}).items():
AttributeError: 'list' object has no attribute 'items'
```

Also add some more instructions in the comments.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`hacking/shippable/rebalance.py`

