### PR TITLE
Fix hostname test on docker.

### DIFF
--- a/test/integration/targets/hostname/tasks/main.yml
+++ b/test/integration/targets/hostname/tasks/main.yml
@@ -1,5 +1,5 @@
 # Setting the hostname in our test containers doesn't work currently
-- when: ansible_facts.virtualization_type != 'docker'
+- when: ansible_facts.virtualization_type not in ('docker', 'container')
   block:
     - name: Include distribution specific variables
       include_vars: "{{ lookup('first_found', params) }}"


### PR DESCRIPTION
##### SUMMARY

The test is not supported when running in a container. It now recognizes both 'docker' and 'container' as virtualization types that should cause the test to be skipped.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

hostname integration test
