### PR TITLE
Expand user home on galaxy install src

### DIFF
--- a/changelogs/fragments/70942_galaxy_install.yml
+++ b/changelogs/fragments/70942_galaxy_install.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - galaxy - expand ``~`` (user home) from role src (https://github.com/ansible/ansible/pull/70942/).

--- a/docs/docsite/rst/galaxy/user_guide.rst
+++ b/docs/docsite/rst/galaxy/user_guide.rst
@@ -272,6 +272,9 @@ Use the following example as a guide for specifying roles in *requirements.yml*:
 
     # from locally cloned git repository (file:// requires full paths)
     - src: file:///home/bennojoy/nginx
+    
+    # from locally cloned repository
+    - name: ~/src/bennojoy/nginx
 
     # from GitHub
     - src: https://github.com/bennojoy/nginx

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -38,6 +38,7 @@ from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.urls import open_url
 from ansible.playbook.role.requirement import RoleRequirement
 from ansible.utils.display import Display
+from ansible.utils.path import unfrackpath
 
 display = Display()
 
@@ -64,7 +65,7 @@ class GalaxyRole(object):
 
         self.name = name
         self.version = version
-        self.src = src or name
+        self.src = unfrackpath(src or name)
         self.scm = scm
         self.paths = [os.path.join(x, self.name) for x in galaxy.roles_paths]
 


### PR DESCRIPTION
#### SUMMARY
Fix bug where ansible-galaxy install would fail when given paths starting with tilde (user home).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
galaxy

##### ADDITIONAL INFORMATION

Related: https://github.com/ansible/galaxy/issues/2030