### PR TITLE
Reject unknown types from results queue

### DIFF
--- a/changelogs/fragments/70023-results-type-filtering.yml
+++ b/changelogs/fragments/70023-results-type-filtering.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- Strategy - Ensure we only process expected types from the results queue
+  and produce warnings for any object we receive from the queue that doesn't
+  match our expectations.
+  (https://github.com/ansible/ansible/issues/70023)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -100,16 +100,17 @@ def results_thread_main(strategy):
             result = strategy._final_q.get()
             if isinstance(result, StrategySentinel):
                 break
+            elif isinstance(result, TaskResult):
+                with strategy._results_lock:
+                    # only handlers have the listen attr, so this must be a handler
+                    # we split up the results into two queues here to make sure
+                    # handler and regular result processing don't cross wires
+                    if 'listen' in result._task_fields:
+                        strategy._handler_results.append(result)
+                    else:
+                        strategy._results.append(result)
             else:
-                strategy._results_lock.acquire()
-                # only handlers have the listen attr, so this must be a handler
-                # we split up the results into two queues here to make sure
-                # handler and regular result processing don't cross wires
-                if 'listen' in result._task_fields:
-                    strategy._handler_results.append(result)
-                else:
-                    strategy._results.append(result)
-                strategy._results_lock.release()
+                display.warning('Received an invalid object (%s) in the result queue: %r' % (type(result), result))
         except (IOError, EOFError):
             break
         except Queue.Empty:


### PR DESCRIPTION
##### SUMMARY
Reject unknown types from results queue. Fixes #70023

This is a partial backport of https://github.com/ansible/ansible/pull/70501, that only includes the bugfix to reject unknown types.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
```
lib/ansible/plugins/strategy/__init__.py
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
