### PR TITLE
[2.8] kubectl: redacted token and password from console log

### DIFF
--- a/changelogs/fragments/159_kubectl.yml
+++ b/changelogs/fragments/159_kubectl.yml
@@ -1,0 +1,2 @@
+security_fixes:
+- kubectl - connection plugin now redact kubectl_token and kubectl_password in console log (https://github.com/ansible-collections/community.kubernetes/issues/65).


### PR DESCRIPTION

##### SUMMARY

Further backport of 2.9 backport #71535

** SECURITY_FIX ** for CVE-2020-1753

kubectl connection plugin now redact kubectl_token and
kubectl_password from console log.

Fixes: ansible-collections/community.kubernetes#65

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

kubectl