### PR TITLE
runas - create new SYSTEM token on become

### DIFF
--- a/changelogs/fragments/runas-become-system-privileges.yml
+++ b/changelogs/fragments/runas-become-system-privileges.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- runas - create a new token when running as ``SYSTEM`` to ensure it has the full privileges assigned to that account


### PR DESCRIPTION
##### SUMMARY
Based on the conversation in https://github.com/ansible/ansible/issues/71453 when we try and become the `SYSTEM` account we may not have all the privileges available for that account, i.e. we impersonated a service running as `SYSTEM` but with a limited set of privileges.

Calling `LogonUser` or `LsaLogonUser` to get a new `SYSTEM` token does not work, it just returns the impersonated token leaving us back to where we were before. Instead the `GetPrimaryTokenForUser` is set to get the token with the higher number of privileges that are available for that SID. It's not perfect but it's better than today where a very limit `SYSTEM` token could be used.

For example on my test setup `win_whoami` now shows these privileges on the become task

```yaml
privileges:
  SeAssignPrimaryTokenPrivilege: disabled
  SeAuditPrivilege: enabled-by-default
  SeBackupPrivilege: disabled
  SeChangeNotifyPrivilege: enabled-by-default
  SeCreateGlobalPrivilege: enabled-by-default
  SeCreatePagefilePrivilege: enabled-by-default
  SeCreatePermanentPrivilege: enabled-by-default
  SeCreateSymbolicLinkPrivilege: enabled-by-default
  SeCreateTokenPrivilege: enabled
  SeDebugPrivilege: enabled-by-default
  SeDelegateSessionUserImpersonatePrivilege: enabled-by-default
  SeImpersonatePrivilege: enabled-by-default
  SeIncreaseBasePriorityPrivilege: enabled-by-default
  SeIncreaseQuotaPrivilege: disabled
  SeIncreaseWorkingSetPrivilege: enabled-by-default
  SeLoadDriverPrivilege: disabled
  SeLockMemoryPrivilege: enabled-by-default
  SeManageVolumePrivilege: disabled
  SeProfileSingleProcessPrivilege: enabled-by-default
  SeRelabelPrivilege: disabled
  SeRestorePrivilege: disabled
  SeSecurityPrivilege: disabled
  SeShutdownPrivilege: disabled
  SeSystemEnvironmentPrivilege: disabled
  SeSystemProfilePrivilege: enabled-by-default
  SeSystemtimePrivilege: disabled
  SeTakeOwnershipPrivilege: disabled
  SeTcbPrivilege: enabled-by-default
  SeTimeZonePrivilege: enabled-by-default
  SeTrustedCredManAccessPrivilege: disabled
  SeUndockPrivilege: disabled
```

Whereas in devel I only get

```yaml
privileges:
  SeAssignPrimaryTokenPrivilege: disabled
  SeAuditPrivilege: enabled-by-default
  SeBackupPrivilege: disabled
  SeChangeNotifyPrivilege: enabled-by-default
  SeCreateGlobalPrivilege: enabled-by-default
  SeCreatePermanentPrivilege: enabled-by-default
  SeDebugPrivilege: enabled-by-default
  SeImpersonatePrivilege: enabled-by-default
  SeIncreaseBasePriorityPrivilege: enabled-by-default
  SeIncreaseQuotaPrivilege: disabled
  SeLoadDriverPrivilege: disabled
  SeManageVolumePrivilege: disabled
  SeProfileSingleProcessPrivilege: enabled-by-default
  SeRestorePrivilege: disabled
  SeSecurityPrivilege: disabled
  SeShutdownPrivilege: disabled
  SeSystemEnvironmentPrivilege: disabled
  SeTakeOwnershipPrivilege: disabled
  SeTcbPrivilege: enabled-by-default
  SeTrustedCredManAccessPrivilege: disabled
  SeUndockPrivilege: disabled
```

In this particular case we were able to duplicate the `lssas` process so we even have the `SeCreateTokenPrivilege`! That's not always a guarantee but we can be sure that we have the best token that's available to us for impersonation.

Fixes https://github.com/ansible/ansible/issues/71453

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
runas