### PR TITLE
Make changelog tool be more strict about suffixes

### DIFF
--- a/packaging/release/changelogs/changelog.py
+++ b/packaging/release/changelogs/changelog.py
@@ -211,6 +211,8 @@ def load_fragments(paths=None, exceptions=None):
     fragments = []
 
     for path in paths:
+        if path.startswith('.') or not path.endswith(('.yml', '.yaml')):
+            continue
         try:
             fragments.append(ChangelogFragment.load(path))
         except Exception as ex:

--- a/packaging/release/changelogs/changelog.py
+++ b/packaging/release/changelogs/changelog.py
@@ -211,7 +211,8 @@ def load_fragments(paths=None, exceptions=None):
     fragments = []
 
     for path in paths:
-        if path.startswith('.') or not path.endswith(('.yml', '.yaml')):
+        bn_path = os.path.basename(path)
+        if bn_path.startswith('.') or not bn_path.endswith(('.yml', '.yaml')):
             continue
         try:
             fragments.append(ChangelogFragment.load(path))

--- a/test/sanity/code-smell/changelog.py
+++ b/test/sanity/code-smell/changelog.py
@@ -18,6 +18,9 @@ def main():
         if ext not in allowed_extensions:
             print('%s:%d:%d: extension must be one of: %s' % (path, 0, 0, ', '.join(allowed_extensions)))
 
+        if os.path.basename(path).startswith('.'):
+            print('%s:%d:%d: file must not be a dotfile' % (path, 0, 0))
+
     cmd = ['packaging/release/changelogs/changelog.py', 'lint'] + paths
     subprocess.check_call(cmd)
 


### PR DESCRIPTION

##### SUMMARY
Change:
- Files must end in .yml or .yaml, and must not be dotfiles.
- This is to prevent (for example) emacs backup files (.yml~) from being
  included in changelogs during releases.
- Backport of https://github.com/ansible-community/antsibull-changelog/pull/33 (not yet merged as of this writing)

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

changelog tool