### PR TITLE
command warnings: don't send the param from action

### DIFF
--- a/changelogs/fragments/command-warnings-deprecation-2.yml
+++ b/changelogs/fragments/command-warnings-deprecation-2.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix to previous deprecation change (#70504) which caused command warning deprecation to show in all cases, even when not specified by the user.

--- a/lib/ansible/plugins/action/command.py
+++ b/lib/ansible/plugins/action/command.py
@@ -17,7 +17,7 @@ class ActionModule(ActionBase):
         del tmp  # tmp no longer has any effect
 
         # Command module has a special config option to turn off the command nanny warnings
-        if 'warn' not in self._task.args:
+        if 'warn' not in self._task.args and C.COMMAND_WARNINGS:
             self._task.args['warn'] = C.COMMAND_WARNINGS
 
         wrap_async = self._task.async_val and not self._connection.has_native_async


### PR DESCRIPTION

##### SUMMARY

Change:
- Followup to #70504. We need to not pass the 'warn' parameter from the
  action plugin either, unless it's True. Otherwise, even though it
  defaults to false, we always show the deprecation.

Test Plan:
- Local

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

command, shell