### PR TITLE
Proper example for splitext filter in docs

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1519,6 +1519,14 @@ To get the root and extension of a path or file name (new in version 2.0)::
     # with path == 'nginx.conf' the return would be ('nginx', '.conf')
     {{ path | splitext }}
 
+Accessing the two tokens from splitext filter is easy but doesn't follow standard array way::
+
+    # with path == 'nginx.conf' the return would be 'nginx'
+    {{ path | splitext | first }} 
+
+    # with path == 'nginx.conf' the return would be 'conf'
+    {{ path | splitext | last }}
+
 To join one or more path components::
 
     {{ ('/etc', path, 'subdir', file) | path_join }}

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1519,7 +1519,7 @@ To get the root and extension of a path or file name (new in version 2.0)::
     # with path == 'nginx.conf' the return would be ('nginx', '.conf')
     {{ path | splitext }}
 
-Accessing the two tokens from splitext filter is easy but doesn't follow standard array way::
+The ``splitext`` filter returns a string. The individual components can be accessed by using the ``first`` and ``last`` filters::
 
     # with path == 'nginx.conf' the return would be 'nginx'
     {{ path | splitext | first }} 


### PR DESCRIPTION
##### SUMMARY
The splitext filter had not a clear example of how to extract its 2 tokens. I had to dig over the original PR #11432 to find a match.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
Updating splitext documentation, no issues seem to be correlated.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
splitext

##### ADDITIONAL INFORMATION
While looking at previous docs I just tried the array approach to access the data from splitext like:

```
  {{ data | splitext[0] }}
```

but that wouldn't just work.

Searching on Duckduckgo returned the original PR #11432 in which `first` sentence is shown. At first (dumb of me) I used `second` to access the last token, realizing later that `last` was the obvious proper way. This is IMHO counter-intuitive from the standard array way Ansible uses and should be documented properly.