### PR TITLE
Custom salt for ansible-vault encrypt (Fixes #35480)

### DIFF
--- a/changelogs/fragments/71424-deterministic-vault-encode.yml
+++ b/changelogs/fragments/71424-deterministic-vault-encode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add support for custom salt for vault encoding to make it deterministic (https://github.com/ansible/ansible/issues/35480).

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1206,6 +1206,14 @@ DEFAULT_VAULT_IDENTITY:
   ini:
   - {key: vault_identity, section: defaults}
   yaml: {key: defaults.vault_identity}
+DEFAULT_VAULT_ENCRYPT_SALT:
+  name: Vault salt to use for encryption
+  default: ~
+  description: 'The salt to use for the vault encryption. If is not provided, random salt will be used.'
+  env: [{name: ANSIBLE_VAULT_ENCRYPT_SALT}]
+  ini:
+  - {key: vault_encrypt_salt, section: defaults}
+  yaml: {key: defaults.vault_encrypt_salt}
 DEFAULT_VAULT_ENCRYPT_IDENTITY:
   name: Vault id to use for encryption
   default:

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -1264,9 +1264,9 @@ class VaultAES256:
 
     @classmethod
     def _get_salt(cls):
-        custom_salt = os.getenv('ANSIBLE_VAULT_SALT')
-        if custom_salt:
-            return to_bytes(custom_salt)
+        vault_salt = C.DEFAULT_VAULT_ENCRYPT_SALT
+        if vault_salt:
+            return to_bytes(vault_salt)
         return os.urandom(32)
 
     @classmethod

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -1263,10 +1263,17 @@ class VaultAES256:
         return to_bytes(hmac.hexdigest(), errors='surrogate_or_strict'), hexlify(b_ciphertext)
 
     @classmethod
+    def _get_salt(cls):
+        custom_salt = os.getenv('ANSIBLE_VAULT_SALT')
+        if custom_salt:
+            return to_bytes(custom_salt)
+        return os.urandom(32)
+
+    @classmethod
     def encrypt(cls, b_plaintext, secret):
         if secret is None:
             raise AnsibleVaultError('The secret passed to encrypt() was None')
-        b_salt = os.urandom(32)
+        b_salt = cls._get_salt()
         b_password = secret.bytes
         b_key1, b_key2, b_iv = cls._gen_key_initctr(b_password, b_salt)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Please read https://github.com/ansible/ansible/issues/35480 for details.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Ansible-Vault

##### ADDITIONAL INFORMATION
The `encrypt()` method was not deterministic due to random salt each time. This is simplest solution to fix this - let user define it's own salt in environment variable. It is user role to make sure salt is "good enough". Using dedicated class method gives possibilities for future extensions, ie. generating salt from plain text value.
By default, it acts as it was before.