### PR TITLE
winrm - Added kinit_args to control the args for kinit calls

### DIFF
--- a/changelogs/fragments/winrm_kinit_args.yaml
+++ b/changelogs/fragments/winrm_kinit_args.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- winrm - Added ``ansible_winrm_kinit_args`` that can be used to control the args that are sent to the ``kinit`` call for Kerberos authentication.

--- a/test/units/plugins/connection/test_winrm.py
+++ b/test/units/plugins/connection/test_winrm.py
@@ -229,6 +229,10 @@ class TestWinRMKerbAuth(object):
          (["kinit2", "user@domain"],)],
         [{"_extras": {'ansible_winrm_kerberos_delegation': True}},
          (["kinit", "-f", "user@domain"],)],
+        [{"_extras": {}, 'ansible_winrm_kinit_args': '-f -p'},
+         (["kinit", "-f", "-p", "user@domain"],)],
+        [{"_extras": {}, 'ansible_winrm_kerberos_delegation': True, 'ansible_winrm_kinit_args': '-p'},
+         (["kinit", "-p", "user@domain"],)]
     ])
     def test_kinit_success_subprocess(self, monkeypatch, options, expected):
         def mock_communicate(input=None, timeout=None):
@@ -261,6 +265,10 @@ class TestWinRMKerbAuth(object):
          ("kinit2", ["user@domain"],)],
         [{"_extras": {'ansible_winrm_kerberos_delegation': True}},
          ("kinit", ["-f", "user@domain"],)],
+        [{"_extras": {}, 'ansible_winrm_kinit_args': '-f -p'},
+         ("kinit", ["-f", "-p", "user@domain"],)],
+        [{"_extras": {}, 'ansible_winrm_kerberos_delegation': True, 'ansible_winrm_kinit_args': '-p'},
+         ("kinit", ["-p", "user@domain"],)]
     ])
     def test_kinit_success_pexpect(self, monkeypatch, options, expected):
         pytest.importorskip("pexpect")


### PR DESCRIPTION
##### SUMMARY
Currently if someone wants to pass along extra args for the `kinit` call with WinRM Kerberos authentication that isn't possible. This adds the var `ansible_winrm_kinit_args` that can be used to specify custom args for this call. Note: if setting both custom args and `ansible_winrm_kerberos_delegation` then the `-f` will not automatically be added to the args. This must also be set in your custom args.

Fixes https://github.com/ansible/ansible/issues/64113

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
winrm