### PR TITLE
[2.10] cron - Allow non-ascii (UTF-8) chars in cron file paths and jobs (#70426)

### DIFF
--- a/changelogs/fragments/70426-allow-non-ascii-chars-in-cron.yml
+++ b/changelogs/fragments/70426-allow-non-ascii-chars-in-cron.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cron - encode and decode crontab files in UTF-8 explicitly to allow non-ascii chars in cron filepath and job (https://github.com/ansible/ansible/issues/69492)

--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -122,3 +122,65 @@
 
   - assert:
       that: not cron_file_stats.stat.exists
+
+- name: Allow non-ascii chars in job (#69492)
+  block:
+  - name: Cron file creation
+    cron:
+      cron_file: cron_filename
+      name: "cron job that contain non-ascii chars in job (これは日本語です; This is Japanese)"
+      job: 'echo "うどんは好きだがお化け👻は苦手である。"'
+      user: root
+
+  - name: "Ensure cron_file contains job string"
+    replace:
+      path: /etc/cron.d/cron_filename
+      regexp: "うどんは好きだがお化け👻は苦手である。"
+      replace: "それは機密情報🔓です。"
+    register: find_chars
+    failed_when: (find_chars is not changed) or (find_chars is failed)
+
+  - name: Cron file deletion
+    cron:
+      cron_file: cron_filename
+      name: "cron job that contain non-ascii chars in job (これは日本語です; This is Japanese)"
+      state: absent
+
+  - name: Check file succesfull deletion
+    stat:
+      path: /etc/cron.d/cron_filename
+    register: cron_file_stats
+
+  - assert:
+      that: not cron_file_stats.stat.exists
+
+- name: Allow non-ascii chars in cron_file (#69492)
+  block:
+  - name: Cron file creation with non-ascii filename (これは日本語です; This is Japanese)
+    cron:
+      cron_file: 'なせば大抵なんとかなる👊'
+      name: "integration test cron"
+      job: 'echo "Hello, ansible!"'
+      user: root
+
+  - name: Check file exists
+    stat:
+      path: "/etc/cron.d/なせば大抵なんとかなる👊"
+    register: cron_file_stats
+
+  - assert:
+      that: cron_file_stats.stat.exists
+
+  - name: Cron file deletion
+    cron:
+      cron_file: 'なせば大抵なんとかなる👊'
+      name: "integration test cron"
+      state: absent
+
+  - name: Check file succesfull deletion
+    stat:
+      path: "/etc/cron.d/なせば大抵なんとかなる👊"
+    register: cron_file_stats
+
+  - assert:
+      that: not cron_file_stats.stat.exists


### PR DESCRIPTION
##### SUMMARY

Backport of #70426 to ansible 2.10.
cherry-picked from 5ce47646add41077872b9cd9e0e8a24874995aae

It fixes #69492

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

`lib/ansible/modules/cron.py`

##### ADDITIONAL INFORMATION

ansible 2.10
