### PR TITLE
Fixed invalid urls inside guide_packet.rst and collections_using.rst

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_packet.rst
+++ b/docs/docsite/rst/scenario_guides/guide_packet.rst
@@ -123,7 +123,7 @@ You can also identify specific Packet devices with the 'device_ids' parameter. T
 More Complex Playbooks
 ======================
 
-In this example, we'll create a CoreOS cluster with `user data <https://support.packet.com/kb/articles/user-data>`_.
+In this example, we'll create a CoreOS cluster with `user data <https://packet.com/developers/docs/servers/key-features/user-data/>`_.
 
 
 The CoreOS cluster will use `etcd <https://etcd.io/>`_ for discovery of other servers in the cluster. Before provisioning your servers, you'll need to generate a discovery token for your cluster:

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -5,7 +5,7 @@
 Using collections
 *****************
 
-Collections are a distribution format for Ansible content that can include playbooks, roles, modules, and plugins. As modules move from the core Ansible repository into collections, the module documentation will move to the `collections pages <https://docs.ansible.com/ansible/latest/user_guide/collections_using.html>`.
+Collections are a distribution format for Ansible content that can include playbooks, roles, modules, and plugins. As modules move from the core Ansible repository into collections, the module documentation will move to the :ref:`collections pages <list_of_collections>`.
 
 You can install and use collections through `Ansible Galaxy <https://galaxy.ansible.com>`_.
 

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -5,7 +5,7 @@
 Using collections
 *****************
 
-Collections are a distribution format for Ansible content that can include playbooks, roles, modules, and plugins. As modules move from the core Ansible repository into collections, the module documentation will move to the :ref:`collections pages <list_of_collections>`.
+Collections are a distribution format for Ansible content that can include playbooks, roles, modules, and plugins. As modules move from the core Ansible repository into collections, the module documentation will move to the `collections pages <https://docs.ansible.com/ansible/latest/user_guide/collections_using.html>`.
 
 You can install and use collections through `Ansible Galaxy <https://galaxy.ansible.com>`_.
 


### PR DESCRIPTION
##### SUMMARY
1. docs/docsite/rst/user_guide/collections_using.rst
Did not find any 404

2. docs/docsite/rst/scenario_guides/vmware_scenarios/vmware_requirements.rst
Did not find any 404

3. docs/docsite/rst/dev_guide/testing_units.rst
Did not find any 404

4. docs/docsite/rst/porting_guides/porting_guide_base_2.11.rst
I guess this branch is not created yet

5. docs/docsite/rst/scenario_guides/vmware_scenarios/vmware_external_doc_links.rst
Did not find any 404

6. docs/docsite/rst/user_guide/intro_dynamic_inventory.rst
Did not find any 404

7. docs/docsite/rst/scenario_guides/guide_azure.rst
Did not find any 404

8. docs/docsite/rst/scenario_guides/guide_infoblox.rst
Did not find any 404

9. docs/docsite/rst/scenario_guides/guide_packet.rst
Fixed link to packet user data

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

Fixes #71254