### PR TITLE
[tests] pin docker to <4.3.0

### DIFF
--- a/test/integration/targets/setup_docker/defaults/main.yml
+++ b/test/integration/targets/setup_docker/defaults/main.yml
@@ -8,7 +8,7 @@ docker_packages:
 
 docker_pip_extra_packages: []
 docker_pip_packages:
-  - docker
+  - docker<4.3.0
 
 docker_cleanup_packages:
   - docker


### PR DESCRIPTION

##### SUMMARY
Change:
- New python docker lib wants a newer docker than we have in CI.

Test Plan:
- CI

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Test Pull Request

##### COMPONENT NAME

tests