### PR TITLE
[stable-2.10] Add pause to avoid same mtime in test.

### DIFF
--- a/test/integration/targets/file/tasks/directory_as_dest.yml
+++ b/test/integration/targets/file/tasks/directory_as_dest.yml
@@ -242,6 +242,10 @@
     follow: False
   register: file8_initial_dir_stat
 
+- name: Pause to ensure stat times are not the exact same
+  pause:
+    seconds: 1
+
 - name: Use touch with directory as dest
   file:
     dest: '{{output_dir}}/sub1'


### PR DESCRIPTION
##### SUMMARY

[stable-2.10] Add pause to avoid same mtime in test.

Backport of https://github.com/ansible/ansible/pull/71610

(cherry picked from commit 3d769f3a76a867ea61df16eee328bd40fc91a950)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

test/integration/targets/file/tasks/directory_as_dest.yml