### PR TITLE
Zabbix: Handle KeyError in zabbix_host module (#65392)

### DIFF
--- a/changelogs/fragments/65304-fix_zabbix_host_inventory_mode_key_error.yml
+++ b/changelogs/fragments/65304-fix_zabbix_host_inventory_mode_key_error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - zabbix_host - fixed inventory_mode key error, which occurs with Zabbix 4.4.1 or more (https://github.com/ansible/ansible/issues/65304).

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -310,6 +310,7 @@ except ImportError:
     ZBX_IMP_ERR = traceback.format_exc()
     HAS_ZABBIX_API = False
 
+from distutils.version import LooseVersion
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 
 
@@ -317,6 +318,7 @@ class Host(object):
     def __init__(self, module, zbx):
         self._module = module
         self._zapi = zbx
+        self._zbx_api_version = zbx.api_version()[:5]
 
     # exist host
     def is_host_exist(self, host_name):
@@ -565,11 +567,15 @@ class Host(object):
                 return True
 
         if inventory_mode:
-            if host['inventory']:
-                if int(host['inventory']['inventory_mode']) != self.inventory_mode_numeric(inventory_mode):
+            if LooseVersion(self._zbx_api_version) <= LooseVersion('4.4.0'):
+                if host['inventory']:
+                    if int(host['inventory']['inventory_mode']) != self.inventory_mode_numeric(inventory_mode):
+                        return True
+                elif inventory_mode != 'disabled':
                     return True
-            elif inventory_mode != 'disabled':
-                return True
+            else:
+                if int(host['inventory_mode']) != self.inventory_mode_numeric(inventory_mode):
+                    return True
 
         if inventory_zabbix:
             proposed_inventory = copy.deepcopy(host['inventory'])

--- a/test/integration/targets/zabbix_host/tasks/zabbix_host_tests.yml
+++ b/test/integration/targets/zabbix_host/tasks/zabbix_host_tests.yml
@@ -680,6 +680,34 @@
       that:
           - "zabbix_host1 is not changed"
 
+- name: "test: change host inventory mode to disabled"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    inventory_mode: disabled
+  register: zabbix_host1
+
+- name: expect to succeed and that things have changed
+  assert:
+      that:
+          - "zabbix_host1 is changed"
+
+- name: "test: change host inventory mode to manual"
+  zabbix_host:
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    inventory_mode: manual
+  register: zabbix_host1
+
+- name: expect to succeed and that things have changed
+  assert:
+      that:
+          - "zabbix_host1 is changed"
+
 - name: "test: attempt to delete host created earlier"
   zabbix_host:
     server_url: "{{ zabbix_server_url }}"


### PR DESCRIPTION
##### SUMMARY
Backport of #65392

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/monitoring/zabbix/zabbix_host.py
test/integration/targets/zabbix_host/tasks/zabbix_host_tests.yml

##### ADDITIONAL INFORMATION
We've been asked if it is possible to fix failures when zabbix modules are being run on zabbix 5.0. This is 1 of 3 backport requests incoming and should be merged first.

For additional discussion please see https://github.com/ansible-collections/community.zabbix/issues/34#issuecomment-673356625