### PR TITLE
[RFC] action/playbook: Add turbo mode for faster local execution

### DIFF
--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -55,6 +55,7 @@ class PlaybookCLI(CLI):
                                  help="one-step-at-a-time: confirm each task before running")
         self.parser.add_argument('--start-at-task', dest='start_at_task',
                                  help="start the playbook at the task matching this name")
+        self.parser.add_argument('--turbo', dest='turbo', default=False, action='store_true')
         self.parser.add_argument('args', help='Playbook(s)', metavar='playbook', nargs='+')
 
     def post_process_args(self, options):

--- a/lib/ansible/modules/setup.py
+++ b/lib/ansible/modules/setup.py
@@ -145,7 +145,7 @@ EXAMPLES = """
 """
 
 # import module snippets
-from ..module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule
 
 from ansible.module_utils.facts.namespace import PrefixFactNamespace
 from ansible.module_utils.facts import ansible_collector

--- a/lib/ansible/plugins/action/turbo.py
+++ b/lib/ansible/plugins/action/turbo.py
@@ -1,0 +1,99 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import importlib.machinery
+import io
+import json
+import multiprocessing
+import sys
+import types
+import time
+
+from ansible.utils.display import Display
+display = Display()
+
+TURBO_MODULES = {}
+
+
+def _turbo_target(q, module, module_path, module_args):
+    """
+    This is what we run in in the TurboProcess.
+    """
+    result = {
+        "error": 0,
+    }
+    try:
+        # Redirect stdout to a buffer...
+        sys.stdout = io.TextIOWrapper(io.BytesIO())
+        sys.stderr = io.TextIOWrapper(io.BytesIO())
+
+        # Prepare stdin for the module to contain ANSIBLE_MODULE_ARGS
+        bio = io.BytesIO()
+        bio.write(json.dumps({"ANSIBLE_MODULE_ARGS": module_args}).encode("utf-8"))
+        bio.seek(0)
+        sys.stdin = io.TextIOWrapper(bio)
+        sys.argv = [module_path]
+
+        module.main()
+    except SystemExit:
+        # That's fine, sys.exit called explicity
+        pass
+    except RuntimeError:
+        result["error"] = 2
+    except Exception as e:
+        result["error"] = 1
+        try:
+            result["exception"] = repr(e)
+        except Exception:
+            result["exception"] = str(e)
+
+    try:
+        sys.stdout.seek(0)
+        result["stdout"] = sys.stdout.read()
+    except Exception:
+        result["stdout"] = "turbo: could not read stdout"
+
+    try:
+        sys.stderr.seek(0)
+        result["stderr"] = sys.stderr.read()
+    except Exception:
+        result["stderr"] = "turbo: could not read stderr"
+
+    # Send back the result
+    q.put(result)
+
+
+def prepare_turbo(module_path, module_args, final_environment, become_kwargs):
+    """
+    :returns: None or a Process object that can be started.
+    """
+    __unused = (final_environment, become_kwargs)  # XXX
+    if not module_path.endswith(".py"):
+        display.vvv("module_path %s not ending in .py" % module_path)
+        return None
+
+    package = module_path.rsplit(".", 1)[0]
+
+    a, b, c = package.split("/")[-3:]
+    if a != "ansible" or b != "modules":
+        display.vvv("Non-ansible module: %s (?)" % module_path)
+
+    # Load the requested module into ansible.turbo.odules
+    name = ".".join(["ansible", "turbo", "modules", c])
+
+    m = TURBO_MODULES.get(name)
+    if m is None:
+        display.vvv("Loading %s as %s" % (module_path, name))
+        start_time = time.time()
+        m = types.ModuleType(name)
+        m.__path__ = module_path
+        loader = importlib.machinery.SourceFileLoader(name, module_path)
+        loader.exec_module(m)
+        took = time.time() - start_time
+        display.debug("[TURBO] Loaded %s (%s) took=%.4fs" % (name, module_path, took))
+        TURBO_MODULES[name] = m
+
+    q = multiprocessing.Queue()
+    args = (q, m, module_path, module_args)
+    proc = multiprocessing.Process(target=_turbo_target, args=args)
+    return (q, proc)

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -135,6 +135,7 @@ lib/ansible/playbook/collectionsearch.py required-and-default-attributes  # http
 lib/ansible/playbook/helpers.py pylint:blacklisted-name
 lib/ansible/playbook/role/__init__.py pylint:blacklisted-name
 lib/ansible/plugins/action/normal.py action-plugin-docs # default action plugin for modules without a dedicated action plugin
+lib/ansible/plugins/action/turbo.py action-plugin-docs # experiment, likely wrongly placed
 lib/ansible/plugins/cache/base.py ansible-doc!skip  # not a plugin, but a stub for backwards compatibility
 lib/ansible/plugins/lookup/sequence.py pylint:blacklisted-name
 lib/ansible/plugins/strategy/__init__.py pylint:blacklisted-name


### PR DESCRIPTION
##### SUMMARY

This is a proof-of-concept / request-for-comments for speeding up local
Ansible execution. Caveat: It's very limited in scope and not generically
applicable as is (e.g., it ignores any details about become/runas usage).
The motivation for this experiment comes from an environment where fairly
basic playbooks using Ansible builtin functionality are run as root in
local mode.

It introduces a "turbo" module  style which, when the connection is `local`,
executes modules directly inside a subprocess instead of going through
AnsiballZ. In experiments, this improves playbook runtime by a factor
of 3 to 5.



##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
action/playbook

##### ADDITIONAL INFORMATION

A simple performance experiment was done with the following playbook:

    ---
    - name: Test
      hosts: localhost
      gather_facts: False
      tasks:
      - template:
          src: 'template1.j2'
          dest: '/tmp/template-item-{{ item }}'
        loop: '{{ range(32) }}'
      - copy:
          content: 'copy {{ item|string }}'
          dest: '/tmp/file_{{ item }}'
        loop: '{{ range(32) }}'

    $ time PYTHONPATH=$(pwd)/lib python3 bin/ansible-playbook ./perftest/test.yml
    ...
    real    0m24,434s
    user    0m21,394s
    sys     0m4,843s

    $ time PYTHONPATH=$(pwd)/lib python3 bin/ansible-playbook ./perftest/test.yml --turbo
    ...
    real    0m4,707s
    user    0m3,519s
    sys     0m1,909s

This was added without any real knowledge of the Ansible code base, so it
may look somewhat off ;-)

The purpose of this is mainly to to hear if maybe there are other ways
to speed up local Ansible execution and/or whether integrating a real
version of something like this could be of interest.