### PR TITLE
Document galaxy install from local clones

### DIFF
--- a/docs/docsite/rst/galaxy/user_guide.rst
+++ b/docs/docsite/rst/galaxy/user_guide.rst
@@ -270,7 +270,7 @@ Use the following example as a guide for specifying roles in *requirements.yml*:
     # from galaxy
     - name: yatesr.timezone
 
-    # from locally cloned git repository, relative paths are not supported
+    # from locally cloned git repository (file:// requires full paths)
     - src: file:///home/bennojoy/nginx
 
     # from GitHub

--- a/docs/docsite/rst/galaxy/user_guide.rst
+++ b/docs/docsite/rst/galaxy/user_guide.rst
@@ -270,6 +270,9 @@ Use the following example as a guide for specifying roles in *requirements.yml*:
     # from galaxy
     - name: yatesr.timezone
 
+    # from locally cloned git repository, relative paths are not supported
+    - src: file:///home/bennojoy/nginx
+
     # from GitHub
     - src: https://github.com/bennojoy/nginx
 


### PR DESCRIPTION
##### SUMMARY
Installing from local git repos was not documented for galaxy install and many people asked about this undocumented feature.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
galaxy

##### ADDITIONAL INFORMATION

Related: https://github.com/ansible/galaxy/issues/#2030