### PR TITLE
[2.10] Fix passing the connection timeout to connection plugins (#71722)

### DIFF
--- a/changelogs/fragments/71722-fix-default-connection-timeout.yaml
+++ b/changelogs/fragments/71722-fix-default-connection-timeout.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Pass the connection's timeout to connection plugins instead of the task's timeout.

--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -288,6 +288,8 @@ Ansible version 2.1 introduced the ``smart`` connection plugin. The ``smart`` co
 
 To create a new connection plugin (for example, to support SNMP, Message bus, or other transports), copy the format of one of the existing connection plugins and drop it into ``connection`` directory on your :ref:`local plugin path <local_plugins>`.
 
+Connection plugins can support common options (such as the ``--timeout`` flag) by defining an entry in the documentation for the attribute name (in this case ``timeout``). If the common option has a non-null default, the plugin should define the same default since a different default would be ignored.
+
 For example connection plugins, see the source code for the `connection plugins included with Ansible Core <https://github.com/ansible/ansible/tree/devel/lib/ansible/plugins/connection>`_.
 
 .. _developing_filter_plugins:

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -1014,6 +1014,10 @@ class TaskExecutor:
 
         task_keys = self._task.dump_attrs()
 
+        # The task_keys 'timeout' attr is the task's timeout, not the connection timeout.
+        # The connection timeout is threaded through the play_context for now.
+        task_keys['timeout'] = self._play_context.timeout
+
         if self._play_context.password:
             # The connection password is threaded through the play_context for
             # now. This is something we ultimately want to avoid, but the first


### PR DESCRIPTION
##### SUMMARY
Backport #71722

* Fix passing the connection timeout to connection plugins

(cherry picked from commit 70485421998463036c93ce927b3029fd0e7d4301)

##### ISSUE TYPE
- Bugfix Pull Request
