### PR TITLE
gather_facts - Add link to docs on how to configure facts modules

### DIFF
--- a/lib/ansible/modules/gather_facts.py
+++ b/lib/ansible/modules/gather_facts.py
@@ -40,6 +40,6 @@ RETURN = """
 """
 
 EXAMPLES = """
-# Display facts from all hosts and store them indexed by I(hostname) at C(/tmp/facts).
+# Display facts from all hosts and store them indexed by hostname at /tmp/facts.
 # ansible all -m gather_facts --tree /tmp/facts
 """

--- a/lib/ansible/modules/gather_facts.py
+++ b/lib/ansible/modules/gather_facts.py
@@ -13,7 +13,9 @@ module: gather_facts
 version_added: 2.8
 short_description: Gathers facts about remote hosts
 description:
-     - This module takes care of executing the configured facts modules, the default is to use the M(ansible.builtin.setup) module.
+     - This module takes care of executing the
+       L(configured facts modules,https://docs.ansible.com/ansible/latest/reference_appendices/config.html#facts-modules),
+       the default is to use the M(ansible.builtin.setup) module.
      - This module is automatically called by playbooks to gather useful variables about remote hosts that can be used in playbooks.
      - It can also be executed directly by C(/usr/bin/ansible) to check what variables are available to a host.
      - Ansible provides many I(facts) about the system, automatically.

--- a/lib/ansible/modules/gather_facts.py
+++ b/lib/ansible/modules/gather_facts.py
@@ -13,9 +13,7 @@ module: gather_facts
 version_added: 2.8
 short_description: Gathers facts about remote hosts
 description:
-     - This module takes care of executing the
-       L(configured facts modules,https://docs.ansible.com/ansible/latest/reference_appendices/config.html#facts-modules),
-       the default is to use the M(ansible.builtin.setup) module.
+     - This module takes care of executing the R(configured facts modules,FACTS_MODULES), the default is to use the M(ansible.builtin.setup) module.
      - This module is automatically called by playbooks to gather useful variables about remote hosts that can be used in playbooks.
      - It can also be executed directly by C(/usr/bin/ansible) to check what variables are available to a host.
      - Ansible provides many I(facts) about the system, automatically.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The docs mention "configured facts modules" but I had a hard time figuring out how to do that. Figured I'd add a link to the relevant documentation.

If there's a way to do a relative/generated link, let me know, I wasn't able to see a way to do that for that document.

- Also removed some unrendered markup from the examples section.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
gather_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
