### PR TITLE
Suggest ansible ad-hoc command while developing module

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_locally.rst
+++ b/docs/docsite/rst/dev_guide/developing_locally.rst
@@ -43,7 +43,7 @@ Once you save your module file in one of these locations, Ansible will load it a
 
 To confirm that ``my_custom_module`` is available:
 
-* type ``ansible-doc -t module my_custom_module``. You should see the documentation for that module.
+* type ``ansible localhost -m my_custom_module``. You should see the output for that module.
 
 .. note::
 

--- a/docs/docsite/rst/dev_guide/developing_locally.rst
+++ b/docs/docsite/rst/dev_guide/developing_locally.rst
@@ -45,6 +45,10 @@ To confirm that ``my_custom_module`` is available:
 
 * type ``ansible localhost -m my_custom_module``. You should see the output for that module.
 
+or 
+
+* type ``ansible-doc -t module my_custom_module``. You should see the documentation for that module.
+
 .. note::
 
 	Currently, ``ansible-doc`` command can only parse Python modules for the module documentation. If you have module written in a different programming language other than Python, please write a documentation in Python file adjacent to module file.


### PR DESCRIPTION
##### SUMMARY
The current documentation asks runs the doc command which will fail if  the module does not have documentation. It fails in a way that doesn't hint at missing documentation. Even if providing docs is best practices it was very confusing to me as a new user as to why my custom module wasn't working. 

[WARNING]: module rust_helloworld_module not found in: /Users/my_home/.ansible/plugins/modules/rust_helloworld_module:/usr/local/Cellar/ansible/2.9.10/libexec/lib/python3.8/site-
packages/ansible/modules


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
