### PR TITLE
template connection variables accessed directly before using

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -798,7 +798,10 @@ class TaskExecutor:
             cvars = variables
 
         # use magic var if it exists, if not, let task inheritance do it's thing.
-        self._play_context.connection = cvars.get('ansible_connection', self._task.connection)
+        if cvars.get('ansible_connection') is not None:
+            self._play_context.connection = templar.template(cvars['ansible_connection'])
+        else:
+            self._play_context.connection = self._task.connection
 
         # TODO: play context has logic to update the conneciton for 'smart'
         # (default value, will chose between ssh and paramiko) and 'persistent'
@@ -820,13 +823,13 @@ class TaskExecutor:
 
         # load become plugin if needed
         if cvars.get('ansible_become') is not None:
-            become = boolean(templar.template(cvars.get('ansible_become')))
+            become = boolean(templar.template(cvars['ansible_become']))
         else:
             become = self._task.become
 
         if become:
             if cvars.get('ansible_become_method'):
-                become_plugin = self._get_become(templar.template(cvars.get('ansible_become_method')))
+                become_plugin = self._get_become(templar.template(cvars['ansible_become_method']))
             else:
                 become_plugin = self._get_become(self._task.become_method)
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -798,7 +798,10 @@ class TaskExecutor:
             cvars = variables
 
         # use magic var if it exists, if not, let task inheritance do it's thing.
-        self._play_context.connection = cvars.get('ansible_connection', self._task.connection)
+        if cvars.get('ansible_connection'):
+            self._play_context.connection = templar.template(cvars['ansible_connection'])
+        else:
+            self._play_context.connection = self._task.connection
 
         # TODO: play context has logic to update the conneciton for 'smart'
         # (default value, will chose between ssh and paramiko) and 'persistent'
@@ -819,8 +822,16 @@ class TaskExecutor:
             raise AnsibleError("the connection plugin '%s' was not found" % conn_type)
 
         # load become plugin if needed
-        if boolean(cvars.get('ansible_become', self._task.become)):
-            become_plugin = self._get_become(cvars.get('ansible_become_method', self._task.become_method))
+        if cvars.get('ansible_become') is not None:
+            become = boolean(templar.template(cvars.get('ansible_become')))
+        else:
+            become = self._task.become
+
+        if become:
+            if cvars.get('ansible_become_method'):
+                become_plugin = self._get_become(templar.template(cvars.get('ansible_become_method')))
+            else:
+                become_plugin = self._get_become(self._task.become_method)
 
             try:
                 connection.set_become_plugin(become_plugin)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -798,10 +798,7 @@ class TaskExecutor:
             cvars = variables
 
         # use magic var if it exists, if not, let task inheritance do it's thing.
-        if cvars.get('ansible_connection'):
-            self._play_context.connection = templar.template(cvars['ansible_connection'])
-        else:
-            self._play_context.connection = self._task.connection
+        self._play_context.connection = cvars.get('ansible_connection', self._task.connection)
 
         # TODO: play context has logic to update the conneciton for 'smart'
         # (default value, will chose between ssh and paramiko) and 'persistent'

--- a/test/integration/targets/var_templating/runme.sh
+++ b/test/integration/targets/var_templating/runme.sh
@@ -13,3 +13,5 @@ ansible-playbook undall.yml -i inventory -v "$@"
 
 # test hostvars templating
 ansible-playbook task_vars_templating.yml -v "$@"
+
+ansible-playbook test_connection_vars.yml -v "$@" 2>&1 | grep 'sudo'

--- a/test/integration/targets/var_templating/test_connection_vars.yml
+++ b/test/integration/targets/var_templating/test_connection_vars.yml
@@ -1,0 +1,26 @@
+---
+- hosts: localhost
+  gather_facts: no
+  vars:
+    my_var:
+      become_method: sudo
+      connection: local
+      become: 1
+  tasks:
+
+  - include_vars: "./vars/connection.yml"
+
+  - command: whoami
+    ignore_errors: yes
+    register: result
+    failed_when: result is not success and (result.module_stderr is defined or result.module_stderr is defined)
+
+  - assert:
+      that:
+        - "'sudo' in result.module_stderr"
+    when: result is not success and result.module_stderr is defined
+
+  - assert:
+      that:
+        - "'Invalid become method specified'  not in result.msg"
+    when: result is not success and result.msg is defined

--- a/test/integration/targets/var_templating/vars/connection.yml
+++ b/test/integration/targets/var_templating/vars/connection.yml
@@ -1,0 +1,3 @@
+ansible_become: "{{ my_var.become }}"
+ansible_become_method: "{{ my_var.become_method }}"
+ansible_connection: "{{ my_var.connection }}"


### PR DESCRIPTION
##### SUMMARY
Fixes #70598

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
Here's a more simple reproducer for the linked issue:

```
---
- hosts: localhost
  gather_facts: no
  tasks:
  - include_vars: vars1.yml
  - include_vars: vars2.yml
  - command: whoami
    become: True
    register: result
    failed_when: result is not success and 'a password is required' not in result.module_stderr
```
vars1.yml
```
outer:
  middle:
    inner: sudo
```
vars2.yml
```
ansible_become_method: "{{ outer.middle.inner }}"
```