### PR TITLE
[2.10] testing_sanity.rst: add argument for running in docker (#71223)

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_sanity.rst
+++ b/docs/docsite/rst/dev_guide/testing_sanity.rst
@@ -22,6 +22,10 @@ How to run
    To run sanity tests using docker, always use the default docker image
    by passing the ``--docker`` or ``--docker default`` argument.
 
+.. note::
+   When using docker and the ``--base-branch`` argument,
+   also use the ``--docker-keep-git`` argument to avoid git related errors.
+
 .. code:: shell
 
    source hacking/env-setup


### PR DESCRIPTION
(cherry picked from commit 56423b1648853d06d24fe65882c7de89a9db04bc)

##### SUMMARY
Backport of testing_sanity.rst: add argument for running in docker (#71223)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/testing_sanity.rst
