### PR TITLE
[2.9] [incidental_setup_docker] changes to upstream repo (#71897)

### DIFF
--- a/changelogs/fragments/docker-logout-newer-docker.yml
+++ b/changelogs/fragments/docker-logout-newer-docker.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - docker_login - now correctly reports changed status on logout for Docker versions released after June 2020.
+  - docker_login - now obeys check_mode for logout

--- a/test/integration/targets/docker-registry/tasks/tests/docker_login.yml
+++ b/test/integration/targets/docker-registry/tasks/tests/docker_login.yml
@@ -68,12 +68,12 @@
       - login_3 is not changed
       - login_4 is not changed
 
-#- name: Log out (check mode)
-#  docker_login:
-#    registry_url: "{{ registry_frontend_address }}"
-#    state: absent
-#  register: logout_1
-#  check_mode: yes
+- name: Log out (check mode)
+  docker_login:
+    registry_url: "{{ registry_frontend_address }}"
+    state: absent
+  register: logout_1
+  check_mode: yes
 
 - name: Log out
   docker_login:
@@ -94,10 +94,10 @@
   register: logout_4
   check_mode: yes
 
-- name: Make sure that login worked
+- name: Make sure that logout worked
   assert:
     that:
-      #- logout_1 is changed
+      - logout_1 is changed
       - logout_2 is changed
       - logout_3 is not changed
       - logout_4 is not changed

--- a/test/integration/targets/setup_docker/tasks/Fedora.yml
+++ b/test/integration/targets/setup_docker/tasks/Fedora.yml
@@ -1,3 +1,8 @@
+- name: Import GPG key
+  rpm_key:
+    key: https://download.docker.com/linux/fedora/gpg
+    state: present
+
 - name: Add repository
   yum_repository:
     file: docker-ce
@@ -6,7 +11,6 @@
     baseurl: https://download.docker.com/linux/fedora/$releasever/$basearch/stable
     enabled: yes
     gpgcheck: yes
-    gpgkey: https://download.docker.com/linux/fedora/gpg
 
 - name: Update cache
   command: dnf makecache

--- a/test/integration/targets/setup_docker/tasks/RedHat-7.yml
+++ b/test/integration/targets/setup_docker/tasks/RedHat-7.yml
@@ -17,10 +17,14 @@
   args:
     warn: no
 
-- name: Add repository
-  command: yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-  args:
-    warn: no
+# They broke their .repo file, so we set it up ourselves
+- name: Set-up repository
+  yum_repository:
+    name: docker-ce
+    description: docker-ce
+    baseurl: https://download.docker.com/linux/centos/{{ ansible_facts.distribution_major_version }}/$basearch/stable
+    gpgcheck: true
+    gpgkey: https://download.docker.com/linux/centos/gpg
 
 - name: Update cache
   command: yum -y makecache fast

--- a/test/integration/targets/setup_docker/tasks/RedHat-8.yml
+++ b/test/integration/targets/setup_docker/tasks/RedHat-8.yml
@@ -11,10 +11,14 @@
   retries: 10
   delay: 2
 
+# They broke their .repo file, so we set it up ourselves
 - name: Set-up repository
-  command: dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-  args:
-    warn: no
+  yum_repository:
+    name: docker-ce
+    description: docker-ce
+    baseurl: https://download.docker.com/linux/centos/{{ ansible_facts.distribution_major_version }}/$basearch/stable
+    gpgcheck: true
+    gpgkey: https://download.docker.com/linux/centos/gpg
 
 - name: Install docker
   dnf:

--- a/test/integration/targets/setup_docker/vars/RedHat-8.yml
+++ b/test/integration/targets/setup_docker/vars/RedHat-8.yml
@@ -4,7 +4,6 @@ docker_prereq_packages:
   - lvm2
   - libseccomp
 
-# Docker CE > 3:18.09.1 requires containerd.io >= 1.2.2-3 which is unavaible at this time
 docker_packages:
-  - docker-ce-3:18.09.1
-  - docker-ce-cli-1:18.09.1
+  - docker-ce-19.03.13
+  - docker-ce-cli-19.03.13


### PR DESCRIPTION
##### SUMMARY

Change:
- The docker-ce.repo file for centos does not work on RHEL since it uses
  $releasever and on RHEL that is, e.g., "7Server".
- Instead, set up the repo manually.
- Additionally, the docker centos8 repo no longer has old versions, so
  we use the (only) version in the repo instead.

Test Plan:
- CI

Signed-off-by: Rick Elrod <rick@elrod.me>
(cherry picked from commit 31ddca4c0db2584b0a68880bdea1d97bd8b22032)


Also:

```
    [docker_login] Fix changed status for newer docker
    
    Change:
    - Newer docker versions report the same message whether or not a logout
      actually happened.
    - Determine change status from looking at the config instead if we can.
    - This also allows us to restore check_mode in logout and re-enable that
      test.
    
    Test Plan:
    - CI, re-enabled tests
    
    Tickets:
    - Refs https://github.com/docker/cli/commit/6248f2fb6fa6c6035d7b94193a70b44ffd9b3c9e
    
    Signed-off-by: Rick Elrod <rick@elrod.me>
```

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
incidental_setup_docker tests