### PR TITLE
Add a link to available jinja2 playbook filters

### DIFF
--- a/lib/ansible/plugins/doc_fragments/constructed.py
+++ b/lib/ansible/plugins/doc_fragments/constructed.py
@@ -24,8 +24,7 @@ options:
   groups:
     description: >
       Add hosts to group based on Jinja2 conditionals.
-      A list of filters can be found here
-      U(https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html).
+      A list of filters can be found here :ref:`playbooks_filters`.
     type: dict
     default: {}
   keyed_groups:

--- a/lib/ansible/plugins/doc_fragments/constructed.py
+++ b/lib/ansible/plugins/doc_fragments/constructed.py
@@ -22,7 +22,10 @@ options:
     type: dict
     default: {}
   groups:
-    description: Add hosts to group based on Jinja2 conditionals.
+    description: >
+      Add hosts to group based on Jinja2 conditionals.
+      A list of filters can be found here
+      U(https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html).
     type: dict
     default: {}
   keyed_groups:


### PR DESCRIPTION
##### SUMMARY
Add a link to available jinja2 playbook filters.
Useful to find quilckly what kind of expression we can use in this option.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugin/doc_fragments/constructed

##### ADDITIONAL INFORMATION
I created a PR https://github.com/ansible-collections/google.cloud/pull/296 to write an example of use.
