### PR TITLE
[WIP] Fix broken docs links for collections overview repo

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -10,7 +10,7 @@ Collections are a distribution format for Ansible content. You can use collectio
 You can publish and use collections through `Ansible Galaxy <https://galaxy.ansible.com>`_.
 
 * For details on how to *use* collections see :ref:`collections`.
-* For the current development status of Collections and FAQ see `Ansible Collections Overview and FAQ <https://github.com/ansible-collections/overview/blob/master/README.rst>`_.
+* For the current development status of Collections and FAQ see `Ansible Collections Overview and FAQ <https://github.com/ansible-collections/overview/blob/main/README.rst>`_.
 
 .. contents::
    :local:

--- a/docs/docsite/rst/plugins/cliconf.rst
+++ b/docs/docsite/rst/plugins/cliconf.rst
@@ -9,7 +9,7 @@ Cliconf Plugins
 
 .. warning::
 
-	Links on this page may not point to the most recent versions of plugins. In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/general/blob/master/README.rst>`_.
+	Links on this page may not point to the most recent versions of plugins. In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/overview/blob/main/README.rst>`_.
 
 Cliconf plugins are abstractions over the CLI interface to network devices. They provide a standard interface
 for Ansible to execute tasks on those network devices.

--- a/docs/docsite/rst/plugins/httpapi.rst
+++ b/docs/docsite/rst/plugins/httpapi.rst
@@ -9,7 +9,7 @@ Httpapi Plugins
 
 .. warning::
 
-	Links on this page may not point to the most recent versions of plugins. In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/general/blob/master/README.rst>`_.
+	Links on this page may not point to the most recent versions of plugins. In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/overview/blob/main/README.rst>`_.
 
 Httpapi plugins tell Ansible how to interact with a remote device's HTTP-based API and execute tasks on the
 device.

--- a/docs/docsite/rst/plugins/netconf.rst
+++ b/docs/docsite/rst/plugins/netconf.rst
@@ -9,7 +9,7 @@ Netconf Plugins
 
 .. warning::
 
-	Links on this page may not point to the most recent versions of plugins. In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/general/blob/master/README.rst>`_.
+	Links on this page may not point to the most recent versions of plugins. In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/overview/blob/main/README.rst>`_.
 
 Netconf plugins are abstractions over the Netconf interface to network devices. They provide a standard interface for Ansible to execute tasks on those network devices.
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -7,7 +7,7 @@ Ansible 2.10 Porting Guide
 
 .. warning::
 
-	Links on this page may not point to the most recent versions of modules. In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/general/blob/master/README.rst>`_. We expect the 2.10 Porting Guide to change frequently up to the 2.10 release. Follow the conversations about collections on our various :ref:`communication` channels for the latest information on the status of the ``devel`` branch.
+	Links on this page may not point to the most recent versions of modules. In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/overview/blob/main/README.rst>`_. We expect the 2.10 Porting Guide to change frequently up to the 2.10 release. Follow the conversations about collections on our various :ref:`communication` channels for the latest information on the status of the ``devel`` branch.
 
 This section discusses the behavioral changes between Ansible 2.9 and Ansible 2.10.
 

--- a/docs/docsite/rst/roadmap/ROADMAP_2_10.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_10.rst
@@ -44,4 +44,4 @@ moving much of the plugins into smaller collection repositories that will be shi
 The following links have more information about this process:
 
 - https://groups.google.com/d/msg/ansible-devel/oKqgCeYTs-M/cHrOgMw8CAAJ
-- https://github.com/ansible-collections/overview/blob/master/README.rst
+- https://github.com/ansible-collections/overview/blob/main/README.rst

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -9,7 +9,7 @@ Collections are a distribution format for Ansible content that can include playb
 You can install and use collections through `Ansible Galaxy <https://galaxy.ansible.com>`_.
 
 * For details on how to *develop* collections see :ref:`developing_collections`.
-* For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/general/blob/master/README.rst>`_.
+* For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/overview/blob/main/README.rst>`_.
 
 .. contents::
    :local:


### PR DESCRIPTION
##### SUMMARY

ansible-collections/general became ansible-collections/overview at some point.

Note: this PR also changes default branch for this repo from master to main, which hasn't actually happened yet (but will soon) so WIP til then.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/developing_collections.rst
docs/docsite/rst/plugins/cliconf.rst
docs/docsite/rst/plugins/httpapi.rst
docs/docsite/rst/plugins/netconf.rst
docs/docsite/rst/porting_guides/porting_guide_2.10.rst
docs/docsite/rst/roadmap/ROADMAP_2_10.rst
docs/docsite/rst/user_guide/collections_using.rst
