### PR TITLE
Updated requirements file to remove 'make' entry

### DIFF
--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -6,4 +6,3 @@ sphinx==2.1.2
 sphinx-notfound-page
 Pygments >= 2.4.0
 straight.plugin # Needed for hacking/build-ansible.py which is the backend build script
-make


### PR DESCRIPTION
SUMMARY
A recent PR was created to add an entry to 'make'. However, it seems to be a /usr/bin/make, and the make entry might be installing the wrong "make". Therefore, removed the entry 'make' from the doc.

ISSUE TYPE
Docs Pull Request

COMPONENT NAME
docs.ansible.com

ADDITIONAL INFORMATION
There's no standard way but a script could be written to install 'make' specifically for rhel (edited)
(on rhel: sudo yum install -y make). Note that unlike the other libraries in requirements.txt, make had to be installed by someone who can become a higher privileged user. (Info. shared by @abadger ).
Earlier PR: #70020