### PR TITLE
Improve error message when ssh client is not found on the host

### DIFF
--- a/changelogs/fragments/70122-improve-error-message-ssh-client-is-not-found.yml
+++ b/changelogs/fragments/70122-improve-error-message-ssh-client-is-not-found.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - SSH plugin - Improve error message when ssh client is not found on the host

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -818,12 +818,17 @@ class Connection(ConnectionBase):
                 p = None
 
         if not p:
-            if PY3 and conn_password:
-                # pylint: disable=unexpected-keyword-arg
-                p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, pass_fds=self.sshpass_pipe)
-            else:
-                p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            stdin = p.stdin
+            try:
+                if PY3 and conn_password:
+                    # pylint: disable=unexpected-keyword-arg
+                    p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                         stderr=subprocess.PIPE, pass_fds=self.sshpass_pipe)
+                else:
+                    p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                         stderr=subprocess.PIPE)
+                stdin = p.stdin
+            except (OSError, IOError) as e:
+                raise AnsibleError('Unable to execute ssh command line on a controller due to: %s' % to_native(e))
 
         # If we are using SSH password authentication, write the password into
         # the pipe we opened in _build_command.


### PR DESCRIPTION
##### SUMMARY
When ssh client is not found on the host, we don't provide accurate error message to the user:
```
TASK [Gathering Facts] ***************************************************************************************************************************************************************************************
task path: /ansible/ansible-mysql-5.5-5.6/test_role.yaml:2
<192.168.1.100> ESTABLISH SSH CONNECTION FOR USER: None
<192.168.1.100> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/root/.ansible/cp/efca44cc99 192.168.1.100 '/bin/sh -c '"'"'echo ~ && sleep 0'"'"''
The full traceback is:
Traceback (most recent call last):
  File "/ansible/lib/ansible/executor/task_executor.py", line 155, in run
    res = self._execute()
  File "/ansible/lib/ansible/executor/task_executor.py", line 650, in _execute
    result = self._handler.run(task_vars=variables)
  File "/ansible/lib/ansible/plugins/action/gather_facts.py", line 87, in run
    res = self._execute_module(module_name=fact_module, module_args=mod_args, task_vars=task_vars, wrap_async=False)
  File "/ansible/lib/ansible/plugins/action/__init__.py", line 824, in _execute_module
    self._make_tmp_path()
  File "/ansible/lib/ansible/plugins/action/__init__.py", line 386, in _make_tmp_path
    tmpdir = self._remote_expand_user(self.get_shell_option('remote_tmp', default='~/.ansible/tmp'), sudoable=False)
  File "/ansible/lib/ansible/plugins/action/__init__.py", line 707, in _remote_expand_user
    data = self._low_level_execute_command(cmd, sudoable=False)
  File "/ansible/lib/ansible/plugins/action/__init__.py", line 1119, in _low_level_execute_command
    rc, stdout, stderr = self._connection.exec_command(cmd, in_data=in_data, sudoable=sudoable)
  File "/ansible/lib/ansible/plugins/connection/ssh.py", line 1217, in exec_command
    (returncode, stdout, stderr) = self._run(cmd, in_data, sudoable=sudoable)
  File "/ansible/lib/ansible/plugins/connection/ssh.py", line 410, in wrapped
    return_tuple = func(self, *args, **kwargs)
  File "/ansible/lib/ansible/plugins/connection/ssh.py", line 1078, in _run
    return self._bare_run(cmd, in_data, sudoable=sudoable, checkrc=checkrc)
  File "/ansible/lib/ansible/plugins/connection/ssh.py", line 825, in _bare_run
    p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File "/usr/lib/python3.6/subprocess.py", line 729, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.6/subprocess.py", line 1364, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: b'ssh': b'ssh'
fatal: [jump]: FAILED! => {
    "msg": "Unexpected failure during module execution.",
    "stdout": ""
}
```

`subprocess` tries to execute `cmd` and fails with it's own exception. 

The goal of this PR is to catch this exception before and provide the accurate error message to the user:

```
TASK [Gathering Facts] ***************************************************************************************************************************************************************************************
task path: /ansible/ansible-mysql-5.5-5.6/test_role.yaml:2
<192.168.1.100> ESTABLISH SSH CONNECTION FOR USER: None
<192.168.1.100> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/root/.ansible/cp/efca44cc99 192.168.1.100 '/bin/sh -c '"'"'echo ~ && sleep 0'"'"''
fatal: [jump]: FAILED! => {
    "msg": "Unable to execute ssh command line on a controller due to: [Errno 2] No such file or directory: b'ssh': b'ssh'"
}
``` 

Fixes #69834

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
SSH plugin
