### PR TITLE
[idea] items2dict: get dict keyed on value of common key

### DIFF
--- a/changelogs/fragments/items2dict-common-dict.yml
+++ b/changelogs/fragments/items2dict-common-dict.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - When its final argument is ``None`, the ``items2dict`` filter can now return a dict whose values are the original elements of the input list, and whose keys are the *value* of some entry in each dict. When the resulting dict is stored and referenced later, this allows for O(1) lookup of a particular key without having to scan the entire list each time.

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -181,6 +181,20 @@ In this example, you must pass the ``key_name`` and ``value_name`` arguments to 
 
 If you do not pass these arguments, or do not pass the correct values for your list, you will see ``KeyError: key`` or ``KeyError: my_typo``.
 
+.. versionadded:: 2.11
+
+If the ``value_name`` is explicitly set to ``None`, the filter will return a dict whose *keys* are the value of the ``key_name`` field of the elements, and whose *values* are the full element (dict). Continuing with the example above::
+
+    {{ tags | items2dict(key_name='fruit', value_name=None) }}
+
+will result in the following dict::
+
+    {"apple": {"fruit": "apple", "color: "red"}, "pear": {"fruit": "pear", "color": "yellow"}, ...}
+
+This is useful when you have a list of similarly-structured dicts and want to be able to index into them by one of their values. For large input lists, running the filter once and storing the result provides fast access to elements of the original list.
+
+Note that if multiple elements in the input list have a ``key_name`` key with the same value, the last one will be used.
+
 Forcing the data type
 ---------------------
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -554,6 +554,12 @@ def list_of_dict_key_value_elements_to_dict(mylist, key_name='key', value_name='
     if not is_sequence(mylist):
         raise AnsibleFilterTypeError("items2dict requires a list, got %s instead." % type(mylist))
 
+    if value_name is None:
+        ret = {}
+        for element in mylist:
+            ret[element[key_name]] = element
+        return ret
+
     return dict((item[key_name], item[value_name]) for item in mylist)
 
 

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -566,6 +566,12 @@
       - items2dict_fail is failed
       - '"items2dict requires a list" in items2dict_fail.msg'
 
+- name: Verify items2dict can key on list of commonly-structured dicts
+  assert:
+    that:
+      - '[{"name": "foo", "version": "10"}, {"name": "banana", "version": "93"}]|items2dict("name", None) == {"foo": {"name": "foo", "version": "10"}, "banana": {"name": "banana", "version": "93"}}'
+      - '[{"name": "foo", "version": "10"}, {"name": "banana", "version": "86"}, {"name": "banana", "version": "93"}]|items2dict("name", None) == {"foo": {"name": "foo", "version": "10"}, "banana": {"name": "banana", "version": "93"}}'
+
 - name: Verify path_join throws on non-string and non-sequence
   set_fact:
     foo: '{{True|path_join}}'


### PR DESCRIPTION
##### SUMMARY

Change:
- Given a list of similarly shaped dicts, this change would allow
  someone to get a dict back that is keyed on the value of a key they
  all share, when given the value_name None.

  For example, given:
```
  lst = [ {"name": "firefox", "version": "1"},
          {"name": "emacs": "version": "23"},
        ]
```
  this change lets us do: lst|items2dict('name', None)
  and would give us:
```
  { "firefox": {"name": "firefox", "version": "1"},
    "emacs": {"name": "emacs": "version": "23"},
  }
```
- Add docs explaining how it works

Test Plan:
- New integration tests

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME

items2dict filter plugin