### PR TITLE
Guard against allowing ansible to ansible-base upgrades

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,9 +101,6 @@ def _validate_install_ansible_base():
 
     %s
                 ''' % (stars, __version__, stars)
-                # '\n\n%s\n\nCannot upgrade ansible==%s to ansible-base. You must first uninstall\n'
-                # 'ansible before installing ansible-base. This is only required when upgrading\n'
-                # 'from ansible<2.10 to ansible-base.\n\n%s\n' % (stars, __version__, stars)
             )
     finally:
         sys.path[:] = sys_path

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ def validate_install_ansible_base():
     sys_modules = set(sys.modules)
     sys_path = sys.path[:]
     abspath = os.path.abspath
-    sys.path[:] = [p for p in sys.path if abspath(p) != os.path.abspath('lib')]
+    sys.path[:] = [p for p in sys.path if abspath(p) != abspath('lib')]
 
     try:
         from ansible.release import __version__

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import ast
-import codecs
 import json
 import os
 import os.path
@@ -34,10 +33,8 @@ from distutils.command.sdist import sdist as SDist
 
 
 def find_package_info(*file_paths):
-    # Open in Latin-1 so that we avoid encoding errors.
-    # Use codecs.open for Python 2 compatibility
     try:
-        with codecs.open(os.path.join(*file_paths), 'r', 'latin1') as f:
+        with open(os.path.join(*file_paths), 'r') as f:
             info_file = f.read()
     except Exception:
         raise RuntimeError("Unable to find package info.")

--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,9 @@ def find_package_info(*file_paths):
     # Open in Latin-1 so that we avoid encoding errors.
     # Use codecs.open for Python 2 compatibility
     try:
-        f = codecs.open(os.path.join(*file_paths), 'r', 'latin1')
-        info_file = f.read()
-        f.close()
-    except:
+        with codecs.open(os.path.join(*file_paths), 'r', 'latin1') as f:
+            info_file = f.read()
+    except Exception:
         raise RuntimeError("Unable to find package info.")
 
     # The version line must have the form
@@ -59,7 +58,7 @@ def _validate_install_ansible_base():
     """Validate that we can install ansible-base. Currently this only
     cares about upgrading to ansible-base from ansible<2.10
     """
-    if os.getenv('ANSIBLE_SKIP_CONFLICT_CHECK', '') not in ('', 0):
+    if os.getenv('ANSIBLE_SKIP_CONFLICT_CHECK', '') not in ('', '0'):
         return
 
     # Save these for later restoring things to pre invocation

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import ast
 import json
 import os
 import os.path

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,8 @@ def validate_install_ansible_base():
         if version_tuple < (2, 10):
             stars = '*' * 76
             raise RuntimeError(
-                '\n\n%s\n\nCannot upgrade ansible==%s to ansible-base. You must first uninstall ansible before '
-                'installing ansible-base\n\n%s\n' % (stars, __version__, stars)
+                '\n\n%s\n\nCannot upgrade ansible==%s to ansible-base. You must first uninstall\n'
+                'ansible before installing ansible-base\n\n%s\n' % (stars, __version__, stars)
             )
     finally:
         sys.path[:] = sys_path

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,8 @@ def validate_install_ansible_base():
             stars = '*' * 76
             raise RuntimeError(
                 '\n\n%s\n\nCannot upgrade ansible==%s to ansible-base. You must first uninstall\n'
-                'ansible before installing ansible-base\n\n%s\n' % (stars, __version__, stars)
+                'ansible before installing ansible-base. This is only required when upgrading\n'
+                'from ansible<2.10 to ansible-base\n\n%s\n' % (stars, __version__, stars)
             )
     finally:
         sys.path[:] = sys_path

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ def validate_install_ansible_base():
             raise RuntimeError(
                 '\n\n%s\n\nCannot upgrade ansible==%s to ansible-base. You must first uninstall\n'
                 'ansible before installing ansible-base. This is only required when upgrading\n'
-                'from ansible<2.10 to ansible-base\n\n%s\n' % (stars, __version__, stars)
+                'from ansible<2.10 to ansible-base.\n\n%s\n' % (stars, __version__, stars)
             )
     finally:
         sys.path[:] = sys_path


### PR DESCRIPTION
##### SUMMARY
Guard against allowing ansible to ansible-base upgrades

There doesn't seem to be a great way for erroring in `setup.py` without generating some form of exception. `RuntimeError` is used elsewhere, so I've used it here too.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup.py

##### ADDITIONAL INFORMATION
The output is roughly the same from pip 9 through pip 20:

```
    ERROR: Command errored out with exit status 1:
     command: /Users/matt/venvs/tmp-3c6561a2d73f68d4/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/Users/matt/projects/ansibledev/ansible/setup.py'"'"'; __file__='"'"'/Users/matt/projects/ansibledev/ansible/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/tmp/pip-pip-egg-info-mthvusdc
         cwd: /Users/matt/projects/ansibledev/ansible/
    Complete output (27 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/Users/matt/projects/ansibledev/ansible/setup.py", line 108, in <module>
        _validate_install_ansible_base()
      File "/Users/matt/projects/ansibledev/ansible/setup.py", line 75, in _validate_install_ansible_base
        raise RuntimeError(
    RuntimeError:

        ****************************************************************************

        Cannot install ansible-base with a pre-existing ansible==2.9.10
        installation.

        Installing ansible-base with ansible-2.9 or older currently installed with
        pip is known to cause problems. Please uninstall ansible and install the new
        version:

            pip uninstall ansible
            pip install ansible-base

        If you want to skip the conflict checks and manually resolve any issues
        afterwards, set the ANSIBLE_SKIP_CONFLICT_CHECK environment variable:

            ANSIBLE_SKIP_CONFLICT_CHECK=1 pip install ansible-base

        ****************************************************************************

    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```