### PR TITLE
[config manager] coerce more 'type: str' to string

### DIFF
--- a/changelogs/fragments/more-types-to-string-config.yml
+++ b/changelogs/fragments/more-types-to-string-config.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "config - more types are now automatically coerced to string when ``type: str`` is used and the value is parsed as a different type"

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -149,7 +149,7 @@ def ensure_type(value, value_type, origin=None):
                 errmsg = 'dictionary'
 
         elif value_type in ('str', 'string'):
-            if isinstance(value, (string_types, AnsibleVaultEncryptedUnicode)):
+            if isinstance(value, (string_types, AnsibleVaultEncryptedUnicode, bool, int, float, complex)):
                 value = unquote(to_text(value, errors='surrogate_or_strict'))
             else:
                 errmsg = 'string'

--- a/test/units/config/test_manager.py
+++ b/test/units/config/test_manager.py
@@ -60,6 +60,18 @@ ensure_test_data = [
     ('a', 'string', string_types),
     ('Café', 'string', string_types),
     ('', 'string', string_types),
+    ('29', 'str', string_types),
+    ('13.37', 'str', string_types),
+    ('123j', 'string', string_types),
+    ('0x123', 'string', string_types),
+    ('true', 'string', string_types),
+    ('True', 'string', string_types),
+    (0, 'str', string_types),
+    (29, 'str', string_types),
+    (13.37, 'str', string_types),
+    (123j, 'string', string_types),
+    (0x123, 'string', string_types),
+    (True, 'string', string_types),
     ('None', 'none', type(None))
 ]
 


### PR DESCRIPTION

##### SUMMARY

Change:
- When a plugin defines `type: str` on a parameter, treat all input from
  YAML as a string instead of whatever it parsed as.

Test Plan:
- CI

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

config manager