### PR TITLE
Improve proposed fix for bare variables

### DIFF
--- a/changelogs/fragments/70687-improve-deprecation-message-bare-variable.yaml
+++ b/changelogs/fragments/70687-improve-deprecation-message-bare-variable.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - improve deprecation message when using bare variable (https://github.com/ansible/ansible/pull/70687)

--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -133,8 +133,10 @@ class Conditional:
             disable_lookups = hasattr(conditional, '__UNSAFE__')
             conditional = templar.template(conditional, disable_lookups=disable_lookups)
             if bare_vars_warning and not isinstance(conditional, bool):
-                display.deprecated('evaluating %r as a bare variable, this behaviour will go away and you might need to add |bool'
-                                   ' to the expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle' % original,
+                display.deprecated('evaluating %r as a bare variable, this behaviour will go away and you might need to add " | bool"'
+                                   ' (if you would like to evaluate input string from prompt) or " is truthy"'
+                                   ' (if you would like to apply Python\'s evaluation method) to the expression in the future. '
+                                   'Also see CONDITIONAL_BARE_VARS configuration toggle' % original,
                                    version="2.12", collection_name='ansible.builtin')
             if not isinstance(conditional, text_type) or conditional == "":
                 return conditional


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #62370
Related to https://github.com/ansible/ansible/issues/21914#issuecomment-503531481

`when: non_bool_variable` in tasks now issues a warning that suggests append `| bool`.  However, this filter is NEVER alternative.  See these examples.  Who in the world thinks it is an alternative of bare variables?

```plain
None | bool => None (why doesn't it False?)
"foo" | bool => False (why doesn't it True?)
2 | bool => False (why doesn't it True?)
["1"] | bool => False (why doesn't it True?)
{"foo": "bar"} | bool => False  (why doesn't it True?)
```

This makes me put up with an unreasonable way `not (not foo)`.
Now PR #62602, suggesting more reasonable way, has been merged, the broken suggestion to add `bool` filter must be replaced with one to add `truthy` test.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

`lib/ansible/playbook/conditional.py`
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
[DEPRECATION WARNING]: evaluating [] as a bare variable, this behaviour will go
away and you might need to add |bool to the expression in the future. Also see
CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in
version 2.12.
```
↓
```
[DEPRECATION WARNING]: evaluating [] as a bare variable, this behaviour will go
away and you might need to add " is truthy" to the expression in the future. Also see
CONDITIONAL_BARE_VARS configuration toggle.. This feature will be removed in
version 2.12.
```
