### PR TITLE
Honor setup's fact_path when facter is installed.

### DIFF
--- a/lib/ansible/module_utils/facts/other/facter.py
+++ b/lib/ansible/module_utils/facts/other/facter.py
@@ -58,7 +58,7 @@ class FacterFactCollector(BaseFactCollector):
         # if fact_path is set, return facter with --external-dir
         fact_path = module.params.get('fact_path', None)
         if (fact_path is not None) and os.path.exists(fact_path):
-            cmd_opts.append( "--external-dir=%s" % fact_path)
+            cmd_opts.append("--external-dir=%s" % fact_path)
 
         return cmd_opts
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When `facter` is installed on target machine it'll fetch facts from either `/etc/facter/facts.d/` (when run as root) or `~/.facter/facts.d/` (when run as non-root) as it should per documentation. However fact_path is not honored when set so an execution with an unprivileged user cannot pick up `ansible_facts['facter_*']` facts from `/etc/facter/facts.d/` if set.

This fix adds functionality to set fact_path either in a setup module or in a playbook to make it possible for root and non-root users to use the exact same playbook when `facter` is installed:

```yaml
- hosts: all
  fact_path: /etc/facter/facts.d
  tasks:
  - debug: msg="{{ ansible_facts }}"
``` 

`ansible -m setup -a "fact_path=/etc/facter/facts.d" localhost`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
setup

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
To reproduce:

1. install facter
2. create /etc/facter/facts.d/my-fact-file.txt: `echo gomer_pyle=this_is_my_rifle_this_is_my_gun > /etc/facter/facts.d/fmj.txt`
3. run `sudo ansible -m setup -a "fact_path=/etc/facter/facts.d" localhost | grep gomer_pyle` 
4. run `ansible -m setup -a "fact_path=/etc/facter/facts.d" localhost | grep gomer_pyle` 
5. compare outputs.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
before:
# ansible -m setup -a "fact_path=/etc/facter/facts.d" localhost | grep gomer_pyle
# 
after:
# ansible -m setup -a "fact_path=/etc/facter/facts.d" localhost | grep gomer_pyle
        "facter_gomer_pyle": "this_is_my_rifle_this_is_my_gun",

```
