### PR TITLE
[WIP] Add _post_validate_tags to flatten extended tags that need templating

### DIFF
--- a/lib/ansible/playbook/taggable.py
+++ b/lib/ansible/playbook/taggable.py
@@ -48,7 +48,11 @@ class Taggable:
 
         if self.tags:
             templar = Templar(loader=self._loader, variables=all_vars)
-            tags = resolve_extended_attr('tags', self._tags, self.tags, templar, ds=self.get_ds())
+            # since this is a mix-in, it may not have an underlying datastructure associated with it
+            ds = None
+            if hasattr(self, '_ds'):
+                ds = getattr(self, '_ds')
+            tags = resolve_extended_attr('tags', self._tags, self.tags, templar, ds=ds)
 
             _temp_tags = set()
             for tag in tags:

--- a/lib/ansible/playbook/taggable.py
+++ b/lib/ansible/playbook/taggable.py
@@ -71,7 +71,7 @@ class Taggable:
         unique_tags = []
 
         if not isinstance(value, list):
-            raise AnsibleParserError("the field '%s' should be a list, but is a %s" % (name, type(value)))
+            raise AnsibleParserError("the field 'tags' should be a list, but is a %s" % (type(value)))
 
         for tag in value:
             # Deduplicate extended nested list variables

--- a/lib/ansible/playbook/taggable.py
+++ b/lib/ansible/playbook/taggable.py
@@ -19,7 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.errors import AnsibleError
+from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.module_utils.six import string_types
 from ansible.playbook.attribute import FieldAttribute
 from ansible.template import Templar
@@ -42,12 +42,63 @@ class Taggable:
         else:
             raise AnsibleError('tags must be specified as a list', obj=ds)
 
+    def _post_validate_tags(self, attr, value, templar):
+        '''Tags are templatable and use extend=True, so this value
+        may be extended from the parent and contain possible variable
+        items which should be strings, ints, or a list of those items
+
+        If an item is a templated list it is flattened by using its contents to extend the list of unique tags
+
+        e.g.
+        vars:
+          list_or_individual_tag: ['tag1', 'tag2']
+        tasks:
+        - name: block with tags
+          tags: "{{ list_or_individual_tag }}"
+          block:
+              ...
+              - name: task with tags
+                module:
+                tags: "{{ list_or_individual_tag }}"  # deduplicate in post validation as the value may be different from the parent scope
+
+        The extended tags received by this function will be ['tag1', 'tag2', '{{ list_or_individual_tag }}']
+
+        :raises AnsibleParserError: if tags contains invalid types
+        :return: List of strings and integers
+        :rtype: list
+        '''
+
+        unique_tags = []
+
+        if not isinstance(value, list):
+            raise AnsibleParserError("the field '%s' should be a list, but is a %s" % (name, type(value)))
+
+        for tag in value:
+            # Deduplicate extended nested list variables
+            if templar.is_template(tag):
+                tag = templar.template(tag)
+
+            if isinstance(tag, list):
+                for item in tag:
+                    if not isinstance(item, attr.listof):
+                        raise AnsibleParserError("the field 'tags' should be a list of %s, "
+                                                 "but the item '%s' is a %s" % (attr.listof, item, type(item)), obj=self.get_ds())
+                    if item not in unique_tags:
+                        unique_tags.append(item)
+            else:
+                if not isinstance(tag, attr.listof):
+                    raise AnsibleParserError("the field 'tags' should be a list of %s, "
+                                             "but the item '%s' is a %s" % (attr.listof, tag, type(tag)), obj=self.get_ds())
+                if tag not in unique_tags:
+                    unique_tags.append(tag)
+
+        return unique_tags
+
     def evaluate_tags(self, only_tags, skip_tags, all_vars):
         ''' this checks if the current item should be executed depending on tag options '''
 
         if self.tags:
-            templar = Templar(loader=self._loader, variables=all_vars)
-            tags = templar.template(self.tags)
+            tags = self._post_validate_tags(self._tags, self.tags, Templar(loader=self._loader, variables=all_vars))
 
             _temp_tags = set()
             for tag in tags:

--- a/test/integration/targets/conditionals/play.yml
+++ b/test/integration/targets/conditionals/play.yml
@@ -549,3 +549,40 @@
             - item
         loop:
           - 1 == 1
+
+
+    - name: Test inheriting and extending templated conditions
+      vars:
+        conditions_1:
+          - true
+          - true
+        conditions_2:
+          - true
+      when: bare|bool
+      block:
+        - name: create a block with a variable conditional list
+          when: conditions_1
+          block:
+
+          - name: run a task with another variable conditional list
+            debug:
+            when: conditions_2
+            register: result
+            failed_when: result.skipped is defined and result.skipped
+
+          - name: check that the parent value is inherited correctly
+            set_fact:
+              conditions_1:
+                - true
+                - false
+
+          - name: this should inherit condition_1 and resolve to the value set in the task before
+            failed_when: result.skipped is undefined or not result.skipped
+            register: result
+            fail:
+              msg: This task should have been skipped
+
+        - name: validate that modifiying the child's value of conditions_1 didn't affect the parent scope
+          failed_when: result.skipped is defined and result.skipped
+          register: result
+          debug:

--- a/test/integration/targets/module_defaults/tasks/main.yml
+++ b/test/integration/targets/module_defaults/tasks/main.yml
@@ -87,3 +87,73 @@
       - assert:
           that:
             foo.msg == "Hello world!"
+
+- name: test inheriting and extending variable module_defaults
+  vars:
+    test_file: /tmp/ansible-test.module_defaults.foo
+    defaults_1:
+      - debug:
+          msg: initial msg
+      - file:
+          path: "{{ test_file }}"
+      - fail:
+          msg: initial failure msg
+    defaults_2:
+      - debug:
+          msg: new msg
+  block:
+
+    - name: create a block with a templated value for module_defaults
+      module_defaults: "{{ defaults_1 }}"
+      block:
+
+        - name: block containing tasks that inherit + extend module_defaults
+          block:
+
+            - debug:
+              register: result
+
+            - assert:
+                that:
+                  - result.msg == "initial msg"
+
+            - debug:
+              register: result
+              module_defaults: "{{ defaults_2 }}"
+
+            - assert:
+                that:
+                  - result.msg == "new msg"
+
+            - name: test that the parent value was extended rather than overridden
+              file:
+                state: absent
+              register: result
+
+            - assert:
+                that:
+                  - not result is failed
+
+            - name: test post validation for inheriting templated defaults
+              set_fact:
+                defaults_1:
+                  - debug:
+                      msg: updated msg
+
+            - name: test that inheriting defaults_1 has the updated values
+              debug:
+              register: result
+
+            - assert:
+                that:
+                  - result.msg == "updated msg"
+
+            - file:
+                state: absent
+              ignore_errors: yes
+              register: result
+
+            - assert:
+                that:
+                  - result is failed
+                  - 'result.msg == "missing required arguments: path"'

--- a/test/integration/targets/tags/runme.sh
+++ b/test/integration/targets/tags/runme.sh
@@ -47,3 +47,11 @@ export LC_ALL=en_US.UTF-8
 # Run templated tags
 [ "$("${COMMAND[@]}" --tags tag3 | grep -F Task_with | xargs)" = \
 "Task_with_always_tag TAGS: [always] Task_with_templated_tags TAGS: [tag3]" ]
+
+# Run extend tags
+[ "$("${COMMAND[@]}" --tags tag4 | grep -F Task_in_block_with_extended_tags | xargs)" = \
+"Task_in_block_with_extended_tags TAGS: [tag4, {{ extend_tags }}]" ]
+
+# Run extend tags with added tags
+[ "$("${COMMAND[@]}" --tags tag6 | grep -F Task_in_block_with_added_tag | xargs)" = \
+"Task_in_block_with_added_tag TAGS: [tag4, tag5, tag6, {{ extend_tags }}]" ]

--- a/test/integration/targets/tags/test_tags.yml
+++ b/test/integration/targets/tags/test_tags.yml
@@ -5,6 +5,8 @@
   vars:
     the_tags:
       - tag3
+    extend_tags:
+      - tag4
   tasks:
     - name: Task_with_tag
       debug: msg=
@@ -31,3 +33,13 @@
     - name: Task_with_templated_tags
       debug: msg=templated
       tags: "{{ the_tags }}"
+    - name: Block_with_extend
+      tags: "{{ extend_tags }}"
+      block:
+      - name: Task_in_block_with_extended_tags
+        debug:
+        # Tag inherits and extends - no tags is implicitly
+        # tags: "{{ extend_tags }}"
+      - name: Task_in_block_with_added_tag
+        debug:
+        tags: tag5, tag6

--- a/test/units/playbook/test_conditional.py
+++ b/test/units/playbook/test_conditional.py
@@ -37,16 +37,18 @@ class TestConditional(unittest.TestCase):
     def test_true_boolean(self):
         self.cond.when = [True]
         m = MagicMock()
+        m.is_template.return_value = False
         ret = self.cond.evaluate_conditional(m, {})
         self.assertTrue(ret)
-        self.assertFalse(m.is_template.called)
+        self.assertFalse(m.is_template.return_value)
 
     def test_false_boolean(self):
         self.cond.when = [False]
         m = MagicMock()
+        m.is_template.return_value = False
         ret = self.cond.evaluate_conditional(m, {})
         self.assertFalse(ret)
-        self.assertFalse(m.is_template.called)
+        self.assertFalse(m.is_template.return_value)
 
     def test_undefined(self):
         when = [u"{{ some_undefined_thing }}"]


### PR DESCRIPTION
##### SUMMARY
Fixes #69903

Since the tags FieldAttribute uses `extend=True`, we may get a list containing list variables. Post validation needs to flatten and deduplicate those after templating.

##### ISSUE TYPE
- Bugfix Pull Request
