### PR TITLE
Fix: [Errno 2] No such file or directory

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -901,7 +901,7 @@ class GalaxyCLI(CLI):
             else:
                 in_templates_dir = rel_root_dir == 'templates'
 
-            dirs = [d for d in dirs if not any(r.match(d) for r in skeleton_ignore_re)]
+            dirs[:] = [d for d in dirs if not any(r.match(d) for r in skeleton_ignore_re)]
 
             for f in files:
                 filename, ext = os.path.splitext(f)


### PR DESCRIPTION
Rollback a part of [39b3942](https://github.com/ansible/ansible/commit/39b394204870fda6de789809a3d69f58da3e7c31) to fix #71977

##### SUMMARY
ansible-galaxy (cli) returns an error, with this change, the error is resolved.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy