### PR TITLE
Chore: elevate how authentication is done

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1401,13 +1401,14 @@ def open_url(url, data=None, headers=None, method=None, use_proxy=True,
     Module environment is optional (used for logging)
     '''
     method = method or ('POST' if data else 'GET')
-    return Request(module=module).open(method, url, data=data, headers=headers, use_proxy=use_proxy,
-                          force=force, last_mod_time=last_mod_time, timeout=timeout, validate_certs=validate_certs,
-                          url_username=url_username, url_password=url_password, http_agent=http_agent,
-                          force_basic_auth=force_basic_auth, follow_redirects=follow_redirects,
-                          client_cert=client_cert, client_key=client_key, cookies=cookies,
-                          use_gssapi=use_gssapi, unix_socket=unix_socket, ca_path=ca_path,
-                          unredirected_headers=unredirected_headers)
+    return Request(module=module).open(
+        method, url, data=data, headers=headers, use_proxy=use_proxy,
+        force=force, last_mod_time=last_mod_time, timeout=timeout, validate_certs=validate_certs,
+        url_username=url_username, url_password=url_password, http_agent=http_agent,
+        force_basic_auth=force_basic_auth, follow_redirects=follow_redirects,
+        client_cert=client_cert, client_key=client_key, cookies=cookies,
+        use_gssapi=use_gssapi, unix_socket=unix_socket, ca_path=ca_path,
+        unredirected_headers=unredirected_headers)
 
 
 def prepare_multipart(fields):


### PR DESCRIPTION
##### SUMMARY

I spent a few days trying to figure out where bad requests came from when ansible ran and attempted to download public downloads from Github repositories. I discovered that a netrc configuration is used when in the environment and apparently the configuration contained within is added to requests.

For context, the netrc file is setup "by" our CI server (to be able to clone private github repositories), but I was unaware of this. I saw there are a few tickets here and on multiple Ansible roles where people stumble into this and I thought it was a good idea to add some logging to the file. But this is more or less an RFC, happy to change/adjust.

This code seems to affect a bunch of different modules.

Related: #61666 #27293

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

 - `uri`
 - `get_url`
 - `lookup('url', ...)`
