### PR TITLE
Document security concern for users setting the system_tmpdirs shell …

### DIFF
--- a/lib/ansible/plugins/doc_fragments/shell_common.py
+++ b/lib/ansible/plugins/doc_fragments/shell_common.py
@@ -34,9 +34,11 @@ options:
     version_added: "2.10"
   system_tmpdirs:
     description:
-       - "List of valid system temporary directories for Ansible to choose when it cannot use
-         ``remote_tmp``, normally due to permission issues.  These must be world readable, writable,
-         and executable."
+       - "List of valid system temporary directories on the managed machine for Ansible to choose
+         when it cannot use ``remote_tmp``, normally due to permission issues.  These must be world
+         readable, writable, and executable. This list should only contain directories which the
+         system administrator has pre-created with the proper ownership and permissions otherwise
+         security issues can arise."
     default: [ /var/tmp, /tmp ]
     type: list
     env: [{name: ANSIBLE_SYSTEM_TMPDIRS}]


### PR DESCRIPTION
…plugin config

system_tmpdirs is only meant for systems which officially store their
temporary files in someplace other than /tmp or /var/tmp.  Those
types of directories should have been pre-created by the system
administrator (usually by the operating system's setup). There is a
security risk if the user puts a directory that has not been pre-created
into this list so be sure to document not to do that.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION

/cc @jborean93 @samdoran for technical review

This should likely get backported as well as setting this to a directory which the sysadmin has not created will open the security issue in all supported versions.