### PR TITLE
[stable-2.9] Support collection constraints in ansible-test.

### DIFF
--- a/changelogs/fragments/ansible-test-collection-constraints.yml
+++ b/changelogs/fragments/ansible-test-collection-constraints.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - ansible-test - Collections can now specify pip constraints for unit and integration test requirements using ``tests/unit/constraints.txt`` and ``tests/integration/constraints.txt`` respectively.


### PR DESCRIPTION
##### SUMMARY

This allows collections to specify requirements and constraints for packages that ansible-test has requirements or constraints for.

Backport of https://github.com/ansible/ansible/pull/72154

(cherry picked from commit 5f76bd2af7deb2a04e0415b54be263f5c9b22a07)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
