### PR TITLE
ipa module utils can not handle HA FreeIPA with Python3 #71110

### DIFF
--- a/changelogs/fragments/71112-ipa-python3.yml
+++ b/changelogs/fragments/71112-ipa-python3.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ipa_hostgroup - fix an issue with loadbalanced ipa and cookie handling with python3 - (https://github.com/ansible/ansible/issues/71110).
+   - ipa_hostgroup - fix an issue with load-balanced ipa and cookie handling with Python 3 - (https://github.com/ansible/ansible/issues/71110).

--- a/changelogs/fragments/71112-ipa-python3.yml
+++ b/changelogs/fragments/71112-ipa-python3.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ipa_hostgroup - fix an issue with loadbalanced ipa and cookie handling with python3 - (https://github.com/ansible/ansible/issues/71110).

--- a/lib/ansible/module_utils/ipa.py
+++ b/lib/ansible/module_utils/ipa.py
@@ -96,7 +96,7 @@ class IPAClient(object):
                 if status_code not in [200, 201, 204]:
                     self._fail('login', info['msg'])
 
-                self.headers = {'Cookie': info['set-cookie']}
+                self.headers = {'Cookie': info.get('set-cookie')}
             except Exception as e:
                 self._fail('login', to_native(e))
         if not self.headers:

--- a/lib/ansible/module_utils/ipa.py
+++ b/lib/ansible/module_utils/ipa.py
@@ -96,7 +96,7 @@ class IPAClient(object):
                 if status_code not in [200, 201, 204]:
                     self._fail('login', info['msg'])
 
-                self.headers = {'Cookie': resp.info().get('Set-Cookie')}
+                self.headers = {'Cookie': info['set-cookie']}
             except Exception as e:
                 self._fail('login', to_native(e))
         if not self.headers:


### PR DESCRIPTION

##### SUMMARY
Fixes #71110  and backport https://github.com/ansible-collections/community.general/issues/737 to stable-2.9

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ipa_hostgroup 
identity/ipa*
ipa*
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Please check the issue.
```
