### PR TITLE
[2.9] Fix UnboundLocalError error for net_put

### DIFF
--- a/changelogs/fragments/net_put-unboundlocalerror.yaml
+++ b/changelogs/fragments/net_put-unboundlocalerror.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - net_put - Fixed UnboundLocalError when there is no change
+    This is a backport from U(https://github.com/ansible-collections/ansible.netcommon/pull/6)

--- a/lib/ansible/plugins/action/net_put.py
+++ b/lib/ansible/plugins/action/net_put.py
@@ -35,6 +35,7 @@ display = Display()
 class ActionModule(ActionBase):
 
     def run(self, tmp=None, task_vars=None):
+        changed = False
         socket_path = None
         network_os = self._get_network_os(task_vars).split('.')[-1]
         persistent_connection = self._play_context.connection.split('.')[-1]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
`changed` was undefined in the net_put action module. This fixes that oversight
Backported from https://github.com/ansible-collections/ansible.netcommon/pull/6

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
net_put