### PR TITLE
[stable-2.9] Pin version of netaddr in docker_container test

### DIFF
--- a/test/integration/targets/docker_container/tasks/main.yml
+++ b/test/integration/targets/docker_container/tasks/main.yml
@@ -12,7 +12,7 @@
 # Install netaddr
 - name: Install netaddr for ipaddr filter
   pip:
-    name: netaddr
+    name: netaddr==0.7.19
 
 # Run the tests
 - block:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A recent update to `netaddr` broke Python 2.7 support.

This was fixed in [community.general](https://github.com/ansible-collections/community.general/commit/a6c225e4a0fd3efe8797385c6c825bb6270802ba#diff-20d7d456274a65bddb17c3f5ea13105a) by removing the use of the filter (`ipaddr`) that relied upon `netaddr`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/docker_container`