### PR TITLE
Update "ansible-vault edit" command to be working with VSCODE. 

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -872,6 +872,7 @@ class VaultEditor:
         try:
             # drop the user into an editor on the tmp file
             subprocess.call(cmd)
+            user_input = ("Put anything into console when You are done editing decrypted file")
         except Exception as e:
             # if an error happens, destroy the decrypted file
             self._shred_file(tmp_path)


### PR DESCRIPTION
First of all, sorry if this is a wrong way of proposing changes. If it is please inform me how should I do it properly and what should I do with this fork.

The issue:

I wanted to edit my ansible vault files with vscode, so I exported EDITOR variable to /snap/bin/code which is the 'code' command for my environment. The issue is that subprocess.call(cmd) doesn't wait for anything (It's probably because the command "code" automatically returns some value, but I'm not sure). To fix that I've added waiting for user to declarevthat he finished changing the file.
So far, the workaround worked fine with code and default vi.

Thanks for any replies in advance and again, sorry If I took wrong way to propose the changes.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
