### PR TITLE
Collection list site packages

### DIFF
--- a/changelogs/fragments/collection-list-site-packages.yaml
+++ b/changelogs/fragments/collection-list-site-packages.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- Fix ansible-galaxy collection list to show collections in site-packages
+  (https://github.com/ansible/ansible/issues/70147)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -43,6 +43,7 @@ from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.yaml.loader import AnsibleLoader
 from ansible.playbook.role.requirement import RoleRequirement
 from ansible.template import Templar
+from ansible.utils.collection_loader import AnsibleCollectionConfig
 from ansible.utils.display import Display
 from ansible.utils.plugin_docs import get_versioned_doclink
 
@@ -155,7 +156,8 @@ class GalaxyCLI(CLI):
 
         collections_path = opt_help.argparse.ArgumentParser(add_help=False)
         collections_path.add_argument('-p', '--collection-path', dest='collections_path', type=opt_help.unfrack_path(pathsep=True),
-                                      default=C.COLLECTIONS_PATHS, action=opt_help.PrependListAction,
+                                      default=AnsibleCollectionConfig.collection_paths,
+                                      action=opt_help.PrependListAction,
                                       help="One or more directories to search for collections in addition "
                                       "to the default COLLECTIONS_PATHS. Separate multiple paths "
                                       "with '{0}'.".format(os.path.pathsep))
@@ -1262,7 +1264,7 @@ class GalaxyCLI(CLI):
 
         collections_search_paths = set(context.CLIARGS['collections_path'])
         collection_name = context.CLIARGS['collection']
-        default_collections_path = C.config.get_configuration_definition('COLLECTIONS_PATHS').get('default')
+        default_collections_path = AnsibleCollectionConfig.collection_paths
 
         warnings = []
         path_found = False

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -415,6 +415,17 @@ f_ansible_galaxy_status \
 
 unset ANSIBLE_COLLECTIONS_PATH
 
+f_ansible_galaxy_status \
+    "collection list with collections installed from python package"
+
+    mkdir -p test-site-packages
+    ln -s ${galaxy_testdir}/local/ansible_collections test-site-packages/ansible_collections
+    ansible-galaxy collection list
+    PYTHONPATH=./test-site-packages/:$PYTHONPATH ansible-galaxy collection list | tee out.txt
+
+    grep ".ansible/collections/ansible_collections" out.txt
+    grep "test-site-packages/ansible_collections" out.txt
+
 ## end ansible-galaxy collection list
 
 

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -419,9 +419,9 @@ f_ansible_galaxy_status \
     "collection list with collections installed from python package"
 
     mkdir -p test-site-packages
-    ln -s ${galaxy_testdir}/local/ansible_collections test-site-packages/ansible_collections
+    ln -s "${galaxy_testdir}/local/ansible_collections" test-site-packages/ansible_collections
     ansible-galaxy collection list
-    PYTHONPATH=./test-site-packages/:$PYTHONPATH ansible-galaxy collection list | tee out.txt
+    PYTHONPATH="./test-site-packages/:$PYTHONPATH" ansible-galaxy collection list | tee out.txt
 
     grep ".ansible/collections/ansible_collections" out.txt
     grep "test-site-packages/ansible_collections" out.txt


### PR DESCRIPTION
##### SUMMARY
ansible-galaxy collection list now lists collections in site-packages.
    
This is a short term (2.10) fix for #70147.  For 2.11+ we need to implement something that handles the install case too.  but that is bound up in the discussion about collection update.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
* lib/ansible/cli/galaxy.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
