### PR TITLE
[stable-2.10] Only pass kwargs to our string checker not callable checkers (#70151)

### DIFF
--- a/changelogs/fragments/70017-avoid-params-to-callable-checkers.yml
+++ b/changelogs/fragments/70017-avoid-params-to-callable-checkers.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    if the ``type`` for a module parameter in the argument spec is callable,
+    do not pass ``kwargs`` to avoid errors (https://github.com/ansible/ansible/issues/70017)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1764,8 +1764,9 @@ class AnsibleModule(object):
         type_checker, wanted_name = self._get_wanted_type(wanted, param)
         validated_params = []
         # Get param name for strings so we can later display this value in a useful error message if needed
+        # Only pass 'kwargs' to our checkers and ignore custom callable checkers
         kwargs = {}
-        if wanted_name == 'str':
+        if wanted_name == 'str' and isinstance(wanted, string_types):
             if isinstance(param, string_types):
                 kwargs['param'] = param
             elif isinstance(param, dict):
@@ -1800,8 +1801,9 @@ class AnsibleModule(object):
 
             type_checker, wanted_name = self._get_wanted_type(wanted, k)
             # Get param name for strings so we can later display this value in a useful error message if needed
+            # Only pass 'kwargs' to our checkers and ignore custom callable checkers
             kwargs = {}
-            if wanted_name == 'str':
+            if wanted_name == 'str' and isinstance(type_checker, string_types):
                 kwargs['param'] = list(param.keys())[0]
 
                 # Get the name of the parent key if this is a nested option


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #70151 for Ansible 2.10
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/basic.py`