### PR TITLE
Speedup modify module

### DIFF
--- a/changelogs/fragments/70475-modify-module.yaml
+++ b/changelogs/fragments/70475-modify-module.yaml
@@ -1,0 +1,5 @@
+minor_changes:
+- AnsiballZ - Improve performance of ``ModuleDepFinder`` by using faster
+  lookups and reducing the object types that are walked while looking for
+  ``import`` statements.
+  (https://github.com/ansible/ansible/pull/70475)

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -29,6 +29,7 @@ import shlex
 import zipfile
 import re
 import pkgutil
+from ast import AST, Import, ImportFrom
 from io import BytesIO
 
 from ansible.release import __version__, __author__
@@ -465,23 +466,26 @@ class ModuleDepFinder(ast.NodeVisitor):
         self.module_fqn = module_fqn
 
         self._visit_map = {
-            'Import': self.visit_Import,
-            'ImportFrom': self.visit_ImportFrom,
+            Import: self.visit_Import,
+            ImportFrom: self.visit_ImportFrom,
         }
 
     def generic_visit(self, node):
-        """Called if no explicit visitor function exists for a node."""
+        """Overridden ``generic_visit`` that makes some assumptions about our
+        use case, and improves performance by calling visitors directly instead
+        of calling ``visit`` to offload calling visitors.
+        """
         visit_map = self._visit_map
+        generic_visit = self.generic_visit
         for field, value in ast.iter_fields(node):
             if isinstance(value, list):
                 for item in value:
-                    if isinstance(item, ast.AST):
-                        try:
-                            visitor = visit_map[item.__class__.__name__]
-                        except KeyError:
-                            visitor = self.generic_visit
-                            visit_map[item.__class__.__name__] = self.generic_visit
-                        visitor(item)
+                    if isinstance(item, (Import, ImportFrom)):
+                        visit_map[item.__class__](item)
+                    elif isinstance(item, AST):
+                        generic_visit(item)
+
+    visit = generic_visit
 
     def visit_Import(self, node):
         """
@@ -734,7 +738,7 @@ def recursive_finder(name, module_fqn, data, py_module_names, py_module_cache, z
         raise AnsibleError("Unable to import %s due to %s" % (name, e.msg))
 
     finder = ModuleDepFinder(module_fqn)
-    finder.generic_visit(tree)
+    finder.visit(tree)
 
     #
     # Determine what imports that we've found are modules (vs class, function.

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -482,14 +482,6 @@ class ModuleDepFinder(ast.NodeVisitor):
                             visitor = self.generic_visit
                             visit_map[item.__class__.__name__] = self.generic_visit
                         visitor(item)
-            elif isinstance(value, ast.AST):
-                if isinstance(value, ast.IfExp):
-                    print(vars(value))
-                    print(vars(value.body))
-                    try:
-                        print(value.body[0].name)
-                    except:
-                        pass
 
     def visit_Import(self, node):
         """


### PR DESCRIPTION
##### SUMMARY
This PR implements a few performance enhancements to our `ast.NodeVisitor` to speed up traversing the AST.

1. Implement a function lookup table, instead of using `getattr`
1. Override `generic_visit` to not call `visit`, eliminating function calls
1. Override `generic_visit` to not walk `expr` objects, as imports can only happen within `stmt`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/module_common.py

##### ADDITIONAL INFORMATION
cProfile of `recursive_finder` before this change:

```
     26/1    0.006    0.000    0.247    0.247 executor/module_common.py:696(recursive_finder)
```

After:

```
     26/1    0.005    0.000    0.162    0.162 executor/module_common.py:719(recursive_finder)
```