### PR TITLE
adds name lines to handler re-use examples

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_reuse.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse.rst
@@ -152,7 +152,7 @@ Includes are executed at run-time, so the name of the include exists during play
 
 .. code-block:: yaml
 
-   - trigger an included (dynamic) handler
+   - name: Trigger an included (dynamic) handler
      hosts: localhost
      handlers:
        - name: Restart services
@@ -168,11 +168,11 @@ Imports are processed before the play begins, so the name of the import no longe
 
 .. code-block:: yaml
 
-   - trigger an imported (static) handler
+   - name: Trigger an imported (static) handler
      hosts: localhost
      handlers:
-     - name: Restart services
-       import_tasks: restarts.yml
+       - name: Restart services
+         import_tasks: restarts.yml
      tasks:
        - command: "true"
          notify: Restart apache


### PR DESCRIPTION
##### SUMMARY
Docs: Adds `name:` lines to the examples that demonstrate how to trigger handlers with dynamic and static re-use. Also tidies up the indentation. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
handlers
