### PR TITLE
[stable-2.9] reboot - fix Void Linux (#70704)

### DIFF
--- a/changelogs/fragments/70704-void-linux-reboot.yml
+++ b/changelogs/fragments/70704-void-linux-reboot.yml
@@ -1,0 +1,3 @@
+bugfixes:
+ - reboot - Add support for the runit init system, used on Void Linux, that
+   does not support the normal Linux syntax.

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -57,6 +57,7 @@ class ActionModule(ActionBase):
 
     SHUTDOWN_COMMAND_ARGS = {
         'alpine': '',
+        'void': '-r +{delay_min} "{message}"',
         'freebsd': '-r +{delay_sec}s "{message}"',
         'linux': DEFAULT_SHUTDOWN_COMMAND_ARGS,
         'macosx': '-r +{delay_min} "{message}"',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #70704 for Ansible 2.9
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/action/reboot.py`