### PR TITLE
[backport][2.10][PR #70445] Fix the internal Python API usage examples

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_api.rst
+++ b/docs/docsite/rst/dev_guide/developing_api.rst
@@ -71,6 +71,18 @@ This example is a simple demonstration that shows how to minimally run a couple 
     # variable manager takes care of merging all the different sources to give you a unified view of variables available in each context
     variable_manager = VariableManager(loader=loader, inventory=inventory)
 
+    # Instantiate task queue manager, which takes care of forking
+    # and setting up all objects to iterate over host list and tasks.
+    # IMPORTANT: This also adds library dirs paths to the module loader
+    # IMPORTANT: and so it must be initialized before calling `Play.load()`.
+    tqm = TaskQueueManager(
+        inventory=inventory,
+        variable_manager=variable_manager,
+        loader=loader,
+        passwords=passwords,
+        stdout_callback=results_callback,  # Use our custom callback instead of the ``default`` callback plugin, which prints to stdout
+    )
+
     # create data structure that represents our play, including tasks, this is basically what our YAML loader does internally.
     play_source =  dict(
             name = "Ansible Play",
@@ -86,16 +98,8 @@ This example is a simple demonstration that shows how to minimally run a couple 
     # this will also automatically create the task objects from the info provided in play_source
     play = Play().load(play_source, variable_manager=variable_manager, loader=loader)
 
-    # Run it - instantiate task queue manager, which takes care of forking and setting up all objects to iterate over host list and tasks
-    tqm = None
+    # Actually run it
     try:
-        tqm = TaskQueueManager(
-                  inventory=inventory,
-                  variable_manager=variable_manager,
-                  loader=loader,
-                  passwords=passwords,
-                  stdout_callback=results_callback,  # Use our custom callback instead of the ``default`` callback plugin, which prints to stdout
-              )
         result = tqm.run(play) # most interesting data for a play is actually sent to the callback's methods
     finally:
         # we always need to cleanup child procs and the structures we use to communicate with them

--- a/examples/scripts/uptime.py
+++ b/examples/scripts/uptime.py
@@ -45,9 +45,26 @@ def main():
     loader = DataLoader()
     passwords = dict()
 
+    # Instantiate our ResultsCollector for handling results as
+    # they come in. Ansible expects this to be one of its main
+    # display outlets.
+    callback = ResultsCollector()
+
     # create inventory and pass to var manager
     inventory = InventoryManager(loader=loader, sources=sources)
     variable_manager = VariableManager(loader=loader, inventory=inventory)
+
+    # Instantiate task queue manager, which takes care of forking
+    # and setting up all objects to iterate over host list and tasks.
+    # IMPORTANT: This also adds library dirs paths to the module loader
+    # IMPORTANT: and so it must be initialized before calling `Play.load()`.
+    tqm = TaskQueueManager(
+        inventory=inventory,
+        variable_manager=variable_manager,
+        loader=loader,
+        passwords=passwords,
+        stdout_callback=callback,
+    )
 
     # create play with tasks
     play_source = dict(
@@ -59,16 +76,7 @@ def main():
     play = Play().load(play_source, variable_manager=variable_manager, loader=loader)
 
     # actually run it
-    tqm = None
-    callback = ResultsCollector()
     try:
-        tqm = TaskQueueManager(
-            inventory=inventory,
-            variable_manager=variable_manager,
-            loader=loader,
-            passwords=passwords,
-            stdout_callback=callback,
-        )
         result = tqm.run(play)
     finally:
         if tqm is not None:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of 8d97c8c.

The previous version initialized the `TaskQueueManager` after calling
`Play.load()` while advertising a way to inject a custom library
location path. This caused the tasks loader not to find any custom
modules because it was triggered before the path was actually added
to the module loader.

This patch changes the order of the operations to ensure that the
customized `context.CLIARGS` actually influences things.

Resolves https://github.com/ansible/ansible/issues/69758.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request Backport

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Internal Python API usage examples.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A