### PR TITLE
Fix 'role_name : handler' notation if handler contains role name

### DIFF
--- a/changelogs/fragments/70582-allow-handler-contain-role-name.yml
+++ b/changelogs/fragments/70582-allow-handler-contain-role-name.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- 'Allow notify handler via `role_name : handler_name` when handler name contains role name'

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -118,18 +118,34 @@ class Task(Base, Conditional, Taggable, CollectionSearch):
     def get_name(self, include_role_fqcn=True):
         ''' return the name of the task '''
 
-        if self._role:
-            role_name = self._role.get_name(include_role_fqcn=include_role_fqcn)
+        role_name = None
+        role_fqcn_name = None
 
-        if self._role and self.name and role_name not in self.name:
-            return "%s : %s" % (role_name, self.name)
-        elif self.name:
-            return self.name
-        else:
-            if self._role:
-                return "%s : %s" % (role_name, self.action)
+        if not self._role:
+            if self.name:
+                return "%s" % self.name
             else:
-                return "%s" % (self.action,)
+                return "%s" % self.action
+
+        role_name = self._role.get_name(include_role_fqcn=False)
+
+        if include_role_fqcn:
+            role_fqcn_name = self._role.get_name(include_role_fqcn=True)
+
+        if self.name:
+            if role_fqcn_name and not self.name.startswith("%s : " % role_fqcn_name):
+                return "%s : %s" % (role_fqcn_name, self.name)
+            if role_name and not self.name.startswith("%s : " % role_name):
+                return "%s : %s" % (role_name, self.name)
+            return "%s" % self.name
+
+        if role_fqcn_name:
+            return "%s : %s" % (role_fqcn_name, self.action)
+
+        if role_name:
+            return "%s : %s" % (role_name, self.action)
+
+        return "%s" % self.action
 
     def _merge_kv(self, ds):
         if ds is None:

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/roles/common_handlers/handlers/main.yml
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/roles/common_handlers/handlers/main.yml
@@ -4,3 +4,24 @@
   set_fact:
     handler_counter: '{{ handler_counter|int + 1 }}'
   failed_when: handler_counter|int > 1
+
+# The following handler contains the role name and should be callable as:
+# 'common_handlers test_fqcn_handler'
+# 'common_handlers : common_handlers test_fqcn_handler`
+# 'testns.testcoll.common_handlers : common_handlers test_fqcn_handler'
+- name: common_handlers test_fqcn_handler
+  set_fact:
+    handler_counter: '{{ handler_counter|int + 1}}'
+  failed_when: handler_counter|int > 2
+
+# The following handler starts with 'role name : ' and should _not_ be listed as:
+# 'common_handlers : common_handlers : test_fqcn_handler`
+# 'testns.testcoll.common_handlers : common_handlers : test_fqcn_handler'
+- name: 'common_handlers : test_fqcn_handler'
+  meta: noop
+
+# The following handler starts with 'fqcn : ' and should _not_ be listed as:
+# 'common_handlers : testns.testcoll.common_handlers : test_fqcn_handler`
+# 'testns.testcoll.common_handlers : testns.testcoll.common_handlers : test_fqcn_handler'
+- name: 'testns.testcoll.common_handlers : test_fqcn_handler'
+  meta: noop

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/roles/test_fqcn_handlers/tasks/main.yml
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/roles/test_fqcn_handlers/tasks/main.yml
@@ -1,7 +1,30 @@
-- debug:
+- name: Fire fqcn handler 1
+  debug:
     msg: Fire fqcn handler
   changed_when: true
   notify:
     - 'testns.testcoll.common_handlers : test_fqcn_handler'
     - 'common_handlers : test_fqcn_handler'
     - 'test_fqcn_handler'
+
+- debug:
+    msg: Fire fqcn handler with role name
+  changed_when: true
+  notify:
+    - 'testns.testcoll.common_handlers : common_handlers test_fqcn_handler'
+    - 'common_handlers : common_handlers test_fqcn_handler'
+    - 'common_handlers test_fqcn_handler'
+
+#- debug:
+#    msg: "handler beginning with 'role name : ' should not get fqcn prefix"
+#  changed_when: true
+#  notify:
+#    - 'common_handlers : common_handlers : test_fqcn_handler'
+#    - 'testns.testcoll.common_handlers : common_handlers : test_fqcn_handler'
+#
+#- debug:
+#    msg: "handler beginning with 'fqcn.role name : ' should not get fqcn prefix"
+#  changed_when: true
+#  notify:
+#    - 'common_handlers : testns.testcoll.common_handlers : test_fqcn_handler'
+#    - 'testns.testcoll.common_handlers : testns.testcoll.common_handlers : test_fqcn_handler'


### PR DESCRIPTION
##### SUMMARY

Allow handler name to contain role name when using `role_name : handler name` notation to notify handlers containing role name.

Handler names beginning with `role_name : ` will _not_ be callable by their `role_name : handler name`, nor their `role_fqcn : handler name` notation to avoid confusion.  
Not sure if this is truly expected behaviour, since `role_name : role_name : handler name` or `role_fqcn : role_name : handler name` could work just as well, but I didn't want to make this design decision.

I had to refactor the `get_name` method a bit to be able to check if the handler name starts with `role_name : ` or `role_fqcn : `.  
Otherwise the first call with `include_role_fqcn = False` would not check if the role name begins with the fqcn role name and the second call with `include_role_fqcn = True` would not check if the role name begins with the non-fqcn role name, thus allowing the handler name to start with said prefixes.

Fixes #70582 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION

I've added a test to check if handlers containing the role name are callable through their prefixed aliases.  
I have _not_ been able to figure out how to use integration tests to ensure that handler names beginning with the `role_name : ` or `role_fqcn : ` prefix are properly ignored.