### PR TITLE
iptables: Add a note about ipv6-icmp, icmpv6

### DIFF
--- a/changelogs/fragments/70905_iptables_ipv6.yml
+++ b/changelogs/fragments/70905_iptables_ipv6.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- iptables - add a note about ipv6-icmp in protocol parameter (https://github.com/ansible/ansible/issues/70905).

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -72,8 +72,8 @@ options:
   protocol:
     description:
       - The protocol of the rule or of the packet to check.
-      - The specified protocol can be one of C(tcp), C(udp), C(udplite), C(icmp), C(esp),
-        C(ah), C(sctp) or the special keyword C(all), or it can be a numeric value,
+      - The specified protocol can be one of C(tcp), C(udp), C(udplite), C(icmp), C(ipv6-icmp) or C(icmpv6),
+        C(esp), C(ah), C(sctp) or the special keyword C(all), or it can be a numeric value,
         representing one of these protocols or a different one.
       - A protocol name from I(/etc/protocols) is also allowed.
       - A C(!) argument before the protocol inverts the test.


### PR DESCRIPTION
##### SUMMARY

ipv6-icmp ping is valid protocol and adding note about
it in protocol parameter.

Fixes: #70905

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/70905_iptables_ipv6.yml
lib/ansible/modules/iptables.py
