### PR TITLE
Adding container to Linux-specific subclass of Virtual

### DIFF
--- a/changelogs/fragments/70697-linux-virtual-facts.yml
+++ b/changelogs/fragments/70697-linux-virtual-facts.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Linux virtualization facts now returns a ``container`` bool value that helps identify whether or not the target system is running in a container. (https://github.com/ansible/ansible/pull/70697)

--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -29,6 +29,7 @@ class LinuxVirtual(Virtual):
     This is a Linux-specific subclass of Virtual.  It defines
     - virtualization_type
     - virtualization_role
+    - container
     """
     platform = 'Linux'
 
@@ -46,6 +47,8 @@ class LinuxVirtual(Virtual):
         host_tech = set()
         guest_tech = set()
 
+        # assume container is False
+        virtual_facts['container'] = False
         # lxc/docker
         if os.path.exists('/proc/1/cgroup'):
             for line in get_file_lines('/proc/1/cgroup'):

--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -57,12 +57,14 @@ class LinuxVirtual(Virtual):
                     if not found_virt:
                         virtual_facts['virtualization_type'] = 'docker'
                         virtual_facts['virtualization_role'] = 'guest'
+                        virtual_facts['container'] = True
                         found_virt = True
                 if re.search('/lxc/', line) or re.search('/machine.slice/machine-lxc', line):
                     guest_tech.add('lxc')
                     if not found_virt:
                         virtual_facts['virtualization_type'] = 'lxc'
                         virtual_facts['virtualization_role'] = 'guest'
+                        virtual_facts['container'] = True
                         found_virt = True
 
         # lxc does not always appear in cgroups anymore but sets 'container=lxc' environment var, requires root privs
@@ -73,18 +75,21 @@ class LinuxVirtual(Virtual):
                     if not found_virt:
                         virtual_facts['virtualization_type'] = 'lxc'
                         virtual_facts['virtualization_role'] = 'guest'
+                        virtual_facts['container'] = True
                         found_virt = True
                 if re.search('container=podman', line):
                     guest_tech.add('podman')
                     if not found_virt:
                         virtual_facts['virtualization_type'] = 'podman'
                         virtual_facts['virtualization_role'] = 'guest'
+                        virtual_facts['container'] = True
                         found_virt = True
                 if re.search('^container=.', line):
                     guest_tech.add('container')
                     if not found_virt:
                         virtual_facts['virtualization_type'] = 'container'
                         virtual_facts['virtualization_role'] = 'guest'
+                        virtual_facts['container'] = True
                         found_virt = True
 
         if os.path.exists('/proc/vz') and not os.path.exists('/proc/lve'):
@@ -97,6 +102,7 @@ class LinuxVirtual(Virtual):
                 guest_tech.add('openvz')
                 if not found_virt:
                     virtual_facts['virtualization_role'] = 'guest'
+                    virtual_facts['container'] = True
             found_virt = True
 
         systemd_container = get_file_content('/run/systemd/container')
@@ -105,6 +111,7 @@ class LinuxVirtual(Virtual):
             if not found_virt:
                 virtual_facts['virtualization_type'] = systemd_container
                 virtual_facts['virtualization_role'] = 'guest'
+                virtual_facts['container'] = True
                 found_virt = True
 
         if os.path.exists("/proc/xen"):


### PR DESCRIPTION
##### SUMMARY
Add container fact to the Linux-specific subclass of Virtual to help identify if the target system is running in a container. This stemmed from issues where we were using a lot of when clauses to determine if virtualization_type != docker, lcx, podman, etc.. I figured this information is already in the linux virtual facts module, so why not add a boolean to help identify a container or not.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
The linux subclass of virtual facts

##### ADDITIONAL INFORMATION
None at this time
