### PR TITLE
Remove some constants.py deprecated items

### DIFF
--- a/changelogs/fragments/constants-deprecation.yml
+++ b/changelogs/fragments/constants-deprecation.yml
@@ -1,0 +1,4 @@
+removed_features:
+  - The deprecated ``ansible.constants.mk_boolean()`` has been removed.
+  - The deprecated ``ansible.constants.get_config()`` has been removed.
+  - The deprecated ``ansible.constants.BECOME_METHODS`` has been removed.

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -39,32 +39,6 @@ def _deprecated(msg, version='2.8'):
         sys.stderr.write(' [DEPRECATED] %s, to be removed in %s\n' % (msg, version))
 
 
-def mk_boolean(value):
-    ''' moved to module_utils'''
-    _deprecated('ansible.constants.mk_boolean() is deprecated.  Use ansible.module_utils.parsing.convert_bool.boolean() instead')
-    return boolean(value, strict=False)
-
-
-def get_config(parser, section, key, env_var, default_value, value_type=None, expand_relative_paths=False):
-    ''' kept for backwarsd compatibility, but deprecated '''
-    _deprecated('ansible.constants.get_config() is deprecated. There is new config API, see porting docs.')
-
-    value = None
-    # small reconstruction of the old code env/ini/default
-    value = os.environ.get(env_var, None)
-    if value is None:
-        try:
-            value = get_ini_config_value(parser, {'key': key, 'section': section})
-        except Exception:
-            pass
-    if value is None:
-        value = default_value
-
-    value = ensure_type(value, value_type)
-
-    return value
-
-
 def set_constant(name, value, export=vars()):
     ''' sets constants and returns resolved options dict '''
     export[name] = value
@@ -84,15 +58,6 @@ class _DeprecatedSequenceConstant(Sequence):
         _deprecated(self._msg, version=self._version)
         return self._value[y]
 
-
-# Deprecated constants
-BECOME_METHODS = _DeprecatedSequenceConstant(
-    ['sudo', 'su', 'pbrun', 'pfexec', 'doas', 'dzdo', 'ksu', 'runas', 'pmrun', 'enable', 'machinectl'],
-    ('ansible.constants.BECOME_METHODS is deprecated, please use '
-     'ansible.plugins.loader.become_loader. This list is statically '
-     'defined and may not include all become methods'),
-    '2.10'
-)
 
 # CONSTANTS ### yes, actual ones
 BLACKLIST_EXTS = ('.pyc', '.pyo', '.swp', '.bak', '~', '.rpm', '.md', '.txt', '.rst')

--- a/test/units/test_constants.py
+++ b/test/units/test_constants.py
@@ -92,31 +92,3 @@ def cwd():
     os.getcwd = old_cwd
     if hasattr(os, 'getcwdu'):
         os.getcwdu = old_cwdu
-
-
-class TestMkBoolean:
-    def test_bools(self):
-        assert constants.mk_boolean(True) is True
-        assert constants.mk_boolean(False) is False
-
-    def test_none(self):
-        assert constants.mk_boolean(None) is False
-
-    def test_numbers(self):
-        assert constants.mk_boolean(1) is True
-        assert constants.mk_boolean(0) is False
-        assert constants.mk_boolean(0.0) is False
-
-# Current mk_boolean doesn't consider these to be true values
-#    def test_other_numbers(self):
-#        assert constants.mk_boolean(2) is True
-#        assert constants.mk_boolean(-1) is True
-#        assert constants.mk_boolean(0.1) is True
-
-    def test_strings(self):
-        assert constants.mk_boolean("true") is True
-        assert constants.mk_boolean("TRUE") is True
-        assert constants.mk_boolean("t") is True
-        assert constants.mk_boolean("yes") is True
-        assert constants.mk_boolean("y") is True
-        assert constants.mk_boolean("on") is True


### PR DESCRIPTION

##### SUMMARY
Change:
- Remove mk_boolean
- Remove BECOME_METHODS
- Remove get_config

Test Plan:
- CI, removed mk_boolean unit tests

Tickets:
- Fixes #69678

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

constants