### PR TITLE
Fix ansible-test error in community.aws

### DIFF
--- a/changelogs/fragments/70507-validate-null-author.yaml
+++ b/changelogs/fragments/70507-validate-null-author.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixes ansible-test traceback when plugin author is NoneType (https://github.com/ansible/ansible/pull/70507)

--- a/changelogs/fragments/70507-validate-null-author.yaml
+++ b/changelogs/fragments/70507-validate-null-author.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Fixes ansible-test traceback when plugin author is NoneType (https://github.com/ansible/ansible/pull/70507)
+  - Fixes ansible-test traceback when plugin author is not a string (https://github.com/ansible/ansible/pull/70507)

--- a/changelogs/fragments/70507-validate-null-author.yaml
+++ b/changelogs/fragments/70507-validate-null-author.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Fixes ansible-test traceback when plugin author is not a string (https://github.com/ansible/ansible/pull/70507)
+  - Fixes ansible-test traceback when plugin author is not a string or a list of strings (https://github.com/ansible/ansible/pull/70507)

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -418,7 +418,7 @@ def author(value):
 
     for line in value:
         if not isinstance(line, string_types):
-            raise Invalid("Specify author as a list of strings")
+            raise Invalid("Specify author as a string or a list of strings, or not specify author at all")
         m = author_line.search(line)
         if not m:
             raise Invalid("Invalid author")

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -412,16 +412,20 @@ def deprecation_schema(for_collection):
 
 
 def author(value):
+    if value is None:
+        return value  # let schema checks handle
 
     if not is_iterable(value):
         value = [value]
 
     for line in value:
         if not isinstance(line, string_types):
-            raise Invalid("Specify author as a string or a list of strings, or not specify author at all")
+            continue  # let schema checks handle
         m = author_line.search(line)
         if not m:
             raise Invalid("Invalid author")
+
+    return value
 
 
 def doc_schema(module_name, for_collection=False, deprecated_module=False):

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -417,6 +417,8 @@ def author(value):
         value = [value]
 
     for line in value:
+        if line is None:
+            raise Invalid("Specify an author")
         m = author_line.search(line)
         if not m:
             raise Invalid("Invalid author")

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -417,8 +417,8 @@ def author(value):
         value = [value]
 
     for line in value:
-        if line is None:
-            raise Invalid("Specify an author")
+        if not isinstance(line, string_types):
+            raise Invalid("Specify author as a list of strings")
         m = author_line.search(line)
         if not m:
             raise Invalid("Invalid author")


### PR DESCRIPTION
##### SUMMARY
This is a followup from an email on the ansible-devel email list.

This fixes an error I got when running `ansible-test` for `community.aws`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py

##### ADDITIONAL INFORMATION
Also in email, the steps for running the sanity tests:

```
cd ~/Documents/test
git clone https://github.com/ansible-collections/community.aws.git
ansible-galaxy collection build
rm -rf ~/.ansible/collections/ansible_collections/community/aws/
ansible-galaxy collection install community-aws-1.0.0.tar.gz
cd ~/.ansible/collections/ansible_collections/community/aws/
ansible-test sanity
```

I tried with Ansible 2.11, 2.10, 2.9, gave up, then realized something was wrong. 

The error I got when running the test looked like this:

```paste below
>>> Standard Error
Traceback (most recent call last):
  File "/Users/alancoding/.virtualenvs/ansible29/lib/python3.7/site-packages/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 849, in _validate_docs_schema
    schema(doc)
  File "/Users/alancoding/.virtualenvs/ansible29/lib/python3.7/site-packages/voluptuous/schema_builder.py", line 272, in __call__
    return self._compiled([], data)
  File "/Users/alancoding/.virtualenvs/ansible29/lib/python3.7/site-packages/voluptuous/schema_builder.py", line 594, in validate_dict
    return base_validate(path, iteritems(data), out)
  File "/Users/alancoding/.virtualenvs/ansible29/lib/python3.7/site-packages/voluptuous/schema_builder.py", line 386, in validate_mapping
    cval = cvalue(key_path, value)
  File "/Users/alancoding/.virtualenvs/ansible29/lib/python3.7/site-packages/voluptuous/validators.py", line 205, in _run
    return self._exec(self._compiled, value, path)
  File "/Users/alancoding/.virtualenvs/ansible29/lib/python3.7/site-packages/voluptuous/validators.py", line 285, in _exec
    v = func(path, v)
  File "/Users/alancoding/.virtualenvs/ansible29/lib/python3.7/site-packages/voluptuous/schema_builder.py", line 817, in validate_callable
    return schema(data)
  File "/Users/alancoding/.virtualenvs/ansible29/lib/python3.7/site-packages/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py", line 177, in author
    m = author_line.search(line)
TypeError: expected string or bytes-like object

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/alancoding/.virtualenvs/ansible29/lib/python3.7/site-packages/ansible_test/_data/sanity/validate-modules/validate-modules", line 8, in <module>
    main()
  File "/Users/alancoding/.virtualenvs/ansible29/lib/python3.7/site-packages/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 1901, in main
    run()
  File "/Users/alancoding/.virtualenvs/ansible29/lib/python3.7/site-packages/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 1799, in run
    mv1.validate()
  File "/Users/alancoding/.virtualenvs/ansible29/lib/python3.7/site-packages/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 1621, in validate
    doc_info, docs = self._validate_docs()
  File "/Users/alancoding/.virtualenvs/ansible29/lib/python3.7/site-packages/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 1013, in _validate_docs
    'invalid-documentation',
  File "/Users/alancoding/.virtualenvs/ansible29/lib/python3.7/site-packages/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 851, in _validate_docs_schema
    for error in e.errors:
AttributeError: 'TypeError' object has no attribute 'errors'
```

The root cause appears to be due to `~/.ansible/collections/ansible_collections/community/aws//plugins/modules/redshift.py` and one other module (`plugins/modules/redshift_subnet_group.py`). See in specific:

```
DOCUMENTATION = '''
---
author:
version_added: 1.0.0
  - "Jens Carl (@j-carl), Hothead Games Inc."
  - "Rafael Driutti (@rafaeldriutti)"
module: redshift
short_description: create, delete, or modify an Amazon Redshift instance
```

Link:

https://github.com/ansible-collections/community.aws/blob/3b56fbdef774f26d9e2564507a0e686367224b11/plugins/modules/redshift.py#L13

The author value is none there.

I really don't care if users are allowed to do this or not, I just don't want it to prevent the tests from running. There's a valid point that CI is currently broken due to this.

This is modeled after @sivel's fix in https://github.com/ansible/ansible/pull/56882
