### PR TITLE
New AWS module mod_defaults

### DIFF
--- a/changelogs/fragments/72145-s3_metrics_configuration-in-module_defaults.yml
+++ b/changelogs/fragments/72145-s3_metrics_configuration-in-module_defaults.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "module_defaults - add new module s3_metrics_configuration from c.g to aws module_defaults group (https://github.com/ansible/ansible/pull/72145)."
+  - "module_defaults - add new module s3_metrics_configuration from community.aws to aws module_defaults group (https://github.com/ansible/ansible/pull/72145)."

--- a/changelogs/fragments/72145-s3_metrics_configuration-in-module_defaults.yml
+++ b/changelogs/fragments/72145-s3_metrics_configuration-in-module_defaults.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - module_defaults - add new module s3_metrics_configuration from c.g to aws module_defaults group (https://github.com/ansible/ansible/pull/72145).
+  - "module_defaults - add new module s3_metrics_configuration from c.g to aws module_defaults group (https://github.com/ansible/ansible/pull/72145)."

--- a/changelogs/fragments/72145-s3_metrics_configuration-in-module_defaults.yml
+++ b/changelogs/fragments/72145-s3_metrics_configuration-in-module_defaults.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - module_defaults - add new module s3_metrics_configuration from c.g to aws module_defaults group (https://github.com/ansible/ansible/pull/72145).

--- a/lib/ansible/config/module_defaults.yml
+++ b/lib/ansible/config/module_defaults.yml
@@ -1,5 +1,7 @@
 version: '1.0'
 groupings:
+  s3_metrics_configuration:
+  - aws
   aws_acm:
   - aws
   aws_acm_facts:


### PR DESCRIPTION
##### SUMMARY
To support this new module in CI, we need it to be in 2.9's mod_defaults

https://github.com/ansible-collections/community.aws/pull/217

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/config/module_defaults.yml

