### PR TITLE
Copy also tags when copying play

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -340,4 +340,6 @@ class Play(Base, Taggable, CollectionSearch):
         new_me.ROLE_CACHE = self.ROLE_CACHE.copy()
         new_me._included_conditional = self._included_conditional
         new_me._included_path = self._included_path
+        new_me.only_tags = self.only_tags
+        new_me.skip_tags = self.skip_tags
         return new_me


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I am trying to interact with ansible programmatically. This is not supported but I thought I would open the PR just in case. 

I have the following code:

```python
...

playbooks = [
    Playbook.load(
        p,
        loader=loader,
        variable_manager=variable_manager,
    )
    for p in playbook_paths
]

tqm = None
try:
    tqm = TaskQueueManager(
        inventory=inventory,
        variable_manager=variable_manager,
        loader=loader,
        passwords=None,
        stdout_callback="default",  # Use our custom callback instead of the ``default`` callback plugin, which prints to stdout
    )

    for playbook in playbooks:
        for play in playbook.get_plays():
            play.only_tags = frozenset({"my-tag"})
            result = tqm.run(play)
finally:
    # we always need to cleanup child procs and the structures we use to communicate with them
    if tqm is not None:
        tqm.cleanup()
```

When I run this, all tasks get run regardless of the `only_tags` setting. I tried to find out why and the reason is that the queue manager copies the play objects before running them. The copy method of `Play`, however, does not copy `only_tags` and `skipped_tags`. These are available from elsewhere (I guess the variable manager).

The way to specify tags is through the cli context. However, this makes the code feel it depends on the command line interface with the user, instead of the interface using what is available in code. 

In any case, if I include the two properties in the copy, the above seems to work ok. I am probably missing some insight, but thought I shared.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
play

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
