### PR TITLE
[stable-2.10] Test changes to allow using "macos" test image (#71849)

### DIFF
--- a/test/integration/targets/ansible-runner/aliases
+++ b/test/integration/targets/ansible-runner/aliases
@@ -2,4 +2,5 @@ shippable/posix/group3
 skip/python3
 skip/aix
 skip/osx
+skip/macos
 skip/freebsd

--- a/test/integration/targets/apt/aliases
+++ b/test/integration/targets/apt/aliases
@@ -2,5 +2,6 @@ shippable/posix/group5
 destructive
 skip/freebsd
 skip/osx
+skip/macos
 skip/rhel
 skip/aix

--- a/test/integration/targets/apt_key/aliases
+++ b/test/integration/targets/apt_key/aliases
@@ -1,5 +1,6 @@
 shippable/posix/group1
 skip/freebsd
 skip/osx
+skip/macos
 skip/rhel
 skip/aix

--- a/test/integration/targets/apt_repository/aliases
+++ b/test/integration/targets/apt_repository/aliases
@@ -2,5 +2,6 @@ destructive
 shippable/posix/group1
 skip/freebsd
 skip/osx
+skip/macos
 skip/rhel
 skip/aix

--- a/test/integration/targets/connection_delegation/aliases
+++ b/test/integration/targets/connection_delegation/aliases
@@ -1,4 +1,5 @@
 shippable/posix/group1
 skip/freebsd  # No sshpass
 skip/osx  # No sshpass
+skip/macos # No sshpass
 skip/rhel  # No sshpass

--- a/test/integration/targets/cron/aliases
+++ b/test/integration/targets/cron/aliases
@@ -2,3 +2,4 @@ destructive
 shippable/posix/group4
 skip/aix
 skip/osx
+skip/macos

--- a/test/integration/targets/dnf/aliases
+++ b/test/integration/targets/dnf/aliases
@@ -4,3 +4,4 @@ skip/aix
 skip/power/centos
 skip/freebsd
 skip/osx
+skip/macos

--- a/test/integration/targets/dpkg_selections/aliases
+++ b/test/integration/targets/dpkg_selections/aliases
@@ -3,4 +3,5 @@ destructive
 skip/aix
 skip/freebsd
 skip/osx
+skip/macos
 skip/rhel

--- a/test/integration/targets/facts_linux_network/aliases
+++ b/test/integration/targets/facts_linux_network/aliases
@@ -2,3 +2,4 @@ needs/privileged
 shippable/posix/group2
 skip/freebsd
 skip/osx
+skip/macos

--- a/test/integration/targets/incidental_cloud_init_data_facts/aliases
+++ b/test/integration/targets/incidental_cloud_init_data_facts/aliases
@@ -2,4 +2,5 @@ destructive
 shippable/posix/incidental
 skip/aix
 skip/osx
+skip/macos
 skip/freebsd

--- a/test/integration/targets/incidental_flatpak_remote/aliases
+++ b/test/integration/targets/incidental_flatpak_remote/aliases
@@ -3,5 +3,6 @@ destructive
 skip/aix
 skip/freebsd
 skip/osx
+skip/macos
 skip/rhel
 needs/root

--- a/test/integration/targets/incidental_inventory_docker_swarm/aliases
+++ b/test/integration/targets/incidental_inventory_docker_swarm/aliases
@@ -2,6 +2,7 @@ shippable/posix/incidental
 skip/aix
 skip/power/centos
 skip/osx
+skip/macos
 skip/freebsd
 destructive
 skip/docker  # The tests sometimes make docker daemon unstable; hence,

--- a/test/integration/targets/incidental_mongodb_parameter/aliases
+++ b/test/integration/targets/incidental_mongodb_parameter/aliases
@@ -2,6 +2,7 @@ destructive
 shippable/posix/incidental
 skip/aix
 skip/osx
+skip/macos
 skip/freebsd
 skip/rhel
 needs/root

--- a/test/integration/targets/incidental_setup_zabbix/aliases
+++ b/test/integration/targets/incidental_setup_zabbix/aliases
@@ -1,6 +1,7 @@
 destructive
 shippable/posix/group1
 skip/osx
+skip/macos
 skip/freebsd
 skip/rhel
 hidden

--- a/test/integration/targets/incidental_timezone/aliases
+++ b/test/integration/targets/incidental_timezone/aliases
@@ -2,3 +2,4 @@ destructive
 shippable/posix/incidental
 skip/aix
 skip/osx
+skip/macos

--- a/test/integration/targets/incidental_ufw/aliases
+++ b/test/integration/targets/incidental_ufw/aliases
@@ -2,6 +2,7 @@ shippable/posix/incidental
 skip/aix
 skip/power/centos
 skip/osx
+skip/macos
 skip/freebsd
 skip/rhel8.0
 skip/rhel8.0b

--- a/test/integration/targets/incidental_zabbix_host/aliases
+++ b/test/integration/targets/incidental_zabbix_host/aliases
@@ -2,5 +2,6 @@ destructive
 shippable/posix/incidental
 skip/aix
 skip/osx
+skip/macos
 skip/freebsd
 skip/rhel

--- a/test/integration/targets/module_no_log/aliases
+++ b/test/integration/targets/module_no_log/aliases
@@ -2,3 +2,4 @@ shippable/posix/group1
 skip/aix  # not configured to log user.info to /var/log/syslog
 skip/freebsd  # not configured to log user.info to /var/log/syslog
 skip/osx  # not configured to log user.info to /var/log/syslog
+skip/macos # not configured to log user.info to /var/log/syslog

--- a/test/integration/targets/old_style_cache_plugins/aliases
+++ b/test/integration/targets/old_style_cache_plugins/aliases
@@ -1,3 +1,4 @@
 shippable/posix/group3
 skip/osx
+skip/macos
 disabled

--- a/test/integration/targets/package_facts/aliases
+++ b/test/integration/targets/package_facts/aliases
@@ -1,3 +1,4 @@
 shippable/posix/group3
 skip/aix
 skip/osx
+skip/macos

--- a/test/integration/targets/service/aliases
+++ b/test/integration/targets/service/aliases
@@ -2,3 +2,4 @@ destructive
 shippable/posix/group1
 skip/aix
 skip/osx
+skip/macos

--- a/test/integration/targets/service_facts/aliases
+++ b/test/integration/targets/service_facts/aliases
@@ -2,3 +2,4 @@ shippable/posix/group3
 skip/aix
 skip/freebsd
 skip/osx
+skip/macos

--- a/test/integration/targets/subversion/aliases
+++ b/test/integration/targets/subversion/aliases
@@ -2,5 +2,6 @@ setup/always/setup_passlib
 shippable/posix/group2
 skip/aix
 skip/osx
+skip/macos
 destructive
 needs/root

--- a/test/integration/targets/yum/aliases
+++ b/test/integration/targets/yum/aliases
@@ -3,3 +3,4 @@ shippable/posix/group4
 skip/aix
 skip/freebsd
 skip/osx
+skip/macos

--- a/test/utils/shippable/macos.sh
+++ b/test/utils/shippable/macos.sh
@@ -1,0 +1,1 @@
+remote.sh


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #71849 for Ansible 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/ansible-runner/aliases`
`test/integration/targets/apt/aliases`
`test/integration/targets/apt_key/aliases`
`test/integration/targets/apt_repository/aliases`
`test/integration/targets/connection_delegation/aliases`
`test/integration/targets/cron/aliases`
`test/integration/targets/dnf/aliases`
`test/integration/targets/dpkg_selections/aliases`
`test/integration/targets/facts_linux_network/aliases`
`test/integration/targets/incidental_cloud_init_data_facts/aliases`
`test/integration/targets/incidental_flatpak_remote/aliases`
`test/integration/targets/incidental_inventory_docker_swarm/aliases`
`test/integration/targets/incidental_mongodb_parameter/aliases`
`test/integration/targets/incidental_setup_zabbix/aliases`
`test/integration/targets/incidental_timezone/aliases`
`test/integration/targets/incidental_ufw/aliases`
`test/integration/targets/incidental_zabbix_host/aliases`
`test/integration/targets/module_no_log/aliases`
`test/integration/targets/old_style_cache_plugins/aliases`
`test/integration/targets/package_facts/aliases`
`test/integration/targets/service/aliases`
`test/integration/targets/service_facts/aliases`
`test/integration/targets/subversion/aliases`
`test/integration/targets/yum/aliases`
