### PR TITLE
modules apt: Force update if default_release is not available

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -1080,8 +1080,20 @@ def main():
                 apt_pkg.config['APT::Default-Release'] = p['default_release']
             except AttributeError:
                 apt_pkg.Config['APT::Default-Release'] = p['default_release']
-            # reopen cache w/ modified config
-            cache.open(progress=None)
+
+            # If default_release is provided and for some reason the apt cache
+            # is not up-to-date cache.open fails with apt_pkg.Error.
+            #
+            # This can happen if a new repository is added with a new release
+            # (such as 'buster-backports') and 'apt-get update' has not been
+            # executed yet (i.e. missing related files in /var/lib/apt/lists).
+            try:
+                # reopen cache w/ modified config
+                cache.open(progress=None)
+            except apt_pkg.Error:
+                # In that case the cache is forced to be updated in next block.
+                p['update_cache'] = True
+                p['cache_valid_time'] = 0
 
         mtimestamp, updated_cache_time = get_updated_cache_time()
         # Cache valid time is default 0, which will update the cache if


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This patch fixes following `apt_pkg.Error` which is triggered on `cache.open()` when three conditions are satisfied:

* A repository with a new release name (such as `buster-backports`) is added.
* The apt cache is not up-to-date (i.e. no `/var/lib/apt/lists/*buster-backports*` file is found).
* Ansible apt module is invoked with `default_default` set to this new release.

Even if `update_cache` is set to `yes` the apt cache is not updated and the module fails with this error:

```
E:The value 'buster-backports' is invalid for APT::Default-Release as such a release is not available in the sources
```

The solution is to force a cache update if `default_release` is set and `apt_pkg.Error` is raised.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module: apt

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Here is the playbook used to raise the bug with Ansible 2.8 or 2.9 on a Debian buster host:

```
- hosts: '*'
  become_user: root
  become_method: sudo
  become: yes
  gather_facts: yes

  tasks:

    # setup
    
    # Start with just a default sources.list entry.
    - name: Remove any apt sources and lists
      shell:
        rm -f /etc/apt/sources.list /etc/apt/sources.list.d/* /var/lib/apt/lists/*
      failed_when: false
      args:
        warn: no
      
    - name: Make sure test package is not installed yet
      apt:
        pkg: wireguard-tools
        state: absent
        purge: yes
      
    - name: Add default repository and force update
      apt_repository:
        repo: 'deb http://deb.debian.org/debian buster main contrib non-free'
        update_cache: yes

    # Add an new repository and simulate a manual addition
    - name: Add a repository with a new release
      apt_repository:
        repo: 'deb http://deb.debian.org/debian buster-backports main contrib non-free'
        update_cache: no

    # / setup
        
    # The failing task:
    - name: install a package from the new repository
      apt:
        pkg: wireguard-tools
        default_release: buster-backports
        update_cache: yes
        cache_valid_time: 3600

```


<!--- Paste verbatim command output below, e.g. before and after your change -->

Before the change:
```
TASK [install a package from the new repository] ****************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: apt_pkg.Error: E:The value 'buster-backports' is invalid for APT::Default-Release as such a release is not available in the sources
fatal: [host.example.com]: FAILED! => changed=false
  module_stderr: |-
    Traceback (most recent call last):
      File "<stdin>", line 102, in <module>
      File "<stdin>", line 94, in _ansiballz_main
      File "<stdin>", line 40, in invoke_module
      File "/usr/lib/python3.7/runpy.py", line 205, in run_module
        return _run_module_code(code, init_globals, run_name, mod_spec)
      File "/usr/lib/python3.7/runpy.py", line 96, in _run_module_code
        mod_name, mod_spec, pkg_name, script_name)
      File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
        exec(code, run_globals)
      File "/tmp/ansible_apt_payload_zjcd3sdd/ansible_apt_payload.zip/ansible/modules/packaging/os/apt.py", line 1217, in <module>
      File "/tmp/ansible_apt_payload_zjcd3sdd/ansible_apt_payload.zip/ansible/modules/packaging/os/apt.py", line 1083, in main
      File "/usr/lib/python3/dist-packages/apt/cache.py", line 230, in open
        self._cache = apt_pkg.Cache(progress)
    apt_pkg.Error: E:The value 'buster-backports' is invalid for APT::Default-Release as such a release is not available in the sources
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1
```

After the change:
```
TASK [install a package from the new repository] ***********************************************************************************************************************************************************
changed: [host.example.com]
```
