### PR TITLE
2.9.11 localstack bug

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -351,16 +351,16 @@ def ec2_connect(module):
 
     region, ec2_url, boto_params = get_aws_connection_info(module)
 
-    # If we have a region specified, connect to its endpoint.
-    if region:
-        try:
-            ec2 = connect_to_aws(boto.ec2, region, **boto_params)
-        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError, boto.provider.ProfileNotFoundError) as e:
-            module.fail_json(msg=str(e))
-    # Otherwise, no region so we fallback to the old connection method
-    elif ec2_url:
+    # If ec2_url is present use it
+    if ec2_url:
         try:
             ec2 = boto.connect_ec2_endpoint(ec2_url, **boto_params)
+        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError, boto.provider.ProfileNotFoundError) as e:
+            module.fail_json(msg=str(e))
+    # Otherwise, if we have a region specified, connect to its endpoint.
+    elif region:
+        try:
+            ec2 = connect_to_aws(boto.ec2, region, **boto_params)
         except (boto.exception.NoAuthHandlerFound, AnsibleAWSError, boto.provider.ProfileNotFoundError) as e:
             module.fail_json(msg=str(e))
     else:


### PR DESCRIPTION
If we use localstack (AWS local-dev stack) we overwrite aws_url.
Until now if region has been specified, the aws_url was ignored.
Now aws_url will have precedence over region

##### SUMMARY
I was trying to work with localstack, but I have noticed that presence of region overwrites my localstack URL, so this is my proposal to fix it

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_instance


