### PR TITLE
basic: Handle exception in default selector

### DIFF
--- a/changelogs/fragments/71704_selector.yml
+++ b/changelogs/fragments/71704_selector.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- basic - handle exceptions for default selectors in Python 2.7 (https://github.com/ansible/ansible/issues/71704).

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2712,7 +2712,7 @@ class AnsibleModule(object):
             stderr = b''
             try:
                 selector = selectors.DefaultSelector()
-            except OSError:
+            except (IOError, OSError):
                 # Failed to detect default selector for the given platform
                 # Select PollSelector which is supported by major platforms
                 selector = selectors.PollSelector()


### PR DESCRIPTION
##### SUMMARY

In Python 2.7, default selector raises IOError
instead of OSError. Fix handles this exception.

Fixes: #71704

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/71704_selector.yml
lib/ansible/module_utils/basic.py
