### PR TITLE
git: verify, only use --raw when we need it

### DIFF
--- a/changelogs/fragments/64469_git_no_raw.yml
+++ b/changelogs/fragments/64469_git_no_raw.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - git - Only pass ``--raw`` flag to git verify commands (verify-tag, verify-commit) when ``gpg_whitelist`` is in use. Otherwise don't pass it so that non-whitelist GPG validation still works on older Git versions. (https://github.com/ansible/ansible/issues/64469)

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -182,6 +182,7 @@ options:
            - A list of trusted GPG fingerprints to compare to the fingerprint of the
              GPG-signed commit.
            - Only used when I(verify_commit=yes).
+           - Use of this feature requires Git 2.6+ due to its reliance on git's C(--raw) flag to C(verify-commit) and C(verify-tag).
         type: list
         default: []
         version_added: "2.9"
@@ -958,7 +959,9 @@ def verify_commit_sign(git_path, module, dest, version, gpg_whitelist):
         git_sub = "verify-tag"
     else:
         git_sub = "verify-commit"
-    cmd = "%s %s %s --raw" % (git_path, git_sub, version)
+    cmd = "%s %s %s" % (git_path, git_sub, version)
+    if gpg_whitelist:
+        cmd += " --raw"
     (rc, out, err) = module.run_command(cmd, cwd=dest)
     if rc != 0:
         module.fail_json(msg='Failed to verify GPG signature of commit/tag "%s"' % version, stdout=out, stderr=err, rc=rc)

--- a/test/integration/targets/git/tasks/gpg-verification.yml
+++ b/test/integration/targets/git/tasks/gpg-verification.yml
@@ -75,6 +75,8 @@
     repo: "{{ git_gpg_source }}"
     dest: "{{ git_gpg_dest }}"
     verify_commit: yes
+  when:
+    - git_version.stdout is version("2.1.0", '>=')
 
 - name: GPG-VERIFICATION | Clone repo and verify a signed lightweight tag
   environment:
@@ -84,6 +86,8 @@
     dest: "{{ git_gpg_dest }}"
     version: lightweight_tag/signed_commit
     verify_commit: yes
+  when:
+    - git_version.stdout is version("2.1.0", '>=')
 
 - name: GPG-VERIFICATION | Clone repo and verify an unsigned lightweight tag (should fail)
   environment:
@@ -95,12 +99,16 @@
     verify_commit: yes
   register: git_verify
   ignore_errors: yes
+  when:
+    - git_version.stdout is version("2.1.0", '>=')
 
 - name: GPG-VERIFICATION | Check that unsigned lightweight tag verification failed
   assert:
     that:
       - git_verify is failed
       - git_verify.msg is match("Failed to verify GPG signature of commit/tag.+")
+  when:
+    - git_version.stdout is version("2.1.0", '>=')
 
 - name: GPG-VERIFICATION | Clone repo and verify a signed commit
   environment:
@@ -110,6 +118,8 @@
     dest: "{{ git_gpg_dest }}"
     version: "{{ git_gpg_signed_commit.stdout }}"
     verify_commit: yes
+  when:
+    - git_version.stdout is version("2.1.0", '>=')
 
 - name: GPG-VERIFICATION | Clone repo and verify an unsigned commit
   environment:
@@ -121,12 +131,16 @@
     verify_commit: yes
   register: git_verify
   ignore_errors: yes
+  when:
+    - git_version.stdout is version("2.1.0", '>=')
 
 - name: GPG-VERIFICATION | Check that unsigned commit verification failed
   assert:
     that:
       - git_verify is failed
       - git_verify.msg is match("Failed to verify GPG signature of commit/tag.+")
+  when:
+    - git_version.stdout is version("2.1.0", '>=')
 
 - name: GPG-VERIFICATION | Clone repo and verify a signed annotated tag
   environment:
@@ -162,6 +176,8 @@
     dest: "{{ git_gpg_dest }}"
     version: some_branch/signed_tip
     verify_commit: yes
+  when:
+    - git_version.stdout is version("2.1.0", '>=')
 
 - name: GPG-VERIFICATION | Clone repo and verify an unsigned branch (should fail)
   environment:
@@ -173,18 +189,22 @@
     verify_commit: yes
   register: git_verify
   ignore_errors: yes
+  when:
+    - git_version.stdout is version("2.1.0", '>=')
 
 - name: GPG-VERIFICATION | Check that unsigned branch verification failed
   assert:
     that:
       - git_verify is failed
       - git_verify.msg is match("Failed to verify GPG signature of commit/tag.+")
+  when:
+    - git_version.stdout is version("2.1.0", '>=')
 
 - name: GPG-VERIFICATION | Stop gpg-agent so we can remove any locks on the GnuPG dir
   command: gpgconf --kill gpg-agent
-  when: ansible_os_family != 'Suse' or ansible_distribution_version != '42.3'  # OpenSUSE 42.3 ships with an older version of gpg-agent that doesn't support this
   environment:
     GNUPGHOME: "{{ git_gpg_gpghome }}"
+  ignore_errors: yes
 
 - name: GPG-VERIFICATION | Remove GnuPG verification workdir
   file:

--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -32,7 +32,7 @@
   when:
     - not gpg_version.stderr
     - gpg_version.stdout
-    - not (ansible_os_family == 'RedHat' and ansible_distribution_major_version|int < 7)
+    - not (ansible_os_family == 'RedHat' and ansible_distribution_major_version is version('7', '<')
 - import_tasks: localmods.yml
 - import_tasks: reset-origin.yml
 - import_tasks: ambiguous-ref.yml

--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -32,7 +32,7 @@
   when:
     - not gpg_version.stderr
     - gpg_version.stdout
-    - not (ansible_os_family == 'RedHat' and ansible_distribution_major_version is version('7', '<')
+    - not (ansible_os_family == 'RedHat' and ansible_distribution_major_version is version('7', '<'))
 - import_tasks: localmods.yml
 - import_tasks: reset-origin.yml
 - import_tasks: ambiguous-ref.yml

--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -32,6 +32,7 @@
   when:
     - not gpg_version.stderr
     - gpg_version.stdout
+    - not (ansible_os_family == 'RedHat' and ansible_distribution_major_version < 7)
 - import_tasks: localmods.yml
 - import_tasks: reset-origin.yml
 - import_tasks: ambiguous-ref.yml

--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -32,7 +32,6 @@
   when:
     - not gpg_version.stderr
     - gpg_version.stdout
-    - git_version.stdout is version("2.1.0", '>=')
 - import_tasks: localmods.yml
 - import_tasks: reset-origin.yml
 - import_tasks: ambiguous-ref.yml

--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -32,7 +32,7 @@
   when:
     - not gpg_version.stderr
     - gpg_version.stdout
-    - not (ansible_os_family == 'RedHat' and ansible_distribution_major_version < 7)
+    - not (ansible_os_family == 'RedHat' and ansible_distribution_major_version|int < 7)
 - import_tasks: localmods.yml
 - import_tasks: reset-origin.yml
 - import_tasks: ambiguous-ref.yml


### PR DESCRIPTION

##### SUMMARY

Change:
- Allow older git to verify tags again
- Enable verification tests everywhere, even if most of them only work
  on newer git. Some of them work on older git and they test the --raw
  parameter.

Test Plan:
- Re-enabled subset of git tests

Tickets:
- Fixes #64469

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

git module