### PR TITLE
Fix typo in the documentation

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
@@ -579,7 +579,7 @@ type
 * bytes
 * bits
 
-The ``raw`` type, performs no type validation or type casing, and maintains the type of the passed value.
+The ``raw`` type, performs no type validation or type casting, and maintains the type of the passed value.
 
 elements
 """"""""


### PR DESCRIPTION
##### SUMMARY
Fix typo in the documentation casting instead of casing


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
