### PR TITLE
Fix ansible-doc's plugin name retrieval for text output

### DIFF
--- a/changelogs/fragments/71966-ansible-doc-plugin-name.yml
+++ b/changelogs/fragments/71966-ansible-doc-plugin-name.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-doc - properly show plugin name when ``name:`` is used instead of ``<plugin_type>:`` (https://github.com/ansible/ansible/pull/71966)."

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -385,7 +385,7 @@ class DocCLI(CLI):
             text = DocCLI.get_snippet_text(doc)
         else:
             try:
-                text = DocCLI.get_man_text(doc, collection_name)
+                text = DocCLI.get_man_text(doc, collection_name, plugin_type)
             except Exception as e:
                 raise AnsibleError("Unable to retrieve documentation from '%s' due to: %s" % (plugin, to_native(e)))
 
@@ -619,7 +619,7 @@ class DocCLI(CLI):
                 text.append('')
 
     @staticmethod
-    def get_man_text(doc, collection_name=''):
+    def get_man_text(doc, collection_name='', plugin_type=''):
         # Create a copy so we don't modify the original
         doc = dict(doc)
 
@@ -629,7 +629,7 @@ class DocCLI(CLI):
         pad = display.columns * 0.20
         limit = max(display.columns - int(pad), 70)
 
-        plugin_name = doc.get(context.CLIARGS['type'], doc.get('plugin_type'))
+        plugin_name = doc.get(context.CLIARGS['type'], doc.get('name')) or doc.get('plugin_type') or plugin_type
         if collection_name:
             plugin_name = '%s.%s' % (collection_name, plugin_name)
 


### PR DESCRIPTION
##### SUMMARY
This makes sure that ansible-doc's text output displays the correct plugin name when `name:` is used instead of `<plugin_type>:`.

For the `auto` inventory plugin, the output of `ansible-doc -t inventory auto` before this PR is:
```
> ANSIBLE.BUILTIN.INVENTORY    (/path/to/ansible/lib/ansible/plugins/inventory/auto.py)
```
The output after this PR:
```
> ANSIBLE.BUILTIN.AUTO    (/path/to/ansible/lib/ansible/plugins/inventory/auto.py)
```
This is even more important because in #71795 the decision is to use `name:` and stop using `<plugin_type>:`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-doc
