### PR TITLE
Update integration tests to support rpmfluff-0.6

### DIFF
--- a/changelogs/fragments/rpmfluff-compat-fixes.yml
+++ b/changelogs/fragments/rpmfluff-compat-fixes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Address compat with rpmfluff-0.6 for integration tests

--- a/test/integration/targets/setup_rpm_repo/files/create-repo.py
+++ b/test/integration/targets/setup_rpm_repo/files/create-repo.py
@@ -5,8 +5,21 @@ __metaclass__ = type
 
 import sys
 from collections import namedtuple
-import rpmfluff
 
+try:
+    from rpmfluff import SimpleRpmBuild
+    from rpmfluff import YumRepoBuild
+except ImportError:
+    from rpmfluff.rpmbuild import SimpleRpmBuild
+    from rpmfluff.yumrepobuild import YumRepoBuild
+
+try:
+    from rpmfluff import can_use_rpm_weak_deps
+except ImportError:
+    try:
+        from rpmfluff.utils import can_use_rpm_weak_deps
+    except ImportError:
+        can_use_rpm_weak_deps = None
 
 RPM = namedtuple('RPM', ['name', 'version', 'release', 'epoch', 'recommends'])
 
@@ -32,12 +45,12 @@ def main():
 
     pkgs = []
     for spec in SPECS:
-        pkg = rpmfluff.SimpleRpmBuild(spec.name, spec.version, spec.release, [arch])
+        pkg = SimpleRpmBuild(spec.name, spec.version, spec.release, [arch])
         pkg.epoch = spec.epoch
 
         if spec.recommends:
             # Skip packages that require weak deps but an older version of RPM is being used
-            if not hasattr(rpmfluff, "can_use_rpm_weak_deps") or not rpmfluff.can_use_rpm_weak_deps():
+            if not can_use_rpm_weak_deps or not can_use_rpm_weak_deps():
                 continue
 
             for recommend in spec.recommends:
@@ -45,7 +58,7 @@ def main():
 
         pkgs.append(pkg)
 
-    repo = rpmfluff.YumRepoBuild(pkgs)
+    repo = YumRepoBuild(pkgs)
     repo.make(arch)
 
     for pkg in pkgs:


### PR DESCRIPTION
##### SUMMARY
Update integration tests to support rpmfluff-0.6

rpmfluff-0.6 was just released today, and contains a number of restructuring changes that have caused things to not be addressable in the current script.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/setup_rpm_repo/files/create-repo.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
