### PR TITLE
[get_url] permit to have a checksum only file

### DIFF
--- a/changelogs/fragments/get_url-accept-file-for-checksum.yml
+++ b/changelogs/fragments/get_url-accept-file-for-checksum.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- get_url - permit to pass to parameter ``checksum`` an URL pointing to a file containing only a checksum (https://github.com/ansible/ansible/issues/54390).

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -511,11 +511,18 @@ def main():
                 lines = [line.rstrip('\n') for line in f]
             os.remove(checksum_tmpsrc)
             checksum_map = []
-            for line in lines:
-                parts = line.split(None, 1)
-                if len(parts) == 2:
-                    checksum_map.append((parts[0], parts[1]))
             filename = url_filename(url)
+            if len(lines) == 1 and len(lines[0].split()) == 1:
+                # Only a single line with a single string
+                # treat it as a checksum only file
+                checksum_map.append((lines[0], filename))
+            else:
+                # The assumption here is the file is in the format of
+                # checksum filename
+                for line in lines:
+                    parts = line.split(None, 1)
+                    if len(parts) == 2:
+                        checksum_map.append((parts[0], parts[1]))
 
             # Look through each line in the checksum file for a hash corresponding to
             # the filename in the url, returning the first hash that is found.

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -367,6 +367,13 @@
       30949cc401e30ac494d695ab8764a9f76aae17c5d73c67f65e9b558f47eff892  ./not_target1.txt
       d0dbfc1945bc83bf6606b770e442035f2c4e15c886ee0c22fb3901ba19900b5b  ./not_target2.txt
 
+# completing 27617 with bug 54390
+- name: create sha256 checksum only with no filename inside
+  copy:
+    dest: '{{ files_dir }}/sha256sum_checksum_only.txt'
+    content: |
+      b1b6ce5073c8fac263a8fc5edfffdbd5dec1980c784e09c5bc69f8fb6056f006
+
 - copy:
     src: "testserver.py"
     dest: "{{ remote_tmp_dir }}/testserver.py"
@@ -478,11 +485,22 @@
     path: "{{ remote_tmp_dir }}/71420sha256_with_dot.txt"
   register: stat_result_sha256_with_file_scheme_71420
 
+- name: download src with sha256 checksum url with no filename
+  get_url:
+    url: 'http://localhost:{{ http_port }}/27617.txt'
+    dest: '{{ remote_tmp_dir }}/27617sha256_with_no_filename.txt'
+    checksum: 'sha256:http://localhost:{{ http_port }}/sha256sum_checksum_only.txt'
+  register: result_sha256_checksum_only
+
+- stat:
+    path: "{{ remote_tmp_dir }}/27617.txt"
+  register: stat_result_sha256_checksum_only
+
 - name: Assert that the file was downloaded
   assert:
     that:
-      - result_sha1_check_mode is changed
       - result_sha1 is changed
+      - result_sha1_check_mode is changed
       - result_sha256 is changed
       - result_sha256_with_dot is changed
       - result_sha256_with_file_scheme is changed
@@ -493,11 +511,13 @@
       - result_sha1_71420 is changed
       - result_sha256_71420 is changed
       - result_sha256_with_dot_71420 is changed
+      - result_sha256_checksum_only is changed
       - result_sha256_with_file_scheme_71420 is changed
       - "stat_result_sha1_71420.stat.exists == true"
       - "stat_result_sha256_71420.stat.exists == true"
       - "stat_result_sha256_with_dot_71420.stat.exists == true"
       - "stat_result_sha256_with_file_scheme_71420.stat.exists == true"
+      - "stat_result_sha256_checksum_only.stat.exists == true"
 
 #https://github.com/ansible/ansible/issues/16191
 - name: Test url split with no filename


### PR DESCRIPTION
##### SUMMARY
checksum parameter can also accept a checksum only file (no filename beside the checksum).
fixes #54390

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
get_url

##### ADDITIONAL INFORMATION
Code is from @sivel and it cover a part of the patch done by @Zype76 in #68869 