### PR TITLE
fix downloading collections in git repos and tar.gz artifacts

### DIFF
--- a/changelogs/fragments/70524-fix-download-collections.yaml
+++ b/changelogs/fragments/70524-fix-download-collections.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy collection download - fix downloading tar.gz files and collections in git repositories (https://github.com/ansible/ansible/issues/70429)

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -68,7 +68,8 @@ Downloading collections
 To download a collection and its dependencies for an offline install, run ``ansible-galaxy collection download``. This
 downloads the collections specified and their dependencies to the specified folder and creates a ``requirements.yml``
 file which can be used to install those collections on a host without access to a Galaxy server. All the collections
-are downloaded by default to the ``./collections`` folder.
+are downloaded by default to the ``./collections`` folder. For ``ansible-galaxy`` 2.10 and earlier, the collections downloaded
+must have an associated Galaxy server or be a ``tar.gz`` artifact. Ansible 2.10 skips SCM collections.
 
 Just like the ``install`` command, the collections are sourced based on the
 :ref:`configured galaxy server config <galaxy_server_config>`. Even if a collection to download was specified by a URL

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -68,8 +68,7 @@ Downloading collections
 To download a collection and its dependencies for an offline install, run ``ansible-galaxy collection download``. This
 downloads the collections specified and their dependencies to the specified folder and creates a ``requirements.yml``
 file which can be used to install those collections on a host without access to a Galaxy server. All the collections
-are downloaded by default to the ``./collections`` folder. For ``ansible-galaxy`` 2.10 and earlier, the collections downloaded
-must have an associated Galaxy server or be a ``tar.gz`` artifact. Ansible 2.10 skips SCM collections.
+are downloaded by default to the ``./collections`` folder.
 
 Just like the ``install`` command, the collections are sourced based on the
 :ref:`configured galaxy server config <galaxy_server_config>`. Even if a collection to download was specified by a URL

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -610,10 +610,10 @@ def download_collections(collections, output_path, apis, validate_certs, no_deps
                     shutil.copy(requirement.b_path, to_bytes(dest_path, errors='surrogate_or_strict'))
                 elif requirement.api is None and requirement.b_path:
                     temp_path = to_text(b_temp_path, errors='surrogate_or_string')
-                    scm_build_path = os.path.join(temp_path, 'tmp_build')
-                    os.makedirs(scm_build_path, mode=0o0755)
+                    scm_build_path = os.path.join(temp_path, 'tmp_build-%s' % collection_filename)
+                    os.makedirs(to_bytes(scm_build_path, errors='surrogate_or_strict'), mode=0o0755)
                     temp_download_path = build_collection(os.path.join(temp_path, name), scm_build_path, True)
-                    shutil.move(temp_download_path, dest_path)
+                    shutil.move(to_bytes(temp_download_path, errors='surrogate_or_strict'), to_bytes(dest_path, errors='surrogate_or_strict'))
                 else:
                     b_temp_download_path = requirement.download(b_temp_path)
                     shutil.move(b_temp_download_path, to_bytes(dest_path, errors='surrogate_or_strict'))

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -603,9 +603,18 @@ def download_collections(collections, output_path, apis, validate_certs, no_deps
                 dest_path = os.path.join(output_path, collection_filename)
                 requirements.append({'name': collection_filename, 'version': requirement.latest_version})
 
+                if requirement.api is None and requirement.b_path and not os.path.isfile(requirement.b_path):
+                    display.display("Skipping collection '%s'. The requirement doesn't have an associated Galaxy server" % name)
+                    continue
+
                 display.display("Downloading collection '%s' to '%s'" % (name, dest_path))
-                b_temp_download_path = requirement.download(b_temp_path)
-                shutil.move(b_temp_download_path, to_bytes(dest_path, errors='surrogate_or_strict'))
+
+                if requirement.api is None and requirement.b_path and os.path.isfile(requirement.b_path):
+                    shutil.copy(requirement.b_path, to_bytes(dest_path, errors='surrogate_or_strict'))
+                else:
+                    b_temp_download_path = requirement.download(b_temp_path)
+                    shutil.move(b_temp_download_path, to_bytes(dest_path, errors='surrogate_or_strict'))
+
                 display.display("%s (%s) was downloaded successfully" % (name, requirement.latest_version))
 
             requirements_path = os.path.join(output_path, 'requirements.yml')

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/download.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/download.yml
@@ -1,0 +1,36 @@
+- name: create test download dir
+  file:
+    path: '{{ galaxy_dir }}/download'
+    state: directory
+
+- name: download a git repository
+  command: 'ansible-galaxy collection download git+https://github.com/ansible-collections/amazon.aws.git,37875c5b4ba5bf3cc43e07edf29f3432fd76def5'
+  args:
+    chdir: '{{ galaxy_dir }}/download'
+  register: download_collection
+
+- name: check that the file was downloaded
+  stat:
+    path: '{{ galaxy_dir }}/download/collections/amazon-aws-1.0.0.tar.gz'
+  register: download_collection_actual
+
+- assert:
+    that:
+      - '"Downloading collection ''amazon.aws'' to" in download_collection.stdout'
+      - download_collection_actual.stat.exists
+
+- name: test the downloaded repository can be installed
+  command: 'ansible-galaxy collection install -r requirements.yml'
+  args:
+    chdir: '{{ galaxy_dir }}/download/collections/'
+
+- name: list installed collections
+  command: 'ansible-galaxy collection list'
+  register: installed_collections
+
+- assert:
+    that:
+      - "'amazon.aws' in installed_collections.stdout"
+
+- include_tasks: ./empty_installed_collections.yml
+  when: cleanup

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/main.yml
@@ -22,6 +22,7 @@
   - include_tasks: ./multi_collection_repo_individual.yml
   - include_tasks: ./setup_recursive_scm_dependency.yml
   - include_tasks: ./scm_dependency_deduplication.yml
+  - include_tasks: ./download.yml
 
   always:
 

--- a/test/integration/targets/ansible-galaxy-collection/tasks/download.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/download.yml
@@ -104,3 +104,39 @@
   assert:
     that:
       - '"Skipping install, no requirements found" in install_no_requirements.stdout'
+
+- name: Test downloading a tar.gz collection artifact
+  block:
+
+    - name: get result of build basic collection on current directory
+      stat:
+        path: '{{ galaxy_dir }}/scratch/ansible_test/my_collection/ansible_test-my_collection-1.0.0.tar.gz'
+      register: result
+
+    - name: create default skeleton
+      command: ansible-galaxy collection init ansible_test.my_collection {{ galaxy_verbosity }}
+      args:
+        chdir: '{{ galaxy_dir }}/scratch'
+      when: not result.stat.exists
+
+    - name: build the tar.gz
+      command:  ansible-galaxy collection build {{ galaxy_verbosity }}
+      args:
+        chdir: '{{ galaxy_dir }}/scratch/ansible_test/my_collection'
+      when: not result.stat.exists
+
+    - name: download a tar.gz file
+      command: ansible-galaxy collection download '{{ galaxy_dir }}/scratch/ansible_test/my_collection/ansible_test-my_collection-1.0.0.tar.gz'
+      args:
+        chdir: '{{ galaxy_dir }}/download'
+      register: download_collection
+
+    - name: get result of downloaded tar.gz
+      stat:
+        path: '{{ galaxy_dir }}/download/collections/ansible_test-my_collection-1.0.0.tar.gz'
+      register: download_collection_actual
+
+    - assert:
+        that:
+        - '"Downloading collection ''ansible_test.my_collection'' to" in download_collection.stdout'
+        - download_collection_actual.stat.exists


### PR DESCRIPTION
##### SUMMARY
Fixes #70429

The fix for the traceback should be backported, but since downloading collections from git repositories is technically a feature, maybe only the first commit is backportable. @sivel @samdoran @jborean93  Do any of you have thoughts on that?

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
