### PR TITLE
Remove remaining examples of 1.1.1.1

### DIFF
--- a/test/integration/targets/incidental_ufw/tasks/tests/interface.yml
+++ b/test/integration/targets/incidental_ufw/tasks/tests/interface.yml
@@ -9,8 +9,8 @@
     interface_in: foo
     interface_out: bar
     proto: tcp
-    from_ip: 1.1.1.1
-    to_ip: 8.8.8.8
+    from_ip: 10.1.1.1
+    to_ip: 10.8.8.8
     from_port: 1111
     to_port: 2222
 
@@ -20,7 +20,7 @@
     route: yes
     interface_in: foo
     proto: tcp
-    from_ip: 1.1.1.1
+    from_ip: 10.1.1.1
     from_port: 1111
 
 - name: Route with interface out
@@ -29,7 +29,7 @@
     route: yes
     interface_out: bar
     proto: tcp
-    from_ip: 1.1.1.1
+    from_ip: 10.1.1.1
     from_port: 1111
 
 - name: Non-route with interface in
@@ -37,7 +37,7 @@
     rule: allow
     interface_in: foo
     proto: tcp
-    from_ip: 1.1.1.1
+    from_ip: 10.1.1.1
     from_port: 3333
 
 - name: Non-route with interface out
@@ -45,7 +45,7 @@
     rule: allow
     interface_out: bar
     proto: tcp
-    from_ip: 1.1.1.1
+    from_ip: 10.1.1.1
     from_port: 4444
 
 - name: Check result
@@ -54,11 +54,11 @@
 
 - assert:
     that:
-      - '"8.8.8.8 2222/tcp on bar ALLOW FWD 1.1.1.1 1111/tcp on foo " in stdout'
-      - '"Anywhere ALLOW FWD 1.1.1.1 1111/tcp on foo " in stdout'
-      - '"Anywhere on bar ALLOW FWD 1.1.1.1 1111/tcp " in stdout'
-      - '"Anywhere on foo ALLOW 1.1.1.1 3333/tcp " in stdout'
-      - '"Anywhere ALLOW OUT 1.1.1.1 4444/tcp on bar " in stdout'
+      - '"10.8.8.8 2222/tcp on bar ALLOW FWD 10.1.1.1 1111/tcp on foo " in stdout'
+      - '"Anywhere ALLOW FWD 10.1.1.1 1111/tcp on foo " in stdout'
+      - '"Anywhere on bar ALLOW FWD 10.1.1.1 1111/tcp " in stdout'
+      - '"Anywhere on foo ALLOW 10.1.1.1 3333/tcp " in stdout'
+      - '"Anywhere ALLOW OUT 10.1.1.1 4444/tcp on bar " in stdout'
   vars:
     stdout: '{{ ufw_status.stdout_lines }}'
 
@@ -68,9 +68,9 @@
     interface_in: foo
     interface_out: bar
     proto: tcp
-    from_ip: 1.1.1.1
+    from_ip: 10.1.1.1
     from_port: 1111
-    to_ip: 8.8.8.8
+    to_ip: 10.8.8.8
     to_port: 2222
   ignore_errors: yes
   register: ufw_non_route_iface

--- a/test/support/integration/plugins/modules/ec2_group.py
+++ b/test/support/integration/plugins/modules/ec2_group.py
@@ -374,7 +374,7 @@ ip_permissions:
     - from_port: 8182
       ip_protocol: tcp
       ip_ranges:
-        - cidr_ip: "198.51.100.1/32"
+        - cidr_ip: "1.1.1.1/32"
       ipv6_ranges: []
       prefix_list_ids: []
       to_port: 8182

--- a/test/support/integration/plugins/modules/ec2_group.py
+++ b/test/support/integration/plugins/modules/ec2_group.py
@@ -374,7 +374,7 @@ ip_permissions:
     - from_port: 8182
       ip_protocol: tcp
       ip_ranges:
-        - cidr_ip: "1.1.1.1/32"
+        - cidr_ip: "198.51.100.1/32"
       ipv6_ranges: []
       prefix_list_ids: []
       to_port: 8182

--- a/test/units/module_utils/basic/test_selinux.py
+++ b/test/units/module_utils/basic/test_selinux.py
@@ -194,7 +194,7 @@ class TestSELinux(ModuleTestCase):
 
             mount_data = [
                 '/dev/disk1 / ext4 rw,seclabel,relatime,data=ordered 0 0\n',
-                '1.1.1.1:/path/to/nfs /some/path nfs ro 0 0\n',
+                '10.1.1.1:/path/to/nfs /some/path nfs ro 0 0\n',
                 'whatever /weird/random/fstype foos rw 0 0\n',
             ]
 


### PR DESCRIPTION
##### SUMMARY

These appear to be the last examples of 1.1.1.1 being used.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

tests

##### ADDITIONAL INFORMATION

While ec2_group.py is only really there as a helper, I've added it for completeness and also opened https://github.com/ansible-collections/amazon.aws/pull/100 for cleaning up upstream