### PR TITLE
Don't do conflict check on sdist and egg_info

### DIFF
--- a/changelogs/fragments/71279-skip-conflict-check.yml
+++ b/changelogs/fragments/71279-skip-conflict-check.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- setup.py - Skip doing conflict checks for ``sdist`` and ``egg_info`` commands
+  (https://github.com/ansible/ansible/pull/71279)

--- a/changelogs/fragments/71279-skip-conflict-check.yml
+++ b/changelogs/fragments/71279-skip-conflict-check.yml
@@ -1,3 +1,3 @@
 minor_changes:
 - setup.py - Skip doing conflict checks for ``sdist`` and ``egg_info`` commands
-  (https://github.com/ansible/ansible/pull/71279)
+  (https://github.com/ansible/ansible/pull/71310)

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,10 @@ def _validate_install_ansible_base():
     cares about upgrading to ansible-base from ansible<2.10
     """
     # Skip common commands we can ignore
+    # Do NOT add bdist_wheel here, we don't ship wheels
+    # and bdist_wheel is the only place we can prevent pip
+    # from installing, as pip creates a wheel, and installs the wheel
+    # and we have no influence over installation within a wheel
     if set(('sdist', 'egg_info')).intersection(sys.argv):
         return
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,10 @@ def _validate_install_ansible_base():
     """Validate that we can install ansible-base. Currently this only
     cares about upgrading to ansible-base from ansible<2.10
     """
+    # Skip common commands we can ignore
+    if set(('sdist', 'egg_info')).intersection(sys.argv):
+        return
+
     if os.getenv('ANSIBLE_SKIP_CONFLICT_CHECK', '') not in ('', '0'):
         return
 


### PR DESCRIPTION
##### SUMMARY
Don't do conflict check on sdist and egg_info. Fixes #71279

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
