### PR TITLE
[2.10] Top-level deprecation of plugin did not get collection_name added when deprecating by version

### DIFF
--- a/changelogs/fragments/70344-plugin-deprecation-collection-name.yml
+++ b/changelogs/fragments/70344-plugin-deprecation-collection-name.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-doc - collection name for plugin top-level deprecation was not inserted when deprecating by version (https://github.com/ansible/ansible/pull/70344)."

--- a/lib/ansible/utils/plugin_docs.py
+++ b/lib/ansible/utils/plugin_docs.py
@@ -41,14 +41,14 @@ def merge_fragment(target, source):
 
 
 def _process_versions_and_dates(fragment, is_module, return_docs, callback):
-    def process_deprecation(deprecation):
+    def process_deprecation(deprecation, top_level=False):
         if not isinstance(deprecation, MutableMapping):
             return
-        if is_module and 'removed_in' in deprecation:  # used in module deprecations
+        if (is_module or top_level) and 'removed_in' in deprecation:  # used in module deprecations
             callback(deprecation, 'removed_in', 'removed_from_collection')
         if 'removed_at_date' in deprecation:
             callback(deprecation, 'removed_at_date', 'removed_from_collection')
-        if not is_module and 'version' in deprecation:  # used in plugin option deprecations
+        if not (is_module or top_level) and 'version' in deprecation:  # used in plugin option deprecations
             callback(deprecation, 'version', 'removed_from_collection')
 
     def process_option_specifiers(specifiers):
@@ -95,7 +95,7 @@ def _process_versions_and_dates(fragment, is_module, return_docs, callback):
     if 'version_added' in fragment:
         callback(fragment, 'version_added', 'version_added_collection')
     if isinstance(fragment.get('deprecated'), MutableMapping):
-        process_deprecation(fragment['deprecated'])
+        process_deprecation(fragment['deprecated'], top_level=True)
     if isinstance(fragment.get('options'), MutableMapping):
         process_options(fragment['options'])
 


### PR DESCRIPTION
##### SUMMARY
Backport of #70344 to stable-2.10.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/utils/plugin_docs.py
