### PR TITLE
Add intentional coverage for incidental_lvg

### DIFF
--- a/test/integration/targets/hardware_facts/aliases
+++ b/test/integration/targets/hardware_facts/aliases
@@ -1,0 +1,3 @@
+destructive
+needs/privileged
+shippable/posix/group/2

--- a/test/integration/targets/hardware_facts/aliases
+++ b/test/integration/targets/hardware_facts/aliases
@@ -1,3 +1,3 @@
 destructive
 needs/privileged
-shippable/posix/group/2
+shippable/posix/group2

--- a/test/integration/targets/hardware_facts/meta/main.yml
+++ b/test/integration/targets/hardware_facts/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_remote_tmp_dir

--- a/test/integration/targets/hardware_facts/tasks/Linux.yml
+++ b/test/integration/targets/hardware_facts/tasks/Linux.yml
@@ -1,0 +1,92 @@
+- name: Test LVM facts
+  block:
+    - name: Install lvm2
+      package:
+        name: lvm2
+        state: present
+      register: lvm_pkg
+
+    - name: Create files to use as a disk devices
+      command: "dd if=/dev/zero of={{ remote_tmp_dir }}/img{{ item }} bs=1M count=10"
+      with_sequence: 'count=2'
+
+    - name: Create loop device for file
+      command: "losetup --show -f {{ remote_tmp_dir }}/img{{ item }}"
+      with_sequence: 'count=2'
+      register: loop_devices
+
+    - name: Get loop names
+      set_fact:
+        loop_device1: "{{ loop_devices.results[0].stdout }}"
+        loop_device2: "{{ loop_devices.results[1].stdout }}"
+
+    - name: Create pvs
+      command: pvcreate {{ item }}
+      with_items:
+        - "{{ loop_device1 }}"
+        - "{{ loop_device2 }}"
+
+    - name: Create vg
+      command: vgcreate first {{ loop_device1 }}
+
+    - name: Create another vg
+      command: vgcreate second {{ loop_device2 }}
+
+    - name: Create lv
+      command: lvcreate -L 4M first --name one
+
+    - name: Create another lv
+      command: lvcreate -L 4M first --name two
+
+    - name: Create yet another lv
+      command: lvcreate -L 4M second --name uno
+
+    - name: Gather facts
+      setup:
+
+    - assert:
+        that:
+          - ansible_lvm.pvs[loop_device1].vg == 'first'
+          - ansible_lvm.pvs[loop_device2].vg == 'second'
+          - ansible_lvm.lvs.one.vg == 'first'
+          - ansible_lvm.lvs.two.vg == 'first'
+          - ansible_lvm.lvs.uno.vg == 'second'
+          - ansible_lvm.vgs.first.num_lvs == "2"
+          - ansible_lvm.vgs.second.num_lvs == "1"
+
+  always:
+    - name: remove lvs
+      shell: "lvremove /dev/{{ item }}/* -f"
+      with_items:
+        - first
+        - second
+
+    - name: remove vgs
+      command: "vgremove {{ item }}"
+      with_items:
+        - first
+        - second
+
+    - name: remove pvs
+      command: "pvremove {{ item }}"
+      with_items:
+        - "{{ loop_device1 }}"
+        - "{{ loop_device2 }}"
+
+    - name: Detach loop device
+      command: "losetup -d {{ item }}"
+      with_items:
+        - "{{ loop_device1 }}"
+        - "{{ loop_device2 }}"
+
+    - name: Remove device files
+      file:
+        path: "{{ remote_tmp_dir }}/img{{ item }}"
+        state: absent
+      with_sequence: 'count={{ loop_devices.results|length }}'
+
+    - name: Remove lvm-tools
+      package:
+        name: lvm2
+        state: absent
+      when: lvm_pkg is changed

--- a/test/integration/targets/hardware_facts/tasks/main.yml
+++ b/test/integration/targets/hardware_facts/tasks/main.yml
@@ -1,0 +1,2 @@
+- include_tasks: Linux.yml
+  when: ansible_system == 'Linux'


### PR DESCRIPTION

##### SUMMARY

Change:
- Add hardware_facts test target which manually sets up some LVM devices
  and tests facts against them.

Test Plan:
- New integration tests

Tickets:
- Refs #71041 and #71042 both of which I discovered during this

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME

tests