### PR TITLE
Ensure -k is set to delegated hosts without a pass

### DIFF
--- a/changelogs/fragments/delegation_password.yml
+++ b/changelogs/fragments/delegation_password.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Ensure password passed in by -k is used on delegated hosts that do not have ansible_password set

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -507,7 +507,8 @@ class TaskExecutor:
 
         if self._task.delegate_to:
             # use vars from delegated host (which already include task vars) instead of original host
-            cvars = variables.get('ansible_delegated_vars', {}).get(self._task.delegate_to, {})
+            delegate_vars = variables.get('ansible_delegated_vars', {}).get(self._task.delegate_to, {})
+            cvars = combine_vars(variables, delegate_vars)
             orig_vars = templar.available_variables
         else:
             # just use normal host vars

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -928,7 +928,7 @@ class TaskExecutor:
             # now. This is something we ultimately want to avoid, but the first
             # step is to get connection plugins pulling the password through the
             # config system instead of directly accessing play_context.
-            task_keys['password'] = task_keys['remote_password'] = self._play_context.password
+            task_keys['password'] = self._play_context.password
 
         # set options with 'templated vars' specific to this plugin and dependent ones
         self._connection.set_options(task_keys=task_keys, var_options=options)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -507,8 +507,7 @@ class TaskExecutor:
 
         if self._task.delegate_to:
             # use vars from delegated host (which already include task vars) instead of original host
-            delegate_vars = variables.get('ansible_delegated_vars', {}).get(self._task.delegate_to, {})
-            cvars = combine_vars(variables, delegate_vars)
+            cvars = variables.get('ansible_delegated_vars', {}).get(self._task.delegate_to, {})
             orig_vars = templar.available_variables
         else:
             # just use normal host vars

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -929,7 +929,7 @@ class TaskExecutor:
             # now. This is something we ultimately want to avoid, but the first
             # step is to get connection plugins pulling the password through the
             # config system instead of directly accessing play_context.
-            task_keys['password'] = self._play_context.password
+            task_keys['password'] = task_keys['remote_password'] = self._play_context.password
 
         # set options with 'templated vars' specific to this plugin and dependent ones
         self._connection.set_options(task_keys=task_keys, var_options=options)

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -40,7 +40,7 @@ options:
     - name: ansible_winrm_pass
     - name: ansible_winrm_password
     aliases:
-    - password  # Needed for --ask-pass to come through on delegation  
+    - password  # Needed for --ask-pass to come through on delegation
   port:
     description:
     - The port for PSRP to connect on the remote target.

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -39,7 +39,7 @@ options:
     - name: ansible_password
     - name: ansible_winrm_pass
     - name: ansible_winrm_password
-    aliases: [ password ]
+    aliases: [ password ]  # Needed for --ask-pass to come through on delegation
   port:
     description:
     - The port for PSRP to connect on the remote target.

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -39,7 +39,8 @@ options:
     - name: ansible_password
     - name: ansible_winrm_pass
     - name: ansible_winrm_password
-    aliases: [ password ]  # Needed for --ask-pass to come through on delegation
+    aliases:
+    - password  # Needed for --ask-pass to come through on delegation  
   port:
     description:
     - The port for PSRP to connect on the remote target.

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -40,6 +40,7 @@ DOCUMENTATION = """
             - name: ansible_winrm_pass
             - name: ansible_winrm_password
         type: str
+        aliases: [ password ]  # Needed for --ask-pass to come through on delegation
       port:
         description:
             - port for winrm to connect on remote target

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -40,7 +40,8 @@ DOCUMENTATION = """
             - name: ansible_winrm_pass
             - name: ansible_winrm_password
         type: str
-        aliases: [ password ]  # Needed for --ask-pass to come through on delegation
+        aliases:
+        - password  # Needed for --ask-pass to come through on delegation
       port:
         description:
             - port for winrm to connect on remote target

--- a/test/integration/targets/connection_delegation/action_plugins/delegation_action.py
+++ b/test/integration/targets/connection_delegation/action_plugins/delegation_action.py
@@ -1,0 +1,12 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+        return {
+            'remote_password': self._connection.get_option('remote_password'),
+        }

--- a/test/integration/targets/connection_delegation/aliases
+++ b/test/integration/targets/connection_delegation/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group1

--- a/test/integration/targets/connection_delegation/aliases
+++ b/test/integration/targets/connection_delegation/aliases
@@ -1,1 +1,4 @@
 shippable/posix/group1
+skip/freebsd  # No sshpass
+skip/osx  # No sshpass
+skip/rhel  # No sshpass

--- a/test/integration/targets/connection_delegation/connection_plugins/delegation_connection.py
+++ b/test/integration/targets/connection_delegation/connection_plugins/delegation_connection.py
@@ -39,4 +39,4 @@ class Connection(ConnectionBase):
         super(Connection, self).fetch_file(in_path, out_path)
 
     def close(self):
-        super(Connection, sefl).close()
+        super(Connection, self).close()

--- a/test/integration/targets/connection_delegation/connection_plugins/delegation_connection.py
+++ b/test/integration/targets/connection_delegation/connection_plugins/delegation_connection.py
@@ -1,0 +1,42 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+author: Ansible Core Team
+connection: delegation_connection
+short_description: Test connection for delegated host check
+description:
+- Some further description that you don't care about.
+options:
+  remote_password:
+    description: The remote password
+    type: str
+    vars:
+    - name: ansible_password
+"""
+
+from ansible.plugins.connection import ConnectionBase
+
+
+class Connection(ConnectionBase):
+
+    transport = 'delegation_connection'
+    has_pipelining = True
+
+    def __init__(self, *args, **kwargs):
+        super(Connection, self).__init__(*args, **kwargs)
+
+    def _connect(self):
+        super(Connection, self)._connect()
+
+    def exec_command(self, cmd, in_data=None, sudoable=True):
+        super(Connection, self).exec_command(cmd, in_data, sudoable)
+
+    def put_file(self, in_path, out_path):
+        super(Connection, self).put_file(in_path, out_path)
+
+    def fetch_file(self, in_path, out_path):
+        super(Connection, self).fetch_file(in_path, out_path)
+
+    def close(self):
+        super(Connection, sefl).close()

--- a/test/integration/targets/connection_delegation/connection_plugins/delegation_connection.py
+++ b/test/integration/targets/connection_delegation/connection_plugins/delegation_connection.py
@@ -13,6 +13,9 @@ options:
     type: str
     vars:
     - name: ansible_password
+    # Tests that an aliased key gets the -k option which hardcodes the value to password
+    aliases:
+    - password
 """
 
 from ansible.plugins.connection import ConnectionBase

--- a/test/integration/targets/connection_delegation/inventory.ini
+++ b/test/integration/targets/connection_delegation/inventory.ini
@@ -1,0 +1,1 @@
+my_host  ansible_host=127.0.0.1 ansible_connection=delegation_connection

--- a/test/integration/targets/connection_delegation/runme.sh
+++ b/test/integration/targets/connection_delegation/runme.sh
@@ -2,4 +2,8 @@
 
 set -ux
 
+echo "Checking if sshpass is present"
+which sshpass 2>&1 || exit 0
+echo "sshpass is present, continuing with test"
+
 sshpass -p my_password ansible-playbook -i inventory.ini test.yml -k "$@"

--- a/test/integration/targets/connection_delegation/runme.sh
+++ b/test/integration/targets/connection_delegation/runme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -ux
+
+sshpass -p my_password ansible-playbook -i inventory.ini test.yml -k "$@"

--- a/test/integration/targets/connection_delegation/test.yml
+++ b/test/integration/targets/connection_delegation/test.yml
@@ -1,0 +1,23 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+  - name: test connection receives -k from play_context when delegating
+    delegation_action:
+    delegate_to: my_host
+    register: result
+
+  - assert:
+      that:
+      - result.remote_password == 'my_password'
+
+  - name: ensure vars set for that host take precedence over -k
+    delegation_action:
+    delegate_to: my_host
+    vars:
+      ansible_password: other_password
+    register: result
+
+  - assert:
+      that:
+      - result.remote_password == 'other_password'


### PR DESCRIPTION
##### SUMMARY
The change in https://github.com/ansible/ansible/pull/69244 stopped combining the original vars with the delegated host vars. This meant certain variables set by the play context on the host was not transferred to the delegated host, like `ansible_password`. This change reimplements the combining of connection vars to replicate the original behaviour.

Fixes https://github.com/ansible/ansible/issues/71103

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
task_executor