### PR TITLE
Make changelog tool be more strict about suffixes

### DIFF
--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -6,6 +6,7 @@ changes_file: changelog.yaml
 changes_format: combined
 keep_fragments: true
 always_refresh: true
+ignore_other_fragment_extensions: true
 mention_ancestor: false
 notesdir: fragments
 prelude_section_name: release_summary

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -45,7 +45,7 @@ setuptools < 37 ; python_version == '2.6' # setuptools 37 and later require pyth
 setuptools < 45 ; python_version == '2.7' # setuptools 45 and later require python 3.5 or later
 
 # freeze antsibull-changelog for consistent test results
-antsibull-changelog == 0.3.1
+antsibull-changelog == 0.7.0
 
 # freeze pylint and its requirements for consistent test results
 astroid == 2.2.5

--- a/test/lib/ansible_test/_data/sanity/code-smell/changelog.py
+++ b/test/lib/ansible_test/_data/sanity/code-smell/changelog.py
@@ -21,6 +21,10 @@ def main():
             continue
 
         if path.startswith('changelogs/fragments/.'):
+            if path in ('changelogs/fragments/.keep', 'changelogs/fragments/.gitkeep'):
+                continue
+
+            print('%s:%d:%d: file must not be a dotfile' % (path, 0, 0))
             continue
 
         ext = os.path.splitext(path)[1]


### PR DESCRIPTION
##### SUMMARY
Analogue to #70798 for devel (and stable-2.10). Bumps the antsibull-changelog version to 0.7.0, which includes a new option to be more strict about suffixes (ansible-community/antsibull-changelog#33), enables this option in changelogs/config.yaml, and adjusts the sanity test to flag all files that are not processed, with the exception of `.keep` and `.gitkeep`. (`.keep` and `.gitkeep` seem to be the most common ways of people making sure empty subdirectories are kept by git and other version control systems: https://stackoverflow.com/questions/7229885/what-are-the-differences-between-gitignore-and-gitkeep)

CC @relrod @mattclay

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
changelog
changelog sanity test
