### PR TITLE
ansible-galaxy - fix download for subdirs in SCM

### DIFF
--- a/changelogs/fragments/galaxy-download-scm.yaml
+++ b/changelogs/fragments/galaxy-download-scm.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-galaxy download - fix bug when downloading a collection in a SCM subdirectory

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -616,10 +616,9 @@ def download_collections(collections, output_path, apis, validate_certs, no_deps
                     shutil.copy(requirement.b_path, to_bytes(dest_path, errors='surrogate_or_strict'))
                 elif requirement.api is None and requirement.b_path:
                     temp_path = to_text(b_temp_path, errors='surrogate_or_string')
-                    scm_build_path = os.path.join(temp_path, 'tmp_build-%s' % collection_filename)
-                    os.makedirs(to_bytes(scm_build_path, errors='surrogate_or_strict'), mode=0o0755)
-                    temp_download_path = build_collection(os.path.join(temp_path, name), scm_build_path, True)
-                    shutil.move(to_bytes(temp_download_path, errors='surrogate_or_strict'), to_bytes(dest_path, errors='surrogate_or_strict'))
+                    temp_download_path = build_collection(requirement.b_path, temp_path, True)
+                    shutil.move(to_bytes(temp_download_path, errors='surrogate_or_strict'),
+                                to_bytes(dest_path, errors='surrogate_or_strict'))
                 else:
                     b_temp_download_path = requirement.download(b_temp_path)
                     shutil.move(b_temp_download_path, to_bytes(dest_path, errors='surrogate_or_strict'))

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/download.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/download.yml
@@ -4,20 +4,30 @@
     state: directory
 
 - name: download a git repository
-  command: 'ansible-galaxy collection download git+https://github.com/ansible-collections/amazon.aws.git,37875c5b4ba5bf3cc43e07edf29f3432fd76def5'
+  command: >
+    ansible-galaxy collection download
+    git+https://github.com/ansible-collections/amazon.aws.git,37875c5b4ba5bf3cc43e07edf29f3432fd76def5
+    git+https://github.com/AlanCoding/awx.git#awx_collection,750c22a150d04eef1cb625fd4f83cce57949416c
   args:
     chdir: '{{ galaxy_dir }}/download'
   register: download_collection
 
-- name: check that the file was downloaded
+- name: check that the amazon.aws collection was downloaded
   stat:
     path: '{{ galaxy_dir }}/download/collections/amazon-aws-1.0.0.tar.gz'
-  register: download_collection_actual
+  register: download_collection_amazon_actual
+
+- name: check that the awx.awx collection was downloaded
+  stat:
+    path: '{{ galaxy_dir }}/download/collections/awx-awx-0.0.1-devel.tar.gz'
+  register: download_collection_awx_actual
 
 - assert:
     that:
       - '"Downloading collection ''amazon.aws'' to" in download_collection.stdout'
-      - download_collection_actual.stat.exists
+      - '"Downloading collection ''awx.awx'' to" in download_collection.stdout'
+      - download_collection_amazon_actual.stat.exists
+      - download_collection_awx_actual.stat.exists
 
 - name: test the downloaded repository can be installed
   command: 'ansible-galaxy collection install -r requirements.yml'
@@ -31,6 +41,7 @@
 - assert:
     that:
       - "'amazon.aws' in installed_collections.stdout"
+      - "'awx.awx' in installed_collections.stdout"
 
 - include_tasks: ./empty_installed_collections.yml
   when: cleanup


### PR DESCRIPTION
##### SUMMARY
The logic to handle downloading collections that have a specific subdir fails because the path used when building the downloaded SCM was incorrect.

Fixes https://github.com/ansible/ansible/issues/70429

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy