### PR TITLE
Fix with_dict/with_list being passed incorrect type tests

### DIFF
--- a/test/integration/targets/loops/tasks/main.yml
+++ b/test/integration/targets/loops/tasks/main.yml
@@ -213,17 +213,26 @@
   with_dict: "{{ a_list }}"
   register: with_dict_passed_a_list
   ignore_errors: True
+  vars:
+    a_list:
+      - 1
+      - 2
 - assert:
     that:
       - with_dict_passed_a_list is failed
+      - '"with_dict expects a dict" in with_dict_passed_a_list.msg'
 - debug:
     msg: "with_list passed a dict: {{item}}"
   with_list: "{{ a_dict }}"
   register: with_list_passed_a_dict
   ignore_errors: True
+  vars:
+    a_dict:
+      key: value
 - assert:
     that:
       - with_list_passed_a_dict is failed
+      - '"with_list expects a list" in with_list_passed_a_dict.msg'
 
 - debug:
     var: "item"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
These tests were failing due to a variable passed being undefined
instead of being of an incorrect type which is the actual
intent of the tests.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/loops/tasks/main.yml`