### PR TITLE
[stable-2.10] pause - fix curses.setupterm() error (#47851)

### DIFF
--- a/changelogs/fragments/pause-catch-error-when-no-std-exists.yml
+++ b/changelogs/fragments/pause-catch-error-when-no-std-exists.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pause - handle exception when there is no stdout (https://github.com/ansible/ansible/pull/47851)

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -41,7 +41,7 @@ try:
     try:
         curses.setupterm()
         HAS_CURSES = True
-    except curses.error:
+    except (curses.error, TypeError):
         HAS_CURSES = False
 except ImportError:
     HAS_CURSES = False


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #47851 for Ansible 2.10
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/action/pause.py`