### PR TITLE
[stable-2.8] Pin psutil version in pids test

### DIFF
--- a/test/integration/targets/pids/tasks/main.yml
+++ b/test/integration/targets/pids/tasks/main.yml
@@ -3,10 +3,10 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 - name: "Installing the psutil module"
   pip:
-    name: psutil
+    name: psutil==5.6.7
 
-- name: "Checking the empty result" 
-  pids: 
+- name: "Checking the empty result"
+  pids:
     name: "blahblah"
   register: emptypids
 
@@ -14,7 +14,7 @@
   assert:
     that:
     - emptypids is not changed
-    - emptypids.pids == [] 
+    - emptypids.pids == []
 
 - name: "Picking a random process name"
   command: "echo 'some-random-long-name-{{ 99999999 | random }}'"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A recent update to `psutil` introduced a breaking change. The `pids` test target does not exist in `devel` or `stable-2.10`, which is why this change is directly against this branch.

Related to #70667
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/pids`