### PR TITLE
[stable-2.10] Drop "rhui-" prefix from RHEL repositories in AMI (#71130)

### DIFF
--- a/test/integration/targets/incidental_setup_docker/tasks/RedHat-7.yml
+++ b/test/integration/targets/incidental_setup_docker/tasks/RedHat-7.yml
@@ -12,8 +12,8 @@
     name: setup_epel
 
 - name: Enable extras repository for RHEL on AWS
-  # RHEL 7.6 uses rhui-REGION-rhel-server-extras and RHEL 7.7+ use rhui-rhel-7-server-rhui-extras-rpms
-  command: yum-config-manager --enable rhui-REGION-rhel-server-extras rhui-rhel-7-server-rhui-extras-rpms
+  # RHEL 7.6 uses REGION-rhel-server-extras and RHEL 7.7+ use rhel-7-server-rhui-extras-rpms
+  command: yum-config-manager --enable REGION-rhel-server-extras rhel-7-server-rhui-extras-rpms
   args:
     warn: no
 

--- a/test/integration/targets/yum/tasks/yuminstallroot.yml
+++ b/test/integration/targets/yum/tasks/yuminstallroot.yml
@@ -78,8 +78,8 @@
   block:
     # Need to enable this RHUI repo for RHEL7 testing in AWS, CentOS has Extras
     # enabled by default and this is not needed there.
-    - name: enable rhui-rhel-7-server-rhui-extras-rpms repo for RHEL7
-      command: yum-config-manager --enable rhui-rhel-7-server-rhui-extras-rpms
+    - name: enable rhel-7-server-rhui-extras-rpms repo for RHEL7
+      command: yum-config-manager --enable rhel-7-server-rhui-extras-rpms
     - name: update cache to pull repodata
       yum:
         update_cache: yes
@@ -118,5 +118,5 @@
         state: absent
         name:
           - buildah
-    - name: disable rhui-rhel-7-server-rhui-extras-rpms repo for RHEL7
-      command: yum-config-manager --disable rhui-rhel-7-server-rhui-extras-rpms
+    - name: disable rhel-7-server-rhui-extras-rpms repo for RHEL7
+      command: yum-config-manager --disable rhel-7-server-rhui-extras-rpms


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #71130 for Ansible 2.10
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/incidental_setup_docker`
`test/integration/targets/yum`