### PR TITLE
[backport][2.9] vmware_guest: Add support for HW version 15 (vSphere 6.7U2)

### DIFF
--- a/changelogs/fragments/71563-vmware_guest-support_hw_version_15.yml
+++ b/changelogs/fragments/71563-vmware_guest-support_hw_version_15.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - vmware_guest - Support HW version 15 / vSphere 6.7U2
+  - vmware_guest - Support HW version 15 / vSphere 6.7U2 (https://github.com/ansible-collections/vmware/pull/99).

--- a/changelogs/fragments/71563-vmware_guest-support_hw_version_15.yml
+++ b/changelogs/fragments/71563-vmware_guest-support_hw_version_15.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_guest - Support HW version 15 / vSphere 6.7U2

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1251,12 +1251,12 @@ class PyVmomiHelper(PyVmomi):
                 except ValueError:
                     hw_version_check_failed = True
 
-                if temp_version not in range(3, 15):
+                if temp_version not in range(3, 16):
                     hw_version_check_failed = True
 
                 if hw_version_check_failed:
                     self.module.fail_json(msg="Failed to set hardware.version '%s' value as valid"
-                                              " values range from 3 (ESX 2.x) to 14 (ESXi 6.5 and greater)." % temp_version)
+                                              " values range from 3 (ESX 2.x) to 15 (ESXi 6.7U2 and greater)." % temp_version)
                 # Hardware version is denoted as "vmx-10"
                 version = "vmx-%02d" % temp_version
                 self.configspec.version = version


### PR DESCRIPTION
##### SUMMARY
We need to deploy VMs with HW version 15 (vSphere 6.7U2) but ansible 2.9 doesn't support this; 2.10 does but isn't stable yet.

Fixes #71563, backport of VMware collection ansible-collections/vmware#99

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
vSphere 6.7U2 isn't that new, latest versions are 6.7U3 and 7.0.
