### PR TITLE
Cap pytest version to avoid relative import issue.

### DIFF
--- a/changelogs/fragments/ansible-test-pytest-cap.yml
+++ b/changelogs/fragments/ansible-test-pytest-cap.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Add ``pytest < 6.0.0`` constraint for managed installations on Python 3.x to avoid issues with relative imports.

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -17,6 +17,7 @@ idna < 2.6, >= 2.5 # linode requires idna < 2.9, >= 2.5, requests requires idna 
 paramiko < 2.4.0 ; python_version < '2.7' # paramiko 2.4.0 drops support for python 2.6
 pytest < 3.3.0 ; python_version < '2.7' # pytest 3.3.0 drops support for python 2.6
 pytest < 5.0.0 ; python_version == '2.7' # pytest 5.0.0 and later will no longer support python 2.7
+pytest < 6.0.0 ; python_version > '2.7' # pytest 6.0.0 and later have issues with relative imports (further investigation required)
 pytest-forked < 1.0.2 ; python_version < '2.7' # pytest-forked 1.0.2 and later require python 2.7 or later
 pytest-forked >= 1.0.2 ; python_version >= '2.7' # pytest-forked before 1.0.2 does not work with pytest 4.2.0+ (which requires python 2.7+)
 ntlm-auth >= 1.3.0 # message encryption support using cryptography


### PR DESCRIPTION
##### SUMMARY

Cap pytest version to avoid relative import issue.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

The latest pytest 6.0.0 release has issues with some relative imports. One such example:

https://app.shippable.com/github/ansible/ansible/runs/171330/19/console

Further investigation is needed to understand why it's breaking. In the meantime the updated constraint avoids the issue.