### PR TITLE
Added missing azure redirection

### DIFF
--- a/changelogs/fragments/azure-redirection.yaml
+++ b/changelogs/fragments/azure-redirection.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- azure_rm_publicipaddress - Added missing redirection entry

--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -3808,6 +3808,8 @@ plugin_routing:
       redirect: community.azure.azure_rm_dnszone_facts
     azure_rm_networkinterface_facts:
       redirect: community.azure.azure_rm_networkinterface_facts
+    azure_rm_publicipaddress:
+      redirect: community.azure.azure_rm_publicipaddress
     azure_rm_publicipaddress_facts:
       redirect: community.azure.azure_rm_publicipaddress_facts
     azure_rm_securitygroup_facts:


### PR DESCRIPTION
##### SUMMARY
The entry for `azure_rm_publicipaddress` seemed to be missing but does exist in the new collection at https://github.com/ansible-collections/azure/blob/dev/plugins/modules/azure_rm_publicipaddress.py. This just adds the redirection so existing playbooks that use this module won't fail when updating to 2.10.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
azure_rm_publicipaddress