### PR TITLE
[stable-2.9] Pin psutil version in tests

### DIFF
--- a/test/integration/targets/pids/tasks/main.yml
+++ b/test/integration/targets/pids/tasks/main.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 - name: "Installing the psutil module"
   pip:
-    name: psutil
+    name: psutil==5.6.7
 
 - name: "Checking the empty result" 
   pids: 

--- a/test/integration/targets/setup_mongodb/defaults/main.yml
+++ b/test/integration/targets/setup_mongodb/defaults/main.yml
@@ -45,5 +45,5 @@ redhat_packages_py3:
   - python3-pip
 
 pip_packages:
-  - psutil
-  - pymongo
+  - psutil==5.6.7
+  - pymongo==3.10.1


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A recent update to `psutil` introduced a breaking change. The `pids` and `setup_mongodb` test targets do not exist in `devel` or `stable-2.10`, which is why this change is directly against this branch.

Related to #70667
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/pids`
`test/integration/targets/setup_mongodb`