### PR TITLE
Fix broken links due to master -> main branch rename

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -9,7 +9,7 @@ Collections are a distribution format for Ansible content. You can use collectio
 You can publish and use collections through `Ansible Galaxy <https://galaxy.ansible.com>`_.
 
 * For details on how to *use* collections see :ref:`collections`.
-* For the current development status of Collections and FAQ see `Ansible Collections Overview and FAQ <https://github.com/ansible-collections/overview/blob/master/README.rst>`_.
+* For the current development status of Collections and FAQ see `Ansible Collections Overview and FAQ <https://github.com/ansible-collections/overview/blob/main/README.rst>`_.
 
 .. contents::
    :local:
@@ -532,7 +532,7 @@ Collection versions use `Semantic Versioning <https://semver.org/>`_ for version
 Migrating Ansible content to a different collection
 ====================================================
 
-First, look at `Ansible Collection Checklist <https://github.com/ansible-collections/overview/blob/master/collection_requirements.rst>`_.
+First, look at `Ansible Collection Checklist <https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst>`_.
 
 To migrate content from one collection to another, you need to create three PRs as follows:
 

--- a/docs/docsite/rst/plugins/cliconf.rst
+++ b/docs/docsite/rst/plugins/cliconf.rst
@@ -9,7 +9,7 @@ Cliconf Plugins
 
 .. warning::
 
-	Links on this page may not point to the most recent versions of plugins. In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/overview/blob/master/README.rst>`_.
+	Links on this page may not point to the most recent versions of plugins. In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/overview/blob/main/README.rst>`_.
 
 Cliconf plugins are abstractions over the CLI interface to network devices. They provide a standard interface
 for Ansible to execute tasks on those network devices.

--- a/docs/docsite/rst/plugins/httpapi.rst
+++ b/docs/docsite/rst/plugins/httpapi.rst
@@ -9,7 +9,7 @@ Httpapi Plugins
 
 .. warning::
 
-	Links on this page may not point to the most recent versions of plugins. In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/overview/blob/master/README.rst>`_.
+	Links on this page may not point to the most recent versions of plugins. In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/overview/blob/main/README.rst>`_.
 
 Httpapi plugins tell Ansible how to interact with a remote device's HTTP-based API and execute tasks on the
 device.

--- a/docs/docsite/rst/plugins/netconf.rst
+++ b/docs/docsite/rst/plugins/netconf.rst
@@ -9,7 +9,7 @@ Netconf Plugins
 
 .. warning::
 
-	Links on this page may not point to the most recent versions of plugins. In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/overview/blob/master/README.rst>`_.
+	Links on this page may not point to the most recent versions of plugins. In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/overview/blob/main/README.rst>`_.
 
 Netconf plugins are abstractions over the Netconf interface to network devices. They provide a standard interface for Ansible to execute tasks on those network devices.
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.10.rst
@@ -9,7 +9,7 @@ Ansible 2.10 Porting Guide
 
 .. warning::
 
-         In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/overview/blob/master/README.rst>`_. We expect the 2.10 Porting Guide to change frequently up to the 2.10 release. Follow the conversations about collections on our various :ref:`communication` channels for the latest information on the status of the ``devel`` branch.
+         In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/overview/blob/main/README.rst>`_. We expect the 2.10 Porting Guide to change frequently up to the 2.10 release. Follow the conversations about collections on our various :ref:`communication` channels for the latest information on the status of the ``devel`` branch.
 
 This section discusses the behavioral changes between Ansible 2.9 and Ansible 2.10.
 

--- a/docs/docsite/rst/porting_guides/porting_guide_base_2.10.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_base_2.10.rst
@@ -7,7 +7,7 @@ Ansible-base 2.10 Porting Guide
 
 .. warning::
 
-	In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/overview/blob/master/README.rst>`_. We expect the 2.10 Porting Guide to change frequently up to the 2.10 release. Follow the conversations about collections on our various :ref:`communication` channels for the latest information on the status of the ``devel`` branch.
+	In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/overview/blob/main/README.rst>`_. We expect the 2.10 Porting Guide to change frequently up to the 2.10 release. Follow the conversations about collections on our various :ref:`communication` channels for the latest information on the status of the ``devel`` branch.
 
 This section discusses the behavioral changes between Ansible 2.9 and Ansible-base 2.10.
 

--- a/docs/docsite/rst/roadmap/ROADMAP_2_10.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_10.rst
@@ -48,4 +48,4 @@ moving much of the plugins into smaller collection repositories that will be shi
 The following links have more information about this process:
 
 - https://groups.google.com/d/msg/ansible-devel/oKqgCeYTs-M/cHrOgMw8CAAJ
-- https://github.com/ansible-collections/overview/blob/master/README.rst
+- https://github.com/ansible-collections/overview/blob/main/README.rst

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -10,7 +10,7 @@ Collections are a distribution format for Ansible content that can include playb
 You can install and use collections through `Ansible Galaxy <https://galaxy.ansible.com>`_.
 
 * For details on how to *develop* collections see :ref:`developing_collections`.
-* For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/overview/blob/master/README.rst>`_.
+* For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/overview/blob/main/README.rst>`_.
 
 .. contents::
    :local:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
[ansible-collections/overview](https://github.com/ansible-collections/overview/) renamed its default branch from `master` to `main`. As a result, some links are partially broken. GitHub currently says "Branch doesn't exist; redirecting to default branch", but it may not always do that, and it's good to be tidy.

Please don't argue about the renaming. I'm just tidying up.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
General?

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Didn't open an issue because I thought it's trivial.

For posterity, I used this command:

```bash
grep -Erl 'ansible-collections/overview/(tree|blob)/master' | xargs sed -ri 's"(ansible-collections/overview/(tree|blob))/master"\1/main"'
```