### PR TITLE
Ensure native jinja is off for non-native tests

### DIFF
--- a/test/integration/targets/set_fact/runme.sh
+++ b/test/integration/targets/set_fact/runme.sh
@@ -26,5 +26,5 @@ fi
 ansible-playbook -i inventory --flush-cache "$@" set_fact_no_cache.yml
 
 # Test boolean conversions in set_fact
-ansible-playbook -v set_fact_bool_conv.yml
+ANSIBLE_JINJA2_NATIVE=0 ansible-playbook -v set_fact_bool_conv.yml
 ANSIBLE_JINJA2_NATIVE=1 ansible-playbook -v set_fact_bool_conv_jinja2_native.yml

--- a/test/integration/targets/templating_lookups/runme.sh
+++ b/test/integration/targets/templating_lookups/runme.sh
@@ -9,4 +9,4 @@ ansible-playbook template_lookup_vaulted/playbook.yml --vault-password-file temp
 ansible-playbook template_deepcopy/playbook.yml -i template_deepcopy/hosts "$@"
 
 # https://github.com/ansible/ansible/issues/66943
-ansible-playbook template_lookup_safe_eval_unicode/playbook.yml "$@"
+ANSIBLE_JINJA2_NATIVE=0 ansible-playbook template_lookup_safe_eval_unicode/playbook.yml "$@"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Even if native jinja is off by default now it is better to be
explicit and it will be prepared in case we changed that default.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/set_fact/runme.sh`
`test/integration/targets/templating_lookups/runme.sh`