### PR TITLE
Ansible is broken by Google Compute Engine strict os-login plus 2FA

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -638,7 +638,7 @@ class Connection(ConnectionBase):
             self._add_args(
                 b_command, (
                     b"-o", b"KbdInteractiveAuthentication=no",
-                    b"-o", b"PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey",
+                    b"-o", b"PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey,keyboard-interactive",
                     b"-o", b"PasswordAuthentication=no"
                 ),
                 u"ansible_password/ansible_ssh_password not set"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugin/ssh.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Since Sept 10th when Google enforced 2FA with os-login, ansible is no longer able to open ssh connection even with valid ssh pubkey.  The reason is google compute engine VMs require keyboard-interactive as preferred method, even when using a service-account with valid sshkey binding.   Adding this as 'supported' ssh connection method, allows ansible to make ssh connection to VMs with script os-login (no user sshkeys) and 2 factor authentication enforced.  Ansible is broken otherwise.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```