### PR TITLE
bug fixing in azure_rm_aks.py

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_aks.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_aks.py
@@ -327,6 +327,8 @@ def create_addon_dict(addon):
     addon = addon or dict()
     for key in addon.keys():
         result[key] = addon[key].config
+        if result[key] is None:
+            result[key] = {}
         result[key]['enabled'] = addon[key].enabled
     return result
 


### PR DESCRIPTION
##### SUMMARY
fixing a severe bug in azure_rm

avoid  'NoneType' object item assignment in create_addon_dict function

the same bug has been fixed in azure collection, see  https://github.com/ansible-collections/azure/pull/170

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_aks.py

