### PR TITLE
Fix race condition when creating async dir

### DIFF
--- a/changelogs/fragments/async-race-condition.yml
+++ b/changelogs/fragments/async-race-condition.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- async_wrapper - Fix race condition when ``~/.ansible_async`` folder tries to be created by multiple async tasks at the same time - https://github.com/ansible/ansible/issues/59306

--- a/lib/ansible/modules/async_wrapper.py
+++ b/lib/ansible/modules/async_wrapper.py
@@ -239,7 +239,6 @@ def main():
 
     # setup job output directory
     jobdir = os.path.expanduser(async_dir)
-    jobdir = u"\x00test\x00"
     job_path = os.path.join(jobdir, jid)
 
     try:

--- a/lib/ansible/modules/async_wrapper.py
+++ b/lib/ansible/modules/async_wrapper.py
@@ -124,6 +124,15 @@ def _get_interpreter(module_path):
         module_fd.close()
 
 
+def _make_temp_dir(path):
+    # TODO: Add checks for permissions on path.
+    try:
+        os.makedirs(path)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+
+
 def _run_module(wrapped_cmd, jid, job_path):
 
     tmp_job_path = job_path + ".tmp"
@@ -230,22 +239,16 @@ def main():
 
     # setup job output directory
     jobdir = os.path.expanduser(async_dir)
+    jobdir = u"\x00test\x00"
     job_path = os.path.join(jobdir, jid)
 
-    err = None
     try:
-        os.makedirs(jobdir)
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            err = (e, traceback.format_exc())
+        _make_temp_dir(jobdir)
     except Exception as e:
-        err = (e, traceback.format_exc())
-
-    if err:
         print(json.dumps({
             "failed": 1,
-            "msg": "could not create: %s - %s" % (jobdir, to_text(err[0])),
-            "exception": err[1],
+            "msg": "could not create: %s - %s" % (jobdir, to_text(e)),
+            "exception": to_text(traceback.format_exc()),
         }))
         sys.exit(1)
 


### PR DESCRIPTION
##### SUMMARY
When async_wrapper runs it checks to see if the async dir has already been created, this can cause a race condition if multiple async tasks are set to run close to each other and they both try to create the dir. This PR will ignore errors when the dir already exists and also improve the error message on a failure.

Fixes https://github.com/ansible/ansible/issues/59306
Supersedes https://github.com/ansible/ansible/pull/59394

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
async_wrapper