### PR TITLE
[stable-2.9] openssl_privatekey test - Add pause for macOS

### DIFF
--- a/test/integration/targets/openssl_privatekey/tasks/impl.yml
+++ b/test/integration/targets/openssl_privatekey/tasks/impl.yml
@@ -266,6 +266,12 @@
     select_crypto_backend: '{{ select_crypto_backend }}'
   register: privatekey_mode_2
 
+# stat time granularity on macOS is only one second
+- name: Pause
+  pause:
+    seconds: 1
+  when: ansible_facts.distribution == 'MacOSX'
+
 - name: Generate privatekey_mode (mode 0400, force)
   openssl_privatekey:
     path: '{{ output_dir }}/privatekey_mode.pem'


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The stat time granularity on macOS is one second. We recently upgraded to faster macOS hosts, so some tests that run closely together to see if something changed will have the same timestamp intermittently.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/openssl_privatekey`