### PR TITLE
Do not add connection vars to the output results

### DIFF
--- a/changelogs/fragments/set_fact-connection_vars.yml
+++ b/changelogs/fragments/set_fact-connection_vars.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Stop adding the connection variables to the output results

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -707,9 +707,8 @@ class TaskExecutor:
         # also now add conneciton vars results when delegating
         if self._task.delegate_to:
             result["_ansible_delegated_vars"] = {'ansible_delegated_host': self._task.delegate_to}
-            for k in plugin_vars + RETURN_VARS:
-                if k in cvars and cvars[k] is not None:
-                    result["_ansible_delegated_vars"][k] = cvars[k]
+            for k in plugin_vars:
+                result["_ansible_delegated_vars"][k] = cvars.get(k)
 
         # and return
         display.debug("attempt loop complete, returning result")

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -710,10 +710,6 @@ class TaskExecutor:
             for k in plugin_vars + RETURN_VARS:
                 if k in cvars and cvars[k] is not None:
                     result["_ansible_delegated_vars"][k] = cvars[k]
-        else:
-            for k in plugin_vars + RETURN_VARS:
-                if k in cvars and cvars[k] is not None:
-                    result[k] = cvars[k]
 
         # and return
         display.debug("attempt loop complete, returning result")

--- a/test/integration/targets/connection/test.sh
+++ b/test/integration/targets/connection/test.sh
@@ -8,3 +8,16 @@ set -eux
 
                 ansible-playbook test_connection.yml -i "${INVENTORY}" "$@"
 LC_ALL=C LANG=C ansible-playbook test_connection.yml -i "${INVENTORY}" "$@"
+
+# Check that connection vars do not appear in the output
+# https://github.com/ansible/ansible/pull/70853
+trap "rm out.txt" EXIT
+
+ansible all -i "${INVENTORY}" -m set_fact -a "testing=value" -v | tee out.txt
+if grep 'ansible_host' out.txt
+then
+    echo "FAILURE: Connection vars in output"
+    exit 1
+else
+    echo "SUCCESS: Connection vars not found"
+fi


### PR DESCRIPTION
##### SUMMARY
A change in https://github.com/ansible/ansible/pull/70331 caused any connection vars for a host to appear in the result output which could leak information.

This is pretty much just reverting this section of the PR https://github.com/ansible/ansible/commit/84adaba6f5f020b2f0b1f13129d093b326bf5065#diff-76ffc0551f8cf3d6255500316568e60bL700-R717.

This should be backported to stable-2.10

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
task_executor