### PR TITLE
Allow using lookup plugins in inventory constructed logic

### DIFF
--- a/lib/ansible/plugins/doc_fragments/constructed.py
+++ b/lib/ansible/plugins/doc_fragments/constructed.py
@@ -29,4 +29,8 @@ options:
     description: Add hosts to group based on the values of a variable.
     type: list
     default: []
+  disable_lookups:
+    description:
+        - Prevent use of lookups in jinja2 expressions.
+    default: True
 '''

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -355,7 +355,9 @@ class Constructable(object):
         ''' helper method for plugins to compose variables for Ansible based on jinja2 expression and inventory vars'''
         t = self.templar
         t.available_variables = variables
-        return t.template('%s%s%s' % (t.environment.variable_start_string, template, t.environment.variable_end_string), disable_lookups=True)
+        return t.template(
+            '%s%s%s' % (t.environment.variable_start_string, template, t.environment.variable_end_string),
+            disable_lookups=self.get_option('disable_lookups'))
 
     def _set_composite_vars(self, compose, variables, host, strict=False):
         ''' loops over compose entries to create vars for hosts '''

--- a/lib/ansible/plugins/inventory/constructed.py
+++ b/lib/ansible/plugins/inventory/constructed.py
@@ -28,6 +28,7 @@ EXAMPLES = r'''
     # inventory.config file in YAML format
     plugin: constructed
     strict: False
+    disable_lookups: False  # needed to construct the variable gce_projects
     compose:
         var_sum: var1 + var2
 
@@ -46,6 +47,9 @@ EXAMPLES = r'''
 
         # complex group membership
         multi_group: (group_names | intersect(['alpha', 'beta', 'omega'])) | length >= 2
+
+        # add a variable from environment lookup
+        gce_projects: "lookup('env', 'GCE_PROJECTS')"
 
     keyed_groups:
         # this creates a group per distro (distro_CentOS, distro_Debian) and assigns the hosts that have matching values to it,


### PR DESCRIPTION
##### SUMMARY
Allow using lookups in inventory files for anything subclassing the `constructed` inventory plugin.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/constructed.py

##### ADDITIONAL INFORMATION
Demo:

```
compose:
  cmeyers: "lookup('env', 'GCE_PROJECTS')"
  cmeyers2: "query('awx.awx.tower_schedule_rrule', 'none')"
strict: true
disable_lookups: false
plugin: constructed
```

Using:

```
$ GCE_PROJECTS=foo ansible-inventory -i host1, -i testing/awx_424_0bzcwopc/constructed.yml --list --export
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under
development. This is a rapidly changing source of code and can become unstable at any point.
{
    "_meta": {
        "hostvars": {
            "host1": {
                "cmeyers": {
                    "__ansible_unsafe": "foo"
                },
                "cmeyers2": {
                    "__ansible_unsafe": "DTSTART;TZID=America/New_York:20200726T125825 RRULE:FREQ=DAILY;COUNT=1;INTERVAL=1"
                }
            }
        }
    },
    "all": {
        "children": [
            "ungrouped"
        ]
    },
    "ungrouped": {
        "hosts": [
            "host1"
        ]
    }
}
```

FYI to @willtome @chrismeyersfsu 