### PR TITLE
[stable-2.10] Fix ansible-test coverage traceback. (#71446)

### DIFF
--- a/changelogs/fragments/ansible-test-coverage-py26.yml
+++ b/changelogs/fragments/ansible-test-coverage-py26.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Fix ``ansible-test coverage`` reporting sub-commands (``report``, ``html``, ``xml``) on Python 2.6.

--- a/test/integration/targets/ansible-test/collection-tests/coverage.sh
+++ b/test/integration/targets/ansible-test/collection-tests/coverage.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+
+cp -a "${TEST_DIR}/ansible_collections" "${WORK_DIR}"
+cd "${WORK_DIR}/ansible_collections/ns/col"
+
+# rename the sanity ignore file to match the current ansible version and update import ignores with the python version
+ansible_version="$(python -c 'import ansible.release; print(".".join(ansible.release.__version__.split(".")[:2]))')"
+sed "s/ import$/ import-${ANSIBLE_TEST_PYTHON_VERSION}/;" < "tests/sanity/ignore.txt" > "tests/sanity/ignore-${ansible_version}.txt"
+
+# common args for all tests
+common=(--venv --color --truncate 0 "${@}")
+test_common=("${common[@]}" --python "${ANSIBLE_TEST_PYTHON_VERSION}")
+
+# run a lightweight test that generates code coverge output
+ansible-test sanity --test import "${test_common[@]}" --coverage
+
+# report on code coverage in all supported formats
+ansible-test coverage report "${common[@]}"
+ansible-test coverage html "${common[@]}"
+ansible-test coverage xml "${common[@]}"

--- a/test/lib/ansible_test/_internal/cli.py
+++ b/test/lib/ansible_test/_internal/cli.py
@@ -926,6 +926,7 @@ def add_environments(parser, isolated_delegation=True):
             remote_provider=None,
             remote_aws_region=None,
             remote_terminate=None,
+            remote_endpoint=None,
             python_interpreter=None,
         )
 

--- a/test/lib/ansible_test/_internal/coverage/__init__.py
+++ b/test/lib/ansible_test/_internal/coverage/__init__.py
@@ -104,7 +104,7 @@ def run_coverage(args, output_file, command, cmd):  # type: (CoverageConfig, str
     env = common_environment()
     env.update(dict(COVERAGE_FILE=output_file))
 
-    cmd = ['python', '-m', 'coverage', command, '--rcfile', COVERAGE_CONFIG_PATH] + cmd
+    cmd = ['python', '-m', 'coverage.__main__', command, '--rcfile', COVERAGE_CONFIG_PATH] + cmd
 
     intercept_command(args, target_name='coverage', env=env, cmd=cmd, disable_coverage=True)
 


### PR DESCRIPTION
##### SUMMARY

[stable-2.10] Fix ansible-test coverage traceback. (#71446)

* Add integration test for ansible-test coverage.

* Fix ansible-test coverage traceback.

* Fix coverage reporting on Python 2.6.

Backport of https://github.com/ansible/ansible/pull/71446

(cherry picked from commit f5b6df14ab2e691f5f059fff0fcf59449132549f)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
