### PR TITLE
add the role version number to the ansible-galaxy error/warning message

### DIFF
--- a/changelogs/fragments/ansible-galaxy-warning-error-message-fix.yml
+++ b/changelogs/fragments/ansible-galaxy-warning-error-message-fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ansible-galaxy - add the role version to the ansible-galaxy error/warning message

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1122,7 +1122,7 @@ class GalaxyCLI(CLI):
             try:
                 installed = role.install()
             except AnsibleError as e:
-                display.warning(u"- %s %s was NOT installed successfully: %s " % (role.name, role.version, to_text(e)))
+                display.warning(u"- %s %s was NOT installed successfully: %s " % (role.name, role.version or '*', to_text(e)))
                 self.exit_without_ignore()
                 continue
 
@@ -1164,7 +1164,7 @@ class GalaxyCLI(CLI):
                                     display.display('- dependency %s is already installed, skipping.' % dep_role.name)
 
             if not installed:
-                display.warning("- %s %s was NOT installed successfully." % (role.name, role.version))
+                display.warning("- %s %s was NOT installed successfully." % (role.name, role.version or '*'))
                 self.exit_without_ignore()
 
         return 0

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1122,7 +1122,7 @@ class GalaxyCLI(CLI):
             try:
                 installed = role.install()
             except AnsibleError as e:
-                display.warning(u"- %s was NOT installed successfully: %s " % (role.name, to_text(e)))
+                display.warning(u"- %s %s was NOT installed successfully: %s " % (role.name, role.version, to_text(e)))
                 self.exit_without_ignore()
                 continue
 
@@ -1164,7 +1164,7 @@ class GalaxyCLI(CLI):
                                     display.display('- dependency %s is already installed, skipping.' % dep_role.name)
 
             if not installed:
-                display.warning("- %s was NOT installed successfully." % role.name)
+                display.warning("- %s %s was NOT installed successfully." % (role.name, role.version))
                 self.exit_without_ignore()
 
         return 0

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -184,6 +184,26 @@ popd # ${galaxy_testdir}
 rm -fr "${galaxy_testdir}"
 
 
+# Galaxy install test case
+#
+# Ensure that proper error message is thrown for non-existent role
+#
+
+f_ansible_galaxy_status \
+    "install a non-existant role"
+
+galaxy_testdir=$(mktemp -d)
+pushd "${galaxy_testdir}"
+
+    ansible-galaxy install notaroll,1.0 --ignore-errors | tee out.txt
+    
+     # Test that the proper error/warning message was thrown
+    [[ $(grep -c '- notaroll 1.0 was NOT installed successfully' out.txt ) -eq 0 ]]
+
+popd # ${galaxy_testdir}
+rm -fr "${galaxy_testdir}"
+
+
 # Galaxy role list tests
 #
 # Basic tests to ensure listing roles works

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -198,7 +198,7 @@ pushd "${galaxy_testdir}"
     ansible-galaxy install notaroll,1.0 --ignore-errors | tee out.txt
     
      # Test that the proper error/warning message was thrown
-    [[ $(grep -c '- notaroll 1.0 was NOT installed successfully' out.txt ) -eq 0 ]]
+    [[ $(grep -c '^- notaroll 1.0 was NOT installed successfully' out.txt ) -eq 0 ]]
 
 popd # ${galaxy_testdir}
 rm -fr "${galaxy_testdir}"


### PR DESCRIPTION
##### SUMMARY
cc @sudhirmohanraj, This is taken from your original PR #52853 which was closed.

Fixes: #52111 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-galaxy
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
[niks@localhost]$ ansible-galaxy install -r requirements.yml 
- downloading role 'dummy', owned by 
[WARNING]: - dummy was NOT installed successfully: None (HTTP Code: 400, Message: Bad Request)
ERROR! - you can use --ignore-errors to skip failed roles and finish processing the list.
```

After this PR:
```
(venv) [niks@localhost ]$ ansible-galaxy install -r /home/niks/ansible_test/requirements.yml 
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can
become unstable at any point.
Starting galaxy role install process
- downloading role 'dummy', owned by 
[WARNING]: - dummy 1.1 was NOT installed successfully: None (HTTP Code: 400, Message: Bad Request)
ERROR! - you can use --ignore-errors to skip failed roles and finish processing the list.
```




