### PR TITLE
ansible-test: Use docker --detach option in privileged mode

### DIFF
--- a/test/lib/ansible_test/_internal/delegation.py
+++ b/test/lib/ansible_test/_internal/delegation.py
@@ -289,10 +289,17 @@ def delegate_docker(args, exclude, require, integration_targets):
                 httptester_id = None
 
             test_options = [
-                '--detach',
                 '--volume', '/sys/fs/cgroup:/sys/fs/cgroup:ro',
                 '--privileged=%s' % str(privileged).lower(),
             ]
+
+            # We add the detach option here to prevent the container
+            # init process from killing all TTY sessions on the host
+            # ref: https://github.com/docker/for-linux/issues/106
+            if privileged:
+                test_options.extend([
+                    '--detach=true'
+                ])
 
             if args.docker_memory:
                 test_options.extend([


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When using ansible-test with the --docker-privileged option,
it causes all the TTY sessions on the host to be killed. This
happens on, at the very least, a Fedora 32 host. This is a
known issue [a] which requires the --detach option to be used
to solve.

[a] https://github.com/docker/for-linux/issues/106

Fixed: #70684
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-test

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
