### PR TITLE
Fix up the redirection of the win setup module

### DIFF
--- a/changelogs/fragments/win_setup-redirection.yaml
+++ b/changelogs/fragments/win_setup-redirection.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win setup - Fix redirection path for the windows setup module

--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -4096,11 +4096,11 @@ plugin_routing:
       redirect: ansible.posix.selinux
     sysctl:
       redirect: ansible.posix.sysctl
-    async_status:
+    async_status.ps1:
       redirect: ansible.windows.async_status
     setup.ps1:
-      redirect: ansible.windows.setup.ps1
-    slurp:
+      redirect: ansible.windows.setup
+    slurp.ps1:
       redirect: ansible.windows.slurp
     win_acl:
       redirect: ansible.windows.win_acl


### PR DESCRIPTION
##### SUMMARY
The setup module for Windows has the extension in the redirected module path which caused the failure

```
2019 | FAILED! => {
    "msg": "The module setup was redirected to ansible.windows.setup.ps1, which could not be loaded."
}
```

By removing the extension it is properly redirected to the ansible.windows collection. This also adds the `.ps1` extensions to the windows slurp and async_status redirection entries (not the target) to ensure they are only chosen over the Python async_status/slrup module if the user targets a Windows host.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup