### PR TITLE
testing_sanity.rst: add argument for running in docker

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_sanity.rst
+++ b/docs/docsite/rst/dev_guide/testing_sanity.rst
@@ -21,7 +21,7 @@ How to run
 .. note::
    To run sanity tests using docker, always use the default docker image
    by passing the ``--docker`` or ``--docker default`` argument.
-   Also use the ``--docker-keep-git`` argument when running all sunity test
+   Also use the ``--docker-keep-git`` argument when running all sanity test
    or validate-modules test subset to avoid git related errors.
 
 .. code:: shell

--- a/docs/docsite/rst/dev_guide/testing_sanity.rst
+++ b/docs/docsite/rst/dev_guide/testing_sanity.rst
@@ -21,8 +21,10 @@ How to run
 .. note::
    To run sanity tests using docker, always use the default docker image
    by passing the ``--docker`` or ``--docker default`` argument.
-   Also use the ``--docker-keep-git`` argument when running all sanity test
-   or validate-modules test subset to avoid git related errors.
+
+.. note::
+   When using docker and the ``--base-branch`` argument,
+   also use the ``--docker-keep-git`` argument to avoid git related errors.
 
 .. code:: shell
 
@@ -35,7 +37,7 @@ How to run
    ansible-test sanity lib/ansible/modules/files/template.py
 
    # Run all tests inside docker (good if you don't have dependencies installed)
-   ansible-test sanity --docker default --docker-keep-git
+   ansible-test sanity --docker default
 
    # Run validate-modules against a specific file
    ansible-test sanity --test validate-modules lib/ansible/modules/files/template.py

--- a/docs/docsite/rst/dev_guide/testing_sanity.rst
+++ b/docs/docsite/rst/dev_guide/testing_sanity.rst
@@ -21,6 +21,8 @@ How to run
 .. note::
    To run sanity tests using docker, always use the default docker image
    by passing the ``--docker`` or ``--docker default`` argument.
+   Also use the ``--docker-keep-git`` argument when running all sunity test
+   or validate-modules test subset to avoid git related errors.
 
 .. code:: shell
 
@@ -33,7 +35,7 @@ How to run
    ansible-test sanity lib/ansible/modules/files/template.py
 
    # Run all tests inside docker (good if you don't have dependencies installed)
-   ansible-test sanity --docker default
+   ansible-test sanity --docker default --docker-keep-git
 
    # Run validate-modules against a specific file
    ansible-test sanity --test validate-modules lib/ansible/modules/files/template.py


### PR DESCRIPTION
##### SUMMARY
fixes #71224
testing_sanity.rst: add a note about arguments

when running
```
ansible-test sanity --base-branch devel lib/ansible/modules/lineinfile.py --docker default
```
to avoid errors like:
```
Running sanity test 'validate-modules' with Python 3.6
ERROR: Command "/usr/bin/python3.6 /root/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate-modules --format json --arg-spec lib/ansible/modules/lineinfile.py --base-branch devel" returned exit status 1.
>>> Standard Error
Traceback (most recent call last):
  File "/root/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate-modules", line 8, in <module>
    main()
  File "/root/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 2444, in main
    run()
  File "/root/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 2313, in run
    git_cache = GitCache(args.base_branch)
  File "/root/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 2383, in __init__
    self.base_tree = self._git(['ls-tree', '-r', '--name-only', self.base_branch, 'lib/ansible/modules/'])
  File "/root/ansible/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py", line 2431, in _git
    raise GitError(stderr, p.returncode)
validate_modules.main.GitError: b'fatal: not a git repository (or any of the parent directories): .git\n'
ERROR: Command "docker exec 024ef901a6abe0e993a5d59d92cd3370edc58bc12afd272e891c9c67adab7f27 /usr/bin/env ANSIBLE_TEST_CONTENT_ROOT=/root/ansible LC_ALL=en_US.UTF-8 /usr/bin/python3.6 /root/ansible/bin/ansible-test sanity --base-branch devel lib/ansible/modules/lineinfile.py --docker-no-pull --metadata test/results/.tmp/metadata-vklM9L.json --truncate 141 --redact --color yes --requirements --base-branch devel" returned exit status 1.
```

##### ISSUE TYPE
- Docs Pull Request
