### PR TITLE
ansible-test - do not validate blacklisted ps modules

### DIFF
--- a/changelogs/fragments/validate-modules-ps-doc-blacklist.yaml
+++ b/changelogs/fragments/validate-modules-ps-doc-blacklist.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- ansible-test - Do not try to validate modules that are in the PS_DOC_BLACKLIST like ``setup.ps1``, ``slurp.ps1``, and ``async_status.ps1``
+- ansible-test - Do not try to validate PowerShell modules ``setup.ps1``, ``slurp.ps1``, and ``async_status.ps1``

--- a/changelogs/fragments/validate-modules-ps-doc-blacklist.yaml
+++ b/changelogs/fragments/validate-modules-ps-doc-blacklist.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-test - Do not try to validate modules that are in the PS_DOC_BLACKLIST like ``setup.ps1``, ``slurp.ps1``, and ``async_status.ps1``

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -2204,6 +2204,9 @@ class ModuleValidator(Validator):
             self._check_for_os_call()
 
         if self._powershell_module():
+            if self.basename in self.PS_DOC_BLACKLIST:
+                return
+
             self._validate_ps_replacers()
             docs_path = self._find_ps_docs_py_file()
 


### PR DESCRIPTION
##### SUMMARY
Previously this was fine because none of the blacklisted PowerShell modules used the newer argspec style so the validation never occurred. Now that https://github.com/ansible-collections/ansible.windows/pull/78 adds that to `setup.ps1` we need to ensure that the validation does not occur because the docs do not exist.

Without this fix `ansible-test sanity --test validate-modules setup` fails with

```
ERROR: Command "/home/jborean/venvs/ansible-py38/bin/python /home/jborean/dev/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate-modules --format json --arg-spec plugins/modules/setup.ps1 --collection ansible_collections/ansible/windows --collection-version 0.0.1-beta.3" returned exit status 1.
>>> Standard Error
Traceback (most recent call last):
  File "/home/jborean/dev/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate-modules", line 8, in <module>
    main()
  File "/home/jborean/dev/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 2445, in main
    run()
  File "/home/jborean/dev/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 2342, in run
    mv1.validate()
  File "/home/jborean/dev/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 2213, in validate
    with ModuleValidator(docs_path, base_branch=self.base_branch, git_cache=self.git_cache) as docs_mv:
  File "/home/jborean/dev/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 262, in __init__
    self.basename = os.path.basename(self.path)
  File "/home/jborean/venvs/ansible-py38/lib/python3.8/posixpath.py", line 142, in basename
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

This is because `self._find_ps_docs_py_file()` returns `None` due to the module being blacklisted.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
validate-modules