### PR TITLE
[2.10] Docsite: improve developing_modules_documenting.rst (#71590)

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -331,12 +331,14 @@ Per playbook best practices, each example should include a ``name:`` line::
 
     EXAMPLES = r'''
     - name: Ensure foo is installed
-      modulename:
+      namespace.collection.modulename:
         name: foo
         state: present
     '''
 
 The ``name:`` line should be capitalized and not include a trailing dot.
+
+Use a fully qualified collection name (FQCN) as a part of the module's name like in the example above. For modules in ``ansible-base``, use the ``ansible.builtin.`` identifier, for example ``ansible.builtin.debug``.
 
 If your examples use boolean options, use yes/no values. Since the documentation generates boolean values as yes/no, having the examples use these values as well makes the module documentation more consistent.
 
@@ -393,12 +395,12 @@ Here are two example ``RETURN`` sections, one with three simple fields and one w
 
     RETURN = r'''
     packages:
-        description: Information about package requirements
+        description: Information about package requirements.
         returned: success
         type: complex
         contains:
             missing:
-                description: Packages that are missing from the system
+                description: Packages that are missing from the system.
                 returned: success
                 type: list
                 sample:


### PR DESCRIPTION
* Docsite: improve developing_modules_documenting.rst

* add necessary dots to returns descriptions
(cherry picked from commit bfba0ffc452b6817ce82e68cfb4a06a1debff15c)

##### SUMMARY
Backport of Docsite: improve developing_modules_documenting.rst (#71590)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/developing_modules_documenting.rst
