### PR TITLE
[stable-2.8] CI provider fixes for ansible-test. (#71929)

### DIFF
--- a/changelogs/fragments/ansible-test-azp-resource-prefix.yml
+++ b/changelogs/fragments/ansible-test-azp-resource-prefix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - The ``resource_prefix`` variable provided to tests running on Azure Pipelines is now converted to lowercase to match other CI providers.

--- a/changelogs/fragments/ansible-test-change-classification.yml
+++ b/changelogs/fragments/ansible-test-change-classification.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Change classification using ``--changed`` now consistently handles common configuration files for supported CI providers.

--- a/test/runner/lib/ci/azp.py
+++ b/test/runner/lib/ci/azp.py
@@ -73,7 +73,7 @@ class AzurePipelines(CIProvider):
         except KeyError as ex:
             raise MissingEnvironmentVariable(name=ex.args[0])
 
-        prefix = re.sub(r'[^a-zA-Z0-9]+', '-', prefix)
+        prefix = re.sub(r'[^a-zA-Z0-9]+', '-', prefix).lower()
 
         return prefix
 

--- a/test/runner/lib/classification.py
+++ b/test/runner/lib/classification.py
@@ -365,6 +365,9 @@ class PathMapper(object):
 
         minimal = {}
 
+        if path.startswith('.azure-pipelines/'):
+            return all_tests(self.args)  # test infrastructure, run all tests
+
         if path.startswith('.github/'):
             return minimal
 
@@ -827,6 +830,7 @@ class PathMapper(object):
                 return minimal
 
             if path in (
+                    'azure-pipelines.yml',
                     'shippable.yml',
                     '.coveragerc',
             ):


### PR DESCRIPTION
##### SUMMARY

* Make Azure Pipelines resource_prefix lowercase.
* Make classification of CI files consistent.

Backport of https://github.com/ansible/ansible/pull/71929

(cherry picked from commit 92b66e3e31470ab09d503537b692e1cf671a4e51)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
