### PR TITLE
Upgrade pylint used by ansible-test.

### DIFF
--- a/changelogs/fragments/ansible-test-pylint-upgrade.yml
+++ b/changelogs/fragments/ansible-test-pylint-upgrade.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - ansible-test - Update ``pylint`` and its dependencies to the latest available versions to support Python 3.9.
+known_issues:
+  - ansible-test - The ``pylint`` sanity test no longer correctly detects "bad" variable names for non-constants.
+                   See https://github.com/PyCQA/pylint/issues/3701 for additional details.

--- a/test/integration/targets/ansible-test/ansible_collections/ns/col/plugins/filter/check_pylint.py
+++ b/test/integration/targets/ansible-test/ansible_collections/ns/col/plugins/filter/check_pylint.py
@@ -18,4 +18,6 @@ result = {None: None}[{}.get('something')]
 # pylint 2.3.1 and 2.4.4 report the following error but 2.5.0 and 2.6.0 do not
 #   blacklisted-name: Black listed name "foo"
 # see: https://github.com/PyCQA/pylint/issues/3701
+# regression: documented as a known issue and removed from ignore.txt so pylint can be upgraded to 2.6.0
+#             if future versions of pylint fix this issue then the ignore should be restored
 foo = {}.keys()

--- a/test/integration/targets/ansible-test/ansible_collections/ns/col/tests/sanity/ignore.txt
+++ b/test/integration/targets/ansible-test/ansible_collections/ns/col/tests/sanity/ignore.txt
@@ -1,4 +1,3 @@
-plugins/filter/check_pylint.py pylint:blacklisted-name
 plugins/modules/bad.py import
 plugins/modules/bad.py pylint:ansible-bad-module-import
 tests/integration/targets/hello/files/bad.py pylint:ansible-bad-function

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -55,13 +55,15 @@ antsibull-changelog == 0.9.0
 antsibull >= 0.21.0
 
 # freeze pylint and its requirements for consistent test results
-astroid == 2.3.3
-isort == 4.3.15
+# NOTE: six is not frozen since it is a requirement for more than just pylint
+astroid == 2.4.2
+isort == 5.7.0
 lazy-object-proxy == 1.4.3
 mccabe == 0.6.1
-pylint == 2.3.1
-typed-ast == 1.4.1
-wrapt == 1.11.1
+pylint == 2.6.0
+toml == 0.10.2
+typed-ast == 1.4.2
+wrapt == 1.12.1
 
 # freeze pycodestyle for consistent test results
 pycodestyle == 2.6.0

--- a/test/lib/ansible_test/_data/sanity/pylint/config/ansible-test.cfg
+++ b/test/lib/ansible_test/_data/sanity/pylint/config/ansible-test.cfg
@@ -6,8 +6,11 @@ disable=
     cyclic-import,  # consistent results require running with --jobs 1 and testing all files
     duplicate-code,  # consistent results require running with --jobs 1 and testing all files
     import-error,  # inconsistent results which depend on the availability of imports
+    import-outside-toplevel,  # common pattern in ansible related code
     no-name-in-module,  # inconsistent results which depend on the availability of imports
     no-self-use,
+    raise-missing-from,  # Python 2.x does not support raise from
+    super-with-arguments,  # Python 2.x does not support super without arguments
     too-few-public-methods,
     too-many-ancestors,  # inconsistent results between python 3.6 and 3.7+
     too-many-arguments,

--- a/test/lib/ansible_test/_data/sanity/pylint/config/collection.cfg
+++ b/test/lib/ansible_test/_data/sanity/pylint/config/collection.cfg
@@ -36,6 +36,7 @@ disable=
     global-statement,
     global-variable-undefined,
     import-error,  # inconsistent results which depend on the availability of imports
+    import-outside-toplevel,  # common pattern in ansible related code
     import-self,
     inconsistent-return-statements,
     invalid-envvar-default,
@@ -49,6 +50,8 @@ disable=
     method-hidden,
     misplaced-comparison-constant,
     missing-docstring,
+    no-else-break,
+    no-else-continue,
     no-else-raise,
     no-else-return,
     no-init,
@@ -65,6 +68,7 @@ disable=
     pointless-string-statement,
     possibly-unused-variable,
     protected-access,
+    raise-missing-from,  # Python 2.x does not support raise from
     redefined-argument-from-local,
     redefined-builtin,
     redefined-outer-name,
@@ -76,6 +80,7 @@ disable=
     simplifiable-if-statement,
     subprocess-popen-preexec-fn,
     super-init-not-called,
+    super-with-arguments,  # Python 2.x does not support super without arguments
     superfluous-parens,
     too-few-public-methods,
     too-many-ancestors,  # inconsistent results between python 3.6 and 3.7+

--- a/test/lib/ansible_test/_data/sanity/pylint/config/default.cfg
+++ b/test/lib/ansible_test/_data/sanity/pylint/config/default.cfg
@@ -1,6 +1,7 @@
 [MESSAGES CONTROL]
 
 disable=
+    import-outside-toplevel,  # common pattern in ansible related code
     abstract-method,
     access-member-before-definition,
     arguments-differ,
@@ -49,6 +50,8 @@ disable=
     method-hidden,
     misplaced-comparison-constant,
     missing-docstring,
+    no-else-break,
+    no-else-continue,
     no-else-raise,
     no-else-return,
     no-init,
@@ -65,6 +68,7 @@ disable=
     pointless-string-statement,
     possibly-unused-variable,
     protected-access,
+    raise-missing-from,  # Python 2.x does not support raise from
     redefined-argument-from-local,
     redefined-builtin,
     redefined-outer-name,
@@ -76,6 +80,7 @@ disable=
     simplifiable-if-statement,
     subprocess-popen-preexec-fn,
     super-init-not-called,
+    super-with-arguments,  # Python 2.x does not support super without arguments
     superfluous-parens,
     too-few-public-methods,
     too-many-ancestors,  # inconsistent results between python 3.6 and 3.7+

--- a/test/lib/ansible_test/_data/sanity/pylint/config/sanity.cfg
+++ b/test/lib/ansible_test/_data/sanity/pylint/config/sanity.cfg
@@ -6,8 +6,11 @@ disable=
     cyclic-import,  # consistent results require running with --jobs 1 and testing all files
     duplicate-code,  # consistent results require running with --jobs 1 and testing all files
     import-error,  # inconsistent results which depend on the availability of imports
+    import-outside-toplevel,  # common pattern in ansible related code
     missing-docstring,
     no-name-in-module,  # inconsistent results which depend on the availability of imports
+    raise-missing-from,  # Python 2.x does not support raise from
+    super-with-arguments,  # Python 2.x does not support super without arguments
     too-few-public-methods,
     too-many-ancestors,  # inconsistent results between python 3.6 and 3.7+
     too-many-arguments,

--- a/test/lib/ansible_test/_internal/sanity/pylint.py
+++ b/test/lib/ansible_test/_internal/sanity/pylint.py
@@ -64,14 +64,6 @@ class PylintTest(SanitySingleVersion):
         """Error code for ansible-test matching the format used by the underlying test program, or None if the program does not use error codes."""
         return 'ansible-test'
 
-    @property
-    def supported_python_versions(self):  # type: () -> t.Optional[t.Tuple[str, ...]]
-        """A tuple of supported Python versions or None if the test does not depend on specific Python versions."""
-        # Python 3.9 is not supported on pylint < 2.5.0.
-        # Unfortunately pylint 2.5.0 and later include an unfixed regression.
-        # See: https://github.com/PyCQA/pylint/issues/3701
-        return tuple(python_version for python_version in super(PylintTest, self).supported_python_versions if python_version not in ('3.9',))
-
     def filter_targets(self, targets):  # type: (t.List[TestTarget]) -> t.List[TestTarget]
         """Return the given list of test targets, filtered to include only those relevant for the test."""
         return [target for target in targets if os.path.splitext(target.path)[1] == '.py' or is_subdir(target.path, 'bin')]

--- a/test/sanity/code-smell/rstcheck.py
+++ b/test/sanity/code-smell/rstcheck.py
@@ -28,6 +28,7 @@ def main():
                              stdin=subprocess.DEVNULL,
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE,
+                             check=False,
                              )
 
     if process.stdout:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -144,7 +144,6 @@ lib/ansible/plugins/lookup/sequence.py pylint:blacklisted-name
 lib/ansible/plugins/strategy/__init__.py pylint:blacklisted-name
 lib/ansible/plugins/strategy/linear.py pylint:blacklisted-name
 lib/ansible/vars/hostvars.py pylint:blacklisted-name
-test/integration/targets/ansible-test/ansible_collections/ns/col/plugins/filter/check_pylint.py pylint:blacklisted-name
 test/integration/targets/ansible-test-docker/ansible_collections/ns/col/plugins/modules/hello.py pylint:relative-beyond-top-level
 test/integration/targets/ansible-test-docker/ansible_collections/ns/col/tests/unit/plugins/module_utils/test_my_util.py pylint:relative-beyond-top-level
 test/integration/targets/ansible-test-docker/ansible_collections/ns/col/tests/unit/plugins/modules/test_hello.py pylint:relative-beyond-top-level

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -72,6 +72,7 @@ lib/ansible/module_utils/six/__init__.py no-basestring
 lib/ansible/module_utils/six/__init__.py no-dict-iteritems
 lib/ansible/module_utils/six/__init__.py no-dict-iterkeys
 lib/ansible/module_utils/six/__init__.py no-dict-itervalues
+lib/ansible/module_utils/six/__init__.py pylint:self-assigning-variable
 lib/ansible/module_utils/six/__init__.py replace-urlopen
 lib/ansible/module_utils/urls.py pylint:blacklisted-name
 lib/ansible/module_utils/urls.py replace-urlopen

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -203,8 +203,10 @@ test/lib/ansible_test/_data/requirements/sanity.ps1 pslint:PSCustomUseLiteralPat
 test/lib/ansible_test/_data/sanity/pylint/plugins/string_format.py use-compat-six
 test/lib/ansible_test/_data/setup/ConfigureRemotingForAnsible.ps1 pslint:PSCustomUseLiteralPath
 test/lib/ansible_test/_data/setup/windows-httptester.ps1 pslint:PSCustomUseLiteralPath
+test/support/integration/plugins/module_utils/aws/core.py pylint:property-with-parameters
 test/support/integration/plugins/module_utils/cloud.py future-import-boilerplate
 test/support/integration/plugins/module_utils/cloud.py metaclass-boilerplate
+test/support/integration/plugins/module_utils/cloud.py pylint:isinstance-second-argument-not-valid-type
 test/support/integration/plugins/module_utils/compat/ipaddress.py future-import-boilerplate
 test/support/integration/plugins/module_utils/compat/ipaddress.py metaclass-boilerplate
 test/support/integration/plugins/module_utils/compat/ipaddress.py no-unicode-literals
@@ -213,6 +215,8 @@ test/support/integration/plugins/module_utils/database.py metaclass-boilerplate
 test/support/integration/plugins/module_utils/mysql.py future-import-boilerplate
 test/support/integration/plugins/module_utils/mysql.py metaclass-boilerplate
 test/support/integration/plugins/module_utils/network/common/utils.py future-import-boilerplate
+test/support/network-integration/collections/ansible_collections/ansible/netcommon/plugins/module_utils/network/common/facts/facts.py pylint:unnecessary-comprehension
+test/support/network-integration/collections/ansible_collections/ansible/netcommon/plugins/netconf/default.py pylint:unnecessary-comprehension
 test/support/integration/plugins/module_utils/network/common/utils.py metaclass-boilerplate
 test/support/integration/plugins/module_utils/postgres.py future-import-boilerplate
 test/support/integration/plugins/module_utils/postgres.py metaclass-boilerplate


### PR DESCRIPTION
##### SUMMARY

This upgrades the pylint version used in ansible-test from 2.3.1 to 2.6.0. It also upgrades all the pylint dependencies to their latest versions.

This enables running of the pylint sanity test on Python 3.9.

Replaces https://github.com/ansible/ansible/pull/68073

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

This PR is currently blocked on a change in behavior with pylint starting with version 2.5.0 which causes the blacklisted-name check to be skipped on constants: https://github.com/PyCQA/pylint/issues/3701

Ideally this PR can be updated once a fixed version of pylint is released.