### PR TITLE
Fix storing delegate_to facts

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -244,7 +244,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
 
                 # update the local vars copy for the retry
                 if use_vars.get('ansible_facts') is None:
-                     use_vars['ansible_facts'] = {}
+                    use_vars['ansible_facts'] = {}
                 use_vars['ansible_facts'][discovered_key] = self._discovered_interpreter
 
                 # TODO: this condition prevents 'wrong host' from being updated

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -242,22 +242,25 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 # we'll propagate back to the controller in the task result
                 discovered_key = 'discovered_interpreter_%s' % idre.interpreter_name
 
+                # update the local vars copy for the retry
+                if use_vars.get('ansible_facts') is None:
+                     use_vars['ansible_facts'] = {}
+                use_vars['ansible_facts'][discovered_key] = self._discovered_interpreter
+
                 # TODO: this condition prevents 'wrong host' from being updated
                 # but in future we would want to be able to update 'delegated host facts'
                 # irrespective of task settings
                 if not self._task.delegate_to or self._task.delegate_facts:
                     # store in local task_vars facts collection for the retry and any other usages in this worker
-                    if use_vars.get('ansible_facts') is None:
-                        task_vars['ansible_facts'] = use_vars['ansible_facts'] = {}
-                    task_vars['ansible_facts'][discovered_key] = use_vars['ansible_facts'][discovered_key] = self._discovered_interpreter
+                    if task_vars.get('ansible_facts') is None:
+                        task_vars['ansible_facts'] = {}
+                    task_vars['ansible_facts'][discovered_key] = self._discovered_interpreter
                     # preserve this so _execute_module can propagate back to controller as a fact
                     self._discovered_interpreter_key = discovered_key
                 else:
                     if task_vars['ansible_delegated_vars'][self._task.delegate_to].get('ansible_facts') is None:
                         task_vars['ansible_delegated_vars'][self._task.delegate_to]['ansible_facts'] = {}
-                        use_vars['ansible_delegated_vars'][self._task.delegate_to]['ansible_facts'] = {}
                     task_vars['ansible_delegated_vars'][self._task.delegate_to]['ansible_facts'][discovered_key] = self._discovered_interpreter
-                    use_vars['ansible_delegated_vars'][self._task.delegate_to]['ansible_facts'][discovered_key] = self._discovered_interpreter
 
         return (module_style, module_shebang, module_data, module_path)
 

--- a/test/integration/targets/delegate_to/runme.sh
+++ b/test/integration/targets/delegate_to/runme.sh
@@ -73,3 +73,5 @@ ansible-playbook discovery_applied.yml -i inventory -v "$@"
 
 # https://github.com/ansible/ansible/issues/70168
 ansible-playbook verify_interpreter_delegate_facts.yml -i inventory -v "$@"
+
+ansible-playbook verify_interpreter_auto_delegate_to.yml -i inventory -v "$@"

--- a/test/integration/targets/delegate_to/verify_interpreter_auto_delegate_to.yml
+++ b/test/integration/targets/delegate_to/verify_interpreter_auto_delegate_to.yml
@@ -1,0 +1,7 @@
+- hosts: testhost
+  gather_facts: no
+  tasks:
+    - command: hostname
+      delegate_to: testhost3
+      vars:
+        ansible_python_interpreter: auto

--- a/test/integration/targets/delegate_to/verify_interpreter_auto_delegate_to.yml
+++ b/test/integration/targets/delegate_to/verify_interpreter_auto_delegate_to.yml
@@ -1,7 +1,7 @@
 - hosts: testhost
   gather_facts: no
   tasks:
-    - command: hostname
+    - detect_interpreter:
       delegate_to: testhost3
       vars:
         ansible_python_interpreter: auto


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
```
Traceback (most recent call last):
  File "/home/mkrizek/src/ansible/lib/ansible/executor/task_executor.py", line 155, in run
    res = self._execute()
  File "/home/mkrizek/src/ansible/lib/ansible/executor/task_executor.py", line 650, in _execute
    result = self._handler.run(task_vars=variables)
  File "/home/mkrizek/src/ansible/lib/ansible/plugins/action/command.py", line 24, in run
    results = merge_hash(results, self._execute_module(task_vars=task_vars, wrap_async=wrap_async))
  File "/home/mkrizek/src/ansible/lib/ansible/plugins/action/__init__.py", line 860, in _execute_module
    (module_style, shebang, module_data, module_path) = self._configure_module(module_name=module_name, module_args=module_args, task_vars=task_vars)
  File "/home/mkrizek/src/ansible/lib/ansible/plugins/action/__init__.py", line 260, in _configure_module
    use_vars['ansible_delegated_vars'][self._task.delegate_to]['ansible_facts'][discovered_key] = self._discovered_interpreter
KeyError: 'ansible_delegated_vars'
```
Follow up for https://github.com/ansible/ansible/pull/70171

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/action/__init__.py `