### PR TITLE
Give subversion module a validate_certs option

### DIFF
--- a/changelogs/fragments/22599_svn_validate_certs.yml
+++ b/changelogs/fragments/22599_svn_validate_certs.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - subversion - Now has a ``validate_certs`` option, which, when true, will avoid passing ``--trust-server-cert`` to ``svn`` commands (https://github.com/ansible/ansible/issues/22599)
+  - subversion - ``validate_certs`` option, which, when true, will avoid passing ``--trust-server-cert`` to ``svn`` commands (https://github.com/ansible/ansible/issues/22599).

--- a/changelogs/fragments/22599_svn_validate_certs.yml
+++ b/changelogs/fragments/22599_svn_validate_certs.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - subversion - Now has a ``validate_certs`` option, which, when true, will avoid passing ``--trust-server-cert`` to ``svn`` commands (https://github.com/ansible/ansible/issues/22599)

--- a/test/integration/targets/subversion/roles/subversion/defaults/main.yml
+++ b/test/integration/targets/subversion/roles/subversion/defaults/main.yml
@@ -8,3 +8,4 @@ subversion_repo_url: http://127.0.0.1:{{ apache_port }}/svn/{{ subversion_repo_n
 subversion_repo_auth_url: http://127.0.0.1:{{ apache_port }}/svnauth/{{ subversion_repo_name }}
 subversion_username: subsvn_user'''
 subversion_password: Password123!
+subversion_external_repo_url: https://github.com/ansible/ansible-base-test-container  # GitHub serves SVN

--- a/test/integration/targets/subversion/roles/subversion/tasks/tests.yml
+++ b/test/integration/targets/subversion/roles/subversion/tasks/tests.yml
@@ -130,4 +130,16 @@
       - "export_branches.stat.isdir"
       - "subverted4.changed"
 
+- name: clone a small external repo with validate_certs=true
+  subversion:
+    repo: "{{ subversion_external_repo_url }}"
+    dest: "{{ subversion_test_dir }}/svn-external1"
+    validate_certs: yes
+
+- name: clone a small external repo with validate_certs=false
+  subversion:
+    repo: "{{ subversion_external_repo_url }}"
+    dest: "{{ subversion_test_dir }}/svn-external2"
+    validate_certs: no
+
 # TBA: test for additional options or URL variants welcome


### PR DESCRIPTION
##### SUMMARY
Change:
- Add `validate_certs` option to subversion module. Defaults to off for
  backwards compatibility.

Tickets:
- Fixes #22599
- Fixes #40036

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME

subversion module