### PR TITLE
nmcli: Add compatibility for new networkmanager library (#65726)

### DIFF
--- a/changelogs/fragments/65726-nmcli-Add-compatibility-for-new-networkmanager-library.yaml
+++ b/changelogs/fragments/65726-nmcli-Add-compatibility-for-new-networkmanager-library.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- nmcli - Add compatibility for new networkmanager library (https://github.com/ansible/ansible/pull/65726).

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -22,14 +22,18 @@ author:
 short_description: Manage Networking
 requirements:
 - dbus
-- NetworkManager-glib
+- NetworkManager-libnm (or NetworkManager-glib on older systems)
 - nmcli
 version_added: "2.0"
 description:
     - Manage the network devices. Create, modify and manage various connection and device type e.g., ethernet, teams, bonds, vlans etc.
-    - 'On CentOS and Fedora like systems, the requirements can be met by installing the following packages: NetworkManager-glib,
+    - 'On CentOS 8 and Fedora >=29 like systems, the requirements can be met by installing the following packages: NetworkManager-nmlib,
+      libsemanage-python, policycoreutils-python.'
+    - 'On CentOS 7 and Fedora <=28 like systems, the requirements can be met by installing the following packages: NetworkManager-glib,
       libnm-qt-devel.x86_64, nm-connection-editor.x86_64, libsemanage-python, policycoreutils-python.'
     - 'On Ubuntu and Debian like systems, the requirements can be met by installing the following packages: network-manager,
+      python-dbus (or python3-dbus, depending on the Python version in use), libnm-dev.'
+    - 'On older Ubuntu and Debian like systems, the requirements can be met by installing the following packages: network-manager,
       python-dbus (or python3-dbus, depending on the Python version in use), libnm-glib-dev.'
     - 'On openSUSE, the requirements can be met by installing the following packages: NetworkManager, python2-dbus-python (or
       python3-dbus-python), typelib-1_0-NMClient-1_0 and typelib-1_0-NetworkManager-1_0.'
@@ -369,7 +373,7 @@ EXAMPLES = r'''
   - name: install needed network manager libs
     package:
       name:
-        - NetworkManager-glib
+        - NetworkManager-libnm
         - nm-connection-editor
         - libsemanage-python
         - policycoreutils-python
@@ -563,16 +567,20 @@ except ImportError:
     HAVE_DBUS = False
 
 NM_CLIENT_IMP_ERR = None
+HAVE_NM_CLIENT = True
 try:
     import gi
-    gi.require_version('NMClient', '1.0')
-    gi.require_version('NetworkManager', '1.0')
-
-    from gi.repository import NetworkManager, NMClient
-    HAVE_NM_CLIENT = True
+    gi.require_version('NM', '1.0')
+    from gi.repository import NM
 except (ImportError, ValueError):
-    NM_CLIENT_IMP_ERR = traceback.format_exc()
-    HAVE_NM_CLIENT = False
+    try:
+        import gi
+        gi.require_version('NMClient', '1.0')
+        gi.require_version('NetworkManager', '1.0')
+        from gi.repository import NetworkManager, NMClient
+    except (ImportError, ValueError):
+        NM_CLIENT_IMP_ERR = traceback.format_exc()
+        HAVE_NM_CLIENT = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_native


### PR DESCRIPTION
Fixes: #48055
* add compatibility for new networkmanager library
* update debian/ubuntu docs
* move import gi into try

(cherry picked from commit 663171e21820f1696b93c3f182626b0fd006b61b)