### PR TITLE
Adds FAQ and other pointers for collections

### DIFF
--- a/docs/docsite/README.md
+++ b/docs/docsite/README.md
@@ -11,7 +11,7 @@ Contributions to the documentation are welcome.
 
 The Ansible community produces guidance on contributions, building documentation, and submitting pull requests, which you can find in [Contributing to the Ansible Documentation](https://docs.ansible.com/ansible/latest/community/documentation_contributions.html).
 
-You can also join the [Docs Working Group](https://github.com/ansible/community/wiki/Docs) and/or the `ansible-docs` channel on freenode IRC.
+You can also join the [Docs Working Group](https://github.com/ansible/community/wiki/Docs) and/or the ``#ansible-docs`` channel on freenode IRC.
 
 Ansible style guide
 ===================

--- a/docs/docsite/README.md
+++ b/docs/docsite/README.md
@@ -1,7 +1,7 @@
 Ansible documentation
 =====================
 
-This project hosts the source behind [docs.ansible.com](https://docs.ansible.com/).
+This project hosts the source behind the general pages of [docs.ansible.com](https://docs.ansible.com/). Module-specific documentation is hosted in the various collections repositories. See [Ansible Galaxy](https://galaxy.ansible.com/), the list of [Ansible-maintained collections](https://docs.ansible.com/ansible/devel/community/contributing_maintained_collections.html), and the [ansible-collections organization](https://github.com/ansible-collections) for collections sources.
 
 To create clear, concise, and consistent contributions to Ansible documentation, please refer to the following information.
 
@@ -11,7 +11,7 @@ Contributions to the documentation are welcome.
 
 The Ansible community produces guidance on contributions, building documentation, and submitting pull requests, which you can find in [Contributing to the Ansible Documentation](https://docs.ansible.com/ansible/latest/community/documentation_contributions.html).
 
-You can also join the [Docs Working Group](https://github.com/ansible/community/wiki/Docs).
+You can also join the [Docs Working Group](https://github.com/ansible/community/wiki/Docs) and/or the `ansible-docs` channel on freenode IRC.
 
 Ansible style guide
 ===================
@@ -23,4 +23,4 @@ The Ansible community uses a range of tools and programs for working with Ansibl
 
 GitHub
 ======
-[Ansible documentation](https://github.com/ansible/ansible/tree/devel/docs/docsite) is hosted on the Ansible GitHub project. For GitHub workflows and other information, see the [GitHub Guides](https://guides.github.com/).
+[Ansible documentation](https://github.com/ansible/ansible/tree/devel/docs/docsite) is hosted on the Ansible GitHub project and various collection repositories, especially those in the [ansible-collections organization](https://github.com/ansible-collections). For general GitHub workflows and other information, see the [GitHub Guides](https://guides.github.com/).

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -5,6 +5,16 @@ Frequently Asked Questions
 
 Here are some commonly asked questions and their answers.
 
+.. _collections_transition:
+
+Where did all the modules go?
++++++++++++++++++++++++++++++
+
+In July, 2019, we announced that collections would be the `future of Ansible content delivery <https://www.ansible.com/blog/the-future-of-ansible-content-delivery>`_. A collection is a distribution format for Ansible content that can include playbooks, roles, modules, and plugins. In Ansible 2.9 we added support for collections. In Ansible 2.10 we extracted most modules from the main ansible/ansible repository and placed them in :ref:`collections <list_of_collections>`. Collections may be maintained by the Ansible team, by the Ansible community, or by Ansible partners. The `ansible/ansible repository <https://github.com/ansible/ansible>`_ now contains the code for basic features and functions, such as copying module code to managed nodes. This code is also known as ``ansible-base``.
+
+* To learn more about using collections, see :ref:`collections`.
+* To learn more about developing collections, see :ref:`developing_collections`.
+* To learn more about contributing to existing collections, see :ref:`contributing_maintained_collections`.
 
 .. _set_environment:
 

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -14,7 +14,14 @@ In July, 2019, we announced that collections would be the `future of Ansible con
 
 * To learn more about using collections, see :ref:`collections`.
 * To learn more about developing collections, see :ref:`developing_collections`.
-* To learn more about contributing to existing collections, see :ref:`contributing_maintained_collections`.
+* To learn more about contributing to existing collections, see the individual collection repository for guidelines, or see :ref:`contributing_maintained_collections` to contribute to one of the Ansible-maintained collections.
+
+.. _find_my_module:
+
+Where did this specific module go?
+++++++++++++++++++++++++++++++++++
+
+IF you are searching for a specific module, you can check the `runtime.yml <https://github.com/ansible/ansible/blob/devel/lib/ansible/config/ansible_builtin_runtime.yml>`_ file, which lists the first destination for each module that we extracted from the main ansible/ansible repository. Some modules have moved again since then. You can also search on `Ansible Galaxy <https://galaxy.ansible.com/>`_ or ask on one of our :ref:`IRC channels <communication_irc>`.
 
 .. _set_environment:
 

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -5,7 +5,7 @@
 Using collections
 *****************
 
-Collections are a distribution format for Ansible content that can include playbooks, roles, modules, and plugins. As modules move from the core Ansible repository into collections, the module documentation will move to the `collections documentation page <https://docs.ansible.com/collections/>`_
+Collections are a distribution format for Ansible content that can include playbooks, roles, modules, and plugins. As modules move from the core Ansible repository into collections, the module documentation will move to the :ref:`collections pages <list_of_collections>`.
 
 You can install and use collections through `Ansible Galaxy <https://galaxy.ansible.com>`_.
 


### PR DESCRIPTION
##### SUMMARY
Related to #67484. 

Adds an FAQ entry for "Where have all the modules gone?", adds some links and language about collections to the documentation README.md.

The original ticket also said we should add something about the modules-to-collections migration to the User Guide. We have added:
https://docs.ansible.com/ansible/devel/user_guide/basic_concepts.html#collections
https://docs.ansible.com/ansible/devel/user_guide/collections_using.html
and some smaller pointers in the User Guide like https://github.com/ansible/ansible/pull/70307/files. Is that enough for this ticket?

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
collections
