### PR TITLE
zabbix_host fix support for Zabbix 5.0

### DIFF
--- a/changelogs/fragments/community-zabbix-51.yaml
+++ b/changelogs/fragments/community-zabbix-51.yaml
@@ -1,0 +1,5 @@
+minor_changes:
+- zabbix_host - now supports providing ``details`` for snmp interfaces.
+
+bugfixes:
+- zabbix_host - fixed support for Zabbix 5.0


### PR DESCRIPTION
##### SUMMARY
This is partial (back)port of fix present in community.zabbix ([ansible-collections/comunity.zabbix#51](https://github.com/ansible-collections/community.zabbix/pull/51)), which fixes `zabbix_host` failing on Zabbix 5.0. This one will be included with 2.10 as community.zabbix is a part of it.

This will not fail once #71288 is merged

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/monitoring/zabbix/zabbix_host.py

##### ADDITIONAL INFORMATION
We've been asked if it is possible to fix failures when zabbix modules are being run on zabbix 5.0. This is 2 of 3 backport requests incoming. I am honestly not sure how to backport functionality from collections, but since this one has been requested I am trying it this way. Let me know if I should change anything.

For additional discussion please see ansible-collections/community.zabbix#34 (comment)
