### PR TITLE
[stable-2.9] Allow changed/failed mgmt on strategy actions (#70919)

### DIFF
--- a/changelogs/fragments/changed_when_group_by.yml
+++ b/changelogs/fragments/changed_when_group_by.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Restore the ability for changed_when/failed_when to function with group_by (#70844).

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -37,11 +37,11 @@ from ansible.errors import AnsibleError, AnsibleFileNotFound, AnsibleParserError
 from ansible.executor import action_write_locks
 from ansible.executor.process.worker import WorkerProcess
 from ansible.executor.task_result import TaskResult
-from ansible.inventory.host import Host
 from ansible.module_utils.six.moves import queue as Queue
 from ansible.module_utils.six import iteritems, itervalues, string_types
 from ansible.module_utils._text import to_text
 from ansible.module_utils.connection import Connection, ConnectionError
+from ansible.playbook.conditional import Conditional
 from ansible.playbook.handler import Handler
 from ansible.playbook.helpers import load_list_of_blocks
 from ansible.playbook.included_file import IncludedFile
@@ -67,6 +67,9 @@ class StrategySentinel:
     pass
 
 
+_sentinel = StrategySentinel()
+
+
 def SharedPluginLoaderObj():
     '''This only exists for backwards compat, do not use.
     '''
@@ -75,7 +78,19 @@ def SharedPluginLoaderObj():
     return plugin_loader
 
 
-_sentinel = StrategySentinel()
+def post_process_whens(result, task, templar):
+    cond = None
+    if task.changed_when:
+        cond = Conditional(loader=templar._loader)
+        cond.when = task.changed_when
+        result['changed'] = cond.evaluate_conditional(templar, templar.available_variables)
+
+    if task.failed_when:
+        if cond is None:
+            cond = Conditional(loader=templar._loader)
+        cond.when = task.failed_when
+        failed_when_result = cond.evaluate_conditional(templar, templar.available_variables)
+        result['failed_when_result'] = result['failed'] = failed_when_result
 
 
 def results_thread_main(strategy):
@@ -646,10 +661,12 @@ class StrategyBase:
                         # this task added a new host (add_host module)
                         new_host_info = result_item.get('add_host', dict())
                         self._add_host(new_host_info, iterator)
+                        post_process_whens(result_item, original_task, handler_templar)
 
                     elif 'add_group' in result_item:
                         # this task added a new group (group_by module)
                         self._add_group(original_host, result_item)
+                        post_process_whens(result_item, original_task, handler_templar)
 
                     if 'ansible_facts' in result_item:
                         # if delegated fact and we are delegating facts, we need to change target host for them

--- a/test/integration/targets/changed_when/tasks/main.yml
+++ b/test/integration/targets/changed_when/tasks/main.yml
@@ -38,3 +38,24 @@
   assert:
     that:
        - "not shell_result.changed"
+
+- name: Add hosts to test group and ensure it appears as changed
+  group_by:
+      key: "cw_test1_{{ inventory_hostname }}"
+  register: groupby
+
+- name: verify its changed
+  assert:
+    that:
+      - groupby is changed
+
+- name: Add hosts to test group and ensure it does NOT appear as changed
+  group_by:
+      key: "cw_test2_{{ inventory_hostname }}"
+  changed_when: False
+  register: groupby
+
+- name: verify its not changed
+  assert:
+    that:
+      - groupby is not changed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #70919 for Ansible 2.9
(cherry picked from commit f9c3c6cba6f74f9c50c023389bf8f37a8534ada1)<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/strategy/__init__.py`