### PR TITLE
Fix fallback to unshallowing shallow clone

### DIFF
--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -898,7 +898,7 @@ def fetch(git_path, module, repo, dest, version, remote, depth, bare, refspec, g
             refspecs.append('+refs/heads/%s:refs/remotes/%s/%s' % (version, remote, version))
         elif is_remote_tag(git_path, module, dest, repo, version):
             refspecs.append('+refs/tags/' + version + ':refs/tags/' + version)
-        if refspecs:
+        if not refspecs:
             # if refspecs is empty, i.e. version is neither heads nor tags
             # assume it is a version hash
             # fall back to a full clone, otherwise we might not be able to checkout


### PR DESCRIPTION
Currently git may not find the correct commit with depth=1000000 and a shallow clone, caused by an error in the final fall back if clause. The comment in the if clause is correct, just missing a 'not' operator for the comment / behavior to work.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
git

##### ADDITIONAL INFORMATION
Reproduce steps:

* Clone repo with 2 commits and depth=1 (shallow clone)
* Try updating the repo using ansible to the initial commit with depth=2
* error: pathspec 'initial commit hash' did not match any file(s) known to git.