### PR TITLE
[backport][2.9] vmware_guest_custom_attributes: Fix issue with duplicate custom attribute names

### DIFF
--- a/changelogs/fragments/412-vmware_guest_custom_attributes.yml
+++ b/changelogs/fragments/412-vmware_guest_custom_attributes.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_guest_custom_attributes - Fixed issue when trying to set a VM custom attribute when there are custom attributes with the same name for other object types (https://github.com/ansible-collections/community.vmware/issues/412).

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_custom_attributes.py
@@ -197,7 +197,8 @@ class VmAttributeManager(PyVmomi):
 
     def check_exists(self, field):
         for x in self.custom_field_mgr:
-            if x.name == field:
+            # The custom attribute should be either global (managedObjectType == None) or VM specific
+            if x.managedObjectType in (None, vim.VirtualMachine) and x.name == field:
                 return x
         return False
 


### PR DESCRIPTION
##### SUMMARY
When running a task with vmware_guest_custom_attributes if the name of any attribute already exists as a HostSystem attribute, the module will crash with an unhandled exception.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_custom_attributes

##### ADDITIONAL INFORMATION
When there are two custom attributes named foo, one for VMs and one for ESXi hosts, the module might try to set the host custom attribute on the VM and crash.

Backport of ansible-collections/community.vmware#414