### PR TITLE
Update ansible-test default test containers.

### DIFF
--- a/changelogs/fragments/ansible-test-default-containers-update.yml
+++ b/changelogs/fragments/ansible-test-default-containers-update.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - ansible-test - Updated the default test containers to include Python 3.9.0b3.

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,5 +1,5 @@
-default name=quay.io/ansible/default-test-container:2.2 python=3.6,2.6,2.7,3.5,3.7,3.8,3.9 seccomp=unconfined context=collection
-default name=quay.io/ansible/ansible-base-test-container:1.2 python=3.6,2.6,2.7,3.5,3.7,3.8,3.9 seccomp=unconfined context=ansible-base
+default name=quay.io/ansible/default-test-container:2.6.0 python=3.6,2.6,2.7,3.5,3.7,3.8,3.9 seccomp=unconfined context=collection
+default name=quay.io/ansible/ansible-base-test-container:1.4.0 python=3.6,2.6,2.7,3.5,3.7,3.8,3.9 seccomp=unconfined context=ansible-base
 centos6 name=quay.io/ansible/centos6-test-container:1.17.0 python=2.6 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.17.0 python=2.7 seccomp=unconfined
 centos8 name=quay.io/ansible/centos8-test-container:1.17.0 python=3.6 seccomp=unconfined


### PR DESCRIPTION
##### SUMMARY

Update ansible-test default test containers.

The main change is the upgrade to Python 3.9.0b3.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
