### PR TITLE
Fix netconf validate capability check (#71195)

### DIFF
--- a/changelogs/fragments/71195-netconf_config_validate_issue.yaml
+++ b/changelogs/fragments/71195-netconf_config_validate_issue.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- Fixed Ansible Reports Validate Not Supported by Netconf Server when Enabled in Netconf - (https://github.com/ansible-collections/ansible.netcommon/issues/119).
+- Fixed Ansible reporting validate not supported by netconf server when enabled in netconf - (https://github.com/ansible-collections/ansible.netcommon/issues/119).

--- a/changelogs/fragments/71195-netconf_config_validate_issue.yaml
+++ b/changelogs/fragments/71195-netconf_config_validate_issue.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fixed Ansible Reports Validate Not Supported by Netconf Server when Enabled in Netconf - (https://github.com/ansible-collections/ansible.netcommon/issues/119).

--- a/lib/ansible/plugins/netconf/__init__.py
+++ b/lib/ansible/plugins/netconf/__init__.py
@@ -353,7 +353,7 @@ class NetconfBase(AnsiblePlugin):
         operations['supports_startup'] = ':startup' in capabilities
         operations['supports_xpath'] = ':xpath' in capabilities
         operations['supports_writable_running'] = ':writable-running' in capabilities
-        operations['supports_validate'] = ':writable-validate' in capabilities
+        operations['supports_validate'] = ':validate' in capabilities
 
         operations['lock_datastore'] = []
         if operations['supports_writable_running']:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible-collections/ansible.netcommon/issues/119
*  Use ``:validate`` string to check if the netconf
   server supports validate capability as per netconf RFC

(cherry picked from commit 7635d23cee873fc98f69782c2665746da64ca416)

Merged to devel https://github.com/ansible/ansible/pull/71195
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/netconf/__init__.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
