### PR TITLE
[tests/dnf] work around dnf packaging issue (#72249) [2.10]

### DIFF
--- a/test/integration/targets/dnf/tasks/logging.yml
+++ b/test/integration/targets/dnf/tasks/logging.yml
@@ -3,7 +3,9 @@
 #  Note: https://bugzilla.redhat.com/show_bug.cgi?id=1788212
 - name: Install latest version python3-dnf
   dnf:
-    name: python3-dnf
+    name:
+      - python3-dnf
+      - python3-libdnf  # https://bugzilla.redhat.com/show_bug.cgi?id=1887502
     state: latest
   register: dnf_result
 


### PR DESCRIPTION

##### SUMMARY

Change:
- In this test we end up upgrading dnf (and python3-dnf) so that we can
  test its new logging behavior. However, the latest Fedora 32 dnf had a
  packaging issue which caused it to not pull in the latest
  python3-libdnf. This is fixed, but not synced out to mirrors yet.
  Fixing it in this test will get CI passing again in the meanwhile.

Test Plan:
- CI

Tickets:
- https://bugzilla.redhat.com/show_bug.cgi?id=1887502

Signed-off-by: Rick Elrod <rick@elrod.me>
(cherry picked from commit 9ddb1d76afd8edd9c363d2f12a2c9c7c2d4372f7)

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Test Pull Request

##### COMPONENT NAME

dnf tests