### PR TITLE
Fix fortimanager httpapi redirect

### DIFF
--- a/changelogs/fragments/71073-fortimanager-httpapi-redirect.yml
+++ b/changelogs/fragments/71073-fortimanager-httpapi-redirect.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "fortimanager httpapi plugin - fix redirect to point to the ``fortinet.fortimanager`` collection (https://github.com/ansible/ansible/pull/71073)."

--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -9485,7 +9485,7 @@ plugin_routing:
     fortianalyzer:
       redirect: community.network.fortianalyzer
     fortimanager:
-      redirect: fortinet.fortios.fortimanager
+      redirect: fortinet.fortimanager.fortimanager
     ftd:
       redirect: community.network.ftd
     vmware:


### PR DESCRIPTION
##### SUMMARY
The fortimanager httpapi plugin is in fortinet.fortimanager, not in fortinet.fortios

CC @relrod @gundalow

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/config/ansible_builtin_runtime.yml
