### PR TITLE
[2.9] Fix ansible-doc's plugin name retrieval for text output

### DIFF
--- a/changelogs/fragments/71965-ansible-doc-plugin-name.yml
+++ b/changelogs/fragments/71965-ansible-doc-plugin-name.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- "ansible-doc - properly show plugin name when ``name:`` is used instead of ``<plugin_type>:`` (https://github.com/ansible/ansible/pull/71965)."
+- "ansible-doc - do not crash if plugin name cannot be found (https://github.com/ansible/ansible/pull/71965)."

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -344,7 +344,7 @@ class DocCLI(CLI):
         if context.CLIARGS['show_snippet'] and plugin_type == 'module':
             text = DocCLI.get_snippet_text(doc)
         else:
-            text = DocCLI.get_man_text(doc)
+            text = DocCLI.get_man_text(doc, plugin_type=plugin_type)
 
         return text
 
@@ -590,7 +590,7 @@ class DocCLI(CLI):
         return text
 
     @staticmethod
-    def get_man_text(doc):
+    def get_man_text(doc, plugin_type=None):
 
         DocCLI.IGNORE = DocCLI.IGNORE + (context.CLIARGS['type'],)
         opt_indent = "        "
@@ -598,7 +598,8 @@ class DocCLI(CLI):
         pad = display.columns * 0.20
         limit = max(display.columns - int(pad), 70)
 
-        text.append("> %s    (%s)\n" % (doc.get(context.CLIARGS['type'], doc.get('plugin_type')).upper(), doc.pop('filename')))
+        plugin_name = doc.get(context.CLIARGS['type'], doc.get('name')) or doc.get('plugin_type') or plugin_type
+        text.append("> %s    (%s)\n" % (plugin_name.upper(), doc.pop('filename')))
 
         if isinstance(doc['description'], list):
             desc = " ".join(doc.pop('description'))


### PR DESCRIPTION
##### SUMMARY
This is **NOT** a backport. It is a 2.9-only fix, since the 2.10/devel code is sufficiently different.

Fixes the crash mentioned in https://github.com/ansible/ansible/issues/71795#issuecomment-699605840 and shows the correct plugin name.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-doc
