### PR TITLE
[incidental_setup_docker] changes to upstream repo

### DIFF
--- a/test/integration/targets/incidental_setup_docker/tasks/RedHat-7.yml
+++ b/test/integration/targets/incidental_setup_docker/tasks/RedHat-7.yml
@@ -17,10 +17,14 @@
   args:
     warn: no
 
-- name: Add repository
-  command: yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-  args:
-    warn: no
+# They broke their .repo file, so we set it up ourselves
+- name: Set-up repository
+  yum_repository:
+    name: docker-ce
+    description: docker-ce
+    baseurl: https://download.docker.com/linux/centos/{{ ansible_facts.distribution_major_version }}/$basearch/stable
+    gpgcheck: true
+    gpgkey: https://download.docker.com/linux/centos/gpg
 
 - name: Update cache
   command: yum -y makecache fast

--- a/test/integration/targets/incidental_setup_docker/tasks/RedHat-8.yml
+++ b/test/integration/targets/incidental_setup_docker/tasks/RedHat-8.yml
@@ -11,10 +11,14 @@
   retries: 10
   delay: 2
 
+# They broke their .repo file, so we set it up ourselves
 - name: Set-up repository
-  command: dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-  args:
-    warn: no
+  yum_repository:
+    name: docker-ce
+    description: docker-ce
+    baseurl: https://download.docker.com/linux/centos/{{ ansible_facts.distribution_major_version }}/$basearch/stable
+    gpgcheck: true
+    gpgkey: https://download.docker.com/linux/centos/gpg
 
 - name: Install docker
   dnf:

--- a/test/integration/targets/incidental_setup_docker/vars/RedHat-8.yml
+++ b/test/integration/targets/incidental_setup_docker/vars/RedHat-8.yml
@@ -6,5 +6,5 @@ docker_prereq_packages:
 
 # Docker CE > 3:18.09.1 requires containerd.io >= 1.2.2-3 which is unavaible at this time
 docker_packages:
-  - docker-ce-3:18.09.1
-  - docker-ce-cli-1:18.09.1
+  - docker-ce-19.03.13
+  - docker-ce-cli-19.03.13

--- a/test/integration/targets/incidental_setup_docker/vars/RedHat-8.yml
+++ b/test/integration/targets/incidental_setup_docker/vars/RedHat-8.yml
@@ -4,7 +4,6 @@ docker_prereq_packages:
   - lvm2
   - libseccomp
 
-# Docker CE > 3:18.09.1 requires containerd.io >= 1.2.2-3 which is unavaible at this time
 docker_packages:
   - docker-ce-19.03.13
   - docker-ce-cli-19.03.13


### PR DESCRIPTION

##### SUMMARY

Change:
- The docker-ce.repo file for centos does not work on RHEL since it uses
  $releasever and on RHEL that is, e.g., "7Server".
- Instead, set up the repo manually.
- Additionally, the docker centos8 repo no longer has old versions, so
  we use the (only) version in the repo instead.

Test Plan:
- CI

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Test Pull Request

##### COMPONENT NAME

incidental_setup_docker tests