### PR TITLE
[stable-2.9] systemd - supports new systemctl output message for chroot (#71197)

### DIFF
--- a/changelogs/fragments/71197-systemctl-ignore-message.yaml
+++ b/changelogs/fragments/71197-systemctl-ignore-message.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - systemd - fixed chroot usage on new versions of systemd, that broke because of upstream changes in systemctl output
+  - systemd - made the systemd module work correctly when the SYSTEMD_OFFLINE environment variable is set

--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -279,7 +279,7 @@ def is_deactivating_service(service_status):
 
 
 def request_was_ignored(out):
-    return '=' not in out and 'ignoring request' in out
+    return '=' not in out and ('ignoring request' in out or 'ignoring command' in out)
 
 
 def parse_systemctl_show(lines):
@@ -537,8 +537,8 @@ def main():
                         if rc != 0:
                             module.fail_json(msg="Unable to %s service %s: %s" % (action, unit, err))
             # check for chroot
-            elif is_chroot(module):
-                module.warn("Target is a chroot. This can lead to false positives or prevent the init system tools from working.")
+            elif is_chroot(module) or os.environ.get('SYSTEMD_OFFLINE') == '1':
+                module.warn("Target is a chroot or systemd is offline. This can lead to false positives or prevent the init system tools from working.")
             else:
                 # this should not happen?
                 module.fail_json(msg="Service is in unknown state", status=result['status'])

--- a/test/integration/targets/systemd/tasks/main.yml
+++ b/test/integration/targets/systemd/tasks/main.yml
@@ -47,4 +47,10 @@
               - 'not systemd_test0.changed'
               - 'systemd_test0.state == "started"'
 
+    - name: check that the module works even when systemd is offline (eg in chroot)
+      systemd:
+          name: "{{ running_names.stdout_lines|random }}"
+          state: started
+      environment:
+          SYSTEMD_OFFLINE: 1
   when: 'systemctl_check.rc == 0'


### PR DESCRIPTION
The message generated by systemctl has been updated in https://github.com/systemd/systemd/commit/9321e23c40f3dc6bd785105ce882cbad6447a1c6, which requires a corresponding change in the systemd module.

In addition, this fixes the module when the SYSTEMD_OFFLINE environment variable is set.

(cherry picked from commit a1a50bb3cd0c2d6f2f4cb260a43553c23e806d8a)