### PR TITLE
Backport documentation correction to 2.9

### DIFF
--- a/lib/ansible/plugins/doc_fragments/files.py
+++ b/lib/ansible/plugins/doc_fragments/files.py
@@ -23,8 +23,6 @@ options:
       number which will have unexpected results.
     - As of Ansible 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or
       C(u=rw,g=r,o=r)).
-    - As of Ansible 2.6, the mode may also be the special string C(preserve).
-    - When set to C(preserve) the file will be given the same permissions as the source file.
     type: str
   owner:
     description:


### PR DESCRIPTION
##### SUMMARY
[stable-2.9] Backport documentation correction

Backport of the following PRs:

- https://github.com/ansible/ansible/pull/71486

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
doc_fragments plugin