### PR TITLE
[2.10] Docs: mention about Ansible workshops

### DIFF
--- a/docs/docsite/rst/community/how_can_I_help.rst
+++ b/docs/docsite/rst/community/how_can_I_help.rst
@@ -77,7 +77,7 @@ Working groups are a way for Ansible community members to self-organize around p
 Teach Ansible to others
 =======================
 
-We're working on a standardized Ansible workshop called `Lightbulb <https://github.com/ansible/lightbulb>`_ that can provide a good hands-on introduction to Ansible usage and concepts.
+We're working on a standardized `Ansible workshop <https://ansible.github.io/workshops/>`_ that can provide a good hands-on introduction to Ansible usage and concepts.
 
 Social media
 ============


### PR DESCRIPTION
##### SUMMARY

Lightbulb is deprecated in favor of https://ansible.github.io/workshops/
Update links accordingly.
Fixes: #70296

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit e4f48c920cd9501804f4e2e626a895c51509cdea)


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/community/how_can_I_help.rst
