### PR TITLE
Remove ANSIBLE_COLLECTIONS_PATHS dep warning

### DIFF
--- a/changelogs/fragments/galaxy_collections_paths-remove-dep.yml
+++ b/changelogs/fragments/galaxy_collections_paths-remove-dep.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ANSIBLE_COLLECTIONS_PATHS - remove deprecation so that users of Ansible 2.9 and 2.10+ can use the same var when specifying a collection path without a warning.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -233,20 +233,12 @@ COLLECTIONS_PATHS:
   default: ~/.ansible/collections:/usr/share/ansible/collections
   type: pathspec
   env:
-  - name: ANSIBLE_COLLECTIONS_PATHS
-    deprecated:
-      why: all PATH-type options are singular PATH
-      version: "2.14"
-      alternatives: the "ANSIBLE_COLLECTIONS_PATH" environment variable
+  - name: ANSIBLE_COLLECTIONS_PATHS  # TODO: Deprecate this and ini once PATH has been in a few releases.
   - name: ANSIBLE_COLLECTIONS_PATH
     version_added: '2.10'
   ini:
   - key: collections_paths
     section: defaults
-    deprecated:
-      why: all path-type options are singular path
-      version: "2.14"
-      alternatives: the "collections_path" ini setting
   - key: collections_path
     section: defaults
     version_added: '2.10'


### PR DESCRIPTION
##### SUMMARY
In Ansible 2.10 we added `ANSIBLE_COLLECTIONS_PATH` as the proper way of specifying a collection path and deprecated the plural form to conform to our usual standard of singular config options. Ultimately this means that for someone to support both 2.9 and 2.10 they need to use a config option that is deprecated and will output warnings saying not to.

This PR removes that deprecation for now and proposes it is added in the future once `ANSIBLE_COLLECTIONS_PATH` is supported in the oldest supported Ansible version or sometime close to that so they can be used in parallel.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ANSIBLE_COLLECTIONS_PATHS
