### PR TITLE
[stable-2.10] Fix version comparison for determining what ansible to build against

### DIFF
--- a/hacking/build_library/build_ansible/command_plugins/docs_build.py
+++ b/hacking/build_library/build_ansible/command_plugins/docs_build.py
@@ -77,6 +77,10 @@ def generate_full_docs(args):
 
     with TemporaryDirectory() as tmp_dir:
         sh.git(['clone', 'https://github.com/ansible-community/ansible-build-data'], _cwd=tmp_dir)
+        # This is wrong.  Once ansible and ansible-base major.minor versions get out of sync this
+        # will stop working.  We probably need to walk all subdirectories in reverse version order
+        # looking for the latest ansible version which uses something compatible with
+        # ansible_base_major_ver.
         deps_files = glob.glob(os.path.join(tmp_dir, 'ansible-build-data',
                                             ansible_base_major_ver, '*.deps'))
         if not deps_files:
@@ -88,7 +92,7 @@ def generate_full_docs(args):
         for filename in deps_files:
             with open(filename, 'r') as f:
                 deps_data = yaml.safe_load(f.read())
-            new_version = Version(deps_data['_ansible_base_version'])
+            new_version = Version(deps_data['_ansible_version'])
             if new_version > latest_ver:
                 latest_ver = new_version
                 latest = filename


### PR DESCRIPTION
* The version comparison for determining what ansible package to build
  docs against was comparing the version number for ansible-base but it
  needed to check the version number for ansible instead

* add a comment about some bad logic than needs to be fixed after 2.10.0
(cherry picked from commit 37a7485)

Co-authored-by: Toshio Kuratomi <a.badger@gmail.com>


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

