### PR TITLE
[2.10] Redirect gluster modules to gluster.gluster.

### DIFF
--- a/changelogs/fragments/71240-gluster-modules-redirect.yml
+++ b/changelogs/fragments/71240-gluster-modules-redirect.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "gluster modules - fix redirect to point to the ``gluster.gluster`` collection (https://github.com/ansible/ansible/pull/71240)."

--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -2939,13 +2939,13 @@ plugin_routing:
     emc_vnx_sg_member:
       redirect: community.general.emc_vnx_sg_member
     gluster_heal_facts:
-      redirect: community.general.gluster_heal_info
+      redirect: gluster.gluster.gluster_heal_info
     gluster_heal_info:
-      redirect: community.general.gluster_heal_info
+      redirect: gluster.gluster.gluster_heal_info
     gluster_peer:
-      redirect: community.general.gluster_peer
+      redirect: gluster.gluster.gluster_peer
     gluster_volume:
-      redirect: community.general.gluster_volume
+      redirect: gluster.gluster.gluster_volume
     ss_3par_cpg:
       redirect: community.general.ss_3par_cpg
     ibm_sa_domain:


### PR DESCRIPTION
##### SUMMARY
Backport of #71240 to stable-2.10.

Should be merged for ansible-base 2.10.1.

CC @gundalow @abadger @nitzmahone @pkesavap

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/config/ansible_builtin_runtime.yml
