### PR TITLE
accumulate update filters (#71726)

### DIFF
--- a/changelogs/fragments/66132_dnf_show_pkgs_in_check_mode.yml
+++ b/changelogs/fragments/66132_dnf_show_pkgs_in_check_mode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - dnf - now shows specific package changes (installations/removals) under ``results`` in check_mode. (https://github.com/ansible/ansible/issues/66132)

--- a/changelogs/fragments/70854-dnf-mutually-exclusive-filters.yml
+++ b/changelogs/fragments/70854-dnf-mutually-exclusive-filters.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "dnf - it is now possible to specify both ``security: true`` and ``bugfix: true`` to install updates of both types. Previously, only security would get installed if both were true. (https://github.com/ansible/ansible/issues/70854)"

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -669,12 +669,16 @@ class DnfModule(YumDnf):
                 results=[],
                 rc=1
             )
+
+        filters = []
         if self.bugfix:
             key = {'advisory_type__eq': 'bugfix'}
-            base._update_security_filters = [base.sack.query().filter(**key)]
+            filters.append(base.sack.query().filter(**key))
         if self.security:
             key = {'advisory_type__eq': 'security'}
-            base._update_security_filters = [base.sack.query().filter(**key)]
+            filters.append(base.sack.query().filter(**key))
+        if filters:
+            base._update_security_filters = filters
 
         return base
 

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -1180,6 +1180,18 @@ class DnfModule(YumDnf):
                 self.module.exit_json(**response)
             else:
                 response['changed'] = True
+
+                # If packages got installed/removed, add them to the results.
+                # We do this early so we can use it for both check_mode and not.
+                if self.download_only:
+                    install_action = 'Downloaded'
+                else:
+                    install_action = 'Installed'
+                for package in self.base.transaction.install_set:
+                    response['results'].append("{0}: {1}".format(install_action, package))
+                for package in self.base.transaction.remove_set:
+                    response['results'].append("Removed: {0}".format(package))
+
                 if failure_response['failures']:
                     failure_response['msg'] = 'Failed to install some of the specified packages'
                     self.module.fail_json(**failure_response)
@@ -1220,15 +1232,11 @@ class DnfModule(YumDnf):
                             self.module.fail_json(msg=msg)
 
                 if self.download_only:
-                    for package in self.base.transaction.install_set:
-                        response['results'].append("Downloaded: {0}".format(package))
+                    # No further work left to do, and the results were already updated above.
+                    # Just return them.
                     self.module.exit_json(**response)
                 else:
                     self.base.do_transaction()
-                    for package in self.base.transaction.install_set:
-                        response['results'].append("Installed: {0}".format(package))
-                    for package in self.base.transaction.remove_set:
-                        response['results'].append("Removed: {0}".format(package))
 
                 if failure_response['failures']:
                     failure_response['msg'] = 'Failed to install some of the specified packages'

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -48,6 +48,20 @@
         - "not dnf_result.changed"
 
 # INSTALL
+- name: install sos (check_mode)
+  dnf:
+    name: sos
+    state: present
+    update_cache: True
+  check_mode: True
+  register: dnf_result
+
+- assert:
+    that:
+      - dnf_result is success
+      - dnf_result.results|length > 0
+      - "dnf_result.results[0].startswith('Installed: ')"
+
 - name: install sos
   dnf:
     name: sos
@@ -74,6 +88,18 @@
         - "'results' in dnf_result"
 
 # INSTALL AGAIN
+- name: install sos again (check_mode)
+  dnf:
+    name: sos
+    state: present
+  check_mode: True
+  register: dnf_result
+
+- assert:
+    that:
+      - dnf_result is not changed
+      - dnf_result.results|length == 0
+
 - name: install sos again
   dnf:
     name: sos
@@ -188,12 +214,33 @@
         - "rpm_sos_result.rc == 0"
         - "rpm_pciutils_result.rc == 0"
 
+- name: uninstall sos and pciutils (check_mode)
+  dnf:
+    name:
+      - sos
+      - pciutils
+    state: removed
+  check_mode: True
+  register: dnf_result
+
+- assert:
+    that:
+      - dnf_result is success
+      - dnf_result.results|length == 2
+      - "dnf_result.results[0].startswith('Removed: ')"
+      - "dnf_result.results[1].startswith('Removed: ')"
+
 - name: uninstall sos and pciutils
   dnf:
     name:
       - sos
       - pciutils
     state: removed
+  register: dnf_result
+
+- assert:
+    that:
+      - dnf_result is changed
 
 - name: install non-existent rpm
   dnf:
@@ -239,6 +286,19 @@
   dnf:
     name: sos
     state: absent
+
+- name: Test download_only (check_mode)
+  dnf:
+    name: sos
+    state: latest
+    download_only: true
+  check_mode: true
+  register: dnf_result
+
+- assert:
+    that:
+      - dnf_result is success
+      - "dnf_result.results[0].startswith('Downloaded: ')"
 
 - name: Test download_only
   dnf:

--- a/test/integration/targets/dnf/tasks/filters.yml
+++ b/test/integration/targets/dnf/tasks/filters.yml
@@ -1,0 +1,134 @@
+# We have a test repo set up with a valid updateinfo.xml which is referenced
+# from its repomd.xml.
+- block:
+    - set_fact:
+        updateinfo_repo: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/setup_rpm_repo/repo-with-updateinfo
+
+    - name: Install the test repo
+      yum_repository:
+        name: test-repo-with-updateinfo
+        description: test-repo-with-updateinfo
+        baseurl: "{{ updateinfo_repo }}"
+        gpgcheck: no
+
+    - name: Install old versions of toaster and oven
+      dnf:
+        name:
+          - "{{ updateinfo_repo }}/toaster-1.2.3.4-1.el8.noarch.rpm"
+          - "{{ updateinfo_repo }}/oven-1.2.3.4-1.el8.noarch.rpm"
+        disable_gpg_check: true
+
+    - name: Ask for pending updates
+      dnf:
+        name: '*'
+        state: latest
+        update_only: true
+        disable_gpg_check: true
+        disablerepo: '*'
+        enablerepo: test-repo-with-updateinfo
+      register: update_no_filter
+
+    - assert:
+        that:
+          - update_no_filter is changed
+          - '"Installed: toaster-1.2.3.5-1.el8.noarch" in update_no_filter.results'
+          - '"Installed: oven-1.2.3.5-1.el8.noarch" in update_no_filter.results'
+          - '"Removed: toaster-1.2.3.4-1.el8.noarch" in update_no_filter.results'
+          - '"Removed: oven-1.2.3.4-1.el8.noarch" in update_no_filter.results'
+
+    - name: Install old versions of toaster and oven
+      dnf:
+        name:
+          - "{{ updateinfo_repo }}/toaster-1.2.3.4-1.el8.noarch.rpm"
+          - "{{ updateinfo_repo }}/oven-1.2.3.4-1.el8.noarch.rpm"
+        allow_downgrade: true
+        disable_gpg_check: true
+
+    - name: Ask for pending updates with security=true
+      dnf:
+        name: '*'
+        state: latest
+        update_only: true
+        disable_gpg_check: true
+        security: true
+        disablerepo: '*'
+        enablerepo: test-repo-with-updateinfo
+      register: update_security
+
+    - assert:
+        that:
+          - update_security is changed
+          - '"Installed: toaster-1.2.3.5-1.el8.noarch" in update_security.results'
+          - '"Removed: toaster-1.2.3.4-1.el8.noarch" in update_security.results'
+          - '"Installed: oven-1.2.3.5-1.el8.noarch" not in update_security.results'
+          - '"Removed: oven-1.2.3.4-1.el8.noarch" not in update_security.results'
+
+    - name: Install old versions of toaster and oven
+      dnf:
+        name:
+          - "{{ updateinfo_repo }}/toaster-1.2.3.4-1.el8.noarch.rpm"
+          - "{{ updateinfo_repo }}/oven-1.2.3.4-1.el8.noarch.rpm"
+        allow_downgrade: true
+        disable_gpg_check: true
+
+    - name: Ask for pending updates with bugfix=true
+      dnf:
+        name: '*'
+        state: latest
+        update_only: true
+        disable_gpg_check: true
+        bugfix: true
+        disablerepo: '*'
+        enablerepo: test-repo-with-updateinfo
+      register: update_bugfix
+
+    - assert:
+        that:
+          - update_bugfix is changed
+          - '"Installed: toaster-1.2.3.5-1.el8.noarch" not in update_bugfix.results'
+          - '"Removed: toaster-1.2.3.4-1.el8.noarch" not in update_bugfix.results'
+          - '"Installed: oven-1.2.3.5-1.el8.noarch" in update_bugfix.results'
+          - '"Removed: oven-1.2.3.4-1.el8.noarch" in update_bugfix.results'
+
+    - name: Install old versions of toaster and oven
+      dnf:
+        name:
+          - "{{ updateinfo_repo }}/toaster-1.2.3.4-1.el8.noarch.rpm"
+          - "{{ updateinfo_repo }}/oven-1.2.3.4-1.el8.noarch.rpm"
+        allow_downgrade: true
+        disable_gpg_check: true
+
+    - name: Ask for pending updates with bugfix=true and security=true
+      dnf:
+        name: '*'
+        state: latest
+        update_only: true
+        disable_gpg_check: true
+        bugfix: true
+        security: true
+        disablerepo: '*'
+        enablerepo: test-repo-with-updateinfo
+      register: update_bugfix
+
+    - assert:
+        that:
+          - update_bugfix is changed
+          - '"Installed: toaster-1.2.3.5-1.el8.noarch" in update_bugfix.results'
+          - '"Removed: toaster-1.2.3.4-1.el8.noarch" in update_bugfix.results'
+          - '"Installed: oven-1.2.3.5-1.el8.noarch" in update_bugfix.results'
+          - '"Removed: oven-1.2.3.4-1.el8.noarch" in update_bugfix.results'
+
+  always:
+    - name: Remove installed packages
+      dnf:
+        name:
+          - toaster
+          - oven
+        state: absent
+
+    - name: Remove the repo
+      yum_repository:
+        name: test-repo-with-updateinfo
+        state: absent
+  tags:
+    - filters

--- a/test/integration/targets/dnf/tasks/filters_check_mode.yml
+++ b/test/integration/targets/dnf/tasks/filters_check_mode.yml
@@ -1,0 +1,110 @@
+# We have a test repo set up with a valid updateinfo.xml which is referenced
+# from its repomd.xml.
+- block:
+    - set_fact:
+        updateinfo_repo: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/setup_rpm_repo/repo-with-updateinfo
+
+    - name: Install the test repo
+      yum_repository:
+        name: test-repo-with-updateinfo
+        description: test-repo-with-updateinfo
+        baseurl: "{{ updateinfo_repo }}"
+        gpgcheck: no
+
+    - name: Install old versions of toaster and oven
+      dnf:
+        name:
+          - "{{ updateinfo_repo }}/toaster-1.2.3.4-1.el8.noarch.rpm"
+          - "{{ updateinfo_repo }}/oven-1.2.3.4-1.el8.noarch.rpm"
+        disable_gpg_check: true
+
+    - name: Ask for pending updates (check_mode)
+      dnf:
+        name: '*'
+        state: latest
+        update_only: true
+        disable_gpg_check: true
+      check_mode: true
+      register: update_no_filter
+
+    - assert:
+        that:
+          - update_no_filter is changed
+          - '"would have if not in check mode" in update_no_filter.msg'
+          - '"Installed: toaster-1.2.3.5-1.el8.noarch" in update_no_filter.results'
+          - '"Installed: oven-1.2.3.5-1.el8.noarch" in update_no_filter.results'
+          - '"Removed: toaster-1.2.3.4-1.el8.noarch" in update_no_filter.results'
+          - '"Removed: oven-1.2.3.4-1.el8.noarch" in update_no_filter.results'
+
+    - name: Ask for pending updates with security=true (check_mode)
+      dnf:
+        name: '*'
+        state: latest
+        update_only: true
+        disable_gpg_check: true
+        security: true
+      check_mode: true
+      register: update_security
+
+    - assert:
+        that:
+          - update_security is changed
+          - '"would have if not in check mode" in update_security.msg'
+          - '"Installed: toaster-1.2.3.5-1.el8.noarch" in update_security.results'
+          - '"Removed: toaster-1.2.3.4-1.el8.noarch" in update_security.results'
+          - '"Installed: oven-1.2.3.5-1.el8.noarch" not in update_security.results'
+          - '"Removed: oven-1.2.3.4-1.el8.noarch" not in update_security.results'
+
+    - name: Ask for pending updates with bugfix=true (check_mode)
+      dnf:
+        name: '*'
+        state: latest
+        update_only: true
+        disable_gpg_check: true
+        bugfix: true
+      check_mode: true
+      register: update_bugfix
+
+    - assert:
+        that:
+          - update_bugfix is changed
+          - '"would have if not in check mode" in update_bugfix.msg'
+          - '"Installed: toaster-1.2.3.5-1.el8.noarch" not in update_bugfix.results'
+          - '"Removed: toaster-1.2.3.4-1.el8.noarch" not in update_bugfix.results'
+          - '"Installed: oven-1.2.3.5-1.el8.noarch" in update_bugfix.results'
+          - '"Removed: oven-1.2.3.4-1.el8.noarch" in update_bugfix.results'
+
+    - name: Ask for pending updates with bugfix=true and security=true (check_mode)
+      dnf:
+        name: '*'
+        state: latest
+        update_only: true
+        disable_gpg_check: true
+        bugfix: true
+        security: true
+      check_mode: true
+      register: update_bugfix
+
+    - assert:
+        that:
+          - update_bugfix is changed
+          - '"would have if not in check mode" in update_bugfix.msg'
+          - '"Installed: toaster-1.2.3.5-1.el8.noarch" in update_bugfix.results'
+          - '"Removed: toaster-1.2.3.4-1.el8.noarch" in update_bugfix.results'
+          - '"Installed: oven-1.2.3.5-1.el8.noarch" in update_bugfix.results'
+          - '"Removed: oven-1.2.3.4-1.el8.noarch" in update_bugfix.results'
+
+  always:
+    - name: Remove installed packages
+      dnf:
+        name:
+          - toaster
+          - oven
+        state: absent
+
+    - name: Remove the repo
+      yum_repository:
+        name: test-repo-with-updateinfo
+        state: absent
+  tags:
+    - filters

--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -23,6 +23,18 @@
   when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('23', '>=')) or
         (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
 
+- include_tasks: filters_check_mode.yml
+  when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('23', '>=')) or
+        (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
+  tags:
+    - filters
+
+- include_tasks: filters.yml
+  when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('23', '>=')) or
+        (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
+  tags:
+    - filters
+
 - include_tasks: gpg.yml
   when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('23', '>=')) or
         (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))


### PR DESCRIPTION

##### SUMMARY

Change:
- Previously when `security: true` and `bugfix: true` were both given,
  only security updates would get applied. Filters now accumulate so
  that both get applied in this case.

Test Plan:
- New integration tests for both check_mode and not. These tests make
  use of a contrived yum repository which is stored in S3.

Tickets:
- Fixes #70854

Signed-off-by: Rick Elrod <rick@elrod.me>
Co-authored-by: Matt Martz <matt@sivel.net>

Co-authored-by: Matt Martz <matt@sivel.net>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

dnf