### PR TITLE
fix collection package root location under pytest >=6.0.0

### DIFF
--- a/changelogs/fragments/ansible-test-pytest-cap-revert.yml
+++ b/changelogs/fragments/ansible-test-pytest-cap-revert.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Remove ``pytest < 6.0.0`` constraint for managed installations on Python 3.x now that pytest 6 is supported.

--- a/changelogs/fragments/pytest-collections-fix.yml
+++ b/changelogs/fragments/pytest-collections-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test units - fixed collection location code to work under pytest >= 6.0.0

--- a/test/lib/ansible_test/_data/pytest/plugins/ansible_pytest_collections.py
+++ b/test/lib/ansible_test/_data/pytest/plugins/ansible_pytest_collections.py
@@ -3,7 +3,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-import sys
 
 # set by ansible-test to a single directory, rather than a list of directories as supported by Ansible itself
 ANSIBLE_COLLECTIONS_PATH = os.path.join(os.environ['ANSIBLE_COLLECTIONS_PATH'], 'ansible_collections')
@@ -38,13 +37,16 @@ def pytest_configure():
     except AttributeError:
         pytest_configure.executed = True
 
+    # noinspection PyProtectedMember
     from ansible.utils.collection_loader._collection_finder import _AnsibleCollectionFinder
 
     # allow unit tests to import code from collections
 
+    # noinspection PyProtectedMember
     _AnsibleCollectionFinder(paths=[os.path.dirname(ANSIBLE_COLLECTIONS_PATH)])._install()  # pylint: disable=protected-access
 
     try:
+        # noinspection PyProtectedMember
         from _pytest import pathlib as _pytest_pathlib
     except ImportError:
         _pytest_pathlib = None

--- a/test/lib/ansible_test/_data/pytest/plugins/ansible_pytest_collections.py
+++ b/test/lib/ansible_test/_data/pytest/plugins/ansible_pytest_collections.py
@@ -16,7 +16,7 @@ def collection_resolve_package_path(path):
         if str(parent) == ANSIBLE_COLLECTIONS_PATH:
             return parent
 
-    raise Exception('File "%s" not found in collection path "%s".' % (str(path), ANSIBLE_COLLECTIONS_PATH))
+    raise Exception('File "%s" not found in collection path "%s".' % (path, ANSIBLE_COLLECTIONS_PATH))
 
 
 # this monkeypatch to py.path.local.LocalPath.pypkgpath fixes PEP420 resolution for collections in pytest < 6.0.0

--- a/test/lib/ansible_test/_data/pytest/plugins/ansible_pytest_collections.py
+++ b/test/lib/ansible_test/_data/pytest/plugins/ansible_pytest_collections.py
@@ -9,6 +9,18 @@ import sys
 ANSIBLE_COLLECTIONS_PATH = os.path.join(os.environ['ANSIBLE_COLLECTIONS_PATH'], 'ansible_collections')
 
 
+# this monkeypatch to _pytest.pathlib.resolve_package_path fixes PEP420 resolution for collections in pytest >= 6.0.0
+# NB: this code should never run under py2
+def collection_resolve_package_path(path):
+    """Configure the Python package path so that pytest can find our collections."""
+    for parent in path.parents:
+        if str(parent) == ANSIBLE_COLLECTIONS_PATH:
+            return parent
+
+    raise Exception('File "%s" not found in collection path "%s".' % (str(path), ANSIBLE_COLLECTIONS_PATH))
+
+
+# this monkeypatch to py.path.local.LocalPath.pypkgpath fixes PEP420 resolution for collections in pytest < 6.0.0
 def collection_pypkgpath(self):
     """Configure the Python package path so that pytest can find our collections."""
     for parent in self.parts(reverse=True):
@@ -32,13 +44,18 @@ def pytest_configure():
 
     _AnsibleCollectionFinder(paths=[os.path.dirname(ANSIBLE_COLLECTIONS_PATH)])._install()  # pylint: disable=protected-access
 
-    # noinspection PyProtectedMember
-    import py._path.local
+    import _pytest.pathlib
+    if hasattr(_pytest.pathlib, 'resolve_package_path'):
+        _pytest.pathlib.resolve_package_path = collection_resolve_package_path
+    else:
+        # looks like pytest <= 6.0.0, use the old hack against py.path
+        # noinspection PyProtectedMember
+        import py._path.local
 
-    # force collections unit tests to be loaded with the ansible_collections namespace
-    # original idea from https://stackoverflow.com/questions/50174130/how-do-i-pytest-a-project-using-pep-420-namespace-packages/50175552#50175552
-    # noinspection PyProtectedMember
-    py._path.local.LocalPath.pypkgpath = collection_pypkgpath  # pylint: disable=protected-access
+        # force collections unit tests to be loaded with the ansible_collections namespace
+        # original idea from https://stackoverflow.com/questions/50174130/how-do-i-pytest-a-project-using-pep-420-namespace-packages/50175552#50175552
+        # noinspection PyProtectedMember
+        py._path.local.LocalPath.pypkgpath = collection_pypkgpath  # pylint: disable=protected-access
 
 
 pytest_configure()

--- a/test/lib/ansible_test/_data/pytest/plugins/ansible_pytest_collections.py
+++ b/test/lib/ansible_test/_data/pytest/plugins/ansible_pytest_collections.py
@@ -44,9 +44,13 @@ def pytest_configure():
 
     _AnsibleCollectionFinder(paths=[os.path.dirname(ANSIBLE_COLLECTIONS_PATH)])._install()  # pylint: disable=protected-access
 
-    import _pytest.pathlib
-    if hasattr(_pytest.pathlib, 'resolve_package_path'):
-        _pytest.pathlib.resolve_package_path = collection_resolve_package_path
+    try:
+        from _pytest import pathlib as _pytest_pathlib
+    except ImportError:
+        _pytest_pathlib = None
+
+    if hasattr(_pytest_pathlib, 'resolve_package_path'):
+        _pytest_pathlib.resolve_package_path = collection_resolve_package_path
     else:
         # looks like pytest <= 6.0.0, use the old hack against py.path
         # noinspection PyProtectedMember

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -17,7 +17,6 @@ idna < 2.6, >= 2.5 # linode requires idna < 2.9, >= 2.5, requests requires idna 
 paramiko < 2.4.0 ; python_version < '2.7' # paramiko 2.4.0 drops support for python 2.6
 pytest < 3.3.0 ; python_version < '2.7' # pytest 3.3.0 drops support for python 2.6
 pytest < 5.0.0 ; python_version == '2.7' # pytest 5.0.0 and later will no longer support python 2.7
-pytest < 6.0.0 ; python_version > '2.7' # pytest 6.0.0 and later have issues with relative imports (further investigation required)
 pytest-forked < 1.0.2 ; python_version < '2.7' # pytest-forked 1.0.2 and later require python 2.7 or later
 pytest-forked >= 1.0.2 ; python_version >= '2.7' # pytest-forked before 1.0.2 does not work with pytest 4.2.0+ (which requires python 2.7+)
 ntlm-auth >= 1.3.0 # message encryption support using cryptography


### PR DESCRIPTION
##### SUMMARY
pytest 6.0.0 changed the test location impl to no longer use `pyimport` from `py.path`, so we had to adjust our pytest plugin's monkeypatch to detect that and patch the new function. Longer term, we might want to work with `pytest` to see if we can get a couple of changes made to `--import-mode=importlib` to work with the collection loader (or convert the collection loader to a new-style loader once we don't have py2 controller).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
