### PR TITLE
Docs: ansible_host can contain FQDN

### DIFF
--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -269,7 +269,7 @@ In YAML:
           ansible_host: 192.0.2.50
 
 In the above example, running Ansible against the host alias "jumper" will connect to 192.0.2.50 on port 5555.
-This only works for hosts with static IPs, or when you are connecting through tunnels.
+This can be useful when you are connecting through tunnels.
 
 .. note::
    Values passed in the INI format using the ``key=value`` syntax are interpreted differently depending on where they are declared:

--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -268,8 +268,7 @@ In YAML:
           ansible_port: 5555
           ansible_host: 192.0.2.50
 
-In the above example, running Ansible against the host alias "jumper" will connect to 192.0.2.50 on port 5555.
-This can be useful when you are connecting through tunnels.
+In the above example, running Ansible against the host alias "jumper" will connect to 192.0.2.50 on port 5555. See :ref:`behavioral inventory parameters <behavioral_parameters>` to further customize the connection to hosts.
 
 .. note::
    Values passed in the INI format using the ``key=value`` syntax are interpreted differently depending on where they are declared:


### PR DESCRIPTION
##### SUMMARY
It is possible to use FQDN as well as IPs for ansible_host. Verified on ansible 2.9.11 and coherent with other [examples](docs/docsite/rst/user_guide/intro_inventory.rst).

Change inventory documentation to reflect that.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
inventory

##### ADDITIONAL INFORMATION