### PR TITLE
AnsiballZ - remove deprecated excommunicate command

### DIFF
--- a/changelogs/fragments/ansiballz-remove-excommunicate.yaml
+++ b/changelogs/fragments/ansiballz-remove-excommunicate.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - remove ``excommunicate`` debug command from AnsiballZ

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -237,10 +237,6 @@ def _ansiballz_main():
         basedir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'debug_dir')
         args_path = os.path.join(basedir, 'args')
 
-        if command == 'excommunicate':
-            print('The excommunicate debug command is deprecated and will be removed in 2.11.  Use execute instead.')
-            command = 'execute'
-
         if command == 'explode':
             # transform the ZIPDATA into an exploded directory of code and then
             # print the path to the code.  This is an easy way for people to look


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This command was scheduled for removal in 2.11 in favor of `execute`, which lines up with our documentation.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/executor/module_common.py`