### PR TITLE
[2.9] Redirect inventory script links

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_azure.rst
+++ b/docs/docsite/rst/scenario_guides/guide_azure.rst
@@ -260,7 +260,7 @@ Dynamic Inventory Script
 
 If you are not familiar with Ansible's dynamic inventory scripts, check out :ref:`Intro to Dynamic Inventory <intro_dynamic_inventory>`.
 
-The Azure Resource Manager inventory script is called  `azure_rm.py  <https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/azure_rm.py>`_. It authenticates with the Azure API exactly the same as the
+The Azure Resource Manager inventory script is called  `azure_rm.py  <https://raw.githubusercontent.com/ansible/ansible/stable-2.9/contrib/inventory/azure_rm.py>`_. It authenticates with the Azure API exactly the same as the
 Azure modules, which means you will either define the same environment variables described above in `Using Environment Variables`_,
 create a ``$HOME/.azure/credentials`` file (also described above in `Storing in a File`_), or pass command line parameters. To see available command
 line options execute the following:

--- a/docs/docsite/rst/scenario_guides/guide_infoblox.rst
+++ b/docs/docsite/rst/scenario_guides/guide_infoblox.rst
@@ -248,9 +248,9 @@ Dynamic inventory script
 
 You can use the Infoblox dynamic inventory script to import your network node inventory with Infoblox NIOS. To gather the inventory from Infoblox, you need two files:
 
-- `infoblox.yaml <https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/infoblox.yaml>`_ - A file that specifies the NIOS provider arguments and optional filters.
+- `infoblox.yaml <https://raw.githubusercontent.com/ansible/ansible/stable-2.9/contrib/inventory/infoblox.yaml>`_ - A file that specifies the NIOS provider arguments and optional filters.
 
-- `infoblox.py <https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/infoblox.py>`_ - The python script that retrieves the NIOS inventory.
+- `infoblox.py <https://raw.githubusercontent.com/ansible/ansible/stable-2.9/contrib/inventory/infoblox.py>`_ - The python script that retrieves the NIOS inventory.
 
 To use the Infoblox dynamic inventory script:
 

--- a/docs/docsite/rst/scenario_guides/guide_packet.rst
+++ b/docs/docsite/rst/scenario_guides/guide_packet.rst
@@ -126,7 +126,7 @@ More Complex Playbooks
 In this example, we'll create a CoreOS cluster with `user data <https://support.packet.com/kb/articles/user-data>`_.
 
 
-The CoreOS cluster will use `etcd <https://coreos.com/etcd/>`_ for discovery of other servers in the cluster. Before provisioning your servers, you'll need to generate a discovery token for your cluster:
+The CoreOS cluster will use `etcd <https://etcd.io/>`_ for discovery of other servers in the cluster. Before provisioning your servers, you'll need to generate a discovery token for your cluster:
 
 .. code-block:: bash
 
@@ -206,9 +206,9 @@ Once you create a couple of devices, you might appreciate the dynamic inventory 
 Dynamic Inventory Script
 ========================
 
-The dynamic inventory script queries the Packet API for a list of hosts, and exposes it to Ansible so you can easily identify and act on Packet devices. You can find it in Ansible's git repo at `contrib/inventory/packet_net.py <https://github.com/ansible/ansible/blob/devel/contrib/inventory/packet_net.py>`_.
+The dynamic inventory script queries the Packet API for a list of hosts, and exposes it to Ansible so you can easily identify and act on Packet devices. You can find it in Ansible's git repo at `contrib/inventory/packet_net.py <https://github.com/ansible/ansible/blob/stable-2.9/contrib/inventory/packet_net.py>`_.
 
-The inventory script is configurable via a `ini file <https://github.com/ansible/ansible/blob/devel/contrib/inventory/packet_net.ini>`_.
+The inventory script is configurable via a `ini file <https://github.com/ansible/ansible/blob/stable-2.9/contrib/inventory/packet_net.ini>`_.
 
 If you want to use the inventory script, you must first export your Packet API token to a PACKET_API_TOKEN environment variable.
 

--- a/docs/docsite/rst/scenario_guides/vmware_scenarios/vmware_requirements.rst
+++ b/docs/docsite/rst/scenario_guides/vmware_scenarios/vmware_requirements.rst
@@ -35,7 +35,7 @@ Installing vCenter SSL certificates for Ansible
 Installing ESXi SSL certificates for Ansible
 --------------------------------------------
 
-* Enable SSH Service on ESXi either by using Ansible VMware module `vmware_host_service_manager <https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/vmware/vmware_host_config_manager.py>`_ or manually using vSphere Web interface.
+* Enable SSH Service on ESXi either by using Ansible VMware module `vmware_host_service_manager <https://github.com/ansible/ansible/blob/stable-2.9/lib/ansible/modules/cloud/vmware/vmware_host_config_manager.py>`_ or manually using vSphere Web interface.
 
 * SSH to ESXi server using administrative credentials, and navigate to directory ``/etc/vmware/ssl``
 


### PR DESCRIPTION
##### SUMMARY
Replacement for #71731. Fixes links to inventory scripts from `devel` to `stable-2.9`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/scenario_guides/guide_azure.rst
docs/docsite/rst/scenario_guides/guide_infoblox.rst
docs/docsite/rst/scenario_guides/guide_packet.rst
docs/docsite/rst/user_guide/intro_dynamic_inventory.rst
