### PR TITLE
Allow checksum file to be local file:// url

### DIFF
--- a/changelogs/fragments/71205_get_url_allow_checksum_file_url.yml
+++ b/changelogs/fragments/71205_get_url_allow_checksum_file_url.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - get_url - allow checksum urls to point to file:// resources, moving scheme test to function

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -487,7 +487,7 @@ def main():
         except ValueError:
             module.fail_json(msg="The checksum parameter has to be in format <algorithm>:<checksum>", **result)
 
-        if checksum.startswith('http://') or checksum.startswith('https://') or checksum.startswith('ftp://'):
+        if checksum.startswith('http://') or checksum.startswith('https://') or checksum.startswith('ftp://') or checksum.startswith('file://'):
             checksum_url = checksum
             # download checksum file to checksum_tmpsrc
             checksum_tmpsrc, checksum_info = url_get(module, checksum_url, dest, use_proxy, last_mod_time, force, timeout, headers, tmp_dest)

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -416,6 +416,14 @@ def extract_filename_from_headers(headers):
     return res
 
 
+def is_url(checksum):
+     """
+     Returns True if checksum value has supported URL scheme, else False."""
+     supported_schemes = ('http', 'https', 'ftp', 'file')
+     
+     return urlsplit(checksum).scheme in supported_schemes
+
+
 # ==============================================================
 # main
 
@@ -487,7 +495,7 @@ def main():
         except ValueError:
             module.fail_json(msg="The checksum parameter has to be in format <algorithm>:<checksum>", **result)
 
-        if checksum.startswith('http://') or checksum.startswith('https://') or checksum.startswith('ftp://') or checksum.startswith('file://'):
+        if is_url(checksum):
             checksum_url = checksum
             # download checksum file to checksum_tmpsrc
             checksum_tmpsrc, checksum_info = url_get(module, checksum_url, dest, use_proxy, last_mod_time, force, timeout, headers, tmp_dest)

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -417,11 +417,11 @@ def extract_filename_from_headers(headers):
 
 
 def is_url(checksum):
-     """
-     Returns True if checksum value has supported URL scheme, else False."""
-     supported_schemes = ('http', 'https', 'ftp', 'file')
-     
-     return urlsplit(checksum).scheme in supported_schemes
+    """
+    Returns True if checksum value has supported URL scheme, else False."""
+    supported_schemes = ('http', 'https', 'ftp', 'file')
+
+    return urlsplit(checksum).scheme in supported_schemes
 
 
 # ==============================================================

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -411,7 +411,7 @@
   get_url:
     url: 'http://localhost:{{ http_port }}/27617.txt'
     dest: '{{ remote_tmp_dir }}/27617sha256_with_file_scheme.txt'
-    checksum: 'file://{{ files_dir }}/sha256sum.txt'
+    checksum: 'sha256:file://{{ files_dir }}/sha256sum.txt'
   register: result_sha256_with_file_scheme
 
 - stat:

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -407,15 +407,28 @@
     path: "{{ remote_tmp_dir }}/27617sha256_with_dot.txt"
   register: stat_result_sha256_with_dot
 
+- name: download src with sha256 checksum url with file scheme
+  get_url:
+    url: 'http://localhost:{{ http_port }}/27617.txt'
+    dest: '{{ remote_tmp_dir }}/27617sha256_with_file_scheme.txt'
+    checksum: 'file://{{ files_dir }}/sha256sum.txt'
+  register: result_sha256_with_file_scheme
+
+- stat:
+    path: "{{ remote_tmp_dir }}/27617sha256_with_dot.txt"
+  register: stat_result_sha256_with_file_scheme
+
 - name: Assert that the file was downloaded
   assert:
     that:
       - result_sha1 is changed
       - result_sha256 is changed
       - result_sha256_with_dot is changed
+      - result_sha256_with_file_scheme is changed
       - "stat_result_sha1.stat.exists == true"
       - "stat_result_sha256.stat.exists == true"
       - "stat_result_sha256_with_dot.stat.exists == true"
+      - "stat_result_sha256_with_file_scheme.stat.exists == true"
 
 #https://github.com/ansible/ansible/issues/16191
 - name: Test url split with no filename


### PR DESCRIPTION
##### SUMMARY
A partial fix for #69364 in that the SHASUMS file can be downloaded and GPG verified but then used from the downloaded location to verify the get_url's file.

or
When using get_url to download a file that has a GPG signed SHASUMS file, this would allow for less filter hackary.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
get_url