### PR TITLE
Validate plugin option type 'dict' / 'dictionary'

### DIFF
--- a/changelogs/fragments/71928-ensure_type-dict.yml
+++ b/changelogs/fragments/71928-ensure_type-dict.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "plugin option validation - now the option type ``dict``/``dictionary`` is also validated by the config manager (https://github.com/ansible/ansible/pull/71928)."

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -24,7 +24,7 @@ except ImportError:
 from ansible.config.data import ConfigData
 from ansible.errors import AnsibleOptionsError, AnsibleError
 from ansible.module_utils._text import to_text, to_bytes, to_native
-from ansible.module_utils.common._collections_compat import Sequence
+from ansible.module_utils.common._collections_compat import Mapping, Sequence
 from ansible.module_utils.six import PY3, string_types
 from ansible.module_utils.six.moves import configparser
 from ansible.module_utils.parsing.convert_bool import boolean
@@ -143,6 +143,10 @@ def ensure_type(value, value_type, origin=None):
                 value = [resolve_path(x, basedir=basedir) for x in value]
             else:
                 errmsg = 'pathlist'
+
+        elif value_type in ('dict', 'dictionary'):
+            if not isinstance(value, Mapping):
+                errmsg = 'dictionary'
 
         elif value_type in ('str', 'string'):
             if isinstance(value, (string_types, AnsibleVaultEncryptedUnicode)):

--- a/lib/ansible/plugins/doc_fragments/shell_common.py
+++ b/lib/ansible/plugins/doc_fragments/shell_common.py
@@ -56,10 +56,10 @@ options:
     vars:
       - name: ansible_async_dir
   environment:
-    type: dict or list
-    default: {}
+    type: list
+    default: [{}]
     description:
-      - dictionary of environment variables and their values to use when executing commands.
+      - List of dictionaries of environment variables and their values to use when executing commands.
   admin_users:
     type: list
     default: ['root', 'toor']

--- a/lib/ansible/plugins/doc_fragments/shell_common.py
+++ b/lib/ansible/plugins/doc_fragments/shell_common.py
@@ -56,7 +56,7 @@ options:
     vars:
       - name: ansible_async_dir
   environment:
-    type: dict
+    type: dict or list
     default: {}
     description:
       - dictionary of environment variables and their values to use when executing commands.

--- a/lib/ansible/plugins/doc_fragments/shell_windows.py
+++ b/lib/ansible/plugins/doc_fragments/shell_windows.py
@@ -42,8 +42,8 @@ options:
     - 'no'
   environment:
     description:
-    - Dictionary of environment variables and their values to use when
+    - List of dictionaries of environment variables and their values to use when
       executing commands.
-    type: dict or list
-    default: {}
+    type: list
+    default: [{}]
 """

--- a/lib/ansible/plugins/doc_fragments/shell_windows.py
+++ b/lib/ansible/plugins/doc_fragments/shell_windows.py
@@ -44,6 +44,6 @@ options:
     description:
     - Dictionary of environment variables and their values to use when
       executing commands.
-    type: dict
+    type: dict or list
     default: {}
 """


### PR DESCRIPTION
##### SUMMARY
Until now, the type `dict`/`dictionary` was not validated in `ensure_type()` in lib/ansible/config/manager.py, even though that type is used also in plugins included with ansible/ansible (see for example https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/lookup/url.py#L39).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/config/manager.py
