### PR TITLE
[2.9] basic: use PollSelector implementation

### DIFF
--- a/changelogs/fragments/70238_selector.yml
+++ b/changelogs/fragments/70238_selector.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- basic - use PollSelector implementation when DefaultSelector fails (https://github.com/ansible/ansible/issues/70238).

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2594,7 +2594,13 @@ class AnsibleModule(object):
 
             stdout = b''
             stderr = b''
-            selector = selectors.DefaultSelector()
+            try:
+                selector = selectors.DefaultSelector()
+            except OSError:
+                # Failed to detect default selector for the given platform
+                # Select PollSelector which is supported by major platforms
+                selector = selectors.PollSelector()
+
             selector.register(cmd.stdout, selectors.EVENT_READ)
             selector.register(cmd.stderr, selectors.EVENT_READ)
             if os.name == 'posix':


### PR DESCRIPTION
##### SUMMARY

Some platform such as ESXi does not implement EpollSelector,
which is selected by DefaultSelector. Use PollSelector which is
based upon 'Poll' implementation. This works perfectly with
a platform like VMware ESXi.

Fixes: #70238

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit 8cccede0d435c799385828ce55521c910dc69b13)


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/70238_selector.yml
lib/ansible/module_utils/basic.py
