### PR TITLE
Ensure we clean up if an exception kills strategy.run

### DIFF
--- a/changelogs/fragments/23958-cleanup.yml
+++ b/changelogs/fragments/23958-cleanup.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- Ensure if a traceback halts ``strategy.run`` that we still attempt to clean up
+  (https://github.com/ansible/ansible/issues/23958)

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -289,14 +289,16 @@ class TaskQueueManager:
             self._start_at_done = True
 
         # and run the play using the strategy and cleanup on way out
-        play_return = strategy.run(iterator, play_context)
+        try:
+            play_return = strategy.run(iterator, play_context)
+        finally:
+            strategy.cleanup()
+            self._cleanup_processes()
 
         # now re-save the hosts that failed from the iterator to our internal list
         for host_name in iterator.get_failed_hosts():
             self._failed_hosts[host_name] = True
 
-        strategy.cleanup()
-        self._cleanup_processes()
         return play_return
 
     def cleanup(self):


### PR DESCRIPTION
##### SUMMARY
Ensure we clean up if an exception kills strategy.run. Fixes #23958

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/task_queue_manager.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
