### PR TITLE
hacking: fix announce script version parsing (#71008)

### DIFF
--- a/hacking/build_library/build_ansible/announce.py
+++ b/hacking/build_library/build_ansible/announce.py
@@ -235,8 +235,11 @@ def is_ansible_base(version):
     ver_split = []
     for component in version.split('.'):
         if not component.isdigit():
-            # Take everything up until the first non-numeric component
-            break
+            if 'rc' in component:
+                ver_split.append(int(component.split('rc')[0]))
+            if 'b' in component:
+                ver_split.append(int(component.split('b')[0]))
+            continue
         ver_split.append(int(component))
     return tuple(ver_split) >= (2, 10, 0)
 


### PR DESCRIPTION

##### SUMMARY

Backport of #71008 because I never backported it.

Change:
- Fix a bug where rc/beta versions throw off the "is this an
  ansible-base release"? check.

Test Plan:
- Used it for 2.10.0rc4

Signed-off-by: Rick Elrod <rick@elrod.me>
(cherry picked from commit 75e8da09501dd9de565cb7854205b8e06615565f)

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
hacking
