### PR TITLE
[2.10 backport] misc collection metadata fixes

### DIFF
--- a/changelogs/fragments/collection_meta_use_libyaml.yml
+++ b/changelogs/fragments/collection_meta_use_libyaml.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - collection metadata - ensure collection loader uses libyaml/CSafeLoader to parse collection metadata if available

--- a/lib/ansible/utils/collection_loader/_collection_meta.py
+++ b/lib/ansible/utils/collection_loader/_collection_meta.py
@@ -4,14 +4,30 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from yaml import safe_load
+from yaml import load
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml import SafeLoader
+
+try:
+    from collections.abc import Mapping   # pylint: disable=ansible-bad-import-from
+except ImportError:
+    from collections import Mapping  # pylint: disable=ansible-bad-import-from
 
 
 def _meta_yml_to_dict(yaml_string_data, content_id):
-    routing_dict = safe_load(yaml_string_data)
+    """
+    Converts string YAML dictionary to a Python dictionary. This function may be monkeypatched to another implementation
+    by some tools (eg the import sanity test).
+    :param yaml_string_data: a bytes-ish YAML dictionary
+    :param content_id: a unique ID representing the content to allow other implementations to cache the output
+    :return: a Python dictionary representing the YAML dictionary content
+    """
+    # NB: content_id is passed in, but not used by this implementation
+    routing_dict = load(yaml_string_data, Loader=SafeLoader)
     if not routing_dict:
         routing_dict = {}
-    # TODO: change this to Mapping abc?
-    if not isinstance(routing_dict, dict):
-        raise ValueError('collection metadata must be a dictionary')
+    if not isinstance(routing_dict, Mapping):
+        raise ValueError('collection metadata must be an instance of Python Mapping')
     return routing_dict


### PR DESCRIPTION
##### SUMMARY
Backport of #70403

* misc collection metadata fixes

* parse collection meta with libyaml if available
* require only Mapping for validation
* add explanatory text for _meta_yml_to_dict

* ignore custom pylint rule

* this code shouldn't import a bunch of stuff from ansible, since it's run under the import sanity test

(cherry picked from commit b9e38e8b55efdb6cf7debac2b9a495c20c73241c)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
