### PR TITLE
[stable-2.10] Test netconf plugins in ansible-doc sanity test.

### DIFF
--- a/changelogs/fragments/ansible-test-sanity-ansible-doc.yml
+++ b/changelogs/fragments/ansible-test-sanity-ansible-doc.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - The ``ansible-doc`` sanity test now works for ``netconf`` plugins.

--- a/test/lib/ansible_test/_internal/sanity/ansible_doc.py
+++ b/test/lib/ansible_test/_internal/sanity/ansible_doc.py
@@ -50,18 +50,17 @@ class AnsibleDocTest(SanitySingleVersion):
     def filter_targets(self, targets):  # type: (t.List[TestTarget]) -> t.List[TestTarget]
         """Return the given list of test targets, filtered to include only those relevant for the test."""
         # This should use documentable plugins from constants instead
-        plugin_type_blacklist = set([
+        unsupported_plugin_types = set([
             # not supported by ansible-doc
             'action',
             'doc_fragments',
             'filter',
             'module_utils',
-            'netconf',
             'terminal',
             'test',
         ])
 
-        plugin_paths = [plugin_path for plugin_type, plugin_path in data_context().content.plugin_paths.items() if plugin_type not in plugin_type_blacklist]
+        plugin_paths = [plugin_path for plugin_type, plugin_path in data_context().content.plugin_paths.items() if plugin_type not in unsupported_plugin_types]
 
         return [target for target in targets
                 if os.path.splitext(target.path)[1] == '.py'


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/70278

(cherry picked from commit 8d92df45374affb08fdd7a6d7da6a15dfaa008c2)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
