### PR TITLE
reset logging to INFO (#70878)

### DIFF
--- a/changelogs/fragments/keep_log_at_info.yml
+++ b/changelogs/fragments/keep_log_at_info.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - reset logging level to INFO due to CVE-2019-14846.

--- a/changelogs/fragments/keep_log_at_info.yml
+++ b/changelogs/fragments/keep_log_at_info.yml
@@ -1,2 +1,2 @@
-bugfixes:
+security_fixes:
   - reset logging level to INFO due to CVE-2019-14846.

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -79,7 +79,8 @@ logger = None
 if getattr(C, 'DEFAULT_LOG_PATH'):
     path = C.DEFAULT_LOG_PATH
     if path and (os.path.exists(path) and os.access(path, os.W_OK)) or os.access(os.path.dirname(path), os.W_OK):
-        logging.basicConfig(filename=path, level=logging.DEBUG,
+        # NOTE: level is kept at INFO to avoid security disclosures caused by certain libraries when using DEBUG
+        logging.basicConfig(filename=path, level=logging.INFO,  # DO NOT set to logging.DEBUG
                             format='%(asctime)s p=%(process)d u=%(user)s n=%(name)s | %(message)s')
 
         logger = logging.getLogger('ansible')

--- a/test/units/utils/display/test_logger.py
+++ b/test/units/utils/display/test_logger.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+import logging
+import sys
+
+
+def test_logger():
+    '''
+    Avoid CVE-2019-14846 as 3rd party libs will disclose secrets when
+    logging is set to DEBUG
+    '''
+
+    # clear loaded modules to have unadultered test.
+    for loaded in list(sys.modules.keys()):
+        if 'ansible' in loaded:
+            del sys.modules[loaded]
+
+    # force logger to exist via config
+    from ansible import constants as C
+    C.DEFAULT_LOG_PATH = '/dev/null'
+
+    # initialize logger
+    from ansible.utils.display import logger
+
+    assert logger.root.level != logging.DEBUG


### PR DESCRIPTION
- due to CVE-2019-14846
 - also added comments and test to avoid 'oportunistic' reversion

(cherry picked from commit 1223ce656aa3b44d7e6d9b8d9460d3ae63b09fdc)


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
display