### PR TITLE
docs: Mention CVE-2020-1736 in the documentation

### DIFF
--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -66,7 +66,7 @@ options:
   mode:
     description:
     - The permissions of the destination file or directory.
-    - For those used to C(/usr/bin/chmod) remember that modes are actually octal numbers.
+    - For those used to I(/usr/bin/chmod) remember that modes are actually octal numbers.
       You must either add a leading zero so that Ansible's YAML parser knows it is an octal number
       (like C(0644) or C(01777)) or quote it (like C('644') or C('1777')) so Ansible receives a string
       and can do its own conversion from string into number. Giving Ansible a number without following

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -68,8 +68,8 @@ options:
     - The permissions of the destination file or directory.
     - For those used to I(/usr/bin/chmod) remember that modes are actually octal numbers.
       You must either add a leading zero so that Ansible's YAML parser knows it is an octal number
-      (like C(0644) or C(01777)) or quote it (like C('644') or C('1777'), or even C('0644') to enforce explicitness and consistency) so Ansible receives a string
-      and can do its own conversion from string into number. Giving Ansible a number without following
+      (like C(0644) or C(01777)) or quote it (like C('644') or C('1777'), or even C('0644') to enforce explicitness and consistency)
+      so Ansible receives a string and can do its own conversion from string into number. Giving Ansible a number without following
       one of these rules will end up with a decimal number which will have unexpected results.
     - As of Ansible 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).
     - As of Ansible 2.3, the mode may also be the special string C(preserve).

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -68,7 +68,7 @@ options:
     - The permissions of the destination file or directory.
     - For those used to I(/usr/bin/chmod) remember that modes are actually octal numbers.
       You must either add a leading zero so that Ansible's YAML parser knows it is an octal number
-      (like C(0644) or C(01777)) or quote it (like C('644') or C('1777')) so Ansible receives a string
+      (like C(0644) or C(01777)) or quote it (like C('644') or C('1777'), or even C('0644') to enforce explicitness and consistency) so Ansible receives a string
       and can do its own conversion from string into number. Giving Ansible a number without following
       one of these rules will end up with a decimal number which will have unexpected results.
     - As of Ansible 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -73,6 +73,8 @@ options:
       one of these rules will end up with a decimal number which will have unexpected results.
     - As of Ansible 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).
     - As of Ansible 2.3, the mode may also be the special string C(preserve).
+    - As of Ansible 2.9.10, not specifying C(mode) could pose a security issue (permissions
+      less restrictive than expected) in some cases. See CVE-2020-1736 for more information.
     - C(preserve) means that the file will be given the same permissions as the source file.
     - When doing a recursive copy, see also C(directory_mode).
     type: path

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -68,7 +68,7 @@ options:
     - The permissions of the destination file or directory.
     - For those used to C(/usr/bin/chmod) remember that modes are actually octal numbers.
       You must either add a leading zero so that Ansible's YAML parser knows it is an octal number
-      (like C(0644) or C(01777))or quote it (like C('644') or C('1777')) so Ansible receives a string
+      (like C(0644) or C(01777)) or quote it (like C('644') or C('1777')) so Ansible receives a string
       and can do its own conversion from string into number. Giving Ansible a number without following
       one of these rules will end up with a decimal number which will have unexpected results.
     - As of Ansible 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).

--- a/lib/ansible/plugins/doc_fragments/files.py
+++ b/lib/ansible/plugins/doc_fragments/files.py
@@ -19,12 +19,10 @@ options:
     - The permissions the resulting file or directory should have.
     - For those used to I(/usr/bin/chmod) remember that modes are actually octal numbers.
       You must either add a leading zero so that Ansible's YAML parser knows it is an octal number
-      (like C(0644) or C(01777)) or quote it (like C('644') or C('1777'), or even C('0644') to enforce explicitness and consistency) so Ansible receives
-      a string and can do its own conversion from string into number.
-    - Giving Ansible a number without following one of these rules will end up with a decimal
-      number which will have unexpected results.
-    - As of Ansible 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or
-      C(u=rw,g=r,o=r)).
+      (like C(0644) or C(01777)) or quote it (like C('644') or C('1777'), or even C('0644') to enforce explicitness and consistency)
+      so Ansible receives a string and can do its own conversion from string into number. Giving Ansible a number without following
+      one of these rules will end up with a decimal number which will have unexpected results.
+    - As of Ansible 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).
     type: raw
   owner:
     description:

--- a/lib/ansible/plugins/doc_fragments/files.py
+++ b/lib/ansible/plugins/doc_fragments/files.py
@@ -23,6 +23,8 @@ options:
       so Ansible receives a string and can do its own conversion from string into number. Giving Ansible a number without following
       one of these rules will end up with a decimal number which will have unexpected results.
     - As of Ansible 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).
+    - As of Ansible 2.9.10, not specifying C(mode) could pose a security issue (permissions
+      less restrictive than expected) in some cases. See CVE-2020-1736 for more information.
     type: raw
   owner:
     description:

--- a/lib/ansible/plugins/doc_fragments/files.py
+++ b/lib/ansible/plugins/doc_fragments/files.py
@@ -10,8 +10,8 @@ class ModuleDocFragment(object):
 
     # Standard files documentation fragment
 
-    # Note: mode is overridden by the copy and template modules so if you change the description
-    # here, you should also change it there.
+    # Note: mode is overridden by the copy module so if you change
+    #       the description here, you should also change it there.
     DOCUMENTATION = r'''
 options:
   mode:

--- a/lib/ansible/plugins/doc_fragments/files.py
+++ b/lib/ansible/plugins/doc_fragments/files.py
@@ -19,7 +19,7 @@ options:
     - The permissions the resulting file or directory should have.
     - For those used to I(/usr/bin/chmod) remember that modes are actually octal numbers.
       You must either add a leading zero so that Ansible's YAML parser knows it is an octal number
-      (like C(0644) or C(01777)) or quote it (like C('644') or C('1777')) so Ansible receives
+      (like C(0644) or C(01777)) or quote it (like C('644') or C('1777'), or even C('0644') to enforce explicitness and consistency) so Ansible receives
       a string and can do its own conversion from string into number.
     - Giving Ansible a number without following one of these rules will end up with a decimal
       number which will have unexpected results.

--- a/lib/ansible/plugins/doc_fragments/shell_windows.py
+++ b/lib/ansible/plugins/doc_fragments/shell_windows.py
@@ -7,8 +7,8 @@ __metaclass__ = type
 class ModuleDocFragment(object):
 
     # Windows shell documentation fragment
-    # FIXME: set_module_language don't belong here but must be set so they don't fail when someone
-    #  get_option('set_module_language') on this plugin
+    # FIXME: set_module_language don't belong here but must be set so they don't
+    #        fail when someone get_option('set_module_language') on this plugin
     DOCUMENTATION = """
 options:
   async_dir:


### PR DESCRIPTION
• Add a comment to parameter 'mode' to highlight CVE-2020-1736 and the versions of Ansible that are vulnerable.

As of Ansible 2.9.10, this vulnerability has not been properly addressed so that string '2.9.10' is subject to a future change.
Tickets: #67794, #71324

• Improve parts of the documentation.