### PR TITLE
[stable-2.10] Don't do conflict check on sdist and egg_info (#71310)

### DIFF
--- a/changelogs/fragments/71279-skip-conflict-check.yml
+++ b/changelogs/fragments/71279-skip-conflict-check.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- setup.py - Skip doing conflict checks for ``sdist`` and ``egg_info`` commands
+  (https://github.com/ansible/ansible/pull/71310)

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,14 @@ def _validate_install_ansible_base():
     """Validate that we can install ansible-base. Currently this only
     cares about upgrading to ansible-base from ansible<2.10
     """
+    # Skip common commands we can ignore
+    # Do NOT add bdist_wheel here, we don't ship wheels
+    # and bdist_wheel is the only place we can prevent pip
+    # from installing, as pip creates a wheel, and installs the wheel
+    # and we have no influence over installation within a wheel
+    if set(('sdist', 'egg_info')).intersection(sys.argv):
+        return
+
     if os.getenv('ANSIBLE_SKIP_CONFLICT_CHECK', '') not in ('', '0'):
         return
 


### PR DESCRIPTION
* Don't do conflict check on sdist and egg_info. Fixes #71279

* Add changelog

* adjust changelog PR link

Co-authored-by: Rick Elrod <rick@elrod.me>

* add warning about bdist_wheel

Co-authored-by: Rick Elrod <rick@elrod.me>
(cherry picked from commit 959af7d)


Co-authored-by: Matt Martz <matt@sivel.net>