### PR TITLE
[stable-2.8] Cap pytest version to avoid relative import issue.

### DIFF
--- a/changelogs/fragments/ansible-test-pytest-cap.yml
+++ b/changelogs/fragments/ansible-test-pytest-cap.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Add ``pytest < 6.0.0`` constraint for managed installations on Python 3.x to avoid issues with relative imports.

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -17,6 +17,7 @@ paramiko < 2.4.0 ; python_version < '2.7' # paramiko 2.4.0 drops support for pyt
 paramiko < 2.5.0 ; python_version >= '2.7' # paramiko 2.5.0 requires cryptography 2.5.0+
 pytest < 3.3.0 ; python_version < '2.7' # pytest 3.3.0 drops support for python 2.6
 pytest < 5.0.0 ; python_version == '2.7' # pytest 5.0.0 and later will no longer support python 2.7
+pytest < 6.0.0 ; python_version > '2.7' # pytest 6.0.0 and later have issues with relative imports (further investigation required)
 pytest-forked < 1.0.2 ; python_version < '2.7' # pytest-forked 1.0.2 and later require python 2.7 or later
 pytest-forked >= 1.0.2 ; python_version >= '2.7' # pytest-forked before 1.0.2 does not work with pytest 4.2.0+ (which requires python 2.7+)
 ntlm-auth >= 1.0.6 # message encryption support


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/70955

(cherry picked from commit 3a8ac62596f2698f768450ab1cd189eca442bd77)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
