### PR TITLE
[stable-2.9] Allow the TOML inventory to dump unsafe. Fixes #71307 (#71309)

### DIFF
--- a/changelogs/fragments/71307-toml-dumps-unsafe.yml
+++ b/changelogs/fragments/71307-toml-dumps-unsafe.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- TOML inventory - Ensure we register dump functions for ``AnsibleUnsafe`` to support dumping unsafe values.
+  Note that the TOML format has no functionality to mark that the data is unsafe for re-consumption.
+  (https://github.com/ansible/ansible/issues/71307)

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -101,6 +101,7 @@ from ansible.module_utils.six import string_types, text_type
 from ansible.parsing.yaml.objects import AnsibleSequence, AnsibleUnicode
 from ansible.plugins.inventory import BaseFileInventoryPlugin
 from ansible.utils.display import Display
+from ansible.utils.unsafe_proxy import AnsibleUnsafeBytes, AnsibleUnsafeText
 
 try:
     import toml
@@ -124,6 +125,8 @@ if HAS_TOML and hasattr(toml, 'TomlEncoder'):
             self.dump_funcs.update({
                 AnsibleSequence: self.dump_funcs.get(list),
                 AnsibleUnicode: self.dump_funcs.get(str),
+                AnsibleUnsafeBytes: self.dump_funcs.get(str),
+                AnsibleUnsafeText: self.dump_funcs.get(str),
             })
     toml_dumps = partial(toml.dumps, encoder=AnsibleTomlEncoder())
 else:


### PR DESCRIPTION
(cherry picked from commit 9da8801)


Co-authored-by: Matt Martz <matt@sivel.net>