### PR TITLE
Remove "mode: preserve" option from documentation

### DIFF
--- a/lib/ansible/plugins/doc_fragments/files.py
+++ b/lib/ansible/plugins/doc_fragments/files.py
@@ -25,8 +25,6 @@ options:
       number which will have unexpected results.
     - As of Ansible 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or
       C(u=rw,g=r,o=r)).
-    - As of Ansible 2.6, the mode may also be the special string C(preserve).
-    - When set to C(preserve) the file will be given the same permissions as the source file.
     type: raw
   owner:
     description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove "mode: preserve" option from documentation in doc fragments "FILE_COMMON_ARGUMENTS", as it was incorrectly included in the documentation in a number of modules. 
These modules include `lineinfile`, `unarchive` and more loading parts of their documentation using `load_file_common_arguments`. 

Fixes #56839 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Made changes to the doc_fragments plugin.

##### ADDITIONAL INFORMATION
The `copy` and `template` modules documentation remain untouched and still contain "mode: preserve", as intended.
