### PR TITLE
Nuke systemd module user option, 2.11 deprecation

### DIFF
--- a/changelogs/fragments/deprecation-systemd-user.yml
+++ b/changelogs/fragments/deprecation-systemd-user.yml
@@ -1,0 +1,2 @@
+removed_features:
+  - The "user" parameter was previously deprecated and is now removed in favor of "scope"

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -209,7 +209,6 @@ lib/ansible/modules/service.py validate-modules:use-run-command-not-popen
 lib/ansible/modules/setup.py validate-modules:doc-missing-type
 lib/ansible/modules/setup.py validate-modules:parameter-list-no-elements
 lib/ansible/modules/setup.py validate-modules:parameter-type-not-in-doc
-lib/ansible/modules/systemd.py pylint:ansible-deprecated-version
 lib/ansible/modules/systemd.py validate-modules:parameter-invalid
 lib/ansible/modules/systemd.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/systemd.py validate-modules:return-syntax-error


### PR DESCRIPTION

##### SUMMARY

Change:
Remove all references to the 'user' param in systemd module.

Test Plan:
CI and grep.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
systemd