### PR TITLE
[2.9] hashi_vault: Handle equal sign in secret name value

### DIFF
--- a/changelogs/fragments/55658_hashi_vault.yml
+++ b/changelogs/fragments/55658_hashi_vault.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- hashi_vault - Handle equal sign in key=value (https://github.com/ansible/ansible/issues/55658).

--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -269,7 +269,7 @@ class LookupModule(LookupBase):
 
         for param in vault_args:
             try:
-                key, value = param.split('=')
+                key, value = param.split('=', 1)
             except ValueError:
                 raise AnsibleError("hashi_vault lookup plugin needs key=value pairs, but received %s" % terms)
             vault_dict[key] = value

--- a/test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/approle_test.yml
+++ b/test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/approle_test.yml
@@ -30,7 +30,7 @@
 
     - name: 'Failure expected when inexistent secret is read'
       vars:
-        secret_inexistent: "{{ lookup('hashi_vault', conn_params ~ 'secret=' ~ vault_base_path ~ '/secret4 auth_method=approle secret_id=' ~ secret_id ~ ' role_id=' ~ role_id) }}"
+        secret_inexistent: "{{ lookup('hashi_vault', conn_params ~ 'secret=' ~ vault_base_path ~ '/non_existent_secret4 auth_method=approle secret_id=' ~ secret_id ~ ' role_id=' ~ role_id) }}"
       debug:
         msg: 'Failure is expected ({{ secret_inexistent }})'
       register: test_inexistent

--- a/test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
+++ b/test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
@@ -87,10 +87,16 @@
                   path "{{ vault_base_path }}/secret3" {
                     capabilities = ["deny"]
                   }
+                  path "{{ vault_base_path }}/secret4" {
+                    capabilities = ["read", "update"]
+                  }
 
             - name: 'Create secrets'
               command: '{{ vault_cmd }} kv put {{ vault_base_path_kv }}/secret{{ item }} value=foo{{ item }}'
-              loop: [1, 2, 3]
+              loop: [1, 2, 3, 4]
+
+            - name: 'Update KV v2 secret4 with new value to create version'
+              command: '{{ vault_cmd }} kv put {{ vault_base_path_kv }}/secret4 value=foo5'
 
             - name: setup approle auth
               import_tasks: approle_setup.yml

--- a/test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
+++ b/test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
@@ -6,11 +6,12 @@
         secret1: "{{ lookup('hashi_vault', conn_params ~ 'secret=' ~ vault_base_path ~ '/secret1 auth_method=token token=' ~ user_token) }}"
         secret2: "{{ lookup('hashi_vault', conn_params ~ 'secret=' ~ vault_base_path ~ '/secret2 token=' ~ user_token) }}"
         secret3: "{{ lookup('hashi_vault', conn_params ~ ' secret=' ~ vault_base_path ~ '/secret2  token=' ~ user_token) }}"
+        secret4: "{{ lookup('hashi_vault', conn_params ~ ' secret=' ~ vault_base_path ~ '/secret4?version=2  token=' ~ user_token) }}"
 
     - name: 'Check secret values'
       fail:
         msg: 'unexpected secret values'
-      when: secret1['data']['value'] != 'foo1' or secret2['data']['value'] != 'foo2' or secret3['data']['value'] != 'foo2'
+      when: secret1['data']['value'] != 'foo1' or secret2['data']['value'] != 'foo2' or secret3['data']['value'] != 'foo2' or secret4['data']['value'] != 'foo5'
 
     - name: 'Failure expected when erroneous credentials are used'
       vars:
@@ -30,7 +31,7 @@
 
     - name: 'Failure expected when inexistent secret is read'
       vars:
-        secret_inexistent: "{{ lookup('hashi_vault', conn_params ~ 'secret=' ~ vault_base_path ~ '/secret4 token=' ~ user_token) }}"
+        secret_inexistent: "{{ lookup('hashi_vault', conn_params ~ 'secret=' ~ vault_base_path ~ '/non_existent_secret4 token=' ~ user_token) }}"
       debug:
         msg: 'Failure is expected ({{ secret_inexistent }})'
       register: test_inexistent


### PR DESCRIPTION
##### SUMMARY

Fixes: ansible/ansible#55658

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

Backport of ansible-collections/community.general#537

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/55658_hashi_vault.yml
lib/ansible/plugins/lookup/hashi_vault.py
test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/main.yml
test/integration/targets/lookup_hashi_vault/lookup_hashi_vault/tasks/token_test.yml
