### PR TITLE
docs: 'ansible_play_hosts' lists active hosts, not limited by serial

### DIFF
--- a/docs/docsite/rst/reference_appendices/special_variables.rst
+++ b/docs/docsite/rst/reference_appendices/special_variables.rst
@@ -51,7 +51,7 @@ ansible_play_batch
     List of active hosts in the current play run limited by the serial, aka 'batch'. Failed/Unreachable hosts are not considered 'active'.
 
 ansible_play_hosts
-    The same as ansible_play_batch
+    List of hosts in the current play run, not limited by the serial. Failed/Unreachable hosts are included in this list.
 
 ansible_play_hosts_all
     List of all the hosts that were targeted by the play


### PR DESCRIPTION
##### SUMMARY

ansible_play_batch lists the currently targeted host(s) in the serial/batch, while
ansible_play_hosts lists all the hosts which will be targeted by the play.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

```
ansible 2.9.11
  config file = /Users/sklirg/Documents/git/project/ansible.cfg
  configured module search path = ['/Users/sklirg/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.9.11/libexec/lib/python3.8/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.8.5 (default, Jul 21 2020, 10:48:26) [Clang 11.0.3 (clang-1103.0.32.62)]
```

<!--- Paste verbatim command output below, e.g. before and after your change -->

The following inventory
```
[debug]
host1
host2
host3 # unreachable
```

in the following playbook

```yaml
---
- name: debug
  hosts: debug
  tasks:
    - name: ansible_play_batch
      debug:
        var: ansible_play_batch

    - name: ansible_play_hosts
      debug:
        var: ansible_play_hosts
  serial:
    - 1
```


```paste below
TASK [debug : ansible_play_batch] 
ok: [host1] => {
    "ansible_play_batch": [
        "host1"
    ]
}

TASK [debug : ansible_play_hosts] 
ok: [host1] => {
    "ansible_play_hosts": [
        "host1",
        "host2",
        "host3"
    ]
}
```

host2 has the same, just swapping in itself in the ansible_play_batch. 
host3 is unreachable and fails upon starting.