### PR TITLE
fix distribution fact for SLES4SAP (#71559)

### DIFF
--- a/changelogs/fragments/71559-fix-distribution-fact-sles4sap.yaml
+++ b/changelogs/fragments/71559-fix-distribution-fact-sles4sap.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - facts - fix distribution fact for SLES4SAP (https://github.com/ansible/ansible/pull/71559).

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -270,10 +270,6 @@ class DistributionFiles:
                     else:
                         release = "0"  # no minor number, so it is the first release
                     suse_facts['distribution_release'] = release
-                # Starting with SLES4SAP12 SP3 NAME reports 'SLES' instead of 'SLES_SAP'
-                # According to SuSe Support (SR101182877871) we should use the CPE_NAME to detect SLES4SAP
-                if re.search("^CPE_NAME=.*sles_sap.*$", line):
-                    suse_facts['distribution'] = 'SLES_SAP'
         elif path == '/etc/SuSE-release':
             if 'open' in data.lower():
                 data = data.splitlines()
@@ -295,6 +291,10 @@ class DistributionFiles:
                     if release:
                         suse_facts['distribution_release'] = release.group(1)
                         suse_facts['distribution_version'] = collected_facts['distribution_version'] + '.' + release.group(1)
+
+        # See https://www.suse.com/support/kb/doc/?id=000019341 for SLES for SAP
+        if os.path.islink('/etc/products.d/baseproduct') and os.path.realpath('/etc/products.d/baseproduct').endswith('SLES_SAP.prod'):
+            suse_facts['distribution'] = 'SLES_SAP'
 
         return True, suse_facts
 

--- a/test/units/module_utils/facts/system/distribution/test_distribution_sles4sap.py
+++ b/test/units/module_utils/facts/system/distribution/test_distribution_sles4sap.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2020 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible.module_utils.facts.system.distribution import DistributionFiles
+
+
+@pytest.mark.parametrize('realpath', ('SUSE_SLES_SAP.prod', 'SLES_SAP.prod'))
+def test_distribution_sles4sap_suse_sles_sap(mock_module, mocker, realpath):
+    mocker.patch('os.path.islink', return_value=True)
+    mocker.patch('os.path.realpath', return_value='/etc/products.d/' + realpath)
+
+    test_input = {
+        'name': 'SUSE',
+        'path': '',
+        'data': 'suse',
+        'collected_facts': None,
+    }
+
+    test_result = (
+        True,
+        {
+            'distribution': 'SLES_SAP',
+        }
+    )
+
+    distribution = DistributionFiles(module=mock_module())
+    assert test_result == distribution.parse_distribution_file_SUSE(**test_input)

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -393,60 +393,6 @@ TESTSETS = [
         }
     },
     {
-        "name": "SLES4SAP 12 SP2",
-        "input": {
-            "/etc/SuSE-release": (
-                'SUSE Linux Enterprise Server 12 (x86_64)\nVERSION = 12\nPATCHLEVEL = 2\n'
-                '# This file is deprecated and will be removed in a future service pack or release.\n'
-                '# Please check /etc/os-release for details about this release.'),
-            "/etc/os-release": (
-                'NAME="SLES_SAP"\nVERSION="12-SP2"\nVERSION_ID="12.2"\nPRETTY_NAME="SUSE Linux Enterprise Server for SAP Applications 12 SP2"\n'
-                'ID="sles_sap"\nANSI_COLOR="0;32"\nCPE_NAME="cpe:/o:suse:sles_sap:12:sp2"'),
-        },
-        "platform.dist": ['SuSE', '12', 'x86_64'],
-        'distro': {
-            'codename': '',
-            'id': 'sles',
-            'name': 'SUSE Linux Enterprise Server',
-            'version': '12.2',
-            'version_best': '12.2',
-        },
-        "result": {
-            "distribution": "SLES_SAP",
-            "distribution_major_version": "12",
-            "distribution_release": "2",
-            "os_family": "Suse",
-            "distribution_version": "12.2",
-        }
-    },
-    {
-        "name": "SLES4SAP 12 SP3",
-        "input": {
-            "/etc/SuSE-release": (
-                'SUSE Linux Enterprise Server 12 (x86_64)VERSION = 12PATCHLEVEL = 3'
-                '\n# This file is deprecated and will be removed in a future service pack or release.\n'
-                '# Please check /etc/os-release for details about this release.'),
-            "/etc/os-release": (
-                'NAME="SLES"\nVERSION="12-SP3"\nVERSION_ID="12.3"\nPRETTY_NAME="SUSE Linux Enterprise Server 12 SP3"\n'
-                'ID="sles"\nANSI_COLOR="0;32"\nCPE_NAME="cpe:/o:suse:sles_sap:12:sp3"'),
-        },
-        "platform.dist": ['SuSE', '12', 'x86_64'],
-        'distro': {
-            'codename': '',
-            'id': 'sles',
-            'name': 'SUSE Linux Enterprise Server',
-            'version': '12.3',
-            'version_best': '12.3',
-        },
-        "result": {
-            "distribution": "SLES_SAP",
-            "distribution_major_version": "12",
-            "distribution_release": "3",
-            "os_family": "Suse",
-            "distribution_version": "12.3",
-        }
-    },
-    {
         "name": "Debian stretch/sid",
         "input": {
             "/etc/os-release": (


### PR DESCRIPTION
b6b238a fixed the SLES4SAP detection, which was at this time ok.
Sadly Suse changed with SLES 15 the /etc/os-release file, so the above
change will no longer work.

This commit updates the SLES4SAP detection regarding
https://www.suse.com/support/kb/doc/?id=000019341.

The symlink realpath is matched with endswith, because in SLES 12+ the
link target is SLES_SAP.prod, but in SLES 11 the link target is
SUSE_SLES_SAP.prod.

(cherry picked from commit ea119d30894478b84b5fbe271f580cb2b0401b86)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
setup

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

