### PR TITLE
Disable ansible-galaxy-collection test

### DIFF
--- a/test/integration/targets/ansible-galaxy-collection/aliases
+++ b/test/integration/targets/ansible-galaxy-collection/aliases
@@ -1,3 +1,4 @@
 shippable/galaxy/group1
 shippable/galaxy/smoketest
 cloud/galaxy
+disabled


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It it currently failing waiting for collections to be setup.

Some failing tests:
https://app.shippable.com/github/ansible/ansible/runs/168854/87/tests

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/ansible-galaxy-collection`

##### ADDITIONAL INFORMATION
**Steps to Reproduce:**

```
ansible-test integration --docker centos8 ansible-galaxy-collection -v
```

```
...
TASK [ansible-galaxy-collection : setup test collections for install and download test] ***
changed: [testhost] => (item=http://fallaxy-stub:8080/api/) => {"ansible_job_id": "248846212491.1178", "ansible_loop_var": "item", "changed": true, "finished": 0, "item": "http://fallaxy-stub:8080/api/", "results_file": "/root/.ansible_async/248846212491.1178", "started": 1}
changed: [testhost] => (item=pulp_v2) => {"ansible_job_id": "195281005987.1195", "ansible_loop_var": "item", "changed": true, "finished": 0, "item": "pulp_v2", "results_file": "/root/.ansible_async/195281005987.1195", "started": 1}

TASK [ansible-galaxy-collection : Wait for setup_collections] ******************
FAILED - RETRYING: Wait for setup_collections (300 retries left).
FAILED - RETRYING: Wait for setup_collections (299 retries left).
FAILED - RETRYING: Wait for setup_collections (298 retries left).
FAILED - RETRYING: Wait for setup_collections (297 retries left).
FAILED - RETRYING: Wait for setup_collections (296 retries left).
FAILED - RETRYING: Wait for setup_collections (295 retries left).
...
```

