### PR TITLE
Fix building Ansible dist w/ setuptools>=48,<49.1

### DIFF
--- a/changelogs/fragments/70525-setuptools-disutils-reorder.yml
+++ b/changelogs/fragments/70525-setuptools-disutils-reorder.yml
@@ -1,0 +1,7 @@
+bugfixes:
+- >
+  Address the deprecation of the use of stdlib
+  distutils in packaging. It's a short-term hotfix for the problem
+  (https://github.com/ansible/ansible/issues/70456,
+  https://github.com/pypa/setuptools/issues/2230,
+  https://github.com/pypa/setuptools/commit/bd110264)

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,6 @@ import sys
 import warnings
 
 from collections import defaultdict
-from distutils.command.build_scripts import build_scripts as BuildScripts
-from distutils.command.sdist import sdist as SDist
 
 try:
     from setuptools import setup, find_packages
@@ -22,6 +20,15 @@ except ImportError:
           " your package manager (usually python-setuptools) or via pip (pip"
           " install setuptools).", file=sys.stderr)
     sys.exit(1)
+
+# `distutils` must be imported after `setuptools` or it will cause explosions
+# with `setuptools >=48.0.0, <49.1`.
+# Refs:
+# * https://github.com/ansible/ansible/issues/70456
+# * https://github.com/pypa/setuptools/issues/2230
+# * https://github.com/pypa/setuptools/commit/bd110264
+from distutils.command.build_scripts import build_scripts as BuildScripts
+from distutils.command.sdist import sdist as SDist
 
 sys.path.insert(0, os.path.abspath('lib'))
 from ansible.release import __version__, __author__


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change addresses the deprecation of the use of stdlib
`distutils`. It's a short-term hotfix for the problem and we'll
need to consider dropping the use of `distutils` from our `setup.py`.

Refs:
* https://github.com/ansible/ansible/issues/70456
* https://github.com/pypa/setuptools/issues/2230
* https://github.com/pypa/setuptools/commit/bd110264

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
setup.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A