### PR TITLE
Fix string/bytestring comparsion in m_u.basic

### DIFF
--- a/changelogs/fragments/70244-selinux-special-fs.yml
+++ b/changelogs/fragments/70244-selinux-special-fs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix bytestring vs string comparison in module_utils.basic.is_special_selinux_path() so that special-cased filesystems which don't support SELinux context attributes still allow files to be manipulated on them. (https://github.com/ansible/ansible/issues/70244)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -888,11 +888,12 @@ class AnsibleModule(object):
             f.close()
         except Exception:
             return (False, None)
+
         path_mount_point = self.find_mount_point(path)
+
         for line in mount_data:
             (device, mount_point, fstype, options, rest) = line.split(' ', 4)
-
-            if path_mount_point == mount_point:
+            if to_bytes(path_mount_point) == to_bytes(mount_point):
                 for fs in self._selinux_special_fs:
                     if fs in fstype:
                         special_context = self.selinux_context(path_mount_point)

--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -74,6 +74,9 @@
     - import_tasks: acls.yml
       when: ansible_system == 'Linux'
 
+    - import_tasks: selinux.yml
+      when: ansible_os_family == 'RedHat' and ansible_selinux.get('mode') == 'enforcing'
+
     - import_tasks: check_mode.yml
 
     # https://github.com/ansible/ansible/issues/57618

--- a/test/integration/targets/copy/tasks/selinux.yml
+++ b/test/integration/targets/copy/tasks/selinux.yml
@@ -1,0 +1,35 @@
+# Ensure that our logic for special filesystems works as intended
+# https://github.com/ansible/ansible/issues/70244
+- block:
+    - name: Install dosfstools
+      yum:
+        name: dosfstools
+        state: present
+
+    - name: Create a file to use for a fat16 filesystem
+      command: dd if=/dev/zero of=/fat16 bs=1024 count=10240
+
+    - name: mkfs.fat
+      command: mkfs.fat -F16 /fat16
+
+    - name: Mount it
+      command: mount /fat16 /mnt
+
+    - name: Copy a file to it
+      copy:
+        src: /etc/fstab
+        dest: /mnt/fstab
+  always:
+    - name: Unmount it
+      command: umount /mnt
+      ignore_errors: true
+
+    - name: Nuke /fat16
+      file:
+        path: /fat16
+        state: absent
+
+    - name: Uninstall dosfstools
+      yum:
+        name: dosfstools
+        state: absent


### PR DESCRIPTION

##### SUMMARY

Change:
- module_utils.basic.is_special_selinux_path() used a string ==
  bytestring comparison which returned False and made Ansible think that
  certain filesystems aren't, in fact, special-cased, when they should
  be.

Test Plan:
- Added `copy` integration tests for this case.

Tickets:
- Fixes #70244

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

module_utils.basic