### PR TITLE
Fix virt module to support list_vms with a status of paused

### DIFF
--- a/changelogs/fragments/72056-support-list-vms-with-status-paused.yaml
+++ b/changelogs/fragments/72056-support-list-vms-with-status-paused.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fix virt module to support list_vms with a status of paused
+    (https://github.com/ansible/ansible/issues/72059) 

--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -577,7 +577,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             name=dict(type='str', aliases=['guest']),
-            state=dict(type='str', choices=['destroyed', 'pause', 'running', 'shutdown']),
+            state=dict(type='str', choices=['destroyed', 'paused', 'running', 'shutdown']),
             autostart=dict(type='bool'),
             command=dict(type='str', choices=ALL_COMMANDS),
             uri=dict(type='str', default='qemu:///system'),

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -1521,7 +1521,6 @@ lib/ansible/modules/cloud/misc/terraform.py validate-modules:doc-default-does-no
 lib/ansible/modules/cloud/misc/terraform.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/cloud/misc/terraform.py validate-modules:doc-missing-type
 lib/ansible/modules/cloud/misc/virt.py validate-modules:undocumented-parameter
-lib/ansible/modules/cloud/misc/virt.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/cloud/misc/virt.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/cloud/misc/virt_net.py validate-modules:doc-missing-type
 lib/ansible/modules/cloud/misc/virt_pool.py validate-modules:doc-choices-do-not-match-spec


### PR DESCRIPTION
##### SUMMARY
The docs state to use paused but the check_choice module only
accepts pause which doesn't list paused vm's.

Backport of https://github.com/ansible-collections/community.libvirt/pull/30

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
virt

##### ADDITIONAL INFORMATION

Without the fix the below will fail stating that pause is the correct choice. But if you change it state to pause it will not match any paused vm's.

    - name: Get list of all paused VMs
      virt:
        command: list_vms
        state: paused
      register: paused_vms
      become: yes

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
TASK [Get list of all paused VMs] ***********************************************************************************
task path: /var/lib/dci-openshift-agent/test.yml:13
fatal: [provisionhost]: FAILED! => {"changed": false, "msg": "value of state must be one of: destroyed, pause, running, shutdown, got: paused"}

with fix:
TASK [Get list of all paused VMs] *************************************************************************************
task path: /var/lib/dci-openshift-agent/test.yml:13
ok: [provisionhost] => {"changed": false, "list_vms": ["dciokd-wkwfp-bootstrap"]}

TASK [Debug paused VMs, if any] ******************************************************************************
task path: /var/lib/dci-openshift-agent/test.yml:21
ok: [provisionhost] => (item=dciokd-wkwfp-bootstrap) => {
    "ansible_loop_var": "item",
    "item": "dciokd-wkwfp-bootstrap"
}

```
