### PR TITLE
hint in doc of git module to abort on missing http password

### DIFF
--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -266,8 +266,8 @@ EXAMPLES = '''
     repo: https://github.com/ansible/could-be-a-private-repo
     dest: /src/from-private-repo
   environment:
-    GIT_TERMINAL_PROMPT=0 # reports "terminal prompts disabled" on missing password
-    # or GIT_ASKPASS=/bin/true # for git before version 2.3.0, reports "Authentication failed" on missing password
+    GIT_TERMINAL_PROMPT: 0 # reports "terminal prompts disabled" on missing password
+    # or GIT_ASKPASS: /bin/true # for git before version 2.3.0, reports "Authentication failed" on missing password
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -260,6 +260,14 @@ EXAMPLES = '''
 - git:
     single_branch: yes
     branch: master
+
+- name: avoid hanging when http(s) password is missing
+  git:
+    repo: https://github.com/ansible/could-be-a-private-repo
+    dest: /src/from-private-repo
+  environment:
+    GIT_TERMINAL_PROMPT=0 # reports "terminal prompts disabled" on missing password
+    # or GIT_ASKPASS=/bin/true # for git before version 2.3.0, reports "Authentication failed" on missing password
 '''
 
 RETURN = '''


### PR DESCRIPTION
##### SUMMARY

Add a hint in doc of git module how to abort on missing http password.

improves #69489

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

git

##### ADDITIONAL INFORMATION

The example url is an unexisting repo on github, since this will trigger to ask for a password.