### PR TITLE
Add libyaml info to version output, and restore git info

### DIFF
--- a/changelogs/fragments/version-libyaml-git.yml
+++ b/changelogs/fragments/version-libyaml-git.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- CLI - Specify whether PyYAML includes libyaml support in version output
+bugfixes:
+- CLI - Restore git information in version output when running from source

--- a/test/units/cli/test_adhoc.py
+++ b/test/units/cli/test_adhoc.py
@@ -104,7 +104,7 @@ def test_ansible_version(capsys, mocker):
         # Python 2.6 does return a named tuple, so get the first item
         version_lines = version[0].splitlines()
 
-    assert len(version_lines) == 7, 'Incorrect number of lines in "ansible --version" output'
+    assert len(version_lines) == 8, 'Incorrect number of lines in "ansible --version" output'
     assert re.match('ansible [0-9.a-z]+$', version_lines[0]), 'Incorrect ansible version line in "ansible --version" output'
     assert re.match('  config file = .*$', version_lines[1]), 'Incorrect config file line in "ansible --version" output'
     assert re.match('  configured module search path = .*$', version_lines[2]), 'Incorrect module search path in "ansible --version" output'
@@ -112,3 +112,4 @@ def test_ansible_version(capsys, mocker):
     assert re.match('  ansible collection location = .*$', version_lines[4]), 'Incorrect collection location in "ansible --version" output'
     assert re.match('  executable location = .*$', version_lines[5]), 'Incorrect executable locaction in "ansible --version" output'
     assert re.match('  python version = .*$', version_lines[6]), 'Incorrect python version in "ansible --version" output'
+    assert re.match('  libyaml = .*$', version_lines[7]), 'Missing libyaml in "ansible --version" output'


### PR DESCRIPTION
##### SUMMARY
Add libyaml info to version output, and restore git info

```
ansible 2.11.0.dev0 (version-libyaml-git a3aaecb247) last updated 2020/09/25 11:48:32 (GMT -500)
  config file = None
  configured module search path = ['/Users/matt/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/matt/projects/ansibledev/ansible/lib/ansible
  ansible collection location = /Users/matt/.ansible/collections:/usr/share/ansible/collections
  executable location = /Users/matt/projects/ansibledev/ansible/bin/ansible
  python version = 3.8.0 (default, Nov 13 2019, 16:14:51) [Clang 11.0.0 (clang-1100.0.33.12)]
  libyaml = True
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
```
lib/ansible/cli/arguments/option_helpers.py
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
