### PR TITLE
stat: Handle colon in filename

### DIFF
--- a/changelogs/fragments/70256_stat_colon_split.yml
+++ b/changelogs/fragments/70256_stat_colon_split.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- stat - handle colons in filename while parsing the mimetype output (https://github.com/ansible/ansible/issues/70256).

--- a/lib/ansible/modules/stat.py
+++ b/lib/ansible/modules/stat.py
@@ -513,11 +513,11 @@ def main():
         output['mimetype'] = output['charset'] = 'unknown'
         mimecmd = module.get_bin_path('file')
         if mimecmd:
-            mimecmd = [mimecmd, '-i', b_path]
+            mimecmd = [mimecmd, '--mime-type', '--mime-encoding', b_path]
             try:
                 rc, out, err = module.run_command(mimecmd)
                 if rc == 0:
-                    mimetype, charset = out.split(':')[1].split(';')
+                    mimetype, charset = out.rsplit(':', 1)[1].split(';')
                     output['mimetype'] = mimetype.strip()
                     output['charset'] = charset.split('=')[1].strip()
             except Exception:

--- a/test/integration/targets/stat/tasks/main.yml
+++ b/test/integration/targets/stat/tasks/main.yml
@@ -155,3 +155,25 @@
         - "'xgrp' in stat_result.stat"
         - "'xoth' in stat_result.stat"
         - "'xusr' in stat_result.stat"
+
+- name: make a new file with colon in filename
+  copy:
+    dest: "{{ output_dir }}/foo:bar.txt"
+    mode: '0644'
+    content: "hello world"
+
+- name: check stat of a file with colon in name
+  stat:
+    path: "{{ output_dir }}/foo:bar.txt"
+    follow: True
+  register: stat_result
+
+- debug:
+    var: stat_result
+
+- assert:
+    that:
+        - "'changed' in stat_result"
+        - "stat_result.changed == false"
+        - "stat_result.stat.mimetype == 'text/plain'"
+        - "stat_result.stat.charset == 'us-ascii'"


### PR DESCRIPTION
##### SUMMARY

Handle colon appearing in filename while parsing the mimetype and charset
using file command.

Fixes: #70256

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/70256_stat_colon_split.yml
lib/ansible/modules/stat.py
test/integration/targets/stat/tasks/main.yml
