### PR TITLE
remove 2.7 from version-switcher dropdown

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -150,7 +150,7 @@ html_context = {
     'current_version': version,
     'latest_version': '2.9',
     # list specifically out of order to make latest work
-    'available_versions': ('latest', '2.9_ja', '2.8', '2.7', 'devel'),
+    'available_versions': ('latest', '2.9_ja', '2.8', 'devel'),
     'css_files': ('_static/ansible.css',  # overrides to the standard theme
                   ),
 }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
2.7 is already EOL.  This is an independent PR so it can be backported to 2.10, 2.9, and 2.8
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
 Partial for #70925
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs.ansible.com
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
