### PR TITLE
2.9: Emit proper error for `x in y` when y is undefined (#70990)

### DIFF
--- a/changelogs/fragments/70984-templating-ansibleundefined-in-operator.yml
+++ b/changelogs/fragments/70984-templating-ansibleundefined-in-operator.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - templating - fix error message for ``x in y`` when y is undefined (https://github.com/ansible/ansible/issues/70984)

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -244,6 +244,10 @@ class AnsibleUndefined(StrictUndefined):
     def __repr__(self):
         return 'AnsibleUndefined'
 
+    def __contains__(self, item):
+        # Return original Undefined object to preserve the first failure context
+        return self
+
 
 class AnsibleContext(Context):
     '''

--- a/test/integration/targets/template/tasks/main.yml
+++ b/test/integration/targets/template/tasks/main.yml
@@ -706,5 +706,14 @@
         - 'diff_result.stdout == ""'
         - "diff_result.rc == 0"
 
+- debug:
+    msg: "{{ 'x' in y }}"
+  ignore_errors: yes
+  register: error
+
+- name: check that proper error message is emitted when in operator is used
+  assert:
+    that: "\"'y' is undefined\" in error.msg"
+
 # aliases file requires root for template tests so this should be safe
 - include: backup_test.yml


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/70990
(cherry picked from commit bf7276a4e88de6e102ad06aa1d0716ae799d87ea)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/template/__init__.py`