### PR TITLE
[2.10] Add fail_on_autoremove option to apt module to avoid unintended package removals. (#70056)

### DIFF
--- a/changelogs/fragments/70056-add-a-param-to-apt-module-to-avoid-unintended-uninstalls.yml
+++ b/changelogs/fragments/70056-add-a-param-to-apt-module-to-avoid-unintended-uninstalls.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - apt - add ``fail_on_autoremove`` param to apt module to avoid unintended package removals (https://github.com/ansible/ansible/issues/63231)

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -142,7 +142,7 @@ options:
       - 'C(fail_on_autoremove) is only supported with state except C(absent)'
     type: bool
     default: 'no'
-    version_added: "2.11"
+    version_added: "2.10"
   force_apt_get:
     description:
       - Force usage of apt-get instead of aptitude

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -179,6 +179,44 @@
 - name: uninstall hello with apt
   apt: pkg=hello state=absent purge=yes
 
+# INSTALL WITHOUT REMOVALS
+- name: Install hello, that conflicts with hello-traditional
+  apt: 
+    pkg: hello
+    state: present
+    update_cache: no
+
+- name: check hello
+  shell: dpkg-query -l hello
+  register: dpkg_result
+
+- name: verify installation of hello
+  assert:
+    that:
+        - "apt_result.changed"
+        - "dpkg_result.rc == 0"
+
+- name: Try installing hello-traditional, that conflicts with hello
+  apt: 
+    pkg: hello-traditional
+    state: present
+    fail_on_autoremove: yes
+  ignore_errors: yes
+  register: apt_result
+
+- name: verify failure of installing hello-traditional, because it is required to remove hello to install.
+  assert:
+    that:
+      - apt_result is failed
+      - '"Packages need to be removed but remove is disabled." in apt_result.msg'
+
+- name: uninstall hello with apt
+  apt: 
+    pkg: hello
+    state: absent
+    purge: yes
+    update_cache: no
+
 - name: install deb file
   apt: deb="/var/cache/apt/archives/hello_{{ hello_version.stdout }}_{{ hello_architecture.stdout }}.deb"
   register: apt_initial


### PR DESCRIPTION
##### SUMMARY

Backport of #70056
(cherry picked from commit 4997063b4a)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

`lib/ansible/modules/apt.py`
