### PR TITLE
RHEV virt facts: Detect vdsmd in addition to vdsm

### DIFF
--- a/changelogs/fragments/66147_rhev_vdsm_vdsmd.yml
+++ b/changelogs/fragments/66147_rhev_vdsm_vdsmd.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - virtualization facts - Detect ``vdsmd`` in addition to ``vdsm`` when trying to detect RHEV hosts. (https://github.com/ansible/ansible/issues/66147)

--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -206,7 +206,7 @@ class LinuxVirtual(Virtual):
                         try:
                             with open(f) as virt_fh:
                                 comm_content = virt_fh.read().rstrip()
-                            if comm_content == 'vdsm':
+                            if comm_content in ('vdsm', 'vdsmd'):
                                 virtual_facts['virtualization_type'] = 'RHEV'
                                 break
                         except Exception:


### PR DESCRIPTION
NOTE: I still need to verify this; but if things are as-stated, this should fix it.

##### SUMMARY

Change:
- Look for the `vdsmd` process in addition to `vdsm` as before.

Tickets:
- Fixes #66147

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

virt facts