### PR TITLE
command module, remove warnings to use modules

### DIFF
--- a/changelogs/fragments/command-module-warnings.yml
+++ b/changelogs/fragments/command-module-warnings.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "command and shell modules: Removed suggestions (warnings) to use modules instead of commands."

--- a/docs/docsite/rst/porting_guides/porting_guide_2.11.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.11.rst
@@ -51,7 +51,7 @@ The following modules no longer exist:
 Deprecation notices
 -------------------
 
-No notable changes
+* command and shell modules - The `warn` parameter is deprecated and no longer has any effect. It will become an invalid parameter in version 2.13.
 
 
 Noteworthy module changes

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -414,17 +414,6 @@ ACTION_WARNINGS:
   - {key: action_warnings, section: defaults}
   type: boolean
   version_added: "2.5"
-COMMAND_WARNINGS:
-  name: Command module warnings
-  default: True
-  description:
-    - By default Ansible will issue a warning when the shell or command module is used and the command appears to be similar to an existing Ansible module.
-    - These warnings can be silenced by adjusting this setting to False. You can also control this at the task level with the module option ``warn``.
-  env: [{name: ANSIBLE_COMMAND_WARNINGS}]
-  ini:
-  - {key: command_warnings, section: defaults}
-  type: boolean
-  version_added: "1.8"
 LOCALHOST_WARNING:
   name: Warning when using implicit inventory with only localhost
   default: True

--- a/lib/ansible/modules/shell.py
+++ b/lib/ansible/modules/shell.py
@@ -54,12 +54,6 @@ options:
       - This expects an absolute path to the executable.
     type: path
     version_added: "0.9"
-  warn:
-    description:
-      - Whether to enable task warnings.
-    type: bool
-    default: yes
-    version_added: "1.8"
   stdin:
     description:
       - Set the stdin of the command directly to the specified value.
@@ -146,12 +140,6 @@ EXAMPLES = r'''
   args:
     executable: /usr/bin/expect
   delegate_to: localhost
-
-# Disabling warnings
-- name: Using curl to connect to a host via SOCKS proxy (unsupported in uri). Ordinarily this would throw a warning
-  shell: curl --socks5 localhost:9000 http://www.ansible.com
-  args:
-    warn: no
 '''
 
 RETURN = r'''

--- a/lib/ansible/plugins/action/command.py
+++ b/lib/ansible/plugins/action/command.py
@@ -16,10 +16,6 @@ class ActionModule(ActionBase):
         results = super(ActionModule, self).run(tmp, task_vars)
         del tmp  # tmp no longer has any effect
 
-        # Command module has a special config option to turn off the command nanny warnings
-        if 'warn' not in self._task.args:
-            self._task.args['warn'] = C.COMMAND_WARNINGS
-
         wrap_async = self._task.async_val and not self._connection.has_native_async
         results = merge_hash(results, self._execute_module(task_vars=task_vars, wrap_async=wrap_async))
 

--- a/test/integration/targets/command_shell/tasks/main.yml
+++ b/test/integration/targets/command_shell/tasks/main.yml
@@ -3,46 +3,6 @@
 # Copyright: (c) 2014, Richard Isaacson <richard.c.isaacson@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: use command to execute sudo
-  command: sudo -h
-  register: become
-
-- name: assert become warning was reported
-  assert:
-    that:
-      - "become.warnings | length() == 1"
-      - "'Consider using' in become.warnings[0]"
-
-- name: use command to execute sudo without warnings
-  command: sudo -h warn=no
-  register: become
-
-- name: assert become warning was not reported
-  assert:
-    that:
-      - "'warnings' not in become"
-
-- name: use command to execute tar
-  command: tar --help
-  register: tar
-
-- name: assert tar warning was reported
-  assert:
-    that:
-      - tar.warnings | length() == 1
-      - '"Consider using the unarchive module rather than running ''tar''" in tar.warnings[0]'
-
-- name: use command to execute chown
-  command: chown -h
-  register: chown
-  ignore_errors: true
-
-- name: assert chown warning was reported
-  assert:
-    that:
-      - chown.warnings | length() == 1
-      - '"Consider using the file module with owner rather than running ''chown''" in chown.warnings[0]'
-
 - name: use command with unsupported executable arg
   command: ls /dev/null
   args:
@@ -55,19 +15,6 @@
       - executable.stdout == '/dev/null'
       - executable.warnings | length() == 1
       - "'no longer supported' in executable.warnings[0]"
-
-# The warning isn't on the task since it comes from the action plugin. Not sure
-# how to test for that.
-#
-# - name: Use command with reboot
-#   command: sleep 2 && /not/shutdown -r now
-#   ignore_errors: yes
-#   register: reboot
-
-# - name: Assert that reboot warning was issued
-#   assert:
-#     that:
-#       - '"Consider using the reboot module" in reboot.warnings[0]'
 
 - name: use command with no command
   command:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -74,6 +74,7 @@ lib/ansible/module_utils/urls.py replace-urlopen
 lib/ansible/modules/command.py validate-modules:doc-missing-type
 lib/ansible/modules/command.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/command.py validate-modules:parameter-list-no-elements
+lib/ansible/modules/command.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/command.py validate-modules:undocumented-parameter
 lib/ansible/modules/expect.py validate-modules:doc-missing-type
 lib/ansible/modules/assemble.py validate-modules:nonexistent-parameter-documented


### PR DESCRIPTION
##### SUMMARY
Change:
- Remove warnings from command module which point to modules

Test Plan:
- CI

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

command module