### PR TITLE
Remove python3-ism in async test

### DIFF
--- a/test/integration/targets/async/library/async_test.py
+++ b/test/integration/targets/async/library/async_test.py
@@ -37,7 +37,8 @@ def main():
             raise Exception('failing via exception')
 
         if 'stderr' in fail_mode:
-            print('printed to stderr', file=sys.stderr)
+            sys.stderr.write('printed to stderr\n')
+            sys.stderr.flush()
 
         module.exit_json(**result)
 


### PR DESCRIPTION

##### SUMMARY

Remove python3-ism in async test
    
Change:
- Use stderr.write() instead of print(file=stderr)
- This is mainly so that the stable backport doesn't cause a needless
  divergence.

Test Plan:
- CI
    

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request



##### COMPONENT NAME

tests, subelements lookup plugin