### PR TITLE
Fix ansible-test self-test change classification.

### DIFF
--- a/test/lib/ansible_test/_internal/classification.py
+++ b/test/lib/ansible_test/_internal/classification.py
@@ -769,26 +769,31 @@ class PathMapper:
         if path.startswith('test/lib/ansible_test/_internal/sanity/'):
             return {
                 'sanity': 'all',  # test infrastructure, run all sanity checks
+                'integration': 'ansible-test',  # run ansible-test self tests
             }
 
         if path.startswith('test/lib/ansible_test/_data/sanity/'):
             return {
                 'sanity': 'all',  # test infrastructure, run all sanity checks
+                'integration': 'ansible-test',  # run ansible-test self tests
             }
 
         if path.startswith('test/lib/ansible_test/_internal/units/'):
             return {
                 'units': 'all',  # test infrastructure, run all unit tests
+                'integration': 'ansible-test',  # run ansible-test self tests
             }
 
         if path.startswith('test/lib/ansible_test/_data/units/'):
             return {
                 'units': 'all',  # test infrastructure, run all unit tests
+                'integration': 'ansible-test',  # run ansible-test self tests
             }
 
         if path.startswith('test/lib/ansible_test/_data/pytest/'):
             return {
                 'units': 'all',  # test infrastructure, run all unit tests
+                'integration': 'ansible-test',  # run ansible-test self tests
             }
 
         if path.startswith('test/lib/ansible_test/_data/requirements/'):


### PR DESCRIPTION
##### SUMMARY

Changes to sanity and unit tests now trigger the ansible-test self-test integration tests.

No changelog entry since this only affects tests for ansible itself and not collections.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
