### PR TITLE
ansible-galaxy - fix fallback for AH searches

### DIFF
--- a/changelogs/fragments/galaxy-collection-fallback.yml
+++ b/changelogs/fragments/galaxy-collection-fallback.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-galaxy collection install - fix fallback mechanism if the AH server did not have the collection requested - https://github.com/ansible/ansible/issues/70940

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -525,11 +525,17 @@ class CollectionRequirement:
                 else:
                     versions = api.get_collection_versions(namespace, name)
             except GalaxyError as err:
-                if err.http_code == 404:
-                    display.vvv("Collection '%s' is not available from server %s %s"
-                                % (collection, api.name, api.api_server))
-                    continue
-                raise
+                if err.http_code != 404:
+                    raise
+
+                versions = []
+
+            # Automation Hub doesn't return a 404 but an empty version list so we check that to align both AH and
+            # Galaxy when the collection is not available on that server.
+            if not versions:
+                display.vvv("Collection '%s' is not available from server %s %s" % (collection, api.name,
+                                                                                    api.api_server))
+                continue
 
             display.vvv("Collection '%s' obtained from server %s %s" % (collection, api.name, api.api_server))
             break

--- a/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
@@ -104,6 +104,24 @@
     server: '{{ pulp_v3_server }}'
     v3: true
 
+# fake.fake does not exist but we check the output to ensure it checked all 3
+# servers defined in the config. We hardcode to -vvv as that's what level the
+# message is shown
+- name: test install fallback on server list
+  command: ansible-galaxy collection install fake.fake -vvv
+  ignore_errors: yes
+  environment:
+    ANSIBLE_CONFIG: '{{ galaxy_dir }}/ansible.cfg'
+  register: missing_fallback
+
+- name: assert test install fallback on server list
+  assert:
+    that:
+    - missing_fallback.rc == 1
+    - '"Collection ''fake.fake'' is not available from server pulp_v2" in missing_fallback.stdout'
+    - '"Collection ''fake.fake'' is not available from server pulp_v3" in missing_fallback.stdout'
+    - '"Collection ''fake.fake'' is not available from server galaxy_ng" in missing_fallback.stdout'
+
 - name: run ansible-galaxy collection download tests
   include_tasks: download.yml
   args:


### PR DESCRIPTION
##### SUMMARY
AH or Galaxy NG does not return a 404 when searching for a collection version listing if the collection does not exist. The fallback mechanism relied on this error code to determine whether to check the next server or not. This PR will treat an empty version list returned from the server as no collection present. This may not be required if AH will change the behaviour to match galaxy.ansible.com, those discussions are happening.

The existing 404 check is still present as galaxy.ansible.com will return a 404 in case the collection does not exist.

Fixes https://github.com/ansible/ansible/issues/70940

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy