### PR TITLE
Backport: ovirt_disk don't move disk when already in storage domain

### DIFF
--- a/changelogs/fragments/72194-ovirt_disk-ignore-move-when-in-sd.yml
+++ b/changelogs/fragments/72194-ovirt_disk-ignore-move-when-in-sd.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - ovirt_disk - dont move disk when already in storage_domain (https://github.com/oVirt/ovirt-ansible-collection/pull/135)
+  - ovirt_disk - don't move disk when already in storage_domain (https://github.com/oVirt/ovirt-ansible-collection/pull/135).

--- a/changelogs/fragments/72194-ovirt_disk-ignore-move-when-in-sd.yml
+++ b/changelogs/fragments/72194-ovirt_disk-ignore-move-when-in-sd.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - ovirt_disk - dont move disk when already in storage_domain (https://github.com/oVirt/ovirt-ansible-collection/pull/135)
+

--- a/changelogs/fragments/72194-ovirt_disk-ignore-move-when-in-sd.yml
+++ b/changelogs/fragments/72194-ovirt_disk-ignore-move-when-in-sd.yml
@@ -1,4 +1,3 @@
 ---
 bugfixes:
   - ovirt_disk - dont move disk when already in storage_domain (https://github.com/oVirt/ovirt-ansible-collection/pull/135)
-

--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -562,6 +562,8 @@ class DisksModule(BaseModule):
         # Initiate move:
         if self._module.params['storage_domain']:
             new_disk_storage_id = get_id_by_name(sds_service, self._module.params['storage_domain'])
+            if new_disk_storage_id in [sd.id for sd in disk.storage_domains]:
+                return changed
             changed = self.action(
                 action='move',
                 entity=disk,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of https://github.com/oVirt/ovirt-ansible-collection/pull/135
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ovirt
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
