### PR TITLE
yum action plugin: 'use' as an alias of 'use_backend'

### DIFF
--- a/changelogs/fragments/70792-yum-action-plugin-use-as-alias-of-use-backend.yml
+++ b/changelogs/fragments/70792-yum-action-plugin-use-as-alias-of-use-backend.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - yum action plugin - yum action plugin changes to support 'use' as an alias of 'use_backend'
+  - yum - yum action plugin changes to support 'use' as an alias of 'use_backend' (https://github.com/ansible/ansible/issues/70774).

--- a/changelogs/fragments/70792-yum-action-plugin-use-as-alias-of-use-backend.yml
+++ b/changelogs/fragments/70792-yum-action-plugin-use-as-alias-of-use-backend.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - yum action plugin - yum action plugin changes to support 'use' as an alias of 'use_backend'

--- a/lib/ansible/modules/yum.py
+++ b/lib/ansible/modules/yum.py
@@ -26,9 +26,7 @@ options:
         upstream yum developers. As of Ansible 2.7+, this module also supports C(YUM4), which is the
         "new yum" and it has an C(dnf) backend.
       - By default, this module will select the backend based on the C(ansible_pkg_mgr) fact.
-      - Since version 2.10 you can also use the C(use) alias for this option.
     default: "auto"
-    aliases: [ use ]
     choices: [ auto, yum, yum4, dnf ]
     version_added: "2.7"
   name:

--- a/lib/ansible/modules/yum.py
+++ b/lib/ansible/modules/yum.py
@@ -26,7 +26,9 @@ options:
         upstream yum developers. As of Ansible 2.7+, this module also supports C(YUM4), which is the
         "new yum" and it has an C(dnf) backend.
       - By default, this module will select the backend based on the C(ansible_pkg_mgr) fact.
+      - Since version 2.10 you can also use the C(use) alias for this option.
     default: "auto"
+    aliases: [ use ]
     choices: [ auto, yum, yum4, dnf ]
     version_added: "2.7"
   name:

--- a/lib/ansible/plugins/action/yum.py
+++ b/lib/ansible/plugins/action/yum.py
@@ -48,15 +48,10 @@ class ActionModule(ActionBase):
         del tmp  # tmp no longer has any effect
 
         # Carry-over concept from the package action plugin
-        module = 'auto'
-
         if 'use' in self._task.args and 'use_backend' in self._task.args:
             raise AnsibleActionFail("parameters are mutually exclusive: ('use', 'use_backend')")
 
-        use_backend = self._task.args.get('use', self._task.args.get('use_backend', None))
-
-        if use_backend:
-            module = use_backend
+        module = self._task.args.get('use', self._task.args.get('use_backend', 'auto'))
 
         if module == 'auto':
             try:

--- a/lib/ansible/plugins/action/yum.py
+++ b/lib/ansible/plugins/action/yum.py
@@ -47,7 +47,22 @@ class ActionModule(ActionBase):
         del tmp  # tmp no longer has any effect
 
         # Carry-over concept from the package action plugin
-        module = self._task.args.get('use_backend', "auto")
+        use_backend = self._task.args.get('use_backend', None)
+        use = self._task.args.get('use', None)
+        module = 'auto'
+
+        if None not in [use_backend, use]:
+            result.update(
+                {
+                    'failed': True,
+                    'msg': "use_backend and use are mutually exclusive. Cannot use both."
+                }
+            )
+            return result
+        elif use_backend is not None:
+            module = use_backend
+        elif use is not None:
+            module = use
 
         if module == 'auto':
             try:

--- a/test/integration/targets/package/tasks/main.yml
+++ b/test/integration/targets/package/tasks/main.yml
@@ -111,4 +111,108 @@
     - name: verify at command is installed
       shell: which at
 
+    - name: remove at package
+      package:
+        name: at
+        state: absent
+      register: at_install0
+
+    - name: validate package removal
+      assert:
+        that:
+          - "at_install0 is changed"
+
   when: ansible_distribution in package_distros
+
+##
+## yum
+##
+#Validation for new parameter 'use' in yum action plugin which aliases to 'use_backend'
+#Issue: https://github.com/ansible/ansible/issues/70774
+- block:
+    - name: verify if using both the parameters 'use' and 'use_backend' throw error
+      yum:
+        name: at
+        state: present
+        use_backend: yum
+        use: yum
+      ignore_errors: yes
+      register: result
+
+    - name: verify error
+      assert:
+        that:
+          - "'parameters are mutually exclusive' in result.msg"
+          - "not result is changed"
+
+    - name: verify if package installation is successful using 'use' parameter
+      yum:
+        name: at
+        state: present
+        use: dnf
+      register: result
+
+    - name: verify the result
+      assert:
+        that:
+          - "result is changed"
+
+    - name: remove at package
+      yum:
+        name: at
+        state: absent
+        use: dnf
+      register: result
+
+    - name: verify package removal
+      assert:
+        that:
+          - "result is changed"
+
+    - name: verify if package installation is successful using 'use_backend' parameter
+      yum:
+        name: at
+        state: present
+        use_backend: dnf
+      register: result
+
+    - name: verify the result
+      assert:
+        that:
+          - "result is changed"
+
+    - name: remove at package
+      yum:
+        name: at
+        state: absent
+        use_backend: dnf
+      register: result
+
+    - name: verify package removal
+      assert:
+        that:
+          - "result is changed"
+
+    - name: verify if package installation is successful without using 'use_backend' and 'use' parameters
+      yum:
+        name: at
+        state: present
+      register: result
+
+    - name: verify the result
+      assert:
+        that:
+          - "result is changed"
+
+    - name: remove at package
+      yum:
+        name: at
+        state: absent
+      register: result
+
+    - name: verify package removal
+      assert:
+        that:
+          - "result is changed"
+
+  when: ansible_distribution == "Fedora"


### PR DESCRIPTION
##### SUMMARY
Made changes to the yum action plugin to support **use** as an alias of **use_backend**.
Fixes #70774 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
yum action plugin
