### PR TITLE
template: add parameter for preserve_trailing_newlines

### DIFF
--- a/changelogs/fragments/69270_template.yml
+++ b/changelogs/fragments/69270_template.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- template - add configurable parameter for preserve_trailing_newlines (https://github.com/ansible/ansible/issues/69270).

--- a/lib/ansible/modules/template.py
+++ b/lib/ansible/modules/template.py
@@ -25,6 +25,12 @@ options:
     type: bool
     default: no
     version_added: '2.4'
+  preserve_trailing_newlines:
+    description:
+    - Preserve the newline characters at the end of the input data.
+    type: bool
+    default: yes
+    version_added: '2.11'
 notes:
 - For Windows you can use M(win_template) which uses '\\r\\n' as C(newline_sequence) by default.
 seealso:

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -49,6 +49,7 @@ class ActionModule(ActionBase):
             follow = boolean(self._task.args.get('follow', False), strict=False)
             trim_blocks = boolean(self._task.args.get('trim_blocks', True), strict=False)
             lstrip_blocks = boolean(self._task.args.get('lstrip_blocks', False), strict=False)
+            preserve_trailing_newlines = boolean(self._task.args.get('preserve_trailing_newlines', True), strict=False)
         except TypeError as e:
             raise AnsibleActionFail(to_native(e))
 
@@ -136,7 +137,7 @@ class ActionModule(ActionBase):
                                                          variable_start_string=variable_start_string, variable_end_string=variable_end_string,
                                                          trim_blocks=trim_blocks, lstrip_blocks=lstrip_blocks,
                                                          available_variables=temp_vars):
-                    resultant = self._templar.do_template(template_data, preserve_trailing_newlines=True, escape_backslashes=False)
+                    resultant = self._templar.do_template(template_data, preserve_trailing_newlines=preserve_trailing_newlines, escape_backslashes=False)
             except AnsibleAction:
                 raise
             except Exception as e:
@@ -151,7 +152,7 @@ class ActionModule(ActionBase):
 
             # remove 'template only' options:
             for remove in ('newline_sequence', 'block_start_string', 'block_end_string', 'variable_start_string', 'variable_end_string',
-                           'trim_blocks', 'lstrip_blocks', 'output_encoding'):
+                           'trim_blocks', 'lstrip_blocks', 'output_encoding', 'preserve_trailing_newlines'):
                 new_task.args.pop(remove, None)
 
             local_tempdir = tempfile.mkdtemp(dir=C.DEFAULT_LOCAL_TMP)

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -877,7 +877,7 @@ class Templar:
             # This only affects the scenario where the final result of templating
             # is a generator, and not where a filter creates a generator in the middle
             # of a template. See ``_unroll_iterator`` for the other case. This is probably
-            # unncessary
+            # unnecessary
             return list(thing)
 
         if USE_JINJA2_NATIVE:

--- a/test/integration/targets/template/tasks/main.yml
+++ b/test/integration/targets/template/tasks/main.yml
@@ -706,5 +706,18 @@
         - 'diff_result.stdout == ""'
         - "diff_result.rc == 0"
 
+- name: Test preserve_trailing_newlines
+  template:
+    src: preserve_trailing_newline.j2
+    dest: "{{ output_dir }}/preserve_trailing_newline.templated"
+    preserve_trailing_newlines: no
+  register: preserve_trailing_newlines_output
+
+- name: Verify templated file is without trailing newline
+  assert:
+    that:
+    - preserve_trailing_newlines_output.changed
+    - preserve_trailing_newlines_output.size == 0
+
 # aliases file requires root for template tests so this should be safe
 - include: backup_test.yml

--- a/test/integration/targets/template/templates/preserve_trailing_newline.j2
+++ b/test/integration/targets/template/templates/preserve_trailing_newline.j2
@@ -1,0 +1,3 @@
+{% if false %}
+foo
+{% endif %}


### PR DESCRIPTION
##### SUMMARY

Add a configurable parameter for preserve_trailing_newlines
while templating.

Fixes: #69270

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/69270_template.yml
lib/ansible/modules/template.py
lib/ansible/plugins/action/template.py
lib/ansible/template/__init__.py
test/integration/targets/template/tasks/main.yml
test/integration/targets/template/templates/preserve_trailing_newline.j2
