### PR TITLE
[stable-2.9] epoch can be a float with strftime filter. Fixes #71257 (#71314).

### DIFF
--- a/changelogs/fragments/71257-strftime-float.yml
+++ b/changelogs/fragments/71257-strftime-float.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- strftime filter - Input epoch is allowed to be a float
+  (https://github.com/ansible/ansible/issues/71257)

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -107,7 +107,7 @@ def strftime(string_format, second=None):
     ''' return a date string using string. See https://docs.python.org/2/library/time.html#time.strftime for format '''
     if second is not None:
         try:
-            second = int(second)
+            second = float(second)
         except Exception:
             raise AnsibleFilterError('Invalid value for epoch value (%s)' % second)
     return time.strftime(string_format, time.localtime(second))


### PR DESCRIPTION
[stable-2.9] epoch can be a float with strftime filter. Fixes #71257 (#71314).

(cherry picked from commit 6289570234ff924a057e8d89ec00606e0ecca0f6)

Co-authored-by: Matt Martz <matt@sivel.net>
