### PR TITLE
password: Add example to generate random string

### DIFF
--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -39,6 +39,7 @@ DOCUMENTATION = """
           - Define comma separated list of names that compose a custom character set in the generated passwords.
           - 'By default generated passwords contain a random mix of upper and lowercase ASCII letters, the numbers 0-9 and punctuation (". , : - _").'
           - "They can be either parts of Python's string module attributes (ascii_letters,digits, etc) or are used literally ( :, -)."
+          - "Other valid values include 'ascii_lowercase', 'ascii_uppercase', 'digits', 'hexdigits', 'octdigits', 'printable', 'punctuation' and 'whitespace'."
           - "To enter comma use two commas ',,' somewhere - preferably at the end. Quotes and double quotes are not supported."
         type: string
       length:
@@ -84,6 +85,10 @@ EXAMPLES = """
     name: "{{ client }}"
     password: "{{ lookup('password', '/tmp/passwordfile chars=ascii_letters,digits,hexdigits,punctuation') }}"
     priv: "{{ client }}_{{ tier }}_{{ role }}.*:ALL"
+
+- name: create lowercase 8 character name for Kubernetes pod name
+  set_fact:
+    random_pod_name: "web-{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=8') }}"
 """
 
 RETURN = """


### PR DESCRIPTION
##### SUMMARY

Password lookup can be used to generate random string
with desired length. This is useful in various scenarios.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/plugins/lookup/password.py
