### PR TITLE
Add intentional coverage for an async_wrapper case (#70593)

### DIFF
--- a/test/integration/targets/async/library/async_test.py
+++ b/test/integration/targets/async/library/async_test.py
@@ -1,3 +1,6 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import json
 import sys
 
@@ -32,6 +35,9 @@ def main():
 
         if 'exception' in fail_mode:
             raise Exception('failing via exception')
+
+        if 'stderr' in fail_mode:
+            print('printed to stderr', file=sys.stderr)
 
         module.exit_json(**result)
 

--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -165,6 +165,18 @@
     - async_result is successful
     - async_result.warnings[0] is search('trailing junk after module output')
 
+- name: test stderr handling
+  async_test:
+    fail_mode: stderr
+  async: 30
+  poll: 1
+  register: async_result
+  ignore_errors: true
+
+- assert:
+    that:
+      - async_result.stderr == "printed to stderr\n"
+
 # NOTE: This should report a warning that cannot be tested
 - name: test async properties on non-async task
   command: sleep 1

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -217,8 +217,6 @@ test/integration/targets/ansible-test/ansible_collections/ns/col/tests/unit/plug
 test/integration/targets/ansible-test-docker/ansible_collections/ns/col/plugins/modules/hello.py pylint:relative-beyond-top-level
 test/integration/targets/ansible-test-docker/ansible_collections/ns/col/tests/unit/plugins/module_utils/test_my_util.py pylint:relative-beyond-top-level
 test/integration/targets/ansible-test-docker/ansible_collections/ns/col/tests/unit/plugins/modules/test_hello.py pylint:relative-beyond-top-level
-test/integration/targets/async/library/async_test.py future-import-boilerplate
-test/integration/targets/async/library/async_test.py metaclass-boilerplate
 test/integration/targets/async_fail/library/async_test.py future-import-boilerplate
 test/integration/targets/async_fail/library/async_test.py metaclass-boilerplate
 test/integration/targets/collections_plugin_namespace/collection_root/ansible_collections/my_ns/my_col/plugins/lookup/lookup_no_future_boilerplate.py future-import-boilerplate


### PR DESCRIPTION

##### SUMMARY

Backport of #70593

Change:
- Test async_wrapper when the module it runs has stderr output

Test Plan:
- CI
- Looked at coverage report and saw green for a few lines that weren't
  previously green.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

tests