### PR TITLE
[ansible-test] attempt to work around podman

### DIFF
--- a/changelogs/fragments/ansible-test-podman-json-format.yml
+++ b/changelogs/fragments/ansible-test-podman-json-format.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - now makes a better attempt to support podman when calling ``docker images`` and asking for JSON format.

--- a/test/lib/ansible_test/_internal/docker_util.py
+++ b/test/lib/ansible_test/_internal/docker_util.py
@@ -195,7 +195,8 @@ def docker_images(args, image):
     except SubprocessError as ex:
         if 'no such image' in ex.stderr:
             return []  # podman does not handle this gracefully, exits 125
-        elif 'function "json" not defined' in ex.stderr:
+
+        if 'function "json" not defined' in ex.stderr:
             # podman > 2 && < 2.2.0 breaks with --format {{json .}}, and requires --format json
             # So we try this as a fallback. If it fails again, we just raise the exception and bail.
             stdout, _dummy = docker_command(args, ['images', image, '--format', 'json'], capture=True, always=True)

--- a/test/lib/ansible_test/_internal/docker_util.py
+++ b/test/lib/ansible_test/_internal/docker_util.py
@@ -202,7 +202,7 @@ def docker_images(args, image):
         else:
             raise ex
 
-    if stdout[0] == '[':
+    if stdout.startswith('['):
         # modern podman outputs a pretty-printed json list. Just load the whole thing.
         return json.loads(stdout)
 

--- a/test/lib/ansible_test/_internal/docker_util.py
+++ b/test/lib/ansible_test/_internal/docker_util.py
@@ -202,13 +202,12 @@ def docker_images(args, image):
         else:
             raise ex
 
-    lines = stdout.splitlines()
-    if lines and lines[0][0] == '[':
+    if stdout[0] == '[':
         # modern podman outputs a pretty-printed json list. Just load the whole thing.
         return json.loads(stdout)
 
-    # docker outputs one json object per line
-    return [json.loads(line) for line in lines]
+    # docker outputs one json object per line (jsonl)
+    return [json.loads(line) for line in stdout.splitlines()]
 
 
 def docker_rm(args, container_id):

--- a/test/lib/ansible_test/_internal/docker_util.py
+++ b/test/lib/ansible_test/_internal/docker_util.py
@@ -194,7 +194,7 @@ def docker_images(args, image):
         stdout, _dummy = docker_command(args, ['images', image, '--format', '{{json .}}'], capture=True, always=True)
     except SubprocessError as ex:
         if 'no such image' in ex.stderr:
-            stdout = ''  # podman does not handle this gracefully, exits 125
+            return []  # podman does not handle this gracefully, exits 125
         elif 'function "json" not defined' in ex.stderr:
             # podman > 2 && < 2.2.0 breaks with --format {{json .}}, and requires --format json
             # So we try this as a fallback. If it fails again, we just raise the exception and bail.

--- a/test/lib/ansible_test/_internal/docker_util.py
+++ b/test/lib/ansible_test/_internal/docker_util.py
@@ -206,9 +206,9 @@ def docker_images(args, image):
     if lines and lines[0][0] == '[':
         # modern podman outputs a pretty-printed json list. Just load the whole thing.
         return json.loads(stdout)
-    else:
-        # docker outputs one json object per line
-        return [json.loads(line) for line in lines]
+
+    # docker outputs one json object per line
+    return [json.loads(line) for line in lines]
 
 
 def docker_rm(args, container_id):

--- a/test/lib/ansible_test/_internal/docker_util.py
+++ b/test/lib/ansible_test/_internal/docker_util.py
@@ -195,10 +195,20 @@ def docker_images(args, image):
     except SubprocessError as ex:
         if 'no such image' in ex.stderr:
             stdout = ''  # podman does not handle this gracefully, exits 125
+        elif 'function "json" not defined' in ex.stderr:
+            # podman > 2 && < 2.2.0 breaks with --format {{json .}}, and requires --format json
+            # So we try this as a fallback. If it fails again, we just raise the exception and bail.
+            stdout, _dummy = docker_command(args, ['images', image, '--format', 'json'], capture=True, always=True)
         else:
             raise ex
-    results = [json.loads(line) for line in stdout.splitlines()]
-    return results
+
+    lines = stdout.splitlines()
+    if lines and lines[0][0] == '[':
+        # modern podman outputs a pretty-printed json list. Just load the whole thing.
+        return json.loads(stdout)
+    else:
+        # docker outputs one json object per line
+        return [json.loads(line) for line in lines]
 
 
 def docker_rm(args, container_id):

--- a/test/units/ansible_test/test_docker_util.py
+++ b/test/units/ansible_test/test_docker_util.py
@@ -81,8 +81,7 @@ def subprocess_error():
         (2, (PODMAN_OUTPUT, '')),
         (0, ('', '')),
     ),
-    ids=('docker JSONL', 'podman JSON sequence', 'empty output'),
-)
+    ids=('docker JSONL', 'podman JSON sequence', 'empty output'))
 def test_docker_images(docker_images, mocker, returned_items_count, patched_dc_stdout):
     mocker.patch(
         'ansible_test._internal.docker_util.docker_command',

--- a/test/units/ansible_test/test_docker_util.py
+++ b/test/units/ansible_test/test_docker_util.py
@@ -93,7 +93,7 @@ def test_podman_fallback(ansible_test, docker_images, subprocess_error, mocker):
     cmd = ['docker', 'images', 'quay.io/ansible/centos7-test-container', '--format', '{{json .}}']
     docker_command_results = [
         subprocess_error(cmd, status=1, stderr='function "json" not defined'),
-        (PODMAN_OUTPUT.lstrip(), ''),
+        (PODMAN_OUTPUT, ''),
     ]
     mocker.patch(
         'ansible_test._internal.docker_util.docker_command',

--- a/test/units/ansible_test/test_docker_util.py
+++ b/test/units/ansible_test/test_docker_util.py
@@ -75,16 +75,20 @@ def subprocess_error():
 
 
 @pytest.mark.parametrize(
-    'dc',
-    [[3, (DOCKER_OUTPUT_MULTIPLE, '')],
-     [2, (PODMAN_OUTPUT, '')],
-     [0, ('', '')]])
-def test_docker_images(docker_images, mocker, dc):
+    ('returned_items_count', 'patched_dc_stdout'),
+    (
+        (3, (DOCKER_OUTPUT_MULTIPLE, '')),
+        (2, (PODMAN_OUTPUT, '')),
+        (0, ('', '')),
+    ),
+    ids=('docker JSONL', 'podman JSON sequence', 'empty output'),
+)
+def test_docker_images(docker_images, mocker, returned_items_count, patched_dc_stdout):
     mocker.patch(
         'ansible_test._internal.docker_util.docker_command',
-        return_value=dc[1])
+        return_value=patched_dc_stdout)
     ret = docker_images('', 'quay.io/ansible/centos7-test-container')
-    assert len(ret) == dc[0]
+    assert len(ret) == returned_items_count
 
 
 def test_podman_fallback(ansible_test, docker_images, subprocess_error, mocker):

--- a/test/units/ansible_test/test_docker_util.py
+++ b/test/units/ansible_test/test_docker_util.py
@@ -1,0 +1,133 @@
+# This file is part of Ansible
+# -*- coding: utf-8 -*-
+#
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+
+import pytest
+from units.compat import unittest
+from units.compat.mock import call, patch, MagicMock
+
+# docker images quay.io/ansible/centos7-test-container --format '{{json .}}'
+DOCKER_OUTPUT_MULTIPLE = """
+{"Containers":"N/A","CreatedAt":"2020-06-11 17:05:58 -0500 CDT","CreatedSince":"3 months ago","Digest":"\u003cnone\u003e","ID":"b0f914b26cc1","Repository":"quay.io/ansible/centos7-test-container","SharedSize":"N/A","Size":"556MB","Tag":"1.17.0","UniqueSize":"N/A","VirtualSize":"555.6MB"}
+{"Containers":"N/A","CreatedAt":"2020-06-11 17:05:58 -0500 CDT","CreatedSince":"3 months ago","Digest":"\u003cnone\u003e","ID":"b0f914b26cc1","Repository":"quay.io/ansible/centos7-test-container","SharedSize":"N/A","Size":"556MB","Tag":"latest","UniqueSize":"N/A","VirtualSize":"555.6MB"}
+{"Containers":"N/A","CreatedAt":"2019-04-01 19:59:39 -0500 CDT","CreatedSince":"18 months ago","Digest":"\u003cnone\u003e","ID":"dd3d10e03dd3","Repository":"quay.io/ansible/centos7-test-container","SharedSize":"N/A","Size":"678MB","Tag":"1.8.0","UniqueSize":"N/A","VirtualSize":"678MB"}
+"""  # noqa: E501
+
+PODMAN_OUTPUT = """
+[
+    {
+        "id": "dd3d10e03dd3580de865560c3440c812a33fd7a1fca8ed8e4a1219ff3d809e3a",
+        "names": [
+            "quay.io/ansible/centos7-test-container:1.8.0"
+        ],
+        "digest": "sha256:6e5d9c99aa558779715a80715e5cf0c227a4b59d95e6803c148290c5d0d9d352",
+        "created": "2019-04-02T00:59:39.234584184Z",
+        "size": 702761933
+    },
+    {
+        "id": "b0f914b26cc1088ab8705413c2f2cf247306ceeea51260d64c26894190d188bd",
+        "names": [
+            "quay.io/ansible/centos7-test-container:latest"
+        ],
+        "digest": "sha256:d8431aa74f60f4ff0f1bd36bc9a227bbb2066330acd8bf25e29d8614ee99e39c",
+        "created": "2020-06-11T22:05:58.382459136Z",
+        "size": 578513505
+    }
+]
+"""
+
+
+class TestDockerImagesParsing(unittest.TestCase):
+    @patch(
+        'ansible_test._internal.docker_util.docker_command',
+        return_value=(DOCKER_OUTPUT_MULTIPLE.lstrip(), ''))
+    def test_docker_multiple_lines(self, dc):
+        '''Test normal docker output'''
+        from ansible_test._internal.docker_util import docker_images
+
+        ret = docker_images('', 'quay.io/ansible/centos7-test-container')
+        self.assertEqual(len(ret), 3)
+
+    @patch(
+        'ansible_test._internal.docker_util.docker_command',
+        return_value=(PODMAN_OUTPUT.lstrip(), ''))
+    def test_podman_multiple(self, dc):
+        '''Test normal podman output'''
+        from ansible_test._internal.docker_util import docker_images
+
+        ret = docker_images('', 'quay.io/ansible/centos7-test-container')
+        self.assertEqual(len(ret), 2)
+
+    @patch(
+        'ansible_test._internal.docker_util.docker_command',
+        return_value=('', ''))
+    def test_no_output(self, dc):
+        '''Test empty output, which docker can emit'''
+        from ansible_test._internal.docker_util import docker_images
+
+        ret = docker_images('', 'quay.io/ansible/centos7-test-container')
+        self.assertEqual(ret, [])
+
+    def test_podman_fallback(self):
+        '''Test podman >2 && <2.2 fallback'''
+        from ansible_test._internal.docker_util import docker_images
+        from ansible_test._internal.util import SubprocessError
+
+        cmd = ['docker', 'images', 'quay.io/ansible/centos7-test-container', '--format', '{{json .}}']
+        docker_command_results = [
+            SubprocessError(cmd, status=1, stderr='function "json" not defined'),
+            (PODMAN_OUTPUT.lstrip(), ''),
+        ]
+        with patch(
+                'ansible_test._internal.docker_util.docker_command',
+                side_effect=docker_command_results) as mock:
+
+            ret = docker_images('', 'quay.io/ansible/centos7-test-container')
+            calls = [
+                call(
+                    '',
+                    ['images', 'quay.io/ansible/centos7-test-container', '--format', '{{json .}}'],
+                    capture=True,
+                    always=True),
+                call(
+                    '',
+                    ['images', 'quay.io/ansible/centos7-test-container', '--format', 'json'],
+                    capture=True,
+                    always=True),
+            ]
+            mock.assert_has_calls(calls)
+            self.assertEqual(len(ret), 2)
+
+    def test_no_such_image(self):
+        '''podman, "no such image" error'''
+        from ansible_test._internal.docker_util import docker_images
+        from ansible_test._internal.util import SubprocessError
+
+        cmd = ['docker', 'images', 'quay.io/ansible/centos7-test-container', '--format', '{{json .}}']
+        exc = SubprocessError(cmd, status=1, stderr='no such image'),
+        with patch(
+                'ansible_test._internal.docker_util.docker_command',
+                side_effect=exc) as mock:
+
+            ret = docker_images('', 'quay.io/ansible/centos7-test-container')
+            self.assertEqual(ret, [])


### PR DESCRIPTION

##### SUMMARY
Change:
- podman > 2 && < 2.2 does not support "images --format {{json .}}"
- podman also now outputs images JSON differently than docker
- Work around both of the above.

Test Plan:
- Tested with podman 2.0.6 in Fedora 31.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Test Pull Request

##### COMPONENT NAME

ansible-test