### PR TITLE
Fix unstable unarchive test

### DIFF
--- a/test/integration/targets/unarchive/tasks/prepare_tests.yml
+++ b/test/integration/targets/unarchive/tasks/prepare_tests.yml
@@ -10,6 +10,7 @@
   copy:
     src: foo.txt
     dest: "{{remote_tmp_dir}}/foo-unarchive.txt"
+    mode: preserve
 
 - name: prep a tar file
   shell: tar cvf test-unarchive.tar foo-unarchive.txt chdir={{remote_tmp_dir}}
@@ -27,6 +28,7 @@
   copy:
     src: foo.txt
     dest: '{{remote_tmp_dir}}/FOO-UNAR.TXT'
+    mode: preserve
 
 # This gets around an unzip timestamp bug in some distributions
 # Recent unzip on Ubuntu and BSD will randomly round some timestamps up.
@@ -84,6 +86,7 @@
   copy:
     src: foo.txt
     dest: '{{remote_tmp_dir}}/unarchive-dir/foo-unarchive.txt'
+    mode: preserve
 
 - name: prep a tar.gz file with directory
   shell: tar czvf test-unarchive-dir.tar.gz unarchive-dir  chdir={{remote_tmp_dir}}

--- a/test/integration/targets/unarchive/tasks/test_tar_gz_keep_newer.yml
+++ b/test/integration/targets/unarchive/tasks/test_tar_gz_keep_newer.yml
@@ -7,6 +7,7 @@
   copy:
     dest: "{{remote_tmp_dir}}/test-unarchive-tar-gz/foo-unarchive.txt"
     content: boo
+    mode: preserve
 
 - name: unarchive a tar.gz file but avoid overwriting newer files (keep_newer=true)
   unarchive:

--- a/test/integration/targets/unarchive/tasks/test_unprivileged_user.yml
+++ b/test/integration/targets/unarchive/tasks/test_unprivileged_user.yml
@@ -16,6 +16,7 @@
       copy:
         src: foo.txt
         dest: "{{ user.home }}/foo-unarchive.txt"
+        mode: preserve
 
     - name: Prep a zip file as unarchivetest1 user
       shell: zip unarchivetest1-unarchive.zip foo-unarchive.txt

--- a/test/integration/targets/unarchive/tasks/test_unprivileged_user.yml
+++ b/test/integration/targets/unarchive/tasks/test_unprivileged_user.yml
@@ -37,21 +37,20 @@
         list_files: True
       register: unarchive10
 
-    - name: verify that the file was marked as changed
+    - name: stat the unarchived file
+      stat:
+        path: "{{ user.home }}/unarchivetest1-unarchive-zip/foo-unarchive.txt"
+      register: archive_path
+
+    - name: verify that the tasks performed as expected
       assert:
         that:
-          - "unarchive10.changed == true"
+          - unarchive10 is changed
           # Verify that file list is generated
           - "'files' in unarchive10"
           - "{{unarchive10['files']| length}} == 1"
           - "'foo-unarchive.txt' in unarchive10['files']"
-
-    - name: verify that the file was unarchived
-      file:
-        path: "{{ user.home }}/unarchivetest1-unarchive-zip/{{ item }}"
-        state: file
-      loop:
-        - foo-unarchive.txt
+          - archive_path.stat.exists
 
     - name: repeat the last request to verify no changes
       unarchive:
@@ -61,10 +60,15 @@
         list_files: True
       register: unarchive10b
 
-    - name: verify that the task was not marked as changed
+    # Due to a bug in the date calculation used to determine if a change
+    # was made or not, this check is unreliable. This seems to only happen on
+    # Ubuntu 1604.
+    # https://github.com/ansible/ansible/blob/58145dff9ca1a713f8ed295a0076779a91c41cba/lib/ansible/modules/unarchive.py#L472-L474
+    - name: Check that unarchiving again reports no change
       assert:
         that:
-          - "unarchive10b.changed == false"
+          - unarchive10b is not changed
+      ignore_errors: yes
 
   always:
     - name: remove our unarchivetest1 user and files


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There is a bug in the time calculation used to determine if a change was made or not. This results in the task reporting changed when it should not, and the test failing. This seems to only happen on Ubuntu1604, but it is documented in the code.

https://github.com/ansible/ansible/blob/58145dff9ca1a713f8ed295a0076779a91c41cba/lib/ansible/modules/unarchive.py#L472-L474

Add `mode` to copy tasks to preserve the existing file mode.

These tests were added in #65666.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/unarchive`