### PR TITLE
[docs] 2.7 is EOL, add 2.10 which is almost out

### DIFF
--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -39,7 +39,7 @@ This table links to the release notes for each major release. These release note
 Ansible Release                     Status
 ==============================      =================================================
 devel                               In development (2.11 unreleased, trunk)
-`2.10 Release Notes`_               Maintained (security **and** general bug fixes)
+`2.10 ansible-base Release Notes`_               Maintained (security **and** general bug fixes)
 `2.9 Release Notes`_                Maintained (security **and** general bug fixes)
 `2.8 Release Notes`_                Maintained (security fixes)
 `2.7 Release Notes`_                Unmaintained (end of life)

--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -35,18 +35,18 @@ Release status
 ``````````````
 This table links to the release notes for each major release. These release notes (changelogs) contain the dates and significant changes in each minor release.
 
-==============================      =================================================
-Ansible Release                     Status
-==============================      =================================================
-devel                               In development (2.11 unreleased, trunk)
-`2.10 ansible-base Release Notes`_               Maintained (security **and** general bug fixes)
-`2.9 Release Notes`_                Maintained (security **and** general bug fixes)
-`2.8 Release Notes`_                Maintained (security fixes)
-`2.7 Release Notes`_                Unmaintained (end of life)
-`2.6 Release Notes`_                Unmaintained (end of life)
-`2.5 Release Notes`_                Unmaintained (end of life)
-<2.5                                Unmaintained (end of life)
-==============================      =================================================
+==================================      =================================================
+Ansible Release                         Status
+==================================      =================================================
+devel                                   In development (2.11 unreleased, trunk)
+`2.10 ansible-base Release Notes`_      Maintained (security **and** general bug fixes)
+`2.9 Release Notes`_                    Maintained (security **and** general bug fixes)
+`2.8 Release Notes`_                    Maintained (security fixes)
+`2.7 Release Notes`_                    Unmaintained (end of life)
+`2.6 Release Notes`_                    Unmaintained (end of life)
+`2.5 Release Notes`_                    Unmaintained (end of life)
+<2.5                                    Unmaintained (end of life)
+==================================      =================================================
 
 You can download the releases from `<https://releases.ansible.com/ansible/>`_.
 

--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -41,7 +41,7 @@ Ansible Release                     Status
 devel                               In development (2.11 unreleased, trunk)
 `2.10 Release Notes`_               Maintained (security **and** general bug fixes)
 `2.9 Release Notes`_                Maintained (security **and** general bug fixes)
-`2.8 Release Notes`_                Maintained (security **and** critical bug fixes)
+`2.8 Release Notes`_                Maintained (security fixes)
 `2.7 Release Notes`_                Unmaintained (end of life)
 `2.6 Release Notes`_                Unmaintained (end of life)
 `2.5 Release Notes`_                Unmaintained (end of life)

--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -38,10 +38,11 @@ This table links to the release notes for each major release. These release note
 ==============================      =================================================
 Ansible Release                     Status
 ==============================      =================================================
-devel                               In development (2.10 unreleased, trunk)
+devel                               In development (2.11 unreleased, trunk)
+`2.10 Release Notes`_               Maintained (security **and** general bug fixes)
 `2.9 Release Notes`_                Maintained (security **and** general bug fixes)
 `2.8 Release Notes`_                Maintained (security **and** critical bug fixes)
-`2.7 Release Notes`_                Maintained (security fixes)
+`2.7 Release Notes`_                Unmaintained (end of life)
 `2.6 Release Notes`_                Unmaintained (end of life)
 `2.5 Release Notes`_                Unmaintained (end of life)
 <2.5                                Unmaintained (end of life)
@@ -55,6 +56,8 @@ You can download the releases from `<https://releases.ansible.com/ansible/>`_.
 
 .. Comment: devel used to point here but we're currently revamping our changelog process and have no
    link to a static changelog for devel _2.6: https://github.com/ansible/ansible/blob/devel/CHANGELOG.md
+.. _2.10 Release Notes:
+.. _2.10: https://github.com/ansible/ansible/blob/stable-2.10/changelogs/CHANGELOG-v2.10.rst
 .. _2.9 Release Notes:
 .. _2.9: https://github.com/ansible/ansible/blob/stable-2.9/changelogs/CHANGELOG-v2.9.rst
 .. _2.8 Release Notes:


### PR DESCRIPTION

##### SUMMARY
Change:
- Remove 2.7 support from the maintenance schedule
- Add 2.10 which is in RC and will be out soon enough.

Test Plan:
- `make webdocs`

Tickets:
- Refs #70605

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME

docs