### PR TITLE
[2.8] pip tests, use py2 compat sampleproject fork

### DIFF
--- a/test/integration/targets/pip/vars/main.yml
+++ b/test/integration/targets/pip/vars/main.yml
@@ -1,12 +1,12 @@
-pip_test_package: sampleproject
+pip_test_package: sampleprojectpy2
 pip_test_packages:
-  - sampleproject
+  - sampleprojectpy2
   - jiphy
 pip_test_pkg_ver:
-  - sampleproject<=100, !=9.0.0,>=0.0.1
+  - sampleprojectpy2<=100, !=9.0.0,>=0.0.1
   - jiphy<100 ,!=9,>=0.0.1
 pip_test_pkg_ver_unsatisfied:
-  - sampleproject>= 999.0.0
+  - sampleprojectpy2>= 999.0.0
   - jiphy >999.0
 pip_test_modules:
   - sample


### PR DESCRIPTION

##### SUMMARY

Change:
- sampleproject has gone py3 only. Use a py2 compatible fork.

Test Plan:
- CI

Signed-off-by: Rick Elrod <rick@elrod.me>

Backport of #70313 

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
tests