### PR TITLE
Follow TRANSFORM_INVALID_GROUP_CHARS in constructed inventory plugin

### DIFF
--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -377,7 +377,7 @@ class Constructable(object):
             self.templar.available_variables = variables
             for group_name in groups:
                 conditional = "{%% if %s %%} True {%% else %%} False {%% endif %%}" % groups[group_name]
-                group_name = original_safe(group_name, force=True)
+                group_name = self._sanitize_group_name(group_name)
                 try:
                     result = boolean(self.templar.template(conditional))
                 except Exception as e:

--- a/lib/ansible/plugins/inventory/constructed.py
+++ b/lib/ansible/plugins/inventory/constructed.py
@@ -72,6 +72,7 @@ import os
 
 from ansible import constants as C
 from ansible.errors import AnsibleParserError
+from ansible.inventory.group import to_safe_group_name
 from ansible.inventory.helpers import get_group_vars
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
 from ansible.module_utils._text import to_native
@@ -83,6 +84,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
     """ constructs groups and vars using Jinja2 template expressions """
 
     NAME = 'constructed'
+
+    _sanitize_group_name = staticmethod(to_safe_group_name)
 
     def __init__(self):
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Follow the configuration variable TRANSFORM_INVALID_GROUP_CHARS in the
constructed plugin when adding hosts to groups.

https://github.com/ansible/ansible/pull/60912 began using the new
group name mangling methods that were added in 2.8, however the force
parameter was passed to the sanitization function, causing it to ignore
the TRANSFORM_INVALID_GROUP_CHARS configuration that is used to disable
the mangling behavior.

Fixes #70741 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`constructed` inventory plugin
