### PR TITLE
Add install_python_apt to apt_repository doc

### DIFF
--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -78,6 +78,12 @@ options:
               a non-Ubuntu target (for example, Debian or Mint).
         type: str
         version_added: '2.3'
+    install_python_apt:
+        description:
+            - Whether to install python apt or not, default is true
+            - If python-apt Python library is not installed this module will not work.
+        type: bool
+        default: true
 author:
 - Alexander Saltanov (@sashka)
 version_added: "0.7"

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -80,7 +80,7 @@ options:
         version_added: '2.3'
     install_python_apt:
         description:
-            - Whether to install python apt or not, default is true
+            - Whether to automatically install python apt or not, if it is not already installed.
             - If python-apt Python library is not installed this module will not work.
         type: bool
         default: true

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -80,8 +80,12 @@ options:
         version_added: '2.3'
     install_python_apt:
         description:
-            - Whether to automatically install python apt or not, if it is not already installed.
+            - Whether to automatically try to install Python apt or not, if it is not already installed.
             - If python-apt Python library is not installed this module will not work.
+            - Note that it is installed by running C(apt-get install python-apt) for Python 2, and C(apt-get install python3-apt) for Python 3.
+              If you are using a Python on the remote that is not the system Python, this will not work. In that case,
+              you should set I(install_python_apt=false) and need to ensure that the Python apt module for your
+              Python version is installed in another way.
         type: bool
         default: true
 author:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -73,10 +73,7 @@ lib/ansible/module_utils/urls.py pylint:blacklisted-name
 lib/ansible/module_utils/urls.py replace-urlopen
 lib/ansible/modules/apt.py validate-modules:parameter-invalid
 lib/ansible/modules/apt_key.py validate-modules:parameter-type-not-in-doc
-lib/ansible/modules/apt_repository.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/apt_repository.py validate-modules:parameter-invalid
-lib/ansible/modules/apt_repository.py validate-modules:parameter-type-not-in-doc
-lib/ansible/modules/apt_repository.py validate-modules:undocumented-parameter
 lib/ansible/modules/assemble.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/async_status.py use-argspec-type-path
 lib/ansible/modules/async_status.py validate-modules!skip


### PR DESCRIPTION
##### SUMMARY
Initially brought up in https://github.com/ansible/ansible/pull/70319#discussion_r449402086.
Putting it here for further discussion.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
apt_repository

##### ADDITIONAL INFORMATION
On minimal Debian `python-apt` is not installed for example and right now ansible shows a warning **after** it installs `python-apt` on the server being managed by ansible, that would be a problem for someones which are sensitive about packages installed on their server.

I mean there would be a situation where a sysadmin would prefer installing a package herself instead of installing `python-apt` and the package from the playbook.

It should be mentioned in documentation that by default this module installs `python-apt` and people should have the choice whether to disable installing it or not.
