### PR TITLE
Document that subversion module requires subversion

### DIFF
--- a/lib/ansible/modules/subversion.py
+++ b/lib/ansible/modules/subversion.py
@@ -85,6 +85,9 @@ options:
     default: "yes"
     version_added: "2.0"
     type: bool
+
+requirements:
+    - subversion (the command line tool with C(svn) entrypoint)
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY
I was crawling the requirements of modules in ansible-base, and discovered this as a notable absence.

The subversion module invokes `svn` on the CLI, and most minimalist container images will not have this out of the box.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/subversion.py

##### ADDITIONAL INFORMATION
For a reference point, see the git module:

https://github.com/ansible/ansible/blob/e396715d7be28da70c34b1e9e191a9ecbe63e52a/lib/ansible/modules/git.py#L189-L190

If anyone wants adjustment to the wording, that's fine. I'd be fine with "subversion" by itself, or we could specify yum/dnf/brew.