### PR TITLE
Support datetime.date object in module result

### DIFF
--- a/changelogs/fragments/70583_datetime_date_in_module_result.yml
+++ b/changelogs/fragments/70583_datetime_date_in_module_result.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add support for datetime.date object type in module result (https://github.com/ansible/ansible/issues/70583).

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -391,7 +391,7 @@ def _remove_values_conditions(value, no_log_strings, deferred_removals):
             if omit_me in stringy_value:
                 return 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER'
 
-    elif isinstance(value, datetime.datetime):
+    elif isinstance(value, (datetime.datetime, datetime.date)):
         value = value.isoformat()
     else:
         raise TypeError('Value of unknown type: %s, %s' % (type(value), value))

--- a/test/integration/targets/module_utils/library/test_datetime.py
+++ b/test/integration/targets/module_utils/library/test_datetime.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+# Most of these names are only available via PluginLoader so pylint doesn't
+# know they exist
+# pylint: disable=no-name-in-module
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+import datetime
+
+module = AnsibleModule(argument_spec=dict(
+    datetime=dict(type=str, required=True),
+    date=dict(type=str, required=True),
+))
+result = {
+    'datetime': datetime.datetime.strptime(module.params.get('datetime'), '%Y-%m-%dT%H:%M:%S'),
+    'date': datetime.datetime.strptime(module.params.get('date'), '%Y-%m-%d').date(),
+}
+module.exit_json(**result)

--- a/test/integration/targets/module_utils/module_utils_test.yml
+++ b/test/integration/targets/module_utils/module_utils_test.yml
@@ -97,3 +97,15 @@
       - file:
           path: "{{ output_dir }}/nulltest"
           state: absent
+
+  - name: Test that date and datetime in module output works
+    test_datetime:
+      date: "2020-10-05"
+      datetime: "2020-10-05T10:05:05"
+    register: datetimetest
+
+  - name:
+    assert:
+      that:
+        - datetimetest.date == '2020-10-05'
+        - datetimetest.datetime == '2020-10-05T10:05:05'

--- a/test/units/module_utils/basic/test_exit_json.py
+++ b/test/units/module_utils/basic/test_exit_json.py
@@ -14,8 +14,8 @@ import pytest
 
 
 EMPTY_INVOCATION = {u'module_args': {}}
-
 DATETIME = datetime.datetime.strptime('2020-07-13 12:50:00', '%Y-%m-%d %H:%M:%S')
+
 
 class TestAnsibleModuleExitJson:
     """

--- a/test/units/module_utils/basic/test_exit_json.py
+++ b/test/units/module_utils/basic/test_exit_json.py
@@ -8,12 +8,14 @@ __metaclass__ = type
 
 import json
 import sys
+import datetime
 
 import pytest
 
 
 EMPTY_INVOCATION = {u'module_args': {}}
 
+DATETIME = datetime.datetime.strptime('2020-07-13 12:50:00', '%Y-%m-%d %H:%M:%S')
 
 class TestAnsibleModuleExitJson:
     """
@@ -26,6 +28,10 @@ class TestAnsibleModuleExitJson:
          {'msg': 'success', 'changed': True, 'invocation': EMPTY_INVOCATION}),
         ({'msg': 'nochange', 'changed': False},
          {'msg': 'nochange', 'changed': False, 'invocation': EMPTY_INVOCATION}),
+        ({'msg': 'message', 'date': DATETIME.date()},
+         {'msg': 'message', 'date': DATETIME.date().isoformat(), 'invocation': EMPTY_INVOCATION}),
+        ({'msg': 'message', 'datetime': DATETIME},
+         {'msg': 'message', 'datetime': DATETIME.isoformat(), 'invocation': EMPTY_INVOCATION}),
     )
 
     # pylint bug: https://github.com/PyCQA/pylint/issues/511


### PR DESCRIPTION
Fixes #70583

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This supports datetime.date objects in output results by adding the object type to the if clause. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/module_utils/basic.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
