### PR TITLE
ansible-galaxy - do not require mandatory keys when listing collections

### DIFF
--- a/changelogs/fragments/70180-collection-list-more-robust.yml
+++ b/changelogs/fragments/70180-collection-list-more-robust.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - do not require mandatory keys in ``galaxy.yml`` for a collection (https://github.com/ansible/ansible/issues/70180)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1339,7 +1339,7 @@ class GalaxyCLI(CLI):
                 collection_path = validate_collection_path(path)
                 if os.path.isdir(collection_path):
                     display.vvv("Searching {0} for collections".format(collection_path))
-                    collections = find_existing_collections(collection_path, fallback_metadata=True)
+                    collections = find_existing_collections(collection_path, fallback_metadata=True, require_mandatory_keys=False)
                 else:
                     # There was no 'ansible_collections/' directory in the path, so there
                     # or no collections here.

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -40,6 +40,7 @@ from ansible.galaxy.user_agent import user_agent
 from ansible.module_utils import six
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.utils.collection_loader import AnsibleCollectionRef
+from ansible.module_utils.common._collections_compat import MutableMapping
 from ansible.utils.display import Display
 from ansible.utils.galaxy import scm_archive_collection
 from ansible.utils.hashing import secure_hash, secure_hash_s
@@ -869,6 +870,7 @@ def _display_progress(msg=None):
     finally:
         display = old_display
 
+
 def _get_galaxy_yml(b_galaxy_yml_path, require_mandatory_keys=True):
     meta_info = get_collections_galaxy_meta_info()
 
@@ -896,6 +898,10 @@ def _get_galaxy_yml(b_galaxy_yml_path, require_mandatory_keys=True):
     except YAMLError as err:
         raise AnsibleError("Failed to parse the galaxy.yml at '%s' with the following error:\n%s"
                            % (to_native(b_galaxy_yml_path), to_native(err)))
+
+    # Sanity test on the contents of the galaxy.yml file
+    if not isinstance(galaxy_yml, MutableMapping):
+        raise AnsibleError("The collection galaxy.yml at '%s' is incorrectly formatted." % to_native(b_galaxy_yml_path))
 
     if require_mandatory_keys:
         set_keys = set(galaxy_yml.keys())

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -282,6 +282,37 @@ def test_missing_required_galaxy_key(galaxy_yml):
         collection._get_galaxy_yml(galaxy_yml)
 
 
+@pytest.mark.parametrize('galaxy_yml', [b'namespace: test_namespace'], indirect=True)
+def test_galaxy_yaml_no_mandatory_keys(galaxy_yml):
+    expected = {
+        'authors': [],
+        'build_ignore': [],
+        'dependencies': {},
+        'description': None,
+        'documentation': None,
+        'homepage': None,
+        'issues': None,
+        'license_file': None,
+        'license_ids': [],
+        'name': None,
+        'namespace': 'test_namespace',
+        'readme': None,
+        'repository': None,
+        'tags': [],
+        'version': None
+    }
+
+    assert collection._get_galaxy_yml(galaxy_yml, False) == expected
+
+
+@pytest.mark.parametrize('galaxy_yml', [b'My life story is so very interesting'], indirect=True)
+def test_galaxy_yaml_no_mandatory_keys_bad_yaml(galaxy_yml):
+    expected = "The collection galaxy.yml at '%s' is incorrectly formatted." % to_native(galaxy_yml)
+
+    with pytest.raises(AnsibleError, match=expected):
+        collection._get_galaxy_yml(galaxy_yml, False)
+
+
 @pytest.mark.parametrize('galaxy_yml', [b"""
 namespace: namespace
 name: collection


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If the `galaxy.yml` file does not contain mandatory keys, display a warning and `*` for the version number.

This fix feels very leaky. `collection list` may be better off using its own method to get metadata about a collection rather than relying on existing functions. Many of the existing functions enforce strict standards, which make sense for everything but `list`, which should be robust and just display information about installed collections.

Fixes #70180

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/cli/galaxy.py`
`lib/ansible/galaxy/collection.py`

##### ADDITIONAL INFORMATION

- [x] Tests

This will still display a warning about an improper/missing version number:
```
> ansible-galaxy collection list

# /usr/local/share/ansible/collections/ansible_collections
Collection        Version
----------------- -------
fortinet.fortios  1.0.6
pureport.pureport 0.0.8
sensu.sensu_go    1.3.0
[WARNING]: Collection at '/Users/sdoran/.ansible/collections/ansible_collections/community/vmware' does not have a valid
version set, falling back to '*'. Found version: 'None'

# /Users/sdoran/.ansible/collections/ansible_collections
Collection                       Version
-------------------------------- ------------
amazon.aws                       0.1.2
ansible.netcommon                0.0.3
ansible.posix                    0.1.1
ansible.windows                  0.0.1-beta.2
awx.awx                          1.0.0
azure.azcollection               1.0.0
check_point.mgmt                 1.0.0
cisco.aci                        1.0.0
cisco.intersight                 1.0.0
cisco.iosxr                      1.0.0
cisco.meraki                     1.0.0
cisco.mso                        1.0.0
cisco.nxos                       1.0.0
cisco.ucs                        1.0.0
community.amazon                 1.0.0
community.general                0.1.1
community.grafana                1.0.0
community.kubernetes             1.0.0
community.vmware                 *
f5networks.f5_modules            1.0.0
fortinet.fortios                 1.0.0
gavinfish.azuretest              1.0.0
google.cloud                     1.0.0
junipernetworks.junos            1.0.0
netapp.aws                       1.0.0
netapp.ontap                     20.2.0
netbox_community.ansible_modules 1.0.0
openstack.cloud                  0.0.1-dev85
pandemonium1986.openstack        1.0.2
samdoran.hiveos                  1.5.0
splunk.enterprise_security       1.0.0
```

That warning is coming from `CollectionRequirement.from_path()`. I could silence the warning in there in we want only for `list`. At a certain point, it feels like `list` is fighting these methods more than using them, though.

I'm open to better ways to solve this, to make `collection list` more robust and not bloat existing methods with extra parameters needed _only_ by `collection list`. It's late on a Friday and this is what I came up with as a first past. 😩 