### PR TITLE
setup - Add defensive null check in case bios date is null

### DIFF
--- a/changelogs/fragments/win_setup-bios.yml
+++ b/changelogs/fragments/win_setup-bios.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- setup - Add a null check for ``Win32_Bios.ReleaseData`` to avoid a failure when that value is not set - https://github.com/ansible/ansible/issues/69736

--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -158,11 +158,15 @@ if($gather_subset.Contains('bios')) {
     $win32_bios = Get-LazyCimInstance Win32_Bios
     $win32_cs = Get-LazyCimInstance Win32_ComputerSystem
     $ansible_facts += @{
-        ansible_bios_date = $win32_bios.ReleaseDate.ToString("MM/dd/yyyy")
+        ansible_bios_date = $null
         ansible_bios_version = $win32_bios.SMBIOSBIOSVersion
         ansible_product_name = $win32_cs.Model.Trim()
         ansible_product_serial = $win32_bios.SerialNumber
         # ansible_product_version = ([string] $win32_cs.SystemFamily)
+    }
+
+    if ($win32_bios.ReleaseDate) {
+        $ansible_facts.ansible_bios_date = $win32_bios.ReleaseDate.ToString("MM/dd/yyyy")
     }
 }
 


### PR DESCRIPTION
##### SUMMARY
This fixes a failure when `Win32_Bios.ReleaseDate` returns a `$null` value. The module is no longer present in devel and stable-2.10 so this isn't an actual backport.

The module in `ansible.windows` was [refactored](https://github.com/ansible-collections/ansible.windows/pull/78) so this change isn't based on anything in there.

Fixes https://github.com/ansible/ansible/issues/69736
Fixes https://github.com/ansible/ansible/issues/71296

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup.ps1