### PR TITLE
[stable-2.10] CI provider fixes for ansible-test. (#71929)

### DIFF
--- a/changelogs/fragments/ansible-test-azp-resource-prefix.yml
+++ b/changelogs/fragments/ansible-test-azp-resource-prefix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - The ``resource_prefix`` variable provided to tests running on Azure Pipelines is now converted to lowercase to match other CI providers.

--- a/changelogs/fragments/ansible-test-change-classification.yml
+++ b/changelogs/fragments/ansible-test-change-classification.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Change classification using ``--changed`` now consistently handles common configuration files for supported CI providers.

--- a/test/lib/ansible_test/_internal/ci/azp.py
+++ b/test/lib/ansible_test/_internal/ci/azp.py
@@ -73,7 +73,7 @@ class AzurePipelines(CIProvider):
         except KeyError as ex:
             raise MissingEnvironmentVariable(name=ex.args[0])
 
-        prefix = re.sub(r'[^a-zA-Z0-9]+', '-', prefix)
+        prefix = re.sub(r'[^a-zA-Z0-9]+', '-', prefix).lower()
 
         return prefix
 

--- a/test/lib/ansible_test/_internal/classification.py
+++ b/test/lib/ansible_test/_internal/classification.py
@@ -377,6 +377,16 @@ class PathMapper:
 
         minimal = {}
 
+        if os.path.sep not in path:
+            if filename in (
+                    'azure-pipelines.yml',
+                    'shippable.yml',
+            ):
+                return all_tests(self.args)  # test infrastructure, run all tests
+
+        if is_subdir(path, '.azure-pipelines'):
+            return all_tests(self.args)  # test infrastructure, run all tests
+
         if is_subdir(path, '.github'):
             return minimal
 
@@ -873,7 +883,6 @@ class PathMapper:
 
             if path in (
                     'setup.py',
-                    'shippable.yml',
             ):
                 return all_tests(self.args)  # broad impact, run all tests
 

--- a/test/sanity/code-smell/package-data.py
+++ b/test/sanity/code-smell/package-data.py
@@ -21,6 +21,7 @@ def assemble_files_to_ship(complete_file_list):
     # All files which are in the repository except these:
     ignore_patterns = (
         # Developer-only tools
+        '.azure-pipelines/*',
         '.github/*',
         '.github/*/*',
         'changelogs/fragments/*',


### PR DESCRIPTION
##### SUMMARY

* Make Azure Pipelines resource_prefix lowercase.
* Make classification of CI files consistent.
* Update package-data sanity test for AZP.

Backport of https://github.com/ansible/ansible/pull/71929

(cherry picked from commit 92b66e3e31470ab09d503537b692e1cf671a4e51)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
