### PR TITLE
[stable-2.10] lineinfile - fix broken exception handling (#70846)

### DIFF
--- a/changelogs/fragments/lineinfile_exc_fix.yml
+++ b/changelogs/fragments/lineinfile_exc_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - lineinfile - fix not subscriptable error in exception handling around file creation

--- a/lib/ansible/modules/lineinfile.py
+++ b/lib/ansible/modules/lineinfile.py
@@ -212,7 +212,7 @@ import tempfile
 
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils._text import to_bytes, to_native, to_text
 
 
 def write_changes(module, b_lines, dest):
@@ -267,7 +267,7 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
             try:
                 os.makedirs(b_destpath)
             except Exception as e:
-                module.fail_json(msg='Error creating %s Error code: %s Error description: %s' % (b_destpath, e[0], e[1]))
+                module.fail_json(msg='Error creating %s (%s)' % (to_text(b_destpath), to_text(e)))
 
         b_lines = []
     else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #70846 for Ansible 2.10
(cherry picked from commit 45c2eb6c0a)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/lineinfile.py`