### PR TITLE
Update porting_guide_2.8.rst

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -52,7 +52,7 @@ In Ansible 2.7 and older::
 
     {{ ((foo | default({})).bar | default({})).baz | default('DEFAULT') }}
 
-    or
+or::
 
     {{ foo.bar.baz if (foo is defined and foo.bar is defined and foo.bar.baz is defined) else 'DEFAULT' }}
 


### PR DESCRIPTION
##### SUMMARY
Removed translatable words from codeblocks as per https://github.com/ansible/ansible/issues/59449

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
Removed translatable words from codeblocks, to prevent mistranslations
##### ISSUE TYPE
- Docs Pull Request