### PR TITLE
user - allow local users with an expiry date to be created (#72022)

### DIFF
--- a/changelogs/fragments/fix_ansible_issue_71942.yaml
+++ b/changelogs/fragments/fix_ansible_issue_71942.yaml
@@ -1,0 +1,5 @@
+bugfixes:
+  - >
+     user - Local users with an expiry date cannot be created as the ``luseradd`` /
+     ``lusermod`` commands do not support the ``-e`` option. Set the expiry time in
+     this case via ``lchage`` after the user was created / modified. (https://github.com/ansible/ansible/issues/71942)

--- a/test/integration/targets/user/tasks/expires_local.yml
+++ b/test/integration/targets/user/tasks/expires_local.yml
@@ -1,0 +1,333 @@
+---
+## local user expires
+# Date is March 3, 2050
+
+- name: Remove local_ansibulluser
+  user:
+    name: local_ansibulluser
+    state: absent
+    remove: yes
+    local: yes
+  tags:
+    - user_test_local_mode
+
+- name: Set user expiration
+  user:
+    name: local_ansibulluser
+    state: present
+    local: yes
+    expires: 2529881062
+  register: user_test_local_expires1
+  tags:
+    - timezone
+    - user_test_local_mode
+
+- name: Set user expiration again to ensure no change is made
+  user:
+    name: local_ansibulluser
+    state: present
+    local: yes
+    expires: 2529881062
+  register: user_test_local_expires2
+  tags:
+    - timezone
+    - user_test_local_mode
+
+- name: Ensure that account with expiration was created and did not change on subsequent run
+  assert:
+    that:
+      - user_test_local_expires1 is changed
+      - user_test_local_expires2 is not changed
+  tags:
+    - user_test_local_mode
+
+- name: Verify expiration date for Linux
+  block:
+    - name: LINUX | Get expiration date for local_ansibulluser
+      getent:
+        database: shadow
+        key: local_ansibulluser
+      tags:
+        - user_test_local_mode
+
+    - name: LINUX | Ensure proper expiration date was set
+      assert:
+        that:
+          - getent_shadow['local_ansibulluser'][6] == '29281'
+      tags:
+        - user_test_local_mode
+  when: ansible_facts.os_family in ['RedHat', 'Debian', 'Suse']
+
+- name: Change timezone
+  timezone:
+    name: America/Denver
+  register: original_timezone
+  tags:
+    - timezone
+    - user_test_local_mode
+
+- name: Change system timezone to make sure expiration comparison works properly
+  block:
+    - name: Create user with expiration again to ensure no change is made in a new timezone
+      user:
+        name: local_ansibulluser
+        state: present
+        local: yes
+        expires: 2529881062
+      register: user_test_local_different_tz
+      tags:
+        - timezone
+        - user_test_local_mode
+
+    - name: Ensure that no change was reported
+      assert:
+        that:
+          - user_test_local_different_tz is not changed
+      tags:
+        - timezone
+        - user_test_local_mode
+
+  always:
+    - name: Restore original timezone - {{ original_timezone.diff.before.name }}
+      timezone:
+        name: "{{ original_timezone.diff.before.name }}"
+      when: original_timezone.diff.before.name != "n/a"
+      tags:
+        - timezone
+        - user_test_local_mode
+
+    - name: Restore original timezone when n/a
+      file:
+        path: /etc/sysconfig/clock
+        state: absent
+      when:
+        - original_timezone.diff.before.name == "n/a"
+        - "'/etc/sysconfig/clock' in original_timezone.msg"
+      tags:
+        - timezone
+        - user_test_local_mode
+
+
+- name: Unexpire user
+  user:
+    name: local_ansibulluser
+    state: present
+    local: yes
+    expires: -1
+  register: user_test_local_expires3
+  tags:
+    - user_test_local_mode
+
+- name: Verify un expiration date for Linux
+  block:
+    - name: LINUX | Get expiration date for local_ansibulluser
+      getent:
+        database: shadow
+        key: local_ansibulluser
+      tags:
+        - user_test_local_mode
+
+    - name: LINUX | Ensure proper expiration date was set
+      assert:
+        msg: "expiry is supposed to be empty or -1, not {{ getent_shadow['local_ansibulluser'][6] }}"
+        that:
+          - not getent_shadow['local_ansibulluser'][6] or getent_shadow['local_ansibulluser'][6] | int < 0
+      tags:
+        - user_test_local_mode
+  when: ansible_facts.os_family in ['RedHat', 'Debian', 'Suse']
+
+- name: Verify un expiration date for Linux/BSD
+  block:
+    - name: Unexpire user again to check for change
+      user:
+        name: local_ansibulluser
+        state: present
+        local: yes
+        expires: -1
+      register: user_test_local_expires4
+      tags:
+        - user_test_local_mode
+
+    - name: Ensure first expiration reported a change and second did not
+      assert:
+        msg: The second run of the expiration removal task reported a change when it should not
+        that:
+          - user_test_local_expires3 is changed
+          - user_test_local_expires4 is not changed
+      tags:
+        - user_test_local_mode
+  when: ansible_facts.os_family in ['RedHat', 'Debian', 'Suse', 'FreeBSD']
+
+# Test setting no expiration when creating a new account
+# https://github.com/ansible/ansible/issues/44155
+- name: Remove local_ansibulluser
+  user:
+    name: local_ansibulluser
+    state: absent
+    remove: yes
+    local: yes
+  tags:
+    - user_test_local_mode
+
+- name: Create user account without expiration
+  user:
+    name: local_ansibulluser
+    state: present
+    local: yes
+    expires: -1
+  register: user_test_local_create_no_expires_1
+  tags:
+    - user_test_local_mode
+
+- name: Create user account without expiration again
+  user:
+    name: local_ansibulluser
+    state: present
+    local: yes
+    expires: -1
+  register: user_test_local_create_no_expires_2
+  tags:
+    - user_test_local_mode
+
+- name: Ensure changes were made appropriately
+  assert:
+    msg: Setting 'expires='-1 resulted in incorrect changes
+    that:
+      - user_test_local_create_no_expires_1 is changed
+      - user_test_local_create_no_expires_2 is not changed
+  tags:
+    - user_test_local_mode
+
+- name: Verify un expiration date for Linux
+  block:
+    - name: LINUX | Get expiration date for local_ansibulluser
+      getent:
+        database: shadow
+        key: local_ansibulluser
+      tags:
+        - user_test_local_mode
+
+    - name: LINUX | Ensure proper expiration date was set
+      assert:
+        msg: "expiry is supposed to be empty or -1, not {{ getent_shadow['local_ansibulluser'][6] }}"
+        that:
+          - not getent_shadow['local_ansibulluser'][6] or getent_shadow['local_ansibulluser'][6] | int < 0
+      tags:
+        - user_test_local_mode
+  when: ansible_facts.os_family in ['RedHat', 'Debian', 'Suse']
+
+# Test setting epoch 0 expiration when creating a new account, then removing the expiry
+# https://github.com/ansible/ansible/issues/47114
+- name: Remove local_ansibulluser
+  user:
+    name: local_ansibulluser
+    state: absent
+    remove: yes
+    local: yes
+  tags:
+    - user_test_local_mode
+
+- name: Create user account with epoch 0 expiration
+  user:
+    name: local_ansibulluser
+    state: present
+    local: yes
+    expires: 0
+  register: user_test_local_expires_create0_1
+  tags:
+    - user_test_local_mode
+
+- name: Create user account with epoch 0 expiration again
+  user:
+    name: local_ansibulluser
+    state: present
+    local: yes
+    expires: 0
+  register: user_test_local_expires_create0_2
+  tags:
+    - user_test_local_mode
+
+- name: Change the user account to remove the expiry time
+  user:
+    name: local_ansibulluser
+    expires: -1
+    local: yes
+  register: user_test_local_remove_expires_1
+  tags:
+    - user_test_local_mode
+
+- name: Change the user account to remove the expiry time again
+  user:
+    name: local_ansibulluser
+    expires: -1
+    local: yes
+  register: user_test_local_remove_expires_2
+  tags:
+    - user_test_local_mode
+
+
+- name: Verify un expiration date for Linux
+  block:
+    - name: LINUX | Ensure changes were made appropriately
+      assert:
+        msg: Creating an account with 'expries=0' then removing that expriation with 'expires=-1' resulted in incorrect changes
+        that:
+          - user_test_local_expires_create0_1 is changed
+          - user_test_local_expires_create0_2 is not changed
+          - user_test_local_remove_expires_1 is changed
+          - user_test_local_remove_expires_2 is not changed
+      tags:
+        - user_test_local_mode
+
+    - name: LINUX | Get expiration date for local_ansibulluser
+      getent:
+        database: shadow
+        key: local_ansibulluser
+      tags:
+        - user_test_local_mode
+
+    - name: LINUX | Ensure proper expiration date was set
+      assert:
+        msg: "expiry is supposed to be empty or -1, not {{ getent_shadow['local_ansibulluser'][6] }}"
+        that:
+          - not getent_shadow['local_ansibulluser'][6] or getent_shadow['local_ansibulluser'][6] | int < 0
+      tags:
+        - user_test_local_mode
+  when: ansible_facts.os_family in ['RedHat', 'Debian', 'Suse']
+
+# Test expiration with a very large negative number. This should have the same
+# result as setting -1.
+- name: Set expiration date using very long negative number
+  user:
+    name: local_ansibulluser
+    state: present
+    local: yes
+    expires: -2529881062
+  register: user_test_local_expires5
+  tags:
+    - user_test_local_mode
+
+- name: Ensure no change was made
+  assert:
+    that:
+      - user_test_local_expires5 is not changed
+  tags:
+    - user_test_local_mode
+
+- name: Verify un expiration date for Linux
+  block:
+    - name: LINUX | Get expiration date for local_ansibulluser
+      getent:
+        database: shadow
+        key: local_ansibulluser
+      tags:
+        - user_test_local_mode
+
+    - name: LINUX | Ensure proper expiration date was set
+      assert:
+        msg: "expiry is supposed to be empty or -1, not {{ getent_shadow['local_ansibulluser'][6] }}"
+        that:
+          - not getent_shadow['local_ansibulluser'][6] or getent_shadow['local_ansibulluser'][6] | int < 0
+      tags:
+        - user_test_local_mode
+  when: ansible_facts.os_family in ['RedHat', 'Debian', 'Suse']

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -1081,3 +1081,6 @@
   when: ansible_facts.system in ['Linux']
   tags:
     - user_test_local_mode
+
+- name: Test expires for local users
+  import_tasks: expires_local.yml


### PR DESCRIPTION
The luseradd / lusermod commands do not support the -e option. Set
the expiry time in this case via lchage after the user was
created / modified.

Fixes: #71942

In Python3 math.floor returns an integer whereas Python2 returns a float.
Hence always convert the result of math.floor to an int to ensure that
lexpires is an integer.

Move local expires tests in a separate file and import the tasks to the
main.yml to keep main.yml smaller.

(cherry picked from commit a7170da851e2a3951311a3c78bcac5346b5edacd)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
user
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
