### PR TITLE
csvfile: use parse_kv() for args, add tests

### DIFF
--- a/changelogs/fragments/csvfile-parse_kv.yml
+++ b/changelogs/fragments/csvfile-parse_kv.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - The ``csvfile`` lookup plugin now uses ``parse_kv()`` internally. As a result, multi-word search keys can now be passed.
+  - The ``csvfile`` lookup plugin's documentation has been fixed; it erroneously said that the delimiter could be ``t`` which was never true. We now accept ``\t``, however, and the error in the documentation has been fixed to note that.

--- a/test/integration/targets/lookup_csvfile/aliases
+++ b/test/integration/targets/lookup_csvfile/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group2
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_csvfile/files/cool list of things.csv
+++ b/test/integration/targets/lookup_csvfile/files/cool list of things.csv
@@ -1,0 +1,3 @@
+woo,i,have,spaces,in,my,filename
+i,am,so,cool,haha,be,jealous
+maybe,i,will,work,like,i,should

--- a/test/integration/targets/lookup_csvfile/files/crlf.csv
+++ b/test/integration/targets/lookup_csvfile/files/crlf.csv
@@ -1,0 +1,2 @@
+this file,has,crlf,line,endings
+ansible,parses,them,just,fine

--- a/test/integration/targets/lookup_csvfile/files/people.csv
+++ b/test/integration/targets/lookup_csvfile/files/people.csv
@@ -1,0 +1,6 @@
+# Last,First,Email,Extension
+Smith,Jane,jsmith@example.com,1234
+Ipsum,Lorem,lipsum@another.example.com,9001
+"German von Lastname",Demo,hello@example.com,123123
+Example,Person,"crazy email"@example.com,9876
+"""The Rock"" Johnson",Dwayne,uhoh@example.com,1337

--- a/test/integration/targets/lookup_csvfile/files/tabs.csv
+++ b/test/integration/targets/lookup_csvfile/files/tabs.csv
@@ -1,0 +1,4 @@
+fruit	bananas	30
+fruit	apples	9
+electronics	tvs	8
+shoes	sneakers	26

--- a/test/integration/targets/lookup_csvfile/files/x1a.csv
+++ b/test/integration/targets/lookup_csvfile/files/x1a.csv
@@ -1,0 +1,3 @@
+separatedbyx1achars
+againbecause
+wecan

--- a/test/integration/targets/lookup_csvfile/tasks/main.yml
+++ b/test/integration/targets/lookup_csvfile/tasks/main.yml
@@ -1,0 +1,54 @@
+- set_fact:
+    this_will_error: "{{ lookup('csvfile', 'file=people.csv delimiter=, col=1') }}"
+  ignore_errors: yes
+  register: no_keyword
+
+- name: Make sure we failed above
+  assert:
+    that:
+      - no_keyword is failed
+      - >
+        "Search key is required but was not found" in no_keyword.msg
+
+- name: Check basic comma-separated file
+  assert:
+    that:
+      - lookup('csvfile', 'Smith file=people.csv delimiter=, col=1') == "Jane"
+      - lookup('csvfile', 'German von Lastname file=people.csv delimiter=, col=1') == "Demo"
+
+- name: Check tab-separated file
+  assert:
+    that:
+      - lookup('csvfile', 'electronics file=tabs.csv delimiter=TAB col=1') == "tvs"
+      - lookup('csvfile', 'fruit file=tabs.csv delimiter=TAB col=1') == "bananas"
+      - lookup('csvfile', 'fruit file=tabs.csv delimiter="\t" col=1') == "bananas"
+
+- name: Check \x1a-separated file
+  assert:
+    that:
+      - lookup('csvfile', 'again file=x1a.csv delimiter=\x1a col=1') == "because"
+
+- name: Check CSV file with CRLF line endings
+  assert:
+    that:
+      - lookup('csvfile', 'this file file=crlf.csv delimiter=, col=2') == "crlf"
+      - lookup('csvfile', 'ansible file=crlf.csv delimiter=, col=1') == "parses"
+
+- name: Check file with multi word filename
+  assert:
+    that:
+      - lookup('csvfile', 'maybe file="cool list of things.csv" delimiter=, col=3') == "work"
+
+- name: Test default behavior
+  assert:
+    that:
+      - lookup('csvfile', 'notfound file=people.csv delimiter=, col=2') == []
+      - lookup('csvfile', 'notfound file=people.csv delimiter=, col=2, default=what?') == "what?"
+
+# NOTE: For historical reasons, this is correct; quotes in the search field must
+# be treated literally as if they appear (escaped as required) in the field in the
+# file. They cannot be used to surround the search text in general.
+- name: Test quotes in the search field
+  assert:
+    that:
+      - lookup('csvfile', '"The Rock" Johnson file=people.csv delimiter=, col=1') == "Dwayne"

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -204,6 +204,7 @@ test/integration/targets/incidental_win_dsc/files/xTestDsc/1.0.1/DSCResources/AN
 test/integration/targets/incidental_win_dsc/files/xTestDsc/1.0.1/xTestDsc.psd1 pslint!skip
 test/integration/targets/incidental_win_ping/library/win_ping_syntax_error.ps1 pslint!skip
 test/integration/targets/incidental_win_reboot/templates/post_reboot.ps1 pslint!skip
+test/integration/targets/lookup_csvfile/files/crlf.csv line-endings
 test/integration/targets/lookup_ini/lookup-8859-15.ini no-smart-quotes
 test/integration/targets/module_precedence/lib_with_extension/a.ini shebang
 test/integration/targets/module_precedence/lib_with_extension/ping.ini shebang


### PR DESCRIPTION

##### SUMMARY
Change:
- Use parse_kv() for parsing in the csvfile lookup plugin. This allows
  us to handle multi-word search keys and filenames. Previously, the
  plugin split on space and so none of these things worked as expected.
- Add integration tests for csvfile, testing a plethora of weird cases.

Test Plan:
- New integration tests, CI

Tickets:
- Fixes #70545

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

csvfile lookup plugin