### PR TITLE
git: Add stricthostkeychecking accept-new option

### DIFF
--- a/changelogs/fragments/70499-git-accept-new-host-key.yaml
+++ b/changelogs/fragments/70499-git-accept-new-host-key.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - git - Add accept_newhostkey option (https://github.com/ansible/ansible/pull/70499).

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -469,6 +469,7 @@ def get_version(module, git_path, dest, ref="HEAD"):
     sha = to_native(stdout).rstrip('\n')
     return sha
 
+
 def ssh_supports_acceptnewhostkey(module):
     ssh_path = module.get_bin_path('ssh', True)
     supports_acceptnewhostkey = True
@@ -477,7 +478,7 @@ def ssh_supports_acceptnewhostkey(module):
         rc, stdout, stderr = module.run_command(cmd, check_rc=True)
         if b"unsupported option" in err:
             supports_acceptnewhostkey = False
-    except:
+    except OSError:
         supports_acceptnewhostkey = False
     return supports_acceptnewhostkey
 
@@ -1185,7 +1186,7 @@ def main():
             ssh_opts = "-o StrictHostKeyChecking=no"
 
     if module.params['accept_newhostkey']:
-        if ssh_supports_acceptnewhostkey(module) == False:
+        if not ssh_supports_acceptnewhostkey(module):
             module.warn("Your ssh client does not support accept_newhostkey option, therefore it cannot be used.")
         else:
             if ssh_opts is not None:

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -325,6 +325,7 @@ from distutils.version import LooseVersion
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import b, string_types
 from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.process import get_bin_path
 
 
 def relocate_repo(module, result, repo_dir, old_repo_dir, worktree_dir):

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -471,7 +471,12 @@ def get_version(module, git_path, dest, ref="HEAD"):
 
 
 def ssh_supports_acceptnewhostkey(module):
-    ssh_path = module.get_bin_path('ssh', True)
+    try:
+        ssh_path = module.get_bin_path('ssh', True)
+    except ValueError as err:
+        module.fail_json(msg='Remote host is missing ssh command, so you cannot '
+                'use acceptnewhostkey option.', details=to_text(err),
+                )
     supports_acceptnewhostkey = True
     cmd = [ssh_path, '-o', 'StrictHostKeyChecking=accept-new', '-V']
     rc, stdout, stderr = module.run_command(cmd)

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -472,7 +472,7 @@ def get_version(module, git_path, dest, ref="HEAD"):
 
 def ssh_supports_acceptnewhostkey(module):
     try:
-        ssh_path = module.get_bin_path('ssh', True)
+        ssh_path = get_bin_path('ssh')
     except ValueError as err:
         module.fail_json(
             msg='Remote host is missing ssh command, so you cannot '

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -469,11 +469,13 @@ def get_version(module, git_path, dest, ref="HEAD"):
     sha = to_native(stdout).rstrip('\n')
     return sha
 
+
 def get_ssh_version(module):
     cmd = "ssh -V"
     rc, stdout, stderr = module.run_command(cmd)
     ssh_version = to_native(stderr).rpartition('p1')[0].rpartition('OpenSSH_')[2]
     return ssh_version
+
 
 def get_submodule_versions(git_path, module, dest, version='HEAD'):
     cmd = [git_path, 'submodule', 'foreach', git_path, 'rev-parse', version]

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -475,10 +475,8 @@ def ssh_supports_acceptnewhostkey(module):
     supports_acceptnewhostkey = True
     try:
         cmd = [ssh_path, '-o', 'StrictHostKeyChecking=accept-new', '-V']
-        rc, stdout, stderr = module.run_command(cmd, check_rc=True)
-        if "unsupported option" in stderr:
-            supports_acceptnewhostkey = False
-    except OSError:
+        rc, stdout, stderr = module.run_command(cmd)
+    except Exception:
         supports_acceptnewhostkey = False
     return supports_acceptnewhostkey
 

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -48,6 +48,15 @@ options:
         type: bool
         default: 'no'
         version_added: "1.5"
+    accept_newhostkey:
+        description:
+            - As of OpenSSH 7.5, "-o StrictHostKeyChecking=accept-new" can be
+              used which is safer and will only accepts host keys which are
+              not present or are the same. if C(yes), ensure that
+              "-o StrictHostKeyChecking=accept-new" is present as an ssh option.
+        type: bool
+        default: 'no'
+        version_added: "2.11"
     ssh_opts:
         description:
             - Creates a wrapper script and exports the path as GIT_SSH
@@ -1106,6 +1115,7 @@ def main():
             verify_commit=dict(default='no', type='bool'),
             gpg_whitelist=dict(default=[], type='list', elements='str'),
             accept_hostkey=dict(default='no', type='bool'),
+            accept_newhostkey=dict(default='no', type='bool'),
             key_file=dict(default=None, type='path', required=False),
             ssh_opts=dict(default=None, required=False),
             executable=dict(default=None, type='path'),
@@ -1153,6 +1163,13 @@ def main():
                 ssh_opts += " -o StrictHostKeyChecking=no"
         else:
             ssh_opts = "-o StrictHostKeyChecking=no"
+
+    if module.params['accept_newhostkey']:
+        if ssh_opts is not None:
+            if ("-o StrictHostKeyChecking=no" not in ssh_opts) and ("-o StrictHostKeyChecking=accept-new" not in ssh_opts):
+                ssh_opts += " -o StrictHostKeyChecking=accept-new"
+        else:
+            ssh_opts = "-o StrictHostKeyChecking=accept-new"
 
     # evaluate and set the umask before doing anything else
     if umask is not None:

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -476,7 +476,7 @@ def ssh_supports_acceptnewhostkey(module):
     try:
         cmd = [ssh_path, '-o', 'StrictHostKeyChecking=accept-new', '-V']
         rc, stdout, stderr = module.run_command(cmd, check_rc=True)
-        if b"unsupported option" in err:
+        if b"unsupported option" in stderr:
             supports_acceptnewhostkey = False
     except OSError:
         supports_acceptnewhostkey = False

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -474,7 +474,8 @@ def ssh_supports_acceptnewhostkey(module):
     try:
         ssh_path = module.get_bin_path('ssh', True)
     except ValueError as err:
-        module.fail_json(msg='Remote host is missing ssh command, so you cannot '
+        module.fail_json(
+            msg='Remote host is missing ssh command, so you cannot '
             'use acceptnewhostkey option.', details=to_text(err))
     supports_acceptnewhostkey = True
     cmd = [ssh_path, '-o', 'StrictHostKeyChecking=accept-new', '-V']

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -1159,7 +1159,7 @@ def main():
 
     if module.params['accept_hostkey']:
         if ssh_opts is not None:
-            if "-o StrictHostKeyChecking=no" not in ssh_opts:
+            if ("-o StrictHostKeyChecking=no" not in ssh_opts) and ("-o StrictHostKeyChecking=accept-new" not in ssh_opts):
                 ssh_opts += " -o StrictHostKeyChecking=no"
         else:
             ssh_opts = "-o StrictHostKeyChecking=no"

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -469,6 +469,11 @@ def get_version(module, git_path, dest, ref="HEAD"):
     sha = to_native(stdout).rstrip('\n')
     return sha
 
+def get_ssh_version(module):
+    cmd = "ssh -V"
+    rc, stdout, stderr = module.run_command(cmd)
+    ssh_version = to_native(stderr).rpartition('p1')[0].rpartition('OpenSSH_')[2]
+    return ssh_version
 
 def get_submodule_versions(git_path, module, dest, version='HEAD'):
     cmd = [git_path, 'submodule', 'foreach', git_path, 'rev-parse', version]
@@ -1165,11 +1170,14 @@ def main():
             ssh_opts = "-o StrictHostKeyChecking=no"
 
     if module.params['accept_newhostkey']:
-        if ssh_opts is not None:
-            if ("-o StrictHostKeyChecking=no" not in ssh_opts) and ("-o StrictHostKeyChecking=accept-new" not in ssh_opts):
-                ssh_opts += " -o StrictHostKeyChecking=accept-new"
+        if get_ssh_version(module) < LooseVersion('7.5'):
+            module.warn("Your OpenSSH is older than 7.5, therefore accept_newhostkey option cannot be used.")
         else:
-            ssh_opts = "-o StrictHostKeyChecking=accept-new"
+            if ssh_opts is not None:
+                if ("-o StrictHostKeyChecking=no" not in ssh_opts) and ("-o StrictHostKeyChecking=accept-new" not in ssh_opts):
+                    ssh_opts += " -o StrictHostKeyChecking=accept-new"
+            else:
+                ssh_opts = "-o StrictHostKeyChecking=accept-new"
 
     # evaluate and set the umask before doing anything else
     if umask is not None:

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -476,7 +476,7 @@ def ssh_supports_acceptnewhostkey(module):
     try:
         cmd = [ssh_path, '-o', 'StrictHostKeyChecking=accept-new', '-V']
         rc, stdout, stderr = module.run_command(cmd, check_rc=True)
-        if b"unsupported option" in stderr:
+        if "unsupported option" in stderr:
             supports_acceptnewhostkey = False
     except OSError:
         supports_acceptnewhostkey = False

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -475,8 +475,7 @@ def ssh_supports_acceptnewhostkey(module):
         ssh_path = module.get_bin_path('ssh', True)
     except ValueError as err:
         module.fail_json(msg='Remote host is missing ssh command, so you cannot '
-                'use acceptnewhostkey option.', details=to_text(err),
-                )
+            'use acceptnewhostkey option.', details=to_text(err))
     supports_acceptnewhostkey = True
     cmd = [ssh_path, '-o', 'StrictHostKeyChecking=accept-new', '-V']
     rc, stdout, stderr = module.run_command(cmd)

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -1128,7 +1128,7 @@ def main():
             archive_prefix=dict(),
             separate_git_dir=dict(type='path'),
         ),
-        mutually_exclusive=[('separate_git_dir', 'bare')],
+        mutually_exclusive=[('separate_git_dir', 'bare'), ('accept_hostkey', 'accept_newhostkey')],
         required_by={'archive_prefix': ['archive']},
         supports_check_mode=True
     )

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -471,8 +471,9 @@ def get_version(module, git_path, dest, ref="HEAD"):
 
 
 def get_ssh_version(module):
-    cmd = "ssh -V"
-    rc, stdout, stderr = module.run_command(cmd)
+    ssh_path = module.get_bin_path('ssh', True)
+    cmd = [ssh_path, '-V']
+    rc, stdout, stderr = module.run_command(cmd, check_rc=True)
     ssh_version = to_native(stderr).rpartition('p1')[0].rpartition('OpenSSH_')[2]
     return ssh_version
 

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -483,14 +483,6 @@ def ssh_supports_acceptnewhostkey(module):
     return supports_acceptnewhostkey
 
 
-def get_ssh_version(module):
-    ssh_path = module.get_bin_path('ssh', True)
-    cmd = [ssh_path, '-V']
-    rc, stdout, stderr = module.run_command(cmd, check_rc=True)
-    ssh_version = to_native(stderr).rpartition('p1')[0].rpartition('OpenSSH_')[2]
-    return ssh_version
-
-
 def get_submodule_versions(git_path, module, dest, version='HEAD'):
     cmd = [git_path, 'submodule', 'foreach', git_path, 'rev-parse', version]
     (rc, out, err) = module.run_command(cmd, cwd=dest)

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -473,10 +473,9 @@ def get_version(module, git_path, dest, ref="HEAD"):
 def ssh_supports_acceptnewhostkey(module):
     ssh_path = module.get_bin_path('ssh', True)
     supports_acceptnewhostkey = True
-    try:
-        cmd = [ssh_path, '-o', 'StrictHostKeyChecking=accept-new', '-V']
-        rc, stdout, stderr = module.run_command(cmd)
-    except Exception:
+    cmd = [ssh_path, '-o', 'StrictHostKeyChecking=accept-new', '-V']
+    rc, stdout, stderr = module.run_command(cmd)
+    if rc != 0:
         supports_acceptnewhostkey = False
     return supports_acceptnewhostkey
 

--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -21,6 +21,7 @@
 
 - import_tasks: formats.yml
 - import_tasks: missing_hostkey.yml
+- import_tasks: missing_hostkey_acceptnew.yml
 - import_tasks: no-destination.yml
 - import_tasks: specific-revision.yml
 - import_tasks: submodules.yml

--- a/test/integration/targets/git/tasks/missing_hostkey.yml
+++ b/test/integration/targets/git/tasks/missing_hostkey.yml
@@ -46,3 +46,16 @@
     that:
       - git_result is changed
   when: github_ssh_private_key is defined
+
+- name: MISSING-HOSTEKY | Remove github.com hostkey from known_hosts
+  lineinfile:
+    dest: '{{ output_dir }}/known_hosts'
+    regexp: "github.com"
+    state: absent
+  when: github_ssh_private_key is defined
+
+- name: MISSING-HOSTKEY | clear checkout_dir
+  file:
+    state: absent
+    path: '{{ checkout_dir }}'
+  when: github_ssh_private_key is defined

--- a/test/integration/targets/git/tasks/missing_hostkey_acceptnew.yml
+++ b/test/integration/targets/git/tasks/missing_hostkey_acceptnew.yml
@@ -46,3 +46,16 @@
     that:
       - git_result is changed
   when: github_ssh_private_key is defined
+
+- name: MISSING-HOSTEKY | Remove github.com hostkey from known_hosts
+  lineinfile:
+    dest: '{{ output_dir }}/known_hosts'
+    regexp: "github.com"
+    state: absent
+  when: github_ssh_private_key is defined
+
+- name: MISSING-HOSTKEY | clear checkout_dir
+  file:
+    state: absent
+    path: '{{ checkout_dir }}'
+  when: github_ssh_private_key is defined

--- a/test/integration/targets/git/tasks/missing_hostkey_acceptnew.yml
+++ b/test/integration/targets/git/tasks/missing_hostkey_acceptnew.yml
@@ -1,3 +1,24 @@
+- name: MISSING-HOSTKEY | check accept_newhostkey support
+  shell: ssh -o StrictHostKeyChecking=accept-new -V
+  register: ssh_supports_accept_newhostkey
+  ignore_errors: true
+
+- block:
+    - name: MISSING-HOSTKEY | accept_newhostkey when ssh does not support the option
+      git:
+        repo: '{{ repo_format2 }}'
+        dest: '{{ checkout_dir }}'
+        accept_newhostkey: true
+        ssh_opts: '-o UserKnownHostsFile={{ output_dir }}/known_hosts'
+      register: git_result
+      ignore_errors: true
+
+    - assert:
+        that:
+          - git_result is failed
+          - "'does not support' in git_result.warnings"
+  when: ssh_supports_accept_newhostkey != 0
+
 - name: MISSING-HOSTKEY | checkout ssh://git@github.com repo without accept_newhostkey (expected fail)
   git:
     repo: '{{ repo_format2 }}'
@@ -10,52 +31,47 @@
     that:
       - git_result is failed
 
-- name: MISSING-HOSTKEY | checkout git@github.com repo with accept_newhostkey (expected pass)
-  git:
-    repo: '{{ repo_format2 }}'
-    dest: '{{ checkout_dir }}'
-    accept_newhostkey: true
-    key_file: '{{ github_ssh_private_key }}'
-    ssh_opts: '-o UserKnownHostsFile={{ output_dir }}/known_hosts'
-  register: git_result
-  when: github_ssh_private_key is defined
+- block:
+    - name: MISSING-HOSTKEY | checkout git@github.com repo with accept_newhostkey (expected pass)
+      git:
+        repo: '{{ repo_format2 }}'
+        dest: '{{ checkout_dir }}'
+        accept_newhostkey: true
+        key_file: '{{ github_ssh_private_key }}'
+        ssh_opts: '-o UserKnownHostsFile={{ output_dir }}/known_hosts'
+      register: git_result
 
-- assert:
-    that:
-      - git_result is changed
-  when: github_ssh_private_key is defined
+    - assert:
+        that:
+          - git_result is changed
 
-- name: MISSING-HOSTKEY | clear checkout_dir
-  file:
-    state: absent
-    path: '{{ checkout_dir }}'
-  when: github_ssh_private_key is defined
+    - name: MISSING-HOSTKEY | clear checkout_dir
+      file:
+        state: absent
+        path: '{{ checkout_dir }}'
 
-- name: MISSING-HOSTKEY | checkout ssh://git@github.com repo with accept_newhostkey (expected pass)
-  git:
-    repo: '{{ repo_format3 }}'
-    dest: '{{ checkout_dir }}'
-    version: 'master'
-    accept_newhostkey: false # should already have been accepted
-    key_file: '{{ github_ssh_private_key }}'
-    ssh_opts: '-o UserKnownHostsFile={{ output_dir }}/known_hosts'
-  register: git_result
-  when: github_ssh_private_key is defined
+    - name: MISSING-HOSTKEY | checkout ssh://git@github.com repo with accept_newhostkey (expected pass)
+      git:
+        repo: '{{ repo_format3 }}'
+        dest: '{{ checkout_dir }}'
+        version: 'master'
+        accept_newhostkey: false # should already have been accepted
+        key_file: '{{ github_ssh_private_key }}'
+        ssh_opts: '-o UserKnownHostsFile={{ output_dir }}/known_hosts'
+      register: git_result
 
-- assert:
-    that:
-      - git_result is changed
-  when: github_ssh_private_key is defined
+    - assert:
+        that:
+          - git_result is changed
 
-- name: MISSING-HOSTEKY | Remove github.com hostkey from known_hosts
-  lineinfile:
-    dest: '{{ output_dir }}/known_hosts'
-    regexp: "github.com"
-    state: absent
-  when: github_ssh_private_key is defined
+    - name: MISSING-HOSTEKY | Remove github.com hostkey from known_hosts
+      lineinfile:
+        dest: '{{ output_dir }}/known_hosts'
+        regexp: "github.com"
+        state: absent
 
-- name: MISSING-HOSTKEY | clear checkout_dir
-  file:
-    state: absent
-    path: '{{ checkout_dir }}'
-  when: github_ssh_private_key is defined
+    - name: MISSING-HOSTKEY | clear checkout_dir
+      file:
+        state: absent
+        path: '{{ checkout_dir }}'
+  when: github_ssh_private_key is defined and ssh_supports_accept_newhostkey.rc == 0

--- a/test/integration/targets/git/tasks/missing_hostkey_acceptnew.yml
+++ b/test/integration/targets/git/tasks/missing_hostkey_acceptnew.yml
@@ -1,0 +1,48 @@
+- name: MISSING-HOSTKEY | checkout ssh://git@github.com repo without accept_newhostkey (expected fail)
+  git:
+    repo: '{{ repo_format2 }}'
+    dest: '{{ checkout_dir }}'
+    ssh_opts: '-o UserKnownHostsFile={{ output_dir }}/known_hosts'
+  register: git_result
+  ignore_errors: true
+
+- assert:
+    that:
+      - git_result is failed
+
+- name: MISSING-HOSTKEY | checkout git@github.com repo with accept_newhostkey (expected pass)
+  git:
+    repo: '{{ repo_format2 }}'
+    dest: '{{ checkout_dir }}'
+    accept_newhostkey: true
+    key_file: '{{ github_ssh_private_key }}'
+    ssh_opts: '-o UserKnownHostsFile={{ output_dir }}/known_hosts'
+  register: git_result
+  when: github_ssh_private_key is defined
+
+- assert:
+    that:
+      - git_result is changed
+  when: github_ssh_private_key is defined
+
+- name: MISSING-HOSTKEY | clear checkout_dir
+  file:
+    state: absent
+    path: '{{ checkout_dir }}'
+  when: github_ssh_private_key is defined
+
+- name: MISSING-HOSTKEY | checkout ssh://git@github.com repo with accept_newhostkey (expected pass)
+  git:
+    repo: '{{ repo_format3 }}'
+    dest: '{{ checkout_dir }}'
+    version: 'master'
+    accept_newhostkey: false # should already have been accepted
+    key_file: '{{ github_ssh_private_key }}'
+    ssh_opts: '-o UserKnownHostsFile={{ output_dir }}/known_hosts'
+  register: git_result
+  when: github_ssh_private_key is defined
+
+- assert:
+    that:
+      - git_result is changed
+  when: github_ssh_private_key is defined

--- a/test/integration/targets/git/tasks/missing_hostkey_acceptnew.yml
+++ b/test/integration/targets/git/tasks/missing_hostkey_acceptnew.yml
@@ -16,7 +16,8 @@
     - assert:
         that:
           - git_result is failed
-          # - "'does not support' in git_result.warnings" (how to handle this?)
+          - git_result.warnings is search("does not support")
+
   when: ssh_supports_accept_newhostkey.rc != 0
 
 - name: MISSING-HOSTKEY | checkout ssh://git@github.com repo without accept_newhostkey (expected fail)

--- a/test/integration/targets/git/tasks/missing_hostkey_acceptnew.yml
+++ b/test/integration/targets/git/tasks/missing_hostkey_acceptnew.yml
@@ -16,8 +16,8 @@
     - assert:
         that:
           - git_result is failed
-          - "'does not support' in git_result.warnings"
-  when: ssh_supports_accept_newhostkey != 0
+          # - "'does not support' in git_result.warnings" (how to handle this?)
+  when: ssh_supports_accept_newhostkey.rc != 0
 
 - name: MISSING-HOSTKEY | checkout ssh://git@github.com repo without accept_newhostkey (expected fail)
   git:


### PR DESCRIPTION
##### SUMMARY
Fixes: https://github.com/ansible/ansible/issues/69846

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
git

##### ADDITIONAL INFORMATION
This PR has a big problem right now, that would be older `openssh` clients like 7.4 (used in CentOS 7), etc.
If there is a variable which could check `openssh` version safely before executing the task, this problem would be solved.

If this problem got solved it would be much easier to be an option, if not it could be reverted to a doc pull request just mentioning `StrictHostKeyChecking=accept-new`.

It would be better if `accept_hostkey` could get `accept-new` value, but as its type is `boolean` and changing it to `str` would lead to problems with current playbooks using this option (`accept_hostkey`), I decided to create a new option.