### PR TITLE
uri status_code elements are type int

### DIFF
--- a/changelogs/fragments/uri-status-code-int.yml
+++ b/changelogs/fragments/uri-status-code-int.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- uri - ``status_code`` elements are type ``int``

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -107,7 +107,7 @@ options:
     description:
       - A list of valid, numeric, HTTP status codes that signifies success of the request.
     type: list
-    elements: str
+    elements: int
     default: [ 200 ]
   timeout:
     description:
@@ -620,7 +620,7 @@ def main():
         follow_redirects=dict(type='str', default='safe', choices=['all', 'no', 'none', 'safe', 'urllib2', 'yes']),
         creates=dict(type='path'),
         removes=dict(type='path'),
-        status_code=dict(type='list', elements='str', default=[200]),
+        status_code=dict(type='list', elements='int', default=[200]),
         timeout=dict(type='int', default=30),
         headers=dict(type='dict', default={}),
         unix_socket=dict(type='path'),


### PR DESCRIPTION
##### SUMMARY
`uri` `status_code` elements are type `int`

This will avoid:

```
[WARNING]: The value "status_code: 200" (type int) was converted to
"status_code: '200'" (type string). If this does not look like what you expect,
quote the entire value to ensure it does not change.
```

This inconsistency was introduced in 3e9943bc5e7a9cd393757aa8100d7fed80bd316e

Ref:
https://github.com/ansible/ansible/blob/3e9943bc5e7a9cd393757aa8100d7fed80bd316e/lib/ansible/modules/uri.py#L648

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/uri.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
