### PR TITLE
2.9: Fix delegate_facts with interpreter not being set (#70293)

### DIFF
--- a/changelogs/fragments/70168-fix-delegate_facts-without-interpreter-set.yml
+++ b/changelogs/fragments/70168-fix-delegate_facts-without-interpreter-set.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Fix ``delegate_facts: true`` when ``ansible_python_interpreter`` is not set. (https://github.com/ansible/ansible/issues/70168)"

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -152,15 +152,11 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             return True
         return False
 
-    def _configure_module(self, module_name, module_args, task_vars=None):
+    def _configure_module(self, module_name, module_args, task_vars):
         '''
         Handles the loading and templating of the module code through the
         modify_module() function.
         '''
-
-        if task_vars is None:
-            use_vars = dict()
-
         if self._task.delegate_to:
             use_vars = task_vars.get('ansible_delegated_vars')[self._task.delegate_to]
         else:
@@ -225,20 +221,18 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 # we'll propagate back to the controller in the task result
                 discovered_key = 'discovered_interpreter_%s' % idre.interpreter_name
 
+                # update the local vars copy for the retry
+                use_vars['ansible_facts'][discovered_key] = self._discovered_interpreter
+
                 # TODO: this condition prevents 'wrong host' from being updated
                 # but in future we would want to be able to update 'delegated host facts'
                 # irrespective of task settings
                 if not self._task.delegate_to or self._task.delegate_facts:
                     # store in local task_vars facts collection for the retry and any other usages in this worker
-                    if use_vars.get('ansible_facts') is None:
-                        task_vars['ansible_facts'] = {}
                     task_vars['ansible_facts'][discovered_key] = self._discovered_interpreter
                     # preserve this so _execute_module can propagate back to controller as a fact
                     self._discovered_interpreter_key = discovered_key
                 else:
-                    task_vars['ansible_delegated_vars'][self._task.delegate_to]
-                    if task_vars['ansible_delegated_vars'][self._task.delegate_to].get('ansible_facts') is None:
-                        task_vars['ansible_delegated_vars'][self._task.delegate_to]['ansible_facts'] = {}
                     task_vars['ansible_delegated_vars'][self._task.delegate_to]['ansible_facts'][discovered_key] = self._discovered_interpreter
 
         return (module_style, module_shebang, module_data, module_path)

--- a/test/integration/targets/interpreter_discovery_python_delegate_facts/aliases
+++ b/test/integration/targets/interpreter_discovery_python_delegate_facts/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group1
+non_local  # this test requires interpreter discovery, which means code coverage must be disabled

--- a/test/integration/targets/interpreter_discovery_python_delegate_facts/delegate_facts.yml
+++ b/test/integration/targets/interpreter_discovery_python_delegate_facts/delegate_facts.yml
@@ -1,0 +1,10 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Test python interpreter discovery with delegate_to without delegate_facts
+      ping:
+      delegate_to: testhost
+    - name: Test python interpreter discovery with delegate_to with delegate_facts
+      ping:
+      delegate_to: testhost
+      delegate_facts: yes

--- a/test/integration/targets/interpreter_discovery_python_delegate_facts/inventory
+++ b/test/integration/targets/interpreter_discovery_python_delegate_facts/inventory
@@ -1,0 +1,2 @@
+[local]
+testhost ansible_connection=local ansible_python_interpreter=auto  # interpreter discovery required

--- a/test/integration/targets/interpreter_discovery_python_delegate_facts/runme.sh
+++ b/test/integration/targets/interpreter_discovery_python_delegate_facts/runme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ansible-playbook delegate_facts.yml -i inventory "$@"

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -159,19 +159,19 @@ class TestActionBase(unittest.TestCase):
                 self.assertEqual(shebang, u"#!/usr/bin/python")
 
                 # test module not found
-                self.assertRaises(AnsibleError, action_base._configure_module, 'badmodule', mock_task.args)
+                self.assertRaises(AnsibleError, action_base._configure_module, 'badmodule', mock_task.args, {})
 
         # test powershell module formatting
         with patch.object(builtins, 'open', mock_open(read_data=to_bytes(powershell_module_replacers.strip(), encoding='utf-8'))):
             mock_task.action = 'win_copy'
             mock_task.args = dict(b=2)
             mock_connection.module_implementation_preferences = ('.ps1',)
-            (style, shebang, data, path) = action_base._configure_module('stat', mock_task.args)
+            (style, shebang, data, path) = action_base._configure_module('stat', mock_task.args, {})
             self.assertEqual(style, "new")
             self.assertEqual(shebang, u'#!powershell')
 
             # test module not found
-            self.assertRaises(AnsibleError, action_base._configure_module, 'badmodule', mock_task.args)
+            self.assertRaises(AnsibleError, action_base._configure_module, 'badmodule', mock_task.args, {})
 
     def test_action_base__compute_environment_string(self):
         fake_loader = DictDataLoader({


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of https://github.com/ansible/ansible/pull/70293
(cherry picked from commit b05e00e99a91b08cc2de95c6e151c9eb268a01d5)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/action/__init__.py`
