### PR TITLE
Add how to run unit test link in testing_units_modules doc

### DIFF
--- a/docs/docsite/rst/dev_guide/testing.rst
+++ b/docs/docsite/rst/dev_guide/testing.rst
@@ -174,6 +174,32 @@ Some ideas of what to test are:
 * Test to see if any Python backtraces returned (that's a bug)
 * Test on different operating systems, or against different library versions
 
+Run sanity tests
+````````````````
+
+.. code:: shell
+
+   ansible-test sanity
+
+More information: :ref:`testing_sanity`
+
+Run unit tests
+``````````````
+
+.. code:: shell
+
+   ansible-test units
+
+More information: :ref:`testing_units`
+
+Run integration tests
+`````````````````````
+
+.. code:: shell
+
+   ansible-test integration -v ping
+
+More information: :ref:`testing_integration`
 
 Any potential issues should be added as comments on the pull request (and it's acceptable to comment if the feature works as well), remembering to include the output of ``ansible --version``
 

--- a/docs/docsite/rst/dev_guide/testing_units_modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_units_modules.rst
@@ -264,6 +264,11 @@ By using previously stored data from various versions of an API we can ensure th
 code is tested against the actual data which will be sent from that version of the system
 even when the version is very obscure and unlikely to be available during testing.
 
+How to run unit test Ansible modules
+================================
+
+Please use this link: :ref:`testing_units#running-tests`
+
 Ansible special cases for unit testing
 ======================================
 

--- a/docs/docsite/rst/dev_guide/testing_units_modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_units_modules.rst
@@ -264,15 +264,6 @@ By using previously stored data from various versions of an API we can ensure th
 code is tested against the actual data which will be sent from that version of the system
 even when the version is very obscure and unlikely to be available during testing.
 
-How to run unit test Ansible modules
-====================================
-
-.. code:: shell
-
-   ansible-test units --docker -v
-
-Please refer to this link for more information: :ref:`testing_units#running-tests`
-
 Ansible special cases for unit testing
 ======================================
 

--- a/docs/docsite/rst/dev_guide/testing_units_modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_units_modules.rst
@@ -265,7 +265,7 @@ code is tested against the actual data which will be sent from that version of t
 even when the version is very obscure and unlikely to be available during testing.
 
 How to run unit test Ansible modules
-================================
+====================================
 
 Please use this link: :ref:`testing_units#running-tests`
 

--- a/docs/docsite/rst/dev_guide/testing_units_modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_units_modules.rst
@@ -267,7 +267,11 @@ even when the version is very obscure and unlikely to be available during testin
 How to run unit test Ansible modules
 ====================================
 
-Please use this link: :ref:`testing_units#running-tests`
+.. code:: shell
+
+   ansible-test units --docker -v
+
+Please refer to this link for more information: :ref:`testing_units#running-tests`
 
 Ansible special cases for unit testing
 ======================================


### PR DESCRIPTION
##### SUMMARY
`testing_units_modules` doc doesn't give any information about how to run unit tests, this PR adds a link to `testing_units` doc which explains how to run tests.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/testing_units_modules.rst