### PR TITLE
hash filter - fail when unsupported type is passed as an argument

### DIFF
--- a/changelogs/fragments/70258-hash-filter-fail-unsupported-type.yml
+++ b/changelogs/fragments/70258-hash-filter-fail-unsupported-type.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - hash filter - fail when unsupported hash type is passed as an argument (https://github.com/ansible/ansible/issues/70258)

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -253,11 +253,11 @@ def randomize_list(mylist, seed=None):
 
 
 def get_hash(data, hashtype='sha1'):
-
-    try:  # see if hash is supported
+    try:
         h = hashlib.new(hashtype)
-    except Exception:
-        return None
+    except Exception as e:
+        # hash is not supported?
+        raise AnsibleFilterError(e)
 
     h.update(to_bytes(data, errors='surrogate_or_strict'))
     return h.hexdigest()

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -110,7 +110,17 @@
     that:
       - '"{{ "hash" | hash("sha1") }}" == "2346ad27d7568ba9896f1b7da6b5991251debdf2"'
       - '"{{ "café" | hash("sha1") }}" == "f424452a9673918c6f09b0cdd35b20be8e6ae7d7"'
-      - '"corned beef"|hash("haha, get it?") == None'
+
+- name: Test unsupported hash type
+  debug:
+    msg: "{{ 'hash' | hash('unsupported_hash_type') }}"
+  ignore_errors: yes
+  register: unsupported_hash_type_res
+
+- assert:
+    that:
+      - "unsupported_hash_type_res is failed"
+      - "'unsupported hash type' in unsupported_hash_type_res.msg"
 
 - name: Flatten tests
   block:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #70258
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`lib/ansible/plugins/filter/core.py`
