### PR TITLE
ansible-test: Be less strict about adjacent spaces in ignore file

### DIFF
--- a/test/lib/ansible_test/_internal/sanity/__init__.py
+++ b/test/lib/ansible_test/_internal/sanity/__init__.py
@@ -286,7 +286,8 @@ class SanityIgnoreParser:
                 self.parse_errors.append((line_no, 1, "Line cannot be empty or contain only a comment"))
                 continue
 
-            parts = line.split(' ')
+            parts = line.replace('  ', ' ')
+            parts = parts.split(' ')
             path = parts[0]
             codes = parts[1:]
 


### PR DESCRIPTION
##### SUMMARY
ansible-test fails when they are two spaces between word instead of one with error like
`ERROR: tests/sanity/ignore-2.10.txt:1:32: Error code after path cannot be empty`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test