### PR TITLE
[2.9] kubectl: redacted token and password from console log

### DIFF
--- a/changelogs/fragments/159_kubectl.yml
+++ b/changelogs/fragments/159_kubectl.yml
@@ -1,0 +1,2 @@
+security_fixes:
+- kubectl - connection plugin now redact kubectl_token and kubectl_password in console log (https://github.com/ansible-collections/community.kubernetes/issues/65).


### PR DESCRIPTION
##### SUMMARY

** SECURITY_FIX ** for CVE-2020-1753

kubectl connection plugin now redact kubectl_token and
kubectl_password from console log.

Fixes: ansible-collections/community.kubernetes#65

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/159_kubectl.yml
lib/ansible/plugins/connection/kubectl.py
