### PR TITLE
powershell - fix nested CLIXML parser

### DIFF
--- a/changelogs/fragments/powershell-nested-clixml.yml
+++ b/changelogs/fragments/powershell-nested-clixml.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- powershell - fix the CLIXML parser when it contains nested CLIXML objects - https://github.com/ansible/ansible/issues/69550

--- a/test/units/plugins/shell/test_powershell.py
+++ b/test/units/plugins/shell/test_powershell.py
@@ -56,6 +56,25 @@ def test_parse_clixml_multiple_streams():
     assert actual == expected
 
 
+def test_parse_clixml_multiple_elements():
+    multiple_elements = b'#< CLIXML\r\n#< CLIXML\r\n<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">' \
+                        b'<Obj S="progress" RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS>' \
+                        b'<I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil />' \
+                        b'<PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj>' \
+                        b'<S S="Error">Error 1</S></Objs>' \
+                        b'<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><Obj S="progress" RefId="0">' \
+                        b'<TN RefId="0"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS>' \
+                        b'<I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil />' \
+                        b'<PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj>' \
+                        b'<Obj S="progress" RefId="1"><TNRef RefId="0" /><MS><I64 N="SourceId">2</I64>' \
+                        b'<PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil />' \
+                        b'<PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj>' \
+                        b'<S S="Error">Error 2</S></Objs>'
+    expected = b"Error 1\r\nError 2"
+    actual = _parse_clixml(multiple_elements)
+    assert actual == expected
+
+
 def test_join_path_unc():
     pwsh = ShellModule()
     unc_path_parts = ['\\\\host\\share\\dir1\\\\dir2\\', '\\dir3/dir4', 'dir5', 'dir6\\']


### PR DESCRIPTION
##### SUMMARY
A very rare edge case can have the stderr from a PowerShell process contain multiple CLIXML objects. This makes sure we can handle these situations.

Fixes https://github.com/ansible/ansible/issues/69550

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
powershell

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
