### PR TITLE
[2.9] postgresql_user: fix false positive warning for no_password_changes option

### DIFF
--- a/changelogs/fragments/17-postgres_user-no_password_changes-no_log.yml
+++ b/changelogs/fragments/17-postgres_user-no_password_changes-no_log.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- postgres_user - remove false positive ``no_log`` warning for ``no_password_changes`` option (https://github.com/ansible/ansible/issues/68106).

--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -871,7 +871,7 @@ def main():
         fail_on_user=dict(type='bool', default='yes', aliases=['fail_on_role']),
         role_attr_flags=dict(type='str', default=''),
         encrypted=dict(type='bool', default='yes'),
-        no_password_changes=dict(type='bool', default='no'),
+        no_password_changes=dict(type='bool', default='no', no_log=False),
         expires=dict(type='str', default=None),
         conn_limit=dict(type='int', default=None),
         session_role=dict(type='str'),


### PR DESCRIPTION

##### SUMMARY
Backport of https://github.com/ansible-collections/community.general/pull/17

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/modules/database/postgresql/postgresql_user.py`
