### PR TITLE
[stable-2.10] Pin ansible-test requirements for RHEL.

### DIFF
--- a/changelogs/fragments/ansible-test-rhel-requirements.yml
+++ b/changelogs/fragments/ansible-test-rhel-requirements.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Provisioning of RHEL instances now includes installation of pinned versions of ``packaging`` and ``pyparsing`` to match the downstream vendored versions.

--- a/test/lib/ansible_test/_data/setup/remote.sh
+++ b/test/lib/ansible_test/_data/setup/remote.sh
@@ -70,6 +70,9 @@ elif [ "${platform}" = "rhel" ]; then
 
         install_pip
     fi
+
+    # pin packaging and pyparsing to match the downstream vendored versions
+    "${python_interpreter}" -m pip install packaging==20.4 pyparsing==2.4.7 --disable-pip-version-check
 elif [ "${platform}" = "centos" ]; then
     while true; do
         yum install -q -y \


### PR DESCRIPTION
##### SUMMARY

[stable-2.10] Pin ansible-test requirements for RHEL.

The `packaging` and `pyparsing` packages are now installed by `ansible-test` during provisioning of RHEL instances to match the downstream vendored versions.

Backport of https://github.com/ansible/ansible/pull/70237

(cherry picked from commit 70c59423fcfeb7560299612189df4b56379a2842)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
