### PR TITLE
[stable-2.9] Drop "rhui-" prefix from RHEL repositories in AMI (#71130)

### DIFF
--- a/test/integration/targets/setup_docker/tasks/RedHat-7.yml
+++ b/test/integration/targets/setup_docker/tasks/RedHat-7.yml
@@ -12,8 +12,8 @@
     name: setup_epel
 
 - name: Enable extras repository for RHEL on AWS
-  # RHEL 7.6 uses rhui-REGION-rhel-server-extras and RHEL 7.7+ use rhui-rhel-7-server-rhui-extras-rpms
-  command: yum-config-manager --enable rhui-REGION-rhel-server-extras rhui-rhel-7-server-rhui-extras-rpms
+  # RHEL 7.6 uses REGION-rhel-server-extras and RHEL 7.7+ use rhel-7-server-rhui-extras-rpms
+  command: yum-config-manager --enable REGION-rhel-server-extras rhel-7-server-rhui-extras-rpms
   args:
     warn: no
 

--- a/test/integration/targets/setup_podman/vars/main.yml
+++ b/test/integration/targets/setup_podman/vars/main.yml
@@ -1,4 +1,4 @@
 repo_command:
   RedHat7:
-    enable: yum-config-manager --enable rhui-REGION-rhel-server-extras rhui-rhel-7-server-rhui-extras-rpms
-    disable: yum-config-manager --disable rhui-REGION-rhel-server-extras rhui-rhel-7-server-rhui-extras-rpms
+    enable: yum-config-manager --enable REGION-rhel-server-extras rhui-rhel-7-server-rhui-extras-rpms
+    disable: yum-config-manager --disable REGION-rhel-server-extras rhui-rhel-7-server-rhui-extras-rpms


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #71130 for Ansible 2.9, plus some changes for tests that only exist in this branch.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/setup_docker`
`test/integration/targets/setup_podman`