### PR TITLE
Correct Debian apt-key command

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -168,7 +168,7 @@ Then run these commands:
 
 .. code-block:: bash
 
-    $ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
+    $ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0x93C4A3FD7BB9C367
     $ sudo apt update
     $ sudo apt install ansible
 


### PR DESCRIPTION
Reference:

Searching just '93C4A3FD7BB9C367' on keyserver.ubuntu.com provides no results. However searching '0x93C4A3FD7BB9C367' brings up the proper key.
