### PR TITLE
[hostname] Unify how we handle permanent hostname lookup and drop py2.4 support

### DIFF
--- a/changelogs/fragments/66432_hostname_check_mode_writes.yml
+++ b/changelogs/fragments/66432_hostname_check_mode_writes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hostname - No longer modifies system files in get_* methods consulted when in check_mode (https://github.com/ansible/ansible/issues/66432)

--- a/changelogs/fragments/66432_hostname_check_mode_writes.yml
+++ b/changelogs/fragments/66432_hostname_check_mode_writes.yml
@@ -1,2 +1,7 @@
 bugfixes:
-  - hostname - No longer modifies system files in get_* methods consulted when in check_mode (https://github.com/ansible/ansible/issues/66432)
+  - hostname - No longer modifies system files in get_* methods and therefore when consulted in check_mode (https://github.com/ansible/ansible/issues/66432)
+
+breaking_changes:
+  - hostname - Drops any remaining support for Python 2.4 by using ``with open()`` to simplify exception handling code which leaked file handles in several spots
+  - hostname - On FreeBSD, the string ``temporarystub`` no longer gets written to the hostname file in the get methods (and in check_mode). As a result, the default hostname will now appear as ``''`` (empty string) instead of ``temporarystub`` for consistency with other strategies. This means the ``before`` result will be different.
+  - hostname - On OpenRC systems and Solaris, the ``before`` value will now be ``''`` (empty string) if the permanent hostname file does not exist, for consistency with other strategies.

--- a/docs/docsite/rst/porting_guides/porting_guide_2.11.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.11.rst
@@ -111,6 +111,9 @@ The M(sysctl) module uses ``atomic_move()`` to operate on ``/etc/sysctl.conf`` o
 
 
 * The ``apt_key`` module has explicitly defined ``file`` as mutually exclusive with ``data``, ``keyserver`` and ``url``. They cannot be used together anymore.
+* ``hostname`` - On FreeBSD, the ``before`` result will no longer be ``"temporarystub"`` if permanent hostname file does not exist. It will instead be ``""`` (empty string) for consistency with other systems.
+* ``hostname`` - On OpenRC and Solaris based systems, the ``before`` result will no longer be ``"UNKNOWN"`` if the permanent hostname file does not exist. It will instead be ``""`` (empty string) for consistency with other systems.
+
 
 Modules removed
 ---------------

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -208,11 +208,8 @@ class DebianStrategy(GenericStrategy):
 
     def get_permanent_hostname(self):
         if not os.path.isfile(self.HOSTNAME_FILE):
-            try:
-                open(self.HOSTNAME_FILE, "a").write("")
-            except IOError as e:
-                self.module.fail_json(msg="failed to write file: %s" %
-                                          to_native(e), exception=traceback.format_exc())
+            return ''
+
         try:
             f = open(self.HOSTNAME_FILE)
             try:
@@ -244,11 +241,8 @@ class SLESStrategy(GenericStrategy):
 
     def get_permanent_hostname(self):
         if not os.path.isfile(self.HOSTNAME_FILE):
-            try:
-                open(self.HOSTNAME_FILE, "a").write("")
-            except IOError as e:
-                self.module.fail_json(msg="failed to write file: %s" %
-                                          to_native(e), exception=traceback.format_exc())
+            return ''
+
         try:
             f = open(self.HOSTNAME_FILE)
             try:
@@ -333,11 +327,8 @@ class AlpineStrategy(GenericStrategy):
 
     def get_permanent_hostname(self):
         if not os.path.isfile(self.HOSTNAME_FILE):
-            try:
-                open(self.HOSTNAME_FILE, "a").write("")
-            except IOError as e:
-                self.module.fail_json(msg="failed to write file: %s" %
-                                          to_native(e), exception=traceback.format_exc())
+            return ''
+
         try:
             f = open(self.HOSTNAME_FILE)
             try:
@@ -468,11 +459,8 @@ class OpenBSDStrategy(GenericStrategy):
 
     def get_permanent_hostname(self):
         if not os.path.isfile(self.HOSTNAME_FILE):
-            try:
-                open(self.HOSTNAME_FILE, "a").write("")
-            except IOError as e:
-                self.module.fail_json(msg="failed to write file: %s" %
-                                          to_native(e), exception=traceback.format_exc())
+            return ''
+
         try:
             f = open(self.HOSTNAME_FILE)
             try:
@@ -533,14 +521,10 @@ class FreeBSDStrategy(GenericStrategy):
     HOSTNAME_FILE = '/etc/rc.conf.d/hostname'
 
     def get_permanent_hostname(self):
-
         name = 'UNKNOWN'
         if not os.path.isfile(self.HOSTNAME_FILE):
-            try:
-                open(self.HOSTNAME_FILE, "a").write("hostname=temporarystub\n")
-            except IOError as e:
-                self.module.fail_json(msg="failed to write file: %s" %
-                                          to_native(e), exception=traceback.format_exc())
+            return ''
+
         try:
             try:
                 f = open(self.HOSTNAME_FILE, 'r')

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -211,25 +211,21 @@ class DebianStrategy(GenericStrategy):
             return ''
 
         try:
-            f = open(self.HOSTNAME_FILE)
-            try:
+            with open(self.HOSTNAME_FILE, 'r') as f:
                 return f.read().strip()
-            finally:
-                f.close()
         except Exception as e:
-            self.module.fail_json(msg="failed to read hostname: %s" %
-                                      to_native(e), exception=traceback.format_exc())
+            self.module.fail_json(
+                msg="failed to read hostname: %s" % to_native(e),
+                exception=traceback.format_exc())
 
     def set_permanent_hostname(self, name):
         try:
-            f = open(self.HOSTNAME_FILE, 'w+')
-            try:
+            with open(self.HOSTNAME_FILE, 'w+') as f:
                 f.write("%s\n" % name)
-            finally:
-                f.close()
         except Exception as e:
-            self.module.fail_json(msg="failed to update hostname: %s" %
-                                      to_native(e), exception=traceback.format_exc())
+            self.module.fail_json(
+                msg="failed to update hostname: %s" % to_native(e),
+                exception=traceback.format_exc())
 
 
 class SLESStrategy(GenericStrategy):
@@ -244,25 +240,21 @@ class SLESStrategy(GenericStrategy):
             return ''
 
         try:
-            f = open(self.HOSTNAME_FILE)
-            try:
+            with open(self.HOSTNAME_FILE) as f:
                 return f.read().strip()
-            finally:
-                f.close()
         except Exception as e:
-            self.module.fail_json(msg="failed to read hostname: %s" %
-                                      to_native(e), exception=traceback.format_exc())
+            self.module.fail_json(
+                msg="failed to read hostname: %s" % to_native(e),
+                exception=traceback.format_exc())
 
     def set_permanent_hostname(self, name):
         try:
-            f = open(self.HOSTNAME_FILE, 'w+')
-            try:
+            with open(self.HOSTNAME_FILE, 'w+') as f:
                 f.write("%s\n" % name)
-            finally:
-                f.close()
         except Exception as e:
-            self.module.fail_json(msg="failed to update hostname: %s" %
-                                      to_native(e), exception=traceback.format_exc())
+            self.module.fail_json(
+                msg="failed to update hostname: %s" % to_native(e),
+                exception=traceback.format_exc())
 
 
 class RedHatStrategy(GenericStrategy):
@@ -274,42 +266,35 @@ class RedHatStrategy(GenericStrategy):
 
     def get_permanent_hostname(self):
         try:
-            f = open(self.NETWORK_FILE, 'rb')
-            try:
+            with open(self.NETWORK_FILE, 'rb') as f:
                 for line in f.readlines():
                     if line.startswith('HOSTNAME'):
                         k, v = line.split('=')
                         return v.strip()
-            finally:
-                f.close()
         except Exception as e:
-            self.module.fail_json(msg="failed to read hostname: %s" %
-                                      to_native(e), exception=traceback.format_exc())
+            self.module.fail_json(
+                msg="failed to read hostname: %s" % to_native(e),
+                exception=traceback.format_exc())
 
     def set_permanent_hostname(self, name):
         try:
             lines = []
             found = False
-            f = open(self.NETWORK_FILE, 'rb')
-            try:
+            with open(self.NETWORK_FILE, 'rb') as f:
                 for line in f.readlines():
                     if line.startswith('HOSTNAME'):
                         lines.append("HOSTNAME=%s\n" % name)
                         found = True
                     else:
                         lines.append(line)
-            finally:
-                f.close()
             if not found:
                 lines.append("HOSTNAME=%s\n" % name)
-            f = open(self.NETWORK_FILE, 'w+')
-            try:
+            with open(self.NETWORK_FILE, 'w+') as f:
                 f.writelines(lines)
-            finally:
-                f.close()
         except Exception as e:
-            self.module.fail_json(msg="failed to update hostname: %s" %
-                                      to_native(e), exception=traceback.format_exc())
+            self.module.fail_json(
+                msg="failed to update hostname: %s" % to_native(e),
+                exception=traceback.format_exc())
 
 
 class AlpineStrategy(GenericStrategy):
@@ -330,25 +315,21 @@ class AlpineStrategy(GenericStrategy):
             return ''
 
         try:
-            f = open(self.HOSTNAME_FILE)
-            try:
+            with open(self.HOSTNAME_FILE) as f:
                 return f.read().strip()
-            finally:
-                f.close()
         except Exception as e:
-            self.module.fail_json(msg="failed to read hostname: %s" %
-                                      to_native(e), exception=traceback.format_exc())
+            self.module.fail_json(
+                msg="failed to read hostname: %s" % to_native(e),
+                exception=traceback.format_exc())
 
     def set_permanent_hostname(self, name):
         try:
-            f = open(self.HOSTNAME_FILE, 'w+')
-            try:
+            with open(self.HOSTNAME_FILE, 'w+') as f:
                 f.write("%s\n" % name)
-            finally:
-                f.close()
         except Exception as e:
-            self.module.fail_json(msg="failed to update hostname: %s" %
-                                      to_native(e), exception=traceback.format_exc())
+            self.module.fail_json(
+                msg="failed to update hostname: %s" % to_native(e),
+                exception=traceback.format_exc())
 
     def set_current_hostname(self, name):
         cmd = [self.hostname_cmd, '-F', self.HOSTNAME_FILE]
@@ -411,42 +392,36 @@ class OpenRCStrategy(GenericStrategy):
     HOSTNAME_FILE = '/etc/conf.d/hostname'
 
     def get_permanent_hostname(self):
-        name = 'UNKNOWN'
+        if not os.path.isfile(self.HOSTNAME_FILE):
+            return ''
+
         try:
-            try:
-                f = open(self.HOSTNAME_FILE, 'r')
+            with open(self.HOSTNAME_FILE, 'r') as f:
                 for line in f:
                     line = line.strip()
                     if line.startswith('hostname='):
-                        name = line[10:].strip('"')
-                        break
-            except Exception as e:
-                self.module.fail_json(msg="failed to read hostname: %s" %
-                                          to_native(e), exception=traceback.format_exc())
-        finally:
-            f.close()
-
-        return name
+                        return line[10:].strip('"')
+        except Exception as e:
+            self.module.fail_json(
+                msg="failed to read hostname: %s" % to_native(e),
+                exception=traceback.format_exc())
 
     def set_permanent_hostname(self, name):
         try:
-            try:
-                f = open(self.HOSTNAME_FILE, 'r')
+            with open(self.HOSTNAME_FILE, 'r') as f:
                 lines = [x.strip() for x in f]
 
                 for i, line in enumerate(lines):
                     if line.startswith('hostname='):
                         lines[i] = 'hostname="%s"' % name
                         break
-                f.close()
 
-                f = open(self.HOSTNAME_FILE, 'w')
+            with open(self.HOSTNAME_FILE, 'w') as f:
                 f.write('\n'.join(lines) + '\n')
-            except Exception as e:
-                self.module.fail_json(msg="failed to update hostname: %s" %
-                                          to_native(e), exception=traceback.format_exc())
-        finally:
-            f.close()
+        except Exception as e:
+            self.module.fail_json(
+                msg="failed to update hostname: %s" % to_native(e),
+                exception=traceback.format_exc())
 
 
 class OpenBSDStrategy(GenericStrategy):
@@ -462,25 +437,21 @@ class OpenBSDStrategy(GenericStrategy):
             return ''
 
         try:
-            f = open(self.HOSTNAME_FILE)
-            try:
+            with open(self.HOSTNAME_FILE) as f:
                 return f.read().strip()
-            finally:
-                f.close()
         except Exception as e:
-            self.module.fail_json(msg="failed to read hostname: %s" %
-                                      to_native(e), exception=traceback.format_exc())
+            self.module.fail_json(
+                msg="failed to read hostname: %s" % to_native(e),
+                exception=traceback.format_exc())
 
     def set_permanent_hostname(self, name):
         try:
-            f = open(self.HOSTNAME_FILE, 'w+')
-            try:
+            with open(self.HOSTNAME_FILE, 'w+') as f:
                 f.write("%s\n" % name)
-            finally:
-                f.close()
         except Exception as e:
-            self.module.fail_json(msg="failed to update hostname: %s" %
-                                      to_native(e), exception=traceback.format_exc())
+            self.module.fail_json(
+                msg="failed to update hostname: %s" % to_native(e),
+                exception=traceback.format_exc())
 
 
 class SolarisStrategy(GenericStrategy):
@@ -521,45 +492,39 @@ class FreeBSDStrategy(GenericStrategy):
     HOSTNAME_FILE = '/etc/rc.conf.d/hostname'
 
     def get_permanent_hostname(self):
-        name = 'UNKNOWN'
         if not os.path.isfile(self.HOSTNAME_FILE):
             return ''
 
         try:
-            try:
-                f = open(self.HOSTNAME_FILE, 'r')
+            with open(self.HOSTNAME_FILE, 'r') as f:
                 for line in f:
                     line = line.strip()
                     if line.startswith('hostname='):
-                        name = line[10:].strip('"')
-                        break
-            except Exception as e:
-                self.module.fail_json(msg="failed to read hostname: %s" %
-                                          to_native(e), exception=traceback.format_exc())
-        finally:
-            f.close()
-
-        return name
+                        return line[10:].strip('"')
+        except Exception as e:
+            self.module.fail_json(
+                msg="failed to read hostname: %s" % to_native(e),
+                exception=traceback.format_exc())
 
     def set_permanent_hostname(self, name):
         try:
-            try:
-                f = open(self.HOSTNAME_FILE, 'r')
-                lines = [x.strip() for x in f]
+            if os.path.isfile(self.HOSTNAME_FILE):
+                with open(self.HOSTNAME_FILE, 'r') as f:
+                    lines = [x.strip() for x in f]
 
-                for i, line in enumerate(lines):
-                    if line.startswith('hostname='):
-                        lines[i] = 'hostname="%s"' % name
-                        break
-                f.close()
+                    for i, line in enumerate(lines):
+                        if line.startswith('hostname='):
+                            lines[i] = 'hostname="%s"' % name
+                            break
+            else:
+                lines = ['hostname="%s"' % name]
 
-                f = open(self.HOSTNAME_FILE, 'w')
+            with open(self.HOSTNAME_FILE, 'w') as f:
                 f.write('\n'.join(lines) + '\n')
-            except Exception as e:
-                self.module.fail_json(msg="failed to update hostname: %s" %
-                                          to_native(e), exception=traceback.format_exc())
-        finally:
-            f.close()
+        except Exception as e:
+            self.module.fail_json(
+                msg="failed to update hostname: %s" % to_native(e),
+                exception=traceback.format_exc())
 
 
 class FedoraHostname(Hostname):

--- a/test/units/modules/test_hostname.py
+++ b/test/units/modules/test_hostname.py
@@ -1,0 +1,35 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from units.compat.mock import patch, MagicMock, mock_open
+from ansible.module_utils import basic
+from ansible.module_utils.common._utils import get_all_subclasses
+from ansible.modules import hostname
+from units.modules.utils import ModuleTestCase, set_module_args
+from ansible.module_utils.six import PY2
+
+
+class TestHostname(ModuleTestCase):
+    @patch('os.path.isfile')
+    def test_stategy_get_never_writes_in_check_mode(self, isfile):
+        isfile.return_value = True
+
+        set_module_args({'name': 'fooname', '_ansible_check_mode': True})
+        subclasses = get_all_subclasses(hostname.GenericStrategy)
+        module = MagicMock()
+        for cls in subclasses:
+            instance = cls(module)
+
+            instance.module.run_command = MagicMock()
+            instance.module.run_command.return_value = (0, '', '')
+
+            m = mock_open()
+            builtins = 'builtins'
+            if PY2:
+                builtins = '__builtin__'
+            with patch('%s.open' % builtins, m):
+                instance.get_permanent_hostname()
+                instance.get_current_hostname()
+                self.assertFalse(
+                    m.return_value.write.called,
+                    msg='%s called write, should not have' % str(cls))


### PR DESCRIPTION
##### SUMMARY
Change:
- Hostname strategies' get_*() methods should never write to the
  filesystem. They are used in check_mode by default to determine if
  there is any work to be done.

Test Plan:
- New unit tests to ensure that (at least when in check_mode) the get
  methods don't ever call write.

Tickets:
- Fixes #66432

Signed-off-by: Rick Elrod <rick@elrod.me>

-------------

[hostname] Simplify code, drop py2.4 support

Change:
- Make strategies behave consistently and return the empty string
  instead of "UNKNOWN" (or "temporarystub") for the "before" value if
  the permanent hostname file does not exist or could not be read.
- Switch to `with open()` instead of annoying exception handling code
  (which was wrong and leaked file handles in several places). This
  drops Python 2.4 support for this module.
- Updated porting guide since users could be relying on these former,
  inconsistent values.

Signed-off-by: Rick Elrod <rick@elrod.me>


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

hostname module