### PR TITLE
Skip forking on a task with a simple when condition or include

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -391,7 +391,8 @@ class StrategyBase:
                     if not task.loop and not task.loop_with and not task.evaluate_conditional(templar, task_vars):
                         self._tqm.send_callback('v2_runner_on_start', host, task)
                         self._results_lock.acquire()
-                        self._results.append(
+                        queue = self._handler_results if isinstance(task, Handler) else self._results
+                        queue.append(
                             TaskResult(
                                 host=host.name,
                                 task=task._uuid,

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -394,13 +394,13 @@ class StrategyBase:
                             conditional = task.evaluate_conditional(templar, task_vars)
                         except AnsibleError as e:
                             tr = TaskResult(
-                                    host=host.name,
-                                    task=task._uuid,
-                                    return_data={
-                                        'failed': True,
-                                        'msg': to_text(e),
-                                    },
-                                )
+                                host=host.name,
+                                task=task._uuid,
+                                return_data={
+                                    'failed': True,
+                                    'msg': to_text(e),
+                                },
+                            )
                         else:
                             if not conditional:
                                 tr = TaskResult(
@@ -412,14 +412,13 @@ class StrategyBase:
                                         'skip_reason': 'Conditional result was False',
                                     },
                                 )
-                        finally:
-                            if tr:
-                                self._tqm.send_callback('v2_runner_on_start', host, task)
-                                queue = self._handler_results if isinstance(task, Handler) else self._results
-                                self._results_lock.acquire()
-                                queue.append(tr)
-                                self._results_lock.release()
-                                break
+                        if tr:
+                            self._tqm.send_callback('v2_runner_on_start', host, task)
+                            queue = self._handler_results if isinstance(task, Handler) else self._results
+                            self._results_lock.acquire()
+                            queue.append(tr)
+                            self._results_lock.release()
+                            break
 
                     worker_prc = WorkerProcess(self._final_q, task_vars, host, task, play_context, self._loader, self._variable_manager, plugin_loader)
                     self._workers[self._cur_worker] = worker_prc

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -369,8 +369,6 @@ class StrategyBase:
                 raise ForkShortCircuit(tr)
 
     def _short_circuit_fork_include(self, host, task, task_vars, templar):
-        vars_copy = task_vars.copy()
-        vars_copy['ansible_search_path'] = task.get_search_path()
         if not task.loop and not task.loop_with:
             tr = None
             # if this task is a TaskInclude, we just return now with a success code so the
@@ -379,15 +377,19 @@ class StrategyBase:
                 include_args = task.args.copy()
                 include_file = include_args.pop('_raw_params', None)
                 if not include_file:
-                    tr = TaskResult(
-                        host=host.name,
-                        task=task._uuid,
-                        return_data={
-                            'failed': True,
-                            'msg': 'No include file was specified to the include',
-                        }
+                    raise ForkShortCircuit(
+                        TaskResult(
+                            host=host.name,
+                            task=task._uuid,
+                            return_data={
+                                'failed': True,
+                                'msg': 'No include file was specified to the include',
+                            }
+                        )
                     )
 
+                vars_copy = task_vars.copy()
+                vars_copy['ansible_search_path'] = task.get_search_path()
                 try:
                     with templar.set_temporary_context(available_variables=vars_copy):
                         include_file = templar.template(include_file)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -369,6 +369,8 @@ class StrategyBase:
                 raise ForkShortCircuit(tr)
 
     def _short_circuit_fork_include(self, host, task, task_vars, templar):
+        vars_copy = task_vars.copy()
+        vars_copy['ansible_search_path'] = task.get_search_path()
         if not task.loop and not task.loop_with:
             tr = None
             # if this task is a TaskInclude, we just return now with a success code so the
@@ -387,7 +389,8 @@ class StrategyBase:
                     )
 
                 try:
-                    include_file = templar.template(include_file)
+                    with templar.set_temporary_context(available_variables=vars_copy):
+                        include_file = templar.template(include_file)
                 except AnsibleError as e:
                     tr = TaskResult(
                         host=host.name,

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -346,8 +346,8 @@ class StrategyBase:
                 conditional = task.evaluate_conditional(templar, task_vars)
             except AnsibleError as e:
                 tr = TaskResult(
-                    host=host.name,
-                    task=task._uuid,
+                    host=host,
+                    task=task,
                     return_data={
                         'failed': True,
                         'msg': to_text(e),
@@ -357,8 +357,8 @@ class StrategyBase:
             else:
                 if not conditional:
                     tr = TaskResult(
-                        host=host.name,
-                        task=task._uuid,
+                        host=host,
+                        task=task,
                         return_data={
                             'changed': False,
                             'skipped': True,
@@ -379,8 +379,8 @@ class StrategyBase:
                 if not include_file:
                     raise ForkShortCircuit(
                         TaskResult(
-                            host=host.name,
-                            task=task._uuid,
+                            host=host,
+                            task=task,
                             return_data={
                                 'failed': True,
                                 'msg': 'No include file was specified to the include',
@@ -395,8 +395,8 @@ class StrategyBase:
                         include_file = templar.template(include_file)
                 except AnsibleError as e:
                     tr = TaskResult(
-                        host=host.name,
-                        task=task._uuid,
+                        host=host,
+                        task=task,
                         return_data={
                             'failed': True,
                             'msg': to_text(e),
@@ -405,8 +405,8 @@ class StrategyBase:
                     )
                 else:
                     tr = TaskResult(
-                        host=host.name,
-                        task=task._uuid,
+                        host=host,
+                        task=task,
                         return_data={
                             'include': include_file,
                             'include_args': include_args,
@@ -417,8 +417,8 @@ class StrategyBase:
             elif task.action == 'include_role':
                 include_args = task.args.copy()
                 tr = TaskResult(
-                    host=host.name,
-                    task=task._uuid,
+                    host=host,
+                    task=task,
                     return_data={
                         'include_args': include_args,
                     }


### PR DESCRIPTION
##### SUMMARY
This PR does a conditional evaluation on tasks that do not have loops, and skips forking if the task should be skipped, or if the task is an include.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
```
lib/ansible/plugins/strategy/__init__.py
```

##### ADDITIONAL INFORMATION
Using a playbook with an `import_tasks` and `when: false` with 100 `ping` tasks:

With this PR:
```
real	0m1.718s
```

Without:
```
real	0m4.134s
```

A playbook that I have that does 100 recursive task includes (also does some `debug` and `set_fact`):

With this PR:
```
real	0m16.332s
```

Without:
```
real	0m23.221s
```