### PR TITLE
Update the tests to work with new httptester container

### DIFF
--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -254,9 +254,9 @@
 # https://github.com/ansible/ansible/issues/29614
 - name: Change mode on an already downloaded file and specify checksum
   get_url:
-    url: 'https://{{ httpbin_host }}/get'
+    url: 'https://{{ httpbin_host }}/base64/cHR1eA=='
     dest: '{{ remote_tmp_dir }}/test'
-    checksum: 'sha256:7036ede810fad2b5d2e7547ec703cae8da61edbba43c23f9d7203a0239b765c4.'
+    checksum: 'sha256:b1b6ce5073c8fac263a8fc5edfffdbd5dec1980c784e09c5bc69f8fb6056f006.'
     mode: '0775'
   register: result
 
@@ -272,9 +272,9 @@
 
 - name: test checksum match in check mode
   get_url:
-    url: 'https://{{ httpbin_host }}/get'
+    url: 'https://{{ httpbin_host }}/base64/cHR1eA=='
     dest: '{{ remote_tmp_dir }}/test'
-    checksum: 'sha256:7036ede810fad2b5d2e7547ec703cae8da61edbba43c23f9d7203a0239b765c4.'
+    checksum: 'sha256:b1b6ce5073c8fac263a8fc5edfffdbd5dec1980c784e09c5bc69f8fb6056f006.'
   check_mode: True
   register: result
 

--- a/test/integration/targets/uri/tasks/redirect-none.yml
+++ b/test/integration/targets/uri/tasks/redirect-none.yml
@@ -249,7 +249,7 @@
     - http_308_head is failure
     - http_308_head.json is not defined
     - http_308_head.location == 'https://{{ httpbin_host }}/anything'
-    - "http_308_head.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
+    - "'Status code was 308 and not [200]: HTTP Error 308: ' in http_308_head.msg"
     - http_308_head.redirected == false
     - http_308_head.status == 308
     - http_308_head.url == 'https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything'
@@ -269,7 +269,7 @@
     - http_308_get is failure
     - http_308_get.json is not defined
     - http_308_get.location == 'https://{{ httpbin_host }}/anything'
-    - "http_308_get.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
+    - "'Status code was 308 and not [200]: HTTP Error 308: ' in http_308_get.msg"
     - http_308_get.redirected == false
     - http_308_get.status == 308
     - http_308_get.url == 'https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything'
@@ -290,7 +290,7 @@
     - http_308_post is failure
     - http_308_post.json is not defined
     - http_308_post.location == 'https://{{ httpbin_host }}/anything'
-    - "http_308_post.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
+    - "'Status code was 308 and not [200]: HTTP Error 308: ' in http_308_post.msg"
     - http_308_post.redirected == false
     - http_308_post.status == 308
     - http_308_post.url == 'https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything'

--- a/test/integration/targets/uri/tasks/redirect-safe.yml
+++ b/test/integration/targets/uri/tasks/redirect-safe.yml
@@ -268,7 +268,7 @@
     - http_308_post is failure
     - http_308_post.json is not defined
     - http_308_post.location == 'https://{{ httpbin_host }}/anything'
-    - "http_308_post.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
+    - "'Status code was 308 and not [200]: HTTP Error 308: ' in http_308_post.msg"
     - http_308_post.redirected == false
     - http_308_post.status == 308
     - http_308_post.url == 'https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything'

--- a/test/integration/targets/uri/tasks/redirect-urllib2.yml
+++ b/test/integration/targets/uri/tasks/redirect-urllib2.yml
@@ -246,7 +246,7 @@
     - http_308_head is failure
     - http_308_head.json is not defined
     - http_308_head.location == 'https://{{ httpbin_host }}/anything'
-    - "http_308_head.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
+    - "'Status code was 308 and not [200]: HTTP Error 308: ' in http_308_head.msg"
     - http_308_head.redirected == false
     - http_308_head.status == 308
     - http_308_head.url == 'https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything'
@@ -266,7 +266,7 @@
     - http_308_get is failure
     - http_308_get.json is not defined
     - http_308_get.location == 'https://{{ httpbin_host }}/anything'
-    - "http_308_get.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
+    - "'Status code was 308 and not [200]: HTTP Error 308: ' in http_308_get.msg"
     - http_308_get.redirected == false
     - http_308_get.status == 308
     - http_308_get.url == 'https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything'
@@ -288,7 +288,7 @@
     - http_308_post is failure
     - http_308_post.json is not defined
     - http_308_post.location == 'https://{{ httpbin_host }}/anything'
-    - "http_308_post.msg == 'Status code was 308 and not [200]: HTTP Error 308: UNKNOWN'"
+    - "'Status code was 308 and not [200]: HTTP Error 308: ' in http_308_post.msg"
     - http_308_post.redirected == false
     - http_308_post.status == 308
     - http_308_post.url == 'https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything'


### PR DESCRIPTION
##### SUMMARY
The PR https://github.com/ansible/http-test-container/pull/6 updates the version of `httpbin` used in the test container. This brings a few changes that are not 100% compatible with how the tests are run. It makes the following change to be a bit less stringent

* `get_url` - Uses an explicit byte value for the checksum checks instead of relying on the `get` content which can change
* `uri` - Validates the redirection code but not the msg, older httptester returns `UNKNOWN` while the newer image returns `PERMANENT REDIRECT`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
get_url
uri