### PR TITLE
[default callback] Show include_tasks task banner

### DIFF
--- a/changelogs/fragments/71277-include_tasks-show-name-with-free-strategy.yml
+++ b/changelogs/fragments/71277-include_tasks-show-name-with-free-strategy.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - default callback - task name is now shown for ``include_tasks`` when using the ``free`` strategy (https://github.com/ansible/ansible/issues/71277).
+  - default callback - task name is now shown for ``include_tasks`` when using the ``linear`` strategy with ``ANSIBLE_DISPLAY_SKIPPED_HOSTS=0``.

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -106,6 +106,8 @@ class CallbackModule(CallbackBase):
         delegated_vars = result._result.get('_ansible_delegated_vars', None)
 
         if isinstance(result._task, TaskInclude):
+            if self._last_task_banner != result._task._uuid:
+                self._print_task_banner(result._task)
             return
         elif result._result.get('changed', False):
             if self._last_task_banner != result._task._uuid:

--- a/test/integration/targets/callback_default/callback_default.out.default.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.default.stdout
@@ -67,6 +67,14 @@ changed: [testhost]
 TASK [Second free task] ********************************************************
 changed: [testhost]
 
+TASK [Include some tasks] ******************************************************
+included: .../test/integration/targets/callback_default/include_me.yml for testhost => (item=1)
+
+TASK [debug] *******************************************************************
+ok: [testhost] => {
+    "item": 1
+}
+
 PLAY RECAP *********************************************************************
-testhost                   : ok=14   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+testhost                   : ok=16   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stdout
@@ -64,6 +64,14 @@ changed: [testhost]
 TASK [Second free task] ********************************************************
 changed: [testhost]
 
+TASK [Include some tasks] ******************************************************
+included: .../test/integration/targets/callback_default/include_me.yml for testhost => (item=1)
+
+TASK [debug] *******************************************************************
+ok: [testhost] => {
+    "item": 1
+}
+
 PLAY RECAP *********************************************************************
-testhost                   : ok=14   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+testhost                   : ok=16   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_ok.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_ok.stdout
@@ -35,6 +35,8 @@ fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed as requested fro
 
 TASK [Rescue task] *************************************************************
 changed: [testhost]
+
+TASK [include_tasks] ***********************************************************
 included: .../test/integration/targets/callback_default/include_me.yml for testhost => (item=1)
 
 RUNNING HANDLER [Test handler 1] ***********************************************
@@ -51,6 +53,9 @@ changed: [testhost]
 TASK [Second free task] ********************************************************
 changed: [testhost]
 
+TASK [Include some tasks] ******************************************************
+included: .../test/integration/targets/callback_default/include_me.yml for testhost => (item=1)
+
 PLAY RECAP *********************************************************************
-testhost                   : ok=14   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+testhost                   : ok=16   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_skipped.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_skipped.stdout
@@ -37,6 +37,8 @@ fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed as requested fro
 
 TASK [Rescue task] *************************************************************
 changed: [testhost]
+
+TASK [include_tasks] ***********************************************************
 included: .../test/integration/targets/callback_default/include_me.yml for testhost => (item=1)
 
 TASK [debug] *******************************************************************
@@ -61,6 +63,14 @@ changed: [testhost]
 TASK [Second free task] ********************************************************
 changed: [testhost]
 
+TASK [Include some tasks] ******************************************************
+included: .../test/integration/targets/callback_default/include_me.yml for testhost => (item=1)
+
+TASK [debug] *******************************************************************
+ok: [testhost] => {
+    "item": 1
+}
+
 PLAY RECAP *********************************************************************
-testhost                   : ok=14   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+testhost                   : ok=16   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok.stdout
@@ -31,6 +31,8 @@ fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed as requested fro
 
 TASK [Rescue task] *************************************************************
 changed: [testhost]
+
+TASK [include_tasks] ***********************************************************
 included: .../test/integration/targets/callback_default/include_me.yml for testhost => (item=1)
 
 RUNNING HANDLER [Test handler 1] ***********************************************
@@ -47,6 +49,9 @@ changed: [testhost]
 TASK [Second free task] ********************************************************
 changed: [testhost]
 
+TASK [Include some tasks] ******************************************************
+included: .../test/integration/targets/callback_default/include_me.yml for testhost => (item=1)
+
 PLAY RECAP *********************************************************************
-testhost                   : ok=14   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
+testhost                   : ok=16   changed=9    unreachable=0    failed=0    skipped=1    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/test.yml
+++ b/test/integration/targets/callback_default/test.yml
@@ -86,3 +86,9 @@
 
     - name: Second free task
       command: echo foo
+
+    # Ensure include_tasks task names get shown (#71277)
+    - name: Include some tasks
+      include_tasks: include_me.yml
+      loop:
+        - 1

--- a/test/integration/targets/callback_default/test_dryrun.yml
+++ b/test/integration/targets/callback_default/test_dryrun.yml
@@ -3,7 +3,7 @@
   hosts: testhost
   gather_facts: no
   tasks:
-  - debug: 
+  - debug:
       msg: 'ansible_check_mode: {{ansible_check_mode}}'
 
   - name: Command
@@ -23,12 +23,12 @@
   gather_facts: no
   check_mode: true
   tasks:
-  - debug: 
+  - debug:
       msg: 'ansible_check_mode: {{ansible_check_mode}}'
 
   - name: Command
     command: ls -l
- 
+
   - name: "Command with check_mode: false"
     command: ls -l
     check_mode: false
@@ -43,7 +43,7 @@
   gather_facts: no
   check_mode: false
   tasks:
-  - debug: 
+  - debug:
       msg: 'ansible_check_mode: {{ansible_check_mode}}'
 
   - name: Command


### PR DESCRIPTION

##### SUMMARY

Change:
- In some cases (always with free strategy, sometimes with linear), the
  default callback would not show the task banner for include_tasks.
- This only affects the include_tasks task itself, not the tasks in the
  included file.

Test Plan:
- Updated default callback tests

Tickets:
- Fixes #71277

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

default callback