### PR TITLE
Avoid wrapping text on non-tty

### DIFF
--- a/changelogs/fragments/71461_tty_wrapping.yml
+++ b/changelogs/fragments/71461_tty_wrapping.yml
@@ -1,2 +1,2 @@
-bugfixes:
+minor_changes:
   - Output is no longer wrapped to 79 columns in absence of a TTY. (https://github.com/ansible/ansible/issues/71461)

--- a/changelogs/fragments/71461_tty_wrapping.yml
+++ b/changelogs/fragments/71461_tty_wrapping.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Output is no longer wrapped to 79 columns in absence of a TTY. (https://github.com/ansible/ansible/issues/71461)

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -430,7 +430,7 @@ class Display(with_metaclass(Singleton, object)):
         try:
             star_len = self.columns - get_text_width(msg)
         except EnvironmentError:
-            star_len = self.columns - len(msg)
+            star_len = min(self.columns, 79) - len(msg)
         if star_len <= 3:
             star_len = 3
         stars = u"*" * star_len
@@ -534,5 +534,6 @@ class Display(with_metaclass(Singleton, object)):
         if os.isatty(1):
             tty_size = unpack('HHHH', fcntl.ioctl(1, TIOCGWINSZ, pack('HHHH', 0, 0, 0, 0)))[1]
         else:
-            tty_size = 0
+            # Avoid wrapping in absence of a tty
+            tty_size = sys.maxsize
         self.columns = max(79, tty_size - 1)

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -535,5 +535,5 @@ class Display(with_metaclass(Singleton, object)):
             tty_size = unpack('HHHH', fcntl.ioctl(1, TIOCGWINSZ, pack('HHHH', 0, 0, 0, 0)))[1]
         else:
             # Avoid wrapping in absence of a tty
-            tty_size = sys.maxsize
+            tty_size = float('inf')
         self.columns = max(79, tty_size - 1)


### PR DESCRIPTION
### SUMMARY
Avoids output wrapping when console is not a tty. Wrapping makes sense only on ttys.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible/lib/ansible/utils/display.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
Fixes: #71461
