### PR TITLE
[2.9] ansible-test: bump acme test container version to 2.0.0

### DIFF
--- a/changelogs/fragments/71097-ansible-test-acme-container.yml
+++ b/changelogs/fragments/71097-ansible-test-acme-container.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "ansible-test - the ACME test container was updated, it now supports external account creation and has a basic OCSP responder (https://github.com/ansible/ansible/pull/71097, https://github.com/ansible/acme-test-container/releases/tag/2.0.0)."

--- a/test/lib/ansible_test/_internal/cloud/acme.py
+++ b/test/lib/ansible_test/_internal/cloud/acme.py
@@ -45,7 +45,7 @@ class ACMEProvider(CloudProvider):
         if os.environ.get('ANSIBLE_ACME_CONTAINER'):
             self.image = os.environ.get('ANSIBLE_ACME_CONTAINER')
         else:
-            self.image = 'quay.io/ansible/acme-test-container:1.9.0'
+            self.image = 'quay.io/ansible/acme-test-container:2.0.0'
         self.container_name = ''
 
     def _wait_for_service(self, protocol, acme_host, port, local_part, name):


### PR DESCRIPTION
##### SUMMARY
Backport of #71097 to stable-2.9.

The new ACME test container is backwards compatible to the previous one.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test
