### PR TITLE
[stable-2.9] Use the first galaxy server supporting v1 for roles (#70375)

### DIFF
--- a/changelogs/fragments/70375-galaxy-server.yml
+++ b/changelogs/fragments/70375-galaxy-server.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- ansible-galaxy - Instead of assuming the first defined server is galaxy,
+  filter based on the servers that support the v1 API, and return the first
+  of those (https://github.com/ansible/ansible/issues/65440)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -54,6 +54,7 @@ class GalaxyCLI(CLI):
 
         self.api_servers = []
         self.galaxy = None
+        self._api = None
         super(GalaxyCLI, self).__init__(args)
 
     def init_parser(self):
@@ -376,7 +377,21 @@ class GalaxyCLI(CLI):
 
     @property
     def api(self):
-        return self.api_servers[0]
+        if self._api:
+            return self._api
+
+        for server in self.api_servers:
+            try:
+                if u'v1' in server.available_api_versions:
+                    self._api = server
+                    break
+            except Exception:
+                continue
+
+        if not self._api:
+            self._api = self.api_servers[0]
+
+        return self._api
 
     def _parse_requirements_file(self, requirements_file, allow_old_format=True):
         """


### PR DESCRIPTION
* Use the first galaxy server supporting v1 for roles. Fixes #65440

* Add changelog fragment

* This is best effort, fall back to original behavior if something bad happens
(cherry picked from commit 1f1d6e5)


Co-authored-by: Matt Martz <matt@sivel.net>