### PR TITLE
Allow BusyBox to modify more user fields

### DIFF
--- a/changelogs/fragments/66679_more_user_modify_on_busybox.yml
+++ b/changelogs/fragments/66679_more_user_modify_on_busybox.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "user - More options now get updated on user modify in the BusyBox ``user`` strategy (currently only used by Alpine). These options now get set: uid, primary group, gecos/comment, home directory, shell. (https://github.com/ansible/ansible/issues/66679)"


### PR DESCRIPTION

##### SUMMARY

Change:
- BusyBox-based distros often don't ship the `shadow` package and thus
  the `usermod` command. Thus unless we place a dependency on that
  package, we need to modify /etc/passwd ourselves.
- This patch does that and now allows us to support uid, primary group,
  GECOS, home directory, and shell.
- Also update documentation around BusyBox and note which fields are
  currently NOT supported.

Test Plan:
- Local Alpine VM

Tickets:
- Fixes #66679 (mostly, somewhat)

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

user module