### PR TITLE
[2.10] debconf: add a note about no_log usage

### DIFF
--- a/changelogs/fragments/32386_debconf_password.yml
+++ b/changelogs/fragments/32386_debconf_password.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- debconf - add a note about no_log=True since module might expose sensitive information to logs (https://github.com/ansible/ansible/issues/32386).

--- a/lib/ansible/modules/debconf.py
+++ b/lib/ansible/modules/debconf.py
@@ -22,6 +22,7 @@ notes:
       Use 'debconf-show <package>' on any Debian or derivative with the package
       installed to see questions/settings available.
     - Some distros will always record tasks involving the setting of passwords as changed. This is due to debconf-get-selections masking passwords.
+    - It is highly recommended to add I(no_log=True) to task while handling sensitive information using this module.
 requirements:
 - debconf
 - debconf-utils
@@ -40,6 +41,7 @@ options:
   vtype:
     description:
       - The type of the value supplied.
+      - It is highly recommended to add I(no_log=True) to task while specifying I(vtype=password).
       - C(seen) was added in Ansible 2.2.
     type: str
     choices: [ boolean, error, multiselect, note, password, seen, select, string, text, title ]
@@ -82,6 +84,14 @@ EXAMPLES = r'''
 - name: Specifying package you can register/return the list of questions and current values
   debconf:
     name: tzdata
+
+- name: Pre-configure tripwire site passphrase
+  debconf:
+    name: tripwire
+    question: tripwire/site-passphrase
+    value: "{{ site_passphrase }}"
+    vtype: password
+  no_log: True
 '''
 
 from ansible.module_utils._text import to_text


### PR DESCRIPTION
##### SUMMARY

debconf module exposes sensitive information to logs, console.
Add a note to user about using no_log=True to hide such
information from console.

Fixes: #32386

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit 84b4387702b50a47a95cab1e289af506161b3f1b)


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/32386_debconf_password.yml
lib/ansible/modules/debconf.py
