### PR TITLE
Clean up symlink cache during 'make clean'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,8 @@ clean:
 	rm -f test/units/.coverage*
 	rm -rf test/results/*/*
 	find test/ -type f -name '*.retry' -delete
+	@echo "Cleaning up symlink cache"
+	rm -f SYMLINK_CACHE.json
 	@echo "Cleaning up Debian building stuff"
 	rm -rf debian
 	rm -rf deb-build


### PR DESCRIPTION
##### SUMMARY
Make building across versions, renamed modules can result in no such file errors by the install.

For this exact case `ec2_vpc_dhcp_option_facts` has been renamed to `ec2_vpc_dhcp_option_info` but I assume it will affect any renamed modules where the symlink cache exists from a previous build

This changes the `make clean` to remove that cache.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
Repo steps - any 2.7 and 2.9 branch seems to replicate this, these are just the latest I've building here in simplified steps.

```
cd src-dir
git clone git://github.com/ansible/ansible.git .
git checkout v2.7.9
make
make install
git checkout v2.9.9
make clean
make
make install
```

Error output
```
copying build/lib.linux-x86_64-2.7/ansible/modules/cloud/amazon/route53_zone.py -> build/bdist.linux-x86_64/egg/ansible/modules/cloud/amazon
error: can't copy 'build/lib.linux-x86_64-2.7/ansible/modules/cloud/amazon/_ec2_vpc_dhcp_options_facts.py': doesn't exist or not a regular file
make: *** [Makefile:218: install] Error 1
```