### PR TITLE
Make sure that apache2-webdav related packages get upgraded

### DIFF
--- a/test/integration/targets/subversion/roles/subversion/tasks/setup.yml
+++ b/test/integration/targets/subversion/roles/subversion/tasks/setup.yml
@@ -14,7 +14,7 @@
   when: ansible_distribution != 'Alpine'
 
 - name: install SVN pre-reqs - Alpine
-  command: 'apk add -U {{ subversion_packages|join(" ") }}'
+  command: 'apk add -U -u {{ subversion_packages|join(" ") }}'
   when: ansible_distribution == 'Alpine'
 
 - name: upgrade SVN pre-reqs


### PR DESCRIPTION
##### SUMMARY
Make sure that apache2-webdav related packages get upgraded

The `apache2-webdav` module advanced from `2.4.43-r0` to `2.4.46-r0` which made it incompatible with the `apache2` installed in the container image.

Make sure we pass `-u` to `apk add` so that it will upgrade dependencies as well, to prevent this.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/subversion/roles/subversion/tasks/setup.yml

##### ADDITIONAL INFORMATION
cc @Shrews