### PR TITLE
2.10: Fix delegate_facts with interpreter not being set (#70293)

### DIFF
--- a/changelogs/fragments/70168-fix-delegate_facts-without-interpreter-set.yml
+++ b/changelogs/fragments/70168-fix-delegate_facts-without-interpreter-set.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Fix ``delegate_facts: true`` when ``ansible_python_interpreter`` is not set. (https://github.com/ansible/ansible/issues/70168)"

--- a/test/integration/targets/interpreter_discovery_python_delegate_facts/aliases
+++ b/test/integration/targets/interpreter_discovery_python_delegate_facts/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group1
+non_local  # this test requires interpreter discovery, which means code coverage must be disabled

--- a/test/integration/targets/interpreter_discovery_python_delegate_facts/delegate_facts.yml
+++ b/test/integration/targets/interpreter_discovery_python_delegate_facts/delegate_facts.yml
@@ -1,0 +1,10 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Test python interpreter discovery with delegate_to without delegate_facts
+      ping:
+      delegate_to: testhost
+    - name: Test python interpreter discovery with delegate_to with delegate_facts
+      ping:
+      delegate_to: testhost
+      delegate_facts: yes

--- a/test/integration/targets/interpreter_discovery_python_delegate_facts/inventory
+++ b/test/integration/targets/interpreter_discovery_python_delegate_facts/inventory
@@ -1,0 +1,2 @@
+[local]
+testhost ansible_connection=local ansible_python_interpreter=auto  # interpreter discovery required

--- a/test/integration/targets/interpreter_discovery_python_delegate_facts/runme.sh
+++ b/test/integration/targets/interpreter_discovery_python_delegate_facts/runme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ansible-playbook delegate_facts.yml -i inventory "$@"

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -164,19 +164,19 @@ class TestActionBase(unittest.TestCase):
                 self.assertEqual(shebang, u"#!/usr/bin/python")
 
                 # test module not found
-                self.assertRaises(AnsibleError, action_base._configure_module, 'badmodule', mock_task.args)
+                self.assertRaises(AnsibleError, action_base._configure_module, 'badmodule', mock_task.args, {})
 
         # test powershell module formatting
         with patch.object(builtins, 'open', mock_open(read_data=to_bytes(powershell_module_replacers.strip(), encoding='utf-8'))):
             mock_task.action = 'win_copy'
             mock_task.args = dict(b=2)
             mock_connection.module_implementation_preferences = ('.ps1',)
-            (style, shebang, data, path) = action_base._configure_module('stat', mock_task.args)
+            (style, shebang, data, path) = action_base._configure_module('stat', mock_task.args, {})
             self.assertEqual(style, "new")
             self.assertEqual(shebang, u'#!powershell')
 
             # test module not found
-            self.assertRaises(AnsibleError, action_base._configure_module, 'badmodule', mock_task.args)
+            self.assertRaises(AnsibleError, action_base._configure_module, 'badmodule', mock_task.args, {})
 
     def test_action_base__compute_environment_string(self):
         fake_loader = DictDataLoader({


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of https://github.com/ansible/ansible/pull/70293
(cherry picked from commit b05e00e99a91b08cc2de95c6e151c9eb268a01d5)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/action/__init__.py`
