### PR TITLE
Update to the ansible-2.10.0 pre-release schedule

### DIFF
--- a/docs/docsite/rst/roadmap/COLLECTIONS_2_10.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_2_10.rst
@@ -27,10 +27,11 @@ Release Schedule
 
   - No new modules or major features will be added after this date. In practice this means we will freeze the semver collection versions to compatible release versions. For example, if the version of community.crypto on this date was community-crypto-1.1.0; ansible-2.10.0 could ship with community-crypto-1.1.1.  It would not ship with community-crypto-1.2.0.
 
-- 2020-09-10: ansible-2.10 final freeze/rc1.
+- 2020-09-08: ansible-2.10.0 beta2.
+- 2020-09-15: ansible-2.10.0 rc1 and final freeze.
 
   - After this date only changes blocking a release are accepted.
-  - Collections will only be updated to a new version if a blocker is approved.  Collection owners should discuss any blockers at a community IRC meeting (on 9-10 and 9-17) to decide whether to bump the version of the collection for a fix. See the `Community IRC meeting agenda <https://github.com/ansible/community/issues/539>`_.
+  - Collections will only be updated to a new version if a blocker is approved.  Collection owners should discuss any blockers at the community IRC meeting (on 9-17) to decide whether to bump the version of the collection for a fix. See the `Community IRC meeting agenda <https://github.com/ansible/community/issues/539>`_.
 
 ** Additional release candidates to be published as needed as blockers are fixed **
 


### PR DESCRIPTION
##### SUMMARY
The ansible-2.10.0 pre-release schedule has shifted to account for ansible-base-2.10.1rc23

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
