### PR TITLE
[WIP] unvault: Return file path for decrypted file

### DIFF
--- a/lib/ansible/plugins/lookup/unvault.py
+++ b/lib/ansible/plugins/lookup/unvault.py
@@ -3,29 +3,44 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
     lookup: unvault
-    author: ansible core team
+    author: Ansible core team
     version_added: "2.10"
-    short_description: read vaulted file(s) contents
+    short_description: Read vaulted file(s) contents
     description:
         - This lookup returns the contents from vaulted (or not) file(s) on the Ansible controller's file system.
+        - This lookup can be also used for returning the actual filename of decrypted file.
     options:
       _terms:
-        description: path(s) of files to read
+        description: Path(s) of files to read.
         required: True
+      filename_only:
+        description:
+        - Return file path instead of content.
+        - If set to C(True), will return only decrypted file path from
+          Ansible Controller's file system instead of content.
+        required: False
+        default: False
     notes:
       - This lookup does not understand 'globbing' nor shell environment variables.
 """
 
-EXAMPLES = """
-- debug: msg="the value of foo.txt is {{lookup('unvault', '/etc/foo.txt')|to_string }}"
+EXAMPLES = r"""
+- debug:
+    msg: "the value of foo.txt is {{ lookup('unvault', '/etc/foo.txt') | to_string }}"
+
+- community.kubernetes.k8s_info:
+    namespace: default
+    kind: pod
+    kubeconfig: "{{ lookup('unvault', '/project/vaulted_kubeconfig', filename_only=True) }}"
 """
 
-RETURN = """
+RETURN = r"""
   _raw:
     description:
       - content of file(s) as bytes
+      - file path(s) of the decrypted files if C(filename_only) is set to C(true)
 """
 
 from ansible.errors import AnsibleParserError
@@ -52,9 +67,12 @@ class LookupModule(LookupBase):
             display.vvvv(u"Unvault lookup found %s" % lookupfile)
             if lookupfile:
                 actual_file = self._loader.get_real_file(lookupfile, decrypt=True)
-                with open(actual_file, 'rb') as f:
-                    b_contents = f.read()
-                ret.append(b_contents)
+                if self.get_option('filename_only'):
+                    ret.append(actual_file)
+                else:
+                    with open(actual_file, 'rb') as f:
+                        b_contents = f.read()
+                    ret.append(b_contents)
             else:
                 raise AnsibleParserError('Unable to find file matching "%s" ' % term)
 


### PR DESCRIPTION
##### SUMMARY

Add a flag to return full file path of decrypted file
which is located on Ansible controller's file system.
Some modules might required decrypted file path instead of
decrypted content of vaulted file, for example - k8s_* modules.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/lookup/unvault.py
