### PR TITLE
Add a new `date_time` fact to provide DST timezone

### DIFF
--- a/changelogs/fragments/70449-facts-add-dst-timezone.yml
+++ b/changelogs/fragments/70449-facts-add-dst-timezone.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - facts - add new fact ``date_time['tz_dst']``, which returns the daylight saving timezone (https://github.com/ansible/ansible/issues/69004).

--- a/lib/ansible/module_utils/facts/system/date_time.py
+++ b/lib/ansible/module_utils/facts/system/date_time.py
@@ -53,6 +53,7 @@ class DateTimeFactCollector(BaseFactCollector):
         date_time_facts['iso8601_basic'] = now.strftime("%Y%m%dT%H%M%S%f")
         date_time_facts['iso8601_basic_short'] = now.strftime("%Y%m%dT%H%M%S")
         date_time_facts['tz'] = time.strftime("%Z")
+        date_time_facts['tz_dst'] = time.tzname[1]
         date_time_facts['tz_offset'] = time.strftime("%z")
 
         facts_dict['date_time'] = date_time_facts

--- a/test/units/module_utils/facts/tests_date_time.py
+++ b/test/units/module_utils/facts/tests_date_time.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+import datetime
+
+from ansible.module_utils.facts.system.date_time import DateTimeFactCollector
+
+TIMESTAMP = datetime.datetime(2020, 7, 11, 12, 34, 56, 124356)
+
+
+@pytest.fixture
+def fake_now(monkeypatch):
+    """Patch `datetime.datetime.now()` to return a deterministic value."""
+    class FakeNow:
+        @classmethod
+        def now(cls):
+            return TIMESTAMP
+
+    monkeypatch.setattr(datetime, 'datetime', FakeNow)
+
+
+@pytest.fixture
+def date_facts(monkeypatch, fake_now):
+    """Return a predictable instance of collected date_time facts."""
+    monkeypatch.setenv('TZ', 'Australia/Melbourne')
+
+    collector = DateTimeFactCollector()
+    data = collector.collect()
+
+    return data
+
+
+@pytest.mark.parametrize(
+    ('fact_name', 'fact_value'),
+    (
+        ('year', '2020'),
+        ('month', '07'),
+        ('weekday', 'Saturday'),
+        ('weekday_number', '6'),
+        ('weeknumber', '27'),
+        ('day', '11'),
+        ('hour', '12'),
+        ('minute', '34'),
+        ('second', '56'),
+        ('epoch', '1594434896'),
+        ('date', '2020-07-11'),
+        ('time', '12:34:56'),
+        ('iso8601_basic', '20200711T123456124356'),
+        ('iso8601_basic_short', '20200711T123456'),
+        ('tz', 'AEST'),
+        ('tz_dst', 'AEDT'),
+        ('tz_offset', '+1000')
+    ),
+)
+def test_date_time_facts(date_facts, fact_name, fact_value):
+    assert date_facts['date_time'][fact_name] == fact_value


### PR DESCRIPTION
##### SUMMARY
According to python module time documentation:
```
 time.tzname

    A tuple of two strings: the first is the name of the local non-DST timezone, the second is the name of the local DST timezone. If no DST timezone is defined, the second string should not be used. 
```
So, next step is to determine if daylight setting is on or off on the host. It could be taken from `time.localtime()`:
```
time.localtime([secs])

    Like gmtime() but converts to local time. If secs is not provided or None, the current time as returned by time() is used. The dst flag is set to 1 when DST applies to the given time.
```

The only thing, that in some edge cases `time.localtime().tm_isdst` returns `-1`:
```
`tm_isdst` may be set to 1 when daylight savings time is in effect, and 0 when it is not. A value of -1 indicates that this is not known, and will usually result in the correct state being filled in.
```

So we take care about `-1` edge case by the following if-else statement: `1 if time.localtime().tm_isdst == 1 else 0`.

Fixes #69004

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/facts/system/date_time.py


##### ADDITIONAL INFORMATION
A simple `playbook.yaml` to test:
```
---
- hosts: localhost
  connection: local
  gather_facts: True
  tasks:
    - debug:
            msg: "{{ ansible_facts['date_time']['tz'] }}"
```

Both system utilities and ansible return the same timezone:
```
root@hostname:~# date +%Z
UTC
```
```
TASK [debug] *************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "UTC"
}
``` 