### PR TITLE
[stable-2.8] Disabled inconsistent pylint checks.

### DIFF
--- a/changelogs/fragments/ansible-test-sanity-pylint-config-fix.yml
+++ b/changelogs/fragments/ansible-test-sanity-pylint-config-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test - Disabled the ``duplicate-code`` and ``cyclic-import`` checks for the ``pylint`` sanity test due to inconsistent results.

--- a/test/sanity/pylint/config/ansible-test
+++ b/test/sanity/pylint/config/ansible-test
@@ -3,6 +3,8 @@
 disable=
     invalid-name,
     no-self-use,
+    cyclic-import,  # consistent results require running with --jobs 1 and testing all files
+    duplicate-code,  # consistent results require running with --jobs 1 and testing all files
     too-few-public-methods,
     too-many-arguments,
     too-many-branches,

--- a/test/sanity/pylint/config/default
+++ b/test/sanity/pylint/config/default
@@ -24,9 +24,11 @@ disable=
     consider-using-in,
     consider-using-set-comprehension,
     consider-using-ternary,
+    cyclic-import,  # consistent results require running with --jobs 1 and testing all files
     deprecated-lambda,
     deprecated-method,
     deprecated-module,
+    duplicate-code,  # consistent results require running with --jobs 1 and testing all files
     eval-used,
     exec-used,
     expression-not-assigned,


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/70118

(cherry picked from commit 8152d8bc1a0981230d43b0e3e54085912193eb9b)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
