### PR TITLE
hacking: replace use of "which" with "command -v"

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -1,3 +1,4 @@
+
 # usage: source hacking/env-setup [-q]
 #    modifies environment for running Ansible from checkout
 
@@ -21,7 +22,7 @@ prepend_path()
 PYTHONPATH=${PYTHONPATH-""}
 PATH=${PATH-""}
 MANPATH=${MANPATH-$(manpath)}
-PYTHON=$(which python 2>/dev/null || which python3 2>/dev/null)
+PYTHON=$(command -v python || command -v python3)
 PYTHON_BIN=${PYTHON_BIN-$PYTHON}
 
 verbosity=${1-info} # Defaults to `info' if unspecified


### PR DESCRIPTION
##### SUMMARY

"command -v" is the POSIX compliant way to get the path to a command.
It returns the path to the command if it exists and exits with a
non-zero status when it does not, without any output. "which" is not
POSIX and it can have various different effects. With Zsh, it says
"python not found" on stdout.

See:
 - https://pubs.opengroup.org/onlinepubs/009695399/utilities/command.html

##### ISSUE TYPE
- Bugfix Pull Request