### PR TITLE
user: Unlock by default with no password, busybox

### DIFF
--- a/changelogs/fragments/68676_busybox_locked_user.yml
+++ b/changelogs/fragments/68676_busybox_locked_user.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - user - When creating a user account with no password on busybox systems such as Alpine, the account is now unlocked after it is created, for consistency with other platforms.
+  - user - When creating a user account with no password on busybox systems such as Alpine, the account is now unlocked after it is created, for consistency with other platforms (https://github.com/ansible/ansible/issues/68676).

--- a/changelogs/fragments/68676_busybox_locked_user.yml
+++ b/changelogs/fragments/68676_busybox_locked_user.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - user - When creating a user account with no password on busybox systems such as Alpine, the account is now unlocked after it is created, for consistency with other platforms.


### PR DESCRIPTION

##### SUMMARY

Change:
- On busybox systems such as Alpine, user accounts which are created
  with no password are locked by default until their password is
  changed. For consistency with other platforms, if not given a
  password, manually unlock the account so that it is accessible by key
  access.

Test Plan:
- Local Alpine VM

Tickets:
- Fixes #68676

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
user module