### PR TITLE
[eos] [2.9] [backport]  Turn on eapi by default.

### DIFF
--- a/changelogs/fragments/63632-eos-enable-eapi.yaml
+++ b/changelogs/fragments/63632-eos-enable-eapi.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- "eos_eapi - enable eapi by default"

--- a/lib/ansible/modules/network/eos/eos_eapi.py
+++ b/lib/ansible/modules/network/eos/eos_eapi.py
@@ -264,7 +264,7 @@ def map_obj_to_commands(updates, module, warnings):
         else:
             add('protocol unix-socket')
 
-    if needs_update('state') and not needs_update('vrf'):
+    if needs_update('state'):
         if want['state'] == 'stopped':
             add('shutdown')
         elif want['state'] == 'started':

--- a/test/units/modules/network/eos/test_eos_eapi.py
+++ b/test/units/modules/network/eos/test_eos_eapi.py
@@ -134,7 +134,7 @@ class TestEosEapiModule(TestEosModule):
 
     def test_eos_eapi_vrf(self):
         set_module_args(dict(vrf='test'))
-        commands = ['management api http-commands', 'vrf test', 'no shutdown']
+        commands = ['management api http-commands', 'no shutdown', 'vrf test', 'no shutdown']
         self.start_unconfigured(changed=True, commands=commands)
 
     def test_eos_eapi_change_from_default_vrf(self):


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/63632
Fixes : https://github.com/ansible-collections/arista.eos/issues/57

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
eos_eapi.py
