### PR TITLE
remove 'alternatives' from COMMAND_WARNINGS config

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -429,7 +429,6 @@ COMMAND_WARNINGS:
   deprecated:
     why: The command warnings feature is being removed.
     version: "2.14"
-    alternatives: N/A, these are just warnings and we no longer plan to show them.
 LOCALHOST_WARNING:
   name: Warning when using implicit inventory with only localhost
   default: True


### PR DESCRIPTION

##### SUMMARY

Change:
- This line causes the deprecation to make no grammatical sense. Nuking
  it.

Test Plan:
- My eyes

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

command