### PR TITLE
[stable-2.9] Document existing ansi_re sequences and add `ESC[m` (#70683)

### DIFF
--- a/changelogs/fragments/70683-terminal-ansi-re.yaml
+++ b/changelogs/fragments/70683-terminal-ansi-re.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Terminal plugins - add "\e[m" to the list of ANSI sequences stripped from device output

--- a/lib/ansible/plugins/terminal/__init__.py
+++ b/lib/ansible/plugins/terminal/__init__.py
@@ -48,8 +48,9 @@ class TerminalBase(with_metaclass(ABCMeta, object)):
 
     #: compiled bytes regular expressions to remove ANSI codes
     ansi_re = [
-        re.compile(br'(\x1b\[\?1h\x1b=)'),
-        re.compile(br'\x08.')
+        re.compile(br'\x1b\[\?1h\x1b='),  # CSI ? 1 h ESC =
+        re.compile(br'\x08.'),            # [Backspace] .
+        re.compile(br"\x1b\[m"),          # ANSI reset code
     ]
 
     #: terminal initial prompt


### PR DESCRIPTION
##### SUMMARY

* Document existing ansi_re sequences and add `ESC[m`
(cherry picked from commit 06a4fc2)

Co-authored-by: Nathaniel Case <ncase@redhat.com>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/terminal/\_\_init__.py