### PR TITLE
Make cache adjudicator's flush call plugin flush

### DIFF
--- a/changelogs/fragments/68770_cache_adjudicator_flush.yml
+++ b/changelogs/fragments/68770_cache_adjudicator_flush.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - The ``flush()`` method of ``CachePluginAdjudicator`` now calls the plugin's ``flush()`` method instead of iterating over the keys that the adjudicator knows about and deleting those from the cache. (https://github.com/ansible/ansible/issues/68770)

--- a/docs/docsite/rst/dev_guide/developing_inventory.rst
+++ b/docs/docsite/rst/dev_guide/developing_inventory.rst
@@ -274,7 +274,7 @@ After the ``parse`` method is complete, the contents of ``self._cache`` is used 
 You have three other cache methods available:
   - ``set_cache_plugin`` forces the cache plugin to be set with the contents of ``self._cache`` before the ``parse`` method completes
   - ``update_cache_if_changed`` sets the cache plugin only if ``self._cache`` has been modified before the ``parse`` method completes
-  - ``clear_cache`` deletes the keys in ``self._cache`` from your cache plugin
+  - ``clear_cache`` flushes the cache, ultimately by calling the cache plugin's ``flush()`` method, whose implementation is dependent upon the particular cache plugin in use. Note that if the user is using the same cache backend for facts and inventory, both will get flushed. To avoid this, the user can specify a distinct cache backend in their inventory plugin configuration.
 
 .. _inventory_source_common_format:
 

--- a/docs/docsite/rst/porting_guides/porting_guide_base_2.11.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_base_2.11.rst
@@ -137,8 +137,7 @@ Noteworthy module changes
 Plugins
 =======
 
-No notable changes
-
+* inventory plugins - ``CachePluginAdjudicator.flush()`` now calls the underlying cache plugin's ``flush()`` instead of only deleting keys that it knows about. Inventory plugins should use ``delete()`` to remove any specific keys. As a user, this means that when an inventory plugin calls its ``clear_cache()`` method, facts could also be flushed from the cache. To work around this, users can configure inventory plugins to use a cache backend that is independent of the facts cache.
 
 Porting custom scripts
 ======================

--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -368,8 +368,7 @@ class CachePluginAdjudicator(MutableMapping):
         self._cache[key] = value
 
     def flush(self):
-        for key in self._cache.keys():
-            self._plugin.delete(key)
+        self._plugin.flush()
         self._cache = {}
 
     def update(self, value):


### PR DESCRIPTION

##### SUMMARY

Change:
- Previously CachePluginAdjudicator#flush only removed entries from the
  cache backend that it knew about by using them earlier. Now it calls
  the underlying plugin's flush() method.

Test Plan:
- New unit tests

Tickets:
- Fixes #68770

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

cache