### PR TITLE
[stable-2.10] epoch can be a float with strftime filter. Fixes #71257 (#71314)

### DIFF
--- a/changelogs/fragments/71257-strftime-float.yml
+++ b/changelogs/fragments/71257-strftime-float.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- strftime filter - Input epoch is allowed to be a float
+  (https://github.com/ansible/ansible/issues/71257)

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -102,7 +102,7 @@ def strftime(string_format, second=None):
     ''' return a date string using string. See https://docs.python.org/2/library/time.html#time.strftime for format '''
     if second is not None:
         try:
-            second = int(second)
+            second = float(second)
         except Exception:
             raise AnsibleFilterError('Invalid value for epoch value (%s)' % second)
     return time.strftime(string_format, time.localtime(second))

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -298,6 +298,7 @@
   assert:
     that:
       - '"%Y-%m-%d"|strftime(1585247522) == "2020-03-26"'
+      - '"%Y-%m-%d"|strftime("1585247522.0") == "2020-03-26"'
       - '("%Y"|strftime(None)).startswith("20")' # Current date, can't check much there.
       - strftime_fail is failed
       - '"Invalid value for epoch value" in strftime_fail.msg'


### PR DESCRIPTION
(cherry picked from commit 6289570)


Co-authored-by: Matt Martz <matt@sivel.net>