### PR TITLE
BSD: use /proc/mounts instead of /etc/fstab while mount fact gathering

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/netbsd.py
+++ b/lib/ansible/module_utils/facts/hardware/netbsd.py
@@ -116,12 +116,9 @@ class NetBSDHardware(Hardware):
         mount_facts = {}
 
         mount_facts['mounts'] = []
-        fstab = get_file_content('/etc/fstab')
-
-        if not fstab:
+        if not os.access("/proc/mounts", os.R_OK):
             return mount_facts
-
-        for line in fstab.splitlines():
+        for line in get_file_lines("/proc/mounts"):
             if line.startswith('#') or line.strip() == '':
                 continue
             fields = re.sub(r'\s+', ' ', line).split()


### PR DESCRIPTION
##### SUMMARY
Use /proc/mounts instead of /etc/fstab to find current mounts. Helps to find ZFS mounts, which are usually not documented in fstab any more.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
NetBSD hardware facts module

##### ADDITIONAL INFORMATION
I am not a Python programmer, I merely copied and pasted the preceding code that already utilizes /proc.