### PR TITLE
zabbix_proxy fix support for Zabbix 5.0

### DIFF
--- a/changelogs/fragments/community-zabbix-53.yaml
+++ b/changelogs/fragments/community-zabbix-53.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- zabbix_proxy - fixed support for Zabbix 5.0

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_proxy.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_proxy.py
@@ -139,6 +139,7 @@ RETURN = r''' # '''
 import traceback
 import atexit
 
+from distutils.version import LooseVersion
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 try:
     from zabbix_api import ZabbixAPI
@@ -153,6 +154,7 @@ class Proxy(object):
     def __init__(self, module, zbx):
         self._module = module
         self._zapi = zbx
+        self._zbx_api_version = zbx.api_version()[:5]
         self.existing_data = None
 
     def proxy_exists(self, proxy_name):
@@ -203,6 +205,10 @@ class Proxy(object):
         if 'interface' in self.existing_data and \
            len(self.existing_data['interface']) > 0:
             old_interface = self.existing_data['interface']
+
+        if LooseVersion(self._zbx_api_version) >= LooseVersion('5.0.0'):
+            if old_interface:
+                old_interface['details'] = str(old_interface['details'])
 
         final_interface = old_interface.copy()
         final_interface.update(new_interface)


### PR DESCRIPTION
##### SUMMARY
This is (back)port of fix present in community.zabbix ([ansible-collections/comunity.zabbix#53](https://github.com/ansible-collections/community.zabbix/pull/53)), which fixes zabbix_proxy failing on Zabbix 5.0. This one will be included with 2.10 as community.zabbix is a part of it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/monitoring/zabbix/zabbix_host.py

##### ADDITIONAL INFORMATION
We've been asked if it is possible to fix failures when zabbix modules are being run on zabbix 5.0. This is 3 of 3 backport requests incoming. I am honestly not sure how to backport functionality from collections, but since this one has been requested I am trying it this way. Let me know if I should change anything.

For additional discussion please see ansible-collections/community.zabbix#34 (comment)
