### PR TITLE
[yum tests] add missing "always" block

### DIFF
--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -869,3 +869,10 @@
           - remove is changed
           - "'toaster-1.2.3.4' not in rpmqa.stdout"
           - "'test-package-that-provides-toaster' in rpmqa.stdout"
+  always:
+    - name: Remove test packages
+      yum:
+        name:
+          - test-package-that-provides-toaster
+          - toaster
+        state: absent


### PR DESCRIPTION

##### SUMMARY

Change:
- So that if yum tests get re-run, we don't error out the second time.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Test Pull Request

##### COMPONENT NAME

tests
