### PR TITLE
Only notify handlers for loop items that changed

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -603,7 +603,7 @@ class StrategyBase:
 
                 for result_item in result_items:
                     if '_ansible_notify' in result_item:
-                        if task_result.is_changed():
+                        if result_item.get('changed', False):
                             # The shared dictionary for notified handlers is a proxy, which
                             # does not detect when sub-objects within the proxy are modified.
                             # So, per the docs, we reassign the list so the proxy picks up and


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Using notify in a loop, where the handler names are templated with the
loop variable does not currently work - all matching handlers are
notified if any item in the loop is marked as changed. This does not
make sense, and is actively unhelpful.

This change notifies handlers only for loop items that have changed.

Fixes: #22579

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
base strategy plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
