### PR TITLE
[2.10] display: use stdout for column width

### DIFF
--- a/changelogs/fragments/display-stdout-column-width.yml
+++ b/changelogs/fragments/display-stdout-column-width.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Ansible output now uses stdout to determine column width instead of stdin

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -430,8 +430,8 @@ class Display(with_metaclass(Singleton, object)):
         return encoding
 
     def _set_column_width(self):
-        if os.isatty(0):
-            tty_size = unpack('HHHH', fcntl.ioctl(0, TIOCGWINSZ, pack('HHHH', 0, 0, 0, 0)))[1]
+        if os.isatty(1):
+            tty_size = unpack('HHHH', fcntl.ioctl(1, TIOCGWINSZ, pack('HHHH', 0, 0, 0, 0)))[1]
         else:
             tty_size = 0
         self.columns = max(79, tty_size - 1)


### PR DESCRIPTION
##### SUMMARY

stdout may differ from stdin so it should be used to determine the column
width, especially since it is the target file descriptor.

(cherry picked from commit 45e0f747026c5b6e29b2a32c78785ff970da5655)


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/display-stdout-column-width.yml
lib/ansible/utils/display.py
