### PR TITLE
Ad-Hoc CLI loops

### DIFF
--- a/changelogs/fragments/ansible-adhoc-loop.yml
+++ b/changelogs/fragments/ansible-adhoc-loop.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add loop parameter to ad-hoc CLI

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -137,16 +137,14 @@ class AdHocCLI(CLI):
         playbook._entries.append(play)
         playbook._file_name = '__adhoc_playbook__'
 
-        if self.callback:
+        if self.callback or context.CLIARGS['loop_spec']:
+            " minimal callback cannot deal with loops "
             cb = self.callback
         elif context.CLIARGS['one_line']:
             cb = 'oneline'
         # Respect custom 'stdout_callback' only with enabled 'bin_ansible_callbacks'
         elif C.DEFAULT_LOAD_CALLBACK_PLUGINS and C.DEFAULT_STDOUT_CALLBACK != 'default':
             cb = C.DEFAULT_STDOUT_CALLBACK
-        elif context.CLIARGS['loop_spec']:
-            " minimal callback cannot deal with loops "
-            cb = None
         else:
             cb = 'minimal'
 

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -53,7 +53,7 @@ class AdHocCLI(CLI):
                                  default=C.DEFAULT_MODULE_NAME)
         self.parser.add_argument('args', metavar='pattern', help='host pattern')
         self.parser.add_argument('-L', '--loop', dest='loop_spec',
-                                help="loop spec for ad-hoc task. (Plain String, but processed by Jinja)")
+                                 help="loop spec for ad-hoc task. (Plain String, but processed by Jinja)")
 
     def post_process_args(self, options):
         '''Post process and validate options for bin/ansible '''

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -140,6 +140,9 @@ class AdHocCLI(CLI):
         # Respect custom 'stdout_callback' only with enabled 'bin_ansible_callbacks'
         elif C.DEFAULT_LOAD_CALLBACK_PLUGINS and C.DEFAULT_STDOUT_CALLBACK != 'default':
             cb = C.DEFAULT_STDOUT_CALLBACK
+        elif context.CLIARGS['loop_spec']:
+            " minimal callback cannot deal with loops "
+            cb = None
         else:
             cb = 'minimal'
 

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -65,16 +65,20 @@ class AdHocCLI(CLI):
 
         return options
 
-    def _play_ds(self, pattern, async_val, poll, loop):
+    def _play_ds(self, pattern, async_val, poll, loop=None):
         check_raw = context.CLIARGS['module_name'] in C.MODULE_REQUIRE_ARGS
 
         mytask = {'action': {'module': context.CLIARGS['module_name'], 'args': parse_kv(context.CLIARGS['module_args'], check_raw=check_raw)}}
 
         # avoid adding to tasks that don't support it, unless set, then give user an error
-        if context.CLIARGS['module_name'] not in ('include_role', 'include_tasks') and any(frozenset((async_val, poll, loop))):
-            mytask['async_val'] = async_val
-            mytask['poll'] = poll
-            mytask['loop'] = loop
+        if context.CLIARGS['module_name'] not in ('include_role', 'include_tasks'):
+
+            if any(frozenset((async_val, poll))):
+                mytask['async_val'] = async_val
+                mytask['poll'] = poll
+
+            if loop:
+                mytask['loop'] = loop
 
         return dict(
             name="Ansible Ad-Hoc",

--- a/test/integration/targets/cli/runme.sh
+++ b/test/integration/targets/cli/runme.sh
@@ -5,3 +5,4 @@ set -eux
 ANSIBLE_ROLES_PATH=../ ansible-playbook setup.yml
 
 python test-cli.py
+python test-adhoc.py

--- a/test/integration/targets/cli/test-adhoc.py
+++ b/test/integration/targets/cli/test-adhoc.py
@@ -16,4 +16,4 @@ out = pexpect.run(
 )
 
 for i in [1, 2, 3]:
-    assert(('"msg": -%i' % i) in out)
+    assert(bytes('"msg": %i' % i) in out)

--- a/test/integration/targets/cli/test-adhoc.py
+++ b/test/integration/targets/cli/test-adhoc.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# Copyright (c) 2020 Christoph Schulz <christoph.2.schulz@atos.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+
+import pexpect
+
+os.environ['ANSIBLE_NOCOLOR'] = '1'
+out = pexpect.run(
+    'ansible localhost -m debug -a msg="{{ item }}" -L "{{ [1, 2, 3] }}"'
+)
+
+for i in [1, 2, 3]:
+    assert(('"msg": -%i' % i) in out)

--- a/test/integration/targets/cli/test-adhoc.py
+++ b/test/integration/targets/cli/test-adhoc.py
@@ -16,4 +16,4 @@ out = pexpect.run(
 )
 
 for i in [1, 2, 3]:
-    assert(bytes('"msg": %i' % i) in out)
+    assert(('"msg": %i' % i).encode() in out)

--- a/test/units/cli/test_adhoc.py
+++ b/test/units/cli/test_adhoc.py
@@ -74,6 +74,14 @@ def test_play_ds_with_include_role():
     assert ret['name'] == 'Ansible Ad-Hoc'
     assert ret['gather_facts'] == 'no'
 
+def test_play_ds_with_loop():
+    """ Ad-hoc with loop """
+    adhoc_cli = AdHocCLI(args=['/bin/ansible', 'localhost', '-m', 'debug'])
+    adhoc_cli.parse()
+    ret = adhoc_cli._play_ds('include_role', None, None, '{{ [1,2,3] }}')
+    assert ret['name'] == 'Ansible Ad-Hoc'
+    assert ret['tasks'] == [{'action': {'module': 'debug', 'args': {}}, 'loop': '{{ [1,2,3] }}'}]
+
 
 def test_run_import_playbook():
     """ Test import_playbook which is not allowed with ad-hoc command"""

--- a/test/units/cli/test_adhoc.py
+++ b/test/units/cli/test_adhoc.py
@@ -74,6 +74,7 @@ def test_play_ds_with_include_role():
     assert ret['name'] == 'Ansible Ad-Hoc'
     assert ret['gather_facts'] == 'no'
 
+
 def test_play_ds_with_loop():
     """ Ad-hoc with loop """
     adhoc_cli = AdHocCLI(args=['/bin/ansible', 'localhost', '-m', 'debug'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Adds a `-L|--loop` parameter to `ansible` ad-hoc CLI.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Ad-Hoc CLI

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

When using `--loop` the ad-hoc CLI will always use the configured/default stdout callback (instead of defaulting to `minimal` callback)

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ ansible localhost -m debug -a msg="{{ item }}" -L "{{ [1,2,3] }}"
[...]

PLAY [Ansible Ad-Hoc] ************************************************************************************

TASK [debug] *********************************************************************************************
ok: [localhost] => (item=1) => {
    "msg": 1
}
ok: [localhost] => (item=2) => {
    "msg": 2
}
ok: [localhost] => (item=3) => {
    "msg": 3
}

PLAY RECAP ***********************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
