### PR TITLE
Remove duplicate unit test

### DIFF
--- a/test/units/playbook/test_conditional.py
+++ b/test/units/playbook/test_conditional.py
@@ -87,19 +87,6 @@ class TestConditional(unittest.TestCase):
         ret = self._eval_con(when, variables)
         self.assertTrue(ret)
 
-    def test_dict_undefined_values(self):
-        variables = {'dict_value': 1,
-                     'some_defined_dict_with_undefined_values': {'key1': 'value1',
-                                                                 'key2': '{{ dict_value }}',
-                                                                 'key3': '{{ undefined_dict_value }}'
-                                                                 }}
-
-        when = [u"some_defined_dict_with_undefined_values is defined"]
-        self.assertRaisesRegexp(errors.AnsibleError,
-                                "The conditional check 'some_defined_dict_with_undefined_values is defined' failed.",
-                                self._eval_con,
-                                when, variables)
-
     def test_nested_hostvars_undefined_values(self):
         variables = {'dict_value': 1,
                      'hostvars': {'host1': {'key1': 'value1',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`test_dict_undefined_values` is a duplicate of `test_dict_undefined_values_is_defined`.
It seems originally `test_dict_undefined_values` was supposed
to do what `test_dict_undefined_values_bare` does so it is safe to remove.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/units/playbook/test_conditional.py`
