### PR TITLE
Add awx/tower module group for collection defaults

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_module_defaults.rst
+++ b/docs/docsite/rst/user_guide/playbooks_module_defaults.rst
@@ -89,6 +89,8 @@ Ansible 2.7 adds a preview-status feature to group together modules that share c
 +=========+===========================+=================+
 | aws     | Amazon Web Services       | 2.7             |
 +---------+---------------------------+-----------------+
+| awx     | Ansible Tower / AWX       | 2.11            |
++---------+---------------------------+-----------------+
 | azure   | Azure                     | 2.7             |
 +---------+---------------------------+-----------------+
 | gcp     | Google Cloud Platform     | 2.7             |

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1323,6 +1323,7 @@ def get_action_args_with_defaults(action, args, defaults, templar, redirected_na
     group_collection_map = {
         'acme': ['community.crypto'],
         'aws': ['amazon.aws', 'community.aws'],
+        'awx': ['ansible.tower', 'awx.awx'],
         'azure': ['azure.azcollection'],
         'cpm': ['wti.remote'],
         'docker': ['community.general'],


### PR DESCRIPTION
##### SUMMARY
Ansible understand default groups for many collections already, but not awx or tower which is quite weird

##### ISSUE TYPE
- Feature Pull Request