### PR TITLE
Antsibull build format backport 71080

### DIFF
--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -56,6 +56,9 @@ base_generate_rst: collections_meta config cli keywords base_plugins testing
 htmldocs: generate_rst
 	CPUS=$(CPUS) $(MAKE) -f Makefile.sphinx html
 
+base_htmldocs: base_generate_rst
+	CPUS=$(CPUS) $(MAKE) -f Makefile.sphinx html
+
 singlehtmldocs: generate_rst
 	CPUS=$(CPUS) $(MAKE) -f Makefile.sphinx singlehtml
 
@@ -115,7 +118,7 @@ config: ../templates/config.rst.j2
 # For now, if we're building on devel, just build base docs.  In the future we'll want to build docs that
 # are the latest versions on galaxy (using a different antsibull-docs subcommand)
 plugins:
-	if expr match "$(VERSION)" '.*[.]dev[0-9]\+$$' &> /dev/null; then \
+	if expr "$(VERSION)" : '.*[.]dev[0-9]\{1,\}$$' &> /dev/null; then \
 		$(PLUGIN_FORMATTER) base -o rst $(PLUGIN_ARGS);\
 	else \
 		$(PLUGIN_FORMATTER) full -o rst $(PLUGIN_ARGS);\

--- a/hacking/build_library/build_ansible/command_plugins/docs_build.py
+++ b/hacking/build_library/build_ansible/command_plugins/docs_build.py
@@ -44,8 +44,8 @@ def generate_base_docs(args):
         #
         modified_deps_file = os.path.join(tmp_dir, 'ansible.deps')
 
-        # The _acd_version doesn't matter
-        deps_file_contents = {'_acd_version': ansible_base__version__,
+        # The _ansible_version doesn't matter since we're only building docs for base
+        deps_file_contents = {'_ansible_version': ansible_base__version__,
                               '_ansible_base_version': ansible_base__version__}
 
         with open(modified_deps_file, 'w') as f:
@@ -53,7 +53,7 @@ def generate_base_docs(args):
 
         # Generate the plugin rst
         return antsibull_docs.run(['antsibull-docs', 'stable', '--deps-file', modified_deps_file,
-                                   '--ansible-base-cache', str(args.top_dir),
+                                   '--ansible-base-source', str(args.top_dir),
                                    '--dest-dir', args.output_dir])
 
         # If we make this more than just a driver for antsibull:
@@ -112,7 +112,7 @@ def generate_full_docs(args):
 
         # Generate the plugin rst
         return antsibull_docs.run(['antsibull-docs', 'stable', '--deps-file', modified_deps_file,
-                                   '--ansible-base-cache', str(args.top_dir),
+                                   '--ansible-base-source', str(args.top_dir),
                                    '--dest-dir', args.output_dir])
 
         # If we make this more than just a driver for antsibull:

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -48,6 +48,9 @@ setuptools < 45 ; python_version == '2.7' # setuptools 45 and later require pyth
 # freeze antsibull-changelog for consistent test results
 antsibull-changelog == 0.3.1
 
+# Make sure we have a new enough antsibull for the CLI args we use
+antsibull >= 0.21.0
+
 # freeze pylint and its requirements for consistent test results
 astroid == 2.2.5
 isort == 4.3.15


### PR DESCRIPTION
##### SUMMARY
Backport of PR #71080 which updates Makefile and tests to use a newer antsibull (removing usage of deprecated commandline args and data file fields).

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
