### PR TITLE
pip: Add support for various pip install modes

### DIFF
--- a/changelogs/fragments/72097-add-support-for-pip-install-modes.yml
+++ b/changelogs/fragments/72097-add-support-for-pip-install-modes.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - pip - add support for different install sites (user, system, prefix, target, and root) (https://github.com/ansible/ansible/pull/72097).

--- a/test/integration/targets/pip/tasks/main.yml
+++ b/test/integration/targets/pip/tasks/main.yml
@@ -1,6 +1,10 @@
 # Current pip unconditionally uses md5.
 # We can re-enable if pip switches to a different hash or allows us to not check md5.
 
+- name: install virtualenv
+  pip:
+    name: virtualenv
+
 - name: find virtualenv command
   command: "which virtualenv virtualenv-{{ ansible_python.version.major }}.{{ ansible_python.version.minor }}"
   register: command

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -26,6 +26,46 @@
     name: "{{ pip_test_packages }}"
     state: absent
 
+### test site locations begin ###
+
+- name: Test site locations
+  when: "ansible_system == 'Linux'"
+  block:
+    - include_tasks: pip_site.yml
+      loop: "{{ pip_test_site_data }}"
+
+- name: Test site locations with virtualenv
+  block:
+    - include_tasks: pip_site_virtualenv.yml
+      loop: "{{ pip_test_site_data }}"
+
+- name: Test install before check mode
+  pip:
+    site: user
+    name: "{{ pip_test_packages }}"
+    state: present
+  register: pip_test_install_1
+
+- name: Test check mode install
+  pip:
+    site: user
+    name: "{{ pip_test_packages }}"
+    state: present
+  check_mode: yes
+  register: pip_test_install_2
+
+- assert:
+    that:
+        - "pip_test_install_1.changed"
+        - "not pip_test_install_2.changed"
+
+- name: ensure packages are not installed (precondition setup)
+  pip:
+    name: "{{ pip_test_packages }}"
+    state: absent
+
+### test site locations end ###
+
 # verify that a package that is uninstalled being set to absent
 # results in an unchanged state and that the test package is not
 # installed
@@ -260,7 +300,8 @@
   pip:
     name: .
     chdir: "{{ output_dir }}/pip_module"
-    extra_args: --user --upgrade --root {{ output_dir }}/pip_root
+    site: user
+    state: latest
 
 - name: register python_site_lib
   command: '{{ ansible_python.executable }} -c "import site; print(site.USER_SITE)"'
@@ -271,7 +312,7 @@
   register: pip_python_user_base
 
 - name: run test module
-  shell: "PYTHONPATH=$(echo {{ output_dir }}/pip_root{{ pip_python_site_lib.stdout }}) {{ output_dir }}/pip_root{{ pip_python_user_base.stdout }}/bin/ansible_test_pip_chdir"
+  shell: "PYTHONPATH=$(echo {{ pip_python_user_base }}/{{ pip_python_site_lib.stdout }}) {{ pip_python_user_base.stdout }}/bin/ansible_test_pip_chdir"
   register: pip_chdir_command
 
 - name: make sure command ran

--- a/test/integration/targets/pip/tasks/pip_site.yml
+++ b/test/integration/targets/pip/tasks/pip_site.yml
@@ -1,0 +1,72 @@
+---
+
+- name: "Testing site location variation {{ item }}"
+  debug:
+    msg: "Testing site location variation: {{ item }}"
+
+- name: Set pathable or not
+  set_fact:
+    pathable: "{{ (item not in ('system', 'user')) | bool }}"
+
+- name: "make sure the location does not exist"
+  file:
+    state: absent
+    name: "{{ output_dir }}/pipenv"
+
+- name: "[{{ item }}] Create temp location"
+  when: pathable
+  tempfile:
+    state: directory
+  register: tmp_prefix_loc
+
+- name: "[{{ item }}] install sample project"
+  pip:
+    name: "{{ pip_test_package }}"
+    site: "{{ item }}"
+    path: "{{ tmp_prefix_loc.path | default(omit) }}"
+    state: present
+  register: site_test_pkg
+  ignore_errors: "{{ pathable }}"
+
+- name: "[{{ item }}] ensure sample project was installed"
+  when: "site_test_pkg is failed and item == 'prefix'"
+  assert:
+    that:
+      - "site_test_pkg.msg == 'This version of pip does not support the site you provided: --prefix'"
+
+- name: "[{{ item }}] ensure sample project was installed"
+  when: "item != 'prefix'"
+  assert:
+    that:
+      - "site_test_pkg is success"
+
+- name: "[{{ item }}] only continue remaining tests if site supported..."
+  when: "site_test_pkg is success"
+  block:
+
+    - name: "[{{ item }}] remove sample project from system"
+      pip:
+        name: "{{ pip_test_package }}"
+        site: "{{ item }}"
+        path: "{{ tmp_prefix_loc.path | default(omit) }}"
+        state: absent
+      register: site_test_pkg_remove
+      ignore_errors: "{{ pathable }}"
+
+    - name: "[{{ item }}] ensure sample project was removed"
+      when: "not pathable"
+      assert:
+        that:
+          - "site_test_pkg_remove is success"
+
+    - name: "[{{ item }}] ensure sample project was NOT removed"
+      when: "pathable"
+      assert:
+        that:
+          - "site_test_pkg_remove is failed"
+
+    - name: manually remove prefixed location
+      when: "pathable"
+      file:
+        state: absent
+        name: "{{ tmp_prefix_loc.path }}"

--- a/test/integration/targets/pip/tasks/pip_site_virtualenv.yml
+++ b/test/integration/targets/pip/tasks/pip_site_virtualenv.yml
@@ -1,0 +1,75 @@
+---
+
+- name: "[{{ item }}] Testing site location variation {{ item }}"
+  debug:
+    msg: "Testing site location variation: {{ item }}"
+
+- name: "[{{ item }}] Set pathable or not"
+  set_fact:
+    pathable: "{{ (item not in ('system', 'user')) | bool }}"
+
+- name: "[{{ item }}] make sure the location does not exist"
+  file:
+    state: absent
+    name: "{{ output_dir }}/pipenv"
+
+- name: "[{{ item }}] Create temp location"
+  when: pathable
+  tempfile:
+    state: directory
+  register: tmp_prefix_loc
+
+- name: "[{{ item }}] set venv location"
+  when: pathable
+  set_fact:
+    tmp_venv: "{{ tmp_prefix_loc.path }}/.venv"
+
+- name: "[{{ item }}] install sample project"
+  pip:
+    name: "{{ pip_test_package }}"
+    site: "{{ item }}"
+    path: "{{ tmp_prefix_loc.path | default(omit) }}"
+    state: present
+    virtualenv: "{{ tmp_venv | default(omit) }}"
+  register: site_test_pkg
+  ignore_errors: "{{ pathable }}"
+
+- name: "[{{ item }}] ensure sample project was installed"
+  when: "not pathable"
+  assert:
+    that:
+      - "site_test_pkg is success"
+
+- name: "[{{ item }}] ensure sample project was NOT installed"
+  when: "pathable"
+  assert:
+    that:
+      - "site_test_pkg is failed"
+
+- name: "[{{ item }}] remove sample project from system"
+  pip:
+    name: "{{ pip_test_package }}"
+    site: "{{ item }}"
+    path: "{{ tmp_prefix_loc.path | default(omit) }}"
+    state: absent
+    virtualenv: "{{ tmp_venv | default(omit) }}"
+  register: site_test_pkg_remove
+  ignore_errors: "{{ pathable }}"
+
+- name: "[{{ item }}] ensure sample project was removed"
+  when: "not pathable"
+  assert:
+    that:
+      - "site_test_pkg_remove is success"
+
+- name: "[{{ item }}] ensure sample project was NOT removed"
+  when: "pathable"
+  assert:
+    that:
+      - "site_test_pkg_remove is failed"
+
+- name: "[{{ item }}] manually remove prefixed location"
+  when: "pathable"
+  file:
+    state: absent
+    name: "{{ tmp_prefix_loc.path }}"

--- a/test/integration/targets/pip/vars/main.yml
+++ b/test/integration/targets/pip/vars/main.yml
@@ -11,3 +11,9 @@ pip_test_pkg_ver_unsatisfied:
 pip_test_modules:
   - sample
   - jiphy
+pip_test_site_data:
+  - system
+  - user
+  - root
+  - prefix
+  - target


### PR DESCRIPTION
##### SUMMARY

Introduces support for the various 'site' locations in pip - system (default), user, target, prefix, root. Fixes #56333, potential fix for #71781

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
pip

##### ADDITIONAL INFORMATION
Currently pip can only be used to install to the 'user site' location by including extra_args, which is not a great user experience. The module also (correctly) marks any invocation with extra_args as 'changed' when in check mode. This will allow at least some tasks to be migrated away and have more accurate idempotency.

Before:
```json
{
  "virtualenv": null,
  "changed": true,
  "requirements": null,
  "name": [
    "pyyaml"
  ],
  "stdout": "Collecting pyyaml==5.3.0\nInstalling collected packages: pyyaml\nSuccessfully installed pyyaml-5.3\n",
  "cmd": [
    "/usr/bin/pip3",
    "install",
    "pyyaml==5.3.0"
  ],
  "state": "present",
  "version": "5.3.0",
  "stderr": "",
  "invocation": {
    "module_args": {
      "virtualenv": null,
      "virtualenv_site_packages": false,
      "executable": "pip3",
      "chdir": null,
      "requirements": null,
      "name": [
        "pyyaml"
      ],
      "virtualenv_python": null,
      "editable": false,
      "umask": null,
      "virtualenv_command": "virtualenv",
      "extra_args": null,
      "state": "present",
      "version": "5.3.0"
    }
  }
}
```

After (user):
```json
{
  "virtualenv": null,
  "changed": true,
  "requirements": null,
  "name": [
    "pyyaml"
  ],
  "stdout": "Collecting pyyaml==5.3.0\nInstalling collected packages: pyyaml\nSuccessfully installed pyyaml-5.3\n",
  "cmd": [
    "/usr/bin/pip3",
    "install",
    "--user",
    "pyyaml==5.3.0"
  ],
  "state": "present",
  "version": "5.3.0",
  "stderr": "",
  "invocation": {
    "module_args": {
      "virtualenv": null,
      "virtualenv_site_packages": false,
      "executable": "pip3",
      "chdir": null,
      "requirements": null,
      "name": [
        "pyyaml"
      ],
      "virtualenv_python": null,
      "editable": false,
      "umask": null,
      "site": "user",
      "virtualenv_command": "virtualenv",
      "extra_args": null,
      "state": "present",
      "version": "5.3.0",
      "path": null
    }
  }
}
```

After (prefix):
```json
{
  "virtualenv": null,
  "changed": true,
  "requirements": null,
  "name": [
    "pyyaml"
  ],
  "stdout": "Collecting pyyaml==5.3.0\nInstalling collected packages: pyyaml\nSuccessfully installed pyyaml-5.3\n",
  "cmd": [
    "/usr/bin/pip3",
    "install",
    "--root",
    "/tmp/prefixed-path",
    "pyyaml==5.3.0"
  ],
  "state": "present",
  "version": "5.3.0",
  "stderr": "",
  "invocation": {
    "module_args": {
      "virtualenv": null,
      "virtualenv_site_packages": false,
      "executable": "pip3",
      "chdir": null,
      "requirements": null,
      "name": [
        "pyyaml"
      ],
      "virtualenv_python": null,
      "editable": false,
      "umask": null,
      "site": "root",
      "virtualenv_command": "virtualenv",
      "extra_args": null,
      "state": "present",
      "version": "5.3.0",
      "path": "/tmp/prefixed-path"
    }
  }
}
```