### PR TITLE
dellemc related module name changes

### DIFF
--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -7760,7 +7760,10 @@ plugin_routing:
       redirect: ansible.netcommon.network.common.utils
     network.dellos10.dellos10:
       redirect: dellemc.os10.network.os10
-    # FIXME: no collection source found for dellos6/dellos9
+    network.dellos9.dellos9:
+      redirect: dellemc.os9.network.os9
+    network.dellos6.dellos6:
+      redirect: dellemc.os6.network.os6
     network.edgeos.edgeos:
       redirect: community.network.network.edgeos.edgeos
     network.edgeswitch.edgeswitch:

--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -6713,23 +6713,23 @@ plugin_routing:
     ovirt_vnic_profile_info:
       redirect: ovirt.ovirt.ovirt_vnic_profile_info
     dellos10_command:
-      redirect: dellemc_networking.os10.os10_command
+      redirect: dellemc.os10.os10_command
     dellos10_facts:
-      redirect: dellemc_networking.os10.os10_facts
+      redirect: dellemc.os10.os10_facts
     dellos10_config:
-      redirect: dellemc_networking.os10.os10_config
+      redirect: dellemc.os10.os10_config
     dellos9_facts:
-      redirect: dellemc.os9.dellos9_facts
+      redirect: dellemc.os9.os9_facts
     dellos9_command:
-      redirect: dellemc.os9.dellos9_command
+      redirect: dellemc.os9.os9_command
     dellos9_config:
-      redirect: dellemc.os9.dellos9_config
+      redirect: dellemc.os9.os9_config
     dellos6_facts:
-      redirect: dellemc.os6.dellos6_facts
+      redirect: dellemc.os6.os6_facts
     dellos6_config:
-      redirect: dellemc.os6.dellos6_config
+      redirect: dellemc.os6.os6_config
     dellos6_command:
-      redirect: dellemc.os6.dellos6_command
+      redirect: dellemc.os6.os6_command
     hcloud_location_facts:
       redirect: hetzner.hcloud.hcloud_location_facts
     hcloud_server_info:
@@ -7759,7 +7759,7 @@ plugin_routing:
     network.common.utils:
       redirect: ansible.netcommon.network.common.utils
     network.dellos10.dellos10:
-      redirect: dellemc_networking.os10.network.os10
+      redirect: dellemc.os10.network.os10
     # FIXME: no collection source found for dellos6/dellos9
     network.edgeos.edgeos:
       redirect: community.network.network.edgeos.edgeos
@@ -8893,11 +8893,11 @@ plugin_routing:
     junos:
       redirect: junipernetworks.junos.junos
     dellos10:
-      redirect: dellemc_networking.os10.os10
+      redirect: dellemc.os10.os10
     dellos9:
-      redirect: dellemc.os9.dellos9
+      redirect: dellemc.os9.os9
     dellos6:
-      redirect: dellemc.os6.dellos6
+      redirect: dellemc.os6.os6
     vyos:
       redirect: vyos.vyos.vyos
   terminal:
@@ -8956,11 +8956,11 @@ plugin_routing:
     junos:
       redirect: junipernetworks.junos.junos
     dellos10:
-      redirect: dellemc_networking.os10.os10
+      redirect: dellemc.os10.os10
     dellos9:
-      redirect: dellemc.os9.dellos9
+      redirect: dellemc.os9.os9
     dellos6:
-      redirect: dellemc.os6.dellos6
+      redirect: dellemc.os6.os6
     vyos:
       redirect: vyos.vyos.vyos
   action:
@@ -9074,11 +9074,11 @@ plugin_routing:
     junos:
       redirect: junipernetworks.junos.junos
     dellos10:
-      redirect: dellemc_networking.os10.os10
+      redirect: dellemc.os10.os10
     dellos9:
-      redirect: dellemc.os9.dellos9
+      redirect: dellemc.os9.os9
     dellos6:
-      redirect: dellemc.os6.dellos6
+      redirect: dellemc.os6.os6
     vyos:
       redirect: vyos.vyos.vyos
   become:
@@ -9399,11 +9399,11 @@ plugin_routing:
     ovirt_info:
       redirect: ovirt.ovirt.ovirt_info
     dellos10:
-      redirect: dellemc_networking.os10.os10
+      redirect: dellemc.os10.os10
     dellos9:
-      redirect: dellemc.os9.dellos9
+      redirect: dellemc.os9.os9
     dellos6:
-      redirect: dellemc.os6.dellos6
+      redirect: dellemc.os6.os6
     hcloud:
       redirect: hetzner.hcloud.hcloud
     skydive:


### PR DESCRIPTION
SUMMARY
dellemc related module name changes
Moving the namespace from dellemc_networking to dellemc
See ansible-collections/dellemc.os10#20.

ISSUE TYPE
Bugfix Pull Request
COMPONENT NAME
lib/ansible/config/ansible_builtin_runtime.yml