### PR TITLE
Clarify that index_var is 0 indexed

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/user_guide/playbooks_loops.rst
@@ -352,6 +352,8 @@ To keep track of where you are in a loop, use the ``index_var`` directive with `
     loop_control:
       index_var: my_idx
 
+.. note:: `index_var` is 0 indexed.
+
 Defining inner and outer variable names with ``loop_var``
 ---------------------------------------------------------
 .. versionadded:: 2.1


### PR DESCRIPTION

+label: docsite_pr

##### SUMMARY
A little further down the page is another index, ansible_loop.index, which shares a similar description but is 1 indexed.
Its zero indexed twin has a 0 suffix.

``ansible_loop.index``      The current iteration of the loop. (1 indexed)
``ansible_loop.index0``     The current iteration of the loop. (0 indexed)

To remove ambiguity around the usage of index_var I feel its worth explicitly mentioning this variable is 0 indexed.

##### ISSUE TYPE
- Docs Pull Request
