### PR TITLE
modules/uri: handle success status code None from file://

### DIFF
--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -677,7 +677,9 @@ def main():
     resp, content, dest = uri(module, url, dest, body, body_format, method,
                               dict_headers, socket_timeout)
     resp['elapsed'] = (datetime.datetime.utcnow() - start).seconds
-    resp['status'] = int(resp['status'])
+    # Note for file:// URL's a valid response is None, which we
+    # convert to 200 here.
+    resp['status'] = int(resp['status']) if resp['status'] is not None else 200
     resp['changed'] = False
 
     # Write the file out if requested

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -54,6 +54,22 @@
   register: pass_checksum
   with_sequence: start=0 end=4 format=pass%d
 
+- name: fetch pass_json_file
+  uri:
+    return_content: yes
+    url: 'file:///{{ files_dir}}/{{ item }}.json'
+  register: fetch_pass_json_file
+  with_sequence: start=0 end=4 format=pass%d
+
+- name: check fetch_pass_json_file
+  assert:
+    that:
+      - '"json" in item.1'
+      - item.0.stat.checksum == item.1.content | checksum
+  with_together:
+    - "{{pass_checksum.results}}"
+    - "{{fetch_pass_json_file.results}}"
+
 - name: fetch pass_json
   uri: return_content=yes url=http://localhost:{{ http_port }}/{{ item }}.json
   register: fetch_pass_json


### PR DESCRIPTION
##### SUMMARY
When passing a file:// URL to the uri module, the status code will be
None for a valid response.  Currently this raises an error in the
modified line as the status is unconditionally cast to an int.  Check
for None and convert this to a 200 to indicate success.  Requests
returns -1 for failure, which is handled as an error.

Update the integration tests to pull the test files using file:// as
well.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
uri

##### ADDITIONAL INFORMATION
You can replicate this easily by grabbing a local file

```
- hosts: localhost
  connection: local
  gather_facts: false
  tasks:

    - uri:
        url: file:///tmp/a-file
        return_content: true
      register: foo

    - debug:
        var: foo
```