### PR TITLE
[stable-2.9] linux facts - return proper broadcast address (#64528)

### DIFF
--- a/changelogs/fragments/linux-network-facts-broadcast-address.yaml
+++ b/changelogs/fragments/linux-network-facts-broadcast-address.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - linux network facts - get the correct value for broadcast address (https://github.com/ansible/ansible/issues/64384)

--- a/lib/ansible/module_utils/facts/network/linux.py
+++ b/lib/ansible/module_utils/facts/network/linux.py
@@ -173,7 +173,8 @@ class LinuxNetwork(Network):
                         if '/' in words[1]:
                             address, netmask_length = words[1].split('/')
                             if len(words) > 3:
-                                broadcast = words[3]
+                                if words[2] == 'brd':
+                                    broadcast = words[3]
                         else:
                             # pointopoint interfaces do not have a prefix
                             address = words[1]

--- a/test/integration/targets/facts_linux_network/aliases
+++ b/test/integration/targets/facts_linux_network/aliases
@@ -1,0 +1,4 @@
+needs/privileged
+shippable/posix/group2
+skip/freebsd
+skip/osx

--- a/test/integration/targets/facts_linux_network/meta/main.yml
+++ b/test/integration/targets/facts_linux_network/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_tests

--- a/test/integration/targets/facts_linux_network/tasks/main.yml
+++ b/test/integration/targets/facts_linux_network/tasks/main.yml
@@ -1,0 +1,18 @@
+- block:
+    - name: Add IP to interface
+      command: ip address add 100.42.42.1/32 dev {{ ansible_facts.default_ipv4.interface }}
+      ignore_errors: yes
+
+    - name: Gather network facts
+      setup:
+        gather_subset: network
+
+    - name: Ensure broadcast is reported as empty
+      assert:
+        that:
+          - ansible_facts[ansible_facts['default_ipv4']['interface']]['ipv4_secondaries'][0]['broadcast'] == ''
+
+  always:
+    - name: Remove IP from interface
+      command: ip address delete 100.42.42.1/32 dev {{ ansible_facts.default_ipv4.interface }}
+      ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #64528 for Ansible 2.9
(cherry picked from commit e6bf202738)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/facts/network/linux.py`