### PR TITLE
subelements: Clarify parameter docs

### DIFF
--- a/changelogs/fragments/38182_subelements.yml
+++ b/changelogs/fragments/38182_subelements.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- subelements - clarify the lookup plugin documentation for parameter handling (https://github.com/ansible/ansible/issues/38182).

--- a/lib/ansible/plugins/lookup/subelements.py
+++ b/lib/ansible/plugins/lookup/subelements.py
@@ -18,8 +18,9 @@ DOCUMENTATION = """
       skip_missing:
         default: False
         description:
-          - If set to True, the lookup plugin will skip the lists items that do not contain the given subkey.
-            If False, the plugin will yield an error and complain about the missing subkey.
+          - Lookup accepts this flag from a dictionary as optional. See Example section for more information.
+          - If set to C(True), the lookup plugin will skip the lists items that do not contain the given subkey.
+          - If set to C(False), the plugin will yield an error and complain about the missing subkey.
 """
 
 EXAMPLES = """
@@ -74,7 +75,7 @@ EXAMPLES = """
 
     - name: list groups for users that have them, don't error if groups key is missing
       debug: var=item
-      loop: "{{lookup('subelements', users, 'groups', {'skip_missing': True})}}"
+      loop: "{{ q('subelements', users, 'groups', {'skip_missing': True}) }}"
 """
 
 RETURN = """


### PR DESCRIPTION
##### SUMMARY

skip_missing parameter in subelements lookup plugin is accepted from
inside the dictionary.

Fixes: #38182

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/38182_subelements.yml
lib/ansible/plugins/lookup/subelements.py
