### PR TITLE
Fix option key for jsonfile file path

### DIFF
--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -14,7 +14,7 @@ DOCUMENTATION = '''
     version_added: "1.9"
     author: Ansible Core (@ansible-core)
     options:
-      _uri:
+      _connection:
         required: True
         description:
           - Path in which the cache plugin will save the JSON files


### PR DESCRIPTION
##### SUMMARY
The json file path option currently has a key of `_uri`, but the env and ini options are both named `_connection`. This caused me some confusion when the error message was explaining that it was missing `_uri`, but actually it needed `_connection` set.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
jsonfile

##### ADDITIONAL INFORMATION

This should make it consistent, I think. I'm new to Ansible internals though, so I may have missed a test or somesuch. I'll see if the checks pass and look deeper if not...

I don't *think* this should have any knock on effects, I think it will only affect documentation and error messages?