### PR TITLE
[2.7] pipe: update docs for Popen with shell=True usage

### DIFF
--- a/changelogs/fragments/70261_pipe_lookup.yml
+++ b/changelogs/fragments/70261_pipe_lookup.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- pipe lookup - update docs for Popen with shell=True usages (https://github.com/ansible/ansible/issues/70159).

--- a/lib/ansible/plugins/lookup/pipe.py
+++ b/lib/ansible/plugins/lookup/pipe.py
@@ -4,32 +4,39 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
     lookup: pipe
     author: Daniel Hokka Zakrisson <daniel@hozac.com>
     version_added: "0.9"
     short_description: read output from a command
     description:
-      - Run a command and return the output
+      - Run a command and return the output.
     options:
       _terms:
-        description: command(s) to run
+        description: command(s) to run.
         required: True
     notes:
       - Like all lookups this runs on the Ansible controller and is unaffected by other keywords, such as become,
         so if you need to different permissions you must change the command or run Ansible as another user.
       - Alternatively you can use a shell/command task that runs against localhost and registers the result.
+      - Pipe lookup internally invokes Popen with shell=True (this is required and intentional).
+        This type of invocation is considered as security issue if appropriate care is not taken to sanitize any user provided or variable input.
+        It is strongly recommended to pass user input or variable input via quote filter before using with pipe lookup.
+        See example section for this.
+        Read more about this L(Bandit B602 docs,https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html)
 """
 
-EXAMPLES = """
+EXAMPLES = r"""
 - name: raw result of running date command"
-  debug: msg="{{ lookup('pipe','date') }}"
+  debug:
+    msg: "{{ lookup('pipe', 'date') }}"
 
 - name: Always use quote filter to make sure your variables are safe to use with shell
-  debug: msg="{{ lookup('pipe','getent ' + myuser|quote ) }}"
+  debug:
+    msg: "{{ lookup('pipe', 'getent ' + myuser | quote ) }}"
 """
 
-RETURN = """
+RETURN = r"""
   _string:
     description:
       - stdout from command


### PR DESCRIPTION
##### SUMMARY

pipe lookup plugin uses Popen with shell=True intentionally.
This is considered a security issue if user input is not validated.
Updated docs to reflect this information for the user. Also, added
Bandit B602 documentation link for further reading.

Fixes: #70159

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit e5649ca3e807f17e7c034ee22791f107162973b0)


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/70261_pipe_lookup.yml
lib/ansible/plugins/lookup/pipe.py
