### PR TITLE
Fix ansible-test Azure Pipelines container auth.

### DIFF
--- a/changelogs/fragments/ansible-test-azp-agent-temp-dir.yml
+++ b/changelogs/fragments/ansible-test-azp-agent-temp-dir.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Using the ``--remote`` option on Azure Pipelines now works from a job running in a container.

--- a/test/lib/ansible_test/_internal/ci/azp.py
+++ b/test/lib/ansible_test/_internal/ci/azp.py
@@ -151,8 +151,14 @@ class AzurePipelinesAuthHelper(CryptographyAuthHelper):
     """
     def publish_public_key(self, public_key_pem):  # type: (str) -> None
         """Publish the given public key."""
+        try:
+            agent_temp_directory = os.environ['AGENT_TEMPDIRECTORY']
+        except KeyError as ex:
+            raise MissingEnvironmentVariable(name=ex.args[0])
+
         # the temporary file cannot be deleted because we do not know when the agent has processed it
-        with tempfile.NamedTemporaryFile(prefix='public-key-', suffix='.pem', delete=False) as public_key_file:
+        # placing the file in the agent's temp directory allows it to be picked up when the job is running in a container
+        with tempfile.NamedTemporaryFile(prefix='public-key-', suffix='.pem', delete=False, dir=agent_temp_directory) as public_key_file:
             public_key_file.write(to_bytes(public_key_pem))
             public_key_file.flush()
 


### PR DESCRIPTION
##### SUMMARY

Using the `--remote` option on Azure Pipelines now works from a job running in a container.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
