### PR TITLE
Remove em dash from the pytest configuration file

### DIFF
--- a/changelogs/fragments/71739-remove-em-dash-from-pytest-config.yml
+++ b/changelogs/fragments/71739-remove-em-dash-from-pytest-config.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- ansible-test - Remove em dash from the Pytest configuration file in order to
+  be readable on systems where preferred encoding is ASCII.
+  (https://github.com/ansible/ansible/issues/71739)

--- a/test/lib/ansible_test/_data/pytest.ini
+++ b/test/lib/ansible_test/_data/pytest.ini
@@ -3,7 +3,7 @@ xfail_strict = true
 mock_use_standalone_module = true
 # It was decided to stick with "legacy" (aka "xunit1") for now.
 # Currently used pytest versions all support xunit2 format too.
-# Except the one used under Python 2.6 — it doesn't process this option
+# Except the one used under Python 2.6 - it doesn't process this option
 # at all. Ref:
 # https://github.com/ansible/ansible/pull/66445#discussion_r372530176
 junit_family = xunit1


### PR DESCRIPTION
##### SUMMARY
On some systems (tested with official Debian Buster-based Python 3.6 docker image), setting the LC_ALL environment variable to en_US.UTF-8 will trigger Python into switching its preferred encoding to ASCII. If any python process tries to read a non-ASCII file in this scenario, it will terminate with an error.

And this is exactly what happens to pytest when it tries to load its configuration that ansible-test supplies because the configuration contains an em dash.

In order to bypass this issue, we replaced the em dash with a regular dash and things started working again.

An alternative solution would be to replace the en_US.UTF locale with something safer (eg. C.UTF-8), but because the reason behind the en_US.UTF-8 locale is not explained anywhere, we opted for the dash replacement.

Fixes #71739

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test
