### PR TITLE
Allow non-ascii (UTF-8) chars in cron file paths and jobs

### DIFF
--- a/changelogs/fragments/70426-allow-non-ascii-chars-in-cron-job.yml
+++ b/changelogs/fragments/70426-allow-non-ascii-chars-in-cron-job.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cron - encode and decode crontab files in UTF-8 explicitly to allow non-ascii chars in cron job (https://github.com/ansible/ansible/issues/69492)

--- a/changelogs/fragments/70426-allow-non-ascii-chars-in-cron-job.yml
+++ b/changelogs/fragments/70426-allow-non-ascii-chars-in-cron-job.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - cron - encode and decode crontab files in UTF-8 explicitly to allow non-ascii chars in cron job (https://github.com/ansible/ansible/issues/69492)

--- a/changelogs/fragments/70426-allow-non-ascii-chars-in-cron.yml
+++ b/changelogs/fragments/70426-allow-non-ascii-chars-in-cron.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cron - encode and decode crontab files in UTF-8 explicitly to allow non-ascii chars in cron filepath and job (https://github.com/ansible/ansible/issues/69492)

--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -237,9 +237,9 @@ class CronTab(object):
 
         if cron_file:
             if os.path.isabs(cron_file):
-                self.cron_file = cron_file
+                self.cron_file = to_text(cron_file, errors='surrogate_or_strict')
             else:
-                self.cron_file = os.path.join('/etc/cron.d', cron_file)
+                self.cron_file = os.path.join(u'/etc/cron.d', to_text(cron_file, errors='surrogate_or_strict'))
         else:
             self.cron_file = None
 

--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -252,7 +252,7 @@ class CronTab(object):
             # read the cronfile
             try:
                 f = open(self.cron_file, 'rb')
-                self.existing = to_text(f.read())
+                self.existing = to_text(f.read(), errors='surrogate_or_strict')
                 self.lines = self.existing.splitlines()
                 f.close()
             except IOError:

--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -210,8 +210,8 @@ import sys
 import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.six.moves import shlex_quote
-
 
 class CronTabError(Exception):
     pass
@@ -251,7 +251,7 @@ class CronTab(object):
             # read the cronfile
             try:
                 f = open(self.cron_file, 'rb')
-                self.existing = f.read().decode('utf-8')
+                self.existing = to_text(f.read())
                 self.lines = self.existing.splitlines()
                 f.close()
             except IOError:
@@ -299,7 +299,7 @@ class CronTab(object):
             os.chmod(path, int('0644', 8))
             fileh = os.fdopen(filed, 'wb')
 
-        fileh.write(self.render().encode(encoding='utf-8'))
+        fileh.write(to_bytes(self.render()))
         fileh.close()
 
         # return if making a backup

--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -213,6 +213,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.six.moves import shlex_quote
 
+
 class CronTabError(Exception):
     pass
 

--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -237,7 +237,8 @@ class CronTab(object):
 
         if cron_file:
             if os.path.isabs(cron_file):
-                self.cron_file = to_text(cron_file, errors='surrogate_or_strict')
+                self.cron_file = cron_file
+                self.b_cron_file = to_bytes(cron_file, errors='surrogate_or_strict')
             else:
                 self.cron_file = os.path.join(u'/etc/cron.d', to_text(cron_file, errors='surrogate_or_strict'))
         else:

--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -253,9 +253,8 @@ class CronTab(object):
         if self.cron_file:
             # read the cronfile
             try:
-                f = open(self.cron_file, 'rb')
-                self.existing = to_text(f.read(), errors='surrogate_or_strict')
-                self.lines = self.existing.splitlines()
+                f = open(self.b_cron_file, 'rb')
+                self.b_existing = to_native(f.read(), errors='surrogate_or_strict')
                 f.close()
             except IOError:
                 # cron file does not exist

--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -630,7 +630,7 @@ def main():
 
     if module._diff:
         diff = dict()
-        diff['before'] = crontab.existing
+        diff['before'] = crontab.n_existing
         if crontab.cron_file:
             diff['before_header'] = crontab.cron_file
         else:
@@ -726,8 +726,8 @@ def main():
                 changed = True
 
     # no changes to env/job, but existing crontab needs a terminating newline
-    if not changed and crontab.existing != '':
-        if not (crontab.existing.endswith('\r') or crontab.existing.endswith('\n')):
+    if not changed and crontab.n_existing != '':
+        if not (crontab.n_existing.endswith('\r') or crontab.n_existing.endswith('\n')):
             changed = True
 
     res_args = dict(

--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -250,8 +250,8 @@ class CronTab(object):
         if self.cron_file:
             # read the cronfile
             try:
-                f = open(self.cron_file, 'r')
-                self.existing = f.read()
+                f = open(self.cron_file, 'rb')
+                self.existing = f.read().decode('utf-8')
                 self.lines = self.existing.splitlines()
                 f.close()
             except IOError:
@@ -291,15 +291,15 @@ class CronTab(object):
         Write the crontab to the system. Saves all information.
         """
         if backup_file:
-            fileh = open(backup_file, 'w')
+            fileh = open(backup_file, 'wb')
         elif self.cron_file:
-            fileh = open(self.cron_file, 'w')
+            fileh = open(self.cron_file, 'wb')
         else:
             filed, path = tempfile.mkstemp(prefix='crontab')
             os.chmod(path, int('0644', 8))
-            fileh = os.fdopen(filed, 'w')
+            fileh = os.fdopen(filed, 'wb')
 
-        fileh.write(self.render())
+        fileh.write(self.render().encode(encoding='utf-8'))
         fileh.close()
 
         # return if making a backup

--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -240,7 +240,8 @@ class CronTab(object):
                 self.cron_file = cron_file
                 self.b_cron_file = to_bytes(cron_file, errors='surrogate_or_strict')
             else:
-                self.cron_file = os.path.join(u'/etc/cron.d', to_text(cron_file, errors='surrogate_or_strict'))
+                self.cron_file = os.path.join('/etc/cron.d', cron_file)
+                self.b_cron_file = os.path.join(b'/etc/cron.d', to_bytes(cron_file, errors='surrogate_or_strict'))
         else:
             self.cron_file = None
 

--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -296,7 +296,7 @@ class CronTab(object):
         if backup_file:
             fileh = open(backup_file, 'wb')
         elif self.cron_file:
-            fileh = open(self.cron_file, 'wb')
+            fileh = open(self.b_cron_file, 'wb')
         else:
             filed, path = tempfile.mkstemp(prefix='crontab')
             os.chmod(path, int('0644', 8))

--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -232,7 +232,7 @@ class CronTab(object):
         self.root = (os.getuid() == 0)
         self.lines = None
         self.ansible = "#Ansible: "
-        self.b_existing = ''
+        self.n_existing = ''
         self.cron_cmd = self.module.get_bin_path('crontab', required=True)
 
         if cron_file:
@@ -254,7 +254,7 @@ class CronTab(object):
             # read the cronfile
             try:
                 f = open(self.b_cron_file, 'rb')
-                self.b_existing = to_native(f.read(), errors='surrogate_or_strict')
+                self.n_existing = to_native(f.read(), errors='surrogate_or_strict')
                 f.close()
             except IOError:
                 # cron file does not exist
@@ -268,7 +268,7 @@ class CronTab(object):
             if rc != 0 and rc != 1:  # 1 can mean that there are no jobs.
                 raise CronTabError("Unable to read crontab")
 
-            self.b_existing = out
+            self.n_existing = out
 
             lines = out.splitlines()
             count = 0
@@ -279,7 +279,7 @@ class CronTab(object):
                     self.lines.append(l)
                 else:
                     pattern = re.escape(l) + '[\r\n]?'
-                    self.b_existing = re.sub(pattern, '', self.b_existing, 1)
+                    self.n_existing = re.sub(pattern, '', self.n_existing, 1)
                 count += 1
 
     def is_empty(self):

--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -210,7 +210,7 @@ import sys
 import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.text.converters import to_bytes, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_native
 from ansible.module_utils.six.moves import shlex_quote
 
 
@@ -232,7 +232,7 @@ class CronTab(object):
         self.root = (os.getuid() == 0)
         self.lines = None
         self.ansible = "#Ansible: "
-        self.existing = ''
+        self.b_existing = ''
         self.cron_cmd = self.module.get_bin_path('crontab', required=True)
 
         if cron_file:
@@ -268,7 +268,7 @@ class CronTab(object):
             if rc != 0 and rc != 1:  # 1 can mean that there are no jobs.
                 raise CronTabError("Unable to read crontab")
 
-            self.existing = out
+            self.b_existing = out
 
             lines = out.splitlines()
             count = 0
@@ -279,7 +279,7 @@ class CronTab(object):
                     self.lines.append(l)
                 else:
                     pattern = re.escape(l) + '[\r\n]?'
-                    self.existing = re.sub(pattern, '', self.existing, 1)
+                    self.b_existing = re.sub(pattern, '', self.b_existing, 1)
                 count += 1
 
     def is_empty(self):

--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -128,14 +128,14 @@
   - name: Cron file creation
     cron:
       cron_file: cron_filename
-      name: "cron job that contain non-ascii chars in name and job (これは日本語です)"
-      job: 'echo "うどんを週に18食は食べている"'
+      name: "cron job that contain non-ascii chars in name and job (これは日本語です; This is Japanese)"
+      job: 'echo "うどんは好きだがお化け👻は苦手である"'
       user: root
 
   - name: Cron file deletion
     cron:
       cron_file: cron_filename
-      name: "cron job that contain non-ascii chars in name and job (これは日本語です)"
+      name: "cron job that contain non-ascii chars in name and job (これは日本語です; This is Japanese)"
       state: absent
 
   - name: Check file succesfull deletion

--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -122,3 +122,26 @@
 
   - assert:
       that: not cron_file_stats.stat.exists
+
+- name: Allow non-ascii char in cron job (#69492)
+  block:
+  - name: Cron file creation
+    cron:
+      cron_file: cron_filename
+      name: "cron job that contain non-ascii chars in name and job (これは日本語です)"
+      job: 'echo "うどんを週に18食は食べている"'
+      user: root
+
+  - name: Cron file deletion
+    cron:
+      cron_file: cron_filename
+      name: "cron job that contain non-ascii chars in name and job (これは日本語です)"
+      state: absent
+
+  - name: Check file succesfull deletion
+    stat:
+      path: /etc/cron.d/cron_filename
+    register: cron_file_stats
+
+  - assert:
+      that: not cron_file_stats.stat.exists

--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -132,15 +132,15 @@
       job: 'echo "うどんは好きだがお化け👻は苦手である"'
       user: root
 
-  - name: "Ensure /tmp/my.conf contains '127.0.0.1'"
+  - name: "Ensure cron_file contains job string"
     lineinfile:
-      name: /tmp/my.conf
+      name: /etc/cron.d/cron_filename
       regexp: "^.*?(うどんは好きだがお化け👻は苦手である).*?$"
-      line: "Not found."
+      line: "Found!"
       state: present
     check_mode: yes
     register: check_contents
-    failed_when: (check_contents is changed) or (check_contents is failed)
+    failed_when: (check_contents is not changed) or (check_contents is failed)
 
   - name: Cron file deletion
     cron:

--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -129,18 +129,16 @@
     cron:
       cron_file: cron_filename
       name: "cron job that contain non-ascii chars in job (これは日本語です; This is Japanese)"
-      job: 'echo "うどんは好きだがお化け👻は苦手である"'
+      job: 'echo "うどんは好きだがお化け👻は苦手である。"'
       user: root
 
   - name: "Ensure cron_file contains job string"
-    lineinfile:
-      name: /etc/cron.d/cron_filename
-      regexp: "^.*?(うどんは好きだがお化け👻は苦手である).*?$"
-      line: "Found!"
-      state: present
-    check_mode: yes
-    register: check_contents
-    failed_when: (check_contents is not changed) or (check_contents is failed)
+    replace:
+      path: /etc/cron.d/cron_filename
+      regexp: "うどんは好きだがお化け👻は苦手である。"
+      replace: "それは機密情報🔓です。"
+    register: find_chars
+    failed_when: (find_chars is not changed) or (find_chars is failed)
 
   - name: Cron file deletion
     cron:

--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -123,24 +123,65 @@
   - assert:
       that: not cron_file_stats.stat.exists
 
-- name: Allow non-ascii chars in cron job (#69492)
+- name: Allow non-ascii chars in job (#69492)
   block:
   - name: Cron file creation
     cron:
       cron_file: cron_filename
-      name: "cron job that contain non-ascii chars in name and job (これは日本語です; This is Japanese)"
+      name: "cron job that contain non-ascii chars in job (これは日本語です; This is Japanese)"
       job: 'echo "うどんは好きだがお化け👻は苦手である"'
       user: root
+
+  - name: "Ensure /tmp/my.conf contains '127.0.0.1'"
+    lineinfile:
+      name: /tmp/my.conf
+      regexp: "^.*?(うどんは好きだがお化け👻は苦手である).*?$"
+      line: "Not found."
+      state: present
+    check_mode: yes
+    register: check_contents
+    failed_when: (check_contents is changed) or (check_contents is failed)
 
   - name: Cron file deletion
     cron:
       cron_file: cron_filename
-      name: "cron job that contain non-ascii chars in name and job (これは日本語です; This is Japanese)"
+      name: "cron job that contain non-ascii chars in job (これは日本語です; This is Japanese)"
       state: absent
 
   - name: Check file succesfull deletion
     stat:
       path: /etc/cron.d/cron_filename
+    register: cron_file_stats
+
+  - assert:
+      that: not cron_file_stats.stat.exists
+
+- name: Allow non-ascii chars in cron_file (#69492)
+  block:
+  - name: Cron file creation with non-ascii filename (これは日本語です; This is Japanese)
+    cron:
+      cron_file: 'なせば大抵なんとかなる👊'
+      name: "integration test cron"
+      job: 'echo "Hello, ansible!"'
+      user: root
+
+  - name: Check file exists
+    stat:
+      path: "/etc/cron.d/なせば大抵なんとかなる👊"
+    register: cron_file_stats
+
+  - assert:
+      that: cron_file_stats.stat.exists
+
+  - name: Cron file deletion
+    cron:
+      cron_file: 'なせば大抵なんとかなる👊'
+      name: "integration test cron"
+      state: absent
+
+  - name: Check file succesfull deletion
+    stat:
+      path: "/etc/cron.d/なせば大抵なんとかなる👊"
     register: cron_file_stats
 
   - assert:

--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -123,7 +123,7 @@
   - assert:
       that: not cron_file_stats.stat.exists
 
-- name: Allow non-ascii char in cron job (#69492)
+- name: Allow non-ascii chars in cron job (#69492)
   block:
   - name: Cron file creation
     cron:


### PR DESCRIPTION
##### SUMMARY

It may fix #69492

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

`lib/ansible/modules/cron.py`
