### PR TITLE
ansible-test: improve version number validation, validate some semantic versioning properties

### DIFF
--- a/changelogs/fragments/71679-ansible-test.yml
+++ b/changelogs/fragments/71679-ansible-test.yml
@@ -1,0 +1,6 @@
+minor_changes:
+- "ansible-test validate-modules - validate removal version numbers (https://github.com/ansible/ansible/pull/71679)."
+- "ansible-test validate-modules - ensure that removal collection version numbers and version_added collection version numbers conform to the semantic versioning specification at https://semver.org/ (https://github.com/ansible/ansible/pull/71679)."
+- "ansible-test pylint - ensure that removal collection version numbers conform to the semantic versioning specification at https://semver.org/ (https://github.com/ansible/ansible/pull/71679)."
+- "ansible-test runtime-metadata - validate removal version numbers, and check removal dates more strictly (https://github.com/ansible/ansible/pull/71679)."
+- "ansible-test runtime-metadata - ensure that removal collection version numbers conform to the semantic versioning specification at https://semver.org/ (https://github.com/ansible/ansible/pull/71679)."

--- a/docs/docsite/rst/dev_guide/testing_validate-modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_validate-modules.rst
@@ -129,6 +129,7 @@ Codes
   parameter-list-no-elements                                   Parameters           Error                  argument in argument_spec "type" is specified as ``list`` without defining "elements"
   parameter-state-invalid-choice                               Parameters           Error                  Argument ``state`` includes ``get``, ``list`` or ``info`` as a choice.  Functionality should be in an ``_info`` or (if further conditions apply) ``_facts`` module.
   python-syntax-error                                          Syntax               Error                  Python ``SyntaxError`` while parsing module
+  removal-version-must-be-major                                Documentation        Error                  According to the semantic versioning specification (https://semver.org/), the only versions in which features are allowed to be removed are major versions (x.0.0)
   return-syntax-error                                          Documentation        Error                  ``RETURN`` is not valid YAML, ``RETURN`` fragments missing  or invalid
   return-invalid-version-added                                 Documentation        Error                  ``version_added`` for return value is not a valid version number
   subdirectory-missing-init                                    Naming               Error                  Ansible module subdirectories must contain an ``__init__.py``
@@ -160,4 +161,5 @@ Codes
   required_if-value-type                                       Documentation        Error                  required_if entry's value is not of the type specified for its key
   required_by-collision                                        Documentation        Error                  required_by entry has repeated terms
   required_by-unknown                                          Documentation        Error                  required_by entry contains option which does not appear in argument_spec (potentially an alias of an option?)
+  version-added-must-be-major-or-minor                         Documentation        Error                  According to the semantic versioning specification (https://semver.org/), the only versions in which features are allowed to be added are major and minor versions (x.y.0)
 ============================================================   ==================   ====================   =========================================================================================

--- a/docs/docsite/rst/dev_guide/testing_validate-modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_validate-modules.rst
@@ -62,10 +62,8 @@ Codes
   **Error Code**                                                 **Type**             **Level**            **Sample Message**
 ------------------------------------------------------------   ------------------   --------------------   -----------------------------------------------------------------------------------------
   ansible-deprecated-version                                   Documentation        Error                  A feature is deprecated and supposed to be removed in the current or an earlier Ansible version
-  ansible-invalid-version                                      Documentation        Error                  The Ansible version at which a feature is supposed to be removed cannot be parsed
   ansible-module-not-initialized                               Syntax               Error                  Execution of the module did not result in initialization of AnsibleModule
   collection-deprecated-version                                Documentation        Error                  A feature is deprecated and supposed to be removed in the current or an earlier collection version
-  collection-invalid-version                                   Documentation        Error                  The collection version at which a feature is supposed to be removed cannot be parsed (it must be a semantic version, see https://semver.org/)
   deprecated-date                                              Documentation        Error                  A date before today appears as ``removed_at_date`` or in ``deprecated_aliases``
   deprecation-mismatch                                         Documentation        Error                  Module marked as deprecated or removed in at least one of the filename, its metadata, or in DOCUMENTATION (setting DOCUMENTATION.deprecated for deprecation or removing all Documentation for removed) but not in all three places.
   doc-choices-do-not-match-spec                                Documentation        Error                  Value for "choices" from the argument_spec does not match the documentation
@@ -94,6 +92,7 @@ Codes
   invalid-examples                                             Documentation        Error                  ``EXAMPLES`` is not valid YAML
   invalid-extension                                            Naming               Error                  Official Ansible modules must have a ``.py`` extension for python modules or a ``.ps1`` for powershell modules
   invalid-module-schema                                        Documentation        Error                  ``AnsibleModule`` schema validation error
+  invalid-removal-version                                      Documentation        Error                  The version at which a feature is supposed to be removed cannot be parsed (for collections, it must be a semantic version, see https://semver.org/)
   invalid-requires-extension                                   Naming               Error                  Module ``#AnsibleRequires -CSharpUtil`` should not end in .cs, Module ``#Requires`` should not end in .psm1
   invalid-tagged-version                                       Documentation        Error                  All version numbers specified in code have to be explicitly tagged with the collection name, in other words, ``community.general:1.2.3`` or ``ansible.builtin:2.10``
   last-line-main-call                                          Syntax               Error                  Call to ``main()`` not the last line (or ``removed_module()`` in the case of deprecated & docs only modules)

--- a/docs/docsite/rst/dev_guide/testing_validate-modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_validate-modules.rst
@@ -94,7 +94,6 @@ Codes
   invalid-module-schema                                        Documentation        Error                  ``AnsibleModule`` schema validation error
   invalid-removal-version                                      Documentation        Error                  The version at which a feature is supposed to be removed cannot be parsed (for collections, it must be a semantic version, see https://semver.org/)
   invalid-requires-extension                                   Naming               Error                  Module ``#AnsibleRequires -CSharpUtil`` should not end in .cs, Module ``#Requires`` should not end in .psm1
-  invalid-tagged-version                                       Documentation        Error                  All version numbers specified in code have to be explicitly tagged with the collection name, in other words, ``community.general:1.2.3`` or ``ansible.builtin:2.10``
   last-line-main-call                                          Syntax               Error                  Call to ``main()`` not the last line (or ``removed_module()`` in the case of deprecated & docs only modules)
   missing-doc-fragment                                         Documentation        Error                  ``DOCUMENTATION`` fragment missing
   missing-existing-doc-fragment                                Documentation        Warning                Pre-existing ``DOCUMENTATION`` fragment missing

--- a/test/lib/ansible_test/_data/sanity/code-smell/runtime-metadata.py
+++ b/test/lib/ansible_test/_data/sanity/code-smell/runtime-metadata.py
@@ -56,6 +56,9 @@ def removal_version(value, is_ansible):
         else:
             version = SemanticVersion()
             version.parse(value)
+            if version.major != 0 and (version.minor != 0 or version.patch != 0):
+                raise Invalid('removal_version (%r) must be a major release, not a minor or patch release '
+                              '(see specification at https://semver.org/)' % (value, ))
     except ValueError:
         raise Invalid(msg)
     return value

--- a/test/lib/ansible_test/_data/sanity/code-smell/runtime-metadata.py
+++ b/test/lib/ansible_test/_data/sanity/code-smell/runtime-metadata.py
@@ -29,6 +29,10 @@ def isodate(value):
     msg = 'Expected ISO 8601 date string (YYYY-MM-DD), or YAML date'
     if not isinstance(value, string_types):
         raise Invalid(msg)
+    # From Python 3.7 in, there is datetime.date.fromisoformat(). For older versions,
+    # we have to do things manually.
+    if not re.match('^[0-9]{4}-[0-9]{2}-[0-9]{2}$', value):
+        raise Invalid(msg)
     try:
         datetime.datetime.strptime(value, '%Y-%m-%d').date()
     except ValueError:

--- a/test/lib/ansible_test/_data/sanity/code-smell/runtime-metadata.py
+++ b/test/lib/ansible_test/_data/sanity/code-smell/runtime-metadata.py
@@ -7,10 +7,10 @@ import datetime
 import os
 import re
 import sys
-import yaml
-
 from distutils.version import StrictVersion
 from functools import partial
+
+import yaml
 
 from voluptuous import All, Any, MultipleInvalid, PREVENT_EXTRA
 from voluptuous import Required, Schema, Invalid
@@ -42,7 +42,6 @@ def isodate(value):
 
 def removal_version(value, is_ansible):
     """Validate a removal version string."""
-    "Validate a removal version"
     msg = (
         'Removal version must be a string' if is_ansible else
         'Removal version must be a semantic version (https://semver.org/)'
@@ -64,9 +63,9 @@ def removal_version(value, is_ansible):
     return value
 
 
-def any_value(v):
+def any_value(value):
     """Accepts anything."""
-    return v
+    return value
 
 
 def validate_metadata_file(path, is_ansible):

--- a/test/lib/ansible_test/_data/sanity/pylint/plugins/deprecated.py
+++ b/test/lib/ansible_test/_data/sanity/pylint/plugins/deprecated.py
@@ -81,6 +81,13 @@ MSGS = {
               "ansible-deprecated-both-version-and-date",
               "Only one of version and date must be specified",
               {'minversion': (2, 6)}),
+    'E9511': ("Removal version (%r) must be a major release, not a minor or "
+              "patch release (see specification at https://semver.org/)",
+              "removal-version-must-be-major",
+              "Used when a call to Display.deprecated or "
+              "AnsibleModule.deprecate for a collection specifies a version "
+              "which is not of the form x.0.0",
+              {'minversion': (2, 6)}),
 }
 
 
@@ -189,6 +196,8 @@ class AnsibleDeprecatedChecker(BaseChecker):
                 if collection_name == self.collection_name and self.collection_version is not None:
                     if self.collection_version >= semantic_version:
                         self.add_message('collection-deprecated-version', node=node, args=(version,))
+                if semantic_version.major != 0 and (semantic_version.minor != 0 or semantic_version.patch != 0):
+                    self.add_message('removal-version-must-be-major', node=node, args=(version,))
             except ValueError:
                 self.add_message('collection-invalid-deprecated-version', node=node, args=(version,))
 

--- a/test/lib/ansible_test/_data/sanity/pylint/plugins/deprecated.py
+++ b/test/lib/ansible_test/_data/sanity/pylint/plugins/deprecated.py
@@ -82,7 +82,7 @@ MSGS = {
               "Only one of version and date must be specified",
               {'minversion': (2, 6)}),
     'E9511': ("Removal version (%r) must be a major release, not a minor or "
-              "patch release (see specification at https://semver.org/)",
+              "patch release (see the specification at https://semver.org/)",
               "removal-version-must-be-major",
               "Used when a call to Display.deprecated or "
               "AnsibleModule.deprecate for a collection specifies a version "

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -143,9 +143,9 @@ def options_with_apply_defaults(v):
     return v
 
 
-def check_removal_version(v, version_name, collection_name_name, error_code='invalid-removal-version'):
-    version = v.get(version_name)
-    collection_name = v.get(collection_name_name)
+def check_removal_version(v, version_field, collection_name_field, error_code='invalid-removal-version'):
+    version = v.get(version_field)
+    collection_name = v.get(collection_name_field)
     if not isinstance(version, string_types) or not isinstance(collection_name, string_types):
         # If they are not strings, schema validation will have already complained.
         return v
@@ -155,7 +155,7 @@ def check_removal_version(v, version_name, collection_name_name, error_code='inv
             parsed_version.parse(version)
         except ValueError as exc:
             raise _add_ansible_error_code(
-                Invalid('%s (%r) is not a valid ansible-base version: %s' % (version_name, version, exc)),
+                Invalid('%s (%r) is not a valid ansible-base version: %s' % (version_field, version, exc)),
                 error_code=error_code)
         return v
     try:
@@ -164,12 +164,12 @@ def check_removal_version(v, version_name, collection_name_name, error_code='inv
         if parsed_version.major != 0 and (parsed_version.minor != 0 or parsed_version.patch != 0):
             raise _add_ansible_error_code(
                 Invalid('%s (%r) must be a major release, not a minor or patch release (see specification at '
-                        'https://semver.org/)' % (version_name, version)),
+                        'https://semver.org/)' % (version_field, version)),
                 error_code='removal-version-must-be-major')
     except ValueError as exc:
         raise _add_ansible_error_code(
             Invalid('%s (%r) is not a valid collection version (see specification at https://semver.org/): '
-                    '%s' % (version_name, version, exc)),
+                    '%s' % (version_field, version, exc)),
             error_code=error_code)
     return v
 
@@ -186,8 +186,8 @@ def option_deprecation(v):
                         'removed_from_collection must be specified as well'),
                 error_code='deprecation-collection-missing')
         check_removal_version(v,
-                              version_name='removed_in_version',
-                              collection_name_name='removed_from_collection',
+                              version_field='removed_in_version',
+                              collection_name_field='removed_from_collection',
                               error_code='invalid-removal-version')
         return
     if v.get('removed_from_collection'):
@@ -229,8 +229,8 @@ def argument_spec_schema(for_collection):
                     },
                 ),
                 partial(check_removal_version,
-                        version_name='version',
-                        collection_name_name='collection_name',
+                        version_field='version',
+                        collection_name_field='collection_name',
                         error_code='invalid-removal-version')
             )]),
         }
@@ -464,8 +464,8 @@ def deprecation_schema(for_collection):
         result = All(
             result,
             partial(check_removal_version,
-                    version_name='removed_in',
-                    collection_name_name='removed_from_collection',
+                    version_field='removed_in',
+                    collection_name_field='removed_from_collection',
                     error_code='invalid-removal-version'))
 
     return result

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -161,6 +161,11 @@ def check_removal_version(v, version_name, collection_name_name, error_code='inv
     try:
         parsed_version = SemanticVersion()
         parsed_version.parse(version)
+        if parsed_version.major != 0 and (parsed_version.minor != 0 or parsed_version.patch != 0):
+            raise _add_ansible_error_code(
+                Invalid('%s (%r) must be a major release, not a minor or patch release (see specification at '
+                        'https://semver.org/)' % (version_name, version)),
+                error_code='removal-version-must-be-major')
     except ValueError as exc:
         raise _add_ansible_error_code(
             Invalid('%s (%r) is not a valid collection version (see specification at https://semver.org/): '
@@ -285,6 +290,12 @@ def version_added(v, error_code='version-added-invalid', accept_historical=False
                 try:
                     version = SemanticVersion()
                     version.parse(version_added)
+                    if version.major != 0 and version.patch != 0:
+                        raise _add_ansible_error_code(
+                            Invalid('version_added (%r) must be a major or minor release, '
+                                    'not a patch release (see specification at '
+                                    'https://semver.org/)' % (version_added, )),
+                            error_code='version-added-must-be-major-or-minor')
                 except ValueError as exc:
                     raise _add_ansible_error_code(
                         Invalid('version_added (%r) is not a valid collection version '


### PR DESCRIPTION
##### SUMMARY
validate-modules sanity test now validates removal version numbers (similar to version_added validation), checks that removal collection versions are major releases, and not minor or patch releases, and checks that version_added collection versions are not patch releases:
```
ERROR: plugins/modules/cloud/docker/docker_container.py:0:0: invalid-deprecated-version: Argument 'read_only' in argument_spec found in mounts has deprecated aliases 'ever' with invalid removal version '1.2.3.4': invalid semantic version '1.2.3.4'
ERROR: plugins/modules/cloud/docker/docker_container.py:0:0: invalid-deprecated-version: Argument 'tmpfs' in argument_spec has an invalid removed_in_version number '1.2.3.4': invalid semantic version '1.2.3.4'
ERROR: plugins/modules/cloud/docker/docker_container.py:0:0: invalid-removal-version: AnsibleModule.argument_spec.mounts.options.read_only.deprecated_aliases.1: version ('1.2.3.4') is not a valid collection version (see specification at https://semver.org/): invalid semantic version '1.2.3.4' @ data['argument_spec']['mounts']['options']['read_only']['deprecated_aliases'][1]. Got {'name': 'ever', 'version': '1.2.3.4', 'collection_name': 'a.b'}
ERROR: plugins/modules/cloud/docker/docker_container.py:0:0: removal-version-must-be-major: AnsibleModule.argument_spec.mounts.options.read_only.deprecated_aliases.0: version ('1.3.0') must be a major release, not a minor or patch release (see specification at https://semver.org/) @ data['argument_spec']['mounts']['options']['read_only']['deprecated_aliases'][0]. Got {'name': 'who', 'version': '1.3.0', 'collection_name': 'a.b'}
ERROR: plugins/modules/cloud/docker/docker_container.py:0:0: removal-version-must-be-major: AnsibleModule.argument_spec.published_ports.deprecated_aliases.0: version ('1.2.0') must be a major release, not a minor or patch release (see specification at https://semver.org/) @ data['argument_spec']['published_ports']['deprecated_aliases'][0]. Got {'name': 'ports', 'version': '1.2.0', 'collection_name': 'a.b'}
ERROR: plugins/modules/cloud/docker/docker_container.py:0:0: version-added-must-be-major-or-minor: DOCUMENTATION.options.device_read_bps.suboptions.rate: version_added ('1.0.1') must be a major or minor release, not a patch release (see specification at https://semver.org/) for dictionary value @ data['options']['device_read_bps']['suboptions']['rate']. Got {'description': ['Device read limit in format C(<number>[<unit>]).', 'Number is a positive integer. Unit can be one of C(B) (byte), C(K) (kibibyte, 1024B), C(M) (mebibyte), C(G) (gibibyte), C(T) (tebibyte), or C(P) (pebibyte).', 'Omitting the unit defaults to bytes.'], 'type': 'str', 'required': True, 'version_added': '1.0.1', 'version_added_collection': 'community.general'}
ERROR: plugins/modules/cloud/misc/helm.py:0:0: removal-version-must-be-major: DOCUMENTATION.deprecated: removed_in ('3.1.0') must be a major release, not a minor or patch release (see specification at https://semver.org/) for dictionary value @ data['deprecated']. Got {'removed_in': '3.1.0', 'why': 'For more details https://github.com/ansible/ansible/issues/61546.', 'alternative': 'Use M(community.kubernetes.helm) instead.', 'removed_from_collection': 'community.general'}
```
(Also removes some error codes from docs/docsite/rst/dev_guide/testing_validate-modules.rst which have been forgotten, or which haven't been reported anymore.)

The pylint sanity test now checks that removal collection versions are major releases, and not minor or patch releases:
```
ERROR: plugins/modules/cloud/docker/docker_container.py:3445:8: removal-version-must-be-major: Removal version ('3.1.0') must be a major release, not a minor or patch release (see specification at https://semver.org/)
```

The runtime-metadata code-smell sanity test now has stricter date validation (f.ex. YYYY-M-D no longer accepted), checks removal version numbers (semver version numbers for collections, StrictVersion for ansible-base), and checks that removal collection versions are major releases, and not minor or patch releases:
```
ERROR: meta/runtime.yml:0:0: Expected ISO 8601 date string (YYYY-MM-DD), or YAML date for dictionary value @ data['plugin_routing']['modules']['gcspanner']['deprecation']['removal_date']. Got '2020-1-4'
ERROR: meta/runtime.yml:0:0: Removal version must be a semantic version (https://semver.org/) for dictionary value @ data['plugin_routing']['modules']['gcp_target_proxy']['deprecation']['removal_version']. Got '2.0.0.0'
ERROR: meta/runtime.yml:0:0: extra keys not allowed @ data['plugin_routing']['modules']['gcp_url_map']['deprecation']['extra_key']. Got 'whatever'
ERROR: meta/runtime.yml:0:0: removal_version ('3.1.0') must be a major release, not a minor or patch release (see specification at https://semver.org/) for dictionary value @ data['plugin_routing']['modules']['helm']['deprecation']['removal_version']. Got '3.1.0'
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
validate-modules sanity test
pylint sanity test
runtime-metadata code-smell sanity test
