### PR TITLE
Add The Bullhorn to the community communication page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,4 +101,3 @@ changelogs/.plugin-cache.yaml
 .ansible-test-timeout.json
 # ansible-test temporary metadata file for use with delgation
 /metadata-*.json
-docs/docsite/rst/_build/html/community/communication.html

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ changelogs/.plugin-cache.yaml
 .ansible-test-timeout.json
 # ansible-test temporary metadata file for use with delgation
 /metadata-*.json
+docs/docsite/rst/_build/html/community/communication.html

--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -92,3 +92,14 @@ Red Hat Ansible `Tower <https://www.ansible.com/products/tower>`_ is a UI, Serve
 The Red Hat Ansible Automation subscription contains support for Ansible, Ansible Tower, Ansible Automation for Networking, and more.
 
 If you have a question about Ansible Tower, visit `Red Hat support <https://access.redhat.com/products/ansible-tower-red-hat/>`_ rather than using the IRC channel or the general project mailing list.
+
+The Bullhorn
+============
+
+**The Bullhorn** is our newsletter for the Ansible developer community. 
+If you have any questions or content you would like to share, please reach out to us at the-bullhorn@redhat.com, or directly `contribute/suggest content <https://github.com/ansible/community/issues/546>`_ for upcoming issues.
+
+Read past issues `here <https://github.com/ansible/community/wiki/News>`_.
+
+`Subscribe <http://eepurl.com/gZmiEP>`_ to receive it.
+


### PR DESCRIPTION
SUMMARY

The page about [communication](https://docs.ansible.com/ansible/latest/community/communication.html#communication) with the Ansible community should include details about contributing to and subscribing to The Bullhorn.

Related to the open issue [#71924](https://github.com/ansible/ansible/issues/71924)

ISSUE TYPE

- Documentation Report

COMPONENT NAME

docs.ansible.com
developers
community

ANSIBLE VERSION

2.10

CONFIGURATION

N/A

OS / ENVIRONMENT

N/A