### PR TITLE
powershell - remove env var

### DIFF
--- a/changelogs/fragments/powershell-version-env.yml
+++ b/changelogs/fragments/powershell-version-env.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- powershell - remove getting the PowerShell version from the env var ``POWERSHELL_VERSION``. This feature never worked properly and can cause conflicts with other libraries that use this var

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -30,12 +30,6 @@ from ansible.plugins.shell import ShellBase
 
 _common_args = ['PowerShell', '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Unrestricted']
 
-# Primarily for testing, allow explicitly specifying PowerShell version via
-# an environment variable.
-_powershell_version = os.environ.get('POWERSHELL_VERSION', None)
-if _powershell_version:
-    _common_args = ['PowerShell', '-Version', _powershell_version] + _common_args[1:]
-
 
 def _parse_clixml(data, stream="Error"):
     """


### PR DESCRIPTION
##### SUMMARY
Setting `-Version blah` when calling PowerShell was only ever designed to work with `-Version 2.0` and we never supported that version. Even setting it to `-Version 6+` would cause an error because `powershell.exe` will never support anything higher than `5.1`. The env var could also cause a conflict with any other tool that requires this so I'm just going to remove the setup and be done with it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
powershell