### PR TITLE
Add base path config for ~/.ansible

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -81,6 +81,18 @@ ANSIBLE_COW_PATH:
   - {key: cowpath, section: defaults}
   type: string
   yaml: {key: display.cowpath}
+ANSIBLE_HOME:
+  name: The Ansible home path
+  description:
+  - The default root path for Ansible config files on the controller.
+  default: ~/.ansible
+  env:
+  - name: ANSIBLE_HOME
+  ini:
+  - key: home
+    section: defaults
+  type: path
+  version_added: '2.11'
 ANSIBLE_PIPELINING:
   name: Connection pipelining
   default: False
@@ -126,7 +138,7 @@ ANSIBLE_SSH_CONTROL_PATH:
   yaml: {key: ssh_connection.control_path}
 ANSIBLE_SSH_CONTROL_PATH_DIR:
   # TODO: move to ssh plugin
-  default: ~/.ansible/cp
+  default: '{{ ANSIBLE_HOME ~ "/cp" }}'
   description:
     - This sets the directory to use for ssh control path if the control path setting is null.
     - Also, provides the `%(directory)s` variable for the control path setting.
@@ -230,7 +242,7 @@ COLLECTIONS_SCAN_SYS_PATH:
 COLLECTIONS_PATHS:
   name: ordered list of root paths for loading installed Ansible collections content
   description: Colon separated paths in which Ansible will search for collections content.
-  default: ~/.ansible/collections:/usr/share/ansible/collections
+  default: '{{ ANSIBLE_HOME ~ "/collections:/usr/share/ansible/collections" }}'
   type: pathspec
   env:
   - name: ANSIBLE_COLLECTIONS_PATHS  # TODO: Deprecate this and ini once PATH has been in a few releases.
@@ -435,7 +447,7 @@ LOCALHOST_WARNING:
   version_added: "2.6"
 DOC_FRAGMENT_PLUGIN_PATH:
   name: documentation fragment plugins path
-  default: ~/.ansible/plugins/doc_fragments:/usr/share/ansible/plugins/doc_fragments
+  default: '{{ ANSIBLE_HOME ~ "/plugins/doc_fragments:/usr/share/ansible/plugins/doc_fragments" }}'
   description: Colon separated paths in which Ansible will search for Documentation Fragments Plugins.
   env: [{name: ANSIBLE_DOC_FRAGMENT_PLUGINS}]
   ini:
@@ -443,7 +455,7 @@ DOC_FRAGMENT_PLUGIN_PATH:
   type: pathspec
 DEFAULT_ACTION_PLUGIN_PATH:
   name: Action plugins path
-  default: ~/.ansible/plugins/action:/usr/share/ansible/plugins/action
+  default: '{{ ANSIBLE_HOME ~ "/plugins/action:/usr/share/ansible/plugins/action" }}'
   description: Colon separated paths in which Ansible will search for Action Plugins.
   env: [{name: ANSIBLE_ACTION_PLUGINS}]
   ini:
@@ -524,7 +536,7 @@ DEFAULT_BECOME_FLAGS:
   - {key: become_flags, section: privilege_escalation}
 BECOME_PLUGIN_PATH:
   name: Become plugins path
-  default: ~/.ansible/plugins/become:/usr/share/ansible/plugins/become
+  default: '{{ ANSIBLE_HOME ~ "/plugins/become:/usr/share/ansible/plugins/become" }}'
   description: Colon separated paths in which Ansible will search for Become Plugins.
   env: [{name: ANSIBLE_BECOME_PLUGINS}]
   ini:
@@ -542,7 +554,7 @@ DEFAULT_BECOME_USER:
   yaml: {key: become.user}
 DEFAULT_CACHE_PLUGIN_PATH:
   name: Cache Plugins Path
-  default: ~/.ansible/plugins/cache:/usr/share/ansible/plugins/cache
+  default: '{{ ANSIBLE_HOME ~ "/plugins/cache:/usr/share/ansible/plugins/cache" }}'
   description: Colon separated paths in which Ansible will search for Cache Plugins.
   env: [{name: ANSIBLE_CACHE_PLUGINS}]
   ini:
@@ -558,7 +570,7 @@ DEFAULT_CALLABLE_WHITELIST:
   type: list
 DEFAULT_CALLBACK_PLUGIN_PATH:
   name: Callback Plugins Path
-  default: ~/.ansible/plugins/callback:/usr/share/ansible/plugins/callback
+  default: '{{ ANSIBLE_HOME ~ "/plugins/callback:/usr/share/ansible/plugins/callback" }}'
   description: Colon separated paths in which Ansible will search for Callback Plugins.
   env: [{name: ANSIBLE_CALLBACK_PLUGINS}]
   ini:
@@ -578,7 +590,7 @@ DEFAULT_CALLBACK_WHITELIST:
   yaml: {key: plugins.callback.whitelist}
 DEFAULT_CLICONF_PLUGIN_PATH:
   name: Cliconf Plugins Path
-  default: ~/.ansible/plugins/cliconf:/usr/share/ansible/plugins/cliconf
+  default: '{{ ANSIBLE_HOME ~ "/plugins/cliconf:/usr/share/ansible/plugins/cliconf" }}'
   description: Colon separated paths in which Ansible will search for Cliconf Plugins.
   env: [{name: ANSIBLE_CLICONF_PLUGINS}]
   ini:
@@ -586,7 +598,7 @@ DEFAULT_CLICONF_PLUGIN_PATH:
   type: pathspec
 DEFAULT_CONNECTION_PLUGIN_PATH:
   name: Connection Plugins Path
-  default: ~/.ansible/plugins/connection:/usr/share/ansible/plugins/connection
+  default: '{{ ANSIBLE_HOME ~ "/plugins/connection:/usr/share/ansible/plugins/connection" }}'
   description: Colon separated paths in which Ansible will search for Connection Plugins.
   env: [{name: ANSIBLE_CONNECTION_PLUGINS}]
   ini:
@@ -628,7 +640,7 @@ DEFAULT_FACT_PATH:
   yaml: {key: facts.gathering.fact_path}
 DEFAULT_FILTER_PLUGIN_PATH:
   name: Jinja2 Filter Plugins Path
-  default: ~/.ansible/plugins/filter:/usr/share/ansible/plugins/filter
+  default: '{{ ANSIBLE_HOME ~ "/plugins/filter:/usr/share/ansible/plugins/filter" }}'
   description: Colon separated paths in which Ansible will search for Jinja2 Filter Plugins.
   env: [{name: ANSIBLE_FILTER_PLUGINS}]
   ini:
@@ -742,7 +754,7 @@ DEFAULT_HOST_LIST:
   yaml: {key: defaults.inventory}
 DEFAULT_HTTPAPI_PLUGIN_PATH:
   name: HttpApi Plugins Path
-  default: ~/.ansible/plugins/httpapi:/usr/share/ansible/plugins/httpapi
+  default: '{{ ANSIBLE_HOME ~ "/plugins/httpapi:/usr/share/ansible/plugins/httpapi" }}'
   description: Colon separated paths in which Ansible will search for HttpApi Plugins.
   env: [{name: ANSIBLE_HTTPAPI_PLUGINS}]
   ini:
@@ -764,7 +776,7 @@ DEFAULT_INTERNAL_POLL_INTERVAL:
     - "The default corresponds to the value hardcoded in Ansible <= 2.1"
 DEFAULT_INVENTORY_PLUGIN_PATH:
   name: Inventory Plugins Path
-  default: ~/.ansible/plugins/inventory:/usr/share/ansible/plugins/inventory
+  default: '{{ ANSIBLE_HOME ~ "/plugins/inventory:/usr/share/ansible/plugins/inventory" }}'
   description: Colon separated paths in which Ansible will search for Inventory Plugins.
   env: [{name: ANSIBLE_INVENTORY_PLUGINS}]
   ini:
@@ -831,7 +843,7 @@ DEFAULT_LOAD_CALLBACK_PLUGINS:
   version_added: "1.8"
 DEFAULT_LOCAL_TMP:
   name: Controller temporary directory
-  default: ~/.ansible/tmp
+  default: '{{ ANSIBLE_HOME ~ "/tmp" }}'
   description: Temporary directory for Ansible to use on the controller.
   env: [{name: ANSIBLE_LOCAL_TEMP}]
   ini:
@@ -856,7 +868,7 @@ DEFAULT_LOG_FILTER:
 DEFAULT_LOOKUP_PLUGIN_PATH:
   name: Lookup Plugins Path
   description: Colon separated paths in which Ansible will search for Lookup Plugins.
-  default: ~/.ansible/plugins/lookup:/usr/share/ansible/plugins/lookup
+  default: '{{ ANSIBLE_HOME ~ "/plugins/lookup:/usr/share/ansible/plugins/lookup" }}'
   env: [{name: ANSIBLE_LOOKUP_PLUGINS}]
   ini:
   - {key: lookup_plugins, section: defaults}
@@ -897,7 +909,7 @@ DEFAULT_MODULE_NAME:
 DEFAULT_MODULE_PATH:
   name: Modules Path
   description: Colon separated paths in which Ansible will search for Modules.
-  default: ~/.ansible/plugins/modules:/usr/share/ansible/plugins/modules
+  default: '{{ ANSIBLE_HOME ~ "/plugins/modules:/usr/share/ansible/plugins/modules" }}'
   env: [{name: ANSIBLE_LIBRARY}]
   ini:
   - {key: library, section: defaults}
@@ -905,14 +917,14 @@ DEFAULT_MODULE_PATH:
 DEFAULT_MODULE_UTILS_PATH:
   name: Module Utils Path
   description: Colon separated paths in which Ansible will search for Module utils files, which are shared by modules.
-  default: ~/.ansible/plugins/module_utils:/usr/share/ansible/plugins/module_utils
+  default: '{{ ANSIBLE_HOME ~ "/plugins/module_utils:/usr/share/ansible/plugins/module_utils" }}'
   env: [{name: ANSIBLE_MODULE_UTILS}]
   ini:
   - {key: module_utils, section: defaults}
   type: pathspec
 DEFAULT_NETCONF_PLUGIN_PATH:
   name: Netconf Plugins Path
-  default: ~/.ansible/plugins/netconf:/usr/share/ansible/plugins/netconf
+  default: '{{ ANSIBLE_HOME ~ "/plugins/netconf:/usr/share/ansible/plugins/netconf" }}'
   description: Colon separated paths in which Ansible will search for Netconf Plugins.
   env: [{name: ANSIBLE_NETCONF_PLUGINS}]
   ini:
@@ -1002,7 +1014,7 @@ DEFAULT_REMOTE_USER:
   - {key: remote_user, section: defaults}
 DEFAULT_ROLES_PATH:
   name: Roles path
-  default: ~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
+  default: '{{ ANSIBLE_HOME ~ "/roles:/usr/share/ansible/roles:/etc/ansible/roles" }}'
   description: Colon separated paths in which Ansible will search for Roles.
   env: [{name: ANSIBLE_ROLES_PATH}]
   expand_relative_paths: True
@@ -1096,7 +1108,7 @@ DEFAULT_STRATEGY:
 DEFAULT_STRATEGY_PLUGIN_PATH:
   name: Strategy Plugins Path
   description: Colon separated paths in which Ansible will search for Strategy Plugins.
-  default: ~/.ansible/plugins/strategy:/usr/share/ansible/plugins/strategy
+  default: '{{ ANSIBLE_HOME ~ "/plugins/strategy:/usr/share/ansible/plugins/strategy" }}'
   env: [{name: ANSIBLE_STRATEGY_PLUGINS}]
   ini:
   - {key: strategy_plugins, section: defaults}
@@ -1132,7 +1144,7 @@ DEFAULT_TASK_INCLUDES_STATIC:
     alternatives: None, as its already built into the decision between include_tasks and import_tasks
 DEFAULT_TERMINAL_PLUGIN_PATH:
   name: Terminal Plugins Path
-  default: ~/.ansible/plugins/terminal:/usr/share/ansible/plugins/terminal
+  default: '{{ ANSIBLE_HOME ~ "/plugins/terminal:/usr/share/ansible/plugins/terminal" }}'
   description: Colon separated paths in which Ansible will search for Terminal Plugins.
   env: [{name: ANSIBLE_TERMINAL_PLUGINS}]
   ini:
@@ -1141,7 +1153,7 @@ DEFAULT_TERMINAL_PLUGIN_PATH:
 DEFAULT_TEST_PLUGIN_PATH:
   name: Jinja2 Test Plugins Path
   description: Colon separated paths in which Ansible will search for Jinja2 Test Plugins.
-  default: ~/.ansible/plugins/test:/usr/share/ansible/plugins/test
+  default: '{{ ANSIBLE_HOME ~ "/plugins/test:/usr/share/ansible/plugins/test" }}'
   env: [{name: ANSIBLE_TEST_PLUGINS}]
   ini:
   - {key: test_plugins, section: defaults}
@@ -1175,7 +1187,7 @@ DEFAULT_UNDEFINED_VAR_BEHAVIOR:
   type: boolean
 DEFAULT_VARS_PLUGIN_PATH:
   name: Vars Plugins Path
-  default: ~/.ansible/plugins/vars:/usr/share/ansible/plugins/vars
+  default: '{{ ANSIBLE_HOME ~ "/plugins/vars:/usr/share/ansible/plugins/vars" }}'
   description: Colon separated paths in which Ansible will search for Vars Plugins.
   env: [{name: ANSIBLE_VARS_PLUGINS}]
   ini:
@@ -1440,7 +1452,7 @@ GALAXY_TOKEN:
   - {key: token, section: galaxy}
   yaml: {key: galaxy.token}
 GALAXY_TOKEN_PATH:
-  default: ~/.ansible/galaxy_token
+  default: '{{ ANSIBLE_HOME ~ "/galaxy_token" }}'
   description: "Local path to galaxy access token file"
   env: [{name: ANSIBLE_GALAXY_TOKEN_PATH}]
   ini:
@@ -1713,7 +1725,7 @@ PARAMIKO_LOOK_FOR_KEYS:
   type: boolean
 PERSISTENT_CONTROL_PATH_DIR:
   name: Persistence socket path
-  default: ~/.ansible/pc
+  default: '{{ ANSIBLE_HOME ~ "/pc" }}'
   description: Path to socket to be used by the connection persistence system.
   env: [{name: ANSIBLE_PERSISTENT_CONTROL_PATH_DIR}]
   ini:


### PR DESCRIPTION
##### SUMMARY
For people wanting to move Ansible config files outside of `~/.ansible` they need to set multiple config values. This changes all those options to use the new constant `ANSIBLE_HOME` so they only have to change that. A common use case would be `ANSIBLE_HOME=$XDG_CONFIG_HOME` (`~/.config`) to align to the XDG specification. This does not affect `remote_tmp` as that is a separate config option.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
base.yml