### PR TITLE
add a note about pip install --user

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -308,6 +308,14 @@ Then install Ansible [1]_::
 
     $ python -m pip install --user ansible
 
+
+.. tip::
+
+    If this is your first time installing packages with pip, you may need to perform some additional configuration before you are able to run
+    Ansible. See the Python documentation on `installing to the user site`_ for more information.
+
+.. _installing to the user site: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
 In order to use the ``paramiko`` connection plugin or modules that require ``paramiko``, install the required module [2]_::
 
     $ python -m pip install --user paramiko


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

the installation instructions for macos suggest using 'pip install
--user', but don't mention that the target directory for this install
won't be in $PATH for a first-time pip user.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs