### PR TITLE
Fix cron file regression

### DIFF
--- a/changelogs/fragments/fix-cron-file-regression.yaml
+++ b/changelogs/fragments/fix-cron-file-regression.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cron - cron file should not be empty after adding var (https://github.com/ansible/ansible/pull/71207)

--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -255,6 +255,7 @@ class CronTab(object):
             try:
                 f = open(self.b_cron_file, 'rb')
                 self.n_existing = to_native(f.read(), errors='surrogate_or_strict')
+                self.lines = self.n_existing.splitlines()
                 f.close()
             except IOError:
                 # cron file does not exist

--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -100,6 +100,32 @@
 - assert:
     that: remove_cron_file is not changed
 
+- name: Non regression test - cron file should not be empty after adding var (#71207)
+  when: ansible_distribution != 'Alpine'
+  block:
+  - name: Cron file creation
+    cron:
+      cron_file: cron_filename
+      name: "simple cron job"
+      job: 'echo "_o/"'
+      user: root
+
+  - name: Add var to the cron file
+    cron:
+      cron_file: cron_filename
+      env: yes
+      name: FOO
+      value: bar
+      user: root
+
+  - name: "Ensure cron_file still contains job string"
+    replace:
+      path: /etc/cron.d/cron_filename
+      regexp: "_o/"
+      replace: "OK"
+    register: find_chars
+    failed_when: (find_chars is not changed) or (find_chars is failed)
+
 # BusyBox does not have /etc/cron.d
 - name: Removing a cron file when the name is specified is allowed (#57471)
   when: ansible_distribution != 'Alpine'


### PR DESCRIPTION
##### SUMMARY

In recent change adding vars or job to a cron file empty the file first and overwrite it with the latest task value.

After quick check it looks like it has been introduced here -> https://github.com/ansible/ansible/pull/70426/files#diff-9610c7caa2298ec9ec94e86fbaa2a833L255.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- module cron

