### PR TITLE
Allow any_errors_fatal to be dynamic

### DIFF
--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -198,7 +198,12 @@ class StrategyModule(StrategyBase):
                         else:
                             # handle step if needed, skip meta actions as they are used internally
                             if not self._step or self._take_step(task, host_name):
-                                if task.any_errors_fatal:
+                                task_any_errors_fatal = task.get_validated_value('any_errors_fatal',
+                                                                                 task._valid_attrs['any_errors_fatal'],
+                                                                                 templar.template(task.any_errors_fatal),
+                                                                                 None)
+
+                                if task_any_errors_fatal:
                                     display.warning("Using any_errors_fatal with the free strategy is not supported, "
                                                     "as tasks are executed independently on each host")
                                 self._tqm.send_callback('v2_playbook_on_task_start', task, is_conditional=False)

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -272,13 +272,18 @@ class StrategyModule(StrategyBase):
                         # corresponding action plugin
                         action = None
 
+                    task_any_errors_fatal = task.get_validated_value('any_errors_fatal',
+                                                                     task._valid_attrs['any_errors_fatal'],
+                                                                     templar.template(task.any_errors_fatal),
+                                                                     None)
+
                     if task.action in C._ACTION_META:
                         # for the linear strategy, we run meta tasks just once and for
                         # all hosts currently being iterated over rather than one host
                         results.extend(self._execute_meta(task, play_context, iterator, host))
                         if task.args.get('_raw_params', None) not in ('noop', 'reset_connection', 'end_host', 'role_complete'):
                             run_once = True
-                        if (task.any_errors_fatal or run_once) and not task.ignore_errors:
+                        if (task_any_errors_fatal or run_once) and not task.ignore_errors:
                             any_errors_fatal = True
                     else:
                         # handle step if needed, skip meta actions as they are used internally
@@ -291,7 +296,7 @@ class StrategyModule(StrategyBase):
 
                         run_once = templar.template(task.run_once) or action and getattr(action, 'BYPASS_HOST_LOOP', False)
 
-                        if (task.any_errors_fatal or run_once) and not task.ignore_errors:
+                        if (task_any_errors_fatal or run_once) and not task.ignore_errors:
                             any_errors_fatal = True
 
                         if not callback_sent:

--- a/test/integration/targets/any_errors_fatal/61025-bad_dynamic_value.yml
+++ b/test/integration/targets/any_errors_fatal/61025-bad_dynamic_value.yml
@@ -1,0 +1,14 @@
+- hosts: all
+  gather_facts: false
+  any_errors_fatal: false
+  ignore_unreachable: true
+  vars:
+    skip_errors: "silliness"
+  tasks:
+    - block:
+      - name: EXPECTED FAILURE any_errors_fatal, simulate failure on one node
+        shell: exit 1
+        when: inventory_hostname == "testhost"
+      - debug:
+          msg: "any_errors_fatal_dynamic_value_continues"
+      any_errors_fatal: "{{ skip_errors }}"

--- a/test/integration/targets/any_errors_fatal/61025-dynamic_block.yml
+++ b/test/integration/targets/any_errors_fatal/61025-dynamic_block.yml
@@ -1,0 +1,14 @@
+- hosts: all
+  gather_facts: false
+  any_errors_fatal: false
+  ignore_unreachable: true
+  vars:
+    skip_errors: true
+  tasks:
+    - block:
+      - name: EXPECTED FAILURE any_errors_fatal, simulate failure on one node
+        shell: exit 1
+        when: inventory_hostname == "testhost"
+      - debug:
+          msg: "any_errors_fatal_dynamic_value_continues"
+      any_errors_fatal: "{{ not skip_errors }}"

--- a/test/integration/targets/any_errors_fatal/61025-import_playbook.yml
+++ b/test/integration/targets/any_errors_fatal/61025-import_playbook.yml
@@ -1,0 +1,3 @@
+- import_playbook: dynamic_playbook.yml
+  vars:
+    skip_errors: true

--- a/test/integration/targets/any_errors_fatal/dynamic_playbook.yml
+++ b/test/integration/targets/any_errors_fatal/dynamic_playbook.yml
@@ -1,0 +1,9 @@
+- hosts: all
+  gather_facts: false
+  any_errors_fatal: "{{ not skip_errors }}"
+  tasks:
+    - name: EXPECTED FAILURE any_errors_fatal, simulate failure on one node
+      shell: exit 1
+      when: inventory_hostname == "testhost"
+    - debug:
+        msg: "any_errors_fatal_dynamic_value_import_playbook_continues"

--- a/test/integration/targets/any_errors_fatal/runme.sh
+++ b/test/integration/targets/any_errors_fatal/runme.sh
@@ -15,9 +15,30 @@ if [ "${res}" -eq 0 ] ; then
 	exit 1
 fi
 
-set -ux
-
 ansible-playbook -i inventory "$@" always_block.yml | tee out.txt | grep 'any_errors_fatal_always_block_start'
 res=$?
 cat out.txt
-exit $res
+if [ "${res}" -ne 0 ] ; then
+	exit 1
+fi
+
+ansible-playbook -i inventory "$@" 61025-dynamic_block.yml | tee out.txt | grep 'any_errors_fatal_dynamic_value_continues'
+res=$?
+cat out.txt
+if [ "${res}" -ne 0 ] ; then
+	exit 1
+fi
+
+ansible-playbook -i inventory "$@" 61025-import_playbook.yml | tee out.txt | grep 'any_errors_fatal_dynamic_value_import_playbook_continues'
+res=$?
+cat out.txt
+if [ "${res}" -ne 0 ] ; then
+	exit 1
+fi
+
+ansible-playbook -i inventory "$@" 61025-bad_dynamic_value.yml 2>&1 | tee out.txt | grep 'not a valid boolean.'
+res=$?
+cat out.txt
+if [ "${res}" -ne 0 ] ; then
+	exit 1
+fi


### PR DESCRIPTION
This change updates the linear and free strategies to ensure that the
value of any_errors_fatal is properly evaulated if it contains a dynamic
value. Previously if it was not set to a boolean false, it would be
true.

Fixes #61025

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

lib/ansible/plugins/strategy/free.py
lib/ansible/plugins/strategy/linear.py

