### PR TITLE
add alpine apk package manager to package_facts [wip]

### DIFF
--- a/changelogs/fragments/70587-package_facts-apk.yml
+++ b/changelogs/fragments/70587-package_facts-apk.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - add support for alpine linux 'apk' package manager in package_facts

--- a/lib/ansible/modules/package_facts.py
+++ b/lib/ansible/modules/package_facts.py
@@ -392,7 +392,7 @@ class APK(CLIMgr):
         for line in package.splitlines():
             m = re.match(r"([\w ].*?)-([0-9-\.r]+)", line.decode("utf-8"))
             if m:
-                raw_pkg_details['Name'] = m.group(2)
+                raw_pkg_details['Name'] = m.group(1)
                 raw_pkg_details['Version'] = m.group(2)
 
         return {

--- a/lib/ansible/modules/package_facts.py
+++ b/lib/ansible/modules/package_facts.py
@@ -390,15 +390,12 @@ class APK(CLIMgr):
     def get_package_details(self, package):
         raw_pkg_details = {}
         for line in package.splitlines():
-            m = re.match(r"([\w ].*?)-([0-9-\.r]+)", line.decode("utf-8"))
+            m = re.match(r"([\w ].*?)-([0-9-\.]+[0-9a-z-\.]*-r[0-9]+)", to_native(line))
             if m:
-                raw_pkg_details['Name'] = m.group(1)
-                raw_pkg_details['Version'] = m.group(2)
+                raw_pkg_details['name'] = m.group(1)
+                raw_pkg_details['version'] = m.group(2)
 
-        return {
-            'name': raw_pkg_details['Name'],
-            'version': raw_pkg_details['Version'],
-        }
+        return raw_pkg_details
 
 
 def main():

--- a/lib/ansible/modules/package_facts.py
+++ b/lib/ansible/modules/package_facts.py
@@ -19,6 +19,7 @@ options:
       - The package manager used by the system so we can query the package information.
       - Since 2.8 this is a list and can support multiple package managers per system.
       - The 'portage' and 'pkg' options were added in version 2.8.
+      - The 'apk' option was added in version 2.11.
     default: ['auto']
     choices: ['auto', 'rpm', 'apt', 'portage', 'pkg', 'pacman', 'apk']
     required: False

--- a/lib/ansible/modules/package_facts.py
+++ b/lib/ansible/modules/package_facts.py
@@ -382,7 +382,7 @@ class APK(CLIMgr):
     atoms = ['name', 'version']
 
     def list_installed(self):
-        rc, out, err = module.run_command([self._cli, 'info', '-v'])])
+        rc, out, err = module.run_command([self._cli, 'info', '-v'])
         if rc != 0 or err:
             raise Exception("Unable to list packages rc=%s : %s" % (rc, err))
         return out.splitlines()

--- a/lib/ansible/modules/package_facts.py
+++ b/lib/ansible/modules/package_facts.py
@@ -20,7 +20,7 @@ options:
       - Since 2.8 this is a list and can support multiple package managers per system.
       - The 'portage' and 'pkg' options were added in version 2.8.
     default: ['auto']
-    choices: ['auto', 'rpm', 'apt', 'portage', 'pkg', 'pacman']
+    choices: ['auto', 'rpm', 'apt', 'portage', 'pkg', 'pacman', 'apk']
     required: False
     type: list
   strategy:
@@ -374,6 +374,31 @@ class PORTAGE(CLIMgr):
 
     def get_package_details(self, package):
         return dict(zip(self.atoms, package.split()))
+
+
+class APK(CLIMgr):
+
+    CLI = 'apk'
+    atoms = ['name', 'version']
+
+    def list_installed(self):
+        rc, out, err = module.run_command([self._cli, 'info', '-v'])])
+        if rc != 0 or err:
+            raise Exception("Unable to list packages rc=%s : %s" % (rc, err))
+        return out.splitlines()
+
+    def get_package_details(self, package):
+        raw_pkg_details = {}
+        for line in package.splitlines():
+            m = re.match(r"([\w ].*?)-([0-9-\.r]+)", line.decode("utf-8"))
+            if m:
+                raw_pkg_details['Name'] = m.group(2)
+                raw_pkg_details['Version'] = m.group(2)
+
+        return {
+            'name': raw_pkg_details['Name'],
+            'version': raw_pkg_details['Version'],
+        }
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY

Extend support of package_facts to alpine apk

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
package_facts

##### ADDITIONAL INFORMATION
Tested with lxc on alpine 3.12

```paste below

host# lxc image copy images:alpine/3.12/amd64 local: --alias alpine-3.12                                                                                                                         host# lxc launch alpine-3.12 a                                                                                                                                                                   
host# lxc exec a -- /bin/ash
~ # apk update                                                                                                                                                                                               
~ # apk add python3 py3-pip python3-dev git gcc musl-dev libffi-dev openssl-dev
~ # pip install git+https://github.com/juju4/ansible@devel-apk
~ # mkdir /dev/shm
~ # chmod 777 /dev/shm
~ # echo 'none /dev/shm tmpfs rw,nosuid,nodev,noexec 0 0' >> /etc/fstab
~ # mount /dev/shm
~ # ansible -i localhost, -c local -m ping all 
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly
changing source of code and can become unstable at any point.
[WARNING]: Platform linux on host localhost is using the discovered Python interpreter at /usr/bin/python3, but future installation of another Python interpreter could change the meaning of that path. See
https://docs.ansible.com/ansible/devel/reference_appendices/interpreter_discovery.html for more information.
localhost | SUCCESS => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python3"
    },
    "changed": false,
    "ping": "pong"
}
~ # ansible -i localhost, -c local -m package_facts all 
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly
changing source of code and can become unstable at any point.
[WARNING]: Platform linux on host localhost is using the discovered Python interpreter at /usr/bin/python3, but future installation of another Python interpreter could change the meaning of that path. See
https://docs.ansible.com/ansible/devel/reference_appendices/interpreter_discovery.html for more information.
localhost | SUCCESS => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python3",
        "packages": {}
    },
    "changed": false
}
~ # apk info -v | head -5
alpine-keys-2.2-r0
libcrypto1.1-1.1.1g-r0
libssl1.1-1.1.1g-r0
libtls-standalone-2.9.1-r1
zlib-1.2.11-r3
```

but following standalone code works
```
import subprocess, re

CLI = 'apk'
atoms = ['name', 'version']

def list_installed():
        rc = 0
        a = subprocess.Popen(['apk', 'info', '-v'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
        output, err = a.communicate()
        print("output list packages rc=%s :\n%s\n %s" % (a, output, err))
        if rc != 0 or err:
            raise Exception("Unable to list packages rc=%s : %s" % (rc, err))
        return output.splitlines()

def get_package_details(package):
        raw_pkg_details = {}
        for line in package:
            m = re.match(r"([\w ].*?)-([0-9-\.r]+)", line.decode("utf-8"))
            if m:
                raw_pkg_details['Name'] = m.group(1)
                raw_pkg_details['Version'] = m.group(2)
                print("debug: %s" % raw_pkg_details)

        return {
            'name': raw_pkg_details['Name'],
            'version': raw_pkg_details['Version'],
        }


list = list_installed()
print(get_package_details(list))
```

any help on what's missing?

Thanks