### PR TITLE
Make sure ansible_become treated as a boolean

### DIFF
--- a/changelogs/fragments/70484-bool-ansible-become.yaml
+++ b/changelogs/fragments/70484-bool-ansible-become.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - The `ansible_become` value was not being treated as a boolean value when set in an INI format
+    inventory file (fixes bug https://github.com/ansible/ansible/issues/70476).

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -19,6 +19,7 @@ from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleParserError, AnsibleUndefinedVariable, AnsibleConnectionFailure, AnsibleActionFail, AnsibleActionSkip
 from ansible.executor.task_result import TaskResult
 from ansible.executor.module_common import get_action_args_with_defaults
+from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.six import iteritems, string_types, binary_type
 from ansible.module_utils.six.moves import xrange
 from ansible.module_utils._text import to_text, to_native
@@ -818,7 +819,7 @@ class TaskExecutor:
             raise AnsibleError("the connection plugin '%s' was not found" % conn_type)
 
         # load become plugin if needed
-        if cvars.get('ansible_become', self._task.become):
+        if boolean(cvars.get('ansible_become', self._task.become)):
             become_plugin = self._get_become(cvars.get('ansible_become_method', self._task.become_method))
 
             try:

--- a/test/integration/targets/inventory_ini/aliases
+++ b/test/integration/targets/inventory_ini/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group5

--- a/test/integration/targets/inventory_ini/inventory.ini
+++ b/test/integration/targets/inventory_ini/inventory.ini
@@ -1,0 +1,5 @@
+[local]
+testhost ansible_connection=local ansible_become=no ansible_become_user=ansibletest1
+
+[all:vars]
+ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/targets/inventory_ini/runme.sh
+++ b/test/integration/targets/inventory_ini/runme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ansible-playbook -v -i inventory.ini test_ansible_become.yml

--- a/test/integration/targets/inventory_ini/test_ansible_become.yml
+++ b/test/integration/targets/inventory_ini/test_ansible_become.yml
@@ -1,0 +1,11 @@
+- hosts: testhost
+  gather_facts: no
+  tasks:
+    - name: Test proper bool evaluation of ansible_become (issue #70476)
+      shell: whoami
+      register: output
+
+    - name: Assert we are NOT the become user specified
+      assert:
+        that:
+          - "output.stdout != 'ansibletest1'"


### PR DESCRIPTION
##### SUMMARY

ansible_become was not being converted to a boolean. Seems to affect hosts using INI format. YAML formatted hosts works correctly.

Fixes #70476

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

task_executor

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Given the hosts.ini:
```
localhost ansible_connection=local ansible_become=no ansible_become_password=XYZ
```

We should be able to run this command and get a non-root user:

```
ansible -m shell -a "whoami" -i hosts.ini localhost
```