### PR TITLE
Update yum_repository documentation for module_hotfixes

### DIFF
--- a/lib/ansible/modules/yum_repository.py
+++ b/lib/ansible/modules/yum_repository.py
@@ -113,7 +113,7 @@ options:
     description:
       - Disable module RPM filtering and make all RPMs from the repository
         available. The default is C(None).
-    version_added: '2.11'
+    version_added: '2.12'
     type: bool
   http_caching:
     description:


### PR DESCRIPTION
##### SUMMARY

The documentation is currently incorrectly listing yum_repository's support for module_hotfixes as having shipped in 2.11 when it has yet to ship. This updates it to 2.12 with the expectation that it will ship in the next release.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

`yum_repository`