### PR TITLE
fix coverage output from synthetic packages

### DIFF
--- a/changelogs/fragments/fix_bogus_coverage.yml
+++ b/changelogs/fragments/fix_bogus_coverage.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- collection loader - fix bogus code coverage entries for synthetic packages

--- a/test/units/utils/collection_loader/test_collection_loader.py
+++ b/test/units/utils/collection_loader/test_collection_loader.py
@@ -594,6 +594,22 @@ def test_bogus_imports():
             import_module(bogus_import)
 
 
+def test_empty_vs_no_code():
+    finder = get_default_finder()
+    reset_collections_loader_state(finder)
+
+    from ansible_collections.testns import testcoll  # synthetic package with no code on disk
+    from ansible_collections.testns.testcoll.plugins import module_utils  # real package with empty code file
+
+    # ensure synthetic packages have no code object at all (prevent bogus coverage entries)
+    assert testcoll.__loader__.get_source(testcoll.__name__) is None
+    assert testcoll.__loader__.get_code(testcoll.__name__) is None
+
+    # ensure empty package inits do have a code object
+    assert module_utils.__loader__.get_source(module_utils.__name__) == b''
+    assert module_utils.__loader__.get_code(module_utils.__name__) is not None
+
+
 def test_finder_playbook_paths():
     finder = get_default_finder()
     reset_collections_loader_state(finder)


### PR DESCRIPTION
##### SUMMARY
* synthetic packages (eg, implicit collection packages without `__init__.py`) were always created at runtime with empty string source, which was compiled to a code object and exec'd during the package load. When run with code coverage, it created a bogus coverage entry (since the `__synthetic__`-suffixed `__file__` entry didn't exist on disk).
* modified collection loader `get_code` to preserve the distinction between `None` (eg synthetic package) and empty string (eg empty `__init__.py`) values from `get_source`, and to return `None` when the source is `None`. This allows the package loader to skip `exec`ing things that truly have no source file on disk, thus not creating bogus coverage entries, while preserving behavior and coverage reporting for empty package inits that actually exist.

Should be backported to 2.10.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
collection loader

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
