### PR TITLE
Warning banner should only show on `/devel/` docs, not on pages with …

### DIFF
--- a/docs/docsite/_themes/sphinx_rtd_theme/ansible_banner.html
+++ b/docs/docsite/_themes/sphinx_rtd_theme/ansible_banner.html
@@ -1,5 +1,8 @@
 <!--- Based on sphinx versionwarning extension. Extension currently only works on READTHEDOCS -->
   <script>
+    startsWith = function(str, needle) {
+      return str.slice(0, needle.length) == needle
+    }
     // Create a banner if we're not on the official docs site
     if (location.host == "docs.testing.ansible.com") {
       document.write('<div id="testing_banner_id" class="admonition important">');
@@ -10,26 +13,27 @@
       element.appendChild(para);
       document.write('</div>');
     }
-
-    // Create a banner if we're not the latest version
-    current_url = window.location.href;
-    if ((current_url.search("latest") > -1) || (current_url.search("/{{ latest_version }}/") > -1)) {
-     // no banner for latest release
-    } else if (current_url.search("devel") > -1) {
-      document.write('<div id="banner_id" class="admonition caution">');
-      para = document.createElement('p');
-      banner_text=document.createTextNode("You are reading the *devel* version of the Ansible documentation - most module documentation is currently missing as the modules have moved to collections. Until docs catches up to this change, use the version selection to the left if you want module documentation or the latest stable release version. The *devel* version is not guaranteed stable.");
-      para.appendChild(banner_text);
-      element = document.getElementById('banner_id');
-      element.appendChild(para);
-      document.write('</div>');
-    } else {
-      document.write('<div id="banner_id" class="admonition caution">');
-      para = document.createElement('p');
-      banner_text=document.createTextNode("You are reading an older version of the Ansible documentation. Use the version selection to the left if you want the latest stable released version.");
-      para.appendChild(banner_text);
-      element = document.getElementById('banner_id');
-      element.appendChild(para);
-      document.write('</div>');
-    }
+    {% if (not READTHEDOCS) and (available_versions is defined) %}
+      // Create a banner if we're not the latest version
+      current_url_path = window.location.pathname;
+      if (startsWith(current_url_path, "/ansible/latest/") || startsWith(current_url_path, "/ansible/{{ latest_version }}/")) {
+       // no banner for latest release
+      } else if (startsWith(current_url_path, "/ansible/devel/")) {
+        document.write('<div id="banner_id" class="admonition caution">');
+        para = document.createElement('p');
+        banner_text=document.createTextNode("You are reading the *devel* version of the Ansible documentation - this version is not guaranteed stable. Use the version selection to the left if you want the latest stable released version.");
+        para.appendChild(banner_text);
+        element = document.getElementById('banner_id');
+        element.appendChild(para);
+        document.write('</div>');
+      } else {
+        document.write('<div id="banner_id" class="admonition caution">');
+        para = document.createElement('p');
+        banner_text=document.createTextNode("You are reading an older version of the Ansible documentation. Use the version selection to the left if you want the latest stable released version.");
+        para.appendChild(banner_text);
+        element = document.getElementById('banner_id');
+        element.appendChild(para);
+        document.write('</div>');
+      }
+    {% endif %}
   </script>


### PR DESCRIPTION
##### SUMMARY
Backport of #70849 - needs to be tested on all maintained versions.

The web server was adding the "this is the devel version" warning to any page with the letters devel in the URL. This PR adds more careful matching for the /devel/ version of the docs. The fix needs to be backported to all maintained versions of the documentation.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com