### PR TITLE
runtime Remove vmware_httpapi entries that were not released

### DIFF
--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -3326,14 +3326,6 @@ plugin_routing:
       redirect: community.mongodb.mongodb_user
     mongodb_shard:
       redirect: community.mongodb.mongodb_shard
-    vmware_appliance_access_info:
-      redirect: vmware.vmware_rest.vmware_appliance_access_info
-    vmware_appliance_health_info:
-      redirect: vmware.vmware_rest.vmware_appliance_health_info
-    vmware_cis_category_info:
-      redirect: vmware.vmware_rest.vmware_cis_category_info
-    vmware_core_info:
-      redirect: vmware.vmware_rest.vmware_core_info
     vcenter_extension_facts:
       redirect: community.vmware.vcenter_extension_facts
     vmware_about_facts:
@@ -9331,14 +9323,6 @@ plugin_routing:
       redirect: community.crypto.acme
     ecs_credential:
       redirect: community.crypto.ecs_credential
-    VmwareRestModule:
-      redirect: vmware.vmware_rest.VmwareRestModule
-    VmwareRestModule_filters:
-      redirect: vmware.vmware_rest.VmwareRestModule_filters
-    VmwareRestModule_full:
-      redirect: vmware.vmware_rest.VmwareRestModule_full
-    VmwareRestModule_state:
-      redirect: vmware.vmware_rest.VmwareRestModule_state
     vca:
       redirect: community.vmware.vca
     vmware:


### PR DESCRIPTION
##### SUMMARY

These modules and plugins were added to ansible/ansible *after*
stable-2.9 was branched, ie they've not been released yet.

The new collection https://github.com/ansible-collections/vmware_rest
will not be released till later in the year.

This is a PR directly against ansible/ansible:stable-2.10

##### ISSUE TYPE
- Bugfix Pull Request
