### PR TITLE
[stable-2.10] assemble: Fix decrypt argument

### DIFF
--- a/changelogs/fragments/70465-assemble-fix-decrypt-argument.yaml
+++ b/changelogs/fragments/70465-assemble-fix-decrypt-argument.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - assemble - fix decrypt argument in the module (https://github.com/ansible/ansible/issues/65450).

--- a/lib/ansible/plugins/action/assemble.py
+++ b/lib/ansible/plugins/action/assemble.py
@@ -97,7 +97,7 @@ class ActionModule(ActionBase):
         regexp = self._task.args.get('regexp', None)
         follow = self._task.args.get('follow', False)
         ignore_hidden = self._task.args.get('ignore_hidden', False)
-        decrypt = self._task.args.get('decrypt', True)
+        decrypt = self._task.args.pop('decrypt', True)
 
         try:
             if src is None or dest is None:

--- a/test/integration/targets/assemble/tasks/main.yml
+++ b/test/integration/targets/assemble/tasks/main.yml
@@ -60,8 +60,30 @@
     - "result.changed == False"
     - "result.checksum == '74152e9224f774191bc0bedf460d35de86ad90e6'"
 
+- name: test assemble with all fragments and decrypt=True
+  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled2" decrypt=yes
+  register: result
+
+- name: assert the fragments were assembled with decrypt=True
+  assert:
+    that:
+    - "result.state == 'file'"
+    - "result.changed == True"
+    - "result.checksum == '74152e9224f774191bc0bedf460d35de86ad90e6'"
+
+- name: test assemble with all fragments and decrypt=True
+  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled2" decrypt=yes
+  register: result
+
+- name: assert that the same assemble made no changes with decrypt=True
+  assert:
+    that:
+    - "result.state == 'file'"
+    - "result.changed == False"
+    - "result.checksum == '74152e9224f774191bc0bedf460d35de86ad90e6'"
+
 - name: test assemble with fragments matching a regex
-  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled2" regexp="^fragment[1-3]$"
+  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled3" regexp="^fragment[1-3]$"
   register: result
 
 - name: assert the fragments were assembled with a regex
@@ -70,8 +92,18 @@
     - "result.state == 'file'"
     - "result.checksum == 'edfe2d7487ef8f5ebc0f1c4dc57ba7b70a7b8e2b'"
 
+- name: test assemble with fragments matching a regex and decrypt=True
+  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled4" regexp="^fragment[1-3]$" decrypt=yes
+  register: result
+
+- name: assert the fragments were assembled with a regex and decrypt=True
+  assert:
+    that:
+    - "result.state == 'file'"
+    - "result.checksum == 'edfe2d7487ef8f5ebc0f1c4dc57ba7b70a7b8e2b'"
+
 - name: test assemble with a delimiter
-  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled3" delimiter="#--- delimiter ---#"
+  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled5" delimiter="#--- delimiter ---#"
   register: result
 
 - name: assert the fragments were assembled with a delimiter
@@ -80,8 +112,18 @@
     - "result.state == 'file'"
     - "result.checksum == 'd986cefb82e34e4cf14d33a3cda132ff45aa2980'"
 
+- name: test assemble with a delimiter and decrypt=True
+  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled6" delimiter="#--- delimiter ---#" decrypt=yes
+  register: result
+
+- name: assert the fragments were assembled with a delimiter and decrypt=True
+  assert:
+    that:
+    - "result.state == 'file'"
+    - "result.checksum == 'd986cefb82e34e4cf14d33a3cda132ff45aa2980'"
+
 - name: test assemble with remote_src=False
-  assemble: src="./" dest="{{output_dir}}/assembled4" remote_src=no
+  assemble: src="./" dest="{{output_dir}}/assembled7" remote_src=no
   register: result
 
 - name: assert the fragments were assembled without remote
@@ -90,8 +132,28 @@
     - "result.state == 'file'"
     - "result.checksum == '048a1bd1951aa5ccc427eeb4ca19aee45e9c68b3'"
 
+- name: test assemble with remote_src=False and decrypt=True
+  assemble: src="./" dest="{{output_dir}}/assembled8" remote_src=no decrypt=yes
+  register: result
+
+- name: assert the fragments were assembled without remote and decrypt=True
+  assert:
+    that:
+    - "result.state == 'file'"
+    - "result.checksum == '048a1bd1951aa5ccc427eeb4ca19aee45e9c68b3'"
+
 - name: test assemble with remote_src=False and a delimiter
-  assemble: src="./" dest="{{output_dir}}/assembled5" remote_src=no delimiter="#--- delimiter ---#"
+  assemble: src="./" dest="{{output_dir}}/assembled9" remote_src=no delimiter="#--- delimiter ---#"
+  register: result
+
+- name: assert the fragments were assembled without remote
+  assert:
+    that:
+    - "result.state == 'file'"
+    - "result.checksum == '505359f48c65b3904127cf62b912991d4da7ed6d'"
+
+- name: test assemble with remote_src=False and a delimiter and decrypt=True
+  assemble: src="./" dest="{{output_dir}}/assembled10" remote_src=no delimiter="#--- delimiter ---#" decrypt=yes
   register: result
 
 - name: assert the fragments were assembled without remote


### PR DESCRIPTION
##### SUMMARY
Backport of #70465 for Ansible 2.10 cherry-picked from the commit [Fix decrypt argument in assemble module (#70465)](https://github.com/ansible/ansible/commit/71c378e139681f09e1c7727e11c5c4d5c7bcba8d).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
assemble
