### PR TITLE
[WIP] update version switcher to remove 2.6 and make 2.10 latest

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -148,9 +148,9 @@ html_context = {
     'github_root_dir': 'devel/lib/ansible',
     'github_cli_version': 'devel/lib/ansible/cli/',
     'current_version': version,
-    'latest_version': '2.9',
+    'latest_version': '2.10',
     # list specifically out of order to make latest work
-    'available_versions': ('latest', '2.9_ja', '2.8', '2.7', 'devel'),
+    'available_versions': ('latest', '2.9_ja', '2.9', '2.8', 'devel'),
     'css_files': ('_static/ansible.css',  # overrides to the standard theme
                   ),
 }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
part of ##70783
DO NOT MERGE until 2.10 release. Then it needs to be backported to 

- [x] 2.10

- [x] 2.9

- [x] 2.8

And all three republished. 

2.7 has already been EOL'd

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs.ansible.com

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
