### PR TITLE
Adds download feature to pip with tests

### DIFF
--- a/lib/ansible/modules/pip.py
+++ b/lib/ansible/modules/pip.py
@@ -71,8 +71,9 @@ options:
     description:
       - The state of module
       - The 'forcereinstall' option is only available in Ansible 2.1 and above.
+      - The 'download' option is only available from C(pip>=8)
     type: str
-    choices: [ absent, forcereinstall, latest, present ]
+    choices: [ absent, forcereinstall, latest, present, download ]
     default: present
   extra_args:
     description:
@@ -226,6 +227,12 @@ EXAMPLES = '''
     name: bottle
     umask: "0022"
   become: True
+
+- name: Download bottle to specific directory
+  pip:
+    name: bottle
+    state: download
+    extra_args: -d /my_packages/
 '''
 
 RETURN = '''
@@ -587,6 +594,7 @@ def main():
         absent=['uninstall', '-y'],
         latest=['install', '-U'],
         forcereinstall=['install', '-U', '--force-reinstall'],
+        download=['download'],
     )
 
     module = AnsibleModule(

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -577,3 +577,38 @@
         - '"black==19.10b0" in pip_prereleases.stdout_lines'
 
   when: ansible_python.version.major == 3
+
+### test pip download begin ###
+
+- name: Test pip download command with arguments
+  block:
+
+    - name: Create a directory to download package
+      file:
+        path: "{{ output_dir }}/packages"
+        state: directory
+        mode: "0755"
+
+    - name: Download package with arguments
+      pip:
+        name: "{{ pip_test_package }}"
+        extra_args: "-d {{ output_dir }}/packages"
+        version: 1.3.1
+        state: download
+
+    - name: Check that the download file exists
+      stat:
+        path: "{{ output_dir }}/packages/sampleprojectpy2-1.3.1.tar.gz"
+      register: stat_result
+
+    - name: Ensure file download was successful
+      assert:
+        that:
+          - stat_result.stat.exists
+
+  when:
+    - ansible_system == 'Linux'
+    - not ansible_distribution | default("") == "CentOS"
+    - not ansible_distribution_major_version | default("") == "6"
+
+### test pip download end ###

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -598,7 +598,7 @@
 
     - name: Check that the download file exists
       stat:
-        path: "{{ output_dir }}/packages/sampleprojectpy2-1.3.1.tar.gz"
+        path: "{{ output_dir }}/packages/{{ pip_test_package }}-1.3.1.tar.gz"
       register: stat_result
 
     - name: Ensure file download was successful


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #69073
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pip
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Adds a simple donwload functionality. The rest of parameters are untouched and can complement the download feature.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
    - name: Create a directory to download package
      file:
        path: "{{ output_dir }}/packages"
        state: directory
        mode: "0755"

    - name: Download package with arguments
      pip:
        name: "{{ pip_test_package }}"
        extra_args: "-d {{ output_dir }}/packages"
        version: 1.3.1
        state: download

    - name: Check that the download file exists
      stat:
        path: "{{ output_dir }}/packages/{{ pip_test_package }}-1.3.1.tar.gz"
      register: stat_result

    - name: Ensure file download was successful
      assert:
        that:
          - stat_result.stat.exists
```
