### PR TITLE
[doc] Fix links to packet inventory files in 2.9 branch

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_packet.rst
+++ b/docs/docsite/rst/scenario_guides/guide_packet.rst
@@ -216,9 +216,9 @@ You can either copy the inventory and ini config out from the cloned git repo, o
 
 .. code-block:: bash
 
-    $ wget https://github.com/ansible/ansible/raw/devel/contrib/inventory/packet_net.py
+    $ wget https://github.com/ansible/ansible/raw/stable-2.9/contrib/inventory/packet_net.py
     $ chmod +x packet_net.py
-    $ wget https://github.com/ansible/ansible/raw/devel/contrib/inventory/packet_net.ini
+    $ wget https://github.com/ansible/ansible/raw/stable-2.9/contrib/inventory/packet_net.ini
 
 In order to understand what the inventory script gives to Ansible you can run:
 


### PR DESCRIPTION
##### SUMMARY
Fix links to packet inventory files in 2.9 branch

fixes #71203 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
