### PR TITLE
Don't sort lists of routes again in os_subnet (#63538)

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_subnet.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnet.py
@@ -202,7 +202,7 @@ def _needs_update(subnet, module, cloud, filters=None):
     if host_routes:
         curr_hr = sorted(subnet['host_routes'], key=lambda t: t.keys())
         new_hr = sorted(host_routes, key=lambda t: t.keys())
-        if sorted(curr_hr) != sorted(new_hr):
+        if curr_hr != new_hr:
             return True
     if no_gateway_ip and subnet['gateway_ip']:
         return True


### PR DESCRIPTION
##### SUMMARY
Small issue, looks like after implementing sorting compatible with python3 old sorts wasn't removed and that lead to an error when dict are being sorted like in python2 just with sorted method without lambda. Also even in python2 it leads to two sort cycles for each routes dies, and that's also not so good.
Fixes:#62126

Backport of https://github.com/ansible/ansible/pull/63538

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
os_subnet

##### ADDITIONAL INFORMATION
Very small fix that removes extra sorted call over already sorted dict