### PR TITLE
note that -e can be used multiple times

### DIFF
--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -348,7 +348,7 @@ def add_runas_prompt_options(parser, runas_group=None):
 def add_runtask_options(parser):
     """Add options for commands that run a task"""
     parser.add_argument('-e', '--extra-vars', dest="extra_vars", action="append",
-                        help="set additional variables as key=value or YAML/JSON, if filename prepend with @", default=[])
+                        help="set additional variables as key=value or YAML/JSON, if filename prepend with @. Can be given multiple times.", default=[])
 
 
 def add_subset_options(parser):


### PR DESCRIPTION
Note that -e (extra-vars) switch can be given multiple times.

##### SUMMARY

It's not evident from the cli switch help text, whether the "-e"/"--extra-vars" option can be used multiple times. The proposed patch makes it explicit.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

ansible-playbook

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
