### PR TITLE
Allow callbacks from forks

### DIFF
--- a/changelogs/fragments/14681-allow-callbacks-from-forks.yml
+++ b/changelogs/fragments/14681-allow-callbacks-from-forks.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- callbacks - Add feature allowing forks to send callback events
+  (https://github.com/ansible/ansible/issues/14681)

--- a/lib/ansible/executor/process/worker.py
+++ b/lib/ansible/executor/process/worker.py
@@ -166,41 +166,38 @@ class WorkerProcess(multiprocessing_context.Process):
             display.debug("done running TaskExecutor() for %s/%s [%s]" % (self._host, self._task, self._task._uuid))
             self._host.vars = dict()
             self._host.groups = []
-            task_result = TaskResult(
+
+            # put the result on the result queue
+            display.debug("sending task result for task %s" % self._task._uuid)
+            self._final_q.send_task_result(
                 self._host.name,
                 self._task._uuid,
                 executor_result,
                 task_fields=self._task.dump_attrs(),
             )
-
-            # put the result on the result queue
-            display.debug("sending task result for task %s" % self._task._uuid)
-            self._final_q.put(task_result)
             display.debug("done sending task result for task %s" % self._task._uuid)
 
         except AnsibleConnectionFailure:
             self._host.vars = dict()
             self._host.groups = []
-            task_result = TaskResult(
+            self._final_q.send_task_result(
                 self._host.name,
                 self._task._uuid,
                 dict(unreachable=True),
                 task_fields=self._task.dump_attrs(),
             )
-            self._final_q.put(task_result, block=False)
 
         except Exception as e:
             if not isinstance(e, (IOError, EOFError, KeyboardInterrupt, SystemExit)) or isinstance(e, TemplateNotFound):
                 try:
                     self._host.vars = dict()
                     self._host.groups = []
-                    task_result = TaskResult(
+                    self._final_q.send_task_result(
                         self._host.name,
                         self._task._uuid,
                         dict(failed=True, exception=to_text(traceback.format_exc()), stdout=''),
                         task_fields=self._task.dump_attrs(),
                     )
-                    self._final_q.put(task_result, block=False)
                 except Exception:
                     display.debug(u"WORKER EXCEPTION: %s" % to_text(e))
                     display.debug(u"WORKER TRACEBACK: %s" % to_text(traceback.format_exc()))

--- a/lib/ansible/executor/process/worker.py
+++ b/lib/ansible/executor/process/worker.py
@@ -54,7 +54,7 @@ class WorkerProcess(multiprocessing_context.Process):
     for reading later.
     '''
 
-    def __init__(self, final_q, task_vars, host, task, play_context, loader, variable_manager, shared_loader_obj, callback_queue):
+    def __init__(self, final_q, task_vars, host, task, play_context, loader, variable_manager, shared_loader_obj):
 
         super(WorkerProcess, self).__init__()
         # takes a task queue manager as the sole param:
@@ -66,7 +66,6 @@ class WorkerProcess(multiprocessing_context.Process):
         self._loader = loader
         self._variable_manager = variable_manager
         self._shared_loader_obj = shared_loader_obj
-        self._callback_queue = callback_queue
 
         # NOTE: this works due to fork, if switching to threads this should change to per thread storage of temp files
         # clear var to ensure we only delete files for this child
@@ -162,7 +161,6 @@ class WorkerProcess(multiprocessing_context.Process):
                 self._loader,
                 self._shared_loader_obj,
                 self._final_q,
-                self._callback_queue,
             ).run()
 
             display.debug("done running TaskExecutor() for %s/%s [%s]" % (self._host, self._task, self._task._uuid))

--- a/lib/ansible/executor/process/worker.py
+++ b/lib/ansible/executor/process/worker.py
@@ -54,7 +54,7 @@ class WorkerProcess(multiprocessing_context.Process):
     for reading later.
     '''
 
-    def __init__(self, final_q, task_vars, host, task, play_context, loader, variable_manager, shared_loader_obj):
+    def __init__(self, final_q, task_vars, host, task, play_context, loader, variable_manager, shared_loader_obj, callback_queue):
 
         super(WorkerProcess, self).__init__()
         # takes a task queue manager as the sole param:
@@ -66,6 +66,7 @@ class WorkerProcess(multiprocessing_context.Process):
         self._loader = loader
         self._variable_manager = variable_manager
         self._shared_loader_obj = shared_loader_obj
+        self._callback_queue = callback_queue
 
         # NOTE: this works due to fork, if switching to threads this should change to per thread storage of temp files
         # clear var to ensure we only delete files for this child
@@ -160,7 +161,8 @@ class WorkerProcess(multiprocessing_context.Process):
                 self._new_stdin,
                 self._loader,
                 self._shared_loader_obj,
-                self._final_q
+                self._final_q,
+                self._callback_queue,
             ).run()
 
             display.debug("done running TaskExecutor() for %s/%s [%s]" % (self._host, self._task, self._task._uuid))

--- a/lib/ansible/executor/process/worker.py
+++ b/lib/ansible/executor/process/worker.py
@@ -160,7 +160,7 @@ class WorkerProcess(multiprocessing_context.Process):
                 self._new_stdin,
                 self._loader,
                 self._shared_loader_obj,
-                self._final_q,
+                self._final_q
             ).run()
 
             display.debug("done running TaskExecutor() for %s/%s [%s]" % (self._host, self._task, self._task._uuid))

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -83,7 +83,7 @@ class TaskExecutor:
     class.
     '''
 
-    def __init__(self, host, task, job_vars, play_context, new_stdin, loader, shared_loader_obj, final_q):
+    def __init__(self, host, task, job_vars, play_context, new_stdin, loader, shared_loader_obj, final_q, callback_queue):
         self._host = host
         self._task = task
         self._job_vars = job_vars
@@ -93,6 +93,7 @@ class TaskExecutor:
         self._shared_loader_obj = shared_loader_obj
         self._connection = None
         self._final_q = final_q
+        self._callback_queue = callback_queue
         self._loop_eval_error = None
 
         self._task.squash()
@@ -600,7 +601,6 @@ class TaskExecutor:
             if self._task.async_val > 0:
                 if self._task.poll > 0 and not result.get('skipped') and not result.get('failed'):
                     result = self._poll_async_result(result=result, templar=templar, task_vars=vars_copy)
-                    # FIXME callback 'v2_runner_on_async_poll' here
 
                 # ensure no log is preserved
                 result["_ansible_no_log"] = self._play_context.no_log
@@ -778,6 +778,21 @@ class TaskExecutor:
                     raise
             else:
                 time_left -= self._task.poll
+                self._callback_queue.put(
+                    (
+                        'v2_runner_on_async_poll',
+                        (
+                            TaskResult(
+                                self._host,
+                                async_task,
+                                async_result,
+                                task_fields=self._task.dump_attrs(),
+                            ),
+                        ),
+                        {}
+                    ),
+                    block=False,
+                )
 
         if int(async_result.get('finished', 0)) != 1:
             if async_result.get('_ansible_parsed'):

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -83,7 +83,7 @@ class TaskExecutor:
     class.
     '''
 
-    def __init__(self, host, task, job_vars, play_context, new_stdin, loader, shared_loader_obj, final_q, callback_queue):
+    def __init__(self, host, task, job_vars, play_context, new_stdin, loader, shared_loader_obj, final_q):
         self._host = host
         self._task = task
         self._job_vars = job_vars
@@ -93,7 +93,6 @@ class TaskExecutor:
         self._shared_loader_obj = shared_loader_obj
         self._connection = None
         self._final_q = final_q
-        self._callback_queue = callback_queue
         self._loop_eval_error = None
 
         self._task.squash()
@@ -778,7 +777,7 @@ class TaskExecutor:
                     raise
             else:
                 time_left -= self._task.poll
-                self._callback_queue.send_callback(
+                self._final_q.send_callback(
                     'v2_runner_on_async_poll',
                     TaskResult(
                         self._host,

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -778,20 +778,14 @@ class TaskExecutor:
                     raise
             else:
                 time_left -= self._task.poll
-                self._callback_queue.put(
-                    (
-                        'v2_runner_on_async_poll',
-                        (
-                            TaskResult(
-                                self._host,
-                                async_task,
-                                async_result,
-                                task_fields=self._task.dump_attrs(),
-                            ),
-                        ),
-                        {}
+                self._callback_queue.send_callback(
+                    'v2_runner_on_async_poll',
+                    TaskResult(
+                        self._host,
+                        async_task,
+                        async_result,
+                        task_fields=self._task.dump_attrs(),
                     ),
-                    block=False,
                 )
 
         if int(async_result.get('finished', 0)) != 1:

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -377,14 +377,11 @@ class TaskExecutor:
                     'msg': 'Failed to template loop_control.label: %s' % to_text(e)
                 })
 
-            self._final_q.put(
-                TaskResult(
-                    self._host.name,
-                    self._task._uuid,
-                    res,
-                    task_fields=task_fields,
-                ),
-                block=False,
+            self._final_q.send_task_result(
+                self._host.name,
+                self._task._uuid,
+                res,
+                task_fields=task_fields,
             )
             results.append(res)
             del task_vars[loop_var]
@@ -671,7 +668,7 @@ class TaskExecutor:
                         result['_ansible_retry'] = True
                         result['retries'] = retries
                         display.debug('Retrying task, attempt %d of %d' % (attempt, retries))
-                        self._final_q.put(TaskResult(self._host.name, self._task._uuid, result, task_fields=self._task.dump_attrs()), block=False)
+                        self._final_q.send_task_result(self._host.name, self._task._uuid, result, task_fields=self._task.dump_attrs())
                         time.sleep(delay)
                         self._handler = self._get_action_handler(connection=self._connection, templar=templar)
         else:

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -32,13 +32,13 @@ from ansible.executor.play_iterator import PlayIterator
 from ansible.executor.stats import AggregateStats
 from ansible.executor.task_result import TaskResult
 from ansible.module_utils.six import PY3, string_types
-from ansible.module_utils.six.moves import queue as Queue
 from ansible.module_utils._text import to_text, to_native
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import callback_loader, strategy_loader, module_loader
 from ansible.plugins.callback import CallbackBase
 from ansible.template import Templar
-from ansible.utils.sentinel import Sentinel
+from ansible.utils.collection_loader import AnsibleCollectionRef
+from ansible.utils.helpers import pct_to_int
 from ansible.vars.hostvars import HostVars
 from ansible.vars.reserved import warn_if_reserved
 from ansible.utils.display import Display

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -40,6 +40,7 @@ from ansible.template import Templar
 from ansible.vars.hostvars import HostVars
 from ansible.vars.reserved import warn_if_reserved
 from ansible.utils.display import Display
+from ansible.utils.lock import lock_decorator
 from ansible.utils.multiprocessing import context as multiprocessing_context
 
 
@@ -350,11 +351,8 @@ class TaskQueueManager:
                 defunct = True
         return defunct
 
+    @lock_decorator(attr='_callback_lock')
     def send_callback(self, method_name, *args, **kwargs):
-        with self._callback_lock:
-            self._send_callback(method_name, *args, **kwargs)
-
-    def _send_callback(self, method_name, *args, **kwargs):
         for callback_plugin in [self._stdout_callback] + self._callback_plugins:
             # a plugin that set self.disabled to True will not be called
             # see osx_say.py example for such a plugin

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -309,6 +309,7 @@ class TaskQueueManager:
                         worker_prc.terminate()
                     except AttributeError:
                         pass
+
     def clear_failed_hosts(self):
         self._failed_hosts = dict()
 

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -37,8 +37,6 @@ from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import callback_loader, strategy_loader, module_loader
 from ansible.plugins.callback import CallbackBase
 from ansible.template import Templar
-from ansible.utils.collection_loader import AnsibleCollectionRef
-from ansible.utils.helpers import pct_to_int
 from ansible.vars.hostvars import HostVars
 from ansible.vars.reserved import warn_if_reserved
 from ansible.utils.display import Display

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -309,12 +309,6 @@ class TaskQueueManager:
                         worker_prc.terminate()
                     except AttributeError:
                         pass
-        try:
-            self.callback_queue.put((Sentinel, (), {}))
-        except IOError:
-            pass
-        self._callback_thread.join()
-
     def clear_failed_hosts(self):
         self._failed_hosts = dict()
 
@@ -331,6 +325,12 @@ class TaskQueueManager:
         return self._workers[:]
 
     def terminate(self):
+        try:
+            self.callback_queue.put((Sentinel, (), {}))
+        except IOError:
+            pass
+        self._callback_thread.join()
+        self.callback_queue.close()
         self._terminated = True
 
     def has_dead_workers(self):

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -294,6 +294,7 @@ class TaskQueueManager:
 
     def _cleanup_processes(self):
         if hasattr(self, '_workers'):
+            self.callback_queue.put((Sentinel, (), {}))
             for attempts_remaining in range(C.WORKER_SHUTDOWN_POLL_COUNT - 1, -1, -1):
                 if not any(worker_prc and worker_prc.is_alive() for worker_prc in self._workers):
                     break
@@ -309,7 +310,6 @@ class TaskQueueManager:
                         worker_prc.terminate()
                     except AttributeError:
                         pass
-        self.callback_queue.put((Sentinel, (), {}))
         self._callback_thread.join()
 
     def clear_failed_hosts(self):

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -69,6 +69,16 @@ class FinalQueue(multiprocessing.queues.Queue):
             block=False
         )
 
+    def send_task_result(self, *args, **kwargs):
+        if isinstance(args[0], TaskResult):
+            tr = args[0]
+        else:
+            tr = TaskResult(*args, **kwargs)
+        self.put(
+            tr,
+            block=False
+        )
+
 
 class TaskQueueManager:
 

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -56,7 +56,7 @@ def callback_thread(tqm):
             if method_name is Sentinel:
                 break
             tqm.send_callback(method_name, *args, **kwargs)
-        except (IOError, EOFError):
+        except (IOError, EOFError, ValueError):
             break
         except Queue.Empty:
             pass
@@ -294,7 +294,6 @@ class TaskQueueManager:
 
     def _cleanup_processes(self):
         if hasattr(self, '_workers'):
-            self.callback_queue.put((Sentinel, (), {}))
             for attempts_remaining in range(C.WORKER_SHUTDOWN_POLL_COUNT - 1, -1, -1):
                 if not any(worker_prc and worker_prc.is_alive() for worker_prc in self._workers):
                     break
@@ -310,6 +309,10 @@ class TaskQueueManager:
                         worker_prc.terminate()
                     except AttributeError:
                         pass
+        try:
+            self.callback_queue.put((Sentinel, (), {}))
+        except IOError:
+            pass
         self._callback_thread.join()
 
     def clear_failed_hosts(self):

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -31,6 +31,7 @@ from ansible.executor.play_iterator import PlayIterator
 from ansible.executor.stats import AggregateStats
 from ansible.executor.task_result import TaskResult
 from ansible.module_utils.six import string_types
+from ansible.module_utils.six.moves import queue as Queue
 from ansible.module_utils._text import to_text, to_native
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import callback_loader, strategy_loader, module_loader

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -421,6 +421,16 @@ class CallbackModule(CallbackBase):
             msg += "Result was: %s" % self._dump_results(result._result)
         self._display.display(msg, color=C.COLOR_DEBUG)
 
+    def v2_runner_on_async_poll(self, result):
+        host = result._host.get_name()
+        jid = result._result.get('ansible_job_id')
+        started = result._result.get('started')
+        finished = result._result.get('finished')
+        self._display.display(
+            'ASYNC POLL on %s: jid=%s started=%s finished=%s' % (host, jid, started, finished),
+            color=C.COLOR_DEBUG
+        )
+
     def v2_playbook_on_notify(self, handler, host):
         if self._display.verbosity > 1:
             self._display.display("NOTIFIED HANDLER %s for %s" % (handler.get_name(), host), color=C.COLOR_VERBOSE, screen_only=True)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -382,8 +382,7 @@ class StrategyBase:
                         'play_context': play_context
                     }
 
-                    worker_prc = WorkerProcess(self._final_q, task_vars, host, task, play_context, self._loader,
-                                               self._variable_manager, plugin_loader)
+                    worker_prc = WorkerProcess(self._final_q, task_vars, host, task, play_context, self._loader, self._variable_manager, plugin_loader)
                     self._workers[self._cur_worker] = worker_prc
                     self._tqm.send_callback('v2_runner_on_start', host, task)
                     worker_prc.start()

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -37,6 +37,7 @@ from ansible.errors import AnsibleError, AnsibleFileNotFound, AnsibleParserError
 from ansible.executor import action_write_locks
 from ansible.executor.process.worker import WorkerProcess
 from ansible.executor.task_result import TaskResult
+from ansible.executor.task_queue_manager import CallbackSend
 from ansible.module_utils.six.moves import queue as Queue
 from ansible.module_utils.six import iteritems, itervalues, string_types
 from ansible.module_utils._text import to_text
@@ -92,7 +93,9 @@ def results_thread_main(strategy):
             result = strategy._final_q.get()
             if isinstance(result, StrategySentinel):
                 break
-            else:
+            elif isinstance(result, CallbackSend):
+                strategy._tqm.send_callback(result.method_name, *result.args, **result.kwargs)
+            elif isinstance(result, TaskResult):
                 strategy._results_lock.acquire()
                 # only handlers have the listen attr, so this must be a handler
                 # we split up the results into two queues here to make sure
@@ -102,6 +105,8 @@ def results_thread_main(strategy):
                 else:
                     strategy._results.append(result)
                 strategy._results_lock.release()
+            else:
+                display.warning('Received an invalid object (%s) in the result queue: %r' % (type(result), result))
         except (IOError, EOFError):
             break
         except Queue.Empty:
@@ -378,7 +383,7 @@ class StrategyBase:
                     }
 
                     worker_prc = WorkerProcess(self._final_q, task_vars, host, task, play_context, self._loader,
-                                               self._variable_manager, plugin_loader, self._tqm.callback_queue)
+                                               self._variable_manager, plugin_loader)
                     self._workers[self._cur_worker] = worker_prc
                     self._tqm.send_callback('v2_runner_on_start', host, task)
                     worker_prc.start()

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -377,7 +377,7 @@ class StrategyBase:
                         'play_context': play_context
                     }
 
-                    worker_prc = WorkerProcess(self._final_q, task_vars, host, task, play_context, self._loader, self._variable_manager, plugin_loader)
+                    worker_prc = WorkerProcess(self._final_q, task_vars, host, task, play_context, self._loader, self._variable_manager, plugin_loader, self._tqm.callback_queue)
                     self._workers[self._cur_worker] = worker_prc
                     self._tqm.send_callback('v2_runner_on_start', host, task)
                     worker_prc.start()

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -377,7 +377,8 @@ class StrategyBase:
                         'play_context': play_context
                     }
 
-                    worker_prc = WorkerProcess(self._final_q, task_vars, host, task, play_context, self._loader, self._variable_manager, plugin_loader, self._tqm.callback_queue)
+                    worker_prc = WorkerProcess(self._final_q, task_vars, host, task, play_context, self._loader,
+                                               self._variable_manager, plugin_loader, self._tqm.callback_queue)
                     self._workers[self._cur_worker] = worker_prc
                     self._tqm.send_callback('v2_runner_on_start', host, task)
                     worker_prc.start()

--- a/lib/ansible/utils/lock.py
+++ b/lib/ansible/utils/lock.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2020 Matt Martz <matt@sivel.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from functools import wraps
+
+
+def lock_decorator(attr='missing_lock_attr', lock=None):
+    '''This decorator is a generic implementation that allows you
+    to either use a pre-defined instance attribute as the location
+    of the lock, or to explicitly pass a lock object.
+
+    This code was implemented with ``threading.Lock`` in mind, but
+    may work with other locks, assuming that they function as
+    context managers.
+
+    When using ``attr``, the assumption is the first argument to
+    the wrapped method, is ``self`` or ``cls``.
+
+    Examples:
+
+        @lock_decorator(attr='_callback_lock')
+        def send_callback(...):
+
+        @lock_decorator(lock=threading.Lock())
+        def some_method(...):
+    '''
+    def outer(func):
+        @wraps(func)
+        def inner(*args, **kwargs):
+            # Python2 doesn't have ``nonlocal``
+            # assign the actual lock to ``_lock``
+            if lock is None:
+                _lock = getattr(args[0], attr)
+            else:
+                _lock = lock
+            with _lock:
+                return func(*args, **kwargs)
+        return inner
+    return outer

--- a/test/integration/targets/async/callback_test.yml
+++ b/test/integration/targets/async/callback_test.yml
@@ -2,6 +2,6 @@
   gather_facts: false
   tasks:
     - name: Async poll callback test
-      command: /bin/sleep 5
+      command: sleep 5
       async: 6
       poll: 1

--- a/test/integration/targets/async/callback_test.yml
+++ b/test/integration/targets/async/callback_test.yml
@@ -1,0 +1,7 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Async poll callback test
+      command: /bin/sleep 5
+      async: 6
+      poll: 1

--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -298,3 +298,11 @@
     {{ ansible_python_interpreter|default('/usr/bin/python') }} -c 'import os; os.fdopen(os.dup(0), "r")'
   async: 1
   poll: 1
+
+- name: run async poll callback test playbook
+  command: ansible-playbook {{ role_path }}/callback_test.yml
+  register: callback_output
+
+- assert:
+    that:
+      - '"ASYNC POLL on localhost" in callback_output.stdout'

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -53,6 +53,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=mock_shared_loader,
             final_q=mock_queue,
+            callback_queue=MagicMock(),
         )
 
     def test_task_executor_run(self):
@@ -80,6 +81,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=mock_shared_loader,
             final_q=mock_queue,
+            callback_queue=MagicMock(),
         )
 
         te._get_loop_items = MagicMock(return_value=None)
@@ -98,7 +100,7 @@ class TestTaskExecutor(unittest.TestCase):
         self.assertIn("failed", res)
 
     def test_task_executor_run_clean_res(self):
-        te = TaskExecutor(None, MagicMock(), None, None, None, None, None, None)
+        te = TaskExecutor(None, MagicMock(), None, None, None, None, None, None, MagicMock())
         te._get_loop_items = MagicMock(return_value=[1])
         te._run_loop = MagicMock(
             return_value=[
@@ -146,6 +148,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=mock_shared_loader,
             final_q=mock_queue,
+            callback_queue=MagicMock(),
         )
 
         items = te._get_loop_items()
@@ -182,6 +185,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=mock_shared_loader,
             final_q=mock_queue,
+            callback_queue=MagicMock(),
         )
 
         def _execute(variables):
@@ -202,6 +206,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=DictDataLoader({}),
             shared_loader_obj=MagicMock(),
             final_q=MagicMock(),
+            callback_queue=MagicMock(),
         )
 
         action_loader = te._shared_loader_obj.action_loader
@@ -236,6 +241,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=DictDataLoader({}),
             shared_loader_obj=MagicMock(),
             final_q=MagicMock(),
+            callback_queue=MagicMock(),
         )
 
         action_loader = te._shared_loader_obj.action_loader
@@ -271,6 +277,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=DictDataLoader({}),
             shared_loader_obj=MagicMock(),
             final_q=MagicMock(),
+            callback_queue=MagicMock(),
         )
 
         action_loader = te._shared_loader_obj.action_loader
@@ -341,6 +348,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=shared_loader,
             final_q=mock_queue,
+            callback_queue=MagicMock(),
         )
 
         te._get_connection = MagicMock(return_value=mock_connection)
@@ -396,6 +404,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=shared_loader,
             final_q=mock_queue,
+            callback_queue=MagicMock(),
         )
 
         te._connection = MagicMock()

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -53,7 +53,6 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=mock_shared_loader,
             final_q=mock_queue,
-            callback_queue=MagicMock(),
         )
 
     def test_task_executor_run(self):
@@ -81,7 +80,6 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=mock_shared_loader,
             final_q=mock_queue,
-            callback_queue=MagicMock(),
         )
 
         te._get_loop_items = MagicMock(return_value=None)
@@ -100,7 +98,7 @@ class TestTaskExecutor(unittest.TestCase):
         self.assertIn("failed", res)
 
     def test_task_executor_run_clean_res(self):
-        te = TaskExecutor(None, MagicMock(), None, None, None, None, None, None, MagicMock())
+        te = TaskExecutor(None, MagicMock(), None, None, None, None, None, None)
         te._get_loop_items = MagicMock(return_value=[1])
         te._run_loop = MagicMock(
             return_value=[
@@ -148,7 +146,6 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=mock_shared_loader,
             final_q=mock_queue,
-            callback_queue=MagicMock(),
         )
 
         items = te._get_loop_items()
@@ -185,7 +182,6 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=mock_shared_loader,
             final_q=mock_queue,
-            callback_queue=MagicMock(),
         )
 
         def _execute(variables):
@@ -206,7 +202,6 @@ class TestTaskExecutor(unittest.TestCase):
             loader=DictDataLoader({}),
             shared_loader_obj=MagicMock(),
             final_q=MagicMock(),
-            callback_queue=MagicMock(),
         )
 
         action_loader = te._shared_loader_obj.action_loader
@@ -241,7 +236,6 @@ class TestTaskExecutor(unittest.TestCase):
             loader=DictDataLoader({}),
             shared_loader_obj=MagicMock(),
             final_q=MagicMock(),
-            callback_queue=MagicMock(),
         )
 
         action_loader = te._shared_loader_obj.action_loader
@@ -277,7 +271,6 @@ class TestTaskExecutor(unittest.TestCase):
             loader=DictDataLoader({}),
             shared_loader_obj=MagicMock(),
             final_q=MagicMock(),
-            callback_queue=MagicMock(),
         )
 
         action_loader = te._shared_loader_obj.action_loader
@@ -348,7 +341,6 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=shared_loader,
             final_q=mock_queue,
-            callback_queue=MagicMock(),
         )
 
         te._get_connection = MagicMock(return_value=mock_connection)
@@ -404,7 +396,6 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=shared_loader,
             final_q=mock_queue,
-            callback_queue=MagicMock(),
         )
 
         te._connection = MagicMock()


### PR DESCRIPTION
##### SUMMARY
POC for supporting callback events that come from the worker

See https://github.com/ansible/ansible/issues/14681

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/executor/task_queue_manager.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
