### PR TITLE
lookup/password: Decrypt password files encrypted with ansible-vault

### DIFF
--- a/changelogs/fragments/71142_lookup_password.yml
+++ b/changelogs/fragments/71142_lookup_password.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - lookup/password - Decrypt password files encrypted with ansible-vault (https://github.com/ansible/ansible/issues/53746).

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -160,22 +160,6 @@ def _parse_parameters(term):
     return relpath, params
 
 
-def _read_password_file(b_path):
-    """Read the contents of a password file and return it
-    :arg b_path: A byte string containing the path to the password file
-    :returns: a text string containing the contents of the password file or
-        None if no password file was present.
-    """
-    content = None
-
-    if os.path.exists(b_path):
-        with open(b_path, 'rb') as f:
-            b_content = f.read().rstrip()
-        content = to_text(b_content, errors='surrogate_or_strict')
-
-    return content
-
-
 def _gen_candidate_chars(characters):
     '''Generate a string containing all valid chars as defined by ``characters``
 
@@ -311,7 +295,10 @@ class LookupModule(LookupBase):
             # make sure only one process finishes all the job first
             first_process, lockfile = _get_lock(b_path)
 
-            content = _read_password_file(b_path)
+            content = None
+            if os.path.exists(b_path):
+                b_content, show_data = self._loader._get_file_contents(b_path)
+                content = to_text(b_content.rstrip(), errors='surrogate_or_strict')
 
             if content is None or b_path == to_bytes('/dev/null'):
                 plaintext_password = random_password(params['length'], chars)


### PR DESCRIPTION
##### SUMMARY

Vault support is included in the copy module and the file lookup:

```yaml
# Returns *encrypted* version of the password
- debug: msg="{{ lookup('password', '{{ playbook_dir }}/mysecret.creds') }}"

# Returns *decrypted* version of the password
- debug: msg="{{ lookup('file', '{{ playbook_dir }}/mysecret.creds') }}"
```

This change adds support to the password lookup as well.

Fixes #53746

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lookup/password

##### ADDITIONAL INFORMATION

I'm using Ansible to generate various passwords and to be able to commit them to git, I'm using `ansible-vault`. To make sure Ansible uses the **decrypted** passwords, I currently have to use a `pre_tasks` section at the beginning of my playbook to decrypt all necessary password files first.

This change would make the process faster and more secure by avoiding unnecessary manual decryption/encryption steps.

It also seems more logical that lookup tasks reading files from disk (`file`, `password`) should behave the same way.