### PR TITLE
Ensure single vaulted values aren't counted as sequences

### DIFF
--- a/changelogs/fragments/70784-vault-is-string.yml
+++ b/changelogs/fragments/70784-vault-is-string.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- JSON Encoder - Ensure we treat single vault encrypted values as strings
+  (https://github.com/ansible/ansible/issues/70784)

--- a/test/units/parsing/test_ajson.py
+++ b/test/units/parsing/test_ajson.py
@@ -158,6 +158,7 @@ class TestAnsibleJSONEncoder:
         Test for passing AnsibleVaultEncryptedUnicode to AnsibleJSONEncoder.default().
         """
         assert ansible_json_encoder.default(test_input) == {'__ansible_vault': expected}
+        assert json.dumps(test_input, cls=AnsibleJSONEncoder, preprocess_unsafe=True) == '{"__ansible_vault": "%s"}' % expected.replace('\n', '\\n')
 
     @pytest.mark.parametrize(
         'test_input,expected',


### PR DESCRIPTION
##### SUMMARY
Ensure single vaulted values aren't counted as sequences. Fixes #70784

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/common/json.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
