### PR TITLE
ansible-doc role arg spec support

### DIFF
--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -221,7 +221,8 @@ def add_basedir_options(parser):
     """Add options for commands which can set a playbook basedir"""
     parser.add_argument('--playbook-dir', default=C.config.get_config_value('PLAYBOOK_DIR'), dest='basedir', action='store',
                         help="Since this tool does not use playbooks, use this as a substitute playbook directory."
-                             "This sets the relative path for many features including roles/ group_vars/ etc.")
+                             "This sets the relative path for many features including roles/ group_vars/ etc.",
+                        type=unfrack_path())
 
 
 def add_check_options(parser):

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -555,6 +555,11 @@ class DocCLI(CLI, RoleMixin):
         if basedir:
             AnsibleCollectionConfig.playbook_paths = basedir
 
+            # Add any 'roles' subdir in playbook dir to the roles search path
+            subdir = os.path.join(basedir, "roles")
+            if os.path.isdir(subdir):
+                roles_path = (subdir,) + roles_path
+
         if plugin_type not in TARGET_OPTIONS:
             raise AnsibleOptionsError("Unknown or undocumentable plugin type: %s" % plugin_type)
         elif plugin_type == 'keyword':

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -33,7 +33,7 @@ from ansible.parsing.plugin_docs import read_docstub
 from ansible.parsing.utils.yaml import from_yaml
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.plugins.loader import action_loader, fragment_loader
-from ansible.utils.collection_loader import AnsibleCollectionConfig
+from ansible.utils.collection_loader import AnsibleCollectionConfig, AnsibleCollectionRef
 from ansible.utils.collection_loader._collection_finder import _get_collection_name_from_path
 from ansible.utils.display import Display
 from ansible.utils.plugin_docs import (
@@ -577,7 +577,6 @@ class DocCLI(CLI, RoleMixin):
                 roles_path = (subdir,) + roles_path
             roles_path = roles_path + (basedir,)
 
-
         if plugin_type not in TARGET_OPTIONS:
             raise AnsibleOptionsError("Unknown or undocumentable plugin type: %s" % plugin_type)
         elif plugin_type == 'keyword':
@@ -592,6 +591,8 @@ class DocCLI(CLI, RoleMixin):
                 coll_filter = None
                 if len(context.CLIARGS['args']) == 1:
                     coll_filter = context.CLIARGS['args'][0]
+                    if not AnsibleCollectionRef.is_valid_collection_name(coll_filter):
+                        raise AnsibleError('Invalid collection name (must be of the form namespace.collection): {0}'.format(coll_filter))
                 elif len(context.CLIARGS['args']) > 1:
                     raise AnsibleOptionsError("Only a single collection filter is supported.")
 

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -129,34 +129,6 @@ class RoleMixin(object):
                         found.add((entry, collname, path))
         return found
 
-    def _find_role(self, role_name, role_paths):
-        """Search for a single role within the supplied search paths and within collections.
-
-        :param role_name: The name of the role.
-        :param role_paths: A set of paths to search. For each path, we will search for
-            a sub-directory with the role name.
-
-        :returns: A string with the found path, or None if not found.
-        """
-        for path in role_paths:
-            if not os.path.isdir(path):
-                display.warning("Invalid role path: {0}".format(path))
-            else:
-                full_path = os.path.join(path, role_name)
-                if os.path.isdir(full_path):
-                    return full_path
-
-        b_colldirs = list_collection_dirs()
-        for b_path in b_colldirs:
-            path = to_text(b_path, errors='surrogate_or_strict')
-            collname = _get_collection_name_from_path(b_path)
-            role_dir = os.path.join(path, 'roles', role_name)
-            if os.path.exists(role_dir):
-                return role_dir
-
-        display.warning("role {0} not found in: {1}".format(role_name, ':'.join(role_paths)))
-        return None
-
     def _create_role_list(self, roles_path):
         """Return a dict describing the listing of all roles with arg specs.
 

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -215,27 +215,6 @@ class RoleMixin(object):
 
         return result
 
-    def _display_role_docs(self, role_name, role_spec_file):
-        """Present the documentation for a single role based on the role arg spec contents.
-
-        :param role_name: The name of the role.
-        :param role_spec_file: Path to the role argument specification file.
-        """
-        print("docs for role %s from %s" % (role_name, role_spec_file))
-
-    def _show_role_documentation(self, roles, role_paths):
-        """Coordinate displaying the role documentation for each given role.
-
-        :param roles: A list of role names.
-        :param role_paths: Iterable of paths to search for the named roles.
-        """
-        for role in roles:
-            role_path = self._find_role(role, role_paths)
-            if role_path:
-                role_spec_file = os.path.join(role_path, 'meta', self.ROLE_ARGSPEC_FILE)
-                if os.path.exists(role_spec_file):
-                    self._display_role_docs(role, role_spec_file)
-
 
 class DocCLI(CLI, RoleMixin):
     ''' displays information on modules installed in Ansible libraries.
@@ -405,6 +384,7 @@ class DocCLI(CLI, RoleMixin):
                 # if no desc, typeerror raised ends this block
                 kdata = {'description': descs[keyword]}
 
+<<<<<<< HEAD
                 # get playbook objects for keyword and use first to get keyword attributes
                 kdata['applies_to'] = []
                 for pobj in PB_OBJECTS:
@@ -412,6 +392,16 @@ class DocCLI(CLI, RoleMixin):
                         obj_class = 'ansible.playbook.%s' % pobj.lower()
                         loaded_class = importlib.import_module(obj_class)
                         PB_LOADED[pobj] = getattr(loaded_class, pobj, None)
+=======
+        if plugin_type == 'role':
+            if context.CLIARGS['list_dir']:
+                list_json = self._create_role_list(roles_path)
+                if do_json:
+                    jdump(list_json)
+                else:
+                    self._display_available_roles(list_json)
+            return 0
+>>>>>>> remove unused code
 
                     if keyword in PB_LOADED[pobj]._valid_attrs:
                         kdata['applies_to'].append(pobj)

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -579,9 +579,10 @@ class DocCLI(CLI, RoleMixin):
             if context.CLIARGS['list_dir']:
                 # If an argument was given with --list, it is a collection filter
                 coll_filter = None
-                if len(context.CLIARGS['args']) >= 1:
+                if len(context.CLIARGS['args']) == 1:
                     coll_filter = context.CLIARGS['args'][0]
-                    display.warning("Only a single collection filter is supported. Ignoring: %s" % ", ".join(context.CLIARGS['args'][1:]))
+                elif len(context.CLIARGS['args']) > 1:
+                    raise AnsibleOptionsError("Only a single collection filter is supported.")
 
                 list_json = self._create_role_list(roles_path, collection_filter=coll_filter)
                 if do_json:

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -649,7 +649,7 @@ class DocCLI(CLI, RoleMixin):
                         else:
                             display.warning("No valid documentation was retrieved from '%s'" % plugin)
             elif plugin_type == 'role':
-                if listing and docs:
+                if context.CLIARGS['list_dir'] and docs:
                     self._display_available_roles(docs)
                 elif docs:
                     self._display_role_doc(docs)

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -560,6 +560,7 @@ class DocCLI(CLI, RoleMixin):
         basedir = context.CLIARGS['basedir']
         plugin_type = context.CLIARGS['type']
         do_json = context.CLIARGS['json_format']
+        roles_path = context.CLIARGS['roles_path']
         listing = context.CLIARGS['list_files'] or context.CLIARGS['list_dir'] or context.CLIARGS['dump']
         docs = {}
 

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -196,14 +196,14 @@ class RoleMixin(object):
             else:
                 fqcn = role
             if fqcn not in result:
-                result[fqcn] = []
+                result[fqcn] = {}
             summary = {}
             summary['collection'] = collection
             summary['entry_points'] = {}
             for entry_point in argspec.keys():
                 entry_spec = argspec[entry_point] or {}
                 summary['entry_points'][entry_point] = entry_spec.get('short_description', '')
-            result[fqcn].append(summary)
+            result[fqcn] = summary
 
         for role, role_path in roles:
             argspec = self._load_argspec(role, role_path=role_path)
@@ -370,9 +370,8 @@ class DocCLI(CLI, RoleMixin):
         roles = list(list_json.keys())
         entry_point_names = set()
         for role in roles:
-            for item in list_json[role]:
-                for entry_point in item['entry_points'].keys():
-                    entry_point_names.add(entry_point)
+            for entry_point in list_json[role]['entry_points'].keys():
+                entry_point_names.add(entry_point)
 
         max_role_len = max(len(x) for x in roles)
         max_ep_len = max(len(x) for x in entry_point_names)
@@ -380,13 +379,12 @@ class DocCLI(CLI, RoleMixin):
         text = []
 
         for role in sorted(roles):
-            for item in list_json[role]:
-                for entry_point, desc in iteritems(item['entry_points']):
-                    if len(desc) > linelimit:
-                        desc = desc[:linelimit] + '...'
-                    text.append("%-*s %-*s %s" % (max_role_len, role,
-                                                  max_ep_len, entry_point,
-                                                  desc))
+            for entry_point, desc in iteritems(list_json[role]['entry_points']):
+                if len(desc) > linelimit:
+                    desc = desc[:linelimit] + '...'
+                text.append("%-*s %-*s %s" % (max_role_len, role,
+                                              max_ep_len, entry_point,
+                                              desc))
 
         # display results
         DocCLI.pager("\n".join(text))

--- a/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/roles/testrole/meta/argument_specs.yml
+++ b/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/roles/testrole/meta/argument_specs.yml
@@ -1,0 +1,22 @@
+---
+main:
+    short_description: testns.testcol.testrole short description for main entry point
+    description:
+        - Longer description for testns.testcol.testrole main entry point.
+    author: Ansible Core (@ansible)
+    options:
+        opt1:
+            description: opt1 description
+            type: "str"
+            required: true
+
+alternate:
+    short_description: testns.testcol.testrole short description for alternate entry point
+    description:
+        - Longer description for testns.testcol.testrole alternate entry point.
+    author: Ansible Core (@ansible)
+    options:
+        altopt1:
+            description: altopt1 description
+            type: "int"
+            required: true

--- a/test/integration/targets/ansible-doc/fakecollrole.output
+++ b/test/integration/targets/ansible-doc/fakecollrole.output
@@ -1,4 +1,4 @@
-> TESTNS.TESTCOL.TESTROLE    (/Users/shrews/Devel/github/Shrews/ansible/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol)
+> TESTNS.TESTCOL.TESTROLE    (/ansible/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol)
 
 ENTRY POINT: alternate - testns.testcol.testrole short description for alternate entry point
 

--- a/test/integration/targets/ansible-doc/fakecollrole.output
+++ b/test/integration/targets/ansible-doc/fakecollrole.output
@@ -1,0 +1,16 @@
+> TESTNS.TESTCOL.TESTROLE    (/Users/shrews/Devel/github/Shrews/ansible/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol)
+
+ENTRY POINT: alternate - testns.testcol.testrole short description for alternate entry point
+
+        Longer description for testns.testcol.testrole alternate entry
+        point.
+
+OPTIONS (= is mandatory):
+
+= altopt1
+        altopt1 description
+
+        type: int
+
+
+AUTHOR: Ansible Core (@ansible)

--- a/test/integration/targets/ansible-doc/fakerole.output
+++ b/test/integration/targets/ansible-doc/fakerole.output
@@ -1,6 +1,6 @@
-> NORMAL_ROLE1    (/ansible/test/integration/targets/ansible-doc/roles/normal_role1)
+> TEST_ROLE1    (/ansible/test/integration/targets/ansible-doc/roles/normal_role1)
 
-ENTRY POINT: main - This is the main entry point.
+ENTRY POINT: main - test_role1 from roles subdir
 
         In to am attended desirous raptures *declared* diverted
         confined at. Collected instantly remaining up certainly to

--- a/test/integration/targets/ansible-doc/fakerole.output
+++ b/test/integration/targets/ansible-doc/fakerole.output
@@ -1,4 +1,4 @@
-> NORMAL_ROLE1    (/Users/shrews/Devel/github/Shrews/ansible/test/integration/targets/ansible-doc/roles/normal_role1)
+> NORMAL_ROLE1    (/ansible/test/integration/targets/ansible-doc/roles/normal_role1)
 
 ENTRY POINT: main - This is the main entry point.
 

--- a/test/integration/targets/ansible-doc/fakerole.output
+++ b/test/integration/targets/ansible-doc/fakerole.output
@@ -1,0 +1,32 @@
+> NORMAL_ROLE1    (/Users/shrews/Devel/github/Shrews/ansible/test/integration/targets/ansible-doc/roles/normal_role1)
+
+ENTRY POINT: main - This is the main entry point.
+
+        In to am attended desirous raptures *declared* diverted
+        confined at. Collected instantly remaining up certainly to
+        `necessary' as. Over walk dull into son boy door went new. At
+        or happiness commanded daughters as. Is `handsome' an declared
+        at received in extended vicinity subjects. Into miss on he
+        over been late pain an. Only week bore boy what fat case left
+        use. Match round scale now style far times. Your me past an
+        much.
+
+OPTIONS (= is mandatory):
+
+= myopt1
+        First option.
+
+        type: str
+
+- myopt2
+        Second option
+        [Default: 8000]
+        type: int
+
+- myopt3
+        Third option.
+        (Choices: choice1, choice2)[Default: (null)]
+        type: str
+
+
+AUTHOR: John Doe (@john), Jane Doe (@jane)

--- a/test/integration/targets/ansible-doc/roles/normal_role1/meta/argument_specs.yml
+++ b/test/integration/targets/ansible-doc/roles/normal_role1/meta/argument_specs.yml
@@ -1,0 +1,3 @@
+---
+main:
+    short_description: normal_role1 short description

--- a/test/integration/targets/ansible-doc/roles/normal_role1/meta/argument_specs.yml
+++ b/test/integration/targets/ansible-doc/roles/normal_role1/meta/argument_specs.yml
@@ -1,3 +1,33 @@
 ---
 main:
-    short_description: normal_role1 short description
+    short_description: This is the main entry point.
+    description:
+        - In to am attended desirous raptures B(declared) diverted confined at. Collected instantly remaining
+          up certainly to C(necessary) as. Over walk dull into son boy door went new.
+        - At or happiness commanded daughters as. Is I(handsome) an declared at received in extended vicinity
+          subjects. Into miss on he over been late pain an. Only week bore boy what fat case left use. Match round
+          scale now style far times. Your me past an much.
+    author:
+      - John Doe (@john)
+      - Jane Doe (@jane)
+
+    options:
+        myopt1:
+            description:
+                - First option.
+            type: "str"
+            required: true
+
+        myopt2:
+            description:
+                - Second option
+            type: "int"
+            default: 8000
+
+        myopt3:
+            description:
+                - Third option.
+            type: "str"
+            choices:
+                - choice1
+                - choice2

--- a/test/integration/targets/ansible-doc/roles/test_role1/meta/argument_specs.yml
+++ b/test/integration/targets/ansible-doc/roles/test_role1/meta/argument_specs.yml
@@ -1,6 +1,6 @@
 ---
 main:
-    short_description: This is the main entry point.
+    short_description: test_role1 from roles subdir
     description:
         - In to am attended desirous raptures B(declared) diverted confined at. Collected instantly remaining
           up certainly to C(necessary) as. Over walk dull into son boy door went new.

--- a/test/integration/targets/ansible-doc/runme.sh
+++ b/test/integration/targets/ansible-doc/runme.sh
@@ -44,8 +44,8 @@ done
 
 # Test role text output
 # we use sed to strip the role path from the first line
-current_role_out="$(ansible-doc -t role -r ./roles normal_role1 | sed '1 s/\(^> NORMAL_ROLE1\).*(.*)$/\1/')"
-expected_role_out="$(sed '1 s/\(^> NORMAL_ROLE1\).*(.*)$/\1/' fakerole.output)"
+current_role_out="$(ansible-doc -t role -r ./roles test_role1 | sed '1 s/\(^> TEST_ROLE1\).*(.*)$/\1/')"
+expected_role_out="$(sed '1 s/\(^> TEST_ROLE1\).*(.*)$/\1/' fakerole.output)"
 test "$current_role_out" == "$expected_role_out"
 
 # Two collection roles are defined, but only 1 has a role arg spec with 2 entry points
@@ -55,9 +55,17 @@ test "$output" -eq 2
 # Include normal roles (no collection filter)
 output=$(ansible-doc -t role -l --playbook-dir . | wc -l)
 test "$output" -eq 3
-)
+
+# Test that a role in the playbook dir with the same name as a role in the
+# 'roles' subdir of the playbook dir does not appear (lower precedence).
+output=$(ansible-doc -t role -l --playbook-dir . | grep "test_role1 from roles subdir" | wc -l)
+test "$output" -eq 1
+output=$(ansible-doc -t role -l --playbook-dir . | grep "test_role1 from playbook dir" | wc -l)
+test "$output" -eq 0
 
 # Test entry point filter
 current_role_out="$(ansible-doc -t role --playbook-dir . testns.testcol.testrole -e alternate| sed '1 s/\(^> TESTNS\.TESTCOL\.TESTROLE\).*(.*)$/\1/')"
 expected_role_out="$(sed '1 s/\(^> TESTNS\.TESTCOL\.TESTROLE\).*(.*)$/\1/' fakecollrole.output)"
 test "$current_role_out" == "$expected_role_out"
+
+)

--- a/test/integration/targets/ansible-doc/runme.sh
+++ b/test/integration/targets/ansible-doc/runme.sh
@@ -58,9 +58,9 @@ test "$output" -eq 3
 
 # Test that a role in the playbook dir with the same name as a role in the
 # 'roles' subdir of the playbook dir does not appear (lower precedence).
-output=$(ansible-doc -t role -l --playbook-dir . | grep "test_role1 from roles subdir" | wc -l)
+output=$(ansible-doc -t role -l --playbook-dir . | grep -c "test_role1 from roles subdir")
 test "$output" -eq 1
-output=$(ansible-doc -t role -l --playbook-dir . | grep "test_role1 from playbook dir" | wc -l)
+output=$(ansible-doc -t role -l --playbook-dir . | grep -c "test_role1 from playbook dir")
 test "$output" -eq 0
 
 # Test entry point filter

--- a/test/integration/targets/ansible-doc/runme.sh
+++ b/test/integration/targets/ansible-doc/runme.sh
@@ -14,8 +14,9 @@ unset ANSIBLE_PLAYBOOK_DIR
 cd "$(dirname "$0")"
 
 # test module docs from collection
-current_out="$(ansible-doc --playbook-dir ./ testns.testcol.fakemodule)"
-expected_out="$(cat fakemodule.output)"
+# we use sed to strip the module path from the first line
+current_out="$(ansible-doc --playbook-dir ./ testns.testcol.fakemodule | sed '1 s/\(^> TESTNS\.TESTCOL\.FAKEMODULE\).*(.*)$/\1/')"
+expected_out="$(sed '1 s/\(^> TESTNS\.TESTCOL\.FAKEMODULE\).*(.*)$/\1/' fakemodule.output)"
 test "$current_out" == "$expected_out"
 
 # test listing diff plugin types from collection
@@ -38,4 +39,14 @@ do
 	justcol=$(ansible-doc -l -t ${ptype} --playbook-dir ./ testns|wc -l)
 	test "$justcol" -eq 1
 done
+
+#### test role functionality
+
+# Two collection roles are defined, but only 1 has a role arg spec with 2 entry points
+output=$(ansible-doc -t role -l --playbook-dir . testns.testcol | wc -l)
+test "$output" -eq 2
+
+# Include normal roles
+output=$(ansible-doc -t role -l --playbook-dir . --roles-path ./roles | wc -l)
+test "$output" -eq 3
 )

--- a/test/integration/targets/ansible-doc/runme.sh
+++ b/test/integration/targets/ansible-doc/runme.sh
@@ -56,3 +56,8 @@ test "$output" -eq 2
 output=$(ansible-doc -t role -l --playbook-dir . | wc -l)
 test "$output" -eq 3
 )
+
+# Test entry point filter
+current_role_out="$(ansible-doc -t role --playbook-dir . testns.testcol.testrole -e alternate| sed '1 s/\(^> TESTNS\.TESTCOL\.TESTROLE\).*(.*)$/\1/')"
+expected_role_out="$(sed '1 s/\(^> TESTNS\.TESTCOL\.TESTROLE\).*(.*)$/\1/' fakecollrole.output)"
+test "$current_role_out" == "$expected_role_out"

--- a/test/integration/targets/ansible-doc/runme.sh
+++ b/test/integration/targets/ansible-doc/runme.sh
@@ -42,6 +42,12 @@ done
 
 #### test role functionality
 
+# Test role text output
+# we use sed to strip the role path from the first line
+current_role_out="$(ansible-doc -t role -r ./roles normal_role1 | sed '1 s/\(^> NORMAL_ROLE1\).*(.*)$/\1/')"
+expected_role_out="$(sed '1 s/\(^> NORMAL_ROLE1\).*(.*)$/\1/' fakerole.output)"
+test "$current_role_out" == "$expected_role_out"
+
 # Two collection roles are defined, but only 1 has a role arg spec with 2 entry points
 output=$(ansible-doc -t role -l --playbook-dir . testns.testcol | wc -l)
 test "$output" -eq 2

--- a/test/integration/targets/ansible-doc/runme.sh
+++ b/test/integration/targets/ansible-doc/runme.sh
@@ -52,7 +52,7 @@ test "$current_role_out" == "$expected_role_out"
 output=$(ansible-doc -t role -l --playbook-dir . testns.testcol | wc -l)
 test "$output" -eq 2
 
-# Include normal roles
-output=$(ansible-doc -t role -l --playbook-dir . --roles-path ./roles | wc -l)
+# Include normal roles (no collection filter)
+output=$(ansible-doc -t role -l --playbook-dir . | wc -l)
 test "$output" -eq 3
 )

--- a/test/integration/targets/ansible-doc/runme.sh
+++ b/test/integration/targets/ansible-doc/runme.sh
@@ -60,7 +60,7 @@ test "$output" -eq 3
 # 'roles' subdir of the playbook dir does not appear (lower precedence).
 output=$(ansible-doc -t role -l --playbook-dir . | grep -c "test_role1 from roles subdir")
 test "$output" -eq 1
-output=$(ansible-doc -t role -l --playbook-dir . | grep -c "test_role1 from playbook dir")
+output=$(ansible-doc -t role -l --playbook-dir . | grep -c "test_role1 from playbook dir" || true)
 test "$output" -eq 0
 
 # Test entry point filter

--- a/test/integration/targets/ansible-doc/test_role1/README.txt
+++ b/test/integration/targets/ansible-doc/test_role1/README.txt
@@ -1,0 +1,3 @@
+Test role that exists in the playbook directory so we can validate
+that a role of the same name that exists in the 'roles' subdirectory
+will take precedence over this one.

--- a/test/integration/targets/ansible-doc/test_role1/meta/argument_specs.yml
+++ b/test/integration/targets/ansible-doc/test_role1/meta/argument_specs.yml
@@ -1,0 +1,4 @@
+---
+main:
+    short_description: test_role1 from playbook dir
+    description: This should not appear in `ansible-doc --list` output.

--- a/test/integration/targets/ansible/playbookdir_cfg.ini
+++ b/test/integration/targets/ansible/playbookdir_cfg.ini
@@ -1,2 +1,2 @@
 [defaults]
-playbook_dir = /tmp
+playbook_dir = /doesnotexist/tmp

--- a/test/integration/targets/ansible/runme.sh
+++ b/test/integration/targets/ansible/runme.sh
@@ -25,13 +25,13 @@ ansible-config view -c ./no-extension 2> err2.txt || grep -q 'Unsupported config
 rm -f err*.txt
 
 # test setting playbook_dir via envvar
-ANSIBLE_PLAYBOOK_DIR=/tmp ansible localhost -m debug -a var=playbook_dir | grep '"playbook_dir": "/tmp"'
+ANSIBLE_PLAYBOOK_DIR=/doesnotexist/tmp ansible localhost -m debug -a var=playbook_dir | grep '"playbook_dir": "/doesnotexist/tmp"'
 
 # test setting playbook_dir via cmdline
-ansible localhost -m debug -a var=playbook_dir --playbook-dir=/tmp | grep '"playbook_dir": "/tmp"'
+ansible localhost -m debug -a var=playbook_dir --playbook-dir=/doesnotexist/tmp | grep '"playbook_dir": "/doesnotexist/tmp"'
 
 # test setting playbook dir via ansible.cfg
-env -u ANSIBLE_PLAYBOOK_DIR ANSIBLE_CONFIG=./playbookdir_cfg.ini ansible localhost -m debug -a var=playbook_dir | grep '"playbook_dir": "/tmp"'
+env -u ANSIBLE_PLAYBOOK_DIR ANSIBLE_CONFIG=./playbookdir_cfg.ini ansible localhost -m debug -a var=playbook_dir | grep '"playbook_dir": "/doesnotexist/tmp"'
 
 # test adhoc callback triggers
 ANSIBLE_STDOUT_CALLBACK=callback_debug ANSIBLE_LOAD_CALLBACK_PLUGINS=1 ansible --playbook-dir . testhost -i ../../inventory -m ping | grep -E '^v2_' | diff -u adhoc-callback.stdout -


### PR DESCRIPTION
##### SUMMARY

Change ansible-doc to support:

- Listing roles (both normal and from collections) that contain a valid role argument specification file (meta/argument_specs.yml). Text format and JSON format are supported.
- Display role arg spec documentation (text format and JSON)

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

ansible-doc

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

### Listing Roles

```
# List roles, including a custom roles path
% ansible-doc -t role -l -r ./roles
community.general.xyz main  xyz main entry point is super awesome
community.general.xyz other xyz other entry point is super lame
sample                main  A sample role.
myuser.utils.ansible  main  Install Ansible related files.
myuser.utils.ssh      main  Install SSH configuration files.
xyz                   main  Role xyz summary that is going to be rather long so I can test line length.


# List roles, with a collection filter
% ansible-doc -t role -l myuser.utils
myuser.utils.ansible  main  Install Ansible related files.
myuser.utils.ssh      main  Install SSH configuration files.

# List roles, JSON format
% ansible-doc -t role -l --json community.general
{
    "community.general.xyz": {
        "collection": "community.general",
        "entry_points": {
            "main": "xyz main entry point is super awesome",
            "other": "xyz other entry point is super lame"
        }
    }
}
```

### Display/output of role arg spec documentation (JSON)

```
# Docs for role matching `xyz` (includes normal roles and collection roles)
% ansible-doc -t role -r ./roles --json xyz
{
    "community.general.xyz": {
        "collection": "community.general",
        "entry_points": {
            "main": {
                "short_description": "xyz main entry point is super awesome"
            },
            "other": {
                "short_description": "xyz other entry point is super lame"
            }
        },
        "path": "/Users/myuser/.ansible/collections/ansible_collections/community/general"
    },
    "xyz": {
        "collection": "",
        "entry_points": {
            "main": {
                "author": "Ansible Core (@ansible)",
                "description": [
                    "A role to demonstrate arg spec format.",
                    "Can lead to insanity."
                ],
                "options": {
                    "myopt1": {
                        "description": [
                            "First option."
                        ],
                        "required": true,
                        "type": "str"
                    },
                    "myopt2": {
                        "default": 8000,
                        "description": [
                            "Second option"
                        ],
                        "type": "int"
                    },
                    "myopt3": {
                        "choices": [
                            "choice1",
                            "choice2"
                        ],
                        "description": [
                            "Third option."
                        ],
                        "type": "str"
                    }
                },
                "short_description": "Role xyz summary that is going to be rather long so I can test line length."
            }
        },
        "path": "/Users/myuser/Devel/role_argspec/roles/xyz"
    }
}

# Docs for a FQCN role
% ansible-doc -t role --json community.general.xyz
{
    "community.general.xyz": {
        "collection": "community.general",
        "entry_points": {
            "main": {
                "short_description": "xyz main entry point is super awesome"
            },
            "other": {
                "short_description": "xyz other entry point is super lame"
            }
        },
        "path": "/Users/myuser/.ansible/collections/ansible_collections/community/general"
    }
```

### Display/output of role arg spec documentation (Text)
```
% ansible-doc -t role --playbook-dir ./ testns.testcol.testrole
> TESTNS.TESTCOL.TESTROLE    (/Users/myuser/Devel/ansible/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol)

ENTRY POINT: main - testns.testcol.testrole short description for main entry point

        Longer description for testns.testcol.testrole main entry point.

OPTIONS (= is mandatory):

= opt1
        opt1 description

        type: str


AUTHOR: Ansible Core (@ansible)

ENTRY POINT: alternate - testns.testcol.testrole short description for alternate entry point

        Longer description for testns.testcol.testrole alternate entry point.

OPTIONS (= is mandatory):

= altopt1
        altopt1 description

        type: int


AUTHOR: Ansible Core (@ansible)


# With an entry point filter
% ansible-doc -t role --playbook-dir . testns.testcol.testrole -e alternate
> TESTNS.TESTCOL.TESTROLE    (/Users/myuser/Devel/ansible/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol)

ENTRY POINT: alternate - testns.testcol.testrole short description for alternate entry point

        Longer description for testns.testcol.testrole alternate entry point.

OPTIONS (= is mandatory):

= altopt1
        altopt1 description

        type: int


AUTHOR: Ansible Core (@ansible)
```
