### PR TITLE
Exabeam's hack ignore devicemapper during gather_facts

### DIFF
--- a/lib/ansible/module_utils/facts/timeout.py
+++ b/lib/ansible/module_utils/facts/timeout.py
@@ -23,7 +23,7 @@ import multiprocessing.pool as mp
 # steps do not exceed a time limit
 
 GATHER_TIMEOUT = None
-DEFAULT_GATHER_TIMEOUT = 10
+DEFAULT_GATHER_TIMEOUT = 60
 
 
 class TimeoutError(Exception):


### PR DESCRIPTION
##### SUMMARY
Please feel free to close it. I understand this PR isn't upstream acceptable. This PR is for GPL compliant.

Exabeam https://www.exabeam.com/ noticed Ansible randomly missing all facts from `LinuxHardwareCollector` class in `gather_facts`, with Docker start/stop containers at the same moment.
We hit that issue about 1 in 100 times from our environment.  (`CentOS 7 x64, Ansible 2.9.4, Docker 19.03.1 "storage-driver": "devicemapper"`)


We made hacks to workaround it:
1. ignore `devicemapper` during `gather_facts`
2. hardcode `gather_timeout from` `10` to `60`, we set it in `ansible.cfg` but seems not working: https://github.com/ansible/ansible/issues/23753
3. use single thread in `get_mount_facts()`, it sometimes hangs (super rare)


We will work on a better fix for this, will submit new PRs when we are ready.
