### PR TITLE
updates network plugin docs pages for 2.10

### DIFF
--- a/docs/docsite/rst/plugins/cliconf.rst
+++ b/docs/docsite/rst/plugins/cliconf.rst
@@ -7,15 +7,9 @@ Cliconf Plugins
    :local:
    :depth: 2
 
-.. warning::
+Cliconf plugins are abstractions over the CLI interface to network devices. They provide a standard interface for Ansible to execute tasks on those network devices.
 
-	Links on this page may not point to the most recent versions of plugins. In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/overview/blob/main/README.rst>`_.
-
-Cliconf plugins are abstractions over the CLI interface to network devices. They provide a standard interface
-for Ansible to execute tasks on those network devices.
-
-These plugins generally correspond one-to-one to network device platforms. The appropriate cliconf plugin will
-thus be automatically loaded based on the ``ansible_network_os`` variable.
+These plugins generally correspond one-to-one to network device platforms. Ansible loads the appropriate cliconf plugin automatically based on the ``ansible_network_os`` variable.
 
 .. _enabling_cliconf:
 
@@ -31,17 +25,16 @@ Using cliconf plugins
 
 The cliconf plugin to use is determined automatically from the ``ansible_network_os`` variable. There should be no reason to override this functionality.
 
-Most cliconf plugins can operate without configuration. A few have additional options that can be set to impact how
-tasks are translated into CLI commands.
+Most cliconf plugins can operate without configuration. A few have additional options that can be set to affect how tasks are translated into CLI commands.
 
 Plugins are self-documenting. Each plugin should document its configuration options.
 
 .. _cliconf_plugin_list:
 
-Plugin list
------------
+Viewing cliconf plugins
+-----------------------
 
-These plugins have migrated to a collection. Updates on where to find and how to use them will be coming soon.
+These plugins have migrated to collections on `Ansible Galaxy <https://galaxy.ansible.com>`_. If you installed Ansible version 2.10 or later using ``pip``, you have access to several cliconf plugins. To list all available cliconf plugins on your control node, type ``ansible-doc -t cliconf -l``. To view plugin-specific documentation and examples, use ``ansible-doc -t cliconf``.
 
 
 .. seealso::

--- a/docs/docsite/rst/plugins/httpapi.rst
+++ b/docs/docsite/rst/plugins/httpapi.rst
@@ -7,15 +7,11 @@ Httpapi Plugins
    :local:
    :depth: 2
 
-.. warning::
-
-	Links on this page may not point to the most recent versions of plugins. In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/overview/blob/main/README.rst>`_.
-
 Httpapi plugins tell Ansible how to interact with a remote device's HTTP-based API and execute tasks on the
 device.
 
-Each plugin represents a particular dialect of API. Some are platform-specific (Arista eAPI, Cisco NXAPI), while
-others might be usable on a variety of platforms (RESTCONF).
+Each plugin represents a particular dialect of API. Some are platform-specific (Arista eAPI, Cisco NXAPI), while others might be usable on a variety of platforms (RESTCONF). Ansible loads the appropriate httpapi plugin automatically based on the ``ansible_network_os`` variable.
+
 
 .. _enabling_httpapi:
 
@@ -55,14 +51,14 @@ The following sample playbook shows the httpapi plugin for an Arista network dev
         debug:
           var: command_output.stdout[0]["version"]
 
-See the full working example at https://github.com/network-automation/httpapi.
+See the full working example `on GitHub <https://github.com/network-automation/httpapi>`_.
 
 .. _httpapi_plugin_list:
 
-Plugin List
------------
+Viewing httpapi plugins
+-----------------------
 
-These plugins have migrated to a collection. Updates on where to find and how to use them will be coming soon.
+These plugins have migrated to collections on `Ansible Galaxy <https://galaxy.ansible.com>`_. If you installed Ansible version 2.10 or later using ``pip``, you have access to several httpapi plugins. To list all available httpapi plugins on your control node, type ``ansible-doc -t httpapi -l``. To view plugin-specific documentation and examples, use ``ansible-doc -t httpapi``.
 
 .. seealso::
 

--- a/docs/docsite/rst/plugins/netconf.rst
+++ b/docs/docsite/rst/plugins/netconf.rst
@@ -7,17 +7,9 @@ Netconf Plugins
    :local:
    :depth: 2
 
-.. warning::
-
-	Links on this page may not point to the most recent versions of plugins. In preparation for the release of 2.10, many plugins and modules have migrated to Collections on  `Ansible Galaxy <https://galaxy.ansible.com>`_. For the current development status of Collections and FAQ see `Ansible Collections Community Guide <https://github.com/ansible-collections/overview/blob/main/README.rst>`_.
-
 Netconf plugins are abstractions over the Netconf interface to network devices. They provide a standard interface for Ansible to execute tasks on those network devices.
 
-These plugins generally correspond one-to-one to network device platforms. The appropriate netconf plugin will
-thus be automatically loaded based on the ``ansible_network_os`` variable. If the platform supports standard
-Netconf implementation as defined in the Netconf RFC specification the ``default`` netconf plugin will be used.
-In case if the platform supports propriety Netconf RPC's in that case the interface can be defined in platform
-specific netconf plugin.
+These plugins generally correspond one-to-one to network device platforms. Ansible loads the appropriate netconf plugin automatically based on the ``ansible_network_os`` variable. If the platform supports standard Netconf implementation as defined in the Netconf RFC specification, Ansible loads the ``default`` netconf plugin. If the platform supports propriety Netconf RPCs, Ansible loads the platform-specific netconf plugin.
 
 .. _enabling_netconf:
 
@@ -33,19 +25,16 @@ Using netconf plugins
 
 The netconf plugin to use is determined automatically from the ``ansible_network_os`` variable. There should be no reason to override this functionality.
 
-Most netconf plugins can operate without configuration. A few have additional options that can be set to impact how
-tasks are translated into netconf commands. A ncclient device specific handler name can be set in the netconf plugin
-or else the value of ``default`` is used as per ncclient device handler.
-
+Most netconf plugins can operate without configuration. A few have additional options that can be set to affect how tasks are translated into netconf commands. A ncclient device specific handler name can be set in the netconf plugin or else the value of ``default`` is used as per ncclient device handler.
 
 Plugins are self-documenting. Each plugin should document its configuration options.
 
 .. _netconf_plugin_list:
 
-Plugin list
------------
+Listing netconf plugins
+-----------------------
 
-These plugins have migrated to a collection. Updates on where to find and how to use them will be coming soon.
+These plugins have migrated to collections on `Ansible Galaxy <https://galaxy.ansible.com>`_. If you installed Ansible version 2.10 or later using ``pip``, you have access to several netconf plugins. To list all available netconf plugins on your control node, type ``ansible-doc -t netconf -l``. To view plugin-specific documentation and examples, use ``ansible-doc -t netconf``.
 
 
 .. seealso::


### PR DESCRIPTION
##### SUMMARY

Closes #71235.

Removes the note about the transition to collections in 2.10. Adds instructions for listing available cliconf, httpapi, and netconf plugins. Adds instructions for accessing plugin documentation with `ansible-doc`. Some general tidying/copyediting. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
cliconf
httpapi
netconf
