### PR TITLE
Add warning about copyright year change

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -44,7 +44,9 @@ After the shebang and UTF-8 coding, there should be a `copyright line <https://w
     # Copyright: (c) 2018, Terry Jones <terry.jones@example.org>
     # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-Major additions to the module (for instance, rewrites) may add additional copyright lines. Any legal review will include the source control history, so an exhaustive copyright header is not necessary. When adding a second copyright line for a significant feature or rewrite, add the newer line above the older one:
+Major additions to the module (for instance, rewrites) may add additional copyright lines. Any legal review will include the source control history, so an exhaustive copyright header is not necessary.
+Please do not edit existing copyright year, this simplifies project administration and unlikely to cause any interesting legal issues.
+When adding a second copyright line for a significant feature or rewrite, add the newer line above the older one:
 
 .. code-block:: python
 

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -45,7 +45,7 @@ After the shebang and UTF-8 coding, there should be a `copyright line <https://w
     # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 Major additions to the module (for instance, rewrites) may add additional copyright lines. Any legal review will include the source control history, so an exhaustive copyright header is not necessary.
-Please do not edit existing copyright year, this simplifies project administration and unlikely to cause any interesting legal issues.
+Please do not edit the existing copyright year. This simplifies project administration and is unlikely to cause any interesting legal issues.
 When adding a second copyright line for a significant feature or rewrite, add the newer line above the older one:
 
 .. code-block:: python


### PR DESCRIPTION
##### SUMMARY

To simplify project administration and avoid any legal issues,
add a warning in the docs.

This reflects - https://github.com/ansible/ansible/issues/45989#issuecomment-423635622

Fixes: #45989

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/developing_modules_documenting.rst
