### PR TITLE
fix netbox inventory plugin name to redirect

### DIFF
--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -8650,7 +8650,7 @@ plugin_routing:
     foreman:
       redirect: theforeman.foreman.foreman
     netbox:
-      redirect: netbox.netbox.netbox
+      redirect: netbox.netbox.nb_inventory
     openstack:
       redirect: openstack.cloud.openstack
     tower:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The netbox inventory plugin name has changed to netbox.netbox.nb_inventory in [v0.1.9](https://github.com/netbox-community/ansible_modules/blob/devel/CHANGELOG.md#v019).

So, it should redirect to `netbox.netbox.nb_inventory`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- ansible_builtri_runtime.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
