### PR TITLE
Replace atomic_move() with a higher level function

### DIFF
--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -12,12 +12,18 @@ import pwd
 import grp
 import time
 import shutil
+import tempfile
 import traceback
 import fcntl
 import sys
 
 from contextlib import contextmanager
 from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.common.sys_info import (
+    selinux_context,
+    selinux_enabled,
+    selinux_mls_enabled,
+)
 from ansible.module_utils.six import b, binary_type
 
 try:
@@ -60,6 +66,30 @@ PERMS_RE = re.compile(r'[^rwxXstugo]')
 _PERM_BITS = 0o7777          # file mode permission bits
 _EXEC_PERM_BITS = 0o0111     # execute permission bits
 _DEFAULT_PERM = 0o0666       # default file permission bits
+
+
+def _unsafe_writes(src, dest):
+    """
+    Sadly there are some situations where we cannot ensure atomicity, but only
+    if the user insists and we get the appropriate error we update the file
+    unsafely
+    """
+
+    try:
+        out_dest = in_src = None
+        try:
+            out_dest = open(dest, 'wb')
+            in_src = open(src, 'rb')
+            shutil.copyfileobj(in_src, out_dest)
+        finally:  # assuring closed files in 2.4 compatible way
+            if out_dest:
+                out_dest.close()
+            if in_src:
+                in_src.close()
+    except (shutil.Error, OSError, IOError) as e:
+        raise
+        self.fail_json(msg='Could not write data to file (%s) from (%s): %s' % (dest, src, to_native(e)),
+                       exception=traceback.format_exc())
 
 
 def is_executable(path):
@@ -109,6 +139,138 @@ def get_file_arg_spec():
     )
     return arg_spec
 
+
+def move_and_set_attributes(src, dest, unsafe_writes=False):
+    """
+    Atomically move a file and set the specified permissions on the dest.
+    If
+    """
+    move_file(src, dest, unsafe_writes=unsafe_writes)
+    set_fs_attributes_if_different()
+    pass
+
+
+def move_file(src, dest, unsafe_writes=False):
+    """
+    Move a file atomically, preserving the source attributes in the destination.
+
+    :arg src:
+    :arg dest:
+    :kwarg unsafe_writes:
+    """
+
+    b_src = to_bytes(src, errors='surrogate_or_strict')
+    b_dest = to_bytes(dest, errors='surrogate_or_strict')
+
+    try:
+        # Optimistically try a rename, solves some corner cases and can avoid useless work,
+        # throws exception if not atomic.
+        os.rename(b_src, b_dest)
+    except (IOError, OSError) as e:
+        # only try workarounds for errno 18 (cross device), 1 (not permitted),  13 (permission
+        # denied) and 26 (text file busy) which happens on vagrant synced folders and other
+        # 'exotic' non posix file systems
+        if e.errno not in [errno.EPERM, errno.EXDEV, errno.EACCES, errno.ETXTBSY, errno.EBUSY]:
+            raise
+    else:
+        # Success!
+        return
+
+    #
+    # The rest of this function is to simulate a rename with a copy
+    #
+
+    # Gather metadata about the src file so we can replicate it at the destination
+    src_stat = os.stat(b_src)
+
+    context = None
+    if selinux_enabled():
+        context = selinux_context(src)
+
+    #
+    # Create a temporary file in the destination directory that we can rename at the end
+    #
+
+    # Use bytes here.  In the shippable CI, this fails with
+    # a UnicodeError with surrogateescape'd strings for an unknown
+    # reason (doesn't happen in a local Ubuntu16.04 VM)
+    b_dest_dir = os.path.dirname(b_dest)
+    b_suffix = os.path.basename(b_dest)
+    error_msg = None
+    tmp_dest_name = None
+    try:
+        # The temp file is created such that only the user can read and write it.
+        tmp_dest_fd, tmp_dest_name = tempfile.mkstemp(prefix=b'.ansible_tmp',
+                                                      dir=b_dest_dir, suffix=b_suffix)
+    except (OSError, IOError) as e:
+        error_msg = ('The destination directory (%s) is not writable by the current user.'
+                     ' Error was: %s' % (os.path.dirname(dest), to_native(e)))
+    except TypeError:
+        # We expect that this is happening because python3.4.x and
+        # below can't handle byte strings in mkstemp().  Traceback
+        # would end in something like:
+        #     file = _os.path.join(dir, pre + name + suf)
+        # TypeError: can't concat bytes to str
+        error_msg = ('Failed creating tmp file for atomic move.  This usually happens when'
+                     ' using Python3 less than Python3.5. Please use Python2.x or Python3.5'
+                     ' or greater.')
+    if error_msg:
+        if unsafe_writes:
+            return self._unsafe_writes(b_src, b_dest)
+        else:
+            raise IOError(error_msg)
+
+    b_tmp_dest_name = to_bytes(tmp_dest_name, errors='surrogate_or_strict')
+
+    try:
+        # close tmp file handle before file operations to prevent text file busy errors on
+        # vboxfs synced folders (windows host)
+        os.close(tmp_dest_fd)
+
+        # leaves tmp file behind when sudo and not root
+        try:
+            shutil.move(b_src, b_tmp_dest_name)
+        except OSError:
+            # cleanup will happen by 'rm' of tmpdir
+            # copy2 will preserve some metadata
+            shutil.copy2(b_src, b_tmp_dest_name)
+
+        # Flags have to be copied manually and aren't supported on all platforms
+        if hasattr(os, 'chflags') and hasattr(src_stat, 'st_flags'):
+            try:
+                os.chflags(b_tmp_dest_name, src_stat.st_flags)
+            except OSError as e:
+                for err in 'EOPNOTSUPP', 'ENOTSUP':
+                    if hasattr(errno, err) and e.errno == getattr(errno, err):
+                        break
+                else:
+                    raise
+
+        # SELinux contexts have to be set manually
+        if context:
+            self.set_context_if_different(b_tmp_dest_name, context, False)
+
+        # Copy2 does not set owner and group so we have to do it here
+        try:
+            tmp_stat = os.stat(b_tmp_dest_name)
+            if src_stat and (tmp_stat.st_uid != src_stat.st_uid
+                             or tmp_stat.st_gid != src_stat.st_gid):
+                os.chown(b_tmp_dest_name, src_stat.st_uid, src_stat.st_gid)
+        except OSError as e:
+            # Allow EPERM to pass in case we're an unprivileged user (historical.  May want
+            # to change this so the caller decides what to do.)
+            if e.errno != errno.EPERM:
+                raise
+
+        # Try to rename our temporary file to the real destination
+        try:
+            os.rename(b_tmp_dest_name, b_dest)
+        except (shutil.Error, OSError, IOError) as e:
+            if unsafe_writes and e.errno == errno.EBUSY:
+                return self._unsafe_writes(b_tmp_dest_name, b_dest)
+            raise
+    finally:
+        self.cleanup(b_tmp_dest_name)
 
 class LockTimeout(Exception):
     pass


### PR DESCRIPTION
##### SUMMARY

CVE-2020-1736

Related to #70221, #71200
Fixes #67794

The original fix for this CVE which changed the default permissions to `600` unless `mode` was explicitly specified in the task was too disruptive. This is an attempt at a better solution, but it will be a more invasive change to the code.

The CVE has two main problems that need to be addressed:

1. Default permissions of temporary files
1. Permissions of newly created files

The previous fix addressed the first item, but did not adequately address the second item. Asking that tasks explcitly specify `mode` was too much of a change requirement. Furthermore, it resulted in overwhelming surprise from the community to find that in the absense of `mode` the default `umask` of the system was not used. That’s a sign it was not a good fix.

Here is my plan for how to fix this:

- deprecate `atomic_move()`
- rewrite `atomic_move()` so it is easier to read and maintain
- create a higher level function that calls the new `move_file()` method as well as `set_mode_if_different()`

The main reasoning behind this is that `atomic_move()` is not a good API. It has a very strong, but unenforced, relationship to `set_fs_attributes_if_different()` and it lacks information about the intended final permissions of the file.

In order to ensure that temporary files are created securely, and that they are never set to a mode greater than the `mode` specified in the task, if present, the new method needs to know about the final intended permissions, not just the system defaults.

The new method will accept `src`, `dest`, and `mode` at a minimum. It may accept the same `file_args` that `set_fs_attributes_if_different()` accepts, but I am not sure at this time.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

`lib/ansible/module_utils/basic.py`

##### ADDITIONAL INFORMATION

In its current state, I am in the process of writing `move_file()` as a function rather than (yet another) method of `AnsibleModule`. Ultimately, I believe this approach will be too disruptive and will have to be done at a later date. There are many methods, particularly `run_command()` that will require a lot of work to remove from `AnsibleModule`.

I will most likely end up creating new methods so this change may be backported, then do the work of moving those methods to functions. Apologies to my future self. 😄