### PR TITLE
Update network integration auth timeout (#71057)

### DIFF
--- a/changelogs/fragments/71239-update-auth-timeout.yml
+++ b/changelogs/fragments/71239-update-auth-timeout.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Updated network integration auth timeout to 90 secs.

--- a/test/integration/network-integration.cfg
+++ b/test/integration/network-integration.cfg
@@ -5,6 +5,7 @@
 host_key_checking = False
 log_path = /tmp/ansible-test.out
 stdout_callback = yaml
+timeout = 90
 
 [ssh_connection]
 ssh_args = '-o UserKnownHostsFile=/dev/null'


### PR DESCRIPTION
##### SUMMARY
Incase of network integration test for connection local
test the paramiko_ssh auth_timeout is the value of timeout
under defaults section which is 10 seconds.
For slower connection 10sec timout value result in authentication
timeout error hence increase the timeout value to 90 seconds
(cherry picked from commit https://github.com/ansible/ansible/commit/6160e82bf2fc840487e620ec48be3bd28fb2b744)

Merged in to devel #71057 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
