### PR TITLE
Add note about integration tests for new modules to the dev guide

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -163,6 +163,10 @@ Testing your newly-created module
 The following two examples will get you started with testing your module code. Please review our :ref:`testing <developing_testing>` section for more detailed
 information, including instructions for :ref:`testing module documentation <testing_module_documentation>`, adding :ref:`integration tests <testing_integration>`, and more.
 
+.. note::
+  Every new module and plugin should have integration tests, even if the tests cannot be run on Ansible CI infrastructure.
+  In this case, the tests should be marked with the ``unsupported`` alias in `aliases file <https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/integration-aliases.html>`_.
+
 Performing sanity tests
 -----------------------
 

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -16,6 +16,10 @@ Some tests may require credentials.  Credentials may be specified with `credenti
 
 Some tests may require root.
 
+.. note::
+  Every new module and plugin should have integration tests, even if the tests cannot be run on Ansible CI infrastructure.
+  In this case, the tests should be marked with the ``unsupported`` alias in `aliases file <https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/integration-aliases.html>`_.
+
 Quick Start
 ===========
 


### PR DESCRIPTION
##### SUMMARY
The question was recently raised: should we keep integration tests marked with `unsupported` alias.

According to https://docs.ansible.com/ansible/devel/dev_guide/testing/sanity/integration-aliases.html,
```
Untested

Every module and plugin should have integration tests, even if the tests cannot be run in CI
```
And it makes a big sense. From my experience, writing integration tests helps create clearer interfaces and catch bugs / unexpected things on development stage.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/developing_modules_general.rst
docs/docsite/rst/dev_guide/testing_integration.rst
