### PR TITLE
Get serial number of NVMe device without sg_inq

### DIFF
--- a/changelogs/fragments/70284-facts-get-nvme-serial-from-file.yml
+++ b/changelogs/fragments/70284-facts-get-nvme-serial-from-file.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Facts collection - get serial number of NVMe device without sg_inq (https://github.com/ansible/ansible/issues/66663).

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -700,6 +700,9 @@ class LinuxHardware(Hardware):
 
             sg_inq = self.module.get_bin_path('sg_inq')
 
+            # we can get NVMe device's serial number from /sys/block/<name>/device/serial
+            serial_path = "/sys/block/%s/device/serial" % (block)
+
             if sg_inq:
                 device = "/dev/%s" % (block)
                 rc, drivedata, err = self.module.run_command([sg_inq, device])
@@ -707,6 +710,10 @@ class LinuxHardware(Hardware):
                     serial = re.search(r"Unit serial number:\s+(\w+)", drivedata)
                     if serial:
                         d['serial'] = serial.group(1)
+            elif os.path.exists(serial_path):
+                with open(serial_path, 'r') as f:
+                    serial = f.read()
+                    d['serial'] = serial.strip('\n')
 
             for key, test in [('removable', '/removable'),
                               ('support_discard', '/queue/discard_granularity'),

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -710,10 +710,10 @@ class LinuxHardware(Hardware):
                     serial = re.search(r"Unit serial number:\s+(\w+)", drivedata)
                     if serial:
                         d['serial'] = serial.group(1)
-            elif os.path.exists(serial_path):
-                with open(serial_path, 'r') as f:
-                    serial = f.read()
-                    d['serial'] = serial.strip('\n')
+            else:
+                serial = get_file_content(serial_path)
+                if serial:
+                    d['serial'] = serial
 
             for key, test in [('removable', '/removable'),
                               ('support_discard', '/queue/discard_granularity'),


### PR DESCRIPTION
##### SUMMARY
We can get NVMe device's serial number from `/sys/block/<name>/device/serial` file. We don't need to have `sg_inq`, which requires root.

Fixes #66663

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
Facts collection, linux.py
