### PR TITLE
Update ansible-runner tests version and deps

### DIFF
--- a/changelogs/fragments/72197-upgrade-test-ansible-runner.yml
+++ b/changelogs/fragments/72197-upgrade-test-ansible-runner.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- ansible-test - Upgrade ansible-runner version used in compatibility tests,
+  remove some tasks that were only needed with older versions, and
+  skip in python2 because ansible-runner is soon dropping it.

--- a/test/integration/targets/ansible-runner/aliases
+++ b/test/integration/targets/ansible-runner/aliases
@@ -1,5 +1,5 @@
 shippable/posix/group3
-skip/python3
+skip/python2  # ansible-runner is for controller and deprecated python2 support
 skip/aix
 skip/osx
 skip/macos

--- a/test/integration/targets/ansible-runner/tasks/adhoc_example1.yml
+++ b/test/integration/targets/ansible-runner/tasks/adhoc_example1.yml
@@ -1,7 +1,5 @@
 - name: execute the script
   command: "'{{ ansible_python_interpreter }}' '{{ role_path }}/files/adhoc_example1.py' '{{ lookup('env', 'OUTPUT_DIR') }}'"
-  environment:
-    AWX_LIB_DIRECTORY: "{{ callback_path }}"
   register: script
 
 - name: parse script output

--- a/test/integration/targets/ansible-runner/tasks/playbook_example1.yml
+++ b/test/integration/targets/ansible-runner/tasks/playbook_example1.yml
@@ -1,7 +1,5 @@
 - name: execute the script
   command: "'{{ ansible_python_interpreter }}' '{{ role_path }}/files/playbook_example1.py' '{{ lookup('env', 'OUTPUT_DIR') }}'"
-  environment:
-    AWX_LIB_DIRECTORY: "{{ callback_path }}"
   register: script
 
 - name: parse script output

--- a/test/integration/targets/ansible-runner/tasks/setup.yml
+++ b/test/integration/targets/ansible-runner/tasks/setup.yml
@@ -1,19 +1,6 @@
-- name: Install docutils
-  pip:
-    name: docutils
-
 - name: Install ansible-runner
   pip:
     name: ansible-runner
-    version: 1.2.0
+    version: 1.4.6
     extra_args:
       -c {{ role_path }}/files/constraints.txt
-
-- name: Find location of ansible-runner installation
-  command: "'{{ ansible_python_interpreter }}' -c 'import os, ansible_runner; print(os.path.dirname(ansible_runner.__file__))'"
-  register: ansible_runner_path
-
-# work around for https://github.com/ansible/ansible-runner/issues/132
-- name: Set callback path to work around ansible-runner bug
-  set_fact:
-    callback_path: ":{{ ansible_runner_path.stdout }}/callbacks"


### PR DESCRIPTION
##### SUMMARY
Refresh of https://github.com/ansible/ansible/pull/68923

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/integration/targets/ansible-runner

##### ADDITIONAL INFORMATION
If this test is running with python 2, then it's not getting fixed, and I would appreciate help figuring out how to skip it in that case.

If this is still producing an error in python 3, then we want information about how to replicate so it can be fixed properly in ansible-runner.

What it's currently doing about setting the callback location violates the point of ansible-runner, and we should get rid of it.

Ping @kdelee 
