### PR TITLE
When updating gcp_compute_backend_service make sure to pass required parameter fingerprint

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_compute_backend_service.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_backend_service.py
@@ -248,7 +248,7 @@ options:
     description:
     - Fingerprint of this resource. A hash of the contents stored in this object. This
       field is used in optimistic locking.
-	required: false
+    required: false
     type: str
   enable_cdn:
     description:

--- a/lib/ansible/modules/cloud/google/gcp_compute_backend_service.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_backend_service.py
@@ -250,6 +250,7 @@ options:
       field is used in optimistic locking.
     required: false
     type: str
+    version_added: 2.9
   enable_cdn:
     description:
     - If true, enable Cloud CDN for this BackendService.

--- a/lib/ansible/modules/cloud/google/gcp_compute_backend_service.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_backend_service.py
@@ -244,6 +244,12 @@ options:
     - An optional description of this resource.
     required: false
     type: str
+  fingerprint:
+    description:
+    - Fingerprint of this resource. A hash of the contents stored in this object. This
+      field is used in optimistic locking.
+	required: false
+    type: str
   enable_cdn:
     description:
     - If true, enable Cloud CDN for this BackendService.

--- a/lib/ansible/modules/cloud/google/gcp_compute_backend_service.py
+++ b/lib/ansible/modules/cloud/google/gcp_compute_backend_service.py
@@ -728,6 +728,7 @@ def main():
             ),
             connection_draining=dict(type='dict', options=dict(draining_timeout_sec=dict(default=300, type='int'))),
             description=dict(type='str'),
+            fingerprint=dict(type='str'),
             enable_cdn=dict(type='bool'),
             health_checks=dict(required=True, type='list', elements='str'),
             iap=dict(
@@ -756,6 +757,7 @@ def main():
     if fetch:
         if state == 'present':
             if is_different(module, fetch):
+                module.params['fingerprint'] = fetch['fingerprint']
                 update(module, self_link(module), kind, fetch)
                 fetch = fetch_resource(module, self_link(module), kind)
                 changed = True
@@ -806,6 +808,7 @@ def delete(module, link, kind):
 
 def resource_to_request(module):
     request = {
+        u'fingerprint': module.params.get('fingerprint'),
         u'kind': 'compute#backendService',
         u'affinityCookieTtlSec': module.params.get('affinity_cookie_ttl_sec'),
         u'backends': BackendServiceBackendsArray(module.params.get('backends', []), module).to_request(),


### PR DESCRIPTION
If we are trying to update gcp_compute_backend_service resource, GCP api is requiring caller to pass fingerprint parameter in payload. This payload is used by the API for optimistic-locking purposes.

Failing to supply the specified parameter leads to the following error 400 - Required field 'resource.fingerprint' not specified

Pull request in question fixes this by copying current fingerprint from resource information returned by the GCP api during update operation.