### PR TITLE
Add --allow-disabled to sanity docs

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_sanity.rst
+++ b/docs/docsite/rst/dev_guide/testing_sanity.rst
@@ -29,6 +29,9 @@ How to run
    # Run all sanity tests
    ansible-test sanity
 
+   # Run all sanity tests including disabled ones
+   ansible-test sanity --allow-disabled
+
    # Run all sanity tests against against certain files
    ansible-test sanity lib/ansible/modules/files/template.py
 


### PR DESCRIPTION
##### SUMMARY
`ansible-test sanity` doesn't run all tests by default and this has not been mentioned on https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html#how-to-run.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/testing_sanity.rst