### PR TITLE
Update playbooks_vars_facts.rst

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_vars_facts.rst
+++ b/docs/docsite/rst/user_guide/playbooks_vars_facts.rst
@@ -541,7 +541,7 @@ You can add static custom facts by adding static files to facts.d, or add dynami
 
 To use facts.d, create an ``/etc/ansible/facts.d`` directory on the remote host or hosts. If you prefer a different directory, create it and specify it using the ``fact_path`` play keyword. Add files to the directory to supply your custom facts. All file names must end with ``.fact``. The files can be JSON, INI, or executable files returning JSON.
 
-To add static facts, simply add a file with the ``.facts`` extension. For example, create ``/etc/ansible/facts.d/preferences.fact`` with this content::
+To add static facts, simply add a file with the ``.fact`` extension. For example, create ``/etc/ansible/facts.d/preferences.fact`` with this content::
 
     [general]
     asdf=1

--- a/docs/docsite/rst/user_guide/playbooks_vars_facts.rst
+++ b/docs/docsite/rst/user_guide/playbooks_vars_facts.rst
@@ -547,6 +547,8 @@ To add static facts, simply add a file with the ``.fact`` extension. For example
     asdf=1
     bar=2
 
+.. note:: Make sure the file is not executable as this will break the ``ansible.builtin.setup`` module.
+
 The next time fact gathering runs, your facts will include a hash variable fact named ``general`` with ``asdf`` and ``bar`` as members. To validate this, run the following::
 
     ansible <hostname> -m ansible.builtin.setup -a "filter=ansible_local"


### PR DESCRIPTION
##### SUMMARY
Clarify documentation


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr


##### COMPONENT NAME
Documentation

##### ADDITIONAL INFORMATION
Remove misleading typo:
Switching to a `fact*s*` extension here suggest static facts beeing treated differently which they are not 
Add explicit note on static files and the executable bit