### PR TITLE
do not add colliding aliases to argument_spec #62315

### DIFF
--- a/changelogs/fragments/62315-fix-FILE_COMMON_ARGUMENTS-alias-collisions.yml
+++ b/changelogs/fragments/62315-fix-FILE_COMMON_ARGUMENTS-alias-collisions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix FILE_COMMON_ARGUMENTS colliding with aliases from module arguments defined by the argument_spec (https://github.com/ansible/ansible/issues/62315).

--- a/test/integration/targets/blockinfile/tasks/main.yml
+++ b/test/integration/targets/blockinfile/tasks/main.yml
@@ -80,6 +80,23 @@
     that:
       - 'not blockinfile_test1.changed'
 
+- name: check diff when using content alias
+  blockinfile:
+    path: "{{ output_dir_test }}/sshd_config"
+    content: |
+      PasswordAuthentication yes
+  diff: true
+  register: blockinfile_test2
+
+- debug:
+    var: blockinfile_test2
+    verbosity: 1
+
+- name: validate diff
+  assert:
+    that:
+      - '"PasswordAuthentication yes" in blockinfile_test2.diff[0].after'
+
 - name: Create a file with blockinfile
   blockinfile:
     path: "{{ output_dir_test }}/empty.txt"

--- a/test/integration/targets/module_utils/library/test_file_common_args_alias_not_in_argument_spec.py
+++ b/test/integration/targets/module_utils/library/test_file_common_args_alias_not_in_argument_spec.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.facts import data
+
+arg_spec = dict(
+    foo=dict(type='str', aliases=['owner'])
+)
+
+module = AnsibleModule(argument_spec=arg_spec, add_file_common_args=True)
+module.exit_json(argument_spec=module.argument_spec, params=module.params)

--- a/test/integration/targets/module_utils/module_utils_test.yml
+++ b/test/integration/targets/module_utils/module_utils_test.yml
@@ -61,6 +61,17 @@
         - result.deprecations[0].msg == "Alias 'baz' is deprecated. See the module docs for more information"
         - result.deprecations[0].version == '9.99'
 
+  - name: Test that aliases are not in the argument_spec
+    test_file_common_args_alias_not_in_argument_spec:
+      owner: 'bar'
+    register: result
+
+  - name: Assert that aliases are not in the argument_spec
+    assert:
+      that:
+        - result.argument_spec.owner is undefined
+        - result.params.foo == 'bar'
+
   - block:
       - name: Get a string with a \0 in it
         command: echo -e 'hi\0foo'

--- a/test/units/module_utils/basic/test_argument_spec.py
+++ b/test/units/module_utils/basic/test_argument_spec.py
@@ -299,6 +299,21 @@ class TestComplexArgSpecs:
         assert isinstance(am.params['foo'], str)
         assert am.params['foo'] == 'hello'
 
+    @pytest.mark.parametrize('stdin', [{'foo': 'bar'}, {'owner': 'bar'}], indirect=['stdin'])
+    def test_file_common_args_alias_not_in_argument_spec(self, stdin):
+        am = basic.AnsibleModule(
+            add_file_common_args=True,
+            argument_spec=dict(
+                foo=dict(required=True, aliases=['owner']),
+                baz=dict(aliases=['mode'], no_log=True),
+            )
+        )
+
+        assert set(['foo', 'baz']).issubset(am.argument_spec.keys())
+        assert am.argument_spec['baz']['no_log']
+        assert 'owner' not in am.argument_spec
+        assert 'mode' not in am.argument_spec
+
     @pytest.mark.parametrize('stdin', [{'foo': 'hello1', 'dup': 'hello2'}], indirect=['stdin'])
     def test_complex_duplicate_warning(self, stdin, complex_argspec):
         """Test that the complex argspec issues a warning if we specify an option both with its canonical name and its alias"""


### PR DESCRIPTION
##### SUMMARY

This is a refreshed PR based on #63017. While #62315 is already fixed on `devel` and I had opened #71555 to just incorporate the test in `test/integration/targets/blockinfile/tasks/main.yml` (which is also included in this PR) I realized this was still a bug to have the `FILE_COMMON_ARGUMENTS` stomping on module aliases, and I opened this PR to address that.

As mentioned in #71555 the issue #62315 was fixed with #66389, and that will go out with the next stable release.

While I have already closed #71555, I do want to call out my comment on that PR, that figuring out how to write a test for Ansible was rather difficult and I struggled with trying to even start the test runner. Eventually I stumbled upon the `--venv` option, and I **really** think that should be much more front and center because it is very likely the option you want to be running with (that or possibly `--docker`). As an initial contributor I don't want to worry about how the packages are installed and I don't want the test system to install packages globally on my system. I'm calling this out because I'm an advanced Python user and I am also very stubborn and wanted to get this fix in. I don't know if this is something you can count on from your average developer. Just my two cents, and I mean what I'm saying as constructively as possible.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils (all modules)