### PR TITLE
[Backport/2.10/70228] default_callback: Move 'check_mode_markers' in doc_fragments (#70228)

### DIFF
--- a/changelogs/fragments/565_default_callback.yml
+++ b/changelogs/fragments/565_default_callback.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- default_callback - moving 'check_mode_markers' documentation in default_callback doc_fragment (https://github.com/ansible-collections/community.general/issues/565).

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -16,25 +16,7 @@ DOCUMENTATION = '''
       - default_callback
     requirements:
       - set as stdout in configuration
-    options:
-      check_mode_markers:
-        name: Show markers when running in check mode
-        description:
-        - "Toggle to control displaying markers when running in check mode. The markers are C(DRY RUN)
-        at the beggining and ending of playbook execution (when calling C(ansible-playbook --check))
-        and C(CHECK MODE) as a suffix at every play and task that is run in check mode."
-        type: bool
-        default: no
-        version_added: 2.9
-        env:
-          - name: ANSIBLE_CHECK_MODE_MARKERS
-        ini:
-          - key: check_mode_markers
-            section: defaults
 '''
-
-# NOTE: check_mode_markers functionality is also implemented in the following derived plugins:
-#       debug.py, yaml.py, dense.py. Maybe their documentation needs updating, too.
 
 
 from ansible import constants as C

--- a/lib/ansible/plugins/doc_fragments/default_callback.py
+++ b/lib/ansible/plugins/doc_fragments/default_callback.py
@@ -68,4 +68,18 @@ class ModuleDocFragment(object):
           - key: show_per_host_start
             section: defaults
         version_added: '2.9'
+      check_mode_markers:
+        name: Show markers when running in check mode
+        description:
+        - Toggle to control displaying markers when running in check mode.
+        - "The markers are C(DRY RUN) at the beggining and ending of playbook execution (when calling C(ansible-playbook --check))
+        and C(CHECK MODE) as a suffix at every play and task that is run in check mode."
+        type: bool
+        default: no
+        version_added: '2.9'
+        env:
+          - name: ANSIBLE_CHECK_MODE_MARKERS
+        ini:
+          - key: check_mode_markers
+            section: defaults
 '''


### PR DESCRIPTION
Callback plugin dense, yaml, and debug implement 'check_mode_markers'
so moving documentation to default callback doc_fragments.

Fixes: https://github.com/ansible-collections/community.general/issues/565

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit 4885ebad270cbdac34fdf5df7438a73a7a515d52)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
backport for: #70228
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
