### PR TITLE
docs: Document become_exe keyword

### DIFF
--- a/docs/docsite/keyword_desc.yml
+++ b/docs/docsite/keyword_desc.yml
@@ -7,6 +7,7 @@ always: List of tasks, in a block, that execute no matter if there is an error i
 any_errors_fatal: Force any un-handled task errors on any host to propagate to all hosts and end the play.
 async: Run a task asynchronously if the C(action) supports this; value is maximum runtime in seconds.
 become: Boolean that controls if privilege escalation is used or not on :term:`Task` execution.
+become_exe: Name or path of the privilege escalation program to run when :term:`become` is True.
 become_flags: A string of flag(s) to pass to the privilege escalation program when :term:`become` is True.
 become_method: Which method of privilege escalation to use (such as sudo or su).
 become_user: "User that you 'become' after using privilege escalation. The remote/login user must have permissions to become this user."


### PR DESCRIPTION
##### SUMMARY
At https://docs.ansible.com/ansible/devel/reference_appendices/playbooks_keywords.html the `become_exe` entry currently reads

>     UNDOCUMENTED!!

This fixes that.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
Playbook keywords reference