### PR TITLE
Backport/2.10/70530

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -622,9 +622,9 @@ DEFAULT_FACT_PATH:
   name: local fact path
   default: ~
   description:
-    - "This option allows you to globally configure a custom path for 'local_facts' for the implied M(setup) task when using fact gathering."
-    - "If not set, it will fallback to the default from the M(setup) module: ``/etc/ansible/facts.d``."
-    - "This does **not** affect  user defined tasks that use the M(setup) module."
+    - "This option allows you to globally configure a custom path for 'local_facts' for the implied M(ansible.builtin.setup) task when using fact gathering."
+    - "If not set, it will fallback to the default from the M(ansible.builtin.setup) module: ``/etc/ansible/facts.d``."
+    - "This does **not** affect  user defined tasks that use the M(ansible.builtin.setup) module."
   env: [{name: ANSIBLE_FACT_PATH}]
   ini:
   - {key: fact_path, section: defaults}
@@ -678,9 +678,9 @@ DEFAULT_GATHER_SUBSET:
   name: Gather facts subset
   default: ['all']
   description:
-      - Set the `gather_subset` option for the M(setup) task in the implicit fact gathering.
+      - Set the `gather_subset` option for the M(ansible.builtin.setup) task in the implicit fact gathering.
         See the module documentation for specifics.
-      - "It does **not** apply to user defined M(setup) tasks."
+      - "It does **not** apply to user defined M(ansible.builtin.setup) tasks."
   env: [{name: ANSIBLE_GATHER_SUBSET}]
   ini:
     - key: gather_subset
@@ -692,17 +692,17 @@ DEFAULT_GATHER_TIMEOUT:
   default: 10
   description:
     - Set the timeout in seconds for the implicit fact gathering.
-    - "It does **not** apply to user defined M(setup) tasks."
+    - "It does **not** apply to user defined M(ansible.builtin.setup) tasks."
   env: [{name: ANSIBLE_GATHER_TIMEOUT}]
   ini:
   - {key: gather_timeout, section: defaults}
   type: integer
   yaml: {key: defaults.gather_timeout}
 DEFAULT_HANDLER_INCLUDES_STATIC:
-  name: Make handler M(include) static
+  name: Make handler M(ansible.builtin.include) static
   default: False
   description:
-    - "Since 2.0 M(include) can be 'dynamic', this setting (if True) forces that if the include appears in a ``handlers`` section to be 'static'."
+    - "Since 2.0 M(ansible.builtin.include) can be 'dynamic', this setting (if True) forces that if the include appears in a ``handlers`` section to be 'static'."
   env: [{name: ANSIBLE_HANDLER_INCLUDES_STATIC}]
   ini:
   - {key: handler_includes_static, section: defaults}
@@ -869,7 +869,7 @@ DEFAULT_LOOKUP_PLUGIN_PATH:
 DEFAULT_MANAGED_STR:
   name: Ansible managed
   default: 'Ansible managed'
-  description: Sets the macro for the 'ansible_managed' variable available for M(template) and M(win_template) modules.  This is only relevant for those two modules.
+  description: Sets the macro for the 'ansible_managed' variable available for M(ansible.builtin.template) and M(ansible.windows.win_template) modules.  This is only relevant for those two modules.
   env: []
   ini:
   - {key: ansible_managed, section: defaults}

--- a/lib/ansible/modules/add_host.py
+++ b/lib/ansible/modules/add_host.py
@@ -38,7 +38,7 @@ notes:
   because you can now have multiple sources.  An example was added that shows how to partially restore the previous behaviour.
 - Windows targets are supported by this module.
 seealso:
-- module: group_by
+- module: ansible.builtin.group_by
 author:
 - Ansible Core Team
 - Seth Vidal (@skvidal)

--- a/lib/ansible/modules/assemble.py
+++ b/lib/ansible/modules/assemble.py
@@ -75,9 +75,9 @@ options:
     type: str
     version_added: '2.0'
 seealso:
-- module: copy
-- module: template
-- module: win_copy
+- module: ansible.builtin.copy
+- module: ansible.builtin.template
+- module: ansible.windows.win_copy
 author:
 - Stephen Fromm (@sfromm)
 extends_documentation_fragment:

--- a/lib/ansible/modules/assert.py
+++ b/lib/ansible/modules/assert.py
@@ -43,9 +43,9 @@ options:
 notes:
      - This module is also supported for Windows targets.
 seealso:
-- module: debug
-- module: fail
-- module: meta
+- module: ansible.builtin.debug
+- module: ansible.builtin.fail
+- module: ansible.builtin.meta
 author:
     - Ansible Core Team
     - Michael DeHaan

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -20,12 +20,12 @@ description:
      - The command(s) will not be
        processed through the shell, so variables like C($HOSTNAME) and operations
        like C("*"), C("<"), C(">"), C("|"), C(";") and C("&") will not work.
-       Use the M(shell) module if you need these features.
+       Use the M(ansible.builtin.shell) module if you need these features.
      - To create C(command) tasks that are easier to read than the ones using space-delimited
        arguments, pass parameters using the C(args) L(task keyword,../reference_appendices/playbooks_keywords.html#task)
        or use C(cmd) parameter.
      - Either a free form command or C(cmd) parameter is required, see the examples.
-     - For Windows targets, use the M(win_command) module instead.
+     - For Windows targets, use the M(ansible.windows.win_command) module instead.
 options:
   free_form:
     description:
@@ -79,21 +79,21 @@ options:
     type: bool
     default: yes
 notes:
-    -  If you want to run a command through the shell (say you are using C(<), C(>), C(|), etc), you actually want the M(shell) module instead.
+    -  If you want to run a command through the shell (say you are using C(<), C(>), C(|), etc), you actually want the M(ansible.builtin.shell) module instead.
        Parsing shell metacharacters can lead to unexpected commands being executed if quoting is not done correctly so it is more secure to
        use the C(command) module when possible.
     -  " C(creates), C(removes), and C(chdir) can be specified after the command.
        For instance, if you only want to run a command if a certain file does not exist, use this."
     -  Check mode is supported when passing C(creates) or C(removes). If running in check mode and either of these are specified, the module will
        check for the existence of the file and report the correct changed status. If these are not supplied, the task will be skipped.
-    -  The C(executable) parameter is removed since version 2.4. If you have a need for this parameter, use the M(shell) module instead.
-    -  For Windows targets, use the M(win_command) module instead.
-    -  For rebooting systems, use the M(reboot) or M(win_reboot) module.
+    -  The C(executable) parameter is removed since version 2.4. If you have a need for this parameter, use the M(ansible.builtin.shell) module instead.
+    -  For Windows targets, use the M(ansible.windows.win_command) module instead.
+    -  For rebooting systems, use the M(ansible.builtin.reboot) or M(ansible.windows.win_reboot) module.
 seealso:
-- module: raw
-- module: script
-- module: shell
-- module: win_command
+- module: ansible.builtin.raw
+- module: ansible.builtin.script
+- module: ansible.builtin.shell
+- module: ansible.windows.win_command
 author:
     - Ansible Core Team
     - Michael DeHaan

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -16,10 +16,10 @@ version_added: historical
 short_description: Copy files to remote locations
 description:
     - The C(copy) module copies a file from the local or remote machine to a location on the remote machine.
-    - Use the M(fetch) module to copy files from remote locations to the local box.
-    - If you need variable interpolation in copied files, use the M(template) module. Using a variable in the C(content)
-      field will result in unpredictable output.
-    - For Windows targets, use the M(win_copy) module instead.
+    - Use the M(ansible.builtin.fetch) module to copy files from remote locations to the local box.
+    - If you need variable interpolation in copied files, use the M(ansible.builtin.template) module.
+      Using a variable in the C(content) field will result in unpredictable output.
+    - For Windows targets, use the M(ansible.windows.win_copy) module instead.
 options:
   src:
     description:
@@ -34,7 +34,8 @@ options:
     description:
     - When used instead of C(src), sets the contents of a file directly to the specified value.
     - Works only when C(dest) is a file. Creates the file if it does not exist.
-    - For advanced formatting or if C(content) contains a variable, use the M(template) module.
+    - For advanced formatting or if C(content) contains a variable, use the
+      M(ansible.builtin.template) module.
     type: str
     version_added: '1.1'
   dest:
@@ -116,14 +117,14 @@ extends_documentation_fragment:
 - files
 - validate
 notes:
-- The M(copy) module recursively copy facility does not scale to lots (>hundreds) of files.
+- The M(ansible.builtin.copy) module recursively copy facility does not scale to lots (>hundreds) of files.
 seealso:
-- module: assemble
-- module: fetch
-- module: file
-- module: synchronize
-- module: template
-- module: win_copy
+- module: ansible.builtin.assemble
+- module: ansible.builtin.fetch
+- module: ansible.builtin.file
+- module: ansible.builtin.template
+- module: ansible.posix.synchronize
+- module: ansible.windows.win_copy
 author:
 - Ansible Core Team
 - Michael DeHaan

--- a/lib/ansible/modules/debug.py
+++ b/lib/ansible/modules/debug.py
@@ -41,8 +41,8 @@ options:
 notes:
     - This module is also supported for Windows targets.
 seealso:
-- module: assert
-- module: fail
+- module: ansible.builtin.assert
+- module: ansible.builtin.fail
 author:
 - Dag Wieers (@dagwieers)
 - Michael DeHaan

--- a/lib/ansible/modules/expect.py
+++ b/lib/ansible/modules/expect.py
@@ -66,12 +66,12 @@ notes:
     response will be repeated. If you need different responses for successive
     question matches, instead of a string response, use a list of strings as
     the response. The list functionality is new in 2.1.
-  - The M(expect) module is designed for simple scenarios. For more complex
-    needs, consider the use of expect code with the M(shell) or M(script)
-    modules. (An example is part of the M(shell) module documentation)
+  - The M(ansible.builtin.expect) module is designed for simple scenarios.
+    For more complex needs, consider the use of expect code with the M(ansible.builtin.shell)
+    or M(ansible.builtin.script) modules. (An example is part of the M(ansible.builtin.shell) module documentation)
 seealso:
-- module: script
-- module: shell
+- module: ansible.builtin.script
+- module: ansible.builtin.shell
 author: "Matt Martz (@sivel)"
 '''
 

--- a/lib/ansible/modules/fail.py
+++ b/lib/ansible/modules/fail.py
@@ -27,9 +27,9 @@ options:
 notes:
     - This module is also supported for Windows targets.
 seealso:
-- module: assert
-- module: debug
-- module: meta
+- module: ansible.builtin.assert
+- module: ansible.builtin.debug
+- module: ansible.builtin.meta
 author:
 - Dag Wieers (@dagwieers)
 '''

--- a/lib/ansible/modules/fetch.py
+++ b/lib/ansible/modules/fetch.py
@@ -15,7 +15,7 @@ DOCUMENTATION = r'''
 module: fetch
 short_description: Fetch files from remote nodes
 description:
-- This module works like M(copy), but in reverse.
+- This module works like M(ansible.builtin.copy), but in reverse.
 - It is used for fetching files from remote machines and storing them locally in a file tree, organized by hostname.
 - Files that already exist at I(dest) will be overwritten if they are different than the I(src).
 - This module is also supported for Windows targets.
@@ -58,7 +58,7 @@ options:
     type: bool
     default: no
 notes:
-- When running fetch with C(become), the M(slurp) module will also be
+- When running fetch with C(become), the M(ansible.builtin.slurp) module will also be
   used to fetch the contents of the file for determining the remote
   checksum. This effectively doubles the transfer size, and
   depending on the file size can consume all available memory on the
@@ -72,8 +72,8 @@ notes:
   non-failing behaviour.
 - This module is also supported for Windows targets.
 seealso:
-- module: copy
-- module: slurp
+- module: ansible.builtin.copy
+- module: ansible.builtin.slurp
 author:
 - Ansible Core Team
 - Michael DeHaan

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -18,8 +18,9 @@ extends_documentation_fragment: files
 description:
 - Set attributes of files, symlinks or directories.
 - Alternatively, remove files, symlinks or directories.
-- Many other modules support the same options as the C(file) module - including M(copy), M(template), and M(assemble).
-- For Windows targets, use the M(win_file) module instead.
+- Many other modules support the same options as the C(file) module - including M(ansible.builtin.copy),
+  M(ansible.builtin.template), and M(ansible.builtin.assemble).
+- For Windows targets, use the M(ansible.windows.win_file) module instead.
 options:
   path:
     description:
@@ -37,7 +38,7 @@ options:
       do not exist. Since Ansible 1.7 they will be created with the supplied permissions.
     - If C(file), without any other options this works mostly as a 'stat' and will return the current state of C(path).
       Even with other options (i.e C(mode)), the file will be modified but will NOT be created if it does not exist;
-      see the C(touch) value or the M(copy) or M(template) module if you want that behavior.
+      see the C(touch) value or the M(ansible.builtin.copy) or M(ansible.builtin.template) module if you want that behavior.
     - If C(hard), the hard link will be created or changed.
     - If C(link), the symbolic link will be created or changed.
     - If C(touch) (new in 1.4), an empty file will be created if the C(path) does not
@@ -105,11 +106,11 @@ options:
     default: "%Y%m%d%H%M.%S"
     version_added: '2.7'
 seealso:
-- module: assemble
-- module: copy
-- module: stat
-- module: template
-- module: win_file
+- module: ansible.builtin.assemble
+- module: ansible.builtin.copy
+- module: ansible.builtin.stat
+- module: ansible.builtin.template
+- module: ansible.windows.win_file
 author:
 - Ansible Core Team
 - Michael DeHaan

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -19,7 +19,7 @@ version_added: "2.0"
 short_description: Return a list of files based on specific criteria
 description:
     - Return a list of files based on specific criteria. Multiple criteria are AND'd together.
-    - For Windows targets, use the M(win_find) module instead.
+    - For Windows targets, use the M(ansible.windows.win_find) module instead.
 options:
     age:
         description:
@@ -115,7 +115,7 @@ options:
         type: int
         version_added: "2.6"
 seealso:
-- module: win_find
+- module: ansible.windows.win_find
 '''
 
 

--- a/lib/ansible/modules/gather_facts.py
+++ b/lib/ansible/modules/gather_facts.py
@@ -13,7 +13,7 @@ module: gather_facts
 version_added: 2.8
 short_description: Gathers facts about remote hosts
 description:
-     - This module takes care of executing the configured facts modules, the default is to use the M(setup) module.
+     - This module takes care of executing the configured facts modules, the default is to use the M(ansible.builtin.setup) module.
      - This module is automatically called by playbooks to gather useful variables about remote hosts that can be used in playbooks.
      - It can also be executed directly by C(/usr/bin/ansible) to check what variables are available to a host.
      - Ansible provides many I(facts) about the system, automatically.

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -25,7 +25,7 @@ description:
        your proxy environment for both protocols is correct.
      - From Ansible 2.4 when run with C(--check), it will do a HEAD request to validate the URL but
        will not download the entire file or verify it against hashes.
-     - For Windows targets, use the M(win_get_url) module instead.
+     - For Windows targets, use the M(ansible.windows.win_get_url) module instead.
 version_added: '0.6'
 options:
   url:
@@ -169,10 +169,10 @@ options:
 extends_documentation_fragment:
     - files
 notes:
-     - For Windows targets, use the M(win_get_url) module instead.
+     - For Windows targets, use the M(ansible.windows.win_get_url) module instead.
 seealso:
-- module: uri
-- module: win_get_url
+- module: ansible.builtin.uri
+- module: ansible.windows.win_get_url
 author:
 - Jan-Piet Mens (@jpmens)
 '''

--- a/lib/ansible/modules/group.py
+++ b/lib/ansible/modules/group.py
@@ -19,7 +19,7 @@ requirements:
 - groupmod
 description:
     - Manage presence of groups on a host.
-    - For Windows targets, use the M(win_group) module instead.
+    - For Windows targets, use the M(ansible.windows.win_group) module instead.
 options:
     name:
         description:
@@ -58,8 +58,8 @@ options:
         default: no
         version_added: "2.8"
 seealso:
-- module: user
-- module: win_group
+- module: ansible.builtin.user
+- module: ansible.windows.win_group
 author:
 - Stephen Fromm (@sfromm)
 '''

--- a/lib/ansible/modules/group_by.py
+++ b/lib/ansible/modules/group_by.py
@@ -32,7 +32,7 @@ notes:
 - Spaces in group names are converted to dashes '-'.
 - This module is also supported for Windows targets.
 seealso:
-- module: add_host
+- module: ansible.builtin.add_host
 author:
 - Jeroen Hoekx (@jhoekx)
 '''

--- a/lib/ansible/modules/import_playbook.py
+++ b/lib/ansible/modules/import_playbook.py
@@ -25,10 +25,10 @@ options:
 notes:
   - This is a core feature of Ansible, rather than a module, and cannot be overridden like a module.
 seealso:
-- module: import_role
-- module: import_tasks
-- module: include_role
-- module: include_tasks
+- module: ansible.builtin.import_role
+- module: ansible.builtin.import_tasks
+- module: ansible.builtin.include_role
+- module: ansible.builtin.include_tasks
 - ref: playbooks_reuse_includes
   description: More information related to including and importing playbooks, roles and tasks.
 '''

--- a/lib/ansible/modules/import_role.py
+++ b/lib/ansible/modules/import_role.py
@@ -16,7 +16,7 @@ description:
   - Much like the C(roles:) keyword, this task loads a role, but it allows you to control when the role tasks run in
     between other tasks of the play.
   - Most keywords, loops and conditionals will only be applied to the imported tasks, not to this statement itself. If
-    you want the opposite behavior, use M(include_role) instead.
+    you want the opposite behavior, use M(ansible.builtin.include_role) instead.
 version_added: '2.4'
 options:
   name:
@@ -54,13 +54,13 @@ notes:
   - Handlers are made available to the whole play.
   - Since Ansible 2.7 variables defined in C(vars) and C(defaults) for the role are exposed at playbook parsing time.
     Due to this, these variables will be accessible to roles and tasks executed before the location of the
-    M(import_role) task.
-  - Unlike M(include_role) variable exposure is not configurable, and will always be exposed.
+    M(ansible.builtin.import_role) task.
+  - Unlike M(ansible.builtin.include_role) variable exposure is not configurable, and will always be exposed.
 seealso:
-- module: import_playbook
-- module: import_tasks
-- module: include_role
-- module: include_tasks
+- module: ansible.builtin.import_playbook
+- module: ansible.builtin.import_tasks
+- module: ansible.builtin.include_role
+- module: ansible.builtin.include_tasks
 - ref: playbooks_reuse_includes
   description: More information related to including and importing playbooks, roles and tasks.
 '''

--- a/lib/ansible/modules/import_tasks.py
+++ b/lib/ansible/modules/import_tasks.py
@@ -21,14 +21,14 @@ options:
     description:
       - The name of the imported file is specified directly without any other option.
       - Most keywords, including loops and conditionals, only applied to the imported tasks, not to this statement itself.
-      - If you need any of those to apply, use M(include_tasks) instead.
+      - If you need any of those to apply, use M(ansible.builtin.include_tasks) instead.
 notes:
   - This is a core feature of Ansible, rather than a module, and cannot be overridden like a module.
 seealso:
-- module: import_playbook
-- module: import_role
-- module: include_role
-- module: include_tasks
+- module: ansible.builtin.import_playbook
+- module: ansible.builtin.import_role
+- module: ansible.builtin.include_role
+- module: ansible.builtin.include_tasks
 - ref: playbooks_reuse_includes
   description: More information related to including and importing playbooks, roles and tasks.
 '''

--- a/lib/ansible/modules/include.py
+++ b/lib/ansible/modules/include.py
@@ -32,15 +32,16 @@ options:
 notes:
   - This is a core feature of Ansible, rather than a module, and cannot be overridden like a module.
   - Include has some unintuitive behaviours depending on if it is running in a static or dynamic in play or in playbook context,
-    in an effort to clarify behaviours we are moving to a new set modules (M(include_tasks), M(include_role), M(import_playbook), M(import_tasks))
+    in an effort to clarify behaviours we are moving to a new set modules (M(ansible.builtin.include_tasks),
+    M(ansible.builtin.include_role), M(ansible.builtin.import_playbook), M(ansible.builtin.import_tasks))
     that have well established and clear behaviours.
   - B(This module will still be supported for some time but we are looking at deprecating it in the near future.)
 seealso:
-- module: import_playbook
-- module: import_role
-- module: import_tasks
-- module: include_role
-- module: include_tasks
+- module: ansible.builtin.import_playbook
+- module: ansible.builtin.import_role
+- module: ansible.builtin.import_tasks
+- module: ansible.builtin.include_role
+- module: ansible.builtin.include_tasks
 - ref: playbooks_reuse_includes
   description: More information related to including and importing playbooks, roles and tasks.
 '''

--- a/lib/ansible/modules/include_role.py
+++ b/lib/ansible/modules/include_role.py
@@ -17,7 +17,7 @@ description:
   - Dynamically loads and executes a specified role as a task.
   - May be used only where Ansible tasks are allowed - inside C(pre_tasks), C(tasks), or C(post_tasks) playbook objects, or as a task inside a role.
   - Task-level keywords, loops, and conditionals apply only to the C(include_role) statement itself.
-  - To apply keywords to the tasks within the role, pass them using the C(apply) option or use M(import_role) instead.
+  - To apply keywords to the tasks within the role, pass them using the C(apply) option or use M(ansible.builtin.import_role) instead.
   - Ignores some keywords, like C(until) and C(retries).
   - This module is also supported for Windows targets.
 version_added: "2.2"
@@ -71,12 +71,12 @@ notes:
   - Before Ansible 2.4, as with C(include), this task could be static or dynamic, If static, it implied that it won't
     need templating, loops or conditionals and will show included tasks in the C(--list) options. Ansible would try to
     autodetect what is needed, but you can set C(static) to C(yes) or C(no) at task level to control this.
-  - After Ansible 2.4, you can use M(import_role) for C(static) behaviour and this action for C(dynamic) one.
+  - After Ansible 2.4, you can use M(ansible.builtin.import_role) for C(static) behaviour and this action for C(dynamic) one.
 seealso:
-- module: import_playbook
-- module: import_role
-- module: import_tasks
-- module: include_tasks
+- module: ansible.builtin.import_playbook
+- module: ansible.builtin.import_role
+- module: ansible.builtin.import_tasks
+- module: ansible.builtin.include_tasks
 - ref: playbooks_reuse_includes
   description: More information related to including and importing playbooks, roles and tasks.
 '''

--- a/lib/ansible/modules/include_tasks.py
+++ b/lib/ansible/modules/include_tasks.py
@@ -20,8 +20,8 @@ options:
   file:
     description:
       - The name of the imported file is specified directly without any other option.
-      - Unlike M(import_tasks), most keywords, including loop, with_items, and conditionals, apply to this statement.
-      - The do until loop is not supported on M(include_tasks).
+      - Unlike M(ansible.builtin.import_tasks), most keywords, including loop, with_items, and conditionals, apply to this statement.
+      - The do until loop is not supported on M(ansible.builtin.include_tasks).
     type: str
     version_added: '2.7'
   apply:
@@ -37,10 +37,10 @@ options:
 notes:
   - This is a core feature of the Ansible, rather than a module, and cannot be overridden like a module.
 seealso:
-- module: import_playbook
-- module: import_role
-- module: import_tasks
-- module: include_role
+- module: ansible.builtin.import_playbook
+- module: ansible.builtin.import_role
+- module: ansible.builtin.import_tasks
+- module: ansible.builtin.include_role
 - ref: playbooks_reuse_includes
   description: More information related to including and importing playbooks, roles and tasks.
 '''

--- a/lib/ansible/modules/include_vars.py
+++ b/lib/ansible/modules/include_vars.py
@@ -77,7 +77,7 @@ options:
 notes:
   - This module is also supported for Windows targets.
 seealso:
-- module: set_fact
+- module: ansible.builtin.set_fact
 - ref: playbooks_delegation
   description: More information related to task delegation.
 '''

--- a/lib/ansible/modules/known_hosts.py
+++ b/lib/ansible/modules/known_hosts.py
@@ -14,8 +14,8 @@ short_description: Add or remove a host from the C(known_hosts) file
 description:
    - The C(known_hosts) module lets you add or remove a host keys from the C(known_hosts) file.
    - Starting at Ansible 2.2, multiple entries per host are allowed, but only one for each key type supported by ssh.
-     This is useful if you're going to want to use the M(git) module over ssh, for example.
-   - If you have a very large number of host keys to manage, you will find the M(template) module more useful.
+     This is useful if you're going to want to use the M(ansible.builtin.git) module over ssh, for example.
+   - If you have a very large number of host keys to manage, you will find the M(ansible.builtin.template) module more useful.
 version_added: "1.9"
 options:
   name:

--- a/lib/ansible/modules/lineinfile.py
+++ b/lib/ansible/modules/lineinfile.py
@@ -131,7 +131,7 @@ seealso:
 - module: ansible.builtin.file
 - module: ansible.builtin.replace
 - module: ansible.builtin.template
-- module: ansible.windows.win_lineinfile
+- module: community.windows.win_lineinfile
 author:
     - Daniel Hokka Zakrissoni (@dhozac)
     - Ahti Kitsik (@ahtik)

--- a/lib/ansible/modules/lineinfile.py
+++ b/lib/ansible/modules/lineinfile.py
@@ -18,9 +18,9 @@ description:
   - This module ensures a particular line is in a file, or replace an
     existing line using a back-referenced regular expression.
   - This is primarily useful when you want to change a single line in a file only.
-  - See the M(replace) module if you want to change multiple, similar lines
-    or check M(blockinfile) if you want to insert/update/remove a block of lines in a file.
-    For other cases, see the M(copy) or M(template) modules.
+  - See the M(ansible.builtin.replace) module if you want to change multiple, similar lines
+    or check M(ansible.builtin.blockinfile) if you want to insert/update/remove a block of lines in a file.
+    For other cases, see the M(ansible.builtin.copy) or M(ansible.builtin.template) modules.
 version_added: "0.7"
 options:
   path:
@@ -118,7 +118,7 @@ options:
     version_added: "2.5"
   others:
     description:
-      - All arguments accepted by the M(file) module also work here.
+      - All arguments accepted by the M(ansible.builtin.file) module also work here.
     type: str
 extends_documentation_fragment:
     - files
@@ -126,12 +126,12 @@ extends_documentation_fragment:
 notes:
   - As of Ansible 2.3, the I(dest) option has been changed to I(path) as default, but I(dest) still works as well.
 seealso:
-- module: blockinfile
-- module: copy
-- module: file
-- module: replace
-- module: template
-- module: win_lineinfile
+- module: ansible.builtin.blockinfile
+- module: ansible.builtin.copy
+- module: ansible.builtin.file
+- module: ansible.builtin.replace
+- module: ansible.builtin.template
+- module: ansible.windows.win_lineinfile
 author:
     - Daniel Hokka Zakrissoni (@dhozac)
     - Ahti Kitsik (@ahtik)

--- a/lib/ansible/modules/meta.py
+++ b/lib/ansible/modules/meta.py
@@ -25,7 +25,7 @@ options:
         - C(refresh_inventory) (added in Ansible 2.0) forces the reload of the inventory, which in the case of dynamic inventory scripts means they will be
           re-executed. If the dynamic inventory script is using a cache, Ansible cannot know this and has no way of refreshing it (you can disable the cache
           or, if available for your specific inventory datasource (e.g. aws), you can use the an inventory plugin instead of an inventory script).
-          This is mainly useful when additional hosts are created and users wish to use them instead of using the M(add_host) module.
+          This is mainly useful when additional hosts are created and users wish to use them instead of using the M(ansible.builtin.add_host) module.
         - C(noop) (added in Ansible 2.0) This literally does 'nothing'. It is mainly used internally and not recommended for general use.
         - C(clear_facts) (added in Ansible 2.1) causes the gathered facts for the hosts specified in the play's list of hosts to be cleared,
           including the fact cache.
@@ -37,14 +37,14 @@ options:
     required: true
 notes:
     - C(meta) is not really a module nor action_plugin as such it cannot be overwritten.
-    - C(clear_facts) will remove the persistent facts from M(set_fact) using C(cacheable=True),
+    - C(clear_facts) will remove the persistent facts from M(ansible.builtin.set_fact) using C(cacheable=True),
       but not the current host variable it creates for the current run.
     - Looping on meta tasks is not supported.
     - Skipping C(meta) tasks using tags is not supported.
     - This module is also supported for Windows targets.
 seealso:
-- module: assert
-- module: fail
+- module: ansible.builtin.assert
+- module: ansible.builtin.fail
 author:
     - Ansible Core Team
 '''

--- a/lib/ansible/modules/package.py
+++ b/lib/ansible/modules/package.py
@@ -18,7 +18,7 @@ author:
 short_description: Generic OS package manager
 description:
      - Installs, upgrade and removes packages using the underlying OS package manager.
-     - For Windows targets, use the M(win_package) module instead.
+     - For Windows targets, use the M(ansible.windows.win_package) module instead.
 options:
   name:
     description:
@@ -41,7 +41,7 @@ requirements:
     - Whatever is required for the package plugins specific for each system.
 notes:
     - This module actually calls the pertinent package modules for each system (apt, yum, etc).
-    - For Windows targets, use the M(win_package) module instead.
+    - For Windows targets, use the M(ansible.windows.win_package) module instead.
 '''
 EXAMPLES = '''
 - name: Install ntpdate

--- a/lib/ansible/modules/pause.py
+++ b/lib/ansible/modules/pause.py
@@ -13,7 +13,7 @@ short_description: Pause playbook execution
 description:
   - Pauses playbook execution for a set amount of time, or until a prompt is acknowledged.
     All parameters are optional. The default behavior is to pause with a prompt.
-  - To pause/wait/sleep per host, use the M(wait_for) module.
+  - To pause/wait/sleep per host, use the M(ansible.builtin.wait_for) module.
   - You can use C(ctrl+c) if you wish to advance a pause earlier than it is set to expire or if you need to abort a playbook run entirely.
     To continue early press C(ctrl+c) and then C(c). To abort a playbook press C(ctrl+c) and then C(a).
   - The pause module integrates into async/parallelized playbooks without any special considerations (see Rolling Updates).

--- a/lib/ansible/modules/ping.py
+++ b/lib/ansible/modules/ping.py
@@ -19,8 +19,8 @@ description:
      contact. It does not make sense in playbooks, but it is useful from
      C(/usr/bin/ansible) to verify the ability to login and that a usable Python is configured.
    - This is NOT ICMP ping, this is just a trivial test module that requires Python on the remote-node.
-   - For Windows targets, use the M(win_ping) module instead.
-   - For Network targets, use the M(net_ping) module instead.
+   - For Windows targets, use the M(ansible.windows.win_ping) module instead.
+   - For Network targets, use the M(ansible.netcommon.net_ping) module instead.
 options:
   data:
     description:
@@ -29,8 +29,8 @@ options:
     type: str
     default: pong
 seealso:
-- module: net_ping
-- module: win_ping
+- module: ansible.netcommon.net_ping
+- module: ansible.windows.win_ping
 author:
     - Ansible Core Team
     - Michael DeHaan

--- a/lib/ansible/modules/raw.py
+++ b/lib/ansible/modules/raw.py
@@ -31,29 +31,29 @@ description:
        case is installing C(python) on a system without python installed by default.
        Another is speaking to any devices such as
        routers that do not have any Python installed. In any other case, using
-       the M(shell) or M(command) module is much more appropriate.
+       the M(ansible.builtin.shell) or M(ansible.builtin.command) module is much more appropriate.
      - Arguments given to C(raw) are run directly through the configured remote shell.
      - Standard output, error output and return code are returned when
        available.
      - There is no change handler support for this module.
      - This module does not require python on the remote system, much like
-       the M(script) module.
+       the M(ansible.builtin.script) module.
      - This module is also supported for Windows targets.
 notes:
     - "If using raw from a playbook, you may need to disable fact gathering
       using C(gather_facts: no) if you're using C(raw) to bootstrap python
       onto the machine."
     - If you want to execute a command securely and predictably, it may be
-      better to use the M(command) or M(shell) modules instead.
+      better to use the M(ansible.builtin.command) or M(ansible.builtin.shell) modules instead.
     - The C(environment) keyword does not work with raw normally, it requires a shell
       which means it only works if C(executable) is set or using the module
       with privilege escalation (C(become)).
     - This module is also supported for Windows targets.
 seealso:
-- module: command
-- module: shell
-- module: win_command
-- module: win_shell
+- module: ansible.builtin.command
+- module: ansible.builtin.shell
+- module: ansible.windows.win_command
+- module: ansible.windows.win_shell
 author:
     - Ansible Core Team
     - Michael DeHaan

--- a/lib/ansible/modules/reboot.py
+++ b/lib/ansible/modules/reboot.py
@@ -15,7 +15,7 @@ notes:
     to specify locations to search if the default paths do not work.
 description:
     - Reboot a machine, wait for it to go down, come back up, and respond to commands.
-    - For Windows targets, use the M(win_reboot) module instead.
+    - For Windows targets, use the M(ansible.windows.win_reboot) module instead.
 version_added: "2.7"
 options:
   pre_reboot_delay:
@@ -71,7 +71,7 @@ options:
     default: 'cat /proc/sys/kernel/random/boot_id'
     version_added: '2.10'
 seealso:
-- module: win_reboot
+- module: ansible.windows.win_reboot
 author:
     - Matt Davis (@nitzmahone)
     - Sam Doran (@samdoran)

--- a/lib/ansible/modules/replace.py
+++ b/lib/ansible/modules/replace.py
@@ -81,7 +81,7 @@ options:
     default: no
   others:
     description:
-      - All arguments accepted by the M(file) module also work here.
+      - All arguments accepted by the M(ansible.builtin.file) module also work here.
     type: str
   encoding:
     description:

--- a/lib/ansible/modules/script.py
+++ b/lib/ansible/modules/script.py
@@ -15,7 +15,7 @@ description:
      - Either a free form command or C(cmd) parameter is required, see the examples.
      - The local script at path will be transferred to the remote node and then executed.
      - The given script will be processed through the shell environment on the remote node.
-     - This module does not require python on the remote system, much like the M(raw) module.
+     - This module does not require python on the remote system, much like the M(ansible.builtin.raw) module.
      - This module is also supported for Windows targets.
 options:
   free_form:
@@ -48,8 +48,8 @@ notes:
   - If the path to the local script contains spaces, it needs to be quoted.
   - This module is also supported for Windows targets.
 seealso:
-- module: shell
-- module: win_shell
+- module: ansible.builtin.shell
+- module: ansible.windows.win_shell
 author:
     - Ansible Core Team
     - Michael DeHaan

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -16,7 +16,7 @@ short_description:  Manage services
 description:
     - Controls services on remote hosts. Supported init systems include BSD init,
       OpenRC, SysV, Solaris SMF, systemd, upstart.
-    - For Windows targets, use the M(win_service) module instead.
+    - For Windows targets, use the M(ansible.windows.win_service) module instead.
 options:
     name:
         description:
@@ -77,7 +77,7 @@ options:
 notes:
     - For AIX, group subsystem names can be used.
 seealso:
-- module: win_service
+- module: ansible.windows.win_service
 author:
     - Ansible Core Team
     - Michael DeHaan

--- a/lib/ansible/modules/set_fact.py
+++ b/lib/ansible/modules/set_fact.py
@@ -46,7 +46,7 @@ notes:
     - Since 'cacheable' is now a module param, 'cacheable' is no longer a valid fact name as of Ansible 2.4.
     - This module is also supported for Windows targets.
 seealso:
-- module: include_vars
+- module: ansible.builtin.include_vars
 - ref: ansible_variable_precedence
   description: More information related to variable precedence and which type of variable wins over others.
 author:

--- a/lib/ansible/modules/setup.py
+++ b/lib/ansible/modules/setup.py
@@ -69,7 +69,7 @@ notes:
       with C(facter_) and C(ohai_) so it's easy to tell their source. All variables are
       bubbled up to the caller. Using the ansible facts and choosing to not
       install I(facter) and I(ohai) means you can avoid Ruby-dependencies on your
-      remote systems. (See also M(facter) and M(ohai).)
+      remote systems. (See also M(community.general.facter) and M(community.general.ohai).)
     - The filter option filters only the first level subkey below ansible_facts.
     - If the target host is Windows, you will not currently have the ability to use
       C(filter) as this is provided by a simpler implementation of the module.

--- a/lib/ansible/modules/shell.py
+++ b/lib/ansible/modules/shell.py
@@ -19,9 +19,9 @@ short_description: Execute shell commands on targets
 description:
      - The C(shell) module takes the command name followed by a list of space-delimited arguments.
      - Either a free form command or C(cmd) parameter is required, see the examples.
-     - It is almost exactly like the M(command) module but runs
+     - It is almost exactly like the M(ansible.builtin.command) module but runs
        the command through a shell (C(/bin/sh)) on the remote node.
-     - For Windows targets, use the M(win_shell) module instead.
+     - For Windows targets, use the M(ansible.windows.win_shell) module instead.
 version_added: "0.2"
 options:
   free_form:
@@ -73,10 +73,10 @@ options:
     version_added: "2.8"
 notes:
   - If you want to execute a command securely and predictably, it may be
-    better to use the M(command) module instead. Best practices when writing
-    playbooks will follow the trend of using M(command) unless the C(shell)
-    module is explicitly required. When running ad-hoc commands, use your best
-    judgement.
+    better to use the M(ansible.builtin.command) module instead. Best practices
+    when writing playbooks will follow the trend of using M(ansible.builtin.command)
+    unless the M(ansible.builtin.shell) module is explicitly required. When running ad-hoc
+    commands, use your best judgement.
   - Check mode is supported when passing C(creates) or C(removes). If running
     in check mode and either of these are specified, the module will check for
     the existence of the file and report the correct changed status. If these
@@ -85,13 +85,13 @@ notes:
     C({{ var | quote }}) instead of just C({{ var }}) to make sure they
     do not include evil things like semicolons.
   - An alternative to using inline shell scripts with this module is to use
-    the M(script) module possibly together with the M(template) module.
-  - For rebooting systems, use the M(reboot) or M(win_reboot) module.
+    the M(ansible.builtin.script) module possibly together with the M(ansible.builtin.template) module.
+  - For rebooting systems, use the M(ansible.builtin.reboot) or M(ansible.windows.win_reboot) module.
 seealso:
-- module: command
-- module: raw
-- module: script
-- module: win_shell
+- module: ansible.builtin.command
+- module: ansible.builtin.raw
+- module: ansible.builtin.script
+- module: ansible.windows.win_shell
 author:
     - Ansible Core Team
     - Michael DeHaan

--- a/lib/ansible/modules/slurp.py
+++ b/lib/ansible/modules/slurp.py
@@ -14,7 +14,7 @@ module: slurp
 version_added: historical
 short_description: Slurps a file from remote nodes
 description:
-     - This module works like M(fetch). It is used for fetching a base64-
+     - This module works like M(ansible.builtin.fetch). It is used for fetching a base64-
        encoded blob containing the data in a remote file.
      - This module is also supported for Windows targets.
 options:
@@ -25,11 +25,11 @@ options:
     required: true
     aliases: [ path ]
 notes:
-   - This module returns an 'in memory' base64 encoded version of the file, take into account that this will require at least twice the RAM as the
-     original file size.
+   - This module returns an 'in memory' base64 encoded version of the file, take
+     into account that this will require at least twice the RAM as the original file size.
    - This module is also supported for Windows targets.
 seealso:
-- module: fetch
+- module: ansible.builtin.fetch
 author:
     - Ansible Core Team
     - Michael DeHaan (@mpdehaan)

--- a/lib/ansible/modules/stat.py
+++ b/lib/ansible/modules/stat.py
@@ -14,7 +14,7 @@ version_added: "1.3"
 short_description: Retrieve file or file system status
 description:
      - Retrieves facts for a file similar to the Linux/Unix 'stat' command.
-     - For Windows targets, use the M(win_stat) module instead.
+     - For Windows targets, use the M(ansible.windows.win_stat) module instead.
 options:
   path:
     description:
@@ -62,8 +62,8 @@ options:
     aliases: [ attr, attributes ]
     version_added: "2.3"
 seealso:
-- module: file
-- module: win_stat
+- module: ansible.builtin.file
+- module: ansible.windows.win_stat
 author: Bruce Pennypacker (@bpennypacker)
 '''
 

--- a/lib/ansible/modules/tempfile.py
+++ b/lib/ansible/modules/tempfile.py
@@ -17,8 +17,8 @@ short_description: Creates temporary files and directories
 description:
   - The C(tempfile) module creates temporary files and directories. C(mktemp) command takes different parameters on various systems, this module helps
     to avoid troubles related to that. Files/directories created by module are accessible only by creator. In case you need to make them world-accessible
-    you need to use M(file) module.
-  - For Windows targets, use the M(win_tempfile) module instead.
+    you need to use M(ansible.builtin.file) module.
+  - For Windows targets, use the M(ansible.windows.win_tempfile) module instead.
 options:
   state:
     description:
@@ -42,8 +42,8 @@ options:
     type: str
     default: ""
 seealso:
-- module: file
-- module: win_tempfile
+- module: ansible.builtin.file
+- module: ansible.windows.win_tempfile
 author:
   - Krzysztof Magosa (@krzysztof-magosa)
 '''

--- a/lib/ansible/modules/template.py
+++ b/lib/ansible/modules/template.py
@@ -26,9 +26,7 @@ options:
     default: no
     version_added: '2.4'
 notes:
-- You can use the M(copy) module with the C(content:) option if you prefer the template inline,
-  as part of the playbook.
-- For Windows you can use M(win_template) which uses '\\r\\n' as C(newline_sequence) by default.
+- For Windows you can use M(ansible.windows.win_template) which uses '\\r\\n' as C(newline_sequence) by default.
 seealso:
 - module: ansible.builtin.copy
 - module: ansible.windows.win_copy

--- a/lib/ansible/modules/template.py
+++ b/lib/ansible/modules/template.py
@@ -30,9 +30,9 @@ notes:
   as part of the playbook.
 - For Windows you can use M(win_template) which uses '\\r\\n' as C(newline_sequence) by default.
 seealso:
-- module: copy
-- module: win_copy
-- module: win_template
+- module: ansible.builtin.copy
+- module: ansible.windows.win_copy
+- module: ansible.windows.win_template
 author:
 - Ansible Core Team
 - Michael DeHaan

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -21,15 +21,15 @@ description:
      - The C(unarchive) module unpacks an archive. It will not unpack a compressed file that does not contain an archive.
      - By default, it will copy the source file from the local system to the target before unpacking.
      - Set C(remote_src=yes) to unpack an archive which already exists on the target.
-     - If checksum validation is desired, use M(get_url) or M(uri) instead to fetch the file and set C(remote_src=yes).
-     - For Windows targets, use the M(win_unzip) module instead.
+     - If checksum validation is desired, use M(ansible.builtin.get_url) or M(ansible.builtin.uri) instead to fetch the file and set C(remote_src=yes).
+     - For Windows targets, use the M(community.windows.win_unzip) module instead.
 options:
   src:
     description:
       - If C(remote_src=no) (default), local path to archive file to copy to the target server; can be absolute or relative. If C(remote_src=yes), path on the
         target server to existing archive file to unpack.
       - If C(remote_src=yes) and C(src) contains C(://), the remote machine will download the file from the URL first. (version_added 2.0). This is only for
-        simple cases, for full download support use the M(get_url) module.
+        simple cases, for full download support use the M(ansible.builtin.get_url) module.
     type: path
     required: true
   dest:
@@ -106,9 +106,9 @@ notes:
     - Existing files/directories in the destination which are not in the archive
       are ignored for purposes of deciding if the archive should be unpacked or not.
 seealso:
-- module: archive
-- module: iso_extract
-- module: win_unzip
+- module: community.general.archive
+- module: community.general.iso_extract
+- module: community.windows.win_unzip
 author: Michael DeHaan
 '''
 

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -15,7 +15,7 @@ short_description: Interacts with webservices
 description:
   - Interacts with HTTP and HTTPS web services and supports Digest, Basic and WSSE
     HTTP authentication mechanisms.
-  - For Windows targets, use the M(win_uri) module instead.
+  - For Windows targets, use the M(ansible.windows.win_uri) module instead.
 version_added: "1.1"
 options:
   url:
@@ -177,10 +177,10 @@ options:
 notes:
   - The dependency on httplib2 was removed in Ansible 2.1.
   - The module returns all the HTTP headers in lower-case.
-  - For Windows targets, use the M(win_uri) module instead.
+  - For Windows targets, use the M(ansible.windows.win_uri) module instead.
 seealso:
-- module: get_url
-- module: win_uri
+- module: ansible.builtin.get_url
+- module: ansible.windows.win_uri
 author:
 - Romeo Theriault (@romeotheriault)
 extends_documentation_fragment: files

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -14,7 +14,7 @@ version_added: "0.2"
 short_description: Manage user accounts
 description:
     - Manage user accounts and user attributes.
-    - For Windows targets, use the M(win_user) module instead.
+    - For Windows targets, use the M(ansible.windows.win_user) module instead.
 options:
     name:
         description:
@@ -250,9 +250,9 @@ notes:
   - On all other platforms, this module uses C(useradd) to create, C(usermod) to modify, and
     C(userdel) to remove accounts.
 seealso:
-- module: authorized_key
-- module: group
-- module: win_user
+- module: ansible.builtin.authorized_key
+- module: ansible.builtin.group
+- module: ansible.windows.win_user
 author:
 - Stephen Fromm (@sfromm)
 '''

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -250,7 +250,7 @@ notes:
   - On all other platforms, this module uses C(useradd) to create, C(usermod) to modify, and
     C(userdel) to remove accounts.
 seealso:
-- module: ansible.builtin.authorized_key
+- module: ansible.posix.authorized_key
 - module: ansible.builtin.group
 - module: ansible.windows.win_user
 author:

--- a/lib/ansible/modules/wait_for.py
+++ b/lib/ansible/modules/wait_for.py
@@ -17,13 +17,13 @@ description:
        This does not produce an error.
      - Waiting for a port to become available is useful for when services are not immediately available after their init scripts return
        which is true of certain Java application servers.
-     - It is also useful when starting guests with the M(virt) module and needing to pause until they are ready.
+     - It is also useful when starting guests with the M(community.libvirt.virt) module and needing to pause until they are ready.
      - This module can also be used to wait for a regex match a string to be present in a file.
      - In Ansible 1.6 and later, this module can also be used to wait for a file to be available or
        absent on the filesystem.
      - In Ansible 1.8 and later, this module can also be used to wait for active connections to be closed before continuing, useful if a node
        is being rotated out of a load balancer pool.
-     - For Windows targets, use the M(win_wait_for) module instead.
+     - For Windows targets, use the M(ansible.windows.win_wait_for) module instead.
 version_added: "0.7"
 options:
   host:
@@ -105,9 +105,9 @@ notes:
   - When waiting for a path, symbolic links will be followed.  Many other modules that manipulate files do not follow symbolic links,
     so operations on the path using other modules may not work exactly as expected.
 seealso:
-- module: wait_for_connection
-- module: win_wait_for
-- module: win_wait_for_process
+- module: ansible.builtin.wait_for_connection
+- module: ansible.windows.win_wait_for
+- module: community.windows.win_wait_for_process
 author:
     - Jeroen Hoekx (@jhoekx)
     - John Jarvis (@jarv)

--- a/lib/ansible/modules/wait_for_connection.py
+++ b/lib/ansible/modules/wait_for_connection.py
@@ -45,7 +45,7 @@ notes:
 seealso:
 - module: ansible.builtin.wait_for
 - module: ansible.windows.win_wait_for
-- module: ansible.windows.win_wait_for_process
+- module: community.windows.win_wait_for_process
 author:
 - Dag Wieers (@dagwieers)
 '''

--- a/lib/ansible/modules/wait_for_connection.py
+++ b/lib/ansible/modules/wait_for_connection.py
@@ -43,9 +43,9 @@ options:
 notes:
 - This module is also supported for Windows targets.
 seealso:
-- module: wait_for
-- module: win_wait_for
-- module: win_wait_for_process
+- module: ansible.builtin.wait_for
+- module: ansible.windows.win_wait_for
+- module: ansible.windows.win_wait_for_process
 author:
 - Dag Wieers (@dagwieers)
 '''

--- a/lib/ansible/modules/yum.py
+++ b/lib/ansible/modules/yum.py
@@ -18,7 +18,7 @@ version_added: historical
 short_description: Manages packages with the I(yum) package manager
 description:
      - Installs, upgrade, downgrades, removes, and lists packages and groups with the I(yum) package manager.
-     - This module only works on Python 2. If you require Python 3 support see the M(dnf) module.
+     - This module only works on Python 2. If you require Python 3 support see the M(ansible.builtin.dnf) module.
 options:
   use_backend:
     description:

--- a/lib/ansible/modules/yum_repository.py
+++ b/lib/ansible/modules/yum_repository.py
@@ -17,7 +17,7 @@ version_added: '2.1'
 short_description: Add or remove YUM repositories
 description:
   - Add or remove YUM repositories in RPM-based Linux distributions.
-  - If you wish to update an existing repository definition use M(ansible.builtin.ini_file) instead.
+  - If you wish to update an existing repository definition use M(community.general.ini_file) instead.
 
 options:
   async:

--- a/lib/ansible/modules/yum_repository.py
+++ b/lib/ansible/modules/yum_repository.py
@@ -17,7 +17,7 @@ version_added: '2.1'
 short_description: Add or remove YUM repositories
 description:
   - Add or remove YUM repositories in RPM-based Linux distributions.
-  - If you wish to update an existing repository definition use M(ini_file) instead.
+  - If you wish to update an existing repository definition use M(ansible.builtin.ini_file) instead.
 
 options:
   async:

--- a/lib/ansible/plugins/lookup/fileglob.py
+++ b/lib/ansible/plugins/lookup/fileglob.py
@@ -19,7 +19,7 @@ DOCUMENTATION = """
     notes:
       - Patterns are only supported on files, not directory/paths.
       - Matching is against local system files on the Ansible controller.
-        To iterate a list of files on a remote node, use the M(find) module.
+        To iterate a list of files on a remote node, use the M(ansible.builtin.find) module.
       - Returns a string list of paths joined by commas, or an empty list if no files match. For a 'true list' pass C(wantlist=True) to the lookup.
 """
 


### PR DESCRIPTION
##### SUMMARY

Backports #70530 and #71340. Adds and updates FQCNs within inter-module `M()` references in the module docs.

Also effectively backports #70658, since the change made there is the basis of later changes.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
