### PR TITLE
To backport ios_user and ios_command TC failure fix

### DIFF
--- a/changelogs/fragments/82_ios_user_ios_command_text_fix.yaml
+++ b/changelogs/fragments/82_ios_user_ios_command_text_fix.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - To fix ios_user and ios_command test case failure fix (https://github.com/ansible-collections/cisco.ios/pull/82)
+

--- a/changelogs/fragments/82_ios_user_ios_command_text_fix.yaml
+++ b/changelogs/fragments/82_ios_user_ios_command_text_fix.yaml
@@ -1,4 +1,3 @@
 ---
 bugfixes:
   - To fix ios_user and ios_command test case failure fix (https://github.com/ansible-collections/cisco.ios/pull/82)
-

--- a/test/integration/targets/ios_command/tests/cli/error_regex.yaml
+++ b/test/integration/targets/ios_command/tests/cli/error_regex.yaml
@@ -11,10 +11,18 @@
         - "\r"
     ignore_errors: True
 
+  - name: increase log buffer size
+    cli_config:
+      config: logging buffered 9600000
+
   - name: send log with error regex match 1
     cli_command: &send_logs
-      command: "send log 'IPSEC-3-REPLAY_ERROR: test log_1'"
+      command: "send log 'IPSEC-3-REPLAY_ERROR: test log_1'\n"
     ignore_errors: True
+
+  - name: pause to avoid rate limiting-1
+    pause:
+      seconds: 20
 
   - name: fetch logs without command specific error regex
     ios_command:
@@ -28,9 +36,9 @@
       that:
         - "result.failed == true"
 
-  - name: pause to avoid rate limiting
+  - name: pause to avoid rate limiting-2
     pause:
-      seconds: 10
+      seconds: 20
 
   - name: clear logs 2
     cli_command: *clear_logs

--- a/test/integration/targets/ios_user/tasks/cli.yaml
+++ b/test/integration/targets/ios_user/tasks/cli.yaml
@@ -14,9 +14,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local"
-  with_first_found: "{{ test_items }}"
-  loop_control:
-    loop_var: test_case_to_run

--- a/test/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/test/integration/targets/ios_user/tests/cli/auth.yaml
@@ -6,22 +6,34 @@
       privilege: 15
       role: network-operator
       state: present
-      provider: "{{ cli }}"
       configured_password: pass123
 
-  - name: test login
-    expect:
-      command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no show version"
-      responses:
-        (?i)password: "pass123"
+  - name: reset connection with {{ ansible_user }
+    meta: reset_connection
+
+  - name: test login for {{ ansible_user }} user with password
+    ios_command:
+      commands:
+        - show version
+    vars:
+      ansible_user: auth_user
+      ansible_password: pass123
+
+  - name: reset connection with {{ ansible_user }
+    meta: reset_connection
 
   - name: test login with invalid password (should fail)
-    expect:
-      command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no show version"
-      responses:
-        (?i)password: "badpass"
+    ios_command:
+      commands:
+        - show version
     ignore_errors: yes
     register: results
+    vars:
+      ansible_user: auth_user
+      ansible_password: badpass
+
+  - name: reset connection with {{ ansible_user }
+      meta: reset_connection
 
   - name: check that attempt failed
     assert:
@@ -33,7 +45,6 @@
     ios_user:
       name: auth_user
       state: absent
-      provider: "{{ cli }}"
     register: result
 
   - name: reset connection
@@ -52,19 +63,34 @@
       privilege: 15
       role: network-operator
       state: present
-      provider: "{{ cli }}"
       sshkey: "{{ lookup('file', 'files/test_rsa.pub') }}"
 
-  - name: test sshkey login
-    shell: "ssh ssh_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o IdentityFile={{ role_path }}/files/test_rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o BatchMode=yes -o PubkeyAuthentication=yes show version"
+  - name: reset connection with {{ ansible_user }
+    meta: reset_connection
 
-  - name: test login without sshkey (should fail)
-    expect:
-      command: "ssh ssh_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no show version"
-      responses:
-        (?i)password: badpass
+  - name: test sshkey login for {{ ansible_user }} user
+    ios_command:
+      commands:
+        - show version
+    vars:
+      ansible_user: ssh_user
+      ansible_private_key_file: "{{ role_path }}/files/test_rsa"
+
+  - name: reset connection with {{ ansible_user }}
+    meta: reset_connection
+
+  - name: test with {{ ansible_user }} user without keys
+    ios_command:
+      commands:
+        - show version
     ignore_errors: yes
     register: results
+    vars:
+      ansible_user: ssh_user
+      ansible_private_key_file: ""
+
+  - name: reset connection with {{ ansible_user }}
+      meta: reset_connection
 
   - name: check that attempt failed
     assert:
@@ -76,7 +102,6 @@
     ios_user:
       name: ssh_user
       state: absent
-      provider: "{{ cli }}"
     register: result
 
   - name: reset connection

--- a/test/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/test/integration/targets/ios_user/tests/cli/auth.yaml
@@ -90,7 +90,7 @@
       ansible_private_key_file: ""
 
   - name: reset connection with {{ ansible_user }}
-      meta: reset_connection
+    meta: reset_connection
 
   - name: check that attempt failed
     assert:

--- a/test/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/test/integration/targets/ios_user/tests/cli/auth.yaml
@@ -33,7 +33,7 @@
       ansible_password: badpass
 
   - name: reset connection with {{ ansible_user }
-      meta: reset_connection
+    meta: reset_connection
 
   - name: check that attempt failed
     assert:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To backport ios_user and ios_command TC failure fix. Backported from: https://github.com/ansible-collections/cisco.ios/pull/82
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ios_user and ios_command

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
