### PR TITLE
allow for duplicate records from getent databases

### DIFF
--- a/changelogs/fragments/getent-append.yaml
+++ b/changelogs/fragments/getent-append.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- getent - append values if duplicates are returned by getent (https://github.com/ansible/ansible/issues/54488)

--- a/lib/ansible/modules/getent.py
+++ b/lib/ansible/modules/getent.py
@@ -140,7 +140,13 @@ def main():
     if rc == 0:
         for line in out.splitlines():
             record = line.split(split)
-            results[dbtree][record[0]] = record[1:]
+            if record[0] in results[dbtree]:
+                results[dbtree][record[0]].update(record[1:])
+            else:
+                results[dbtree][record[0]] = set(record[1:])
+
+        for k, v in results[dbtree].items():
+            results[dbtree][k] = list(v)
 
         module.exit_json(ansible_facts=results)
 

--- a/lib/ansible/modules/getent.py
+++ b/lib/ansible/modules/getent.py
@@ -141,9 +141,12 @@ def main():
         for line in out.splitlines():
             record = line.split(split)
             if record[0] in results[dbtree]:
-                results[dbtree][record[0]].update(record[1:])
+                current = results[dbtree][record[0]]
+                for r in record[1:]:
+                    if r not in current:
+                        current.append(r)
             else:
-                results[dbtree][record[0]] = set(record[1:])
+                results[dbtree][record[0]] = record[1:]
 
         for k, v in results[dbtree].items():
             results[dbtree][k] = list(v)

--- a/lib/ansible/modules/getent.py
+++ b/lib/ansible/modules/getent.py
@@ -140,17 +140,8 @@ def main():
     if rc == 0:
         for line in out.splitlines():
             record = line.split(split)
-            if record[0] in results[dbtree]:
-                current = results[dbtree][record[0]]
-                for r in record[1:]:
-                    if r not in current:
-                        current.append(r)
-            else:
-                results[dbtree][record[0]] = record[1:]
-
-        for k, v in results[dbtree].items():
-            results[dbtree][k] = list(v)
-
+            current = results[dbtree].setdefault(record[0], [])
+            current.extend(record[1:])
         module.exit_json(ansible_facts=results)
 
     elif rc == 1:


### PR DESCRIPTION
##### SUMMARY
Some getent databases (hosts, ahost(|v4|v6)) allow for duplicate records, ensure we combine, rather than overwrite

fixes #54488

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
getent