### PR TITLE
Don't treat empty excludes as a match.

### DIFF
--- a/changelogs/fragments/70640-find-empty-excludes.yml
+++ b/changelogs/fragments/70640-find-empty-excludes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- find module - Don't treat empty excludes as a match (https://github.com/ansible/ansible/issues/70640)

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -224,11 +224,11 @@ from ansible.module_utils.basic import AnsibleModule
 
 def pfilter(f, patterns=None, excludes=None, use_regex=False):
     '''filter using glob patterns'''
-    if patterns is None and excludes is None:
+    if not patterns and not excludes:
         return True
 
     if use_regex:
-        if patterns and excludes is None:
+        if patterns and not excludes:
             for p in patterns:
                 r = re.compile(p)
                 if r.match(f):
@@ -245,7 +245,7 @@ def pfilter(f, patterns=None, excludes=None, use_regex=False):
                     return True
 
     else:
-        if patterns and excludes is None:
+        if patterns and not excludes:
             for p in patterns:
                 if fnmatch.fnmatch(f, p):
                     return True

--- a/test/integration/targets/find/tasks/main.yml
+++ b/test/integration/targets/find/tasks/main.yml
@@ -19,10 +19,14 @@
 - set_fact: output_dir_test={{output_dir}}/test_find
 
 - name: make sure our testing sub-directory does not exist
-  file: path="{{ output_dir_test }}" state=absent
+  file:
+    path: "{{ output_dir_test }}"
+    state: absent
 
 - name: create our testing sub-directory
-  file: path="{{ output_dir_test }}" state=directory
+  file:
+    path: "{{ output_dir_test }}"
+    state: directory
 
 ##
 ## find
@@ -95,3 +99,18 @@
           - 'find_test2.matched == 1'
           - 'find_test2.files[0].pw_name is defined'
           - 'find_test2.files[0].gr_name is defined'
+
+- name: find the xml file with empty excludes
+  find:
+      paths: "{{ output_dir_test }}"
+      patterns: "*.xml"
+      recurse: yes
+      excludes: []
+  register: find_test3
+- debug: var=find_test3
+- name: validate gr_name and pw_name are defined
+  assert:
+      that:
+          - 'find_test3.matched == 1'
+          - 'find_test3.files[0].pw_name is defined'
+          - 'find_test3.files[0].gr_name is defined'


### PR DESCRIPTION
##### SUMMARY
Don't treat empty excludes as a match. Fixes #70640

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/find.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
