### PR TITLE
Strip spaces in module names in explicit actions

### DIFF
--- a/changelogs/fragments/62136_strip_spaces_from_action_names.yml
+++ b/changelogs/fragments/62136_strip_spaces_from_action_names.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - task parsing - strip spaces from action name when using ``action: foo bar=baz`` form. (https://github.com/ansible/ansible/issues/62136)
+  - "task parsing - strip spaces from action name when using ``action: foo bar=baz`` form. (https://github.com/ansible/ansible/issues/62136)"

--- a/changelogs/fragments/62136_strip_spaces_from_action_names.yml
+++ b/changelogs/fragments/62136_strip_spaces_from_action_names.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - task parsing - strip spaces from action name when using ``action: foo bar=baz`` form. (https://github.com/ansible/ansible/issues/62136)

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -131,9 +131,9 @@ class ModuleArgsParser:
 
         tokens = split_args(module_string)
         if len(tokens) > 1:
-            return (tokens[0], " ".join(tokens[1:]))
+            return (tokens[0].strip(), " ".join(tokens[1:]))
         else:
-            return (tokens[0], "")
+            return (tokens[0].strip(), "")
 
     def _normalize_parameters(self, thing, action=None, additional_args=None):
         '''

--- a/test/integration/targets/parsing/roles/test_good_parsing/tasks/main.yml
+++ b/test/integration/targets/parsing/roles/test_good_parsing/tasks/main.yml
@@ -202,3 +202,16 @@
       - should_not_omit_1 is defined
       - should_not_omit_2 is defined
       - should_not_omit_3 == "__omit_place_holder__afb6b9bc3d20bfeaa00a1b23a5930f89"
+
+- name: Ensure module names are stripped of extra spaces (local_action)
+  local_action: set_fact     b="b"
+  register: la_set_fact_b
+
+- name: Ensure module names are stripped of extra spaces (action)
+  action: set_fact     c="c"
+  register: la_set_fact_c
+
+- assert:
+    that:
+      - b == "b"
+      - c == "c"


### PR DESCRIPTION
##### SUMMARY
Change:
- When an action is called like "action: copy foo=bar", strip spaces
  around the action name.
- This allows `action: copy                 foo=bar` to work as expected.

Test Plan:
- New integration tests

Tickets:
- Fixes #62136

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

parsing