### PR TITLE
Get m_u.facts.utils coverage up to 100% (#70614)

### DIFF
--- a/test/integration/targets/gathering_facts/library/file_utils.py
+++ b/test/integration/targets/gathering_facts/library/file_utils.py
@@ -1,0 +1,54 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+import sys
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.facts.utils import (
+    get_file_content,
+    get_file_lines,
+    get_mount_size,
+)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            test=dict(type='str', default='strip'),
+            touch_file=dict(type='str', default='/dev/null'),
+            line_sep_file=dict(type='str', default='/dev/null'),
+            line_sep_sep=dict(type='str', default='\n'),
+        )
+    )
+
+    test = module.params['test']
+    facts = {}
+
+    if test == 'strip':
+        etc_passwd = get_file_content('/etc/passwd')
+        etc_passwd_unstripped = get_file_content('/etc/passwd', strip=False)
+        facts['etc_passwd_newlines'] = etc_passwd.count('\n')
+        facts['etc_passwd_newlines_unstripped'] = etc_passwd_unstripped.count('\n')
+
+    elif test == 'default':
+        path = module.params['touch_file']
+        facts['touch_default'] = get_file_content(path, default='i am a default')
+
+    elif test == 'line_sep':
+        path = module.params['line_sep_file']
+        sep = module.params['line_sep_sep']
+        facts['line_sep'] = get_file_lines(path, line_sep=sep)
+
+    elif test == 'invalid_mountpoint':
+        facts['invalid_mountpoint'] = get_mount_size('/doesnotexist')
+
+    result = {
+        'changed': False,
+        'ansible_facts': facts,
+    }
+
+    module.exit_json(**result)
+
+
+main()

--- a/test/integration/targets/gathering_facts/runme.sh
+++ b/test/integration/targets/gathering_facts/runme.sh
@@ -3,7 +3,7 @@
 set -eux
 
 #ANSIBLE_CACHE_PLUGINS=cache_plugins/ ANSIBLE_CACHE_PLUGIN=none ansible-playbook test_gathering_facts.yml -i inventory -v "$@"
-ansible-playbook test_gathering_facts.yml -i inventory -v "$@"
+ansible-playbook test_gathering_facts.yml -i inventory -e output_dir="$OUTPUT_DIR" -v "$@"
 #ANSIBLE_CACHE_PLUGIN=base ansible-playbook test_gathering_facts.yml -i inventory -v "$@"
 
 ANSIBLE_GATHERING=smart ansible-playbook test_run_once.yml -i inventory -v "$@"

--- a/test/integration/targets/gathering_facts/test_gathering_facts.yml
+++ b/test/integration/targets/gathering_facts/test_gathering_facts.yml
@@ -398,3 +398,77 @@
         # facter/ohai
         that:
           - 'ansible_user_id|default("UNDEF_MIN") != "UNDEF_MIN"'
+
+- hosts: facthost9
+  tags: [ 'fact_file_utils' ]
+  connection: local
+  gather_facts: false
+  tasks:
+    - block:
+        - name: Ensure get_file_content works when strip=False
+          file_utils:
+            test: strip
+
+        - assert:
+            that:
+              - ansible_facts.get('etc_passwd_newlines', 0) + 1 == ansible_facts.get('etc_passwd_newlines_unstripped', 0)
+
+        - name: Make an empty file
+          file:
+            path: "{{ output_dir }}/empty_file"
+            state: touch
+
+        - name: Ensure get_file_content gives default when file is empty
+          file_utils:
+            test: default
+            touch_file: "{{ output_dir }}/empty_file"
+
+        - assert:
+            that:
+              - ansible_facts.get('touch_default') == 'i am a default'
+
+        - copy:
+            dest: "{{ output_dir }}/1charsep"
+            content: "foo:bar:baz:buzz:"
+
+        - copy:
+            dest: "{{ output_dir }}/2charsep"
+            content: "foo::bar::baz::buzz::"
+
+        - name: Ensure get_file_lines works as expected with specified 1-char line_sep
+          file_utils:
+            test: line_sep
+            line_sep_file: "{{ output_dir }}/1charsep"
+            line_sep_sep: ":"
+
+        - assert:
+            that:
+              - ansible_facts.get('line_sep') == ['foo', 'bar', 'baz', 'buzz']
+
+        - name: Ensure get_file_lines works as expected with specified 1-char line_sep
+          file_utils:
+            test: line_sep
+            line_sep_file: "{{ output_dir }}/2charsep"
+            line_sep_sep: "::"
+
+        - assert:
+            that:
+              - ansible_facts.get('line_sep') == ['foo', 'bar', 'baz', 'buzz', '']
+
+        - name: Ensure get_mount_size fails gracefully
+          file_utils:
+            test: invalid_mountpoint
+
+        - assert:
+            that:
+              - ansible_facts['invalid_mountpoint']|length == 0
+
+      always:
+        - name: Remove test files
+          file:
+            path: "{{ item }}"
+            state: absent
+          with_items:
+            - "{{ output_dir }}/empty_file"
+            - "{{ output_dir }}/1charsep"
+            - "{{ output_dir }}/2charsep"


### PR DESCRIPTION
##### SUMMARY

Backport of #70614

* Get m_u.facts.utils coverage up to 100%

Change:
- Add tests to 'gathering_facts' integration target to get
  module_utils.facts.utils coverage up to 100%.
- This also clears incidental coverage from incidental_selinux.

Test Plan:
- CI

Signed-off-by: Rick Elrod <rick@elrod.me>


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

tests