### PR TITLE
Document existing ansi_re sequences and add `ESC[m`

### DIFF
--- a/changelogs/fragments/70683-terminal-ansi-re.yaml
+++ b/changelogs/fragments/70683-terminal-ansi-re.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Terminal plugins - add "\e[m" to the list of ANSI sequences stripped from device output

--- a/lib/ansible/plugins/terminal/__init__.py
+++ b/lib/ansible/plugins/terminal/__init__.py
@@ -48,8 +48,9 @@ class TerminalBase(with_metaclass(ABCMeta, object)):
 
     #: compiled bytes regular expressions to remove ANSI codes
     ansi_re = [
-        re.compile(br'(\x1b\[\?1h\x1b=)'),
-        re.compile(br'\x08.')
+        re.compile(br'\x1b\[\?1h\x1b='),  # CSI ? 1 h ESC =
+        re.compile(br'\x08.'),            # [Backspace] .
+        re.compile(br"\x1b\[m"),          # ANSI reset code
     ]
 
     #: terminal initial prompt


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Attempts to clarify existing `ansi_re` sequences and adds ANSI reset sequence

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/terminal/__init__.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
