### PR TITLE
Fixed Ansible API Example

### DIFF
--- a/examples/scripts/uptime.py
+++ b/examples/scripts/uptime.py
@@ -53,7 +53,7 @@ class ResultsCollectorJSONCallback(CallbackBase):
 def main():
     host_list = ['localhost', 'www.example.com', 'www.google.com']
     # since the API is constructed for CLI it expects certain options to always be set in the context object
-    context.CLIARGS = ImmutableDict(connection='smart', module_path=['/to/mymodules', '/usr/share/ansible'], forks=10, become=None,
+    context.CLIARGS = ImmutableDict(connection='smart', module_path=['/to/mymodules', '/usr/share/ansible'], forks=10, become=False,
                                     become_method=None, become_user=None, check=False, diff=False)
     # required for
     # https://github.com/ansible/ansible/blob/devel/lib/ansible/inventory/manager.py#L204


### PR DESCRIPTION
Would otherwise silently fail with `TypeError: The value 'None' is not a valid boolean.` when trying to parse `become=None`.


##### SUMMARY
The example script in `examples/scripts/uptime.py` failed silently, because it attempted to parse `None` as a boolean, which failed as a `TypeError`, since `None` is not included in `BOOLEANS` in `module_utils/parsing/convert_bool.py`.

``` module_utils/parsing/convert_bool.py
 10 BOOLEANS_TRUE = frozenset(('y', 'yes', 'on', '1', 'true', 't', 1, 1.0, True))
 11 BOOLEANS_FALSE = frozenset(('n', 'no', 'off', '0', 'false', 'f', 0, 0.0, False))
 12 BOOLEANS = BOOLEANS_TRUE.union(BOOLEANS_FALSE)
```


##### ADDITIONAL INFORMATION
Can be reproduced by executing `python uptime.py` in a local virtual environment with ansible installed.