### PR TITLE
[2.9] template connection variables accessed directly before using (#70657)

### DIFF
--- a/changelogs/fragments/70657-template-connection-vars.yaml
+++ b/changelogs/fragments/70657-template-connection-vars.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Template connection variables before using them (https://github.com/ansible/ansible/issues/70598).

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -887,7 +887,10 @@ class TaskExecutor:
             cvars = variables
 
         # use magic var if it exists, if not, let task inheritance do it's thing.
-        self._play_context.connection = cvars.get('ansible_connection', self._task.connection)
+        if cvars.get('ansible_connection') is not None:
+            self._play_context.connection = templar.template(cvars['ansible_connection'])
+        else:
+            self._play_context.connection = self._task.connection
 
         # TODO: play context has logic to update the conneciton for 'smart'
         # (default value, will chose between ssh and paramiko) and 'persistent'
@@ -908,8 +911,16 @@ class TaskExecutor:
             raise AnsibleError("the connection plugin '%s' was not found" % conn_type)
 
         # load become plugin if needed
-        if boolean(cvars.get('ansible_become', self._task.become)):
-            become_plugin = self._get_become(cvars.get('ansible_become_method', self._task.become_method))
+        if cvars.get('ansible_become') is not None:
+            become = boolean(templar.template(cvars['ansible_become']))
+        else:
+            become = self._task.become
+
+        if become:
+            if cvars.get('ansible_become_method'):
+                become_plugin = self._get_become(templar.template(cvars['ansible_become_method']))
+            else:
+                become_plugin = self._get_become(self._task.become_method)
 
             try:
                 connection.set_become_plugin(become_plugin)

--- a/test/integration/targets/var_templating/runme.sh
+++ b/test/integration/targets/var_templating/runme.sh
@@ -13,3 +13,5 @@ ansible-playbook undall.yml -i inventory -v "$@"
 
 # test hostvars templating
 ansible-playbook task_vars_templating.yml -v "$@"
+
+ansible-playbook test_connection_vars.yml -v "$@" 2>&1 | grep 'sudo'

--- a/test/integration/targets/var_templating/test_connection_vars.yml
+++ b/test/integration/targets/var_templating/test_connection_vars.yml
@@ -1,0 +1,26 @@
+---
+- hosts: localhost
+  gather_facts: no
+  vars:
+    my_var:
+      become_method: sudo
+      connection: local
+      become: 1
+  tasks:
+
+  - include_vars: "./vars/connection.yml"
+
+  - command: whoami
+    ignore_errors: yes
+    register: result
+    failed_when: result is not success and (result.module_stderr is defined or result.module_stderr is defined)
+
+  - assert:
+      that:
+        - "'sudo' in result.module_stderr"
+    when: result is not success and result.module_stderr is defined
+
+  - assert:
+      that:
+        - "'Invalid become method specified'  not in result.msg"
+    when: result is not success and result.msg is defined

--- a/test/integration/targets/var_templating/vars/connection.yml
+++ b/test/integration/targets/var_templating/vars/connection.yml
@@ -1,0 +1,3 @@
+ansible_become: "{{ my_var.become }}"
+ansible_become_method: "{{ my_var.become_method }}"
+ansible_connection: "{{ my_var.connection }}"


### PR DESCRIPTION
##### SUMMARY
Backport #70657

* template variables accessed directly when using them instead of FieldAttributes

(cherry picked from commit 8c213c93345db5489c24458880ec3ff81b334dbd)

##### ISSUE TYPE
- Bugfix Pull Request