### PR TITLE
user - Create home and parent directories only when requested

### DIFF
--- a/changelogs/fragments/70600-user-module-dont-create-home-when-create_home-is-false.yml
+++ b/changelogs/fragments/70600-user-module-dont-create-home-when-create_home-is-false.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "user - don't create home directory and missing parents when create_home == false (https://github.com/ansible/ansible/pull/70600)."

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -634,11 +634,12 @@ class User(object):
 
         if self.home is not None:
             # If the specified path to the user home contains parent directories that
-            # do not exist, first create the home directory since useradd cannot
-            # create parent directories
-            parent = os.path.dirname(self.home)
-            if not os.path.isdir(parent):
-                self.create_homedir(self.home)
+            # do not exist and create_home is True first create the parent directory
+            # since useradd cannot create it.
+            if self.create_home:
+                parent = os.path.dirname(self.home)
+                if not os.path.isdir(parent):
+                    self.create_homedir(self.home)
             cmd.append('-d')
             cmd.append(self.home)
 
@@ -2940,7 +2941,7 @@ def main():
             # Check to see if the provided home path contains parent directories
             # that do not exist.
             path_needs_parents = False
-            if user.home:
+            if user.home and user.create_home:
                 parent = os.path.dirname(user.home)
                 if not os.path.isdir(parent):
                     path_needs_parents = True

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -226,7 +226,6 @@
           - user_test3_3 is changed
   when: ansible_facts.system != 'Darwin'
 
-
 # https://github.com/ansible/ansible/issues/41393
 # Create a new user account with a path that has parent directories that do not exist
 - name: Create user with home path that has parents that do not exist
@@ -285,6 +284,43 @@
     state: absent
     remove: yes
 
+# https://github.com/ansible/ansible/issues/70589
+# Create user with create_home: no and parent directory does not exist.
+- name: "Check if parent dir for home dir for user exists (before)"
+  stat:
+    path: "{{ user_home_prefix[ansible_facts.system] }}/thereisnodir"
+  register: create_user_no_create_home_with_no_parent_parent_dir_before
+
+- name: "Create user with create_home == no and home path parent dir does not exist"
+  user:
+    name: randomuser
+    state: present
+    create_home: false
+    home: "{{ user_home_prefix[ansible_facts.system] }}/thereisnodir/randomuser"
+  register: create_user_no_create_home_with_no_parent
+
+- name: "Check if parent dir for home dir for user exists (after)"
+  stat:
+    path: "{{ user_home_prefix[ansible_facts.system] }}/thereisnodir"
+  register: create_user_no_create_home_with_no_parent_parent_dir_after
+
+- name: "Check if home for user is created"
+  stat:
+    path: "{{ user_home_prefix[ansible_facts.system] }}/thereisnodir/randomuser"
+  register: create_user_no_create_home_with_no_parent_home_dir
+
+- name: "Ensure user with non-existing parent paths with create_home: no was created successfully"
+  assert:
+    that:
+      - not create_user_no_create_home_with_no_parent_parent_dir_before.stat.exists
+      - not create_user_no_create_home_with_no_parent_parent_dir_after.stat.isdir is defined
+      - not create_user_no_create_home_with_no_parent_home_dir.stat.exists
+
+- name: Cleanup test account
+  user:
+    name: randomuser
+    state: absent
+    remove: yes
 
 ## user check
 


### PR DESCRIPTION
##### SUMMARY
The home user and the parents directories should only be created when
create_home == True

(cherry picked from commit f3dd8d30527495810d53b07596959950894e8b15)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
user 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
