### PR TITLE
toml: Clarify about inventory examples

### DIFF
--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -4,7 +4,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
     inventory: toml
     version_added: "2.8"
     short_description: Uses a specific TOML file as an inventory source.
@@ -15,7 +15,8 @@ DOCUMENTATION = '''
         - Requires the 'toml' python library
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
+# Following are examples of 3 different inventories in TOML format
 example1: |
     [all.vars]
     has_java = false


### PR DESCRIPTION
##### SUMMARY

Add a note in toml inventory plugin about three different
inventory examples.

Fixes: #67003

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/toml.py
