### PR TITLE
profile_tasks: typecast result before slicing it

### DIFF
--- a/changelogs/fragments/59059_profile_tasks.yml
+++ b/changelogs/fragments/59059_profile_tasks.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- profile_tasks - typecast result before slicing it (https://github.com/ansible/ansible/issues/59059).

--- a/lib/ansible/plugins/callback/profile_tasks.py
+++ b/lib/ansible/plugins/callback/profile_tasks.py
@@ -173,7 +173,7 @@ class CallbackModule(CallbackBase):
         timestamp(self)
         self.current = None
 
-        results = self.stats.items()
+        results = list(self.stats.items())
 
         # Sort the tasks by the specified sort
         if self.sort_order is not None:


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible-collections/ansible.posix/pull/15

Fixes: #59059

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/59059_profile_tasks.yml
lib/ansible/plugins/callback/profile_tasks.py
