### PR TITLE
hacking: disable Ansible conflict check when generating egg_info

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -67,7 +67,7 @@ gen_egg_info()
         # see https://github.com/ansible/ansible/pull/11967
         \rm -rf "$PREFIX_PYTHONPATH"/ansible*.egg-info
     fi
-    $PYTHON_BIN setup.py egg_info
+    ANSIBLE_SKIP_CONFLICT_CHECK=1 $PYTHON_BIN setup.py egg_info
 }
 
 if [ "$ANSIBLE_HOME" != "$PWD" ] ; then


### PR DESCRIPTION
##### SUMMARY

Without this change, sourcing `hacking/env-setup` outputs:

    ****************************************************************************

    Cannot install ansible-base with a pre-existing ansible==2.9.9
    installation.

    Installing ansible-base with ansible-2.9 or older currently installed with
    pip is known to cause problems. Please uninstall ansible and install the new
    version:

        pip uninstall ansible
        pip install ansible-base

    If you want to skip the conflict checks and manually resolve any issues
    afterwards, set the ANSIBLE_SKIP_CONFLICT_CHECK environment variable:

        ANSIBLE_SKIP_CONFLICT_CHECK=1 pip install ansible-base

    ****************************************************************************

This happens if Ansible is already installed on your system (for
example, through Debian packages).

##### ISSUE TYPE
- Bugfix Pull Request