### PR TITLE
[2.10] Fix changelog fragment type.

### DIFF
--- a/changelogs/fragments/67794-atomic_move-default-perms.yml
+++ b/changelogs/fragments/67794-atomic_move-default-perms.yml
@@ -1,4 +1,4 @@
-bugfixes:
+security_fixes:
   - >
     **security issue** atomic_move - change default permissions when creating
     temporary files so they are not world readable (https://github.com/ansible/ansible/issues/67794) (CVE-2020-1736)


### PR DESCRIPTION
##### SUMMARY
Backport of #70902 to stable-2.10. Fixes section of one changelog fragment.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/67794-atomic_move-default-perms.yml
