### PR TITLE
Replace deprectated include with {import,include}_tasks in apt{,_repository,_key} integration tests

### DIFF
--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -16,18 +16,18 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 - block:
-  - include: 'apt.yml'
+  - import_tasks: 'apt.yml'
 
-  - include: 'url-with-deps.yml'
+  - import_tasks: 'url-with-deps.yml'
 
-  - include: 'apt-multiarch.yml'
+  - import_tasks: 'apt-multiarch.yml'
     when:
       - ansible_userspace_architecture != apt_foreign_arch
 
-  - include: 'apt-builddep.yml'
+  - import_tasks: 'apt-builddep.yml'
 
   - block:
-      - include: 'repo.yml'
+      - import_tasks: 'repo.yml'
     always:
       - file:
           path: /etc/apt/sources.list.d/file_tmp_repo.list

--- a/test/integration/targets/apt/tasks/repo.yml
+++ b/test/integration/targets/apt/tasks/repo.yml
@@ -213,7 +213,11 @@
 
 - name: Upgrades
   block:
-    - import_tasks: "upgrade.yml aptitude_present={{ True | bool }} upgrade_type=dist force_apt_get={{ False | bool }}"
+    - import_tasks: "upgrade.yml"
+      vars:
+        aptitude_present: "{{ True | bool }}"
+        upgrade_type: "dist"
+        force_apt_get: "{{ False | bool }}"
 
     - name: Check if aptitude is installed
       command: dpkg-query --show --showformat='${db:Status-Abbrev}' aptitude
@@ -226,7 +230,11 @@
       when:
         - aptitude_status.stdout.find('ii') != -1
 
-    - import_tasks: "upgrade.yml aptitude_present={{ False | bool }} upgrade_type={{ item.upgrade_type }} force_apt_get={{ item.force_apt_get }}"
+    - include_tasks: "upgrade.yml"
+      vars:
+        aptitude_present: "{{ False | bool }}"
+        upgrade_type: "{{ item.upgrade_type }}"
+        force_apt_get: "{{ item.force_apt_get }}"
       with_items:
         - { upgrade_type: safe, force_apt_get: False }
         - { upgrade_type: full, force_apt_get: False }
@@ -238,7 +246,11 @@
         pkg: aptitude
         state: present
 
-    - import_tasks: "upgrade.yml aptitude_present={{ True | bool }} upgrade_type={{ item.upgrade_type }} force_apt_get={{ item.force_apt_get }}"
+    - include_tasks: "upgrade.yml"
+      vars:
+        aptitude_present: "{{ True | bool }}"
+        upgrade_type: "{{ item.upgrade_type }}"
+        force_apt_get: "{{ item.force_apt_get }}"
       with_items:
         - { upgrade_type: safe, force_apt_get: False }
         - { upgrade_type: full, force_apt_get: False }

--- a/test/integration/targets/apt/tasks/repo.yml
+++ b/test/integration/targets/apt/tasks/repo.yml
@@ -213,7 +213,7 @@
 
 - name: Upgrades
   block:
-    - include: "upgrade.yml aptitude_present={{ True | bool }} upgrade_type=dist force_apt_get={{ False | bool }}"
+    - import_tasks: "upgrade.yml aptitude_present={{ True | bool }} upgrade_type=dist force_apt_get={{ False | bool }}"
 
     - name: Check if aptitude is installed
       command: dpkg-query --show --showformat='${db:Status-Abbrev}' aptitude
@@ -226,7 +226,7 @@
       when:
         - aptitude_status.stdout.find('ii') != -1
 
-    - include: "upgrade.yml aptitude_present={{ False | bool }} upgrade_type={{ item.upgrade_type }} force_apt_get={{ item.force_apt_get }}"
+    - import_tasks: "upgrade.yml aptitude_present={{ False | bool }} upgrade_type={{ item.upgrade_type }} force_apt_get={{ item.force_apt_get }}"
       with_items:
         - { upgrade_type: safe, force_apt_get: False }
         - { upgrade_type: full, force_apt_get: False }
@@ -238,7 +238,7 @@
         pkg: aptitude
         state: present
 
-    - include: "upgrade.yml aptitude_present={{ True | bool }} upgrade_type={{ item.upgrade_type }} force_apt_get={{ item.force_apt_get }}"
+    - import_tasks: "upgrade.yml aptitude_present={{ True | bool }} upgrade_type={{ item.upgrade_type }} force_apt_get={{ item.force_apt_get }}"
       with_items:
         - { upgrade_type: safe, force_apt_get: False }
         - { upgrade_type: full, force_apt_get: False }

--- a/test/integration/targets/apt_key/tasks/main.yml
+++ b/test/integration/targets/apt_key/tasks/main.yml
@@ -24,8 +24,8 @@
 - name: create our testing sub-directory
   file: path="{{ output_dir_test }}" state=directory
 
-- include: 'apt_key.yml'
+- import_tasks: 'apt_key.yml'
   when: ansible_distribution in ('Ubuntu', 'Debian')
   
-- include: 'file.yml'
+- import_tasks: 'file.yml'
   when: ansible_distribution in ('Ubuntu', 'Debian')

--- a/test/integration/targets/apt_repository/tasks/apt.yml
+++ b/test/integration/targets/apt_repository/tasks/apt.yml
@@ -35,7 +35,7 @@
 #
 # TEST: apt_repository: repo=<name>
 #
-- include: 'cleanup.yml'
+- import_tasks: 'cleanup.yml'
 
 - name: 'record apt cache mtime'
   stat: path='/var/cache/apt/pkgcache.bin'
@@ -67,7 +67,7 @@
 #
 # TEST: apt_repository: repo=<name> update_cache=no
 #
-- include: 'cleanup.yml'
+- import_tasks: 'cleanup.yml'
 
 - name: 'record apt cache mtime'
   stat: path='/var/cache/apt/pkgcache.bin'
@@ -98,7 +98,7 @@
 #
 # TEST: apt_repository: repo=<name> update_cache=yes
 #
-- include: 'cleanup.yml'
+- import_tasks: 'cleanup.yml'
 
 - name: 'record apt cache mtime'
   stat: path='/var/cache/apt/pkgcache.bin'
@@ -129,7 +129,7 @@
 #
 # TEST: apt_repository: repo=<spec>
 #
-- include: 'cleanup.yml'
+- import_tasks: 'cleanup.yml'
 
 - name: 'record apt cache mtime'
   stat: path='/var/cache/apt/pkgcache.bin'
@@ -164,7 +164,7 @@
 #
 # TEST: apt_repository: repo=<spec> filename=<filename>
 #
-- include: 'cleanup.yml'
+- import_tasks: 'cleanup.yml'
 
 - name: 'record apt cache mtime'
   stat: path='/var/cache/apt/pkgcache.bin'
@@ -230,4 +230,4 @@
 #
 # TEARDOWN
 #
-- include: 'cleanup.yml'
+- import_tasks: 'cleanup.yml'

--- a/test/integration/targets/apt_repository/tasks/main.yml
+++ b/test/integration/targets/apt_repository/tasks/main.yml
@@ -16,10 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- include: 'apt.yml'
+- import_tasks: 'apt.yml'
   when: ansible_distribution in ('Ubuntu')
 
-- include: mode.yaml
+- import_tasks: mode.yaml
   when: ansible_distribution in ('Ubuntu')
   tags:
     - test_apt_repository_mode

--- a/test/integration/targets/apt_repository/tasks/mode.yaml
+++ b/test/integration/targets/apt_repository/tasks/mode.yaml
@@ -8,7 +8,7 @@
     test_repo_spec: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
     test_repo_path: /etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list
 
-- include: mode_cleanup.yaml
+- import_tasks: mode_cleanup.yaml
 
 - name: Add GPG key to verify signatures
   apt_key:
@@ -31,7 +31,7 @@
   debug:
     var: mode_given_yaml_literal_0600
 
-- include: mode_cleanup.yaml
+- import_tasks: mode_cleanup.yaml
 
 - name: Assert mode_given_yaml_literal_0600 is correct
   assert:
@@ -52,7 +52,7 @@
   debug:
     var: no_mode_stat
 
-- include: mode_cleanup.yaml
+- import_tasks: mode_cleanup.yaml
 
 - name: Assert no_mode_stat is correct
   assert:
@@ -74,7 +74,7 @@
   debug:
     var: mode_given_string_stat
 
-- include: mode_cleanup.yaml
+- import_tasks: mode_cleanup.yaml
 
 - name: Mode specified as string 600
   apt_repository:
@@ -92,7 +92,7 @@
   debug:
     var: mode_given_string_600_stat
 
-- include: mode_cleanup.yaml
+- import_tasks: mode_cleanup.yaml
 
 - name: Assert mode is correct
   assert:
@@ -114,7 +114,7 @@
   debug:
     var: mode_given_yaml_literal_600
 
-- include: mode_cleanup.yaml
+- import_tasks: mode_cleanup.yaml
 
 # a literal 600 as the mode will fail currently, in the sense that it
 # doesn't guess and consider 600 and 0600 to be the same, and will instead


### PR DESCRIPTION
##### SUMMARY
Also mentioned in https://github.com/ansible/ansible/pull/56179/files#r282509998.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
apt
apt_key
apt_repository