### PR TITLE
Support Zstd-compressed tar-archives in unarchive

### DIFF
--- a/changelogs/fragments/unarchive-support-zstd.yml
+++ b/changelogs/fragments/unarchive-support-zstd.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - unarchive - support zstd compressed archives

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -798,9 +798,16 @@ class TarXzArchive(TgzArchive):
         self.zipflag = '-J'
 
 
+# Class to handle zstd compressed tar files
+class TarZstdArchive(TgzArchive):
+    def __init__(self, src, b_dest, file_args, module):
+        super(TarZstdArchive, self).__init__(src, b_dest, file_args, module)
+        self.zipflag = '--zstd'
+
+
 # try handlers in order and return the one that works or bail if none work
 def pick_handler(src, dest, file_args, module):
-    handlers = [ZipArchive, TgzArchive, TarArchive, TarBzipArchive, TarXzArchive]
+    handlers = [ZipArchive, TgzArchive, TarArchive, TarBzipArchive, TarXzArchive, TarZstdArchive]
     reasons = set()
     for handler in handlers:
         obj = handler(src, dest, file_args, module)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

GNU tar 1.31 supports Zstd compressed archives with `--zstd`.
Add support to the `unarchive`-module to unarchive zstd compressed archives.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
unarchive

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
