### PR TITLE
Properly handle sshpass return codes

### DIFF
--- a/changelogs/fragments/70904-properly-handle-sshpass-return-codes.yml
+++ b/changelogs/fragments/70904-properly-handle-sshpass-return-codes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - SSH plugin - Raise an exception when ``sshpass`` return code is in range  1-6 (https://github.com/ansible/ansible/issues/58113).

--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -549,8 +549,8 @@ class TestSSHConnectionRetries(object):
         self.conn.get_option = MagicMock()
         self.conn.get_option.return_value = True
 
-        exception_info = pytest.raises(AnsibleAuthenticationFailure, self.conn.exec_command, 'sshpass', 'some data')
-        assert exception_info.value.message == ('Invalid/incorrect username/password. Skipping remaining 5 retries to prevent account lockout: '
+        exception_info = pytest.raises(AnsibleConnectionFailure, self.conn.exec_command, 'sshpass', 'some data')
+        assert exception_info.value.message == ('sshpass error: Invalid/incorrect password. '
                                                 'Permission denied, please try again.')
         assert self.mock_popen.call_count == 1
 


### PR DESCRIPTION
##### SUMMARY
When we get sshpass return code 1-4,6 it means we have a permanent issue which cannot be resolved by retries. The goal of this PR to raise AnsibleAuthenticationFailure() exception with a proper error message when this happens.

Fixes #58133

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/connection/ssh.py