### PR TITLE
doc: avoid mix of single and double quotes

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -76,7 +76,7 @@ Defining different values for true/false/null
 
 You can create a test, then define one value to use when the test returns true and another when the test returns false (new in version 1.9)::
 
-    {{ (status == "needs_restart") | ternary('restart', 'continue') }}
+    {{ (status == 'needs_restart') | ternary('restart', 'continue') }}
 
 In addition, you can define a one value to use on true, one value on false and a third value on null (new in version 2.8)::
 


### PR DESCRIPTION
##### SUMMARY

Avoid mix of single and double quotes in the `ternary`, this way
we can copy/past the example without any surprise.

##### ISSUE TYPE

- Docs Pull Request