### PR TITLE
2.10: _check_failed_state: always use the current/nested state (#71347)

### DIFF
--- a/changelogs/fragments/71306-fix-exit-code-no-failure.yml
+++ b/changelogs/fragments/71306-fix-exit-code-no-failure.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix an exit code for a non-failing playbook (https://github.com/ansible/ansible/issues/71306)

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -491,7 +491,7 @@ class PlayIterator:
             else:
                 return not (state.did_rescue and state.fail_state & self.FAILED_ALWAYS == 0)
         elif state.run_state == self.ITERATING_TASKS and self._check_failed_state(state.tasks_child_state):
-            cur_block = self._blocks[state.cur_block]
+            cur_block = state._blocks[state.cur_block]
             if len(cur_block.rescue) > 0 and state.fail_state & self.FAILED_RESCUE == 0:
                 return False
             else:

--- a/test/integration/targets/blocks/issue71306.yml
+++ b/test/integration/targets/blocks/issue71306.yml
@@ -1,0 +1,16 @@
+- hosts: all
+  gather_facts: no
+  tasks:
+    - block:
+      - block:
+        - block:
+          - name: EXPECTED FAILURE
+            fail:
+            when: ansible_host == "host1"
+
+          - debug:
+              msg: "I am successful!"
+            run_once: true
+        rescue:
+          - debug:
+              msg: "Attemp 1 failed!"

--- a/test/integration/targets/blocks/runme.sh
+++ b/test/integration/targets/blocks/runme.sh
@@ -74,3 +74,12 @@ cat rc_test.out
 [ "$(grep -c 'Failure in always' rc_test.out )" -eq 1 ]
 [ "$(grep -c 'DID NOT RUN' rc_test.out )" -eq 0 ]
 rm -f rc_test.out
+
+# https://github.com/ansible/ansible/issues/71306
+set +e
+exit_code=0
+ansible-playbook -i host1,host2 -vv issue71306.yml > rc_test.out || exit_code=$?
+set -e
+cat rc_test.out
+[ $exit_code -eq 0 ]
+rm -f rc_test_out


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of https://github.com/ansible/ansible/pull/71347

(cherry picked from commit 9792d631b1b92356d41e9a792de4b2479a1bce44)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/executor/play_iterator.py`