### PR TITLE
git modules reports missing https password clearly

### DIFF
--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -1163,6 +1163,8 @@ def main():
     # We screenscrape a huge amount of git commands so use C locale anytime we
     # call run_command()
     module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')
+    if 'GIT_TERMINAL_PROMPT' not in os.environment:
+        module.run_command_environ_update['GIT_TERMINAL_PROMPT'] = 0
 
     if separate_git_dir:
         separate_git_dir = os.path.realpath(separate_git_dir)

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -1163,8 +1163,8 @@ def main():
     # We screenscrape a huge amount of git commands so use C locale anytime we
     # call run_command()
     module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')
-    if 'GIT_TERMINAL_PROMPT' not in os.environment:
-        module.run_command_environ_update['GIT_TERMINAL_PROMPT'] = 0
+    if not os.environ.get('GIT_TERMINAL_PROMPT') and not os.environ.get('GIT_ASKPASS'):
+        module.run_command_environ_update['GIT_ASKPASS'] = '/bin/true' # always return an empty password, avoids prompt
 
     if separate_git_dir:
         separate_git_dir = os.path.realpath(separate_git_dir)


### PR DESCRIPTION
##### SUMMARY
git module reports missing https password instead of hanging

fixes #69489

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
git

##### ADDITIONAL INFORMATION
Asking for the ssh password is prevented on [Line411](https://github.com/ansible/ansible/blob/ab1b5e8f78c5502885cf4c3e5dfcde999d2734eb/lib/ansible/modules/git.py#L411) by setting `-o BatchMode=yes` for ssh. To do the same for https, we can set an environment variable. Not sure if it is done in the correct place.