### PR TITLE
2.9: Detect failure in always block after rescue (#70094)

### DIFF
--- a/changelogs/fragments/70000-playbook-detect-failure-in-always.yml
+++ b/changelogs/fragments/70000-playbook-detect-failure-in-always.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - playbooks - detect and propagate failures in ``always`` blocks after ``rescue`` (https://github.com/ansible/ansible/issues/70000)

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -489,7 +489,7 @@ class PlayIterator:
             elif state.run_state == self.ITERATING_ALWAYS and state.fail_state & self.FAILED_ALWAYS == 0:
                 return False
             else:
-                return not state.did_rescue
+                return not (state.did_rescue and state.fail_state & self.FAILED_ALWAYS == 0)
         elif state.run_state == self.ITERATING_TASKS and self._check_failed_state(state.tasks_child_state):
             cur_block = self._blocks[state.cur_block]
             if len(cur_block.rescue) > 0 and state.fail_state & self.FAILED_RESCUE == 0:

--- a/test/integration/targets/blocks/always_failure_no_rescue_rc.yml
+++ b/test/integration/targets/blocks/always_failure_no_rescue_rc.yml
@@ -1,0 +1,13 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - block:
+        - name: EXPECTED FAILURE
+          fail:
+            msg: Failure in block
+      always:
+        - name: EXPECTED FAILURE
+          fail:
+            msg: Failure in always
+    - debug:
+        msg: DID NOT RUN

--- a/test/integration/targets/blocks/always_failure_with_rescue_rc.yml
+++ b/test/integration/targets/blocks/always_failure_with_rescue_rc.yml
@@ -1,0 +1,16 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - block:
+        - name: EXPECTED FAILURE
+          fail:
+            msg: Failure in block
+      rescue:
+        - debug:
+            msg: Rescue
+      always:
+        - name: EXPECTED FAILURE
+          fail:
+            msg: Failure in always
+    - debug:
+        msg: DID NOT RUN

--- a/test/integration/targets/blocks/always_no_rescue_rc.yml
+++ b/test/integration/targets/blocks/always_no_rescue_rc.yml
@@ -1,0 +1,12 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - block:
+        - name: EXPECTED FAILURE
+          fail:
+            msg: Failure in block
+      always:
+        - debug:
+            msg: Always
+    - debug:
+        msg: DID NOT RUN

--- a/test/integration/targets/blocks/runme.sh
+++ b/test/integration/targets/blocks/runme.sh
@@ -39,3 +39,38 @@ env python -c \
 [ "$(grep -c 'TEST COMPLETE' block_test.out)" = "$(grep -E '^[0-9]+ plays in' block_test_wo_colors.out | cut -f1 -d' ')" ]
 
 ansible-playbook -vv block_rescue_vars.yml
+
+# https://github.com/ansible/ansible/issues/70000
+set +e
+exit_code=0
+ansible-playbook -vv always_failure_with_rescue_rc.yml > rc_test.out || exit_code=$?
+set -e
+cat rc_test.out
+[ $exit_code -eq 2 ]
+[ "$(grep -c 'Failure in block' rc_test.out )" -eq 1 ]
+[ "$(grep -c 'Rescue' rc_test.out )" -eq 1 ]
+[ "$(grep -c 'Failure in always' rc_test.out )" -eq 1 ]
+[ "$(grep -c 'DID NOT RUN' rc_test.out )" -eq 0 ]
+rm -f rc_test_out
+
+set +e
+exit_code=0
+ansible-playbook -vv always_no_rescue_rc.yml > rc_test.out || exit_code=$?
+set -e
+cat rc_test.out
+[ $exit_code -eq 2 ]
+[ "$(grep -c 'Failure in block' rc_test.out )" -eq 1 ]
+[ "$(grep -c 'Always' rc_test.out )" -eq 1 ]
+[ "$(grep -c 'DID NOT RUN' rc_test.out )" -eq 0 ]
+rm -f rc_test.out
+
+set +e
+exit_code=0
+ansible-playbook -vv always_failure_no_rescue_rc.yml > rc_test.out || exit_code=$?
+set -e
+cat rc_test.out
+[ $exit_code -eq 2 ]
+[ "$(grep -c 'Failure in block' rc_test.out )" -eq 1 ]
+[ "$(grep -c 'Failure in always' rc_test.out )" -eq 1 ]
+[ "$(grep -c 'DID NOT RUN' rc_test.out )" -eq 0 ]
+rm -f rc_test.out


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of https://github.com/ansible/ansible/pull/70094

(cherry picked from commit 0ed5b7737708127899762ba768af93cae11e116a)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
play_iterator.py
