### PR TITLE
Make sure that none is not accepted for required module options

### DIFF
--- a/changelogs/fragments/argspec-required-mutually_exclusive.yml
+++ b/changelogs/fragments/argspec-required-mutually_exclusive.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- For Python modules, a value of ``none`` counts as not specified for ``required``, ``required_if``, ``required_together``, ``required_one_of``, ``mutually_exclusive`` checks.
+  This was already the case for ``required_by`` checks.

--- a/lib/ansible/module_utils/common/validation.py
+++ b/lib/ansible/module_utils/common/validation.py
@@ -30,13 +30,13 @@ def count_terms(terms, module_parameters):
     :arg module_parameters: Dictionary of module parameters
 
     :returns: An integer that is the number of occurrences of the terms values
-        in the provided dictionary.
+        in the provided dictionary that are not None.
     """
 
     if not is_iterable(terms):
         terms = [terms]
 
-    return len(set(terms).intersection(module_parameters))
+    return sum(1 for term in terms if module_parameters.get(term) is not None)
 
 
 def check_mutually_exclusive(terms, module_parameters):
@@ -185,7 +185,7 @@ def check_required_arguments(argument_spec, module_parameters):
 
     for (k, v) in argument_spec.items():
         required = v.get('required', False)
-        if required and k not in module_parameters:
+        if required and module_parameters.get(k) is None:
             missing.append(k)
 
     if missing:

--- a/test/integration/targets/apt_repository/tasks/apt.yml
+++ b/test/integration/targets/apt_repository/tasks/apt.yml
@@ -224,7 +224,7 @@
 - assert:
     that:
       - result is failed
-      - result.msg == 'Please set argument \'repo\' to a non-empty value'
+      - result.msg == 'missing required arguments: repo'
 
 - name: Test apt_repository with an empty value for repo
   apt_repository:

--- a/test/integration/targets/argspec/library/argspec.py
+++ b/test/integration/targets/argspec/library/argspec.py
@@ -16,6 +16,9 @@ def main():
             },
             'required_one_of_one': {},
             'required_one_of_two': {},
+            'required_by_one': {},
+            'required_by_two': {},
+            'required_by_three': {},
             'state': {
                 'type': 'str',
                 'choices': ['absent', 'present'],
@@ -27,6 +30,15 @@ def main():
             },
             'required_one_of': {
                 'required_one_of': [['thing', 'other']],
+                'type': 'list',
+                'elements': 'dict',
+                'options': {
+                    'thing': {},
+                    'other': {},
+                },
+            },
+            'required_by': {
+                'required_by': {'thing': 'other'},
                 'type': 'list',
                 'elements': 'dict',
                 'options': {
@@ -89,6 +101,9 @@ def main():
         required_one_of=(
             ('required_one_of_one', 'required_one_of_two'),
         ),
+        required_by={
+            'required_by_one': ('required_by_two', 'required_by_three'),
+        },
         required_together=(
             ('required_together_one', 'required_together_two'),
         ),

--- a/test/integration/targets/argspec/library/argspec.py
+++ b/test/integration/targets/argspec/library/argspec.py
@@ -14,6 +14,8 @@ def main():
             'required': {
                 'required': True,
             },
+            'required_one_of_one': {},
+            'required_one_of_two': {},
             'state': {
                 'type': 'str',
                 'choices': ['absent', 'present'],
@@ -22,6 +24,15 @@ def main():
             'content': {},
             'mapping': {
                 'type': 'dict',
+            },
+            'required_one_of': {
+                'required_one_of': [['thing', 'other']],
+                'type': 'list',
+                'elements': 'dict',
+                'options': {
+                    'thing': {},
+                    'other': {},
+                },
             },
             'required_together': {
                 'required_together': [['thing', 'other']],
@@ -74,6 +85,9 @@ def main():
         ),
         mutually_exclusive=(
             ('path', 'content'),
+        ),
+        required_one_of=(
+            ('required_one_of_one', 'required_one_of_two'),
         ),
         required_together=(
             ('required_together_one', 'required_together_two'),

--- a/test/integration/targets/argspec/library/argspec.py
+++ b/test/integration/targets/argspec/library/argspec.py
@@ -11,6 +11,9 @@ from ansible.module_utils.basic import AnsibleModule
 def main():
     module = AnsibleModule(
         {
+            'required': {
+                'required': True,
+            },
             'state': {
                 'type': 'str',
                 'choices': ['absent', 'present'],

--- a/test/integration/targets/argspec/tasks/main.yml
+++ b/test/integration/targets/argspec/tasks/main.yml
@@ -1,46 +1,63 @@
 - argspec:
+    required: value
+
+- argspec:
+  register: argspec_required_fail
+  ignore_errors: true
+
+- argspec:
     state: absent
+    required: value
 
 - argspec:
     state: present
+    required: value
   register: argspec_required_if_fail
   ignore_errors: true
 
 - argspec:
     state: present
     path: foo
+    required: value
 
 - argspec:
     state: present
     content: foo
+    required: value
 
 - argspec:
     state: present
     content: foo
     path: foo
+    required: value
   register: argspec_mutually_exclusive_fail
   ignore_errors: true
 
 - argspec:
     mapping:
       foo: bar
+    required: value
   register: argspec_good_mapping
 
 - argspec:
     mapping: foo=bar
+    required: value
   register: argspec_good_mapping_kv
 
 - argspec:
     mapping: !!str '{"foo": "bar"}'
+    required: value
   register: argspec_good_mapping_json
 
 - argspec:
     mapping: foo
+    required: value
   register: argspec_bad_mapping_string
   ignore_errors: true
 
 - argspec:
     mapping: 1
+    required: value
   register: argspec_bad_mapping_int
   ignore_errors: true
 
@@ -48,6 +65,7 @@
     mapping:
       - foo
       - bar
+    required: value
   register: argspec_bad_mapping_list
   ignore_errors: true
 
@@ -56,14 +74,17 @@
       - thing: foo
         other: bar
         another: baz
+    required: value
 
 - argspec:
     required_together:
       - another: baz
+    required: value
 
 - argspec:
     required_together:
       - thing: foo
+    required: value
   register: argspec_required_together_fail
   ignore_errors: true
 
@@ -71,33 +92,40 @@
     required_together:
       - thing: foo
         other: bar
+    required: value
 
 - argspec:
     required_if:
       - thing: bar
+    required: value
 
 - argspec:
     required_if:
       - thing: foo
         other: bar
+    required: value
 
 - argspec:
     required_if:
       - thing: foo
+    required: value
   register: argspec_required_if_fail_2
   ignore_errors: true
 
 - argspec:
     json: !!str '{"foo": "bar"}'
+    required: value
   register: argspec_good_json_string
 
 - argspec:
     json:
       foo: bar
+    required: value
   register: argspec_good_json_dict
 
 - argspec:
     json: 1
+    required: value
   register: argspec_bad_json
   ignore_errors: true
 
@@ -105,41 +133,51 @@
     fail_on_missing_params:
       - needed_param
     needed_param: whatever
+    required: value
 
 - argspec:
     fail_on_missing_params:
       - needed_param
+    required: value
   register: argspec_fail_on_missing_params_bad
   ignore_errors: true
 
 - argspec:
     required_together_one: foo
     required_together_two: bar
+    required: value
 
 - argspec:
     required_together_one: foo
+    required: value
   register: argspec_fail_required_together_2
   ignore_errors: true
 
 - argspec:
     suboptions_list_no_elements:
       - thing: foo
+    required: value
   register: argspec_suboptions_list_no_elements
 
 - argspec:
     choices_with_strings_like_bools: on
+    required: value
   register: argspec_choices_with_strings_like_bools_true
 
 - argspec:
     choices_with_strings_like_bools: 'on'
+    required: value
   register: argspec_choices_with_strings_like_bools_true_bool
 
 - argspec:
     choices_with_strings_like_bools: off
+    required: value
   register: argspec_choices_with_strings_like_bools_false
 
 - assert:
     that:
+      - argspec_required_fail is failed
+
       - argspec_required_if_fail is failed
 
       - argspec_mutually_exclusive_fail is failed

--- a/test/integration/targets/argspec/tasks/main.yml
+++ b/test/integration/targets/argspec/tasks/main.yml
@@ -84,7 +84,7 @@
 - argspec:
     required_if:
       - thing: foo
-  register: argpsec_required_if_fail
+  register: argspec_required_if_fail_2
   ignore_errors: true
 
 - argspec:
@@ -118,7 +118,7 @@
 
 - argspec:
     required_together_one: foo
-  register: argspec_fail_required_together
+  register: argspec_fail_required_together_2
   ignore_errors: true
 
 - argspec:
@@ -159,7 +159,7 @@
 
       - argspec_required_together_fail is failed
 
-      - argpsec_required_if_fail is failed
+      - argspec_required_if_fail_2 is failed
 
       - argspec_good_json_string is successful
       - >-
@@ -171,7 +171,7 @@
 
       - argspec_fail_on_missing_params_bad is failed
 
-      - argspec_fail_required_together is failed
+      - argspec_fail_required_together_2 is failed
 
       - >-
         argspec_suboptions_list_no_elements.suboptions_list_no_elements.0 == {'thing': 'foo'}

--- a/test/integration/targets/argspec/tasks/main.yml
+++ b/test/integration/targets/argspec/tasks/main.yml
@@ -8,12 +8,24 @@
   ignore_errors: true
 
 - argspec:
+    required:
+    required_one_of_one: value
+  register: argspec_required_fail_none
+  ignore_errors: true
+
+- argspec:
     required: value
     required_one_of_two: value
 
 - argspec:
     required: value
   register: argspec_required_one_of_fail
+  ignore_errors: true
+
+- argspec:
+    required: value
+    required_one_of_one:
+  register: argspec_required_one_of_fail_none
   ignore_errors: true
 
 - argspec:
@@ -32,6 +44,15 @@
   ignore_errors: true
 
 - argspec:
+    required: value
+    required_one_of_two: value
+    required_by_one: value
+    required_by_two:
+    required_by_three: value
+  register: argspec_required_by_fail_none
+  ignore_errors: true
+
+- argspec:
     state: absent
     required: value
     required_one_of_one: value
@@ -45,6 +66,14 @@
 
 - argspec:
     state: present
+    path:
+    required: value
+    required_one_of_one: value
+  register: argspec_required_if_fail_none
+  ignore_errors: true
+
+- argspec:
+    state: present
     path: foo
     required: value
     required_one_of_one: value
@@ -52,6 +81,13 @@
 - argspec:
     state: present
     content: foo
+    required: value
+    required_one_of_one: value
+
+- argspec:
+    state: present
+    content: foo
+    path:
     required: value
     required_one_of_one: value
 
@@ -131,6 +167,15 @@
 - argspec:
     required_together:
       - thing: foo
+        other:
+    required: value
+    required_one_of_one: value
+  register: argspec_required_together_fail_none
+  ignore_errors: true
+
+- argspec:
+    required_together:
+      - thing: foo
         other: bar
     required: value
     required_one_of_one: value
@@ -157,6 +202,15 @@
   ignore_errors: true
 
 - argspec:
+    required_if:
+      - thing: foo
+        other:
+    required: value
+    required_one_of_one: value
+  register: argspec_required_if_fail_2_none
+  ignore_errors: true
+
+- argspec:
     required_one_of:
       - thing: foo
         other: bar
@@ -172,6 +226,14 @@
   ignore_errors: true
 
 - argspec:
+    required_one_of:
+      - thing:
+    required: value
+    required_one_of_one: value
+  register: argspec_required_one_of_fail_2_none
+  ignore_errors: true
+
+- argspec:
     required_by:
       - thing: foo
         other: bar
@@ -184,6 +246,15 @@
     required: value
     required_one_of_one: value
   register: argspec_required_by_fail_2
+  ignore_errors: true
+
+- argspec:
+    required_by:
+      - thing: foo
+        other:
+    required: value
+    required_one_of_one: value
+  register: argspec_required_by_fail_2_none
   ignore_errors: true
 
 - argspec:
@@ -235,6 +306,14 @@
   ignore_errors: true
 
 - argspec:
+    required_together_one: foo
+    required_together_two:
+    required: value
+    required_one_of_one: value
+  register: argspec_fail_required_together_2_none
+  ignore_errors: true
+
+- argspec:
     suboptions_list_no_elements:
       - thing: foo
     required: value
@@ -262,12 +341,16 @@
 - assert:
     that:
       - argspec_required_fail is failed
+      - argspec_required_fail_none is failed
 
       - argspec_required_one_of_fail is failed
+      - argspec_required_one_of_fail_none is failed
 
       - argspec_required_by_fail is failed
+      - argspec_required_by_fail_none is failed
 
       - argspec_required_if_fail is failed
+      - argspec_required_if_fail_none is failed
 
       - argspec_mutually_exclusive_fail is failed
 
@@ -285,12 +368,16 @@
       - argspec_bad_mapping_list is failed
 
       - argspec_required_together_fail is failed
+      - argspec_required_together_fail_none is failed
 
       - argspec_required_if_fail_2 is failed
+      - argspec_required_if_fail_2_none is failed
 
       - argspec_required_one_of_fail_2 is failed
+      - argspec_required_one_of_fail_2_none is failed
 
       - argspec_required_by_fail_2 is failed
+      - argspec_required_by_fail_2_none is failed
 
       - argspec_good_json_string is successful
       - >-
@@ -303,6 +390,7 @@
       - argspec_fail_on_missing_params_bad is failed
 
       - argspec_fail_required_together_2 is failed
+      - argspec_fail_required_together_2_none is failed
 
       - >-
         argspec_suboptions_list_no_elements.suboptions_list_no_elements.0 == {'thing': 'foo'}

--- a/test/integration/targets/argspec/tasks/main.yml
+++ b/test/integration/targets/argspec/tasks/main.yml
@@ -17,6 +17,21 @@
   ignore_errors: true
 
 - argspec:
+    required: value
+    required_one_of_two: value
+    required_by_one: value
+    required_by_two: value
+    required_by_three: value
+
+- argspec:
+    required: value
+    required_one_of_two: value
+    required_by_one: value
+    required_by_two: value
+  register: argspec_required_by_fail
+  ignore_errors: true
+
+- argspec:
     state: absent
     required: value
     required_one_of_one: value
@@ -157,6 +172,21 @@
   ignore_errors: true
 
 - argspec:
+    required_by:
+      - thing: foo
+        other: bar
+    required: value
+    required_one_of_one: value
+
+- argspec:
+    required_by:
+      - thing: foo
+    required: value
+    required_one_of_one: value
+  register: argspec_required_by_fail_2
+  ignore_errors: true
+
+- argspec:
     json: !!str '{"foo": "bar"}'
     required: value
     required_one_of_one: value
@@ -235,6 +265,8 @@
 
       - argspec_required_one_of_fail is failed
 
+      - argspec_required_by_fail is failed
+
       - argspec_required_if_fail is failed
 
       - argspec_mutually_exclusive_fail is failed
@@ -257,6 +289,8 @@
       - argspec_required_if_fail_2 is failed
 
       - argspec_required_one_of_fail_2 is failed
+
+      - argspec_required_by_fail_2 is failed
 
       - argspec_good_json_string is successful
       - >-

--- a/test/integration/targets/argspec/tasks/main.yml
+++ b/test/integration/targets/argspec/tasks/main.yml
@@ -1,17 +1,30 @@
 - argspec:
     required: value
+    required_one_of_one: value
 
 - argspec:
+    required_one_of_one: value
   register: argspec_required_fail
+  ignore_errors: true
+
+- argspec:
+    required: value
+    required_one_of_two: value
+
+- argspec:
+    required: value
+  register: argspec_required_one_of_fail
   ignore_errors: true
 
 - argspec:
     state: absent
     required: value
+    required_one_of_one: value
 
 - argspec:
     state: present
     required: value
+    required_one_of_one: value
   register: argspec_required_if_fail
   ignore_errors: true
 
@@ -19,17 +32,20 @@
     state: present
     path: foo
     required: value
+    required_one_of_one: value
 
 - argspec:
     state: present
     content: foo
     required: value
+    required_one_of_one: value
 
 - argspec:
     state: present
     content: foo
     path: foo
     required: value
+    required_one_of_one: value
   register: argspec_mutually_exclusive_fail
   ignore_errors: true
 
@@ -37,27 +53,32 @@
     mapping:
       foo: bar
     required: value
+    required_one_of_one: value
   register: argspec_good_mapping
 
 - argspec:
     mapping: foo=bar
     required: value
+    required_one_of_one: value
   register: argspec_good_mapping_kv
 
 - argspec:
     mapping: !!str '{"foo": "bar"}'
     required: value
+    required_one_of_one: value
   register: argspec_good_mapping_json
 
 - argspec:
     mapping: foo
     required: value
+    required_one_of_one: value
   register: argspec_bad_mapping_string
   ignore_errors: true
 
 - argspec:
     mapping: 1
     required: value
+    required_one_of_one: value
   register: argspec_bad_mapping_int
   ignore_errors: true
 
@@ -66,6 +87,7 @@
       - foo
       - bar
     required: value
+    required_one_of_one: value
   register: argspec_bad_mapping_list
   ignore_errors: true
 
@@ -75,16 +97,19 @@
         other: bar
         another: baz
     required: value
+    required_one_of_one: value
 
 - argspec:
     required_together:
       - another: baz
     required: value
+    required_one_of_one: value
 
 - argspec:
     required_together:
       - thing: foo
     required: value
+    required_one_of_one: value
   register: argspec_required_together_fail
   ignore_errors: true
 
@@ -93,39 +118,61 @@
       - thing: foo
         other: bar
     required: value
+    required_one_of_one: value
 
 - argspec:
     required_if:
       - thing: bar
     required: value
+    required_one_of_one: value
 
 - argspec:
     required_if:
       - thing: foo
         other: bar
     required: value
+    required_one_of_one: value
 
 - argspec:
     required_if:
       - thing: foo
     required: value
+    required_one_of_one: value
   register: argspec_required_if_fail_2
+  ignore_errors: true
+
+- argspec:
+    required_one_of:
+      - thing: foo
+        other: bar
+    required: value
+    required_one_of_one: value
+
+- argspec:
+    required_one_of:
+      - {}
+    required: value
+    required_one_of_one: value
+  register: argspec_required_one_of_fail_2
   ignore_errors: true
 
 - argspec:
     json: !!str '{"foo": "bar"}'
     required: value
+    required_one_of_one: value
   register: argspec_good_json_string
 
 - argspec:
     json:
       foo: bar
     required: value
+    required_one_of_one: value
   register: argspec_good_json_dict
 
 - argspec:
     json: 1
     required: value
+    required_one_of_one: value
   register: argspec_bad_json
   ignore_errors: true
 
@@ -134,11 +181,13 @@
       - needed_param
     needed_param: whatever
     required: value
+    required_one_of_one: value
 
 - argspec:
     fail_on_missing_params:
       - needed_param
     required: value
+    required_one_of_one: value
   register: argspec_fail_on_missing_params_bad
   ignore_errors: true
 
@@ -146,10 +195,12 @@
     required_together_one: foo
     required_together_two: bar
     required: value
+    required_one_of_one: value
 
 - argspec:
     required_together_one: foo
     required: value
+    required_one_of_one: value
   register: argspec_fail_required_together_2
   ignore_errors: true
 
@@ -157,26 +208,32 @@
     suboptions_list_no_elements:
       - thing: foo
     required: value
+    required_one_of_one: value
   register: argspec_suboptions_list_no_elements
 
 - argspec:
     choices_with_strings_like_bools: on
     required: value
+    required_one_of_one: value
   register: argspec_choices_with_strings_like_bools_true
 
 - argspec:
     choices_with_strings_like_bools: 'on'
     required: value
+    required_one_of_one: value
   register: argspec_choices_with_strings_like_bools_true_bool
 
 - argspec:
     choices_with_strings_like_bools: off
     required: value
+    required_one_of_one: value
   register: argspec_choices_with_strings_like_bools_false
 
 - assert:
     that:
       - argspec_required_fail is failed
+
+      - argspec_required_one_of_fail is failed
 
       - argspec_required_if_fail is failed
 
@@ -198,6 +255,8 @@
       - argspec_required_together_fail is failed
 
       - argspec_required_if_fail_2 is failed
+
+      - argspec_required_one_of_fail_2 is failed
 
       - argspec_good_json_string is successful
       - >-

--- a/test/integration/targets/incidental_sts_assume_role/tasks/main.yml
+++ b/test/integration/targets/incidental_sts_assume_role/tasks/main.yml
@@ -79,7 +79,7 @@
       assert:
         that:
            - 'result.failed'
-           - "'Missing required parameter in input:' in result.msg"
+           - "'missing required arguments: role_arn, role_session_name' in result.msg"
       when: result.module_stderr is not defined
 
     - name: assert with empty parameters

--- a/test/integration/targets/incidental_vyos_lldp_interfaces/tests/cli/empty_config.yaml
+++ b/test/integration/targets/incidental_vyos_lldp_interfaces/tests/cli/empty_config.yaml
@@ -11,7 +11,7 @@
 
 - assert:
     that:
-      - result.msg == 'value of config parameter must not be empty for state merged'
+      - result.msg == 'state is merged but all of the following are missing: config'
 
 - name: Replaced with empty config should give appropriate error message
   vyos.vyos.vyos_lldp_interfaces:
@@ -22,7 +22,7 @@
 
 - assert:
     that:
-      - result.msg == 'value of config parameter must not be empty for state replaced'
+      - result.msg == 'state is replaced but all of the following are missing: config'
 
 - name: Overridden with empty config should give appropriate error message
   vyos.vyos.vyos_lldp_interfaces:
@@ -33,4 +33,4 @@
 
 - assert:
     that:
-      - result.msg == 'value of config parameter must not be empty for state overridden'
+      - result.msg == 'state is overridden but all of the following are missing: config'

--- a/test/units/module_utils/common/validation/test_check_mutually_exclusive.py
+++ b/test/units/module_utils/common/validation/test_check_mutually_exclusive.py
@@ -52,6 +52,6 @@ def test_check_mutually_exclusive_none():
 
 
 def test_check_mutually_exclusive_no_params(mutually_exclusive_terms):
-    with pytest.raises(TypeError) as te:
+    with pytest.raises(AttributeError) as te:
         check_mutually_exclusive(mutually_exclusive_terms, None)
-    assert "'NoneType' object is not iterable" in to_native(te.value)
+    assert "'NoneType' object has no attribute 'get'" in to_native(te.value)

--- a/test/units/module_utils/common/validation/test_check_required_arguments.py
+++ b/test/units/module_utils/common/validation/test_check_required_arguments.py
@@ -83,6 +83,6 @@ def test_check_required_arguments_missing_none():
 
 
 def test_check_required_arguments_no_params(arguments_terms):
-    with pytest.raises(TypeError) as te:
+    with pytest.raises(AttributeError) as te:
         check_required_arguments(arguments_terms, None)
-    assert "'NoneType' is not iterable" in to_native(te.value)
+    assert "'NoneType' object has no attribute 'get'" in to_native(te.value)

--- a/test/units/module_utils/common/validation/test_check_required_together.py
+++ b/test/units/module_utils/common/validation/test_check_required_together.py
@@ -51,7 +51,7 @@ def test_check_required_together_missing_none():
 
 
 def test_check_required_together_no_params(together_terms):
-    with pytest.raises(TypeError) as te:
+    with pytest.raises(AttributeError) as te:
         check_required_together(together_terms, None)
 
-    assert "'NoneType' object is not iterable" in to_native(te.value)
+    assert "'NoneType' object has no attribute 'get'" in to_native(te.value)


### PR DESCRIPTION
##### SUMMARY
If a value that is required (by required, required_if, required_together, required_one_of, or mutually_exclusive) is specified as `none`/`null`/`~`/empty, it is no longer accepted.

Fixes #69190.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/common/validation.py
