### PR TITLE
facts - fix incorrect time for some date_time_facts

### DIFF
--- a/changelogs/fragments/date-time-facts-fix-utctime.yml
+++ b/changelogs/fragments/date-time-facts-fix-utctime.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - facts - fix incorrect UTC timestamp in ``iso8601_micro`` and ``iso8601``

--- a/lib/ansible/module_utils/facts/system/date_time.py
+++ b/lib/ansible/module_utils/facts/system/date_time.py
@@ -18,8 +18,12 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import datetime
 import time
+
+from datetime import (
+    datetime,
+    timedelta,
+)
 
 from ansible.module_utils.facts.collector import BaseFactCollector
 
@@ -32,7 +36,10 @@ class DateTimeFactCollector(BaseFactCollector):
         facts_dict = {}
         date_time_facts = {}
 
-        now = datetime.datetime.now()
+        utcnow = datetime.utcnow()
+        offset_delta = timedelta(seconds=time.timezone)
+        now = utcnow - offset_delta
+
         date_time_facts['year'] = now.strftime('%Y')
         date_time_facts['month'] = now.strftime('%m')
         date_time_facts['weekday'] = now.strftime('%A')
@@ -48,8 +55,8 @@ class DateTimeFactCollector(BaseFactCollector):
             date_time_facts['epoch'] = str(int(time.time()))
         date_time_facts['date'] = now.strftime('%Y-%m-%d')
         date_time_facts['time'] = now.strftime('%H:%M:%S')
-        date_time_facts['iso8601_micro'] = now.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-        date_time_facts['iso8601'] = now.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        date_time_facts['iso8601_micro'] = utcnow.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        date_time_facts['iso8601'] = utcnow.strftime("%Y-%m-%dT%H:%M:%SZ")
         date_time_facts['iso8601_basic'] = now.strftime("%Y%m%dT%H%M%S%f")
         date_time_facts['iso8601_basic_short'] = now.strftime("%Y%m%dT%H%M%S")
         date_time_facts['tz'] = time.strftime("%Z")

--- a/lib/ansible/module_utils/facts/system/date_time.py
+++ b/lib/ansible/module_utils/facts/system/date_time.py
@@ -50,7 +50,7 @@ class DateTimeFactCollector(BaseFactCollector):
         date_time_facts['epoch'] = now.strftime('%s')
         if date_time_facts['epoch'] == '' or date_time_facts['epoch'][0] == '%':
             # NOTE: in this case, the epoch wont match the rest of the date_time facts? ie, it's a few milliseconds later..? -akl
-            date_time_facts['epoch'] = str(int(time.time()))
+            date_time_facts['epoch'] = str(int(epoch_ts))
         date_time_facts['date'] = now.strftime('%Y-%m-%d')
         date_time_facts['time'] = now.strftime('%H:%M:%S')
         date_time_facts['iso8601_micro'] = utcnow.strftime("%Y-%m-%dT%H:%M:%S.%fZ")

--- a/lib/ansible/module_utils/facts/system/date_time.py
+++ b/lib/ansible/module_utils/facts/system/date_time.py
@@ -18,9 +18,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import time
-
 import datetime
+import time
 
 from ansible.module_utils.facts.collector import BaseFactCollector
 
@@ -49,7 +48,6 @@ class DateTimeFactCollector(BaseFactCollector):
         date_time_facts['second'] = now.strftime('%S')
         date_time_facts['epoch'] = now.strftime('%s')
         if date_time_facts['epoch'] == '' or date_time_facts['epoch'][0] == '%':
-            # NOTE: in this case, the epoch wont match the rest of the date_time facts? ie, it's a few milliseconds later..? -akl
             date_time_facts['epoch'] = str(int(epoch_ts))
         date_time_facts['date'] = now.strftime('%Y-%m-%d')
         date_time_facts['time'] = now.strftime('%H:%M:%S')

--- a/lib/ansible/module_utils/facts/system/date_time.py
+++ b/lib/ansible/module_utils/facts/system/date_time.py
@@ -20,10 +20,7 @@ __metaclass__ = type
 
 import time
 
-from datetime import (
-    datetime,
-    timedelta,
-)
+from datetime import datetime
 
 from ansible.module_utils.facts.collector import BaseFactCollector
 
@@ -36,9 +33,10 @@ class DateTimeFactCollector(BaseFactCollector):
         facts_dict = {}
         date_time_facts = {}
 
-        utcnow = datetime.utcnow()
-        offset_delta = timedelta(seconds=time.timezone)
-        now = utcnow - offset_delta
+        # Store the timestamp once, then get local and UTC versions from that
+        epoch_ts = time.time()
+        now = datetime.fromtimestamp(epoch_ts)
+        utcnow = datetime.utcfromtimestamp(epoch_ts)
 
         date_time_facts['year'] = now.strftime('%Y')
         date_time_facts['month'] = now.strftime('%m')

--- a/lib/ansible/module_utils/facts/system/date_time.py
+++ b/lib/ansible/module_utils/facts/system/date_time.py
@@ -20,7 +20,7 @@ __metaclass__ = type
 
 import time
 
-from datetime import datetime
+import datetime
 
 from ansible.module_utils.facts.collector import BaseFactCollector
 
@@ -35,8 +35,8 @@ class DateTimeFactCollector(BaseFactCollector):
 
         # Store the timestamp once, then get local and UTC versions from that
         epoch_ts = time.time()
-        now = datetime.fromtimestamp(epoch_ts)
-        utcnow = datetime.utcfromtimestamp(epoch_ts)
+        now = datetime.datetime.fromtimestamp(epoch_ts)
+        utcnow = datetime.datetime.utcfromtimestamp(epoch_ts)
 
         date_time_facts['year'] = now.strftime('%Y')
         date_time_facts['month'] = now.strftime('%m')

--- a/test/units/module_utils/facts/test_date_time.py
+++ b/test/units/module_utils/facts/test_date_time.py
@@ -106,6 +106,7 @@ def test_date_time_epoch(date_facts):
 
     epoch_call.assert_called_with('%s')
     assert date_time['epoch'].isdigit()
+    assert len(date_time['epoch']) == 10  # This length will not change any time soon
 
 
 def test_date_time_tz(date_facts):
@@ -121,8 +122,7 @@ def test_date_time_tz(date_facts):
     tz_call.assert_called_with('%z')
     assert date_time['tz'].isupper()
     assert 2 <= len(date_time['tz']) <= 5
-    for letter in date_time['tz']:
-        assert letter in string.ascii_uppercase
+    assert not set(date_time['tz']).difference(set(string.ascii_uppercase))
 
 
 def test_date_time_tz_dst(date_facts):
@@ -135,8 +135,7 @@ def test_date_time_tz_dst(date_facts):
 
     assert date_time['tz_dst'].isupper()
     assert 2 <= len(date_time['tz_dst']) <= 4
-    for letter in date_time['tz_dst']:
-        assert letter in string.ascii_uppercase
+    assert not set(date_time['tz_dst']).difference(set(string.ascii_uppercase))
 
 
 def test_date_time_tz_offset(date_facts):

--- a/test/units/module_utils/facts/test_date_time.py
+++ b/test/units/module_utils/facts/test_date_time.py
@@ -94,7 +94,7 @@ def test_date_time_tz(fake_date_facts):
 
 def test_date_time_tz_dst(fake_date_facts):
     """
-    Test that daylight savings time timezone is between two and five
+    Test that daylight savings time timezone is between two and four
     uppercase letters.
     """
 

--- a/test/units/module_utils/facts/test_date_time.py
+++ b/test/units/module_utils/facts/test_date_time.py
@@ -50,29 +50,6 @@ def fake_date_facts(fake_now):
     return data
 
 
-@pytest.fixture
-def spy_strftime(mocker):
-    return mocker.spy(time, 'strftime')
-
-
-@pytest.fixture
-def date_facts(spy_strftime):
-    """
-    Return a collected facts instance and a mocker.spy object for time.strftime.
-
-    Do attempt to modify the time but instead observe the real calls since
-    it is not possibly to easily change the timezone for testing purposes.
-
-    Maybe something like https://github.com/wolfcw/libfaketime could be used
-    in the future.
-    """
-
-    collector = date_time.DateTimeFactCollector()
-    data = collector.collect()
-
-    return data, spy_strftime
-
-
 @pytest.mark.parametrize(
     ('fact_name', 'fact_value'),
     (
@@ -97,58 +74,41 @@ def test_date_time_facts(fake_date_facts, fact_name, fact_value):
     assert fake_date_facts['date_time'][fact_name] == fact_value
 
 
-def test_date_time_epoch(date_facts):
+def test_date_time_epoch(fake_date_facts):
     """Test that epoch call and format are correct"""
 
-    date_time = date_facts[0]['date_time']
-    spy_strftime = date_facts[1]
-    epoch_call = spy_strftime.call_args_list[9]
-
-    epoch_call.assert_called_with('%s')
-    assert date_time['epoch'].isdigit()
-    assert len(date_time['epoch']) == 10  # This length will not change any time soon
+    assert fake_date_facts['date_time']['epoch'].isdigit()
+    assert len(fake_date_facts['date_time']['epoch']) == 10  # This length will not change any time soon
 
 
-def test_date_time_tz(date_facts):
+def test_date_time_tz(fake_date_facts):
     """
     Test the timezone call is correct and the returned value is between
     two and five uppercase letters.
     """
 
-    date_time = date_facts[0]['date_time']
-    spy_strftime = date_facts[1]
-    tz_call = spy_strftime.call_args_list[15]
-
-    tz_call.assert_called_with('%z')
-    assert date_time['tz'].isupper()
-    assert 2 <= len(date_time['tz']) <= 5
-    assert not set(date_time['tz']).difference(set(string.ascii_uppercase))
+    assert fake_date_facts['date_time']['tz'].isupper()
+    assert 2 <= len(fake_date_facts['date_time']['tz']) <= 5
+    assert not set(fake_date_facts['date_time']['tz']).difference(set(string.ascii_uppercase))
 
 
-def test_date_time_tz_dst(date_facts):
+def test_date_time_tz_dst(fake_date_facts):
     """
     Test that daylight savings time timezone is between two and five
     uppercase letters.
     """
 
-    date_time = date_facts[0]['date_time']
-
-    assert date_time['tz_dst'].isupper()
-    assert 2 <= len(date_time['tz_dst']) <= 4
-    assert not set(date_time['tz_dst']).difference(set(string.ascii_uppercase))
+    assert fake_date_facts['date_time']['tz_dst'].isupper()
+    assert 2 <= len(fake_date_facts['date_time']['tz_dst']) <= 4
+    assert not set(fake_date_facts['date_time']['tz_dst']).difference(set(string.ascii_uppercase))
 
 
-def test_date_time_tz_offset(date_facts):
+def test_date_time_tz_offset(fake_date_facts):
     """
     Test that the timezone offset begins with a `+` or `-` and ends with a
     series of integers.
     """
 
-    date_time = date_facts[0]['date_time']
-    spy_strftime = date_facts[1]
-    tz_offset_call = spy_strftime.call_args_list[17]
-
-    tz_offset_call.assert_called_with('%z')
-    assert date_time['tz_offset'][0] in ['-', '+']
-    assert date_time['tz_offset'][1:].isdigit()
-    assert len(date_time['tz_offset']) == 5
+    assert fake_date_facts['date_time']['tz_offset'][0] in ['-', '+']
+    assert fake_date_facts['date_time']['tz_offset'][1:].isdigit()
+    assert len(fake_date_facts['date_time']['tz_offset']) == 5

--- a/test/units/module_utils/facts/test_date_time.py
+++ b/test/units/module_utils/facts/test_date_time.py
@@ -40,11 +40,9 @@ def fake_now(monkeypatch):
 
 
 @pytest.fixture
-def date_facts(monkeypatch, fake_now):
+def date_facts(fake_now):
     """Return a predictable instance of collected date_time facts."""
 
-    monkeypatch.setenv('TZ', 'Australia/Melbourne')
-    time.tzset()
     collector = date_time.DateTimeFactCollector()
     data = collector.collect()
 
@@ -63,17 +61,21 @@ def date_facts(monkeypatch, fake_now):
         ('hour', '12'),
         ('minute', '34'),
         ('second', '56'),
-        ('epoch', '1594434896'),
         ('date', '2020-07-11'),
         ('time', '12:34:56'),
         ('iso8601_basic', '20200711T123456124356'),
         ('iso8601_basic_short', '20200711T123456'),
         ('iso8601_micro', '2020-07-11T02:34:56.124356Z'),
         ('iso8601', '2020-07-11T02:34:56Z'),
-        ('tz', 'AEST'),
-        ('tz_dst', 'AEDT'),
-        ('tz_offset', '+1000'),
     ),
 )
 def test_date_time_facts(date_facts, fact_name, fact_value):
     assert date_facts['date_time'][fact_name] == fact_value
+
+
+# Need tests for:
+#
+#   ('epoch', '1594434896'),
+#   ('tz', 'AEST'),
+#   ('tz_dst', 'AEDT'),
+#   ('tz_offset', '+1000'),

--- a/test/units/module_utils/facts/test_date_time.py
+++ b/test/units/module_utils/facts/test_date_time.py
@@ -75,32 +75,22 @@ def test_date_time_facts(fake_date_facts, fact_name, fact_value):
 
 
 def test_date_time_epoch(fake_date_facts):
-    """Test that epoch call and format are correct"""
+    """Test that format of returned epoch value is correct"""
 
     assert fake_date_facts['date_time']['epoch'].isdigit()
     assert len(fake_date_facts['date_time']['epoch']) == 10  # This length will not change any time soon
 
 
-def test_date_time_tz(fake_date_facts):
+@pytest.mark.parametrize('fact_name', ('tz', 'tz_dst'))
+def test_date_time_tz(fake_date_facts, fact_name):
     """
-    Test the timezone call is correct and the returned value is between
-    two and five uppercase letters.
-    """
-
-    assert fake_date_facts['date_time']['tz'].isupper()
-    assert 2 <= len(fake_date_facts['date_time']['tz']) <= 5
-    assert not set(fake_date_facts['date_time']['tz']).difference(set(string.ascii_uppercase))
-
-
-def test_date_time_tz_dst(fake_date_facts):
-    """
-    Test that daylight savings time timezone is between two and four
-    uppercase letters.
+    Test the the returned value for timezone consists of only uppercase
+    letters and is the expected length.
     """
 
-    assert fake_date_facts['date_time']['tz_dst'].isupper()
-    assert 2 <= len(fake_date_facts['date_time']['tz_dst']) <= 4
-    assert not set(fake_date_facts['date_time']['tz_dst']).difference(set(string.ascii_uppercase))
+    assert fake_date_facts['date_time'][fact_name].isupper()
+    assert 2 <= len(fake_date_facts['date_time'][fact_name]) <= 5
+    assert not set(fake_date_facts['date_time'][fact_name]).difference(set(string.ascii_uppercase))
 
 
 def test_date_time_tz_offset(fake_date_facts):

--- a/test/units/module_utils/facts/test_date_time.py
+++ b/test/units/module_utils/facts/test_date_time.py
@@ -11,18 +11,32 @@ import time
 
 from ansible.module_utils.facts.system import date_time
 
-UTC_TIMESTAMP = datetime.datetime(2020, 7, 11, 2, 34, 56, 124356)
+EPOCH_TS = 1594449296.123456
+DT = datetime.datetime(2020, 7, 11, 12, 34, 56, 124356)
+DT_UTC = datetime.datetime(2020, 7, 11, 2, 34, 56, 124356)
 
 
 @pytest.fixture
 def fake_now(monkeypatch):
-    """Patch `datetime.datetime.now()` to return a deterministic value."""
+    """
+    Patch `datetime.datetime.fromtimestamp()`, `datetime.datetime.utcfromtimestamp()`,
+    and `time.time()` to return deterministic values.
+    """
+
     class FakeNow:
         @classmethod
-        def utcnow(cls):
-            return UTC_TIMESTAMP
+        def fromtimestamp(cls, timestamp):
+            return DT
+
+        @classmethod
+        def utcfromtimestamp(cls, timestamp):
+            return DT_UTC
+
+    def _time():
+        return EPOCH_TS
 
     monkeypatch.setattr(date_time, 'datetime', FakeNow)
+    monkeypatch.setattr(time, 'time', _time)
 
 
 @pytest.fixture

--- a/test/units/module_utils/facts/test_date_time.py
+++ b/test/units/module_utils/facts/test_date_time.py
@@ -35,7 +35,7 @@ def fake_now(monkeypatch):
     def _time():
         return EPOCH_TS
 
-    monkeypatch.setattr(date_time, 'datetime', FakeNow)
+    monkeypatch.setattr(date_time.datetime, 'datetime', FakeNow)
     monkeypatch.setattr(time, 'time', _time)
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `iso8601_micro` and `iso8601` facts incorrectly called `now.utcnow()`, resulting in a new timestamp at the time it was called, not a conversion of the previously stored timestamp.

Correct this by capturing the epoch timestamp once then creating local and UTC `datetime` objects using this epoch value.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/facts/system/date_time.py`
##### ADDITIONAL INFORMATION
Follow up from #70449

- [x] Add unit tests for various time zones and DST states
