### PR TITLE
Use InventoryManager for inventory_hostnames lookup

### DIFF
--- a/changelogs/fragments/17268-inventory-hostnames.yml
+++ b/changelogs/fragments/17268-inventory-hostnames.yml
@@ -1,3 +1,3 @@
 bugfixes:
-- inventory_hostnames - Use ``InventoryManager`` instead of trying to replicate it's behavior
+- inventory_hostnames - Use ``InventoryManager`` instead of trying to replicate its behavior
   (https://github.com/ansible/ansible/issues/17268)

--- a/changelogs/fragments/17268-inventory-hostnames.yml
+++ b/changelogs/fragments/17268-inventory-hostnames.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- inventory_hostnames - Use ``InventoryManager`` instead of trying to replicate it's behavior
+  (https://github.com/ansible/ansible/issues/17268)

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -140,7 +140,7 @@ def split_host_pattern(pattern):
 class InventoryManager(object):
     ''' Creates and manages inventory '''
 
-    def __init__(self, loader, sources=None):
+    def __init__(self, loader, sources=None, parse=True):
 
         # base objects
         self._loader = loader
@@ -163,7 +163,8 @@ class InventoryManager(object):
             self._sources = sources
 
         # get to work!
-        self.parse_sources(cache=True)
+        if parse:
+            self.parse_sources(cache=True)
 
     @property
     def localhost(self):

--- a/lib/ansible/plugins/lookup/inventory_hostnames.py
+++ b/lib/ansible/plugins/lookup/inventory_hostnames.py
@@ -41,7 +41,8 @@ from ansible.plugins.lookup import LookupBase
 
 class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
-        manager = InventoryManager(self._loader, sources=['%s,' % variables['groups']['all'][0]])
+        manager = InventoryManager(self._loader, parse=False)
+        manager.reconcile_inventory()
         for group, hosts in variables['groups'].items():
             manager.add_group(group)
             for host in hosts:

--- a/lib/ansible/plugins/lookup/inventory_hostnames.py
+++ b/lib/ansible/plugins/lookup/inventory_hostnames.py
@@ -34,41 +34,20 @@ RETURN = """
     type: list
 """
 
-from ansible.inventory.manager import split_host_pattern, order_patterns
+from ansible.errors import AnsibleError
+from ansible.inventory.manager import InventoryManager
 from ansible.plugins.lookup import LookupBase
-from ansible.utils.helpers import deduplicate_list
 
 
 class LookupModule(LookupBase):
-
-    def get_hosts(self, variables, pattern):
-        hosts = []
-        if pattern[0] in ('!', '&'):
-            obj = pattern[1:]
-        else:
-            obj = pattern
-
-        if obj in variables['groups']:
-            hosts = variables['groups'][obj]
-        elif obj in variables['groups']['all']:
-            hosts = [obj]
-        return hosts
-
     def run(self, terms, variables=None, **kwargs):
+        manager = InventoryManager(self._loader, sources=['%s,' % variables['groups']['all'][0]])
+        for group, hosts in variables['groups'].items():
+            manager.add_group(group)
+            for host in hosts:
+                manager.add_host(host, group=group)
 
-        host_list = []
-
-        for term in terms:
-            patterns = order_patterns(split_host_pattern(term))
-
-            for p in patterns:
-                that = self.get_hosts(variables, p)
-                if p.startswith("!"):
-                    host_list = [h for h in host_list if h not in that]
-                elif p.startswith("&"):
-                    host_list = [h for h in host_list if h in that]
-                else:
-                    host_list.extend(that)
-
-        # return unique list
-        return deduplicate_list(host_list)
+        try:
+            return [h.name for h in manager.get_hosts(pattern=terms)]
+        except AnsibleError:
+            return []

--- a/lib/ansible/plugins/lookup/inventory_hostnames.py
+++ b/lib/ansible/plugins/lookup/inventory_hostnames.py
@@ -42,7 +42,6 @@ from ansible.plugins.lookup import LookupBase
 class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
         manager = InventoryManager(self._loader, parse=False)
-        manager.reconcile_inventory()
         for group, hosts in variables['groups'].items():
             manager.add_group(group)
             for host in hosts:

--- a/test/integration/targets/lookup_inventory_hostnames/main.yml
+++ b/test/integration/targets/lookup_inventory_hostnames/main.yml
@@ -10,6 +10,7 @@
       nogroup: "{{ lookup('inventory_hostnames', 'nogroup01', wantlist=true) }}"
       doesnotexist: "{{ lookup('inventory_hostnames', 'doesnotexist', wantlist=true) }}"
       all: "{{ lookup('inventory_hostnames', 'all', wantlist=true) }}"
+      from_patterns: "{{ lookup('inventory_hostnames', 't?s?03', wantlist=True) }}"
 
   - assert:
       that:
@@ -19,3 +20,4 @@
         - nogroup == ['nogroup01']
         - doesnotexist == []
         - all|length == 12
+        - from_patterns == ['test03']


### PR DESCRIPTION
##### SUMMARY
Use InventoryManager for inventory_hostnames lookup. Fixes #17268

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/lookup/inventory_hostnames.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
