### PR TITLE
runtime os_image_facts is now called os_image_info (#70776)

### DIFF
--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -1035,7 +1035,7 @@ plugin_routing:
     os_flavor_facts:
       redirect: openstack.cloud.os_flavor_info
     os_image_facts:
-      redirect: openstack.cloud.os_image_facts
+      redirect: openstack.cloud.os_image_info
     os_keystone_domain_facts:
       redirect: openstack.cloud.os_keystone_domain_info
     os_networks_facts:


### PR DESCRIPTION
##### SUMMARY

(cherry picked from commit 1e0d83524c09cac889b6e961a6db71773ae28003)

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request
