### PR TITLE
[stable-2.10] Use new endpoint for Parallels based instances.

### DIFF
--- a/changelogs/fragments/ansible-test-parallels-endpoint.yml
+++ b/changelogs/fragments/ansible-test-parallels-endpoint.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - ansible-test - Use new endpoint for Parallels based instances with the ``--remote`` option.

--- a/test/lib/ansible_test/_internal/core_ci.py
+++ b/test/lib/ansible_test/_internal/core_ci.py
@@ -187,8 +187,7 @@ class AnsibleCoreCI:
             if self.args.remote_endpoint:
                 self.endpoints = (self.args.remote_endpoint,)
             else:
-                self.endpoints = self._get_parallels_endpoints()
-                self.max_threshold = 6
+                self.endpoints = (AWS_ENDPOINTS['us-east-1'],)
 
             self.ssh_key = SshKey(args)
             self.port = None


### PR DESCRIPTION
##### SUMMARY

[stable-2.10] Use new endpoint for Parallels based instances.

Backport of https://github.com/ansible/ansible/pull/71569

(cherry picked from commit 98febab9751ed73b70c3004fe9dafb4dc09abf26)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
