### PR TITLE
Use the first galaxy server supporting v1 for roles

### DIFF
--- a/changelogs/fragments/70375-galaxy-server.yml
+++ b/changelogs/fragments/70375-galaxy-server.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- ansible-galaxy - Instead of assuming the first defined server is galaxy,
+  filter based on the servers that support the v1 API, and return the first
+  of those (https://github.com/ansible/ansible/issues/65440)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -114,6 +114,7 @@ class GalaxyCLI(CLI):
 
         self.api_servers = []
         self.galaxy = None
+        self._api = None
         super(GalaxyCLI, self).__init__(args)
 
     def init_parser(self):
@@ -499,7 +500,13 @@ class GalaxyCLI(CLI):
 
     @property
     def api(self):
-        return self.api_servers[0]
+        if self._api:
+            return self._api
+        for server in self.api_servers:
+            if u'v1' in server.available_api_versions:
+                self._api = server
+                break
+        return self._api
 
     def _get_default_collection_path(self):
         return C.COLLECTIONS_PATHS[0]

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -502,10 +502,18 @@ class GalaxyCLI(CLI):
     def api(self):
         if self._api:
             return self._api
+
         for server in self.api_servers:
-            if u'v1' in server.available_api_versions:
-                self._api = server
-                break
+            try:
+                if u'v1' in server.available_api_versions:
+                    self._api = server
+                    break
+            except Exception:
+                continue
+
+        if not self._api:
+            self._api = self.api_servers[0]
+
         return self._api
 
     def _get_default_collection_path(self):


### PR DESCRIPTION
##### SUMMARY

Instead of assuming the first defined server is galaxy, filter based on the servers that support the `v1` API, and return the first of those.

Fixes #65440

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/cli/galaxy.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
