### PR TITLE
replace - always return rc

### DIFF
--- a/changelogs/fragments/replace-rc-return-values.yml
+++ b/changelogs/fragments/replace-rc-return-values.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- replace - Always return ``rc`` to ensure return values are consistent - https://github.com/ansible/ansible/pull/71963

--- a/lib/ansible/modules/replace.py
+++ b/lib/ansible/modules/replace.py
@@ -241,7 +241,7 @@ def main():
     params = module.params
     path = params['path']
     encoding = params['encoding']
-    res_args = dict()
+    res_args = dict(rc=0)
 
     params['after'] = to_text(params['after'], errors='surrogate_or_strict', nonstring='passthru')
     params['before'] = to_text(params['before'], errors='surrogate_or_strict', nonstring='passthru')
@@ -278,7 +278,6 @@ def main():
         else:
             res_args['msg'] = 'Pattern for before/after params did not match the given file: %s' % pattern
             res_args['changed'] = False
-            res_args['rc'] = 0
             module.exit_json(**res_args)
     else:
         section = contents
@@ -309,7 +308,6 @@ def main():
         path = os.path.realpath(path)
         write_changes(module, to_bytes(result[0], encoding=encoding), path)
 
-    res_args['rc'] = 0
     res_args['msg'], res_args['changed'] = check_file_attrs(module, changed, msg)
     module.exit_json(**res_args)
 

--- a/lib/ansible/modules/replace.py
+++ b/lib/ansible/modules/replace.py
@@ -278,6 +278,7 @@ def main():
         else:
             res_args['msg'] = 'Pattern for before/after params did not match the given file: %s' % pattern
             res_args['changed'] = False
+            res_args['rc'] = 0
             module.exit_json(**res_args)
     else:
         section = contents
@@ -308,6 +309,7 @@ def main():
         path = os.path.realpath(path)
         write_changes(module, to_bytes(result[0], encoding=encoding), path)
 
+    res_args['rc'] = 0
     res_args['msg'], res_args['changed'] = check_file_attrs(module, changed, msg)
     module.exit_json(**res_args)
 

--- a/test/integration/targets/callback_default/callback_default.out.result_format_yaml_lossy_verbose.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.result_format_yaml_lossy_verbose.stdout
@@ -180,11 +180,13 @@ TASK [replace] *****************************************************************
 changed: [testhost] => 
     changed: true
     msg: 1 replacements made
+    rc: 0
 
 TASK [replace] *****************************************************************
 ok: [testhost] => 
     changed: false
     msg: 1 replacements made
+    rc: 0
 
 RUNNING HANDLER [Test handler 1] ***********************************************
 changed: [testhost] => 

--- a/test/integration/targets/callback_default/callback_default.out.result_format_yaml_verbose.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.result_format_yaml_verbose.stdout
@@ -187,11 +187,13 @@ TASK [replace] *****************************************************************
 changed: [testhost] => 
     changed: true
     msg: 1 replacements made
+    rc: 0
 
 TASK [replace] *****************************************************************
 ok: [testhost] => 
     changed: false
     msg: 1 replacements made
+    rc: 0
 
 RUNNING HANDLER [Test handler 1] ***********************************************
 changed: [testhost] => 


### PR DESCRIPTION
Error handling in playbooks generally expects `rc` to be set to 0 when a module has not failed.  Playbook authors should not have to check for the existence of `rc` first.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added two lines to set res_args['rc'] = 0 before normal module.exit() calls.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
replace

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
