### PR TITLE
Do not add connection vars to the output results (#70853) - 2.10

### DIFF
--- a/changelogs/fragments/set_fact-connection_vars.yml
+++ b/changelogs/fragments/set_fact-connection_vars.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Stop adding the connection variables to the output results

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -798,13 +798,8 @@ class TaskExecutor:
         # also now add conneciton vars results when delegating
         if self._task.delegate_to:
             result["_ansible_delegated_vars"] = {'ansible_delegated_host': self._task.delegate_to}
-            for k in plugin_vars + RETURN_VARS:
-                if k in cvars and cvars[k] is not None:
-                    result["_ansible_delegated_vars"][k] = cvars[k]
-        else:
-            for k in plugin_vars + RETURN_VARS:
-                if k in cvars and cvars[k] is not None:
-                    result[k] = cvars[k]
+            for k in plugin_vars:
+                result["_ansible_delegated_vars"][k] = cvars.get(k)
 
         # and return
         display.debug("attempt loop complete, returning result")

--- a/test/integration/targets/connection/test.sh
+++ b/test/integration/targets/connection/test.sh
@@ -8,3 +8,16 @@ set -eux
 
                 ansible-playbook test_connection.yml -i "${INVENTORY}" "$@"
 LC_ALL=C LANG=C ansible-playbook test_connection.yml -i "${INVENTORY}" "$@"
+
+# Check that connection vars do not appear in the output
+# https://github.com/ansible/ansible/pull/70853
+trap "rm out.txt" EXIT
+
+ansible all -i "${INVENTORY}" -m set_fact -a "testing=value" -v | tee out.txt
+if grep 'ansible_host' out.txt
+then
+    echo "FAILURE: Connection vars in output"
+    exit 1
+else
+    echo "SUCCESS: Connection vars not found"
+fi


### PR DESCRIPTION
(cherry picked from commit 5e1a9689837d404fd9d2db3429acf499cf1a3d2b)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/70853

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
task_executor