### PR TITLE
galaxy: Add examples for galaxy section in ansible.cfg

### DIFF
--- a/changelogs/fragments/68402_galaxy.yml
+++ b/changelogs/fragments/68402_galaxy.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- galaxy - add documentation about galaxy parameters in examples/ansible.cfg (https://github.com/ansible/ansible/issues/68402).

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -492,3 +492,34 @@
 
 # Set how many context lines to show in diff
 #context = 3
+
+[galaxy]
+# Controls whether the display wheel is shown or not
+#display_progress=
+
+# Validate TLS certificates for Galaxy server
+#ignore_certs = False
+
+# Role or collection skeleton directory to use as a template for
+# the init action in ansible-galaxy command
+#role_skeleton=
+
+# Patterns of files to ignore inside a Galaxy role or collection
+# skeleton directory
+#role_skeleton_ignore="^.git$", "^.*/.git_keep$"
+
+# Galaxy Server URL
+#server=https://galaxy.ansible.com
+
+# A list of Galaxy servers to use when installing a collection.
+#server_list=automation_hub, release_galaxy
+
+# Server specific details which are mentioned in server_list
+#[galaxy_server.automation_hub]
+#url=https://cloud.redhat.com/api/automation-hub/
+#auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+#token=my_ah_token
+#
+#[galaxy_server.release_galaxy]
+#url=https://galaxy.ansible.com/
+#token=my_token


### PR DESCRIPTION
##### SUMMARY

Add example section for galaxy section in ansible.cfg

Fixes: #68402

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/68402_galaxy.yml
examples/ansible.cfg
