### PR TITLE
Replace filename with file in apt_key

### DIFF
--- a/changelogs/fragments/70492-replace-filename-with-file-in-apt_key.yml
+++ b/changelogs/fragments/70492-replace-filename-with-file-in-apt_key.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - apt_key - Specifying ``file`` as mutually exclusive with ``data``, ``keyserver``, ``url`` (https://github.com/ansible/ansible/pull/70492).

--- a/docs/docsite/rst/porting_guides/porting_guide_2.11.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.11.rst
@@ -37,7 +37,7 @@ No notable changes
 Modules
 =======
 
-No notable changes
+* The ``apt_key`` module has explicitly defined ``file`` as mutually exclusive with ``data``, ``keyserver`` and ``url``. They cannot be used together anymore.
 
 
 Modules removed

--- a/lib/ansible/modules/apt_key.py
+++ b/lib/ansible/modules/apt_key.py
@@ -280,7 +280,7 @@ def main():
     key_id = module.params['id']
     url = module.params['url']
     data = module.params['data']
-    file = module.params['file']
+    filename = module.params['file']
     keyring = module.params['keyring']
     state = module.params['state']
     keyserver = module.params['keyserver']
@@ -311,11 +311,11 @@ def main():
             # to decide if the key is installed or not.
             module.exit_json(changed=True)
         else:
-            if not file and not data and not keyserver:
+            if not filename and not data and not keyserver:
                 data = download_key(module, url)
 
-            if file:
-                add_key(module, file, keyring)
+            if filename:
+                add_key(module, filename, keyring)
             elif keyserver:
                 import_key(module, keyring, keyserver, key_id)
             else:

--- a/lib/ansible/modules/apt_key.py
+++ b/lib/ansible/modules/apt_key.py
@@ -274,13 +274,13 @@ def main():
             state=dict(type='str', default='present', choices=['absent', 'present']),
         ),
         supports_check_mode=True,
-        mutually_exclusive=(('data', 'filename', 'keyserver', 'url'),),
+        mutually_exclusive=(('data', 'file', 'keyserver', 'url'),),
     )
 
     key_id = module.params['id']
     url = module.params['url']
     data = module.params['data']
-    filename = module.params['file']
+    file = module.params['file']
     keyring = module.params['keyring']
     state = module.params['state']
     keyserver = module.params['keyserver']
@@ -311,11 +311,11 @@ def main():
             # to decide if the key is installed or not.
             module.exit_json(changed=True)
         else:
-            if not filename and not data and not keyserver:
+            if not file and not data and not keyserver:
                 data = download_key(module, url)
 
-            if filename:
-                add_key(module, filename, keyring)
+            if file:
+                add_key(module, file, keyring)
             elif keyserver:
                 import_key(module, keyring, keyserver, key_id)
             else:

--- a/test/integration/targets/apt_key/tasks/file.yml
+++ b/test/integration/targets/apt_key/tasks/file.yml
@@ -9,7 +9,7 @@
     keyserver: keys.gnupg.net
     id: 97A1AE57C3A2372CCA3A4ABA6C13026D12C944D0
   register: both_file_keyserver
-  ignore_errors: True
+  ignore_errors: true
 
 - name: Run apt_key with file only
   apt_key:
@@ -24,7 +24,7 @@
 
 - name: validate results
   assert:
-      that:
-          - 'both_file_keyserver is failed'
-          - 'only_file.changed'
-          - 'not only_keyserver.changed'
+    that:
+      - 'both_file_keyserver is failed'
+      - 'only_file.changed'
+      - 'not only_keyserver.changed'

--- a/test/integration/targets/apt_key/tasks/file.yml
+++ b/test/integration/targets/apt_key/tasks/file.yml
@@ -9,6 +9,7 @@
     keyserver: keys.gnupg.net
     id: 97A1AE57C3A2372CCA3A4ABA6C13026D12C944D0
   register: both_file_keyserver
+  ignore_errors: True
 
 - name: Run apt_key with file only
   apt_key:

--- a/test/integration/targets/apt_key/tasks/file.yml
+++ b/test/integration/targets/apt_key/tasks/file.yml
@@ -1,0 +1,29 @@
+- name: Get Fedora GPG Key
+  get_url:
+    url: https://getfedora.org/static/fedora.gpg
+    dest: /tmp/fedora.gpg
+
+- name: Run apt_key with both file and keyserver
+  apt_key:
+    file: /tmp/fedora.gpg
+    keyserver: keys.gnupg.net
+    id: 97A1AE57C3A2372CCA3A4ABA6C13026D12C944D0
+  register: both_file_keyserver
+
+- name: Run apt_key with file only
+  apt_key:
+    file: /tmp/fedora.gpg
+  register: only_file
+
+- name: Run apt_key with keyserver only
+  apt_key:
+    keyserver: keys.gnupg.net
+    id: 97A1AE57C3A2372CCA3A4ABA6C13026D12C944D0
+  register: only_keyserver
+
+- name: validate results
+  assert:
+      that:
+          - 'both_file_keyserver is failed'
+          - 'only_file.changed'
+          - 'not only_keyserver.changed'

--- a/test/integration/targets/apt_key/tasks/main.yml
+++ b/test/integration/targets/apt_key/tasks/main.yml
@@ -26,3 +26,6 @@
 
 - include: 'apt_key.yml'
   when: ansible_distribution in ('Ubuntu', 'Debian')
+  
+- include: 'file.yml'
+  when: ansible_distribution in ('Ubuntu', 'Debian')

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -109,7 +109,6 @@ lib/ansible/modules/apt.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/apt.py validate-modules:parameter-invalid
 lib/ansible/modules/apt.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/apt.py validate-modules:undocumented-parameter
-lib/ansible/modules/apt_key.py validate-modules:mutually_exclusive-unknown
 lib/ansible/modules/apt_key.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/apt_key.py validate-modules:undocumented-parameter
 lib/ansible/modules/apt_repository.py validate-modules:doc-default-does-not-match-spec


### PR DESCRIPTION
##### SUMMARY
`filename` is not an option in module and has not been defined in `argument_spec`.

First brought up in https://github.com/ansible/ansible/pull/70319#discussion_r449770838.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
apt_key