### PR TITLE
[2.10] api: time.clock compatible code

### DIFF
--- a/changelogs/fragments/70649_time_clock.yml
+++ b/changelogs/fragments/70649_time_clock.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- api - time.clock is removed in Python 3.8, add backward compatible code (https://github.com/ansible/ansible/issues/70649).

--- a/test/units/module_utils/basic/test_argument_spec.py
+++ b/test/units/module_utils/basic/test_argument_spec.py
@@ -14,6 +14,7 @@ import pytest
 
 from units.compat.mock import MagicMock
 from ansible.module_utils import basic
+from ansible.module_utils.api import basic_auth_argument_spec, rate_limit_argument_spec, retry_argument_spec
 from ansible.module_utils.common.warnings import get_deprecation_messages, get_warning_messages
 from ansible.module_utils.six import integer_types, string_types
 from ansible.module_utils.six.moves import builtins
@@ -87,6 +88,25 @@ INVALID_SPECS = (
     # parameter is required
     ({'arg': {'required': True}}, {}, 'missing required arguments: arg'),
 )
+
+BASIC_AUTH_VALID_ARGS = [
+    {'api_username': 'user1', 'api_password': 'password1', 'api_url': 'http://example.com', 'validate_certs': False},
+    {'api_username': 'user1', 'api_password': 'password1', 'api_url': 'http://example.com', 'validate_certs': True},
+]
+
+RATE_LIMIT_VALID_ARGS = [
+    {'rate': 1, 'rate_limit': 1},
+    {'rate': '1', 'rate_limit': 1},
+    {'rate': 1, 'rate_limit': '1'},
+    {'rate': '1', 'rate_limit': '1'},
+]
+
+RETRY_VALID_ARGS = [
+    {'retries': 1, 'retry_pause': 1.5},
+    {'retries': '1', 'retry_pause': '1.5'},
+    {'retries': 1, 'retry_pause': '1.5'},
+    {'retries': '1', 'retry_pause': 1.5},
+]
 
 
 @pytest.fixture
@@ -211,6 +231,38 @@ def test_validator_function(mocker, stdin):
 
     assert isinstance(am.params['arg'], integer_types)
     assert am.params['arg'] == 27
+
+
+@pytest.mark.parametrize('stdin', BASIC_AUTH_VALID_ARGS, indirect=['stdin'])
+def test_validate_basic_auth_arg(mocker, stdin):
+    kwargs = dict(
+        argument_spec=basic_auth_argument_spec()
+    )
+    am = basic.AnsibleModule(**kwargs)
+    assert isinstance(am.params['api_username'], string_types)
+    assert isinstance(am.params['api_password'], string_types)
+    assert isinstance(am.params['api_url'], string_types)
+    assert isinstance(am.params['validate_certs'], bool)
+
+
+@pytest.mark.parametrize('stdin', RATE_LIMIT_VALID_ARGS, indirect=['stdin'])
+def test_validate_rate_limit_argument_spec(mocker, stdin):
+    kwargs = dict(
+        argument_spec=rate_limit_argument_spec()
+    )
+    am = basic.AnsibleModule(**kwargs)
+    assert isinstance(am.params['rate'], integer_types)
+    assert isinstance(am.params['rate_limit'], integer_types)
+
+
+@pytest.mark.parametrize('stdin', RETRY_VALID_ARGS, indirect=['stdin'])
+def test_validate_retry_argument_spec(mocker, stdin):
+    kwargs = dict(
+        argument_spec=retry_argument_spec()
+    )
+    am = basic.AnsibleModule(**kwargs)
+    assert isinstance(am.params['retries'], integer_types)
+    assert isinstance(am.params['retry_pause'], float)
 
 
 @pytest.mark.parametrize('stdin', [{'arg': '123'}, {'arg': 123}], indirect=['stdin'])

--- a/test/units/module_utils/test_api.py
+++ b/test/units/module_utils/test_api.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2020, Abhijeet Kasurde <akasurde@redhat.com>
+# Copyright: (c) 2020, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+from ansible.module_utils.api import rate_limit, retry
+
+import pytest
+
+
+class TestRateLimit:
+
+    def test_ratelimit(self):
+        @rate_limit(rate=1, rate_limit=1)
+        def login_database():
+            return "success"
+        r = login_database()
+
+        assert r == 'success'
+
+
+class TestRetry:
+
+    def test_no_retry_required(self):
+        self.counter = 0
+
+        @retry(retries=4, retry_pause=2)
+        def login_database():
+            self.counter += 1
+            return 'success'
+
+        r = login_database()
+
+        assert r == 'success'
+        assert self.counter == 1
+
+    def test_catch_exception(self):
+
+        @retry(retries=1)
+        def login_database():
+            return 'success'
+
+        with pytest.raises(Exception):
+            login_database()


### PR DESCRIPTION
##### SUMMARY

time.clock is removed in Python 3.8. Add time.clock
compatible code.

Fixes: #70649

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit 055871cbb89739039b18bd670af4d07f32ef80c0)
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/70649_time_clock.yml
lib/ansible/module_utils/api.py
test/units/module_utils/basic/test_argument_spec.py
test/units/module_utils/test_api.py
