### PR TITLE
[2.10] [ansible_builtin_runtime.yml] fix text[fs]m typo (#70893)

### DIFF
--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -9451,8 +9451,8 @@ plugin_routing:
       redirect: ansible.netcommon.hwaddr
     parse_cli:
       redirect: ansible.netcommon.parse_cli
-    parse_cli_textsfm:
-      redirect: ansible.netcommon.parse_cli_textsfm
+    parse_cli_textfsm:
+      redirect: ansible.netcommon.parse_cli_textfsm
     parse_xml:
       redirect: ansible.netcommon.parse_xml
     type5_pw:


### PR DESCRIPTION

##### SUMMARY

Change:
- textsfm -> textfsm

Test Plan:
- Out-of-band ansible_builtin_runtime.yml checker script

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

collections