### PR TITLE
varnames: add tests, fix exception grammar

### DIFF
--- a/changelogs/fragments/varnames-error-grammar.yml
+++ b/changelogs/fragments/varnames-error-grammar.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - varnames lookup plugin - Fixed grammar error in exception message when the plugin is given a non-string term.

--- a/lib/ansible/plugins/lookup/varnames.py
+++ b/lib/ansible/plugins/lookup/varnames.py
@@ -66,7 +66,7 @@ class LookupModule(LookupBase):
         for term in terms:
 
             if not isinstance(term, string_types):
-                raise AnsibleError('Invalid setting identifier, "%s" is not a string, its a %s' % (term, type(term)))
+                raise AnsibleError('Invalid setting identifier, "%s" is not a string, it is a %s' % (term, type(term)))
 
             try:
                 name = re.compile(term)

--- a/test/integration/targets/lookup_varnames/aliases
+++ b/test/integration/targets/lookup_varnames/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group2
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_varnames/tasks/main.yml
+++ b/test/integration/targets/lookup_varnames/tasks/main.yml
@@ -11,8 +11,7 @@
     that:
       - lookup('varnames', '^qz_.+', wantlist=True) == ['qz_1', 'qz_2']
       - lookup('varnames', '^qz_.+', '^qa.*', wantlist=True) == ['qz_1', 'qz_2', 'qa_1']
-      - >-
-        'ansible_python_interpreter' in lookup('varnames', '^ansible_.*', wantlist=True)
+      - "'ansible_python_interpreter' in lookup('varnames', '^ansible_.*', wantlist=True)"
       - lookup('varnames', '^doesnotexist.*', wantlist=True) == []
       - lookup('varnames', '^doesnotexist.*', '.*python_inter.*', wantlist=True) == ['ansible_python_interpreter']
       - lookup('varnames', '^q.*_\d', wantlist=True) == ['qz_1', 'qz_2', 'qa_1']
@@ -33,10 +32,7 @@
 - assert:
     that:
       - fail1res is failed
-      - >-
-        'Invalid setting identifier' in fail1res.msg
+      - "'Invalid setting identifier' in fail1res.msg"
       - fail2res is failed
-      - >-
-        'Unable to use' in fail2res.msg
-      - >-
-        'nothing to repeat' in fail2res.msg
+      - "'Unable to use' in fail2res.msg"
+      - "'nothing to repeat' in fail2res.msg"

--- a/test/integration/targets/lookup_varnames/tasks/main.yml
+++ b/test/integration/targets/lookup_varnames/tasks/main.yml
@@ -1,0 +1,42 @@
+# Example copied from docs
+- name: Set some variables
+  set_fact:
+    qz_1: hello
+    qz_2: world
+    qa_1: "I won't show"
+    qz_: "I won't show either"
+
+- name: Try various regexes and make sure they work
+  assert:
+    that:
+      - lookup('varnames', '^qz_.+', wantlist=True) == ['qz_1', 'qz_2']
+      - lookup('varnames', '^qz_.+', '^qa.*', wantlist=True) == ['qz_1', 'qz_2', 'qa_1']
+      - >-
+        'ansible_python_interpreter' in lookup('varnames', '^ansible_.*', wantlist=True)
+      - lookup('varnames', '^doesnotexist.*', wantlist=True) == []
+      - lookup('varnames', '^doesnotexist.*', '.*python_inter.*', wantlist=True) == ['ansible_python_interpreter']
+      - lookup('varnames', '^q.*_\d', wantlist=True) == ['qz_1', 'qz_2', 'qa_1']
+      - lookup('varnames', '^q.*_\d') == 'qz_1,qz_2,qa_1'
+
+- name: Make sure it fails successfully
+  set_fact:
+    fail1: "{{ lookup('varnames', True, wantlist=True) }}"
+  register: fail1res
+  ignore_errors: yes
+
+- name: Make sure it fails successfully
+  set_fact:
+    fail2: "{{ lookup('varnames', '*', wantlist=True) }}"
+  register: fail2res
+  ignore_errors: yes
+
+- assert:
+    that:
+      - fail1res is failed
+      - >-
+        'Invalid setting identifier' in fail1res.msg
+      - fail2res is failed
+      - >-
+        'Unable to use' in fail2res.msg
+      - >-
+        'nothing to repeat' in fail2res.msg


### PR DESCRIPTION

##### SUMMARY

Change:
- Add integration tests for various cases
- Fix wrong use of "its" in an exception thrown in varnames when it
  throws an AnsibleError, given a term of the wrong type.

Test Plan:
- new tests, CI

Tickets:
- Fixes #70546

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

varnames