### PR TITLE
Pipe lookup plugin usage example documentation fix

### DIFF
--- a/lib/ansible/plugins/lookup/pipe.py
+++ b/lib/ansible/plugins/lookup/pipe.py
@@ -33,7 +33,7 @@ EXAMPLES = r"""
 
 - name: Always use quote filter to make sure your variables are safe to use with shell
   debug:
-    msg: "{{ lookup('pipe', 'getent ' + myuser | quote ) }}"
+    msg: "{{ lookup('pipe', 'getent passwd ' + myuser | quote ) }}"
 """
 
 RETURN = r"""


### PR DESCRIPTION
##### SUMMARY
Usage example used incorrect 'getent' command syntax.
This patch corrects it by adding 'passwd' argument.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
Pipe lookup plugin

##### ADDITIONAL INFORMATION
N/A