### PR TITLE
modules with backup opt can specify backup file

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2279,14 +2279,14 @@ class AnsibleModule(object):
         ''' Return SHA-256 hex digest of local file using digest_from_file(). '''
         return self.digest_from_file(filename, 'sha256')
 
-    def backup_local(self, fn):
+    def backup_local(self, fn, backupdest=''):
         '''make a date-marked backup of the specified file, return True or False on success or failure'''
 
-        backupdest = ''
         if os.path.exists(fn):
-            # backups named basename.PID.YYYY-MM-DD@HH:MM:SS~
-            ext = time.strftime("%Y-%m-%d@%H:%M:%S~", time.localtime(time.time()))
-            backupdest = '%s.%s.%s' % (fn, os.getpid(), ext)
+            if not backupdest:
+                # backups named basename.PID.YYYY-MM-DD@HH:MM:SS~
+                ext = time.strftime("%Y-%m-%d@%H:%M:%S~", time.localtime(time.time()))
+                backupdest = '%s.%s.%s' % (fn, os.getpid(), ext)
 
             try:
                 self.preserved_copy(fn, backupdest)

--- a/lib/ansible/modules/blockinfile.py
+++ b/lib/ansible/modules/blockinfile.py
@@ -68,10 +68,15 @@ options:
     default: no
   backup:
     description:
-    - Create a backup file including the timestamp information so you can
+    - Create a backup file; by default the name includes the timestamp information so you can
       get the original file back if you somehow clobbered it incorrectly.
     type: bool
     default: no
+  backup_file:
+    description:
+    - Only when C(backup) is set, specify the path of the backup file
+    type: path
+    version_added: '2.11'
   marker_begin:
     description:
     - This will be inserted at C({mark}) in the opening ansible block marker.
@@ -201,6 +206,7 @@ def main():
             insertbefore=dict(type='str'),
             create=dict(type='bool', default=False),
             backup=dict(type='bool', default=False),
+            backup_file=dict(type='path'),
             validate=dict(type='str'),
             marker_begin=dict(type='str', default='BEGIN'),
             marker_end=dict(type='str', default='END'),
@@ -331,7 +337,7 @@ def main():
     backup_file = None
     if changed and not module.check_mode:
         if module.boolean(params['backup']) and path_exists:
-            backup_file = module.backup_local(path)
+            backup_file = module.backup_local(path, params['backup_file'])
         # We should always follow symlinks so that we change the real file
         real_path = os.path.realpath(params['path'])
         write_changes(module, result, real_path)

--- a/lib/ansible/modules/replace.py
+++ b/lib/ansible/modules/replace.py
@@ -75,10 +75,15 @@ options:
     version_added: "2.4"
   backup:
     description:
-      - Create a backup file including the timestamp information so you can
+      - Create a backup file; by default the name includes the timestamp information so you can
         get the original file back if you somehow clobbered it incorrectly.
     type: bool
     default: no
+  backup_file:
+    description:
+    - Only when C(backup) is set, specify the path of the backup file
+    type: path
+    version_added: '2.11'
   others:
     description:
       - All arguments accepted by the M(ansible.builtin.file) module also work here.
@@ -216,6 +221,7 @@ def main():
             after=dict(type='str'),
             before=dict(type='str'),
             backup=dict(type='bool', default=False),
+            backup_file=dict(type='path'),
             validate=dict(type='str'),
             encoding=dict(type='str', default='utf-8'),
         ),
@@ -284,8 +290,8 @@ def main():
         changed = False
 
     if changed and not module.check_mode:
-        if params['backup'] and os.path.exists(path):
-            res_args['backup_file'] = module.backup_local(path)
+        if module.boolean(params['backup']) and os.path.exists(path):
+            res_args['backup_file'] = module.backup_local(path, params['backup_file'])
         # We should always follow symlinks so that we change the real file
         path = os.path.realpath(path)
         write_changes(module, to_bytes(result[0], encoding=encoding), path)

--- a/test/integration/targets/blockinfile/tasks/add_block_to_existing_file.yml
+++ b/test/integration/targets/blockinfile/tasks/add_block_to_existing_file.yml
@@ -38,7 +38,7 @@
       - 'blockinfile_test0.msg == "Block inserted"'
       - 'blockinfile_test0_grep.stdout == "2"'
 
-- name: check idemptotence
+- name: check idempotence
   blockinfile:
     path: "{{ output_dir_test }}/sshd_config"
     block: |

--- a/test/integration/targets/lineinfile/tasks/main.yml
+++ b/test/integration/targets/lineinfile/tasks/main.yml
@@ -46,6 +46,16 @@
     insertbefore: "BOF"
   register: result2
 
+- name: insert a line at the beginning of the file, and back it up to a specific file path
+  lineinfile:
+    dest: "{{ output_dir }}/test.txt"
+    state: present
+    line: "New line at the beginning"
+    insertbefore: "BOF"
+    backup: yes
+    backup_file: "{{ output_dir }}/test.txt.bak"
+  register: result3
+
 - name: assert that the line was inserted at the head of the file
   assert:
     that:
@@ -53,6 +63,7 @@
       - result2 is not changed
       - result1.msg == 'line added'
       - result1.backup != ''
+      - result3.backup == output_dir + '/test.txt.bak'
 
 - name: stat the backup file
   stat:


### PR DESCRIPTION
##### SUMMARY
#29639 and #10149 are some of the many requests to stop writing backups to fill up folders.
I chose to let the user decide on the backup filepath because:
* it can be chosen by the user
* the current format is `basename.PID.YYYY-MM-DD@HH:MM:SS~`. I don't want to delete all files with that template, given that `PID` is "random" and deleting the old backups can be performed by users once, with this new approach to always give them a place to write to
* it's simple and does not introduce breaking changes - other approaches can be implemented in the future
* `backup_file` is what gets returned to the user; it seems nice and easier to re-use the same name

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
* blockinfile
* lineinfile
* copy
* replace

##### ADDITIONAL INFORMATION
In those modules, use `backup_file` to specify a path to the backup file when `backup` is set
