### PR TITLE
Support --flush-cache for adhoc, ansible-console, and ansible-inventory

### DIFF
--- a/changelogs/fragments/support_flush_cache.yaml
+++ b/changelogs/fragments/support_flush_cache.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Move '--flush-cache' to inventory options to add support to flush the cache for adhoc, ansible-inventory, and ansible-console.

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -476,7 +476,17 @@ class CLI(with_metaclass(ABCMeta, object)):
         return loader, inventory, variable_manager
 
     @staticmethod
-    def get_host_list(inventory, subset, pattern='all'):
+    def _flush_cache(inventory, variable_manager):
+        for host in inventory.list_hosts():
+            hostname = host.get_name()
+            variable_manager.clear_facts(hostname)
+
+    @staticmethod
+    def get_host_list(inventory, subset, pattern='all', variable_manager=None):
+
+        # flush fact cache if requested
+        if variable_manager is not None and context.CLIARGS['flush_cache']:
+            CLI._flush_cache(inventory, variable_manager)
 
         no_hosts = False
         if len(inventory.list_hosts()) == 0:

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -97,7 +97,7 @@ class AdHocCLI(CLI):
         loader, inventory, variable_manager = self._play_prereqs()
 
         try:
-            hosts = self.get_host_list(inventory, context.CLIARGS['subset'], pattern)
+            hosts = self.get_host_list(inventory, context.CLIARGS['subset'], pattern, variable_manager)
         except AnsibleError:
             if context.CLIARGS['subset']:
                 raise

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -280,14 +280,14 @@ def add_inventory_options(parser):
                         help='outputs a list of matching hosts; does not execute anything else')
     parser.add_argument('-l', '--limit', default=C.DEFAULT_SUBSET, dest='subset',
                         help='further limit selected hosts to an additional pattern')
+    parser.add_argument('--flush-cache', dest='flush_cache', action='store_true',
+                        help="clear the fact cache for every host in inventory")
 
 
 def add_meta_options(parser):
     """Add options for commands which can launch meta tasks from the command line"""
     parser.add_argument('--force-handlers', default=C.DEFAULT_FORCE_HANDLERS, dest='force_handlers', action='store_true',
                         help="run handlers even if a task fails")
-    parser.add_argument('--flush-cache', dest='flush_cache', action='store_true',
-                        help="clear the fact cache for every host in inventory")
 
 
 def add_module_options(parser):

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -431,7 +431,7 @@ class ConsoleCLI(CLI, cmd.Cmd):
 
         self.loader, self.inventory, self.variable_manager = self._play_prereqs()
 
-        hosts = self.get_host_list(self.inventory, context.CLIARGS['subset'], self.pattern)
+        hosts = self.get_host_list(self.inventory, context.CLIARGS['subset'], self.pattern, self.variable_manager)
 
         self.groups = self.inventory.list_groups()
         self.hosts = [x.name for x in hosts]

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -139,10 +139,12 @@ class InventoryCLI(CLI):
             results = self.dump(myvars)
 
         elif context.CLIARGS['graph']:
-            CLI.get_host_list(self.inventory, None, variable_manager=self.vm)
+            if context.CLIARGS['flush_cache']:
+                CLI._flush_cache(sefl.inventory, self.vm)
             results = self.inventory_graph()
         elif context.CLIARGS['list']:
-            CLI.get_host_list(self.inventory, None, variable_manager=self.vm)
+            if context.CLIARGS['flush_cache']:
+                CLI._flush_cache(self.inventory, self.vm)
             top = self._get_group('all')
             if context.CLIARGS['yaml']:
                 results = self.yaml_inventory(top)

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -140,7 +140,7 @@ class InventoryCLI(CLI):
 
         elif context.CLIARGS['graph']:
             if context.CLIARGS['flush_cache']:
-                CLI._flush_cache(sefl.inventory, self.vm)
+                CLI._flush_cache(self.inventory, self.vm)
             results = self.inventory_graph()
         elif context.CLIARGS['list']:
             if context.CLIARGS['flush_cache']:

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -129,7 +129,7 @@ class InventoryCLI(CLI):
 
         results = None
         if context.CLIARGS['host']:
-            hosts = self.inventory.get_hosts(context.CLIARGS['host'])
+            hosts = CLI.get_host_list(self.inventory, None, pattern=context.CLIARGS['host'], variable_manager=self.vm)
             if len(hosts) != 1:
                 raise AnsibleOptionsError("You must pass a single valid host to --host parameter")
 
@@ -139,8 +139,10 @@ class InventoryCLI(CLI):
             results = self.dump(myvars)
 
         elif context.CLIARGS['graph']:
+            CLI.get_host_list(self.inventory, None, variable_manager=self.vm)
             results = self.inventory_graph()
         elif context.CLIARGS['list']:
+            CLI.get_host_list(self.inventory, None, variable_manager=self.vm)
             top = self._get_group('all')
             if context.CLIARGS['yaml']:
                 results = self.yaml_inventory(top)

--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -114,11 +114,7 @@ class PlaybookCLI(CLI):
         # limit if only implicit localhost was in inventory to start with.
         #
         # Fix this when we rewrite inventory by making localhost a real host (and thus show up in list_hosts())
-        CLI.get_host_list(inventory, context.CLIARGS['subset'])
-
-        # flush fact cache if requested
-        if context.CLIARGS['flush_cache']:
-            self._flush_cache(inventory, variable_manager)
+        CLI.get_host_list(inventory, context.CLIARGS['subset'], variable_manager=variable_manager)
 
         # create the playbook executor, which manages running the plays via a task queue manager
         pbex = PlaybookExecutor(playbooks=context.CLIARGS['args'], inventory=inventory,
@@ -194,9 +190,3 @@ class PlaybookCLI(CLI):
             return 0
         else:
             return results
-
-    @staticmethod
-    def _flush_cache(inventory, variable_manager):
-        for host in inventory.list_hosts():
-            hostname = host.get_name()
-            variable_manager.clear_facts(hostname)

--- a/test/integration/targets/flush_fact_cache/aliases
+++ b/test/integration/targets/flush_fact_cache/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group4

--- a/test/integration/targets/flush_fact_cache/assert_cached_fact.yml
+++ b/test/integration/targets/flush_fact_cache/assert_cached_fact.yml
@@ -1,0 +1,5 @@
+---
+- hosts: host1
+  tasks:
+    - assert:
+        that: "cached_fact | default('undefined') == result"

--- a/test/integration/targets/flush_fact_cache/cache_path/host1
+++ b/test/integration/targets/flush_fact_cache/cache_path/host1
@@ -1,0 +1,3 @@
+{
+    "cached_fact": "exists"
+}

--- a/test/integration/targets/flush_fact_cache/inventory.yml
+++ b/test/integration/targets/flush_fact_cache/inventory.yml
@@ -1,0 +1,6 @@
+all:
+  hosts:
+    host1:
+      ansible_host: 127.0.0.1
+      ansible_connection: local
+      ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/test/integration/targets/flush_fact_cache/runme.sh
+++ b/test/integration/targets/flush_fact_cache/runme.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -eux
+
+export ANSIBLE_GATHERING=explicit
+export ANSIBLE_CACHE_PLUGIN=ansible.builtin.jsonfile
+export ANSIBLE_CACHE_PLUGIN_CONNECTION=./cache_path/
+
+function setup_fact_cache {
+cat << EOF > "./cache_path/host1"
+{
+  "cached_fact": "exists"
+}
+EOF
+}
+
+### ansible-playbook
+setup_fact_cache
+ansible-playbook -i inventory.yml assert_cached_fact.yml -e 'result=exists' "$@"
+ansible-playbook -i inventory.yml assert_cached_fact.yml --flush-cache -e "result=undefined" "$@"
+
+### adhoc
+setup_fact_cache
+ansible -i inventory.yml host1 -m debug -a msg="{{ cached_fact | default('undefined') }}" "$@" | grep 'exists'
+ansible -i inventory.yml host1 -m debug -a msg="{{ cached_fact | default('undefined') }}" --flush-cache "$@" | grep 'undefined'
+
+### ansible-console
+setup_fact_cache
+ansible-console -i inventory.yml host1 "$@" << EOS
+assert that="cached_fact | default('undefined') == 'exists'"
+EOS
+ansible-console -i inventory.yml host1 --flush-cache "$@" << EOS
+assert that="cached_fact | default('undefined') == 'undefined'"
+EOS
+
+### ansible-inventory
+setup_fact_cache
+ansible-inventory -i inventory.yml --list "$@" | grep 'exists'
+ansible-inventory -i inventory.yml --list --flush-cache "$@" | grep 'exists' && exit 1 || exit 0


### PR DESCRIPTION
##### SUMMARY
Add support for flushing the cache for adhoc, ansible-console, and ansible-inventory since they also use the fact cache. Follow up to https://github.com/ansible/ansible/pull/71311#issuecomment-675033428

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/cli/__init__.py

