### PR TITLE
Don't strip no log values from keys with special meaning

### DIFF
--- a/changelogs/fragments/70455-no-log-no-modify-keys.yml
+++ b/changelogs/fragments/70455-no-log-no-modify-keys.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Ensure we don't strip no log values from keys with special meaning (https://github.com/ansible/ansible/issues/70455)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -272,6 +272,10 @@ if not _PY_MIN:
     sys.exit(1)
 
 
+_NO_MODIFY_KEYS = frozenset(
+    ('msg', 'exception', 'warnings', 'deprecations', 'failed', 'skipped', 'changed')
+)
+
 #
 # Deprecated functions
 #
@@ -411,7 +415,10 @@ def remove_values(value, no_log_strings):
         old_data, new_data = deferred_removals.popleft()
         if isinstance(new_data, Mapping):
             for old_key, old_elem in old_data.items():
-                new_key = _remove_values_conditions(old_key, no_log_strings, deferred_removals)
+                if old_key in _NO_MODIFY_KEYS:
+                    new_key = old_key
+                else:
+                    new_key = _remove_values_conditions(old_key, no_log_strings, deferred_removals)
                 new_elem = _remove_values_conditions(old_elem, no_log_strings, deferred_removals)
                 new_data[new_key] = new_elem
         else:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -276,6 +276,7 @@ _NO_MODIFY_KEYS = frozenset(
     ('msg', 'exception', 'warnings', 'deprecations', 'failed', 'skipped', 'changed', 'results')
 )
 
+
 #
 # Deprecated functions
 #

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -273,7 +273,7 @@ if not _PY_MIN:
 
 
 _NO_MODIFY_KEYS = frozenset(
-    ('msg', 'exception', 'warnings', 'deprecations', 'failed', 'skipped', 'changed')
+    ('msg', 'exception', 'warnings', 'deprecations', 'failed', 'skipped', 'changed', 'results')
 )
 
 #
@@ -415,7 +415,7 @@ def remove_values(value, no_log_strings):
         old_data, new_data = deferred_removals.popleft()
         if isinstance(new_data, Mapping):
             for old_key, old_elem in old_data.items():
-                if old_key in _NO_MODIFY_KEYS:
+                if old_key in _NO_MODIFY_KEYS or old_key.startswith('_ansible'):
                     new_key = old_key
                 else:
                     new_key = _remove_values_conditions(old_key, no_log_strings, deferred_removals)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -273,7 +273,7 @@ if not _PY_MIN:
 
 
 _NO_MODIFY_KEYS = frozenset(
-    ('msg', 'exception', 'warnings', 'deprecations', 'failed', 'skipped', 'changed', 'results')
+    ('msg', 'exception', 'warnings', 'deprecations', 'failed', 'skipped', 'changed', 'rc', 'stdout', 'stderr')
 )
 
 

--- a/test/units/module_utils/basic/test_no_log.py
+++ b/test/units/module_utils/basic/test_no_log.py
@@ -126,7 +126,6 @@ class TestRemoveValues(unittest.TestCase):
                 'exception': 'bar',
                 'warnings': 'baz',
                 'deprecations': 'qux',
-                'results': [],
                 '_ansible_something': 'baz',
                 'something': 'something',
             },
@@ -139,7 +138,6 @@ class TestRemoveValues(unittest.TestCase):
                 'exception': 'bar',
                 'warnings': 'baz',
                 'deprecations': 'qux',
-                'results': [],
                 '_ansible_something': 'baz',
                 'some********': 'some********',
             }

--- a/test/units/module_utils/basic/test_no_log.py
+++ b/test/units/module_utils/basic/test_no_log.py
@@ -118,6 +118,27 @@ class TestRemoveValues(unittest.TestCase):
             {'key-********': 'value-********'},
         ),
         (
+            {
+                'failed': False,
+                'changed': True,
+                'skipped': False,
+                'msg': 'foo',
+                'exception': 'bar',
+                'warnings': 'baz',
+                'deprecations': 'qux',
+            },
+            frozenset(['fail', 'hang', 'skip', 'msg', 'cept', 'nin', 'cation']),
+            {
+                'failed': False,
+                'changed': True,
+                'skipped': False,
+                'msg': 'foo',
+                'exception': 'bar',
+                'warnings': 'baz',
+                'deprecations': 'qux',
+            }
+        ),
+        (
             'This sentence has an enigma wrapped in a mystery inside of a secret. - mr mystery',
             frozenset(['enigma', 'mystery', 'secret']),
             'This sentence has an ******** wrapped in a ******** inside of a ********. - mr ********'

--- a/test/units/module_utils/basic/test_no_log.py
+++ b/test/units/module_utils/basic/test_no_log.py
@@ -126,8 +126,11 @@ class TestRemoveValues(unittest.TestCase):
                 'exception': 'bar',
                 'warnings': 'baz',
                 'deprecations': 'qux',
+                'results': [],
+                '_ansible_something': 'baz',
+                'something': 'something',
             },
-            frozenset(['fail', 'hang', 'skip', 'msg', 'cept', 'nin', 'cation']),
+            frozenset(['fail', 'hang', 'skip', 'msg', 'cept', 'nin', 'cation', 'sult', 'thing']),
             {
                 'failed': False,
                 'changed': True,
@@ -136,6 +139,9 @@ class TestRemoveValues(unittest.TestCase):
                 'exception': 'bar',
                 'warnings': 'baz',
                 'deprecations': 'qux',
+                'results': [],
+                '_ansible_something': 'baz',
+                'some********': 'some********',
             }
         ),
         (


### PR DESCRIPTION
##### SUMMARY
Don't strip no log values from keys with special meaning. Fixes #70455
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
