### PR TITLE
runtime os_image_facts is now called os_image_info

### DIFF
--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -1035,7 +1035,7 @@ plugin_routing:
     os_flavor_facts:
       redirect: openstack.cloud.os_flavor_info
     os_image_facts:
-      redirect: openstack.cloud.os_image_facts
+      redirect: openstack.cloud.os_image_info
     os_keystone_domain_facts:
       redirect: openstack.cloud.os_keystone_domain_info
     os_networks_facts:


### PR DESCRIPTION
##### SUMMARY

Module has been renamed in collection
https://opendev.org/openstack/ansible-collections-openstack/src/branch/master/plugins/modules/image_info.py#L12

##### ISSUE TYPE
- Bugfix Pull Request

