### PR TITLE
pause - do not hang if run in the background

### DIFF
--- a/changelogs/fragments/32143-pause-background-hangs.yml
+++ b/changelogs/fragments/32143-pause-background-hangs.yml
@@ -1,2 +1,4 @@
 bugfixes:
-  - pause - Fix indefinite hang when using a pause task on a bacground process (https://github.com/ansible/ansible/issues/32142)
+  - >
+    pause - Fix indefinite hang when using a pause task on a background
+    process (https://github.com/ansible/ansible/issues/32142)

--- a/changelogs/fragments/32143-pause-background-hangs.yml
+++ b/changelogs/fragments/32143-pause-background-hangs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pause - Fix indefinite hang when using a pause task on a bacground process (https://github.com/ansible/ansible/issues/32142)

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -70,6 +70,7 @@ def clear_line(stdout):
     stdout.write(b'\x1b[%s' % MOVE_TO_BOL)
     stdout.write(b'\x1b[%s' % CLEAR_TO_EOL)
 
+
 def is_interactive(fd=None):
     if fd is None:
         return False

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -77,7 +77,8 @@ def is_interactive(fd=None):
 
     if isatty(fd):
         # Compare the current process group to the process group associated
-        # with stdin to determine if the process is running in the background.
+        # with terminal of the given file descriptor to determine if the process
+        # is running in the background.
         return getpgrp() == tcgetpgrp(fd)
     else:
         return False

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -182,12 +182,11 @@ class ActionModule(ActionBase):
                 stdout_fd = stdout.fileno()
             except (ValueError, AttributeError):
                 # ValueError: someone is using a closed file descriptor as stdin
-                # AttributeError: someone is using a null file descriptor as stdin on windoez
+                # AttributeError: someone is using a null file descriptor as stdin on windoze
                 stdin = None
-
             if stdin_fd is not None:
-                # Compare the current process group to the proccees group accosicated
-                # with stdin to determine if the process is running the background.
+                # Compare the current process group to the process group associated
+                # with stdin to determine if the process is running in the background.
                 running_in_background = not getpgrp() == tcgetpgrp(stdin_fd)
                 if isatty(stdin_fd) and not running_in_background:
                     # grab actual Ctrl+C sequence

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -181,7 +181,6 @@ class ActionModule(ActionBase):
             # that we can restore them later after we set raw mode
             stdin_fd = None
             stdout_fd = None
-            running_in_background = False
             try:
                 if PY3:
                     stdin = self._connection._new_stdin.buffer

--- a/test/integration/targets/pause/runme.sh
+++ b/test/integration/targets/pause/runme.sh
@@ -18,9 +18,6 @@ ansible-playbook test-pause-no-tty.yml 2>&1 | \
 EOF
 
 
-# ansible-playbook test-pause-background.yml > /dev/null &
-# wait $!
-
 # Test redirecting stdout
 # Issue #41717
 ansible-playbook pause-3.yml > /dev/null \

--- a/test/integration/targets/pause/runme.sh
+++ b/test/integration/targets/pause/runme.sh
@@ -17,7 +17,6 @@ ansible-playbook test-pause-no-tty.yml 2>&1 | \
     }
 EOF
 
-
 # Test redirecting stdout
 # Issue #41717
 ansible-playbook pause-3.yml > /dev/null \

--- a/test/integration/targets/pause/runme.sh
+++ b/test/integration/targets/pause/runme.sh
@@ -18,7 +18,8 @@ ansible-playbook test-pause-no-tty.yml 2>&1 | \
 EOF
 
 
-ansible-playbook test-pause-background.yml &
+# ansible-playbook test-pause-background.yml > /dev/null &
+# wait $!
 
 # Test redirecting stdout
 # Issue #41717

--- a/test/integration/targets/pause/runme.sh
+++ b/test/integration/targets/pause/runme.sh
@@ -17,6 +17,9 @@ ansible-playbook test-pause-no-tty.yml 2>&1 | \
     }
 EOF
 
+
+ansible-playbook test-pause-background.yml &
+
 # Test redirecting stdout
 # Issue #41717
 ansible-playbook pause-3.yml > /dev/null \

--- a/test/integration/targets/pause/test-pause-background.yml
+++ b/test/integration/targets/pause/test-pause-background.yml
@@ -5,7 +5,6 @@
 
   tasks:
     - pause:
+
     - pause:
         seconds: 1
-    - debug:
-        msg: After pause

--- a/test/integration/targets/pause/test-pause-background.yml
+++ b/test/integration/targets/pause/test-pause-background.yml
@@ -1,0 +1,11 @@
+- name: Test pause in a background task
+  hosts: localhost
+  gather_facts: no
+  become: no
+
+  tasks:
+    - pause:
+    - pause:
+        seconds: 1
+    - debug:
+        msg: After pause

--- a/test/integration/targets/pause/test-pause.yml
+++ b/test/integration/targets/pause/test-pause.yml
@@ -4,6 +4,36 @@
   become: no
 
   tasks:
+    - name: non-integer for duraction (EXPECTED FAILURE)
+      pause:
+        seconds: hello
+      register: result
+      ignore_errors: yes
+
+    - assert:
+        that:
+          - result is failed
+          - "'non-integer' in result.msg"
+
+    - name: non-boolean for echo (EXPECTED FAILURE)
+      pause:
+        echo: hello
+      register: result
+      ignore_errors: yes
+
+    - assert:
+        that:
+          - result is failed
+          - "'not a valid boolean' in result.msg"
+
+    - pause:
+        seconds: 0.1
+      register: results
+
+    - assert:
+        that:
+          - results.stdout is search('Paused for \d+\.\d+ seconds')
+
     - pause:
         seconds: 1
       register: results


### PR DESCRIPTION
##### SUMMARY
In addition to checking `isatty()` on the stdin file descriptor, an additional check needs to be done to determine if the TTY process group is the same as the current process group. If they are not, this means the process is run in the background and should not prompt for input.

Fixes #32142
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/action/pause.py`

##### ADDITIONAL INFORMATION
I'm undecided if the module should honor the `seconds` value or whether it should continue immediately when running in the background.

The tests also need improvement and I'm not 100% happy with the way the logic in the infinite loop is written currently. I tried to simplify it a bit to reduced having to duplicate the warning, but I haven't gotten there yet.
