### PR TITLE
tests: Use `hg serve` instead of bitbucket for hg

### DIFF
--- a/test/integration/targets/hg/tasks/main.yml
+++ b/test/integration/targets/hg/tasks/main.yml
@@ -21,32 +21,21 @@
   register: has_hg
   ignore_errors: yes
 
-- name: warn if the underlying system is not capable of running these tests
-  debug:
-    msg: >-
-      The mercurial client is not able to check out Bitbucket repositories as per the changes mentioned here:
-      https://bitbucket.org/blog/deprecating-tlsv1-tlsv1-1-2018-12-01 . Therefore these tests are skipped.
-  when: (ansible_distribution == "Ubuntu" and ansible_distribution_version == "14.04") or ansible_python_version is version("2.7.9", "<")
-
 - block:
   - name: install mercurial
     include_tasks: install.yml
     when: has_hg is failed
 
+  - name: start hg server
+    include_tasks: serve.yml
+
   - name: test mercurial
     include_tasks: run-tests.yml
+
+  always:
+  - name: kill hg server
+    include_tasks: stop-serving.yml
 
   - name: uninstall mercurial
     include_tasks: uninstall.yml
     when: has_hg is failed
-
-  # As per the bitbucket changes in https://bitbucket.org/blog/deprecating-tlsv1-tlsv1-1-2018-12-01 , this
-  #  test will fail under certain circumstances, to avoid false positives, we skip these tests under the following
-  #  circumstances:
-  #
-  # - The ubuntu 14.04 image used on shippable runs python 2.7.6, so we skip explicitly for this image.
-  # - When ansible_python_version is not 2.7.9 or higher, mercurial is likely to also run using this same (old)
-  #   python version, which causes issues as per the link above.
-  when:
-  - not (ansible_distribution == "Ubuntu" and ansible_distribution_version == "14.04")
-  - ansible_python_version is version("2.7.9", ">=")

--- a/test/integration/targets/hg/tasks/run-tests.yml
+++ b/test/integration/targets/hg/tasks/run-tests.yml
@@ -18,13 +18,10 @@
 
 
 - name: set where to extract the repo
-  set_fact: checkout_dir={{ output_dir }}/epdb
+  set_fact: checkout_dir={{ output_dir }}/hgtest-clone
 
 - name: set what repo to use
-  set_fact: repo=https://bitbucket.org/rpathsync/epdb
-
-- name: clean out the output_dir
-  shell: rm -rf {{ output_dir }}/*
+  set_fact: repo=http://localhost:8000
 
 - name: verify that mercurial is installed so this test can continue
   shell: which hg
@@ -74,7 +71,7 @@
       - "not hg_result2.changed"
 
 - name: Checkout non-existent repo clone
-  hg: repo=https://bitbucket.org/pyro46/pythonscript_1 clone=no update=no
+  hg: repo=http://localhost:8000/foo clone=no update=no
   register: hg_result3
   ignore_errors: true
 
@@ -82,5 +79,5 @@
   assert:
     that:
       - hg_result3.msg
-      - "'abort: HTTP Error 404: Not Found' in hg_result3.msg"
+      - hg_result3 is failed
       - "not hg_result3.changed"

--- a/test/integration/targets/hg/tasks/serve.yml
+++ b/test/integration/targets/hg/tasks/serve.yml
@@ -1,0 +1,32 @@
+# Here we set up an hg server to clone from
+
+- name: Create a directory to use
+  file:
+    path: "{{ output_dir }}/hgtest"
+    state: directory
+
+- name: Add a file to it
+  copy:
+    dest: "{{ output_dir }}/hgtest/file.txt"
+    content: howdy
+    mode: 0644
+
+- name: Create repo
+  command: hg init
+  args:
+    chdir: "{{ output_dir }}/hgtest"
+
+- name: Commit in it
+  shell: hg add . && hg --config ui.username=ansible-test commit -m 'commit message here'
+  args:
+    chdir: "{{ output_dir }}/hgtest"
+
+- name: Create a tag in it
+  shell: hg --config ui.username=ansible-test tag 1.2.3.4
+  args:
+    chdir: "{{ output_dir }}/hgtest"
+
+- name: hg serve
+  command: hg serve -d --pid-file {{ output_dir }}/hg.pid -E /tmp/foo
+  args:
+    chdir: "{{ output_dir }}/hgtest"

--- a/test/integration/targets/hg/tasks/stop-serving.yml
+++ b/test/integration/targets/hg/tasks/stop-serving.yml
@@ -1,0 +1,7 @@
+- name: Get pid of hg server
+  slurp:
+    src: "{{ output_dir }}/hg.pid"
+  register: pid
+
+- name: kill hg server
+  command: kill {{ pid.content | b64decode }}


### PR DESCRIPTION
Change:
- Uses `hg serve` instead of a bitbucket repo for hg tests
- bitbucket no longer serves hg

Backport of #71398

Test Plan:
- CI, fixed integration tests

Signed-off-by: Rick Elrod <rick@elrod.me>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Test Pull Request

##### COMPONENT NAME
tests