### PR TITLE
docs: Add note about ansible-doc

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_locally.rst
+++ b/docs/docsite/rst/dev_guide/developing_locally.rst
@@ -45,6 +45,10 @@ To confirm that ``my_custom_module`` is available:
 
 * type ``ansible-doc -t module my_custom_module``. You should see the documentation for that module.
 
+.. note::
+
+	Currently, ``ansible-doc`` command can only parse Python modules for the module documentation. If you have module written in a different programming language other than Python, please write a documentation in Python file adjacent to module file.
+
 To use a local module only in certain playbooks:
 
 * store it in a sub-directory called ``library`` in the directory that contains the playbook(s)


### PR DESCRIPTION
##### SUMMARY

ansible-doc can only parse Python modules, added a note about
this is developer guide.

Fixes: #69109

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/developing_locally.rst
