### PR TITLE
Normalize how None is handled in quote filter

### DIFF
--- a/changelogs/fragments/32174-normalize-None-quote.yml
+++ b/changelogs/fragments/32174-normalize-None-quote.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- quote filter - normalize how ``None`` is handled, to match Python3 behavior
+  (https://github.com/ansible/ansible/issues/32174)

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -110,6 +110,8 @@ def strftime(string_format, second=None):
 
 def quote(a):
     ''' return its argument quoted for shell usage '''
+    if a is None:
+        a = u''
     return shlex_quote(to_text(a))
 
 

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -601,3 +601,10 @@
       bar: 123
     thing_items: '{{ thing_dict.items() }}'
     thing_range: '{{ range(10) }}'
+
+- name: Assert that quote works on None
+  assert:
+    that:
+      - thing|quote == "''"
+  vars:
+    thing: null


### PR DESCRIPTION
##### SUMMARY
Normalize how `None` is handled in quote filter. Fixes #32174

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/filter/core.py

##### ADDITIONAL INFORMATION
This change normalizes how `None` is handled, to better reflect agreement with python3:

```
$ python3
Python 3.8.0 (default, Nov 13 2019, 16:14:51)
[Clang 11.0.0 (clang-1100.0.33.12)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from ansible.module_utils.six.moves import shlex_quote
>>> shlex_quote(None)
"''"
>>> shlex_quote('')
"''"

$ python2
Python 2.7.18 (default, Jul 15 2020, 13:39:05)
[GCC 4.2.1 Compatible Apple LLVM 11.0.3 (clang-1103.0.32.62)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from ansible.module_utils.six.moves import shlex_quote
>>> shlex_quote(None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/matt/git/pyenv/pyenv/versions/2.7.18/lib/python2.7/pipes.py", line 269, in quote
    for c in file:
TypeError: 'NoneType' object is not iterable
>>> shlex_quote('')
```