### PR TITLE
[stable-2.10] Rebalance CI groups to avoid macOS timeouts (#70126)

### DIFF
--- a/test/integration/targets/ansible-galaxy/aliases
+++ b/test/integration/targets/ansible-galaxy/aliases
@@ -1,4 +1,4 @@
 destructive
-shippable/posix/group3
+shippable/posix/group4
 skip/python2.6  # build uses tarfile with features not available until 2.7
 skip/aix

--- a/test/integration/targets/callback_default/aliases
+++ b/test/integration/targets/callback_default/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group1
 skip/aix

--- a/test/integration/targets/connection_ssh/aliases
+++ b/test/integration/targets/connection_ssh/aliases
@@ -1,3 +1,3 @@
 needs/ssh
-shippable/posix/group3
+shippable/posix/group1
 skip/aix

--- a/test/integration/targets/include_import/aliases
+++ b/test/integration/targets/include_import/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 skip/aix

--- a/test/integration/targets/module_precedence/aliases
+++ b/test/integration/targets/module_precedence/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group3
+shippable/posix/group1

--- a/test/integration/targets/pause/aliases
+++ b/test/integration/targets/pause/aliases
@@ -1,3 +1,3 @@
 needs/target/setup_pexpect
-shippable/posix/group3
+shippable/posix/group1
 skip/aix


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #70126 for Ansible 2.10
(cherry picked from commit b2d6db7916)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/ansible-galaxy/aliases`
`test/integration/targets/callback_default/aliases`
`test/integration/targets/connection_ssh/aliases`
`test/integration/targets/include_import/aliases`
`test/integration/targets/module_precedence/aliases`
`test/integration/targets/pause/aliases`