### PR TITLE
add another resource module example

### DIFF
--- a/docs/docsite/rst/network/user_guide/network_resource_modules.rst
+++ b/docs/docsite/rst/network/user_guide/network_resource_modules.rst
@@ -189,7 +189,7 @@ This example uses the ``cisco.ios.ios_vlans`` resource module to retrieve and up
 .. code-block:: yaml
 
   - name: Make VLAN config changes by updating stored facts on the controller.
-   cisoc.ios.ios_vlans:
+    cisco.ios.ios_vlans:
       config: "{{ vlans }}"
       state: merged
     tags: update_config

--- a/docs/docsite/rst/network/user_guide/network_resource_modules.rst
+++ b/docs/docsite/rst/network/user_guide/network_resource_modules.rst
@@ -150,6 +150,50 @@ The following playbook uses the :ref:`eos_l3_interfaces <eos_l3_interfaces_modul
     assert:
       that: not result.changed
 
+Example: Acquiring and updating VLANs on a network device
+==========================================================
+
+This example shows how you can use resource modules to:
+
+#. Retrieve the current configuration on a network device.
+#. Save that configuration locally.
+#. Update that configuration and apply it to the network device.
+
+This example uses the ``cisco.ios.ios_vlans`` resource module to retrieve and update the VLANs on an IOS device.
+
+1. Retrieve the current IOS VLAN configuration:
+
+.. code-block:: yaml
+
+  - name: Gather VLAN information as structured data
+    cisco.ios.ios_facts:
+       gather_subset:
+        - '!all'
+        - '!min'
+       gather_network_resources:
+       - 'vlans'
+
+2. Store the VLAN configuration locally:
+
+.. code-block:: yaml
+
+  - name: Store VLAN facts to host_vars
+    copy:
+      content: "{{ ansible_network_resources | to_nice_yaml }}"
+      dest: "{{ playbook_dir }}/host_vars/{{ inventory_hostname }}"
+
+3. Modify the stored file to update the VLAN configuration locally.
+
+4. Merge the updated VLAN configuration with the existing configuration on the device:
+
+.. code-block:: yaml
+
+  - name: Make VLAN config changes by updating stored facts on the controller.
+   cisoc.ios.ios_vlans:
+      config: "{{ vlans }}"
+      state: merged
+    tags: update_config
+
 .. seealso::
 
   `Network Features in Ansible 2.9 <https://www.ansible.com/blog/network-features-coming-soon-in-ansible-engine-2.9>`_


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Pulled from ansible-devel mail list. Shows how to pull a subset of a network device configuration, modify it, and push it back down to the device, using a network resource module.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs.ansible.com
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
