### PR TITLE
subversion: Fix subversion_pacakges name integration test for Debian

### DIFF
--- a/test/integration/targets/subversion/vars/Debian.yml
+++ b/test/integration/targets/subversion/vars/Debian.yml
@@ -1,6 +1,6 @@
 ---
 subversion_packages:
 - subversion
-- libapache2-svn
+- libapache2-mod-svn
 apache_user: www-data
 apache_group: www-data


### PR DESCRIPTION
##### SUMMARY
In Debian 9 & 10 `libapache2-svn` is missing and therefore without this fix integration test on Debian will fail.
> https://packages.debian.org/jessie/libapache2-mod-svn
> https://packages.debian.org/stretch/libapache2-mod-svn
> https://packages.debian.org/buster/libapache2-mod-svn

> https://packages.debian.org/jessie/libapache2-svn
> https://packages.debian.org/stretch/libapache2-svn (missing)
> https://packages.debian.org/buster/libapache2-svn (missing)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
subversion

##### ADDITIONAL INFORMATION
It can be verified using this image:
https://github.com/aminvakil/distro-test-containers/blob/debian10_dockerfile/debian10-test-container/Dockerfile