### PR TITLE
Fix example to use correct shebang

### DIFF
--- a/examples/scripts/my_test.py
+++ b/examples/scripts/my_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 # Copyright: (c) 2018, Terry Jones <terry.jones@example.org>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/examples/scripts/my_test_facts.py
+++ b/examples/scripts/my_test_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 # Copyright: (c) 2020, Your Name <YourName@example.org>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/examples/scripts/my_test_info.py
+++ b/examples/scripts/my_test_info.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 # Copyright: (c) 2020, Your Name <YourName@example.org>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -1,5 +1,8 @@
 docs/docsite/rst/dev_guide/testing/sanity/no-smart-quotes.rst no-smart-quotes
 examples/play.yml shebang
+examples/scripts/my_test.py shebang # example module but not in a normal module location
+examples/scripts/my_test_facts.py shebang # example module but not in a normal module location
+examples/scripts/my_test_info.py shebang # example module but not in a normal module location
 examples/scripts/ConfigureRemotingForAnsible.ps1 pslint:PSCustomUseLiteralPath
 examples/scripts/upgrade_to_ps3.ps1 pslint:PSCustomUseLiteralPath
 examples/scripts/upgrade_to_ps3.ps1 pslint:PSUseApprovedVerbs


### PR DESCRIPTION
##### SUMMARY
Unless our guidance has changed the shebang should be `#!/usr/bin/python`, this fixes up the example script so this doc https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general.html#creating-a-module reflects our recommendations.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
examples/scripts/my_test.py