### PR TITLE
win async - use full path for powershell (#70703) 2.9

### DIFF
--- a/changelogs/fragments/win_async_full_path.yml
+++ b/changelogs/fragments/win_async_full_path.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- windows async - use full path when calling PowerShell to reduce reliance on environment vars being correct - https://github.com/ansible/ansible/issues/70655

--- a/lib/ansible/executor/powershell/async_wrapper.ps1
+++ b/lib/ansible/executor/powershell/async_wrapper.ps1
@@ -87,7 +87,8 @@ $bootstrap_wrapper = {
 $bootstrap_wrapper = $bootstrap_wrapper.ToString().Replace('$pipe_name = ""', "`$pipe_name = `"$pipe_name`"")
 $bootstrap_wrapper = $bootstrap_wrapper.Replace('$bytes_length = 0', "`$bytes_length = $($payload_bytes.Count)")
 $encoded_command = [System.Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($bootstrap_wrapper))
-$exec_args = "powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -EncodedCommand $encoded_command"
+$pwsh_path = "$env:SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe"
+$exec_args = "`"$pwsh_path`" -NonInteractive -NoProfile -ExecutionPolicy Bypass -EncodedCommand $encoded_command"
 
 # create a named pipe that is set to allow only the current user read access
 $current_user = ([Security.Principal.WindowsIdentity]::GetCurrent()).User


### PR DESCRIPTION
(cherry picked from commit 154efd97f218b7f50fef8331251acc0dd7565ae7)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/70703

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
async_wrapper.ps1