### PR TITLE
VariableManager - add the 'vars' key before getting delegated variables

### DIFF
--- a/changelogs/fragments/71214-add-vars-variable-for-delegated-vars.yaml
+++ b/changelogs/fragments/71214-add-vars-variable-for-delegated-vars.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - VariableManager - Add the 'vars' key before getting delegated variables (https://github.com/ansible/ansible/issues/71092).

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -426,15 +426,15 @@ class VariableManager:
         if task:
             all_vars['environment'] = task.environment
 
-        # if we have a task and we're delegating to another host, figure out the
-        # variables for that host now so we don't have to rely on hostvars later
-        if task and task.delegate_to is not None and include_delegate_to:
-            all_vars['ansible_delegated_vars'], all_vars['_ansible_loop_cache'] = self._get_delegated_vars(play, task, all_vars)
-
         # 'vars' magic var
         if task or play:
             # has to be copy, otherwise recursive ref
             all_vars['vars'] = all_vars.copy()
+
+        # if we have a task and we're delegating to another host, figure out the
+        # variables for that host now so we don't have to rely on hostvars later
+        if task and task.delegate_to is not None and include_delegate_to:
+            all_vars['ansible_delegated_vars'], all_vars['_ansible_loop_cache'] = self._get_delegated_vars(play, task, all_vars)
 
         display.debug("done with get_vars()")
         if C.DEFAULT_DEBUG:

--- a/test/integration/targets/delegate_to/resolve_vars.yml
+++ b/test/integration/targets/delegate_to/resolve_vars.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: though we test for 'vars' this is only for backwards compatibility and the 'vars' variable will be deprecated and removed in the future
+  hosts: localhost
   gather_facts: no
   tasks:
     - add_host:

--- a/test/integration/targets/delegate_to/resolve_vars.yml
+++ b/test/integration/targets/delegate_to/resolve_vars.yml
@@ -1,0 +1,15 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - add_host:
+        name: host1
+        ansible_connection: local
+
+- hosts: localhost
+  gather_facts: no
+  vars:
+    server_name: host1
+  tasks:
+    - command: echo should delegate to host1 with local connection
+      delegate_to: "{{ vars['server_name'] }}"

--- a/test/integration/targets/delegate_to/runme.sh
+++ b/test/integration/targets/delegate_to/runme.sh
@@ -71,3 +71,5 @@ ln -s python secondpython
 )
 ansible-playbook verify_interpreter.yml -i inventory_interpreters -v "$@"
 ansible-playbook discovery_applied.yml -i inventory -v "$@"
+
+ansible-playbook resolve_vars.yml -i inventory -v "$@"


### PR DESCRIPTION
##### SUMMARY
Fixes #71092

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/vars/manager.py
