### PR TITLE
Partial backport of 60552 to fix ansible-collections/community.aws/198

### DIFF
--- a/changelogs/fragments/60552-aws_acm_info-failed.yml
+++ b/changelogs/fragments/60552-aws_acm_info-failed.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- aws_acm_info - fix `KeyError` failure when retrieving keys with a `Failed` status (https://github.com/ansible-collections/community.aws/issues/198)


### PR DESCRIPTION
##### SUMMARY

#60552 included a number of significant changes, but tucked away in there was a bugfix for the case where the status of a Certificate object is in a state where there's no certificate data available.

This PR backports the minimum possible portion of the PR.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

aws_acm_info

##### ADDITIONAL INFORMATION

fixes: https://github.com/ansible-collections/community.aws/pull/42
