### PR TITLE
[2.9] puppet: Fix command line construction

### DIFF
--- a/changelogs/fragments/114_puppet_quote.yml
+++ b/changelogs/fragments/114_puppet_quote.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "puppet - fix command line construction for check mode and ``manifest:`` (https://github.com/ansible/ansible/issues/60576)."

--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -266,16 +266,16 @@ def main():
             cmd += " --certname='%s'" % p['certname']
         if module.check_mode:
             cmd += " --noop"
-        if p['use_srv_records'] is not None:
-            if not p['use_srv_records']:
-                cmd += " --no-use_srv_records"
-            else:
-                cmd += " --use_srv_records"
         elif 'noop' in p:
             if p['noop']:
                 cmd += " --noop"
             else:
                 cmd += " --no-noop"
+        if p['use_srv_records'] is not None:
+            if not p['use_srv_records']:
+                cmd += " --no-use_srv_records"
+            else:
+                cmd += " --use_srv_records"
     else:
         cmd = "%s apply --detailed-exitcodes " % base_cmd
         if p['logdest'] == 'syslog':
@@ -300,7 +300,7 @@ def main():
         if p['execute']:
             cmd += " --execute '%s'" % p['execute']
         else:
-            cmd += shlex_quote(p['manifest'])
+            cmd += " %s" % shlex_quote(p['manifest'])
         if p['summarize']:
             cmd += " --summarize"
         if p['debug']:


### PR DESCRIPTION
##### SUMMARY

Fix command line construction in the puppet module
related to check mode and using manifests directly.

Also, fixes 69ead0ba7864b1e7367eb9755b51d30ecc0da0d2 which
introduced another if-statement in the middle of a if/elif pair,
which causes the elif to execute together with the original if
which created '--noop --no-noop' commands.

Fixes: #60576


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/114_puppet_quote.yml
lib/ansible/modules/system/puppet.py
