### PR TITLE
Fix decrypt argument in assemble module

### DIFF
--- a/changelogs/fragments/70465-assemble-fix-decrypt-argument.yaml
+++ b/changelogs/fragments/70465-assemble-fix-decrypt-argument.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - assemble - fix decrypt argument in the module (https://github.com/ansible/ansible/issues/65450).

--- a/lib/ansible/plugins/action/assemble.py
+++ b/lib/ansible/plugins/action/assemble.py
@@ -97,7 +97,7 @@ class ActionModule(ActionBase):
         regexp = self._task.args.get('regexp', None)
         follow = self._task.args.get('follow', False)
         ignore_hidden = self._task.args.get('ignore_hidden', False)
-        decrypt = self._task.args.get('decrypt', True)
+        decrypt = self._task.args.pop('decrypt', True)
 
         try:
             if src is None or dest is None:

--- a/test/integration/targets/assemble/tasks/main.yml
+++ b/test/integration/targets/assemble/tasks/main.yml
@@ -60,8 +60,30 @@
     - "result.changed == False"
     - "result.checksum == '74152e9224f774191bc0bedf460d35de86ad90e6'"
 
+- name: test assemble with all fragments and decrypt=True
+  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled2" decrypt=yes
+  register: result
+
+- name: assert the fragments were assembled with decrypt=True
+  assert:
+    that:
+    - "result.state == 'file'"
+    - "result.changed == True"
+    - "result.checksum == '74152e9224f774191bc0bedf460d35de86ad90e6'"
+
+- name: test assemble with all fragments and decrypt=True
+  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled2" decrypt=yes
+  register: result
+
+- name: assert that the same assemble made no changes with decrypt=True
+  assert:
+    that:
+    - "result.state == 'file'"
+    - "result.changed == False"
+    - "result.checksum == '74152e9224f774191bc0bedf460d35de86ad90e6'"
+
 - name: test assemble with fragments matching a regex
-  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled2" regexp="^fragment[1-3]$"
+  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled3" regexp="^fragment[1-3]$"
   register: result
 
 - name: assert the fragments were assembled with a regex
@@ -70,8 +92,18 @@
     - "result.state == 'file'"
     - "result.checksum == 'edfe2d7487ef8f5ebc0f1c4dc57ba7b70a7b8e2b'"
 
+- name: test assemble with fragments matching a regex and decrypt=True
+  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled4" regexp="^fragment[1-3]$" decrypt=yes
+  register: result
+
+- name: assert the fragments were assembled with a regex and decrypt=True
+  assert:
+    that:
+    - "result.state == 'file'"
+    - "result.checksum == 'edfe2d7487ef8f5ebc0f1c4dc57ba7b70a7b8e2b'"
+
 - name: test assemble with a delimiter
-  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled3" delimiter="#--- delimiter ---#"
+  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled5" delimiter="#--- delimiter ---#"
   register: result
 
 - name: assert the fragments were assembled with a delimiter
@@ -80,8 +112,18 @@
     - "result.state == 'file'"
     - "result.checksum == 'd986cefb82e34e4cf14d33a3cda132ff45aa2980'"
 
+- name: test assemble with a delimiter and decrypt=True
+  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled6" delimiter="#--- delimiter ---#" decrypt=yes
+  register: result
+
+- name: assert the fragments were assembled with a delimiter and decrypt=True
+  assert:
+    that:
+    - "result.state == 'file'"
+    - "result.checksum == 'd986cefb82e34e4cf14d33a3cda132ff45aa2980'"
+
 - name: test assemble with remote_src=False
-  assemble: src="./" dest="{{output_dir}}/assembled4" remote_src=no
+  assemble: src="./" dest="{{output_dir}}/assembled7" remote_src=no
   register: result
 
 - name: assert the fragments were assembled without remote
@@ -90,8 +132,28 @@
     - "result.state == 'file'"
     - "result.checksum == '048a1bd1951aa5ccc427eeb4ca19aee45e9c68b3'"
 
+- name: test assemble with remote_src=False and decrypt=True
+  assemble: src="./" dest="{{output_dir}}/assembled8" remote_src=no decrypt=yes
+  register: result
+
+- name: assert the fragments were assembled without remote and decrypt=True
+  assert:
+    that:
+    - "result.state == 'file'"
+    - "result.checksum == '048a1bd1951aa5ccc427eeb4ca19aee45e9c68b3'"
+
 - name: test assemble with remote_src=False and a delimiter
-  assemble: src="./" dest="{{output_dir}}/assembled5" remote_src=no delimiter="#--- delimiter ---#"
+  assemble: src="./" dest="{{output_dir}}/assembled9" remote_src=no delimiter="#--- delimiter ---#"
+  register: result
+
+- name: assert the fragments were assembled without remote
+  assert:
+    that:
+    - "result.state == 'file'"
+    - "result.checksum == '505359f48c65b3904127cf62b912991d4da7ed6d'"
+
+- name: test assemble with remote_src=False and a delimiter and decrypt=True
+  assemble: src="./" dest="{{output_dir}}/assembled10" remote_src=no delimiter="#--- delimiter ---#" decrypt=yes
   register: result
 
 - name: assert the fragments were assembled without remote


### PR DESCRIPTION
##### SUMMARY
`assemble` module doesn't have a logic to work with `decrypt` argument. This argument is only needed on an action step, so popping it helps us to use it only where it is needed.

Fixes #65450

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
assemble

##### ADDITIONAL INFORMATION
A simple playbook.yaml to test:
```
---
- hosts: localhost
  connection: local
  tasks:
    - assemble:
        decrypt: yes
        src: 'test_dir/'
        dest: 'foo.file'
```
Before this PR:
```
TASK [assemble] ************************************************************************************************************************************************************************************************
task path: /root/playbook.yaml:5
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp `"&& mkdir /root/.ansible/tmp/ansible-tmp-1593906277.0457492-4992-131237993013662 && echo ansible-tmp-1593906277.0457492-4992-131237993013662="` echo /root/.ansible/tmp/ansible-tmp-1593906277.0457492-4992-131237993013662 `" ) && sleep 0'
Using module file /root/ansible/lib/ansible/modules/assemble.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-49449cql5whm/tmproza54xw TO /root/.ansible/tmp/ansible-tmp-1593906277.0457492-4992-131237993013662/AnsiballZ_assemble.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1593906277.0457492-4992-131237993013662/ /root/.ansible/tmp/ansible-tmp-1593906277.0457492-4992-131237993013662/AnsiballZ_assemble.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1593906277.0457492-4992-131237993013662/AnsiballZ_assemble.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1593906277.0457492-4992-131237993013662/ > /dev/null 2>&1 && sleep 0'
fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "decrypt": true,
            "dest": "foo.file",
            "src": "test_dir/"
        }
    },
    "msg": "Unsupported parameters for (assemble) module: decrypt Supported parameters include: attributes, backup, delimiter, dest, group, ignore_hidden, mode, owner, regexp, remote_src, selevel, serole, setype, seuser, src, unsafe_writes, validate"
}
```
After this PR:
```
TASK [assemble] ************************************************************************************************************************************************************************************************
task path: /root/playbook.yaml:5
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp `"&& mkdir /root/.ansible/tmp/ansible-tmp-1593906227.9061599-4907-174444608266858 && echo ansible-tmp-1593906227.9061599-4907-174444608266858="` echo /root/.ansible/tmp/ansible-tmp-1593906227.9061599-4907-174444608266858 `" ) && sleep 0'
Using module file /root/ansible/lib/ansible/modules/assemble.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-4858nguqepoy/tmpploa_8as TO /root/.ansible/tmp/ansible-tmp-1593906227.9061599-4907-174444608266858/AnsiballZ_assemble.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1593906227.9061599-4907-174444608266858/ /root/.ansible/tmp/ansible-tmp-1593906227.9061599-4907-174444608266858/AnsiballZ_assemble.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1593906227.9061599-4907-174444608266858/AnsiballZ_assemble.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1593906227.9061599-4907-174444608266858/ > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true,
    "checksum": "68d4fcc87957a8cc1f550c9afc7f92c11e518295",
    "dest": "foo.file",
    "gid": 0,
    "group": "root",
    "invocation": {
        "module_args": {
            "attributes": null,
            "backup": false,
            "delimiter": null,
            "dest": "foo.file",
            "group": null,
            "ignore_hidden": false,
            "mode": null,
            "owner": null,
            "regexp": null,
            "remote_src": true,
            "selevel": null,
            "serole": null,
            "setype": null,
            "seuser": null,
            "src": "test_dir/",
            "unsafe_writes": false,
            "validate": null
        }
    },
    "md5sum": "bdfada451f5dfff06345d7df467747f1",
    "mode": "0644",
    "msg": "OK",
    "owner": "root",
    "size": 18,
    "src": "test_dir/",
    "state": "file",
    "uid": 0
}
META: ran handlers
META: ran handlers
```