### PR TITLE
[2.10] shell - Fix missing quote for remote_tmp option

### DIFF
--- a/changelogs/fragments/69578-shell-remote_tmp-quoting.yaml
+++ b/changelogs/fragments/69578-shell-remote_tmp-quoting.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - shell - fix quoting of mkdir command in creation of remote_tmp in order to allow spaces and other special characters (https://github.com/ansible/ansible/issues/69577).

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -157,7 +157,7 @@ class ShellBase(AnsiblePlugin):
 
         # use mkdir -p to ensure parents exist, but mkdir fullpath to ensure last one is created by us
         cmd = 'mkdir -p %s echo %s %s' % (self._SHELL_SUB_LEFT, basetmpdir, self._SHELL_SUB_RIGHT)
-        cmd += '%s mkdir %s' % (self._SHELL_AND, basetmp)
+        cmd += '%s mkdir %s echo %s %s' % (self._SHELL_AND, self._SHELL_SUB_LEFT, basetmp, self._SHELL_SUB_RIGHT)
         cmd += ' %s echo %s=%s echo %s %s' % (self._SHELL_AND, basefile, self._SHELL_SUB_LEFT, basetmp, self._SHELL_SUB_RIGHT)
 
         # change the umask in a subshell to achieve the desired mode

--- a/test/integration/targets/config/runme.sh
+++ b/test/integration/targets/config/runme.sh
@@ -8,3 +8,8 @@ ANSIBLE_TIMEOUT= ansible -m ping testhost -i ../../inventory "$@"
 
 # env var is wrong type, this should be a fatal error pointing at the setting
 ANSIBLE_TIMEOUT='lola' ansible -m ping testhost -i ../../inventory "$@" 2>&1|grep 'Invalid type for configuration option setting: DEFAULT_TIMEOUT'
+
+# https://github.com/ansible/ansible/issues/69577                                                         
+ANSIBLE_REMOTE_TMP="$HOME/.ansible/directory_with_no_space"  ansible -m ping testhost -i ../../inventory "$@" 
+                                                                                                          
+ANSIBLE_REMOTE_TMP="$HOME/.ansible/directory with space"  ansible -m ping testhost -i ../../inventory "$@"


### PR DESCRIPTION
##### SUMMARY

backport of #69578

* Fix missing quoting for remote_tmp in second mkdir of shell module. Issue #69577
* adding changelog
* adding test case
Adding test case written by bmillemathias.
* using $HOME instead of ~
* fixing commit message
* Update 69578-shell-remote_tmp-quoting.yaml

Co-authored-by: Brian Kohles <me@briankohles.com>
(cherry picked from commit 77d0effcc5b2da1ef23e4ba32986a9759c27c10d)


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
shell

##### ADDITIONAL INFORMATION
version 2.10