### PR TITLE
[2.8] kubectl: Follow up fix in connection plugin

### DIFF
--- a/changelogs/fragments/71535_kubectl_followup.yml
+++ b/changelogs/fragments/71535_kubectl_followup.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- kubectl - follow up fix in _build_exec_cmd API (https://github.com/ansible/ansible/issues/72171).

--- a/lib/ansible/plugins/connection/kubectl.py
+++ b/lib/ansible/plugins/connection/kubectl.py
@@ -270,7 +270,7 @@ class Connection(ConnectionBase):
         local_cmd += ['--'] + cmd
         censored_local_cmd += ['--'] + cmd
 
-        return local_cmd
+        return local_cmd, censored_local_cmd
 
     def _connect(self, port=None):
         """ Connect to the container. Nothing to do """


### PR DESCRIPTION
##### SUMMARY

PR #71535 broke, _build_exec_cmd API in kubectl connection
plugin.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/connection/kubectl.py
