### PR TITLE
Adds argspec tests for required, required_one_of and required_by

### DIFF
--- a/test/integration/targets/argspec/library/argspec.py
+++ b/test/integration/targets/argspec/library/argspec.py
@@ -16,6 +16,9 @@ def main():
             },
             'required_one_of_one': {},
             'required_one_of_two': {},
+            'required_by_one': {},
+            'required_by_two': {},
+            'required_by_three': {},
             'state': {
                 'type': 'str',
                 'choices': ['absent', 'present'],
@@ -27,6 +30,15 @@ def main():
             },
             'required_one_of': {
                 'required_one_of': [['thing', 'other']],
+                'type': 'list',
+                'elements': 'dict',
+                'options': {
+                    'thing': {},
+                    'other': {},
+                },
+            },
+            'required_by': {
+                'required_by': {'thing': 'other'},
                 'type': 'list',
                 'elements': 'dict',
                 'options': {
@@ -89,6 +101,9 @@ def main():
         required_one_of=(
             ('required_one_of_one', 'required_one_of_two'),
         ),
+        required_by={
+            'required_by_one': ('required_by_two', 'required_by_three'),
+        },
         required_together=(
             ('required_together_one', 'required_together_two'),
         ),

--- a/test/integration/targets/argspec/library/argspec.py
+++ b/test/integration/targets/argspec/library/argspec.py
@@ -14,6 +14,8 @@ def main():
             'required': {
                 'required': True,
             },
+            'required_one_of_one': {},
+            'required_one_of_two': {},
             'state': {
                 'type': 'str',
                 'choices': ['absent', 'present'],
@@ -22,6 +24,15 @@ def main():
             'content': {},
             'mapping': {
                 'type': 'dict',
+            },
+            'required_one_of': {
+                'required_one_of': [['thing', 'other']],
+                'type': 'list',
+                'elements': 'dict',
+                'options': {
+                    'thing': {},
+                    'other': {},
+                },
             },
             'required_together': {
                 'required_together': [['thing', 'other']],
@@ -74,6 +85,9 @@ def main():
         ),
         mutually_exclusive=(
             ('path', 'content'),
+        ),
+        required_one_of=(
+            ('required_one_of_one', 'required_one_of_two'),
         ),
         required_together=(
             ('required_together_one', 'required_together_two'),

--- a/test/integration/targets/argspec/library/argspec.py
+++ b/test/integration/targets/argspec/library/argspec.py
@@ -11,6 +11,9 @@ from ansible.module_utils.basic import AnsibleModule
 def main():
     module = AnsibleModule(
         {
+            'required': {
+                'required': True,
+            },
             'state': {
                 'type': 'str',
                 'choices': ['absent', 'present'],

--- a/test/integration/targets/argspec/tasks/main.yml
+++ b/test/integration/targets/argspec/tasks/main.yml
@@ -1,46 +1,63 @@
 - argspec:
+    required: value
+
+- argspec:
+  register: argspec_required_fail
+  ignore_errors: true
+
+- argspec:
     state: absent
+    required: value
 
 - argspec:
     state: present
+    required: value
   register: argspec_required_if_fail
   ignore_errors: true
 
 - argspec:
     state: present
     path: foo
+    required: value
 
 - argspec:
     state: present
     content: foo
+    required: value
 
 - argspec:
     state: present
     content: foo
     path: foo
+    required: value
   register: argspec_mutually_exclusive_fail
   ignore_errors: true
 
 - argspec:
     mapping:
       foo: bar
+    required: value
   register: argspec_good_mapping
 
 - argspec:
     mapping: foo=bar
+    required: value
   register: argspec_good_mapping_kv
 
 - argspec:
     mapping: !!str '{"foo": "bar"}'
+    required: value
   register: argspec_good_mapping_json
 
 - argspec:
     mapping: foo
+    required: value
   register: argspec_bad_mapping_string
   ignore_errors: true
 
 - argspec:
     mapping: 1
+    required: value
   register: argspec_bad_mapping_int
   ignore_errors: true
 
@@ -48,6 +65,7 @@
     mapping:
       - foo
       - bar
+    required: value
   register: argspec_bad_mapping_list
   ignore_errors: true
 
@@ -56,14 +74,17 @@
       - thing: foo
         other: bar
         another: baz
+    required: value
 
 - argspec:
     required_together:
       - another: baz
+    required: value
 
 - argspec:
     required_together:
       - thing: foo
+    required: value
   register: argspec_required_together_fail
   ignore_errors: true
 
@@ -71,33 +92,40 @@
     required_together:
       - thing: foo
         other: bar
+    required: value
 
 - argspec:
     required_if:
       - thing: bar
+    required: value
 
 - argspec:
     required_if:
       - thing: foo
         other: bar
+    required: value
 
 - argspec:
     required_if:
       - thing: foo
+    required: value
   register: argspec_required_if_fail_2
   ignore_errors: true
 
 - argspec:
     json: !!str '{"foo": "bar"}'
+    required: value
   register: argspec_good_json_string
 
 - argspec:
     json:
       foo: bar
+    required: value
   register: argspec_good_json_dict
 
 - argspec:
     json: 1
+    required: value
   register: argspec_bad_json
   ignore_errors: true
 
@@ -105,41 +133,51 @@
     fail_on_missing_params:
       - needed_param
     needed_param: whatever
+    required: value
 
 - argspec:
     fail_on_missing_params:
       - needed_param
+    required: value
   register: argspec_fail_on_missing_params_bad
   ignore_errors: true
 
 - argspec:
     required_together_one: foo
     required_together_two: bar
+    required: value
 
 - argspec:
     required_together_one: foo
+    required: value
   register: argspec_fail_required_together_2
   ignore_errors: true
 
 - argspec:
     suboptions_list_no_elements:
       - thing: foo
+    required: value
   register: argspec_suboptions_list_no_elements
 
 - argspec:
     choices_with_strings_like_bools: on
+    required: value
   register: argspec_choices_with_strings_like_bools_true
 
 - argspec:
     choices_with_strings_like_bools: 'on'
+    required: value
   register: argspec_choices_with_strings_like_bools_true_bool
 
 - argspec:
     choices_with_strings_like_bools: off
+    required: value
   register: argspec_choices_with_strings_like_bools_false
 
 - assert:
     that:
+      - argspec_required_fail is failed
+
       - argspec_required_if_fail is failed
 
       - argspec_mutually_exclusive_fail is failed

--- a/test/integration/targets/argspec/tasks/main.yml
+++ b/test/integration/targets/argspec/tasks/main.yml
@@ -84,7 +84,7 @@
 - argspec:
     required_if:
       - thing: foo
-  register: argpsec_required_if_fail
+  register: argspec_required_if_fail_2
   ignore_errors: true
 
 - argspec:
@@ -118,7 +118,7 @@
 
 - argspec:
     required_together_one: foo
-  register: argspec_fail_required_together
+  register: argspec_fail_required_together_2
   ignore_errors: true
 
 - argspec:
@@ -159,7 +159,7 @@
 
       - argspec_required_together_fail is failed
 
-      - argpsec_required_if_fail is failed
+      - argspec_required_if_fail_2 is failed
 
       - argspec_good_json_string is successful
       - >-
@@ -171,7 +171,7 @@
 
       - argspec_fail_on_missing_params_bad is failed
 
-      - argspec_fail_required_together is failed
+      - argspec_fail_required_together_2 is failed
 
       - >-
         argspec_suboptions_list_no_elements.suboptions_list_no_elements.0 == {'thing': 'foo'}

--- a/test/integration/targets/argspec/tasks/main.yml
+++ b/test/integration/targets/argspec/tasks/main.yml
@@ -17,6 +17,21 @@
   ignore_errors: true
 
 - argspec:
+    required: value
+    required_one_of_two: value
+    required_by_one: value
+    required_by_two: value
+    required_by_three: value
+
+- argspec:
+    required: value
+    required_one_of_two: value
+    required_by_one: value
+    required_by_two: value
+  register: argspec_required_by_fail
+  ignore_errors: true
+
+- argspec:
     state: absent
     required: value
     required_one_of_one: value
@@ -157,6 +172,21 @@
   ignore_errors: true
 
 - argspec:
+    required_by:
+      - thing: foo
+        other: bar
+    required: value
+    required_one_of_one: value
+
+- argspec:
+    required_by:
+      - thing: foo
+    required: value
+    required_one_of_one: value
+  register: argspec_required_by_fail_2
+  ignore_errors: true
+
+- argspec:
     json: !!str '{"foo": "bar"}'
     required: value
     required_one_of_one: value
@@ -235,6 +265,8 @@
 
       - argspec_required_one_of_fail is failed
 
+      - argspec_required_by_fail is failed
+
       - argspec_required_if_fail is failed
 
       - argspec_mutually_exclusive_fail is failed
@@ -257,6 +289,8 @@
       - argspec_required_if_fail_2 is failed
 
       - argspec_required_one_of_fail_2 is failed
+
+      - argspec_required_by_fail_2 is failed
 
       - argspec_good_json_string is successful
       - >-

--- a/test/integration/targets/argspec/tasks/main.yml
+++ b/test/integration/targets/argspec/tasks/main.yml
@@ -1,17 +1,30 @@
 - argspec:
     required: value
+    required_one_of_one: value
 
 - argspec:
+    required_one_of_one: value
   register: argspec_required_fail
+  ignore_errors: true
+
+- argspec:
+    required: value
+    required_one_of_two: value
+
+- argspec:
+    required: value
+  register: argspec_required_one_of_fail
   ignore_errors: true
 
 - argspec:
     state: absent
     required: value
+    required_one_of_one: value
 
 - argspec:
     state: present
     required: value
+    required_one_of_one: value
   register: argspec_required_if_fail
   ignore_errors: true
 
@@ -19,17 +32,20 @@
     state: present
     path: foo
     required: value
+    required_one_of_one: value
 
 - argspec:
     state: present
     content: foo
     required: value
+    required_one_of_one: value
 
 - argspec:
     state: present
     content: foo
     path: foo
     required: value
+    required_one_of_one: value
   register: argspec_mutually_exclusive_fail
   ignore_errors: true
 
@@ -37,27 +53,32 @@
     mapping:
       foo: bar
     required: value
+    required_one_of_one: value
   register: argspec_good_mapping
 
 - argspec:
     mapping: foo=bar
     required: value
+    required_one_of_one: value
   register: argspec_good_mapping_kv
 
 - argspec:
     mapping: !!str '{"foo": "bar"}'
     required: value
+    required_one_of_one: value
   register: argspec_good_mapping_json
 
 - argspec:
     mapping: foo
     required: value
+    required_one_of_one: value
   register: argspec_bad_mapping_string
   ignore_errors: true
 
 - argspec:
     mapping: 1
     required: value
+    required_one_of_one: value
   register: argspec_bad_mapping_int
   ignore_errors: true
 
@@ -66,6 +87,7 @@
       - foo
       - bar
     required: value
+    required_one_of_one: value
   register: argspec_bad_mapping_list
   ignore_errors: true
 
@@ -75,16 +97,19 @@
         other: bar
         another: baz
     required: value
+    required_one_of_one: value
 
 - argspec:
     required_together:
       - another: baz
     required: value
+    required_one_of_one: value
 
 - argspec:
     required_together:
       - thing: foo
     required: value
+    required_one_of_one: value
   register: argspec_required_together_fail
   ignore_errors: true
 
@@ -93,39 +118,61 @@
       - thing: foo
         other: bar
     required: value
+    required_one_of_one: value
 
 - argspec:
     required_if:
       - thing: bar
     required: value
+    required_one_of_one: value
 
 - argspec:
     required_if:
       - thing: foo
         other: bar
     required: value
+    required_one_of_one: value
 
 - argspec:
     required_if:
       - thing: foo
     required: value
+    required_one_of_one: value
   register: argspec_required_if_fail_2
+  ignore_errors: true
+
+- argspec:
+    required_one_of:
+      - thing: foo
+        other: bar
+    required: value
+    required_one_of_one: value
+
+- argspec:
+    required_one_of:
+      - {}
+    required: value
+    required_one_of_one: value
+  register: argspec_required_one_of_fail_2
   ignore_errors: true
 
 - argspec:
     json: !!str '{"foo": "bar"}'
     required: value
+    required_one_of_one: value
   register: argspec_good_json_string
 
 - argspec:
     json:
       foo: bar
     required: value
+    required_one_of_one: value
   register: argspec_good_json_dict
 
 - argspec:
     json: 1
     required: value
+    required_one_of_one: value
   register: argspec_bad_json
   ignore_errors: true
 
@@ -134,11 +181,13 @@
       - needed_param
     needed_param: whatever
     required: value
+    required_one_of_one: value
 
 - argspec:
     fail_on_missing_params:
       - needed_param
     required: value
+    required_one_of_one: value
   register: argspec_fail_on_missing_params_bad
   ignore_errors: true
 
@@ -146,10 +195,12 @@
     required_together_one: foo
     required_together_two: bar
     required: value
+    required_one_of_one: value
 
 - argspec:
     required_together_one: foo
     required: value
+    required_one_of_one: value
   register: argspec_fail_required_together_2
   ignore_errors: true
 
@@ -157,26 +208,32 @@
     suboptions_list_no_elements:
       - thing: foo
     required: value
+    required_one_of_one: value
   register: argspec_suboptions_list_no_elements
 
 - argspec:
     choices_with_strings_like_bools: on
     required: value
+    required_one_of_one: value
   register: argspec_choices_with_strings_like_bools_true
 
 - argspec:
     choices_with_strings_like_bools: 'on'
     required: value
+    required_one_of_one: value
   register: argspec_choices_with_strings_like_bools_true_bool
 
 - argspec:
     choices_with_strings_like_bools: off
     required: value
+    required_one_of_one: value
   register: argspec_choices_with_strings_like_bools_false
 
 - assert:
     that:
       - argspec_required_fail is failed
+
+      - argspec_required_one_of_fail is failed
 
       - argspec_required_if_fail is failed
 
@@ -198,6 +255,8 @@
       - argspec_required_together_fail is failed
 
       - argspec_required_if_fail_2 is failed
+
+      - argspec_required_one_of_fail_2 is failed
 
       - argspec_good_json_string is successful
       - >-


### PR DESCRIPTION
##### SUMMARY
Part of #72243 which just extends existing tests to test more aspects of argspec validation.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/integration/targets/argspec/library/argspec.py
test/integration/targets/argspec/tasks/main.yml
