### PR TITLE
package - use existing list of package managers from facts

### DIFF
--- a/changelogs/fragments/package-use-manager-from-facts.yaml
+++ b/changelogs/fragments/package-use-manager-from-facts.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - package - use list of built in package managers from facts rather than creating a new list

--- a/lib/ansible/plugins/action/package.py
+++ b/lib/ansible/plugins/action/package.py
@@ -19,6 +19,7 @@ __metaclass__ = type
 
 from ansible.errors import AnsibleAction, AnsibleActionFail
 from ansible.executor.module_common import get_action_args_with_defaults
+from ansible.module_utils.facts.system.pkg_mgr import PKG_MGRS
 from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
 
@@ -29,8 +30,7 @@ class ActionModule(ActionBase):
 
     TRANSFERS_FILES = False
 
-    BUILTIN_PKG_MGR_MODULES = set(['apk', 'apt', 'dnf', 'homebrew', 'installp', 'macports', 'opkg', 'portage', 'pacman',
-                                   'pkg5', 'pkgin', 'pkgng', 'sorcery', 'svr4pkg', 'swdepot', 'swupd', 'urpmi', 'xbps', 'yum', 'zypper'])
+    BUILTIN_PKG_MGR_MODULES = set([manager['name'] for manager in PKG_MGRS])
 
     def run(self, tmp=None, task_vars=None):
         ''' handler for package operations '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Rather than creating another hard coded list of package managers, use the existing one.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/action/package.py`
##### ADDITIONAL INFORMATION

I'm not sure if it would make sense to move this constant somewhere else now since it is being used by things outside of just facts. Also not sure if there are any negative side effects from creating a relationship between this value in facts and the the action plugin.
