### PR TITLE
test blockinfile alias "content" does not have no_log attribute #62315

### DIFF
--- a/test/integration/targets/blockinfile/tasks/main.yml
+++ b/test/integration/targets/blockinfile/tasks/main.yml
@@ -80,6 +80,23 @@
     that:
       - 'not blockinfile_test1.changed'
 
+- name: check diff when using content alias
+  blockinfile:
+    path: "{{ output_dir_test }}/sshd_config"
+    content: |
+      PasswordAuthentication yes
+  diff: true
+  register: blockinfile_test2
+
+- debug:
+    var: blockinfile_test2
+    verbosity: 1
+
+- name: validate diff
+  assert:
+    that:
+      - '"PasswordAuthentication yes" in blockinfile_test2.diff[0].after'
+
 - name: Create a file with blockinfile
   blockinfile:
     path: "{{ output_dir_test }}/empty.txt"


### PR DESCRIPTION
##### SUMMARY

I was trying to write a test for an updated version of #63017 which fixes #62315, but I was having a lot of trouble with it. While learning how to use the testing environment was a rather large PITA (It would be nice if there was some better hints to using a venv and having ansible-test take care of the package dependencies), I eventually discovered this has already been fixed in #66389. Specifically: https://github.com/ansible/ansible/pull/66389/files#diff-90085fdcec6ed8b273ba885eaee60328L256

I'm not sure if a test is wanted to prove that #62315 can be closed, but I guess I'll be awaiting the next stable release.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
blockinfile
