### PR TITLE
Fix -vvvvv unicode error in executor.module_common

### DIFF
--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -904,7 +904,8 @@ def recursive_finder(name, module_fqn, data, py_module_names, py_module_cache, z
         py_module_file_name = '%s.py' % py_module_path
 
         zf.writestr(py_module_file_name, py_module_cache[py_module_name][0])
-        display.vvvvv("Using module_utils file %s" % py_module_cache[py_module_name][1])
+        mu_file = to_text(py_module_cache[py_module_name][1], errors='surrogate_or_strict')
+        display.vvvvv("Using module_utils file %s" % mu_file)
 
     # Add the names of the files we're scheduling to examine in the loop to
     # py_module_names so that we don't re-examine them in the next pass

--- a/test/integration/targets/module_utils/module_utils_vvvvv.yml
+++ b/test/integration/targets/module_utils/module_utils_vvvvv.yml
@@ -1,0 +1,5 @@
+- hosts: testhost
+  gather_facts: no
+  tasks:
+  - name: Use a specially crafted module to see if things were imported correctly
+    test:

--- a/test/integration/targets/module_utils/runme.sh
+++ b/test/integration/targets/module_utils/runme.sh
@@ -4,5 +4,8 @@ set -eux
 
 ANSIBLE_ROLES_PATH=../ ansible-playbook module_utils_basic_setcwd.yml -i ../../inventory "$@"
 
-ansible-playbook module_utils_test.yml -i ../../inventory -v "$@"
+# Keep the -vvvvv here. This acts as a test for testing that higher verbosity
+# doesn't traceback with unicode in the custom module_utils directory path.
+ansible-playbook module_utils_test.yml -i ../../inventory -vvvvv "$@"
+
 ANSIBLE_MODULE_UTILS=other_mu_dir ansible-playbook module_utils_envvar.yml -i ../../inventory -v "$@"

--- a/test/integration/targets/module_utils/runme.sh
+++ b/test/integration/targets/module_utils/runme.sh
@@ -6,6 +6,8 @@ ANSIBLE_ROLES_PATH=../ ansible-playbook module_utils_basic_setcwd.yml -i ../../i
 
 # Keep the -vvvvv here. This acts as a test for testing that higher verbosity
 # doesn't traceback with unicode in the custom module_utils directory path.
-ansible-playbook module_utils_test.yml -i ../../inventory -vvvvv "$@"
+ansible-playbook module_utils_vvvvvv.yml -i ../../inventory -vvvvv "$@"
+
+ansible-playbook module_utils_test.yml -i ../../inventory -v "$@"
 
 ANSIBLE_MODULE_UTILS=other_mu_dir ansible-playbook module_utils_envvar.yml -i ../../inventory -v "$@"

--- a/test/integration/targets/module_utils/runme.sh
+++ b/test/integration/targets/module_utils/runme.sh
@@ -6,7 +6,7 @@ ANSIBLE_ROLES_PATH=../ ansible-playbook module_utils_basic_setcwd.yml -i ../../i
 
 # Keep the -vvvvv here. This acts as a test for testing that higher verbosity
 # doesn't traceback with unicode in the custom module_utils directory path.
-ansible-playbook module_utils_vvvvvv.yml -i ../../inventory -vvvvv "$@"
+ansible-playbook module_utils_vvvvv.yml -i ../../inventory -vvvvv "$@"
 
 ansible-playbook module_utils_test.yml -i ../../inventory -v "$@"
 


### PR DESCRIPTION

##### SUMMARY

Change:
- Fix a UnicodeDecodeError in executor.module_common that could get
  triggered with -vvvvv.

Test Plan:
- `ansible-test integration --docker centos7 module_utils -vvvvv`
  This would show the error previously, and no loner does after this
  patch.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

module_common