### PR TITLE
[virt facts] recognize containerd as a container

### DIFF
--- a/changelogs/fragments/66304-facts_containerd.yml
+++ b/changelogs/fragments/66304-facts_containerd.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - virtual facts - containerd cgroup is now recognized as container tech (https://github.com/ansible/ansible/issues/66304).

--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -61,6 +61,12 @@ class LinuxVirtual(Virtual):
                         virtual_facts['virtualization_type'] = 'lxc'
                         virtual_facts['virtualization_role'] = 'guest'
                         found_virt = True
+                if re.search('/system.slice/containerd.service', line):
+                    guest_tech.add('containerd')
+                    if not found_virt:
+                        virtual_facts['virtualization_type'] = 'containerd'
+                        virtual_facts['virtualization_role'] = 'guest'
+                        found_virt = True
 
         # lxc does not always appear in cgroups anymore but sets 'container=lxc' environment var, requires root privs
         if os.path.exists('/proc/1/environ'):
@@ -105,7 +111,7 @@ class LinuxVirtual(Virtual):
                 found_virt = True
 
         # ensure 'container' guest_tech is appropriately set
-        if guest_tech.intersection(set(['docker', 'lxc', 'podman', 'openvz'])) or systemd_container:
+        if guest_tech.intersection(set(['docker', 'lxc', 'podman', 'openvz', 'containerd'])) or systemd_container:
             guest_tech.add('container')
 
         if os.path.exists("/proc/xen"):


### PR DESCRIPTION

##### SUMMARY

Change:
- containerd is now recognized as container tech

Test Plan:
- N/A :(

Tickets:
- Fixes #66304 because this is what docker containers show up as
  in Github Actions.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

virt facts