### PR TITLE
Fix waiting for lock immediately returns

### DIFF
--- a/changelogs/fragments/71511-filelock-none.yml
+++ b/changelogs/fragments/71511-filelock-none.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Fix the ``FileLock`` from module_utils immediately returning instead of waiting for the lock as expected (https://github.com/ansible/ansible/pull/71511)

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -158,7 +158,7 @@ class FileLock:
 
         self.lockfd = open(lock_path, 'w')
 
-        if lock_timeout <= 0 and lock_timeout is not None:
+        if lock_timeout is not None and lock_timeout <= 0:
             fcntl.flock(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
             return True

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -158,8 +158,8 @@ class FileLock:
 
         self.lockfd = open(lock_path, 'w')
 
-        if lock_timeout <= 0:
-            fcntl.flock(self.lockfd, fcntl.LOCK_EX)
+        if lock_timeout <= 0 and lock_timeout != None:
+            fcntl.flock(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
             return True
 

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -158,7 +158,7 @@ class FileLock:
 
         self.lockfd = open(lock_path, 'w')
 
-        if lock_timeout <= 0 and lock_timeout != None:
+        if lock_timeout <= 0 and lock_timeout is not None:
             fcntl.flock(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
             os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
             return True

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -159,7 +159,7 @@ class FileLock:
         self.lockfd = open(lock_path, 'w')
 
         if lock_timeout <= 0:
-            fcntl.flock(self.lockfd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            fcntl.flock(self.lockfd, fcntl.LOCK_EX)
             os.chmod(lock_path, stat.S_IWRITE | stat.S_IREAD)
             return True
 

--- a/test/units/module_utils/common/test_file.py
+++ b/test/units/module_utils/common/test_file.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# (c) 2017 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible.module_utils.common.file import (
+    FileLock
+)
+
+
+def test_lock_file():
+    locker = FileLock()
+
+    assert locker.set_lock("lock", "/tmp")
+    assert locker.unlock()
+
+    assert locker.set_lock("lock", "/tmp", None)
+    assert locker.unlock()
+
+    assert locker.set_lock("lock", "/tmp", -1)
+    assert locker.unlock()
+
+    assert locker.set_lock("lock", "/tmp", 0)
+    assert locker.unlock()
+
+    assert locker.set_lock("lock", "/tmp", 1)
+    assert locker.unlock()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix the `FileLock` immediately returning instead of waiting for the lock as expected

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`FileLock`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

N/A
