### PR TITLE
virtualization facts: check /dev/kvm as a fallback

### DIFF
--- a/changelogs/fragments/dev-kvm.yml
+++ b/changelogs/fragments/dev-kvm.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - facts - ``/dev/kvm`` is now consulted in Linux virtualization facts, and the host is considered a KVM host if this file exists and none of the pre-existing checks matched.

--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -238,6 +238,11 @@ class LinuxVirtual(Virtual):
                     virtual_facts['virtualization_role'] = 'guest'
                     return virtual_facts
 
+        if os.path.exists('/dev/kvm'):
+            virtual_facts['virtualization_type'] = 'kvm'
+            virtual_facts['virtualization_role'] = 'host'
+            return virtual_facts
+
         # If none of the above matches, return 'NA' for virtualization_type
         # and virtualization_role. This allows for proper grouping.
         virtual_facts['virtualization_type'] = 'NA'


### PR DESCRIPTION

##### SUMMARY
Change:
- On Linux, there are situations where a host might be a KVM host but
  not have the kernel module enabled (it might be compiled in instead).
  In these cases, /dev/kvm will still exist, and rather than reporting
  NA, we should report that the host is a KVM host.

Test Plan:
- Local

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

virtualization facts