### PR TITLE
Support macOS 10.15 for ansible-test --remote.

### DIFF
--- a/changelogs/fragments/ansible-test-macos-10.15.yml
+++ b/changelogs/fragments/ansible-test-macos-10.15.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Add ``macos/10.15`` as a supported value for the ``--remote`` option.

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -1,6 +1,7 @@
 freebsd/11.1 python=2.7,3.6 python_dir=/usr/local/bin
 freebsd/12.1 python=3.6,2.7 python_dir=/usr/local/bin
 osx/10.11 python=2.7 python_dir=/usr/local/bin
+macos/10.15 python=3.8 python_dir=/usr/local/bin
 rhel/7.6 python=2.7
 rhel/7.8 python=2.7
 rhel/8.1 python=3.6

--- a/test/lib/ansible_test/_data/setup/remote.sh
+++ b/test/lib/ansible_test/_data/setup/remote.sh
@@ -88,6 +88,14 @@ elif [ "${platform}" = "centos" ]; then
     done
 
     install_pip
+elif [ "${platform}" = "macos" ]; then
+    while true; do
+        pip3 install --disable-pip-version-check --quiet \
+            'virtualenv<20' \
+        && break
+        echo "Failed to install packages. Sleeping before trying again..."
+        sleep 10
+    done
 elif [ "${platform}" = "osx" ]; then
     while true; do
         pip install --disable-pip-version-check --quiet \
@@ -147,5 +155,8 @@ EOF
 
 # Make sure ~/ansible/ is the starting directory for interactive shells.
 if [ "${platform}" = "osx" ]; then
+    echo "cd ~/ansible/" >> ~/.bashrc
+elif [ "${platform}" = "macos" ] ; then
+    echo "export BASH_SILENCE_DEPRECATION_WARNING=1" >> ~/.bashrc
     echo "cd ~/ansible/" >> ~/.bashrc
 fi

--- a/test/lib/ansible_test/_internal/core_ci.py
+++ b/test/lib/ansible_test/_internal/core_ci.py
@@ -111,6 +111,7 @@ class AnsibleCoreCI:
                 'centos arch=power',  # avoid ibmvpc as default for no-arch centos to avoid making centos default to power
             ),
             parallels=(
+                'macos',
                 'osx',
             ),
         )

--- a/test/lib/ansible_test/_internal/manage_ci.py
+++ b/test/lib/ansible_test/_internal/manage_ci.py
@@ -211,6 +211,8 @@ class ManagePosixCI:
                 self.become = ['sudo', '-in', 'sh', '-c']
             else:
                 raise NotImplementedError('provider %s has not been implemented' % self.core_ci.provider)
+        elif self.core_ci.platform == 'macos':
+            self.become = ['sudo', '-in', 'PATH=/usr/local/bin:$PATH', 'sh', '-c']
         elif self.core_ci.platform == 'osx':
             self.become = ['sudo', '-in', 'PATH=/usr/local/bin:$PATH']
         elif self.core_ci.platform == 'rhel' or self.core_ci.platform == 'centos':


### PR DESCRIPTION
##### SUMMARY

Support macOS 10.15 for ansible-test --remote.

Use of this new version is experimental, so it is not enabled in CI yet.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
