### PR TITLE
Documentation: improve dev_guide/testing_integration.rst

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -72,7 +72,7 @@ outside of those test subdirectories.  They will also not reconfigure or bounce 
 
 Run as follows for all POSIX platform tests executed by our CI system in a fedora32 docker container::
 
-    ansible-test integration shippable/ --docker fedora32 --docker-no-pull
+    ansible-test integration shippable/ --docker fedora32
 
 You can target a specific tests as well, such as for individual modules::
 
@@ -96,7 +96,7 @@ Destructive Tests
 These tests are allowed to install and remove some trivial packages.  You will likely want to devote these
 to a virtual environment, such as Docker.  They won't reformat your filesystem::
 
-    ansible-test integration destructive/ --docker fedora32 --docker-no-pull
+    ansible-test integration destructive/ --docker fedora32
 
 Windows Tests
 =============

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -145,10 +145,6 @@ For example, to run tests for the ``ping`` module on a Ubuntu 18.04 container::
 
     ansible-test integration ping --docker ubuntu1804
 
-Use the ``--docker-no-pull`` option to avoid pulling the latest container image every time when you run the tests::
-
-    ansible-test integration ping --docker ubuntu1804 --docker-no-pull
-
 Container Images
 ----------------
 

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -70,13 +70,17 @@ outside of those test subdirectories.  They will also not reconfigure or bounce 
 
    Use the ``--docker-no-pull`` option to avoid pulling the latest container image. This is required when using custom local images that are not available for download.
 
-Run as follows for all POSIX platform tests executed by our CI system::
+Run as follows for all POSIX platform tests executed by our CI system in a fedora32 docker container::
 
-    ansible-test integration --docker fedora29 -v shippable/
+    ansible-test integration shippable/ --docker fedora32 --docker-no-pull
 
 You can target a specific tests as well, such as for individual modules::
 
-    ansible-test integration -v ping
+    ansible-test integration ping
+
+You can use the ``-v`` option to make the output more verbose::
+
+    ansible-test integration lineinfile -vvv
 
 Use the following command to list all the available targets::
 
@@ -92,7 +96,7 @@ Destructive Tests
 These tests are allowed to install and remove some trivial packages.  You will likely want to devote these
 to a virtual environment, such as Docker.  They won't reformat your filesystem::
 
-    ansible-test integration --docker fedora29 -v destructive/
+    ansible-test integration destructive/ --docker fedora32 --docker-no-pull
 
 Windows Tests
 =============
@@ -132,14 +136,18 @@ the Ansible continuous integration (CI) system is recommended.
 Running Integration Tests
 -------------------------
 
-To run all CI integration test targets for POSIX platforms in a Ubuntu 16.04 container::
+To run all CI integration test targets for POSIX platforms in a Ubuntu 18.04 container::
 
-    ansible-test integration --docker ubuntu1604 -v shippable/
+    ansible-test integration shippable/ --docker ubuntu1804
 
 You can also run specific tests or select a different Linux distribution.
-For example, to run tests for the ``ping`` module on a Ubuntu 14.04 container::
+For example, to run tests for the ``ping`` module on a Ubuntu 18.04 container::
 
-    ansible-test integration -v ping --docker ubuntu1404
+    ansible-test integration ping --docker ubuntu1804
+
+Use the ``--docker-no-pull`` option to avoid pulling the latest container image::
+
+    ansible-test integration ping --docker ubuntu1804 --docker-no-pull
 
 Container Images
 ----------------
@@ -161,9 +169,9 @@ Python 3
 
 To test with Python 3 use the following images:
 
-  - fedora29
+  - centos8
+  - fedora32
   - opensuse15
-  - ubuntu1604py3
   - ubuntu1804
 
 

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -145,7 +145,7 @@ For example, to run tests for the ``ping`` module on a Ubuntu 18.04 container::
 
     ansible-test integration ping --docker ubuntu1804
 
-Use the ``--docker-no-pull`` option to avoid pulling the latest container image::
+Use the ``--docker-no-pull`` option to avoid pulling the latest container image every time you run the tests::
 
     ansible-test integration ping --docker ubuntu1804 --docker-no-pull
 

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -145,7 +145,7 @@ For example, to run tests for the ``ping`` module on a Ubuntu 18.04 container::
 
     ansible-test integration ping --docker ubuntu1804
 
-Use the ``--docker-no-pull`` option to avoid pulling the latest container image every time you run the tests::
+Use the ``--docker-no-pull`` option to avoid pulling the latest container image every time when you run the tests::
 
     ansible-test integration ping --docker ubuntu1804 --docker-no-pull
 


### PR DESCRIPTION
##### SUMMARY
Documentation: improve dev_guide/testing_integration.rst

- use of `-v` option is a bit confusing in the examples. Looks like it relates to a tested module name.
- improve the examples
- actualize mentioned images
- i don't see `ubuntu1604py3` in the [list](https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt) of supported images, so removed

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`docs/docsite/rst/dev_guide/testing_integration.rst`
