### PR TITLE
[stable 2.10] [backport] Migrate onyx modules from community.network to mellanox.onyx

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -3765,7 +3765,7 @@ files:
   $plugins/action/onyx_config.py:
     maintainers: $team_onyx
     labels: networking
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   $plugins/action/sros:
     maintainers: $team_networking
     labels: networking
@@ -3872,7 +3872,7 @@ files:
     migrated_to: cisco.nxos
   $plugins/cliconf/onyx.py:
     maintainers: $team_onyx
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   $plugins/cliconf/routeros.py:
     maintainers: heuels
     migrated_to: community.general
@@ -4289,7 +4289,7 @@ files:
     migrated_to: cisco.nxos
   $plugins/terminal/onyx.py:
     maintainers: $team_onyx
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   $plugins/terminal/routeros.py:
     maintainers: heuels
     migrated_to: community.general
@@ -7163,7 +7163,7 @@ files:
   lib/ansible/plugins/doc_fragments/online.py:
     migrated_to: community.general
   lib/ansible/plugins/doc_fragments/onyx.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/plugins/doc_fragments/opennebula.py:
     migrated_to: community.general
   lib/ansible/plugins/doc_fragments/openswitch.py:
@@ -7697,9 +7697,9 @@ files:
   lib/ansible/module_utils/network/nso/nso.py:
     migrated_to: community.general
   lib/ansible/module_utils/network/onyx/__init__.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/module_utils/network/onyx/onyx.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/module_utils/network/ordnance/__init__.py:
     migrated_to: community.general
   lib/ansible/module_utils/network/ordnance/ordnance.py:
@@ -9665,79 +9665,79 @@ files:
   lib/ansible/modules/network/nuage/nuage_vspk.py:
     migrated_to: community.general
   lib/ansible/modules/network/onyx/onyx_aaa.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_bfd.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_bgp.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_buffer_pool.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_command.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_config.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_facts.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_igmp.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_igmp_interface.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_igmp_vlan.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_interface.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_l2_interface.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_l3_interface.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_linkagg.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_lldp.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_lldp_interface.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_magp.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_mlag_ipl.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_mlag_vip.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_ntp.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_ntp_servers_peers.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_ospf.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_pfc_interface.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_protocol.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_ptp_global.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_ptp_interface.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_qos.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_snmp.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_snmp_hosts.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_snmp_users.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_syslog_files.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_syslog_remote.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_traffic_class.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_username.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_vlan.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_vxlan.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/onyx/onyx_wjh.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   lib/ansible/modules/network/opx/opx_cps.py:
     migrated_to: community.general
   lib/ansible/modules/network/ordnance/ordnance_config.py:
@@ -11833,187 +11833,187 @@ files:
   test/units/modules/network/nuage/nuage_module.py:
     migrated_to: community.general
   test/units/modules/network/onyx/test_onyx_aaa.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_buffer_pool.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_mlag_ipl_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_show_dcb_ets_interface.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_show_ip_igmp_snooping.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_show_aaa.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/show_qos_interface_ethernet.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_logging_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_wjh_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_magp_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_port_channel_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_command_show_version.txt:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_logging_config_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_lldp_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_vlan_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_facts_show_version.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_snmp_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_lldp_interface_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_interfaces_status.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_show_interfaces_nve_detail.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_config_src.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_pfc_interface_disabled.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_igmp_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_mlag_vip_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_mlag_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_ospf_interfaces_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_l3_interface_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_ntp_servers_peers_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_mlag_port_channel_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_show_ptp_interface.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_bgp_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_l2_interface_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_l3_vlan_interface_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_username_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_facts_show_interfaces_ethernet.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_protocols_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_show_interfaces_nve.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_interfaces_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_show_snmp_hosts.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_pfc_interface_enabled.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_interfaces_rates.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_show_igmp_interfaces.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_config_config.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_show_interface_congestion_control.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_ospf_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_show_bfd.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_facts_show_module.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_ntp_show.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_show_ntp_configured.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_show_ip_igmp_snooping_querier.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_show_ip_igmp_snooping_groups.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_show_ptp_clock.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/fixtures/onyx_show_snmp_users.cfg:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/onyx_module.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/__init__.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_bfd.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_bgp.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_buffer_pool.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_command.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_config.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_facts.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_igmp.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_igmp_interface.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_igmp_vlan.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_interface.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_l2_interface.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_l3_interface.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_linkagg.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_lldp.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_lldp_interface.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_magp.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_mlag_ipl.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_mlag_vip.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_ntp.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_ntp_servers_peers.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_ospf.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_pfc_interface.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_protocol.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_ptp_global.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_ptp_interface.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_qos.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_snmp.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_snmp_hosts.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_snmp_users.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_syslog_files.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_syslog_remote.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_traffic_class.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_username.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_vlan.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_vxlan.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/onyx/test_onyx_wjh.py:
-    migrated_to: community.general
+    migrated_to: mellanox.onyx
   test/units/modules/network/opx/test_opx_cps.py:
     migrated_to: community.general
   test/units/modules/network/opx/fixtures/opx_operation_get.cfg:

--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -2463,79 +2463,79 @@ plugin_routing:
     nuage_vspk:
       redirect: community.network.nuage_vspk
     onyx_aaa:
-      redirect: community.network.onyx_aaa
+      redirect: mellanox.onyx.onyx_aaa
     onyx_bfd:
-      redirect: community.network.onyx_bfd
+      redirect: mellanox.onyx.onyx_bfd
     onyx_bgp:
-      redirect: community.network.onyx_bgp
+      redirect: mellanox.onyx.onyx_bgp
     onyx_buffer_pool:
-      redirect: community.network.onyx_buffer_pool
+      redirect: mellanox.onyx.onyx_buffer_pool
     onyx_command:
-      redirect: community.network.onyx_command
+      redirect: mellanox.onyx.onyx_command
     onyx_config:
-      redirect: community.network.onyx_config
+      redirect: mellanox.onyx.onyx_config
     onyx_facts:
-      redirect: community.network.onyx_facts
+      redirect: mellanox.onyx.onyx_facts
     onyx_igmp:
-      redirect: community.network.onyx_igmp
+      redirect: mellanox.onyx.onyx_igmp
     onyx_igmp_interface:
-      redirect: community.network.onyx_igmp_interface
+      redirect: mellanox.onyx.onyx_igmp_interface
     onyx_igmp_vlan:
-      redirect: community.network.onyx_igmp_vlan
+      redirect: mellanox.onyx.onyx_igmp_vlan
     onyx_interface:
-      redirect: community.network.onyx_interface
+      redirect: mellanox.onyx.onyx_interface
     onyx_l2_interface:
-      redirect: community.network.onyx_l2_interface
+      redirect: mellanox.onyx.onyx_l2_interface
     onyx_l3_interface:
-      redirect: community.network.onyx_l3_interface
+      redirect: mellanox.onyx.onyx_l3_interface
     onyx_linkagg:
-      redirect: community.network.onyx_linkagg
+      redirect: mellanox.onyx.onyx_linkagg
     onyx_lldp:
-      redirect: community.network.onyx_lldp
+      redirect: mellanox.onyx.onyx_lldp
     onyx_lldp_interface:
-      redirect: community.network.onyx_lldp_interface
+      redirect: mellanox.onyx.onyx_lldp_interface
     onyx_magp:
-      redirect: community.network.onyx_magp
+      redirect: mellanox.onyx.onyx_magp
     onyx_mlag_ipl:
-      redirect: community.network.onyx_mlag_ipl
+      redirect: mellanox.onyx.onyx_mlag_ipl
     onyx_mlag_vip:
-      redirect: community.network.onyx_mlag_vip
+      redirect: mellanox.onyx.onyx_mlag_vip
     onyx_ntp:
-      redirect: community.network.onyx_ntp
+      redirect: mellanox.onyx.onyx_ntp
     onyx_ntp_servers_peers:
-      redirect: community.network.onyx_ntp_servers_peers
+      redirect: mellanox.onyx.onyx_ntp_servers_peers
     onyx_ospf:
-      redirect: community.network.onyx_ospf
+      redirect: mellanox.onyx.onyx_ospf
     onyx_pfc_interface:
-      redirect: community.network.onyx_pfc_interface
+      redirect: mellanox.onyx.onyx_pfc_interface
     onyx_protocol:
-      redirect: community.network.onyx_protocol
+      redirect: mellanox.onyx.onyx_protocol
     onyx_ptp_global:
-      redirect: community.network.onyx_ptp_global
+      redirect: mellanox.onyx.onyx_ptp_global
     onyx_ptp_interface:
-      redirect: community.network.onyx_ptp_interface
+      redirect: mellanox.onyx.onyx_ptp_interface
     onyx_qos:
-      redirect: community.network.onyx_qos
+      redirect: mellanox.onyx.onyx_qos
     onyx_snmp:
-      redirect: community.network.onyx_snmp
+      redirect: mellanox.onyx.onyx_snmp
     onyx_snmp_hosts:
-      redirect: community.network.onyx_snmp_hosts
+      redirect: mellanox.onyx.onyx_snmp_hosts
     onyx_snmp_users:
-      redirect: community.network.onyx_snmp_users
+      redirect: mellanox.onyx.onyx_snmp_users
     onyx_syslog_files:
-      redirect: community.network.onyx_syslog_files
+      redirect: mellanox.onyx.onyx_syslog_files
     onyx_syslog_remote:
-      redirect: community.network.onyx_syslog_remote
+      redirect: mellanox.onyx.onyx_syslog_remote
     onyx_traffic_class:
-      redirect: community.network.onyx_traffic_class
+      redirect: mellanox.onyx.onyx_traffic_class
     onyx_username:
-      redirect: community.network.onyx_username
+      redirect: mellanox.onyx.onyx_username
     onyx_vlan:
-      redirect: community.network.onyx_vlan
+      redirect: mellanox.onyx.onyx_vlan
     onyx_vxlan:
-      redirect: community.network.onyx_vxlan
+      redirect: mellanox.onyx.onyx_vxlan
     onyx_wjh:
-      redirect: community.network.onyx_wjh
+      redirect: mellanox.onyx.onyx_wjh
     opx_cps:
       redirect: community.network.opx_cps
     ordnance_config:
@@ -8096,7 +8096,7 @@ plugin_routing:
     nos_config:
       redirect: community.network.nos_config
     onyx_config:
-      redirect: community.network.onyx_config
+      redirect: mellanox.onyx.onyx_config
     slxos:
       redirect: community.network.slxos
     sros:

--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -7732,7 +7732,7 @@ plugin_routing:
     nso:
       redirect: community.network.nso
     onyx:
-      redirect: community.network.onyx
+      redirect: mellanox.onyx.onyx
     ordnance:
       redirect: community.network.ordnance
     panos:
@@ -7981,7 +7981,7 @@ plugin_routing:
     nos:
       redirect: community.network.nos
     onyx:
-      redirect: community.network.onyx
+      redirect: mellanox.onyx.onyx
     routeros:
       redirect: community.network.routeros
     slxos:
@@ -8040,7 +8040,7 @@ plugin_routing:
     nos:
       redirect: community.network.nos
     onyx:
-      redirect: community.network.onyx
+      redirect: mellanox.onyx.onyx
     routeros:
       redirect: community.network.routeros
     slxos:
@@ -8377,7 +8377,7 @@ plugin_routing:
     online:
       redirect: community.general.online
     onyx:
-      redirect: community.network.onyx
+      redirect: mellanox.onyx.onyx
     opennebula:
       redirect: community.general.opennebula
     openswitch:


### PR DESCRIPTION
Signed-off-by: Samer Deeb <samerd@mellanox.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Migrate onyx modules from community.network to mellanox.onyx
backport to stable-2.10
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
