### PR TITLE
galaxy: Handle hidden git directories in role skeleton

### DIFF
--- a/changelogs/fragments/71977-ansible-galaxy-role-init.yml
+++ b/changelogs/fragments/71977-ansible-galaxy-role-init.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-galaxy - fixed galaxy role init command (https://github.com/ansible/ansible/issues/71977)."

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -912,6 +912,8 @@ class GalaxyCLI(CLI):
             else:
                 in_templates_dir = rel_root_dir == 'templates'
 
+            # Filter out ignored directory names
+            # Use [:] to mutate the list os.walk uses
             dirs[:] = [d for d in dirs if not any(r.match(d) for r in skeleton_ignore_re)]
 
             for f in files:

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -912,7 +912,7 @@ class GalaxyCLI(CLI):
             else:
                 in_templates_dir = rel_root_dir == 'templates'
 
-            dirs = [d for d in dirs if not any(r.match(d) for r in skeleton_ignore_re)]
+            dirs[:] = [d for d in dirs if not any(r.match(d) for r in skeleton_ignore_re)]
 
             for f in files:
                 filename, ext = os.path.splitext(f)

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -324,6 +324,19 @@ pushd "${role_testdir}"
 popd # ${role_testdir}
 rm -rf "${role_testdir}"
 
+f_ansible_galaxy_status \
+    "Test if git hidden directories are skipped while using role skeleton (#71977)"
+
+role_testdir=$(mktemp -d)
+pushd "${role_testdir}"
+
+    ansible-galaxy role init sample-role-skeleton
+    git init ./sample-role-skeleton
+    ansible-galaxy role init --role-skeleton=sample-role-skeleton example
+
+popd # ${role_testdir}
+rm -rf "${role_testdir}"
+
 #################################
 # ansible-galaxy collection tests
 #################################


### PR DESCRIPTION
ansible-galaxy role init --role-skeleton=ansible-role-skeleton example fails fix.
The issue was because 'dir' variable was changed to reference to a different list, but since it is a global variable so the update was causing issues.
Now updating 'dir' variable to change value of variable in local scope.

fixes #71977
##### SUMMARY 
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
