### PR TITLE
display: use stdout for column width

### DIFF
--- a/changelogs/fragments/display-stdout-column-width.yml
+++ b/changelogs/fragments/display-stdout-column-width.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Ansible output now uses stdout to determine column width instead of stdin

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -430,8 +430,8 @@ class Display(with_metaclass(Singleton, object)):
         return encoding
 
     def _set_column_width(self):
-        if os.isatty(0):
-            tty_size = unpack('HHHH', fcntl.ioctl(0, TIOCGWINSZ, pack('HHHH', 0, 0, 0, 0)))[1]
+        if os.isatty(1):
+            tty_size = unpack('HHHH', fcntl.ioctl(1, TIOCGWINSZ, pack('HHHH', 0, 0, 0, 0)))[1]
         else:
             tty_size = 0
         self.columns = max(79, tty_size - 1)


### PR DESCRIPTION
stdout may differ from stdin so it should be used to determin the column
width, especially since it is the target fd.

---

In my use case, I have Ansible executed by a script. I open a new pty and prefix
Ansibe output with some other messages. The new pty has changed column width so
the Ansible output stars have correct length. But since Ansible reads attributes
of stdin isntead of stdout, it does not work.


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```