### PR TITLE
Fix the reversed order of return values

### DIFF
--- a/changelogs/fragments/fix_reversed_return_value_order_72088.yaml
+++ b/changelogs/fragments/fix_reversed_return_value_order_72088.yaml
@@ -1,0 +1,6 @@
+bugfixes:
+  - >
+      user - AnsibleModule.run_command returns a tuple of return code, stdout
+      and stderr. The module main function of the user module expects
+      user.create_user to return a tuple of return code, stdout and stderr.
+      Fix the locations where stdout and stderr got reversed.

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -692,7 +692,7 @@ class User(object):
                 return (rc, out, err)
 
         if self.groups is None or len(self.groups) == 0:
-            return (rc, err, out)
+            return (rc, out, err)
 
         for add_group in groups:
             (rc, _out, _err) = self.execute_command([lgroupmod_cmd, '-M', self.name, add_group])

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -2240,20 +2240,20 @@ class DarwinUser(User):
 
         if self.append is False:
             for remove in current - target:
-                (_rc, _err, _out) = self.__modify_group(remove, 'delete')
+                (_rc, _out, _err) = self.__modify_group(remove, 'delete')
                 rc += rc
                 out += _out
                 err += _err
                 changed = True
 
         for add in target - current:
-            (_rc, _err, _out) = self.__modify_group(add, 'add')
+            (_rc, _out, _err) = self.__modify_group(add, 'add')
             rc += _rc
             out += _out
             err += _err
             changed = True
 
-        return (rc, err, out, changed)
+        return (rc, out, err, changed)
 
     def _update_system_user(self):
         '''Hide or show user on login window according SELF.SYSTEM.
@@ -2324,7 +2324,7 @@ class DarwinUser(User):
     def create_user(self, command_name='dscl'):
         cmd = self._get_dscl()
         cmd += ['-create', '/Users/%s' % self.name]
-        (rc, err, out) = self.execute_command(cmd)
+        (rc, out, err) = self.execute_command(cmd)
         if rc != 0:
             self.module.fail_json(msg='Cannot create user "%s".' % self.name, err=err, out=out, rc=rc)
 
@@ -2351,16 +2351,16 @@ class DarwinUser(User):
 
                 cmd = self._get_dscl()
                 cmd += ['-create', '/Users/%s' % self.name, field[1], self.__dict__[field[0]]]
-                (rc, _err, _out) = self.execute_command(cmd)
+                (rc, _out, _err) = self.execute_command(cmd)
                 if rc != 0:
                     self.module.fail_json(msg='Cannot add property "%s" to user "%s".' % (field[0], self.name), err=err, out=out, rc=rc)
 
                 out += _out
                 err += _err
                 if rc != 0:
-                    return (rc, _err, _out)
+                    return (rc, _out, _err)
 
-        (rc, _err, _out) = self._change_user_password()
+        (rc, _out, _err) = self._change_user_password()
         out += _out
         err += _err
 
@@ -2371,7 +2371,7 @@ class DarwinUser(User):
             (rc, _out, _err, changed) = self._modify_group()
             out += _out
             err += _err
-        return (rc, err, out)
+        return (rc, out, err)
 
     def modify_user(self):
         changed = None
@@ -2387,7 +2387,7 @@ class DarwinUser(User):
                 if current is None or current != to_text(self.__dict__[field[0]]):
                     cmd = self._get_dscl()
                     cmd += ['-create', '/Users/%s' % self.name, field[1], self.__dict__[field[0]]]
-                    (rc, _err, _out) = self.execute_command(cmd)
+                    (rc, _out, _err) = self.execute_command(cmd)
                     if rc != 0:
                         self.module.fail_json(
                             msg='Cannot update property "%s" for user "%s".'
@@ -2396,7 +2396,7 @@ class DarwinUser(User):
                     out += _out
                     err += _err
         if self.update_password == 'always' and self.password is not None:
-            (rc, _err, _out) = self._change_user_password()
+            (rc, _out, _err) = self._change_user_password()
             out += _out
             err += _err
             changed = rc

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -675,9 +675,9 @@ class User(object):
             cmd.append('-r')
 
         cmd.append(self.name)
-        (rc, err, out) = self.execute_command(cmd)
+        (rc, out, err) = self.execute_command(cmd)
         if not self.local or rc != 0:
-            return (rc, err, out)
+            return (rc, out, err)
 
         if self.expires is not None:
             if self.expires < time.gmtime(0):
@@ -685,7 +685,7 @@ class User(object):
             else:
                 # Convert seconds since Epoch to days since Epoch
                 lexpires = int(math.floor(self.module.params['expires'])) // 86400
-            (rc, _err, _out) = self.execute_command([lchage_cmd, '-E', to_native(lexpires), self.name])
+            (rc, _out, _err) = self.execute_command([lchage_cmd, '-E', to_native(lexpires), self.name])
             out += _out
             err += _err
             if rc != 0:
@@ -695,7 +695,7 @@ class User(object):
             return (rc, err, out)
 
         for add_group in groups:
-            (rc, _err, _out) = self.execute_command([lgroupmod_cmd, '-M', self.name, add_group])
+            (rc, _out, _err) = self.execute_command([lgroupmod_cmd, '-M', self.name, add_group])
             out += _out
             err += _err
             if rc != 0:
@@ -849,35 +849,35 @@ class User(object):
             cmd.append('-p')
             cmd.append(self.password)
 
-        (rc, err, out) = (None, '', '')
+        (rc, out, err) = (None, '', '')
 
         # skip if no usermod changes to be made
         if len(cmd) > 1:
             cmd.append(self.name)
-            (rc, err, out) = self.execute_command(cmd)
+            (rc, out, err) = self.execute_command(cmd)
 
         if not self.local or not (rc is None or rc == 0):
-            return (rc, err, out)
+            return (rc, out, err)
 
         if lexpires is not None:
-            (rc, _err, _out) = self.execute_command([lchage_cmd, '-E', to_native(lexpires), self.name])
+            (rc, _out, _err) = self.execute_command([lchage_cmd, '-E', to_native(lexpires), self.name])
             out += _out
             err += _err
             if rc != 0:
                 return (rc, out, err)
 
         if len(lgroupmod_add) == 0 and len(lgroupmod_del) == 0:
-            return (rc, err, out)
+            return (rc, out, err)
 
         for add_group in lgroupmod_add:
-            (rc, _err, _out) = self.execute_command([lgroupmod_cmd, '-M', self.name, add_group])
+            (rc, _out, _err) = self.execute_command([lgroupmod_cmd, '-M', self.name, add_group])
             out += _out
             err += _err
             if rc != 0:
                 return (rc, out, err)
 
         for del_group in lgroupmod_del:
-            (rc, _err, _out) = self.execute_command([lgroupmod_cmd, '-m', self.name, del_group])
+            (rc, _out, _err) = self.execute_command([lgroupmod_cmd, '-m', self.name, del_group])
             out += _out
             err += _err
             if rc != 0:


### PR DESCRIPTION
AnsibleModule.run_command returns a tuple of return code, stdout and stderr.
The module main function of the user module expects user.create_user to
return a tuple of return code, stdout and stderr.
Fix the locations where stdout and stderr got reversed.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
user
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
