### PR TITLE
Fix apt delete package by wildcard if it is not found

### DIFF
--- a/changelogs/fragments/70333-apt-delete-package-by-wildcard-not-found.yml
+++ b/changelogs/fragments/70333-apt-delete-package-by-wildcard-not-found.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - apt - fix delete package by wildcard if it is not found (https://github.com/ansible/ansible/issues/62262).

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -618,6 +618,9 @@ def expand_pkgspec_from_fnmatches(m, pkgspec, cache, to_rmv=False):
                 if not matches:
                     if not to_rmv:
                         m.fail_json(msg="No package(s) matching '%s' available" % str(pkgname_pattern))
+                    else:
+                        m.warn("No package(s) matching '%s' to delete. It might be the name(s) was(were) misspelled."
+                               % str(pkgname_pattern))
                 else:
                     new_pkgspec.extend(matches)
             else:

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -582,7 +582,7 @@ def expand_dpkg_options(dpkg_options_compressed):
     return dpkg_options.strip()
 
 
-def expand_pkgspec_from_fnmatches(m, pkgspec, cache):
+def expand_pkgspec_from_fnmatches(m, pkgspec, cache, to_rmv=False):
     # Note: apt-get does implicit regex matching when an exact package name
     # match is not found.  Something like this:
     # matches = [pkg.name for pkg in cache if re.match(pkgspec, pkg.name)]
@@ -616,7 +616,8 @@ def expand_pkgspec_from_fnmatches(m, pkgspec, cache):
                 matches = fnmatch.filter(pkg_name_cache, pkgname_pattern)
 
                 if not matches:
-                    m.fail_json(msg="No package(s) matching '%s' available" % str(pkgname_pattern))
+                    if not to_rmv:
+                        m.fail_json(msg="No package(s) matching '%s' available" % str(pkgname_pattern))
                 else:
                     new_pkgspec.extend(matches)
             else:
@@ -895,7 +896,7 @@ def install_deb(
 def remove(m, pkgspec, cache, purge=False, force=False,
            dpkg_options=expand_dpkg_options(DPKG_OPTIONS), autoremove=False):
     pkg_list = []
-    pkgspec = expand_pkgspec_from_fnmatches(m, pkgspec, cache)
+    pkgspec = expand_pkgspec_from_fnmatches(m, pkgspec, cache, to_rmv=True)
     for package in pkgspec:
         name, version_cmp, version = package_split(package)
         installed, installed_version, upgradable, has_files = package_status(m, name, version_cmp, version, None, cache, state='remove')

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -7,7 +7,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-from ansible.module_utils._text import to_text
 __metaclass__ = type
 
 
@@ -583,7 +582,7 @@ def expand_dpkg_options(dpkg_options_compressed):
     return dpkg_options.strip()
 
 
-def expand_pkgspec_from_fnmatches(m, pkgspec, cache, to_rmv=False):
+def expand_pkgspec_from_fnmatches(m, pkgspec, cache, remove=False):
     # Note: apt-get does implicit regex matching when an exact package name
     # match is not found.  Something like this:
     # matches = [pkg.name for pkg in cache if re.match(pkgspec, pkg.name)]
@@ -617,11 +616,11 @@ def expand_pkgspec_from_fnmatches(m, pkgspec, cache, to_rmv=False):
                 matches = fnmatch.filter(pkg_name_cache, pkgname_pattern)
 
                 if not matches:
-                    if not to_rmv:
-                        m.fail_json(msg="No package(s) matching '%s' available" % to_text(pkgname_pattern))
+                    if not remove:
+                        m.fail_json(msg="No package(s) matching '%s' available" % to_native(pkgname_pattern))
                     else:
                         m.warn("No package(s) matching '%s' to delete. It might be the name(s) was(were) misspelled."
-                               % to_text(pkgname_pattern))
+                               % to_native(pkgname_pattern))
                 else:
                     new_pkgspec.extend(matches)
             else:
@@ -900,7 +899,7 @@ def install_deb(
 def remove(m, pkgspec, cache, purge=False, force=False,
            dpkg_options=expand_dpkg_options(DPKG_OPTIONS), autoremove=False):
     pkg_list = []
-    pkgspec = expand_pkgspec_from_fnmatches(m, pkgspec, cache, to_rmv=True)
+    pkgspec = expand_pkgspec_from_fnmatches(m, pkgspec, cache, remove=True)
     for package in pkgspec:
         name, version_cmp, version = package_split(package)
         installed, installed_version, upgradable, has_files = package_status(m, name, version_cmp, version, None, cache, state='remove')

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -7,6 +7,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils._text import to_text
 __metaclass__ = type
 
 
@@ -617,10 +618,10 @@ def expand_pkgspec_from_fnmatches(m, pkgspec, cache, to_rmv=False):
 
                 if not matches:
                     if not to_rmv:
-                        m.fail_json(msg="No package(s) matching '%s' available" % str(pkgname_pattern))
+                        m.fail_json(msg="No package(s) matching '%s' available" % to_text(pkgname_pattern))
                     else:
                         m.warn("No package(s) matching '%s' to delete. It might be the name(s) was(were) misspelled."
-                               % str(pkgname_pattern))
+                               % to_text(pkgname_pattern))
                 else:
                     new_pkgspec.extend(matches)
             else:


### PR DESCRIPTION
##### SUMMARY
When we install/delete package(s) by wildcard using apt module, we always use function `expand_pkgspec_from_fnmatches()` to find the exact package(s) name(s). The thing is that we match our wildcard name only among packages in apt cache. That's totally correct when we install packages, because we need to be sure that we can install them in the target OS. 
But it's not a case when we are trying to remove package(s) from the target system (`state: 'absent'`). We shouldn't care if we didn't find package(s) for removal in apt cache. The only explanation that there is(are) no package(s) installed in the target system which is(are) matched by wildcard. If so, we don't need to remove them. Ansible shouldn't throw an error in this case.

Fixes #62262

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
apt

##### ADDITIONAL INFORMATION
We have a simple `playbook.yaml`:
```
---
- hosts: localhost
  connection: local
  gather_facts: True
  tasks:
    - apt:
         name: "test-test-test*"
         state: absent
         autoremove: yes

```
Before this PR:
```
TASK [apt] *****************************************************************************************************************************************************************************************************
task path: /ansible/playbook.yaml:6
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp `"&& mkdir /root/.ansible/tmp/ansible-tmp-1593194564.1-9044-82833657605949 && echo ansible-tmp-1593194564.1-9044-82833657605949="` echo /root/.ansible/tmp/ansible-tmp-1593194564.1-9044-82833657605949 `" ) && sleep 0'
Using module file /ansible/lib/ansible/modules/apt.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-8994OqAboD/tmpF1KRHS TO /root/.ansible/tmp/ansible-tmp-1593194564.1-9044-82833657605949/AnsiballZ_apt.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1593194564.1-9044-82833657605949/ /root/.ansible/tmp/ansible-tmp-1593194564.1-9044-82833657605949/AnsiballZ_apt.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1593194564.1-9044-82833657605949/AnsiballZ_apt.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1593194564.1-9044-82833657605949/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
WARNING: The below traceback may *not* be related to the actual failure.
  File "/tmp/ansible_apt_payload_FIkYeG/ansible_apt_payload.zip/ansible/modules/apt.py", line 547, in expand_pkgspec_from_fnmatches
fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "allow_unauthenticated": false,
            "autoclean": false,
            "autoremove": true,
            "cache_valid_time": 0,
            "deb": null,
            "default_release": null,
            "dpkg_options": "force-confdef,force-confold",
            "force": false,
            "force_apt_get": false,
            "install_recommends": null,
            "name": "test-test-test*",
            "only_upgrade": false,
            "package": [
                "test-test-test*"
            ],
            "policy_rc_d": null,
            "purge": false,
            "state": "absent",
            "update_cache": null,
            "update_cache_retries": 5,
            "update_cache_retry_max_delay": 12,
            "upgrade": null
        }
    },
    "msg": "No package(s) matching 'test-test-test*' available"
}
```
After this PR:
```
TASK [apt] *****************************************************************************************************************************************************************************************************
task path: /root/ansible/playbook.yaml:6
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp `"&& mkdir /root/.ansible/tmp/ansible-tmp-1593537430.2411246-5847-78438765107749 && echo ansible-tmp-1593537430.2411246-5847-78438765107749="` echo /root/.ansible/tmp/ansible-tmp-1593537430.2411246-5847-78438765107749 `" ) && sleep 0'
Using module file /root/ansible/lib/ansible/modules/apt.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-5798y68sy6pa/tmp0v22nj5r TO /root/.ansible/tmp/ansible-tmp-1593537430.2411246-5847-78438765107749/AnsiballZ_apt.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1593537430.2411246-5847-78438765107749/ /root/.ansible/tmp/ansible-tmp-1593537430.2411246-5847-78438765107749/AnsiballZ_apt.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1593537430.2411246-5847-78438765107749/AnsiballZ_apt.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1593537430.2411246-5847-78438765107749/ > /dev/null 2>&1 && sleep 0'
[WARNING]: No package(s) matching 'test-test-test*' to delete. It might be the name(s) was(were) misspelled.
ok: [localhost] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "allow_unauthenticated": false,
            "autoclean": false,
            "autoremove": true,
            "cache_valid_time": 0,
            "deb": null,
            "default_release": null,
            "dpkg_options": "force-confdef,force-confold",
            "force": false,
            "force_apt_get": false,
            "install_recommends": null,
            "name": "test-test-test*",
            "only_upgrade": false,
            "package": [
                "test-test-test*"
            ],
            "policy_rc_d": null,
            "purge": false,
            "state": "absent",
            "update_cache": null,
            "update_cache_retries": 5,
            "update_cache_retry_max_delay": 12,
            "upgrade": null
        }
    }
}
META: ran handlers
META: ran handlers
```


