### PR TITLE
Close file descriptor of temporary file after building certificate chain

### DIFF
--- a/changelogs/fragments/71825-close-file-descriptor-after-building-cert-chaing.yml
+++ b/changelogs/fragments/71825-close-file-descriptor-after-building-cert-chaing.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - urls - Close filedescriptor of certificate chain tempfile to prevent stale 
+    filedescriptor leakage (https://github.com/ansible/ansible/pull/71825).

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -900,6 +900,8 @@ class SSLValidationHandler(urllib_request.BaseHandler):
         if HAS_SSLCONTEXT:
             default_verify_paths = ssl.get_default_verify_paths()
             paths_checked[:0] = [default_verify_paths.capath]
+        else:
+            os.close(tmp_fd)
 
         return (tmp_path, cadata, paths_checked)
 


### PR DESCRIPTION
##### SUMMARY
Closes the file descriptor for a temporary certificate chain file after using, preventing hitting open files restrictions when downloading multiple files in one task.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
urls

##### ADDITIONAL INFORMATION
The (with this pull request fixed) problem can be reproduced by using the fetch_url - method from the urls module_utils multiple times in a row within one module. The number of open stale file handles will increase with every fetch. When using this to download a big number of files in a row ansible will crash due to hitting the open files limit.