### PR TITLE
Document tags are not supported with task meta.

### DIFF
--- a/lib/ansible/modules/meta.py
+++ b/lib/ansible/modules/meta.py
@@ -40,6 +40,7 @@ notes:
     - C(clear_facts) will remove the persistent facts from M(set_fact) using C(cacheable=True),
       but not the current host variable it creates for the current run.
     - Looping on meta tasks is not supported.
+    - Skipping C(meta) tasks using tags is not supported.
     - This module is also supported for Windows targets.
 seealso:
 - module: assert


### PR DESCRIPTION
# SUMMARY
Document meta is not able to be skipped tags

fixes #70338

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
meta

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
