### PR TITLE
Simplify module tmpdirs

### DIFF
--- a/changelogs/fragments/module_tmpdir_simplify.yaml
+++ b/changelogs/fragments/module_tmpdir_simplify.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Stop sending ``_ansible_tmpdir`` as the action plugins managed tmpdir to simplify and separate module and controller tmpdirs

--- a/hacking/test-module.py
+++ b/hacking/test-module.py
@@ -130,7 +130,7 @@ def boilerplate_module(modfile, args, interpreters, check, destfile):
 
     # default selinux fs list is pass in as _ansible_selinux_special_fs arg
     complex_args['_ansible_selinux_special_fs'] = C.DEFAULT_SELINUX_SPECIAL_FS
-    complex_args['_ansible_tmpdir'] = C.DEFAULT_LOCAL_TMP
+    complex_args['_ansible_remote_tmp'] = C.DEFAULT_LOCAL_TMP
     complex_args['_ansible_keep_remote_files'] = C.DEFAULT_KEEP_REMOTE_FILES
     complex_args['_ansible_version'] = __version__
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -685,9 +685,8 @@ class AnsibleModule(object):
 
     @property
     def tmpdir(self):
-        # if _ansible_tmpdir was not set and we have a remote_tmp,
-        # the module needs to create it and clean it up once finished.
-        # otherwise we create our own module tmp dir from the system defaults
+        # If not already created, create a temp dir based on _ansible_remote_tmp.
+        # The module is in charge of cleaning up the tmpdir.
         if self._tmpdir is None:
             basedir = None
 

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -841,13 +841,9 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         # make sure modules are aware if they need to keep the remote files
         module_args['_ansible_keep_remote_files'] = C.DEFAULT_KEEP_REMOTE_FILES
 
-        # make sure all commands use the designated temporary directory if created
-        if self._is_become_unprivileged():  # force fallback on remote_tmp as user cannot normally write to dir
-            module_args['_ansible_tmpdir'] = None
-        else:
-            module_args['_ansible_tmpdir'] = self._connection._shell.tmpdir
-
-        # make sure the remote_tmp value is sent through in case modules needs to create their own
+        # We used to have this set to self._connection._shell.tmpdir but to keep things simple we don't anymore
+        # always have a module use the remote_tmp set by the shell plugin and have the module create their own.
+        module_args['_ansible_tmpdir'] = None  # TODO: Remove this after we know it doesn't break anything
         module_args['_ansible_remote_tmp'] = self.get_shell_option('remote_tmp', default='~/.ansible/tmp')
 
     def _execute_module(self, module_name=None, module_args=None, tmp=None, task_vars=None, persist_files=False, delete_remote_tmp=None, wrap_async=False):


### PR DESCRIPTION
##### SUMMARY
We have tempdirs out the wazoo and I'm hoping to try and simplify this in any way we can.

Right now we send 2 variables to a module in relation to tempdirs

* `_ansible_tmpdir`: If an action plugin has created a temp dir and the we aren't becoming an underprivileged user, this value is set to the action plugin managed tempdir 
* `_ansible_remote_tmp`: The value of `remote_tmp` as configured by the shell plugin, defaults to `~/.ansible/tmp`

On the module side it uses `_ansible_tmpdir` if it is set and relies on the controller to remove. If `_ansible_tmpdir` is not set then it will create a temp directory inside `_ansible_remote_tmp` and set an exit handler to clean this up.

This change stops sending `_ansible_tmpdir` so that a module will always create it's own tempdir if required and removes it on exit. There can be cases where there are 2 tempdirs that exist at the same time, 1 from the action plugin, and 1 from the module but this should not matter to the end user or module itself.

What this means is that a module will always use the value of `_ansible_remote_tmp` and not the one derived by the complex logic in the action plugin handler. In the future we can remote `_ansible_tmpdir` but I'm reluctant to remove one of these variables in case some 3rd party module expects that to be present in the module options.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
action/__init__.py
basic.py