### PR TITLE
Make reboot module work on Void Linux target

### DIFF
--- a/changelogs/fragments/70704-void-linux-reboot.yml
+++ b/changelogs/fragments/70704-void-linux-reboot.yml
@@ -1,0 +1,3 @@
+bugfixes:
+ - reboot - Add support for the runit init system, used on Void Linux, that
+   does not support the normal Linux syntax.

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -67,6 +67,7 @@ class ActionModule(ActionBase):
 
     SHUTDOWN_COMMAND_ARGS = {
         'alpine': '',
+        'void': '-r +{delay_min} "{message}"',
         'freebsd': '-r +{delay_sec}s "{message}"',
         'linux': DEFAULT_SHUTDOWN_COMMAND_ARGS,
         'macosx': '-r +{delay_min} "{message}"',


### PR DESCRIPTION
##### SUMMARY
This change makes the reboot module work on a Void Linux target.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
reboot

##### ADDITIONAL INFORMATION
The runit init system used by void linux dosen't support the default command used, it needs a `+` before the mintues.