### PR TITLE
ssh connection - use get_option() rather than _play_context

### DIFF
--- a/changelogs/fragments/70437-ssh-args.yml
+++ b/changelogs/fragments/70437-ssh-args.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >
+    ssh connection plugin - use ``get_option()`` rather than ``_play_context`` to
+    ensure ``ANSBILE_SSH_ARGS`` are applied properly (https://github.com/ansible/ansible/issues/70437)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -611,9 +611,10 @@ class Connection(ConnectionBase):
         # Next, we add [ssh_connection]ssh_args from ansible.cfg.
         #
 
-        if self._play_context.ssh_args:
+        ssh_args = self.get_option('ssh_args')
+        if ssh_args:
             b_args = [to_bytes(a, errors='surrogate_or_strict') for a in
-                      self._split_ssh_args(self._play_context.ssh_args)]
+                      self._split_ssh_args(ssh_args)]
             self._add_args(b_command, b_args, u"ansible.cfg set ssh_args")
 
         # Now we add various arguments controlled by configuration file settings


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `ssh_args` were sometimes not correctly applied to the connection when using `_play_context`. Use `get_option()` instead to ensure the correct ssh_args are always applied.

Fixes #70437 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/connection/ssh.py`