### PR TITLE
Fix galaxy role info bug to support multiple roles

### DIFF
--- a/changelogs/fragments/70148-galaxy-role-info.yaml
+++ b/changelogs/fragments/70148-galaxy-role-info.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Fixes 'nsible-galaxy role info' to support multiple roles on the command line.
+  - Fixes ``ansible-galaxy role info`` to support multiple roles on the command line (https://github.com/ansible/ansible/pull/70148)

--- a/changelogs/fragments/70148-galaxy-role-info.yaml
+++ b/changelogs/fragments/70148-galaxy-role-info.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixes 'nsible-galaxy role info' to support multiple roles on the command line.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -653,6 +653,8 @@ class GalaxyCLI(CLI):
             else:
                 text.append(u"\t%s: %s" % (k, role_info[k]))
 
+        # make sure we have a trailing newline returned
+        text.append(u"")
         return u'\n'.join(text)
 
     @staticmethod
@@ -970,7 +972,7 @@ class GalaxyCLI(CLI):
             if role_spec:
                 role_info.update(role_spec)
 
-            data = self._display_role_info(role_info)
+            data += self._display_role_info(role_info)
 
         self.pager(data)
 

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -273,6 +273,13 @@ f_ansible_galaxy_status \
     ansible-galaxy role info -p ./testroles --offline testdesc | tee out.txt
     grep 'description: Top level' out.txt
 
+    # test multiple role listing
+    ansible-galaxy role init otherrole --init-path ./testroles
+    ansible-galaxy role info -p ./testroles --offline testdesc otherrole | tee out.txt
+    grep 'Role: testdesc' out.txt
+    grep 'Role: otherrole' out.txt
+
+
 popd # ${role_testdir}
 rm -fr "${role_testdir}"
 


### PR DESCRIPTION
##### SUMMARY
'ansible-galaxy role info' appears to have intended to support multiple roles being listed on the command line. It currently ignores all roles except the last. Fix that.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy

##### ADDITIONAL INFORMATION

Example output after the fix:

```
% ansible-galaxy role info --offline geerlingguy.docker geerlingguy.backup

Role: geerlingguy.docker
        description: Docker for Linux.
        dependencies: []
        galaxy_info:
                author: geerlingguy
                company: Midwestern Mac, LLC
                galaxy_tags: ['web', 'system', 'containers', 'docker', 'orchestration', 'compose', 'server']
                license: license (BSD, MIT)
                min_ansible_version: 2.4
                platforms: [{'name': 'EL', 'versions': [7, 8]}, {'name': 'Fedora', 'versions': ['all']}, {'name': 'Debian', 'versions': ['stretch', 'buster']}, {'name':
                role_name: docker
        install_date: Wed Jun 17 18:35:14 2020
        installed_version: 2.8.1
        path: ('/Users/shrews/.ansible/roles', '/usr/share/ansible/roles', '/etc/ansible/roles')

Role: geerlingguy.backup
        description: Backup for Simple Servers.
        dependencies: []
        galaxy_info:
                author: geerlingguy
                company: Midwestern Mac, LLC
                galaxy_tags: ['system', 'backup', 'resilience', 'storage', 'rsync', 'disaster', 'recovery']
                license: license (BSD, MIT)
                min_ansible_version: 2.4
                platforms: [{'name': 'EL', 'versions': ['all']}, {'name': 'GenericUNIX', 'versions': ['all']}, {'name': 'Fedora', 'versions': ['all']}, {'name': 'opensu
        install_date: Mon Jun 15 19:16:26 2020
        installed_version: 1.2.2
        path: ('/Users/shrews/.ansible/roles', '/usr/share/ansible/roles', '/etc/ansible/roles')
```
