### PR TITLE
Nuke _get_item() from callback, deprecated 2.11

### DIFF
--- a/changelogs/fragments/deprecation-callback-get_item.yml
+++ b/changelogs/fragments/deprecation-callback-get_item.yml
@@ -1,0 +1,2 @@
+removed_features:
+  - Removed `_get_item()` alias from callback plugin base class which had been deprecated in favor of `_get_item_label()`.

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -239,13 +239,6 @@ class CallbackBase(AnsiblePlugin):
             item = result.get('_ansible_item_label', result.get('item'))
         return item
 
-    def _get_item(self, result):
-        ''' here for backwards compat, really should have always been named: _get_item_label'''
-        cback = getattr(self, 'NAME', os.path.basename(__file__))
-        self._display.deprecated("The %s callback plugin should be updated to use the _get_item_label method instead" % cback,
-                                 version="2.11", collection_name='ansible.builtin')
-        return self._get_item_label(result)
-
     def _process_items(self, result):
         # just remove them as now they get handled by individual callbacks
         del result._result['results']

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -184,7 +184,6 @@ lib/ansible/playbook/helpers.py pylint:blacklisted-name
 lib/ansible/playbook/role/__init__.py pylint:blacklisted-name
 lib/ansible/plugins/action/normal.py action-plugin-docs # default action plugin for modules without a dedicated action plugin
 lib/ansible/plugins/cache/base.py ansible-doc!skip  # not a plugin, but a stub for backwards compatibility
-lib/ansible/plugins/callback/__init__.py pylint:ansible-deprecated-version
 lib/ansible/plugins/lookup/sequence.py pylint:blacklisted-name
 lib/ansible/plugins/strategy/__init__.py pylint:ansible-deprecated-version
 lib/ansible/plugins/strategy/__init__.py pylint:blacklisted-name

--- a/test/units/plugins/callback/test_callback.py
+++ b/test/units/plugins/callback/test_callback.py
@@ -52,22 +52,6 @@ class TestCallback(unittest.TestCase):
 
 class TestCallbackResults(unittest.TestCase):
 
-    def test_get_item(self):
-        cb = CallbackBase()
-        results = {'item': 'some_item'}
-        res = cb._get_item(results)
-        self.assertEqual(res, 'some_item')
-
-    def test_get_item_no_log(self):
-        cb = CallbackBase()
-        results = {'item': 'some_item', '_ansible_no_log': True}
-        res = cb._get_item(results)
-        self.assertEqual(res, "(censored due to no_log)")
-
-        results = {'item': 'some_item', '_ansible_no_log': False}
-        res = cb._get_item(results)
-        self.assertEqual(res, "some_item")
-
     def test_get_item_label(self):
         cb = CallbackBase()
         results = {'item': 'some_item'}


### PR DESCRIPTION
##### SUMMARY

Change:
- Remove _get_item() alias as it has been deprecated
- Update tests
- Remove relevant sanity curtailment
- Add changelog

Test Plan:
CI, grep

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME

callback