### PR TITLE
[stable-2.10] Guard against allowing ansible to ansible-base upgrades (#70529)

### DIFF
--- a/changelogs/fragments/70525-setuptools-disutils-reorder.yml
+++ b/changelogs/fragments/70525-setuptools-disutils-reorder.yml
@@ -1,0 +1,7 @@
+bugfixes:
+- >
+  Address the deprecation of the use of stdlib
+  distutils in packaging. It's a short-term hotfix for the problem
+  (https://github.com/ansible/ansible/issues/70456,
+  https://github.com/pypa/setuptools/issues/2230,
+  https://github.com/pypa/setuptools/commit/bd110264)

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,6 @@ import sys
 import warnings
 
 from collections import defaultdict
-from distutils.command.build_scripts import build_scripts as BuildScripts
-from distutils.command.sdist import sdist as SDist
 
 try:
     from setuptools import setup, find_packages
@@ -22,6 +20,15 @@ except ImportError:
           " your package manager (usually python-setuptools) or via pip (pip"
           " install setuptools).", file=sys.stderr)
     sys.exit(1)
+
+# `distutils` must be imported after `setuptools` or it will cause explosions
+# with `setuptools >=48.0.0, <49.1`.
+# Refs:
+# * https://github.com/ansible/ansible/issues/70456
+# * https://github.com/pypa/setuptools/issues/2230
+# * https://github.com/pypa/setuptools/commit/bd110264
+from distutils.command.build_scripts import build_scripts as BuildScripts
+from distutils.command.sdist import sdist as SDist
 
 sys.path.insert(0, os.path.abspath('lib'))
 from ansible.release import __version__, __author__


### PR DESCRIPTION
    Fix building Ansible dist w/ setuptools>=48,<49.1 (#70525)

    * Fix building Ansible dist w/ setuptools>=48,<49.1

    This change addresses the deprecation of the use of stdlib
    `distutils`. It's a short-term hotfix for the problem and we'll
    need to consider dropping the use of `distutils` from our `setup.py`.

    Refs:
    * https://github.com/ansible/ansible/issues/70456
    * https://github.com/pypa/setuptools/issues/2230
    * https://github.com/pypa/setuptools/commit/bd110264

    Co-Authored-By: Jason R. Coombs <jaraco@jaraco.com>

    * Add a change note for PR #70525

    Co-authored-by: Jason R. Coombs <jaraco@jaraco.com>
    (cherry picked from commit 918388b85f516116e2cd7dcf0c12eeb19ab561e9)

    Guard against allowing ansible to ansible-base upgrades (#70529)

    * Guard against allowing ansible to ansible-base upgrades

    * newline

    * use alias

    * Add an explicit line detailing this is a 1 time thing

    * period

    * Read __version__ and __author__ rather than import, update working, and add ability to skip conflict checks

    * Remove commented code

    * Re introduce removed changes from rebase

    * Just use open

    * Nuke unused import

    (cherry picked from commit 54b002e1acad1e8d88e81965323d47ddb8c234fb)