### PR TITLE
[WIP] Documentation: add special field for orphaned modules

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -223,6 +223,9 @@ All fields in the ``DOCUMENTATION`` block are lower-case. All fields are require
   * Details of any important information that doesn't fit in one of the above sections.
   * For example, whether ``check_mode`` is or is not supported.
 
+:orphaned:
+
+  * A boolean flag indicating if the module needs maintainers, for example, ``orphaned: true``.
 
 Linking and other format macros within module documentation
 -----------------------------------------------------------

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -661,6 +661,10 @@ class DocCLI(CLI):
         if doc.pop('action', False):
             text.append("  * note: %s\n" % "This module has a corresponding action plugin.")
 
+        if doc.pop('orphaned', False):
+            text.append('ORPHANED: This module needs maintainers!')
+            text.append('')
+
         if doc.get('options', False):
             text.append("OPTIONS (= is mandatory):\n")
             DocCLI.add_fields(text, doc.pop('options'), limit, opt_indent)

--- a/lib/ansible/parsing/plugin_docs.py
+++ b/lib/ansible/parsing/plugin_docs.py
@@ -28,6 +28,7 @@ def read_docstring(filename, verbose=True, ignore_errors=True):
         'returndocs': None,
         'metadata': None,  # NOTE: not used anymore, kept for compat
         'seealso': None,
+        'orphaned': None,
     }
 
     string_to_vars = {

--- a/lib/ansible/utils/plugin_docs.py
+++ b/lib/ansible/utils/plugin_docs.py
@@ -176,6 +176,15 @@ def add_fragments(doc, filename, fragment_loader, is_module=False):
                     doc['seealso'] = []
                 doc['seealso'].extend(seealso)
 
+        if 'orphaned' in fragment and 'orphaned' not in doc:
+            # In case of the whole bunch of modules is orphaned,
+            # we can put the flag to the corresponding fragment
+            # and override this for certain modules if needed, i.e.,
+            # the fragment's value is replaced by the module's value.
+            orphaned = fragment.pop('orphaned')
+            if orphaned:
+                doc['orphaned'] = orphaned
+
         if 'options' not in fragment:
             raise Exception("missing options in fragment (%s), possibly misformatted?: %s" % (fragment_name, filename))
 

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -448,6 +448,7 @@ def doc_schema(module_name, for_collection=False, deprecated_module=False):
         'options': Any(None, *list_dict_option_schema(for_collection)),
         'extends_documentation_fragment': Any(list_string_types, *string_types),
         'version_added_collection': collection_name,
+        'orphaned': Any(None, bool),
     }
 
     if for_collection:

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -448,7 +448,7 @@ def doc_schema(module_name, for_collection=False, deprecated_module=False):
         'options': Any(None, *list_dict_option_schema(for_collection)),
         'extends_documentation_fragment': Any(list_string_types, *string_types),
         'version_added_collection': collection_name,
-        'orphaned': Any(None, bool),
+        'orphaned': bool,
     }
 
     if for_collection:


### PR DESCRIPTION
##### SUMMARY
Implements https://github.com/ansible/proposals/issues/68#issuecomment-630977395
Relates to https://gist.github.com/gregdek/52e6669421d3f65cded51862e16ad0e9
Though it hasn't been decided yet on a meeting. **Should be discussed and decided before merge**, otherwise I'll close this, no problem.

I checked this locally with `ansible-doc`, works as expected.

Related questions:
1. Should i add anything to anything else?
2. Should we create a special field for listing maintainers (they can be not authors) and integrate this with the bot?
3. We could also create an issue for claiming maintainership to automatically put the link in the orphaned modules doc pages

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`docs/docsite/rst/dev_guide/developing_modules_documenting.rst`
