### PR TITLE
Supports new systemctl output message for chroot

### DIFF
--- a/changelogs/fragments/71197-systemctl-ignore-message.yaml
+++ b/changelogs/fragments/71197-systemctl-ignore-message.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - systemd - fixed chroot usage on new versions of systemd, that broke because of upstream changes in systemctl output
+  - systemd - made the systemd module work correctly when the SYSTEMD_OFFLINE environment variable is set

--- a/lib/ansible/modules/systemd.py
+++ b/lib/ansible/modules/systemd.py
@@ -270,7 +270,7 @@ def is_deactivating_service(service_status):
 
 
 def request_was_ignored(out):
-    return '=' not in out and 'ignoring request' in out
+    return '=' not in out and ('ignoring request' in out or 'ignoring command' in out)
 
 
 def parse_systemctl_show(lines):
@@ -517,8 +517,8 @@ def main():
                         if rc != 0:
                             module.fail_json(msg="Unable to %s service %s: %s" % (action, unit, err))
             # check for chroot
-            elif is_chroot(module):
-                module.warn("Target is a chroot. This can lead to false positives or prevent the init system tools from working.")
+            elif is_chroot(module) or os.environ.get('SYSTEMD_OFFLINE') == '1':
+                module.warn("Target is a chroot or systemd is offline. This can lead to false positives or prevent the init system tools from working.")
             else:
                 # this should not happen?
                 module.fail_json(msg="Service is in unknown state", status=result['status'])

--- a/test/integration/targets/systemd/tasks/main.yml
+++ b/test/integration/targets/systemd/tasks/main.yml
@@ -72,4 +72,11 @@
               - result is failed
               - result is search("Could not find the requested service {{ fake_service }}")
 
+    - name: check that the module works even when systemd is offline (eg in chroot)
+      systemd:
+          name: "{{ running_names.stdout_lines|random }}"
+          state: started
+      environment:
+          SYSTEMD_OFFLINE: 1
+
   when: 'systemctl_check.rc == 0'


### PR DESCRIPTION
The message generated by systemctl has been updated in https://github.com/systemd/systemd/commit/9321e23c40f3dc6bd785105ce882cbad6447a1c6, which requires a corresponding change in the systemd module.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/systemd.py`
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
