### PR TITLE
list obsolete packages when using yum: list: updates

### DIFF
--- a/lib/ansible/modules/yum.py
+++ b/lib/ansible/modules/yum.py
@@ -665,7 +665,7 @@ class YumModule(YumDnf):
             if self.releasever:
                 myrepoq.extend('--releasever=%s' % self.releasever)
 
-            cmd = myrepoq + ["--qf", qf] if self.is_ovirt_node() else myrepoq + ["--pkgnarrow=updates", "--qf", qf, pkgspec]
+            cmd = myrepoq + ["--qf", qf] if self.is_ovirt_node() else myrepoq + ["--pkgnarrow=updates", "--qf", qf]
             cmd.insert(1, pkgspec)
             rc, out, err = self.module.run_command(cmd)
 

--- a/lib/ansible/modules/yum.py
+++ b/lib/ansible/modules/yum.py
@@ -544,6 +544,10 @@ class YumModule(YumDnf):
 
         return False
 
+    def is_ovirt_node(self):
+        with open('/etc/os-release') as f:
+            return 'VARIANT_ID="ovirt-node"' in f.read()
+
     def is_installed(self, repoq, pkgspec, qf=None, is_pkg=False):
         if qf is None:
             qf = "%{epoch}:%{name}-%{version}-%{release}.%{arch}\n"
@@ -661,7 +665,8 @@ class YumModule(YumDnf):
             if self.releasever:
                 myrepoq.extend('--releasever=%s' % self.releasever)
 
-            cmd = myrepoq + ["--pkgnarrow=updates", "--qf", qf, pkgspec]
+            cmd = myrepoq + ["--qf", qf] if self.is_ovirt_node() else myrepoq + ["--pkgnarrow=updates", "--qf", qf, pkgspec]
+            cmd.insert(1, pkgspec)
             rc, out, err = self.module.run_command(cmd)
 
             if rc == 0:


### PR DESCRIPTION
Fixes: https://github.com/ansible/ansible/issues/71558

Running the command with the option '--pkgnarrow=updates' gave empty results for RHVH hosts. Without it it shows the packages to update as expected
Also, the command didn't give any results with pkgspec option at the end of it, thus moving it to its beginning

The results for yum: list: updates with the playbook posted in the original issue are:
TASK [print check updates results] ***************************************************************************************************
ok: [192.168.100.170] => {
    "my_updates": {
        "changed": false,
        "failed": false,
        "results": [
            {
                "arch": "noarch",
                "envra": "0:redhat-virtualization-host-image-update-4.3.11-20200825.0.el7_9.noarch",
                "epoch": "0",
                "name": "redhat-virtualization-host-image-update",
                "release": "20200825.0.el7_9",
                "repo": "rhvh4311-updates",
                "version": "4.3.11",
                "yumstate": "available"
            }
        ]
    }
}


Signed-off-by: Dana Elfassy delfassy@redhat.com

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
