### PR TITLE
incidental_setup_openssl - Pin version of Python packages

### DIFF
--- a/test/integration/targets/incidental_setup_openssl/tasks/main.yml
+++ b/test/integration/targets/incidental_setup_openssl/tasks/main.yml
@@ -24,7 +24,15 @@
 - name: Install pyOpenSSL (Darwin)
   become: True
   pip:
-    name: pyOpenSSL
+    name:
+      - pyOpenSSL==19.1.0
+      # dependencies for pyOpenSSL
+      - cffi==1.14.2
+      - cryptography==3.1
+      - enum34==1.1.10
+      - ipaddress==1.0.23
+      - pycparser==2.20
+      - six==1.15.0
   when: ansible_os_family == 'Darwin'
 
 - name: register pyOpenSSL version


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

A recent update to `cffi` that was yanked is still being installed on our Mac OS X 10.11 test image since the version of pip there is very old and does not ignore yanked packages.

Pin the version of pyOpenSSL and its dependencies to fix this and avoid future spontaneous failures.<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/incidental_setup_openssl/tasks/main.yml`