### PR TITLE
Add intentional coverage for an async_wrapper case

### DIFF
--- a/test/integration/targets/async/library/async_test.py
+++ b/test/integration/targets/async/library/async_test.py
@@ -36,6 +36,9 @@ def main():
         if 'exception' in fail_mode:
             raise Exception('failing via exception')
 
+        if 'stderr' in fail_mode:
+            print('printed to stderr', file=sys.stderr)
+
         module.exit_json(**result)
 
     finally:

--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -165,6 +165,18 @@
     - async_result is successful
     - async_result.warnings[0] is search('trailing junk after module output')
 
+- name: test stderr handling
+  async_test:
+    fail_mode: stderr
+  async: 30
+  poll: 1
+  register: async_result
+  ignore_errors: true
+
+- assert:
+    that:
+      - async_result.stderr == "printed to stderr\n"
+
 # NOTE: This should report a warning that cannot be tested
 - name: test async properties on non-async task
   command: sleep 1


### PR DESCRIPTION

##### SUMMARY

Change:
- Test async_wrapper when the module it runs has stderr output

Test Plan:
- CI
- Looked at coverage report and saw green for a few lines that weren't
  previously green.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

tests