### PR TITLE
Fix values of connection variables defined as inventory variables when delegate_to is used

### DIFF
--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -429,6 +429,10 @@ class VariableManager:
         # if we have a task and we're delegating to another host, figure out the
         # variables for that host now so we don't have to rely on hostvars later
         if task and task.delegate_to is not None and include_delegate_to:
+            # connection variables must not be propagated to the delegated host
+            for connection_var in C.COMMON_CONNECTION_VARS:
+                if connection_var in all_vars:
+                    del all_vars[connection_var]
             all_vars['ansible_delegated_vars'], all_vars['_ansible_loop_cache'] = self._get_delegated_vars(play, task, all_vars)
 
         # 'vars' magic var

--- a/test/integration/targets/delegate_to/delegate_vars_hanldling.yml
+++ b/test/integration/targets/delegate_to/delegate_vars_hanldling.yml
@@ -6,6 +6,25 @@
         name: delegatetome
         ansible_host: 127.0.0.4
 
+- name: ensure connection variables are reset when delegated_to is used
+  hosts: testhost
+  gather_facts: false
+  tasks:
+    - name: ensure local connection is used for localhost
+      assert:
+        that:
+          - ansible_connection == 'local'
+          - ansible_host == 'testhost'
+        msg: "ansible_connection, ansible_host: {{ ansible_connection, ansible_host }}"
+
+    - name: ensure SSH connection is used with the delegated host
+      assert:
+        that:
+          - ansible_connection == 'ssh'
+          - ansible_host == '127.0.0.4'
+        msg: "ansible_connection, ansible_host: {{ ansible_connection, ansible_host }}"
+      delegate_to: delegatetome
+
 - name: ensure we dont use orig host vars if delegated one does not define them
   hosts: testhost
   gather_facts: false


### PR DESCRIPTION
##### SUMMARY

When a connection variable is explicitly defined as an inventory variable and `delegate_to` is used, value of this variable is incorrect: the value of the FROM host leaks and is used instead of the expected one.

* Add integration test for #30630: `delegate_to`: check that connection variables are reset
* Fix #30630:  reset connection variables for delegated tasks

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/vars/manager.py

##### ADDITIONAL INFORMATION
Without the patch, added [integration test failed](https://app.shippable.com/github/ansible/ansible/runs/172522/48/console) as expected.