### PR TITLE
Need to return any error code from running antsibull-docs

### DIFF
--- a/hacking/build_library/build_ansible/command_plugins/docs_build.py
+++ b/hacking/build_library/build_ansible/command_plugins/docs_build.py
@@ -52,9 +52,9 @@ def generate_base_docs(args):
             f.write(yaml.dump(deps_file_contents))
 
         # Generate the plugin rst
-        antsibull_docs.run(['antsibull-docs', 'stable', '--deps-file', modified_deps_file,
-                            '--ansible-base-cache', str(args.top_dir),
-                            '--dest-dir', args.output_dir])
+        return antsibull_docs.run(['antsibull-docs', 'stable', '--deps-file', modified_deps_file,
+                                   '--ansible-base-cache', str(args.top_dir),
+                                   '--dest-dir', args.output_dir])
 
         # If we make this more than just a driver for antsibull:
         # Run other rst generation
@@ -107,9 +107,9 @@ def generate_full_docs(args):
             f.write(yaml.dump(deps_data))
 
         # Generate the plugin rst
-        antsibull_docs.run(['antsibull-docs', 'stable', '--deps-file', modified_deps_file,
-                            '--ansible-base-cache', str(args.top_dir),
-                            '--dest-dir', args.output_dir])
+        return antsibull_docs.run(['antsibull-docs', 'stable', '--deps-file', modified_deps_file,
+                                   '--ansible-base-cache', str(args.top_dir),
+                                   '--dest-dir', args.output_dir])
 
         # If we make this more than just a driver for antsibull:
         # Run other rst generation


### PR DESCRIPTION
This way we fail early if there's a problem

##### SUMMARY
Without this change, make webdocs won't fail when running antsibull-docs but will fail later.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
