### PR TITLE
[stable-2.9] Pin version of netaddr and jmespath in filters test

### DIFF
--- a/test/integration/targets/filters/runme.sh
+++ b/test/integration/targets/filters/runme.sh
@@ -7,6 +7,6 @@ source virtualenv.sh
 # Requirements have to be installed prior to running ansible-playbook
 # because plugins and requirements are loaded before the task runs
 
-pip install jmespath netaddr
+pip install jmespath==0.10.0 netaddr==0.7.19
 
 ANSIBLE_ROLES_PATH=../ ansible-playbook filters.yml "$@"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`netaddr` was recently updated and it no longer works on older versions of Python.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/filters/runme.sh`