### PR TITLE
Fix meta tasks used with --flush-cache

### DIFF
--- a/changelogs/fragments/fix_meta_tasks_with_flush_cache.yml
+++ b/changelogs/fragments/fix_meta_tasks_with_flush_cache.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix execution of the meta tasks 'clear_facts', 'clear_host_errors', 'end_play', 'end_host', and 'reset_connection' when the CLI flag '--flush-cache' is provided.

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -190,7 +190,6 @@ class StrategyBase:
         self._final_q = tqm._final_q
         self._step = context.CLIARGS.get('step', False)
         self._diff = context.CLIARGS.get('diff', False)
-        self.flush_cache = context.CLIARGS.get('flush_cache', False)
 
         # the task cache is a dictionary of tuples of (host.name, task._uuid)
         # used to find the original task object of in-flight tasks and to store
@@ -1130,6 +1129,7 @@ class StrategyBase:
 
         skipped = False
         msg = ''
+        # The top-level conditions should only compare meta_action
         if meta_action == 'noop':
             # FIXME: issue a callback for the noop here?
             if task.when:
@@ -1142,7 +1142,7 @@ class StrategyBase:
             self.run_handlers(iterator, play_context)
             self._flushed_hosts[target_host] = False
             msg = "ran handlers"
-        elif meta_action == 'refresh_inventory' or self.flush_cache:
+        elif meta_action == 'refresh_inventory':
             if task.when:
                 self._cond_not_supported_warn(meta_action)
             self._inventory.refresh_inventory()


### PR DESCRIPTION
##### SUMMARY
Flushing the cache is separate from meta tasks. The CLI flag should do it once at the beginning of the playbook, like here https://github.com/ansible/ansible/blob/f7dfa817ae6542509e0c6eb437ea7bcc51242ca2/lib/ansible/cli/playbook.py#L120

As a follow-up PR, it would be good to make this accessible to adhoc, ansible-console, and ansible-inventory.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
