### PR TITLE
Fix setup_paramiko test on Alpine

### DIFF
--- a/test/integration/targets/setup_paramiko/install-Alpine-3-python-3.yml
+++ b/test/integration/targets/setup_paramiko/install-Alpine-3-python-3.yml
@@ -1,3 +1,6 @@
 - name: Install Paramiko for Python 3 on Alpine
   pip: # no apk package manager in core, just use pip
     name: paramiko
+  environment:
+    # Not sure why this fixes the test, but it does.
+    SETUPTOOLS_USE_DISTUTILS: stdlib


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Not entriely sure why this fixes the test since `virtualenv` in Alpine does not install `setuptools` 50 where this issue seems to have shown up. After two hours of investigating, I ran out of time to look into it further.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/setup_paramiko`