### PR TITLE
Create gss_auth option for paramiko_ssh connection plugin

### DIFF
--- a/changelogs/fragments/71190_add_gss_auth_to_paramiko_ssh.yml
+++ b/changelogs/fragments/71190_add_gss_auth_to_paramiko_ssh.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- paramiko_ssh - add support for the paramiko gss_auth option to allow Kerberos GSS-API Authentication (https://github.com/ansible/ansible/issues/71201)

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -365,6 +365,11 @@
 # disable the Paramiko look for keys function
 #look_for_keys = False
 
+# paramiko will not use GSS-API Authentication unless the gss_auth option
+# is passed. This is required for Kerberos Authentication.
+# Uncomment this line to enable GSS-API Authentication in Paramiko 
+#gss_auth = True
+
 # When using persistent connections with Paramiko, the connection runs in a
 # background process. If the host doesn't already have a valid SSH key, by
 # default Ansible will prompt to add the host key. This will cause connections

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1703,6 +1703,14 @@ PARAMIKO_HOST_KEY_AUTO_ADD:
   ini:
   - {key: host_key_auto_add, section: paramiko_connection}
   type: boolean
+PARAMIKO_GSS_AUTH:
+  name: gss auth
+  default: False
+  description: 'Enable GSS-API Authentication'
+  env: [{name: ANSIBLE_PARAMIKO_GSS_AUTH}]
+  ini:
+  - {key: gss_auth, section: paramiko_connection}
+  type: boolean
 PARAMIKO_LOOK_FOR_KEYS:
   name: look for keys
   default: True

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1703,14 +1703,6 @@ PARAMIKO_HOST_KEY_AUTO_ADD:
   ini:
   - {key: host_key_auto_add, section: paramiko_connection}
   type: boolean
-PARAMIKO_GSS_AUTH:
-  name: gss auth
-  default: False
-  description: 'Enable GSS-API Authentication'
-  env: [{name: ANSIBLE_PARAMIKO_GSS_AUTH}]
-  ini:
-  - {key: gss_auth, section: paramiko_connection}
-  type: boolean
 PARAMIKO_LOOK_FOR_KEYS:
   name: look for keys
   default: True

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -69,7 +69,7 @@ DOCUMENTATION = """
         ini:
         - section: paramiko_connection
           key: gss_auth
-          version_added: '2.9'
+          version_added: '2.11'
         type: boolean
       look_for_keys:
         default: True

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -350,12 +350,15 @@ class Connection(ConnectionBase):
             if LooseVersion(paramiko.__version__) >= LooseVersion('2.2.0'):
                 ssh_connect_kwargs['auth_timeout'] = self._play_context.timeout
 
+            # paramiko 1.15.0 introduced gss_auth parameter
+            if LooseVersion(paramiko.__version__) >= LooseVersion('1.15.0'):
+                ssh_connect_kwargs['gss_auth'] = self.get_option('gss_auth')
+
             ssh.connect(
                 self._play_context.remote_addr.lower(),
                 username=self._play_context.remote_user,
                 allow_agent=allow_agent,
                 look_for_keys=self.get_option('look_for_keys'),
-                gss_auth=self.get_option('gss_auth'),
                 key_filename=key_filename,
                 password=conn_password,
                 timeout=self._play_context.timeout,

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -61,6 +61,16 @@ DOCUMENTATION = """
         ini:
           - {key: host_key_auto_add, section: paramiko_connection}
         type: boolean
+      gss_auth:
+        default: False
+        description: enable GSS-API Authentication
+        env:
+            - name: ANSIBLE_PARAMIKO_GSS_AUTH
+        ini:
+        - section: paramiko_connection
+          key: gss_auth
+          version_added: '2.9'
+        type: boolean
       look_for_keys:
         default: True
         description: 'TODO: write it'
@@ -345,6 +355,7 @@ class Connection(ConnectionBase):
                 username=self._play_context.remote_user,
                 allow_agent=allow_agent,
                 look_for_keys=self.get_option('look_for_keys'),
+                gss_auth=self.get_option('gss_auth'),
                 key_filename=key_filename,
                 password=conn_password,
                 timeout=self._play_context.timeout,


### PR DESCRIPTION
##### SUMMARY
Add a new `gss_auth` option for the `paramiko_ssh `connection plugin that will be passed to the upstream `paramiko` library `connect()` method. This will enable GSS-API authentication for paramiko ssh connections, which is required for
Kerberos authentication to succeed.

Set the default for the `gss_auth` option in the `[paramiko_connection]` section to `False` to ensure backwards compatibility.

Fixes #71201

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
paramiko_ssh

##### ADDITIONAL INFORMATION
Without gss_auth enabled for paramiko_ssh against a kerberos authenticated host:
```
(venv) kim.covil@dragon:~/src/ansible$ ansible -m ping -c paramiko -i $HOSTNAME, $HOSTNAME
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
dragon.office.transficc.net | UNREACHABLE! => {
    "changed": false,
    "msg": "Failed to authenticate: Authentication failed.",
    "unreachable": true
}
```

With gss_auth enabled for paramiko_ssh against a kerberos authenticated host:
```
(venv) kim.covil@dragon:~/src/ansible-arnoxit$ cat ansible.cfg
[paramiko_connection]
gss_auth = True
(venv) kim.covil@dragon:~/src/ansible-arnoxit$ ansible -m ping -c paramiko -i $HOSTNAME, $HOSTNAME
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
[WARNING]: Platform linux on host dragon.office.transficc.net is using the discovered Python interpreter at /usr/bin/python, but future installation of another Python interpreter could change the meaning of that path. See https://docs.ansible.com/ansible/devel/reference_appendices/interpreter_discovery.html for
more information.
dragon.office.transficc.net | SUCCESS => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": false,
    "ping": "pong"
}
```
