### PR TITLE
iptables module: Allow passing additional arbitrary arguments to iptables rules

### DIFF
--- a/changelogs/fragments/72189-iptables-allow-extra-arguments.yml
+++ b/changelogs/fragments/72189-iptables-allow-extra-arguments.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- iptables - Add support for arbitrary extra arguments in iptables rules
+  (https://github.com/ansible/ansible/issues/72189)

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -347,6 +347,7 @@ options:
       - List of additional arguments to be used with the rule.
     type: list
     elements: str
+    version_added: "2.11"
     default: []
 '''
 
@@ -475,7 +476,6 @@ EXAMPLES = r'''
     extra_args:
       - "--queue-num 0"
       - "--queue-bypass"
-  become: yes
 '''
 
 import re

--- a/test/units/modules/test_iptables.py
+++ b/test/units/modules/test_iptables.py
@@ -876,3 +876,35 @@ class TestIptables(ModuleTestCase):
             '-j',
             'ACCEPT'
         ])
+
+    def test_extra_args(self):
+        """ Test supplying arbitrary additional arguments """
+        set_module_args({
+            'chain': 'INPUT',
+            'jump': 'NFQUEUE',
+            'extra_args': ['--queue-num 0', '--queue-bypass']
+        })
+
+        commands_results = [
+            (0, '', ''),
+        ]
+
+        with patch.object(basic.AnsibleModule, 'run_command') as run_command:
+            run_command.side_effect = commands_results
+            with self.assertRaises(AnsibleExitJson) as result:
+                iptables.main()
+                self.assertTrue(result.exception.args[0]['changed'])
+
+        self.assertEqual(run_command.call_count, 1)
+        self.assertEqual(run_command.call_args_list[0][0][0], [
+            '/sbin/iptables',
+            '-t',
+            'filter',
+            '-C',
+            'INPUT',
+            '-j',
+            'NFQUEUE',
+            '--queue-num',
+            '0',
+            '--queue-bypass',
+        ])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #72189

There are various extensions that can be used with iptables which have specific flags and options that are not explicitly mentioned in the main iptables CLI.

This patch adds support to the iptables module for supplying arbitrary additional arguments, for example to generate rules such as:

```
iptables -A FORWARD -j NFQUEUE --queue-num 0 --queue-bypass
```

This example rule is pretty common, but it's not currently possible to add/remove/manage it with the iptables module, as `--queue-num 0 --queue-bypass` is not supported.

There are lots of other extensions with too many options to list (for example: #68985), so I've implemented a generic solution that covers a broad range of potential use-cases.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
iptables

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Example usage:
```
- iptables:
    chain: FORWARD
    action: append
    jump: NFQUEUE
    extra_args: "--queue-num 0 --queue-bypass"
  become: yes
```
or:
```
- iptables:
    chain: FORWARD
    action: append
    jump: NFQUEUE
    extra_args:
      - "--queue-num 0"
      - "--queue-bypass"
  become: yes
```
will both create: 
```
iptables -A FORWARD -j NFQUEUE --queue-num 0 --queue-bypass
```