### PR TITLE
Allow hostvars delegation

### DIFF
--- a/changelogs/fragments/delegate_has_hostvars.yml
+++ b/changelogs/fragments/delegate_has_hostvars.yml
@@ -1,2 +1,4 @@
 bugfixes:
-  - ensure delegated vars can resolve hostvars, also fix issue with inventory_hostname and delegated host vars mixing on connection settings.
+  - ensure delegated vars can resolve hostvars object and access vars from hostvars[inventory_hostname].
+  - fix issue with inventory_hostname and delegated host vars mixing on connection settings.
+  - add magic/connection vars updates from delegated host info.

--- a/changelogs/fragments/delegate_has_hostvars.yml
+++ b/changelogs/fragments/delegate_has_hostvars.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ensure delegated vars can resolve hostvars, also fix issue with inventory_hostname and delegated host vars mixing on connection settings.

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -421,9 +421,9 @@ class TaskExecutor:
 
         context_validation_error = None
         try:
-            #TODO: remove play_context as this does not take delegation into account, task itself should hold values
+            # TODO: remove play_context as this does not take delegation into account, task itself should hold values
             #  for connection/shell/become/terminal plugin options to finalize.
-            # kept for now for backwards compatiblity and a few functions that are still exclusive to it.
+            #  Kept for now for backwards compatiblity and a few functions that are still exclusive to it.
 
             # apply the given task's information to the connection info,
             # which may override some fields already set by the play or

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -421,6 +421,10 @@ class TaskExecutor:
 
         context_validation_error = None
         try:
+            #TODO: remove play_context as this does not take delegation into account, task itself should hold values
+            #  for connection/shell/become/terminal plugin options to finalize.
+            # kept for now for backwards compatiblity and a few functions that are still exclusive to it.
+
             # apply the given task's information to the connection info,
             # which may override some fields already set by the play or
             # the options specified on the command line
@@ -439,7 +443,6 @@ class TaskExecutor:
             # a certain subset of variables exist.
             self._play_context.update_vars(variables)
 
-            # FIXME: update connection/shell plugin options
         except AnsibleError as e:
             # save the error, which we'll raise later if we don't end up
             # skipping this task during the conditional evaluation step
@@ -707,6 +710,11 @@ class TaskExecutor:
             for k in plugin_vars + RETURN_VARS:
                 if k in cvars and cvars[k] is not None:
                     result["_ansible_delegated_vars"][k] = cvars[k]
+        else:
+            for k in plugin_vars + RETURN_VARS:
+                if k in cvars and cvars[k] is not None:
+                    result[k] = cvars[k]
+
         # and return
         display.debug("attempt loop complete, returning result")
         return result

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -38,7 +38,7 @@ from ansible.utils.vars import combine_vars, isidentifier
 display = Display()
 
 
-RETURN_VARS = [x for x in C.MAGIC_VARIABLE_MAPPING.items() if 'become' not in x]
+RETURN_VARS = [x for x in C.MAGIC_VARIABLE_MAPPING.items() if 'become' not in x and '_pass' not in x ]
 
 __all__ = ['TaskExecutor']
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -38,7 +38,7 @@ from ansible.utils.vars import combine_vars, isidentifier
 display = Display()
 
 
-RETURN_VARS = [x for x in C.MAGIC_VARIABLE_MAPPING.items() if 'become' not in x and '_pass' not in x ]
+RETURN_VARS = [x for x in C.MAGIC_VARIABLE_MAPPING.items() if 'become' not in x and '_pass' not in x]
 
 __all__ = ['TaskExecutor']
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -38,6 +38,8 @@ from ansible.utils.vars import combine_vars, isidentifier
 display = Display()
 
 
+RETURN_VARS = [x for x in C.MAGIC_VARIABLE_MAPPING.items() if 'become' not in x]
+
 __all__ = ['TaskExecutor']
 
 
@@ -699,10 +701,12 @@ class TaskExecutor:
 
         # add the delegated vars to the result, so we can reference them
         # on the results side without having to do any further templating
+        # also now add conneciton vars results when delegating
         if self._task.delegate_to:
             result["_ansible_delegated_vars"] = {'ansible_delegated_host': self._task.delegate_to}
-            for k in plugin_vars:
-                result["_ansible_delegated_vars"][k] = cvars.get(k)
+            for k in plugin_vars + RETURN_VARS:
+                if k in cvars and cvars[k] is not None:
+                    result["_ansible_delegated_vars"][k] = cvars[k]
         # and return
         display.debug("attempt loop complete, returning result")
         return result

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -602,8 +602,9 @@ class VariableManager:
                 host=delegated_host,
                 task=task,
                 include_delegate_to=False,
-                include_hostvars=False,
+                include_hostvars=True,
             )
+            delegated_host_vars[delegated_host_name]['inventory_hostname'] = vars_copy.get('inventory_hostname')
 
         _ansible_loop_cache = None
         if has_loop and cache_items:

--- a/test/integration/targets/delegate_to/connection_plugins/fakelocal.py
+++ b/test/integration/targets/delegate_to/connection_plugins/fakelocal.py
@@ -1,0 +1,76 @@
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    connection: fakelocal
+    short_description: dont execute anything
+    description:
+        - This connection plugin just verifies parameters passed in
+    author: ansible (@core)
+    version_added: histerical
+    options:
+      password:
+          description: Authentication password for the C(remote_user). Can be supplied as CLI option.
+          vars:
+              - name: ansible_password
+      remote_user:
+          description:
+              - User name with which to login to the remote server, normally set by the remote_user keyword.
+          ini:
+            - section: defaults
+              key: remote_user
+          vars:
+              - name: ansible_user
+'''
+
+from ansible.errors import AnsibleConnectionFailure
+from ansible.plugins.connection import ConnectionBase
+from ansible.utils.display import Display
+
+display = Display()
+
+
+class Connection(ConnectionBase):
+    ''' Local based connections '''
+
+    transport = 'fakelocal'
+    has_pipelining = True
+
+    def __init__(self, *args, **kwargs):
+
+        super(Connection, self).__init__(*args, **kwargs)
+        self.cwd = None
+
+    def _connect(self):
+        ''' verify '''
+
+        if self.get_option('remote_user') == 'invaliduser' and self.get_option('password') == 'badpassword':
+            raise AnsibleConnectionFailure('Got invaliduser and badpassword')
+
+        if not self._connected:
+            display.vvv(u"ESTABLISH FAKELOCAL CONNECTION FOR USER: {0}".format(self._play_context.remote_user), host=self._play_context.remote_addr)
+            self._connected = True
+        return self
+
+    def exec_command(self, cmd, in_data=None, sudoable=True):
+        ''' run a command on the local host '''
+
+        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
+
+        return 0, '{"msg": "ALL IS GOOD"}', ''
+
+    def put_file(self, in_path, out_path):
+        ''' transfer a file from local to local '''
+
+        super(Connection, self).put_file(in_path, out_path)
+
+    def fetch_file(self, in_path, out_path):
+        ''' fetch a file from local to local -- for compatibility '''
+
+        super(Connection, self).fetch_file(in_path, out_path)
+
+    def close(self):
+        ''' terminate the connection; nothing to do here '''
+        self._connected = False

--- a/test/integration/targets/delegate_to/has_hostvars.yml
+++ b/test/integration/targets/delegate_to/has_hostvars.yml
@@ -1,0 +1,56 @@
+- name: ensure delegated host has hostvars available for resolving connection
+  hosts: testhost
+  gather_facts: false
+  tasks:
+
+    - name: ensure delegated host uses current host as inventory_hostname
+      assert:
+        that:
+          - inventory_hostname == ansible_delegated_vars['testhost5']['inventory_hostname']
+      delegate_to: testhost5
+
+    - name: test fakelocal
+      command: ls
+      delegate_to: testhost5
+      ignore_unreachable: True
+      ignore_errors: True
+      register: badlogin
+
+    - name: Set info on inventory_hostname
+      set_fact:
+        login: invaliduser
+        mypass: badpassword
+
+    - name: delegate but try to use inventory_hostname data directly
+      command: ls
+      remote_user: "{{ login }}"
+      delegate_to: testhost5
+      ignore_unreachable: True
+      ignore_errors: True
+      vars:
+        ansible_password: "{{ mypass }}"
+      register: badlogin
+
+    - name: ensure we skipped do to unreachable and not templating error
+      assert:
+        that:
+          - badlogin is not unreachable
+          - badlogin is failed
+          - "'undefined' in badlogin['msg']"
+
+    - name: delegate ls to testhost5 as it uses ssh while testhost is local, but use vars from testhost
+      command: ls
+      remote_user: "{{ hostvars[inventory_hostname]['login'] }}"
+      delegate_to: testhost5
+      ignore_unreachable: True
+      ignore_errors: True
+      vars:
+        ansible_password: "{{ hostvars[inventory_hostname]['mypass'] }}"
+      register: badlogin
+
+    - name: ensure we skipped do to unreachable and not templating error
+      assert:
+        that:
+          - badlogin is unreachable
+          - badlogin is not failed
+          - "'undefined' not in badlogin['msg']"

--- a/test/integration/targets/delegate_to/has_hostvars.yml
+++ b/test/integration/targets/delegate_to/has_hostvars.yml
@@ -9,24 +9,32 @@
           - inventory_hostname == ansible_delegated_vars['testhost5']['inventory_hostname']
       delegate_to: testhost5
 
-    - name: test fakelocal
-      command: ls
-      delegate_to: testhost5
-      ignore_unreachable: True
-      ignore_errors: True
-      register: badlogin
-
     - name: Set info on inventory_hostname
       set_fact:
         login: invaliduser
         mypass: badpassword
 
+    - name: test fakelocal
+      command: ls
+      ignore_unreachable: True
+      ignore_errors: True
+      remote_user: "{{ login }}"
+      vars:
+        ansible_password: "{{ mypass }}"
+        ansible_connection: fakelocal
+      register: badlogin
+
+    - name: ensure we skipped do to unreachable and not templating error
+      assert:
+        that:
+          - badlogin is unreachable
+
     - name: delegate but try to use inventory_hostname data directly
       command: ls
-      remote_user: "{{ login }}"
       delegate_to: testhost5
       ignore_unreachable: True
       ignore_errors: True
+      remote_user: "{{ login }}"
       vars:
         ansible_password: "{{ mypass }}"
       register: badlogin

--- a/test/integration/targets/delegate_to/inventory
+++ b/test/integration/targets/delegate_to/inventory
@@ -3,6 +3,7 @@ testhost ansible_connection=local
 testhost2 ansible_connection=local
 testhost3 ansible_ssh_host=127.0.0.3
 testhost4 ansible_ssh_host=127.0.0.4
+testhost5 ansible_connection=fakelocal
 
 [all:vars]
 ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/targets/delegate_to/runme.sh
+++ b/test/integration/targets/delegate_to/runme.sh
@@ -59,6 +59,7 @@ ansible-playbook test_delegate_to_loop_caching.yml -i inventory -v "$@"
 # ensure we are using correct settings when delegating
 ANSIBLE_TIMEOUT=3 ansible-playbook delegate_vars_hanldling.yml -i inventory -v "$@"
 
+ansible-playbook has_hostvars.yml -i inventory -v "$@"
 
 # test ansible_x_interpreter
 # python

--- a/test/integration/targets/delegate_to/test_delegate_to.yml
+++ b/test/integration/targets/delegate_to/test_delegate_to.yml
@@ -18,6 +18,8 @@
       register: setup_results
       delegate_to: testhost4
 
+    - debug: var=setup_results
+
     - assert:
         that:
           - '"127.0.0.4" in setup_results.ansible_facts.ansible_env["SSH_CONNECTION"]'


### PR DESCRIPTION
allow delegation to use hostvars in the values for connection related properties

fixes #70334 
fixes #22737  incorrect expectation, delegated host should have access to its own vars, not inventory_hostname ones, this PR allows access is wanted via `hostvars[inventory_hostname]`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vars