### PR TITLE
Fix up the redirection of the win setup module (#70158) - 2.10

### DIFF
--- a/changelogs/fragments/win_setup-redirection.yaml
+++ b/changelogs/fragments/win_setup-redirection.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win setup - Fix redirection path for the windows setup module

--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -4096,11 +4096,11 @@ plugin_routing:
       redirect: ansible.posix.selinux
     sysctl:
       redirect: ansible.posix.sysctl
-    async_status:
+    async_status.ps1:
       redirect: ansible.windows.async_status
     setup.ps1:
-      redirect: ansible.windows.setup.ps1
-    slurp:
+      redirect: ansible.windows.setup
+    slurp.ps1:
       redirect: ansible.windows.slurp
     win_acl:
       redirect: ansible.windows.win_acl


### PR DESCRIPTION
(cherry picked from commit 8b24a4c5ed0ca96015bf39f6dbe94546d4f28404)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/70158

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup
async_status
slurp