### PR TITLE
Fix version comparison for determining what ansible to build against

### DIFF
--- a/hacking/build_library/build_ansible/command_plugins/docs_build.py
+++ b/hacking/build_library/build_ansible/command_plugins/docs_build.py
@@ -77,6 +77,10 @@ def generate_full_docs(args):
 
     with TemporaryDirectory() as tmp_dir:
         sh.git(['clone', 'https://github.com/ansible-community/ansible-build-data'], _cwd=tmp_dir)
+        # This is wrong.  Once ansible and ansible-base major.minor versions get out of sync this
+        # will stop working.  We probably need to walk all subdirectories in reverse version order
+        # looking for the latest ansible version which uses something compatible with
+        # ansible_base_major_ver.
         deps_files = glob.glob(os.path.join(tmp_dir, 'ansible-build-data',
                                             ansible_base_major_ver, '*.deps'))
         if not deps_files:
@@ -88,7 +92,7 @@ def generate_full_docs(args):
         for filename in deps_files:
             with open(filename, 'r') as f:
                 deps_data = yaml.safe_load(f.read())
-            new_version = Version(deps_data['_ansible_base_version'])
+            new_version = Version(deps_data['_ansible_version'])
             if new_version > latest_ver:
                 latest_ver = new_version
                 latest = filename


### PR DESCRIPTION
* The version comparison for determining what ansible package to build
  docs against was comparing the version number for ansible-base but it
  needed to check the version number for ansible instead

* add a comment about some bad logic than needs to be fixed after 2.10.0

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

* hacking/build_library/build_ansible/command_plugins/docs_build.py

The build-ansible.py command which builds the documentation

##### ADDITIONAL INFORMATION
docs build is currently not building the community.general tests.  The reason is that the docs build has to find a file which has the set of collections which ansible-X.Y was built against.  But because of the bug fixed by this PR, the docs build script compares the versions of ansible-base which the file was built with, not the version of ansible.  That means, for ansible-2.10.0a7 and ansible-2.10.0a8 which were both built with ansible-base-2.10.0rc4, the docs build will choose the first file that it encounters (which is the older one because of the order they're returned from the filesystem).  This, in turn, means that the older versions of collections are downloaded and the docs built against those.  The version of community.general that is in that file did not contain symlinks to the modules so the modules weren't found by ansible-doc and therefore weren't documented.
