### PR TITLE
[stable-2.10] Fix attribute testing in file integration test. (#71843)

### DIFF
--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -111,10 +111,50 @@
       - "file4_result.changed == true"
       - "file4_result.mode == '0600'"
 
+- name: define file to verify chattr/lsattr with
+  set_fact:
+    attributes_file: "{{ output_dir }}/attributes.txt"
+    attributes_supported: no
+
+- name: create file to verify chattr/lsattr with
+  command: touch "{{ attributes_file }}"
+
+- name: add "A" attribute to file
+  command: chattr +A "{{ attributes_file }}"
+  ignore_errors: yes
+
+- name: get attributes from file
+  # Use of `-v` is important, as that is what the module does (through `set_attributes_if_different` and then `get_file_attributes` in basic.py).
+  # On some systems, such as in containers, attributes work, but file versions may not.
+  # It should be possible to update `set_attributes_if_different` in the future to not use `-v` since the file version is unrelated to the attributes.
+  command: lsattr -vd "{{ attributes_file }}"
+  register: attribute_A_set
+  ignore_errors: yes
+
+- name: remove "A" attribute from file
+  command: chattr -A "{{ attributes_file }}"
+  ignore_errors: yes
+
+- name: get attributes from file
+  # See the note above on use of the `-v` option.
+  command: lsattr -vd "{{ attributes_file }}"
+  register: attribute_A_unset
+  ignore_errors: yes
+
+- name: determine if chattr/lsattr is supported
+  set_fact:
+    attributes_supported: yes
+  when:
+    - attribute_A_set is success
+    - "'A' in attribute_A_set.stdout_lines[0].split()[1]"
+    - attribute_A_unset is success
+    - "'A' not in attribute_A_unset.stdout_lines[0].split()[1]"
+
 - name: explicitly set file attribute "A"
   file: path={{output_dir}}/baz.txt attributes=A
   register: file_attributes_result
   ignore_errors: True
+  when: attributes_supported
 
 - name: add file attribute "A"
   file: path={{output_dir}}/baz.txt attributes=+A


### PR DESCRIPTION
##### SUMMARY

The file test will no longer attempt to test attributes if `lsattr -vd` does not work on the system under test.

Backport of https://github.com/ansible/ansible/pull/71843

(cherry picked from commit 17765cd4e82972efa116ed107ec175e1aedc3ed6)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

file integration test
