### PR TITLE
[2.9] update example in known_hosts.py

### DIFF
--- a/changelogs/CHANGELOG-v2.9.rst
+++ b/changelogs/CHANGELOG-v2.9.rst
@@ -18,7 +18,6 @@ Release Summary
 Minor Changes
 -------------
 
-- known_hosts - update documentation to use correct parameters (https://github.com/ansible/ansible/issues/71417).
 - ansible-test - the ACME test container was updated, it now supports external account creation and has a basic OCSP responder (https://github.com/ansible/ansible/pull/71097, https://github.com/ansible/acme-test-container/releases/tag/2.0.0).
 - debconf - add a note about no_log=True since module might expose sensitive information to logs (https://github.com/ansible/ansible/issues/32386).
 

--- a/changelogs/CHANGELOG-v2.9.rst
+++ b/changelogs/CHANGELOG-v2.9.rst
@@ -18,6 +18,7 @@ Release Summary
 Minor Changes
 -------------
 
+- known_hosts - update documentation to use correct parameters (https://github.com/ansible/ansible/issues/71417).
 - ansible-test - the ACME test container was updated, it now supports external account creation and has a basic OCSP responder (https://github.com/ansible/ansible/pull/71097, https://github.com/ansible/acme-test-container/releases/tag/2.0.0).
 - debconf - add a note about no_log=True since module might expose sensitive information to logs (https://github.com/ansible/ansible/issues/32386).
 

--- a/changelogs/fragments/71417-fix-non-existant-parameter-reference.yml
+++ b/changelogs/fragments/71417-fix-non-existant-parameter-reference.yml
@@ -1,2 +1,2 @@
 minor_changes:    
-  - known_hosts - fix reference to non-existant parameter in example (https://github.com/ansible/ansible/issues/71417)
+  - known_hosts - fix reference to non-existent parameter in example (https://github.com/ansible/ansible/issues/71417)

--- a/changelogs/fragments/71417-fix-non-existant-parameter-reference.yml
+++ b/changelogs/fragments/71417-fix-non-existant-parameter-reference.yml
@@ -1,0 +1,2 @@
+minor_changes:    
+  - known_hosts - fix reference to non-existant parameter in example (https://github.com/ansible/ansible/issues/71417)

--- a/lib/ansible/modules/system/known_hosts.py
+++ b/lib/ansible/modules/system/known_hosts.py
@@ -67,7 +67,7 @@ EXAMPLES = '''
 
 - name: Another way to call known_hosts
   known_hosts:
-    hostname: host1.example.com   # or 10.9.8.77
+    name: host1.example.com   # or 10.9.8.77
     key: host1.example.com,10.9.8.77 ssh-rsa ASDeararAIUHI324324  # some key gibberish
     path: /etc/ssh/ssh_known_hosts
     state: present


### PR DESCRIPTION
##### SUMMARY

Fixes  #71417
The example for the module uses an invalid parameter `hostname`. This PR will update the parameter to correctly be `name`.

Backport of https://github.com/ansible/ansible/pull/64891

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
known_hosts
