### PR TITLE
Intentional coverage, incidental_azure_rm_resource

### DIFF
--- a/test/integration/targets/plugin_loader/normal/library/_symlink.py
+++ b/test/integration/targets/plugin_loader/normal/library/_symlink.py
@@ -1,0 +1,1 @@
+_underscore.py

--- a/test/integration/targets/plugin_loader/normal/library/_underscore.py
+++ b/test/integration/targets/plugin_loader/normal/library/_underscore.py
@@ -1,0 +1,13 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+
+def main():
+    print(json.dumps(dict(changed=False, source='legacy_library_dir')))
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/plugin_loader/normal/underscore.yml
+++ b/test/integration/targets/plugin_loader/normal/underscore.yml
@@ -1,0 +1,15 @@
+- hosts: testhost
+  gather_facts: false
+  tasks:
+    - name: Load a deprecated module
+      underscore:
+      register: res
+
+    - name: Load a deprecated module that is a symlink
+      symlink:
+      register: sym
+
+    - assert:
+        that:
+          - res.source == 'legacy_library_dir'
+          - sym.source == 'legacy_library_dir'


### PR DESCRIPTION

##### SUMMARY

Change:
- Adds some intentional coverage around PluginLoader for cases that
  incidental_azure_rm_resource covered.
- Specifically, modules starting with an underscore, and starting with
  an underscore but a symlink.

Test Plan:
- CI

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME

tests