### PR TITLE
command module, nix warnings for moved modules

### DIFF
--- a/changelogs/fragments/command-module-warnings.yml
+++ b/changelogs/fragments/command-module-warnings.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Command module: Removed suggestions to use modules which have moved to collections and out of ansible-base"

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -215,10 +215,10 @@ def check_command(module, commandline):
                  'rmdir': 'state=absent', 'rm': 'state=absent', 'touch': 'state=touch'}
     commands = {'curl': 'get_url or uri', 'wget': 'get_url or uri',
                 'svn': 'subversion', 'service': 'service',
-                'mount': 'mount', 'rpm': 'yum, dnf or zypper', 'yum': 'yum', 'apt-get': 'apt',
+                'yum': 'yum', 'apt-get': 'apt',
                 'tar': 'unarchive', 'unzip': 'unarchive', 'sed': 'replace, lineinfile or template',
-                'dnf': 'dnf', 'zypper': 'zypper'}
-    become = ['sudo', 'su', 'pbrun', 'pfexec', 'runas', 'pmrun', 'machinectl']
+                'dnf': 'dnf'}
+    become = ['sudo', 'su', 'runas']
     if isinstance(commandline, list):
         command = commandline[0]
     else:


### PR DESCRIPTION
##### SUMMARY

Change:
- Remove warnings from command module which point to modules that no
  longer ship with ansible-base but have moved to collections.

Test Plan:
- CI

Signed-off-by: Rick Elrod <rick@elrod.me>

Backport of #70441

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
command module
