### PR TITLE
JUNIT callback plugin: Fixed JUNIT_TEST_CASE_PREFIX, added JUNIT_TEST_CASE_IGNORE_TEXT

### DIFF
--- a/lib/ansible/plugins/callback/junit.py
+++ b/lib/ansible/plugins/callback/junit.py
@@ -244,7 +244,7 @@ class CallbackModule(CallbackBase):
         if task_data.name.startswith(self._test_case_prefix) or status == 'failed':
             if self._test_case_ignore_text == '' or \
                 self._test_case_ignore_text not in task_data.name:
-                # Only add the task when either test_case_ignore_text is not set or
+                # Only add the task when either test_case_ignore_text is not set or not in the task name
                 task_data.add_host(HostData(host_uuid, host_name, status, result))
 
     def _build_test_case(self, task_data, host_data):

--- a/lib/ansible/plugins/callback/junit.py
+++ b/lib/ansible/plugins/callback/junit.py
@@ -199,7 +199,7 @@ class CallbackModule(CallbackBase):
 
         play = self._play_name
 
-        if task._role != None:
+        if task._role is not None:
             role_name = task._role.get_name(include_role_fqcn=True)
         else:
             role_name = None
@@ -243,14 +243,14 @@ class CallbackModule(CallbackBase):
 
         if task_data.name.startswith(self._test_case_prefix) or status == 'failed':
             if self._test_case_ignore_text == '' or \
-                self._test_case_ignore_text not in task_data.name:
+                    self._test_case_ignore_text not in task_data.name:
                 # Only add the task when either test_case_ignore_text is not set or not in the task name
                 task_data.add_host(HostData(host_uuid, host_name, status, result))
 
     def _build_test_case(self, task_data, host_data):
         """ build a TestCase from the given TaskData and HostData """
 
-        if task_data.role_name != None:
+        if task_data.role_name is not None:
             name = '[%s] %s: %s : %s' % (host_data.name, task_data.play, task_data.role_name, task_data.name)
         else:
             name = '[%s] %s: %s' % (host_data.name, task_data.play, task_data.name)

--- a/lib/ansible/plugins/callback/junit.py
+++ b/lib/ansible/plugins/callback/junit.py
@@ -201,7 +201,7 @@ class CallbackModule(CallbackBase):
         else:
             role_name = None
 
-        name = task._name
+        name = task.name.strip()
         path = task.get_path()
         action = task.action
 

--- a/lib/ansible/plugins/callback/junit.py
+++ b/lib/ansible/plugins/callback/junit.py
@@ -195,7 +195,13 @@ class CallbackModule(CallbackBase):
             return
 
         play = self._play_name
-        name = task.get_name().strip()
+
+        if task._role != None:
+            role_name = task._role.get_name(include_role_fqcn=True)
+        else:
+            role_name = None
+
+        name = task._name
         path = task.get_path()
         action = task.action
 
@@ -204,7 +210,7 @@ class CallbackModule(CallbackBase):
             if args:
                 name += ' ' + args
 
-        self._task_data[uuid] = TaskData(uuid, name, path, play, action)
+        self._task_data[uuid] = TaskData(uuid, name, path, play, action, role_name=role_name)
 
     def _finish_task(self, status, result):
         """ record the results of a task for a single host """
@@ -238,7 +244,10 @@ class CallbackModule(CallbackBase):
     def _build_test_case(self, task_data, host_data):
         """ build a TestCase from the given TaskData and HostData """
 
-        name = '[%s] %s: %s' % (host_data.name, task_data.play, task_data.name)
+        if task_data.role_name != None:
+            name = '[%s] %s: %s : %s' % (host_data.name, task_data.play, task_data.role_name, task_data.name)
+        else:
+            name = '[%s] %s: %s' % (host_data.name, task_data.play, task_data.name)
         duration = host_data.finish - task_data.start
 
         if self._task_relative_path:
@@ -348,8 +357,9 @@ class TaskData:
     Data about an individual task.
     """
 
-    def __init__(self, uuid, name, path, play, action):
+    def __init__(self, uuid, name, path, play, action, role_name=None):
         self.uuid = uuid
+        self.role_name = role_name
         self.name = name
         self.path = path
         self.play = play

--- a/lib/ansible/plugins/callback/junit.py
+++ b/lib/ansible/plugins/callback/junit.py
@@ -142,6 +142,8 @@ class CallbackModule(CallbackBase):
         JUNIT_TEST_CASE_PREFIX (optional): Consider a task only as test case if it has this value as prefix. Additionaly failing tasks are recorded as failed
                                      test cases.
                                      Default: <empty>
+        JUNIT_TEST_CASE_IGNORE_TEXT (optional): Ignore a task if it contains this string (even if it failed).
+                                     Default: <empty>
 
     Requires:
         junit_xml
@@ -164,6 +166,7 @@ class CallbackModule(CallbackBase):
         self._include_setup_tasks_in_report = os.getenv('JUNIT_INCLUDE_SETUP_TASKS_IN_REPORT', 'True').lower()
         self._hide_task_arguments = os.getenv('JUNIT_HIDE_TASK_ARGUMENTS', 'False').lower()
         self._test_case_prefix = os.getenv('JUNIT_TEST_CASE_PREFIX', '')
+        self._test_case_ignore_text = os.getenv('JUNIT_TEST_CASE_IGNORE_TEXT', '')
         self._playbook_path = None
         self._playbook_name = None
         self._play_name = None
@@ -239,7 +242,10 @@ class CallbackModule(CallbackBase):
                 status = 'failed'
 
         if task_data.name.startswith(self._test_case_prefix) or status == 'failed':
-            task_data.add_host(HostData(host_uuid, host_name, status, result))
+            if self._test_case_ignore_text == '' or \
+                self._test_case_ignore_text not in task_data.name:
+                # Only add the task when either test_case_ignore_text is not set or
+                task_data.add_host(HostData(host_uuid, host_name, status, result))
 
     def _build_test_case(self, task_data, host_data):
         """ build a TestCase from the given TaskData and HostData """

--- a/test/integration/targets/callback_junit/aliases
+++ b/test/integration/targets/callback_junit/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group1

--- a/test/integration/targets/callback_junit/expected_reports/junit-callback-test-ignore.xml
+++ b/test/integration/targets/callback_junit/expected_reports/junit-callback-test-ignore.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" ?>
-<testsuites disabled="0" errors="0" failures="0" tests="2" >
-        <testsuite disabled="0" errors="0" failures="0" name="junit-callback-test-ignore" skipped="0" tests="2" >
-                <testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task in a file msg=This is a task with a prefix" >
+<testsuites disabled="0" errors="0" failures="0" tests="2">
+        <testsuite disabled="0" errors="0" failures="0" name="junit-callback-test-ignore" skipped="0" tests="2">
+                <testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task in a file msg=This is a task with a prefix">
                         <system-out>{
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with a prefix&quot;
 }</system-out>
                 </testcase>
-                <testcase name="[testhost] testhost: a_failing_role : JUNIT TASK PREFIX - A task in a role msg=This is a task with a prefix inside a role" >
+                <testcase name="[testhost] testhost: a_failing_role : JUNIT TASK PREFIX - A task in a role msg=This is a task with a prefix inside a role">
                         <system-out>{
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with a prefix inside a role&quot;

--- a/test/integration/targets/callback_junit/expected_reports/junit-callback-test-ignore.xml
+++ b/test/integration/targets/callback_junit/expected_reports/junit-callback-test-ignore.xml
@@ -2,16 +2,20 @@
 <testsuites disabled="0" errors="0" failures="0" tests="2">
         <testsuite disabled="0" errors="0" failures="0" name="junit-callback-test-ignore" skipped="0" tests="2">
                 <testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task in a file msg=This is a task with a prefix">
-                        <system-out>{
+                        <system-out>
+{
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with a prefix&quot;
-}</system-out>
+}
+</system-out>
                 </testcase>
                 <testcase name="[testhost] testhost: a_failing_role : JUNIT TASK PREFIX - A task in a role msg=This is a task with a prefix inside a role">
-                        <system-out>{
+                        <system-out>
+{
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with a prefix inside a role&quot;
-}</system-out>
+}
+</system-out>
                 </testcase>
         </testsuite>
 </testsuites>

--- a/test/integration/targets/callback_junit/expected_reports/junit-callback-test-ignore.xml
+++ b/test/integration/targets/callback_junit/expected_reports/junit-callback-test-ignore.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<testsuites disabled="0" errors="0" failures="0" tests="2" >
+        <testsuite disabled="0" errors="0" failures="0" name="junit-callback-test-ignore" skipped="0" tests="2" >
+                <testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task in a file msg=This is a task with a prefix" >
+                        <system-out>{
+    &quot;changed&quot;: false,
+    &quot;msg&quot;: &quot;This is a task with a prefix&quot;
+}</system-out>
+                </testcase>
+                <testcase name="[testhost] testhost: a_failing_role : JUNIT TASK PREFIX - A task in a role msg=This is a task with a prefix inside a role" >
+                        <system-out>{
+    &quot;changed&quot;: false,
+    &quot;msg&quot;: &quot;This is a task with a prefix inside a role&quot;
+}</system-out>
+                </testcase>
+        </testsuite>
+</testsuites>

--- a/test/integration/targets/callback_junit/expected_reports/junit-callback-test-ignore.xml
+++ b/test/integration/targets/callback_junit/expected_reports/junit-callback-test-ignore.xml
@@ -1,21 +1,37 @@
 <?xml version="1.0" ?>
-<testsuites disabled="0" errors="0" failures="0" tests="2">
-        <testsuite disabled="0" errors="0" failures="0" name="junit-callback-test-ignore" skipped="0" tests="2">
-                <testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task in a file msg=This is a task with a prefix">
-                        <system-out>
+<testsuites disabled="0" errors="0" failures="0" tests="4">
+	<testsuite disabled="0" errors="0" failures="0" name="junit-callback-test-ignore" skipped="0" tests="4">
+		<testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task in a file msg=This is a task with a prefix">
+			<system-out>
 {
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with a prefix&quot;
 }
 </system-out>
-                </testcase>
-                <testcase name="[testhost] testhost: a_failing_role : JUNIT TASK PREFIX - A task in a role msg=This is a task with a prefix inside a role">
-                        <system-out>
+		</testcase>
+		<testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task with a variable in the task name some-string msg=This is a task with a variable in the task name">
+			<system-out>
+{
+    &quot;changed&quot;: false,
+    &quot;msg&quot;: &quot;This is a task with a variable in the task name&quot;
+}
+</system-out>
+		</testcase>
+		<testcase name="[testhost] testhost: a_failing_role : JUNIT TASK PREFIX - A task in a role msg=This is a task with a prefix inside a role">
+			<system-out>
 {
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with a prefix inside a role&quot;
 }
 </system-out>
-                </testcase>
-        </testsuite>
+		</testcase>
+		<testcase name="[testhost] testhost: a_failing_role : JUNIT TASK PREFIX - A task with a variable in the task name some-string msg=This is a task with a variable in the task name">
+			<system-out>
+{
+    &quot;changed&quot;: false,
+    &quot;msg&quot;: &quot;This is a task with a variable in the task name&quot;
+}
+</system-out>
+		</testcase>
+	</testsuite>
 </testsuites>

--- a/test/integration/targets/callback_junit/expected_reports/junit-callback-test-prefix.xml
+++ b/test/integration/targets/callback_junit/expected_reports/junit-callback-test-prefix.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<testsuites disabled="0" errors="0" failures="0" tests="2" >
+        <testsuite disabled="0" errors="0" failures="0" name="junit-callback-test-prefix" skipped="0" tests="2" >
+                <testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task in a file msg=This is a task with a prefix" >
+                        <system-out>{
+    &quot;changed&quot;: false,
+    &quot;msg&quot;: &quot;This is a task with a prefix&quot;
+}</system-out>
+                </testcase>
+                <testcase name="[testhost] testhost: a_role : JUNIT TASK PREFIX - A task in a role msg=This is a task with a prefix" >
+                        <system-out>{
+    &quot;changed&quot;: false,
+    &quot;msg&quot;: &quot;This is a task with a prefix&quot;
+}</system-out>
+                </testcase>
+        </testsuite>
+</testsuites>

--- a/test/integration/targets/callback_junit/expected_reports/junit-callback-test-prefix.xml
+++ b/test/integration/targets/callback_junit/expected_reports/junit-callback-test-prefix.xml
@@ -1,21 +1,37 @@
 <?xml version="1.0" ?>
-<testsuites disabled="0" errors="0" failures="0" tests="2">
-        <testsuite disabled="0" errors="0" failures="0" name="junit-callback-test-prefix" skipped="0" tests="2">
-                <testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task in a file msg=This is a task with a prefix">
-                        <system-out>
+<testsuites disabled="0" errors="0" failures="0" tests="4">
+	<testsuite disabled="0" errors="0" failures="0" name="junit-callback-test-prefix" skipped="0" tests="4">
+		<testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task in a file msg=This is a task with a prefix">
+			<system-out>
 {
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with a prefix&quot;
 }
 </system-out>
-                </testcase>
-                <testcase name="[testhost] testhost: a_role : JUNIT TASK PREFIX - A task in a role msg=This is a task with a prefix">
-                        <system-out>
+		</testcase>
+		<testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task with a variable in the task name some-string msg=This is a task with a variable in the task name">
+			<system-out>
+{
+    &quot;changed&quot;: false,
+    &quot;msg&quot;: &quot;This is a task with a variable in the task name&quot;
+}
+</system-out>
+		</testcase>
+		<testcase name="[testhost] testhost: a_role : JUNIT TASK PREFIX - A task in a role msg=This is a task with a prefix">
+			<system-out>
 {
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with a prefix&quot;
 }
 </system-out>
-                </testcase>
-        </testsuite>
+		</testcase>
+		<testcase name="[testhost] testhost: a_role : JUNIT TASK PREFIX - A task with a variable in the task name some-string msg=This is a task with a variable in the task name">
+			<system-out>
+{
+    &quot;changed&quot;: false,
+    &quot;msg&quot;: &quot;This is a task with a variable in the task name&quot;
+}
+</system-out>
+		</testcase>
+	</testsuite>
 </testsuites>

--- a/test/integration/targets/callback_junit/expected_reports/junit-callback-test-prefix.xml
+++ b/test/integration/targets/callback_junit/expected_reports/junit-callback-test-prefix.xml
@@ -2,16 +2,20 @@
 <testsuites disabled="0" errors="0" failures="0" tests="2">
         <testsuite disabled="0" errors="0" failures="0" name="junit-callback-test-prefix" skipped="0" tests="2">
                 <testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task in a file msg=This is a task with a prefix">
-                        <system-out>{
+                        <system-out>
+{
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with a prefix&quot;
-}</system-out>
+}
+</system-out>
                 </testcase>
                 <testcase name="[testhost] testhost: a_role : JUNIT TASK PREFIX - A task in a role msg=This is a task with a prefix">
-                        <system-out>{
+                        <system-out>
+{
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with a prefix&quot;
-}</system-out>
+}
+</system-out>
                 </testcase>
         </testsuite>
 </testsuites>

--- a/test/integration/targets/callback_junit/expected_reports/junit-callback-test-prefix.xml
+++ b/test/integration/targets/callback_junit/expected_reports/junit-callback-test-prefix.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" ?>
-<testsuites disabled="0" errors="0" failures="0" tests="2" >
-        <testsuite disabled="0" errors="0" failures="0" name="junit-callback-test-prefix" skipped="0" tests="2" >
-                <testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task in a file msg=This is a task with a prefix" >
+<testsuites disabled="0" errors="0" failures="0" tests="2">
+        <testsuite disabled="0" errors="0" failures="0" name="junit-callback-test-prefix" skipped="0" tests="2">
+                <testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task in a file msg=This is a task with a prefix">
                         <system-out>{
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with a prefix&quot;
 }</system-out>
                 </testcase>
-                <testcase name="[testhost] testhost: a_role : JUNIT TASK PREFIX - A task in a role msg=This is a task with a prefix" >
+                <testcase name="[testhost] testhost: a_role : JUNIT TASK PREFIX - A task in a role msg=This is a task with a prefix">
                         <system-out>{
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with a prefix&quot;

--- a/test/integration/targets/callback_junit/expected_reports/junit-callback-test.xml
+++ b/test/integration/targets/callback_junit/expected_reports/junit-callback-test.xml
@@ -1,53 +1,69 @@
 <?xml version="1.0" ?>
-<testsuites disabled="0" errors="0" failures="0" tests="6">
-        <testsuite disabled="0" errors="0" failures="0" name="junit-callback-test" skipped="0" tests="6">
-                <testcase name="[testhost] testhost: A task in a file msg=This is a task with no prefix">
-                        <system-out>
+<testsuites disabled="0" errors="0" failures="0" tests="8">
+	<testsuite disabled="0" errors="0" failures="0" name="junit-callback-test" skipped="0" tests="8">
+		<testcase name="[testhost] testhost: A task in a file msg=This is a task with no prefix">
+			<system-out>
 {
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with no prefix&quot;
 }
 </system-out>
-                </testcase>
-                <testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task in a file msg=This is a task with a prefix">
-                        <system-out>
+		</testcase>
+		<testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task in a file msg=This is a task with a prefix">
+			<system-out>
 {
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with a prefix&quot;
 }
 </system-out>
-                </testcase>
-                <testcase name="[testhost] testhost: A task in a file JUNIT IGNORE THIS TASK msg=This is a task with an ignore string">
-                        <system-out>
+		</testcase>
+		<testcase name="[testhost] testhost: A task in a file JUNIT IGNORE THIS TASK msg=This is a task with an ignore string">
+			<system-out>
 {
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with an ignore string&quot;
 }
 </system-out>
-                </testcase>
-                <testcase name="[testhost] testhost: a_role : A task in a role msg=This is a task with no prefix">
-                        <system-out>
+		</testcase>
+		<testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task with a variable in the task name some-string msg=This is a task with a variable in the task name">
+			<system-out>
+{
+    &quot;changed&quot;: false,
+    &quot;msg&quot;: &quot;This is a task with a variable in the task name&quot;
+}
+</system-out>
+		</testcase>
+		<testcase name="[testhost] testhost: a_role : A task in a role msg=This is a task with no prefix">
+			<system-out>
 {
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with no prefix&quot;
 }
 </system-out>
-                </testcase>
-                <testcase name="[testhost] testhost: a_role : JUNIT TASK PREFIX - A task in a role msg=This is a task with a prefix">
-                        <system-out>
+		</testcase>
+		<testcase name="[testhost] testhost: a_role : JUNIT TASK PREFIX - A task in a role msg=This is a task with a prefix">
+			<system-out>
 {
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with a prefix&quot;
 }
 </system-out>
-                </testcase>
-                <testcase name="[testhost] testhost: a_role : A task in a role JUNIT IGNORE THIS TASK msg=This is a task with an ignore string">
-                        <system-out>
+		</testcase>
+		<testcase name="[testhost] testhost: a_role : A task in a role JUNIT IGNORE THIS TASK msg=This is a task with an ignore string">
+			<system-out>
 {
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with an ignore string&quot;
 }
 </system-out>
-                </testcase>
-        </testsuite>
+		</testcase>
+		<testcase name="[testhost] testhost: a_role : JUNIT TASK PREFIX - A task with a variable in the task name some-string msg=This is a task with a variable in the task name">
+			<system-out>
+{
+    &quot;changed&quot;: false,
+    &quot;msg&quot;: &quot;This is a task with a variable in the task name&quot;
+}
+</system-out>
+		</testcase>
+	</testsuite>
 </testsuites>

--- a/test/integration/targets/callback_junit/expected_reports/junit-callback-test.xml
+++ b/test/integration/targets/callback_junit/expected_reports/junit-callback-test.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" ?>
-<testsuites disabled="0" errors="0" failures="0" tests="6" >
-        <testsuite disabled="0" errors="0" failures="0" name="junit-callback-test" skipped="0" tests="6" >
-                <testcase name="[testhost] testhost: A task in a file msg=This is a task with no prefix" >
+<testsuites disabled="0" errors="0" failures="0" tests="6">
+        <testsuite disabled="0" errors="0" failures="0" name="junit-callback-test" skipped="0" tests="6">
+                <testcase name="[testhost] testhost: A task in a file msg=This is a task with no prefix">
                         <system-out>{
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with no prefix&quot;
 }</system-out>
                 </testcase>
-                <testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task in a file msg=This is a task with a prefix" >
+                <testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task in a file msg=This is a task with a prefix">
                         <system-out>{
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with a prefix&quot;
 }</system-out>
                 </testcase>
-                <testcase name="[testhost] testhost: A task in a file JUNIT IGNORE THIS TASK msg=This is a task with an ignore string" >
+                <testcase name="[testhost] testhost: A task in a file JUNIT IGNORE THIS TASK msg=This is a task with an ignore string">
                         <system-out>{
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with an ignore string&quot;
 }</system-out>
                 </testcase>
-                <testcase name="[testhost] testhost: a_role : A task in a role msg=This is a task with no prefix" >
+                <testcase name="[testhost] testhost: a_role : A task in a role msg=This is a task with no prefix">
                         <system-out>{
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with no prefix&quot;
 }</system-out>
                 </testcase>
-                <testcase name="[testhost] testhost: a_role : JUNIT TASK PREFIX - A task in a role msg=This is a task with a prefix" >
+                <testcase name="[testhost] testhost: a_role : JUNIT TASK PREFIX - A task in a role msg=This is a task with a prefix">
                         <system-out>{
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with a prefix&quot;
 }</system-out>
                 </testcase>
-                <testcase name="[testhost] testhost: a_role : A task in a role JUNIT IGNORE THIS TASK msg=This is a task with an ignore string" >
+                <testcase name="[testhost] testhost: a_role : A task in a role JUNIT IGNORE THIS TASK msg=This is a task with an ignore string">
                         <system-out>{
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with an ignore string&quot;

--- a/test/integration/targets/callback_junit/expected_reports/junit-callback-test.xml
+++ b/test/integration/targets/callback_junit/expected_reports/junit-callback-test.xml
@@ -2,40 +2,52 @@
 <testsuites disabled="0" errors="0" failures="0" tests="6">
         <testsuite disabled="0" errors="0" failures="0" name="junit-callback-test" skipped="0" tests="6">
                 <testcase name="[testhost] testhost: A task in a file msg=This is a task with no prefix">
-                        <system-out>{
+                        <system-out>
+{
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with no prefix&quot;
-}</system-out>
+}
+</system-out>
                 </testcase>
                 <testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task in a file msg=This is a task with a prefix">
-                        <system-out>{
+                        <system-out>
+{
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with a prefix&quot;
-}</system-out>
+}
+</system-out>
                 </testcase>
                 <testcase name="[testhost] testhost: A task in a file JUNIT IGNORE THIS TASK msg=This is a task with an ignore string">
-                        <system-out>{
+                        <system-out>
+{
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with an ignore string&quot;
-}</system-out>
+}
+</system-out>
                 </testcase>
                 <testcase name="[testhost] testhost: a_role : A task in a role msg=This is a task with no prefix">
-                        <system-out>{
+                        <system-out>
+{
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with no prefix&quot;
-}</system-out>
+}
+</system-out>
                 </testcase>
                 <testcase name="[testhost] testhost: a_role : JUNIT TASK PREFIX - A task in a role msg=This is a task with a prefix">
-                        <system-out>{
+                        <system-out>
+{
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with a prefix&quot;
-}</system-out>
+}
+</system-out>
                 </testcase>
                 <testcase name="[testhost] testhost: a_role : A task in a role JUNIT IGNORE THIS TASK msg=This is a task with an ignore string">
-                        <system-out>{
+                        <system-out>
+{
     &quot;changed&quot;: false,
     &quot;msg&quot;: &quot;This is a task with an ignore string&quot;
-}</system-out>
+}
+</system-out>
                 </testcase>
         </testsuite>
 </testsuites>

--- a/test/integration/targets/callback_junit/expected_reports/junit-callback-test.xml
+++ b/test/integration/targets/callback_junit/expected_reports/junit-callback-test.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" ?>
+<testsuites disabled="0" errors="0" failures="0" tests="6" >
+        <testsuite disabled="0" errors="0" failures="0" name="junit-callback-test" skipped="0" tests="6" >
+                <testcase name="[testhost] testhost: A task in a file msg=This is a task with no prefix" >
+                        <system-out>{
+    &quot;changed&quot;: false,
+    &quot;msg&quot;: &quot;This is a task with no prefix&quot;
+}</system-out>
+                </testcase>
+                <testcase name="[testhost] testhost: JUNIT TASK PREFIX - A task in a file msg=This is a task with a prefix" >
+                        <system-out>{
+    &quot;changed&quot;: false,
+    &quot;msg&quot;: &quot;This is a task with a prefix&quot;
+}</system-out>
+                </testcase>
+                <testcase name="[testhost] testhost: A task in a file JUNIT IGNORE THIS TASK msg=This is a task with an ignore string" >
+                        <system-out>{
+    &quot;changed&quot;: false,
+    &quot;msg&quot;: &quot;This is a task with an ignore string&quot;
+}</system-out>
+                </testcase>
+                <testcase name="[testhost] testhost: a_role : A task in a role msg=This is a task with no prefix" >
+                        <system-out>{
+    &quot;changed&quot;: false,
+    &quot;msg&quot;: &quot;This is a task with no prefix&quot;
+}</system-out>
+                </testcase>
+                <testcase name="[testhost] testhost: a_role : JUNIT TASK PREFIX - A task in a role msg=This is a task with a prefix" >
+                        <system-out>{
+    &quot;changed&quot;: false,
+    &quot;msg&quot;: &quot;This is a task with a prefix&quot;
+}</system-out>
+                </testcase>
+                <testcase name="[testhost] testhost: a_role : A task in a role JUNIT IGNORE THIS TASK msg=This is a task with an ignore string" >
+                        <system-out>{
+    &quot;changed&quot;: false,
+    &quot;msg&quot;: &quot;This is a task with an ignore string&quot;
+}</system-out>
+                </testcase>
+        </testsuite>
+</testsuites>

--- a/test/integration/targets/callback_junit/inventory
+++ b/test/integration/targets/callback_junit/inventory
@@ -1,0 +1,2 @@
+[local]
+testhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/targets/callback_junit/junit-callback-test-ignore.yml
+++ b/test/integration/targets/callback_junit/junit-callback-test-ignore.yml
@@ -1,0 +1,15 @@
+---
+- hosts: testhost
+  gather_facts: no
+  tasks:
+    - name: Test tasks
+      import_tasks: tasks/tasks.yml
+
+    - name: A rescue block
+      block:
+        - name: Test tasks in role where a task fails
+          import_role:
+            name: a_failing_role
+      rescue:
+        - debug:
+            msg: "Its all fine actually!"

--- a/test/integration/targets/callback_junit/junit-callback-test-prefix.yml
+++ b/test/integration/targets/callback_junit/junit-callback-test-prefix.yml
@@ -1,0 +1,10 @@
+---
+- hosts: testhost
+  gather_facts: no
+  tasks:
+    - name: Test tasks
+      import_tasks: tasks/tasks.yml
+
+    - name: Test tasks in role
+      import_role:
+        name: a_role

--- a/test/integration/targets/callback_junit/junit-callback-test.yml
+++ b/test/integration/targets/callback_junit/junit-callback-test.yml
@@ -1,0 +1,10 @@
+---
+- hosts: testhost
+  gather_facts: no
+  tasks:
+    - name: Test tasks
+      import_tasks: tasks/tasks.yml
+
+    - name: Test tasks in role
+      import_role:
+        name: a_role

--- a/test/integration/targets/callback_junit/roles/a_failing_role/tasks/main.yml
+++ b/test/integration/targets/callback_junit/roles/a_failing_role/tasks/main.yml
@@ -7,6 +7,12 @@
   debug:
     msg: This is a task with a prefix inside a role
 
+- name: "JUNIT TASK PREFIX - A task with a variable in the task name {{ something }}"
+  debug:
+    msg: This is a task with a variable in the task name
+  vars:
+    something: some-string
+
 - name: "A task in a role JUNIT IGNORE THIS TASK"
   fail:
     msg: "This task fails"

--- a/test/integration/targets/callback_junit/roles/a_failing_role/tasks/main.yml
+++ b/test/integration/targets/callback_junit/roles/a_failing_role/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- name: "A task in a role"
+  debug:
+    msg: This is a task with no prefix
+
+- name: "JUNIT TASK PREFIX - A task in a role"
+  debug:
+    msg: This is a task with a prefix inside a role
+
+- name: "A task in a role JUNIT IGNORE THIS TASK"
+  fail:
+    msg: "This task fails"
+  when: true

--- a/test/integration/targets/callback_junit/roles/a_role/tasks/main.yml
+++ b/test/integration/targets/callback_junit/roles/a_role/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: "A task in a role"
+  debug:
+    msg: This is a task with no prefix
+
+- name: "JUNIT TASK PREFIX - A task in a role"
+  debug:
+    msg: This is a task with a prefix
+
+- name: "A task in a role JUNIT IGNORE THIS TASK"
+  debug:
+    msg: This is a task with an ignore string

--- a/test/integration/targets/callback_junit/roles/a_role/tasks/main.yml
+++ b/test/integration/targets/callback_junit/roles/a_role/tasks/main.yml
@@ -10,3 +10,9 @@
 - name: "A task in a role JUNIT IGNORE THIS TASK"
   debug:
     msg: This is a task with an ignore string
+
+- name: "JUNIT TASK PREFIX - A task with a variable in the task name {{ something }}"
+  debug:
+    msg: This is a task with a variable in the task name
+  vars:
+    something: some-string

--- a/test/integration/targets/callback_junit/runme.sh
+++ b/test/integration/targets/callback_junit/runme.sh
@@ -9,14 +9,14 @@ mkdir reports
 
 ansible-playbook junit-callback-test.yml -i inventory "$@"
 # Copy report to local directory
-mv $(ls -t $JUNIT_OUTPUT_DIR/junit-callback-test-[0-9]* | head -1) reports
+mv "$(find "$JUNIT_OUTPUT_DIR" -name "junit-callback-test-[0-9]*" | sort -r | head -1)" reports
 # Remove classname and time
 cat reports/junit-callback-test-[0-9]* | sed -e 's/time=".*"//' | sed -e 's/classname=".*"//' > reports/junit-callback-test.xml
 
 JUNIT_TEST_CASE_PREFIX="JUNIT TASK PREFIX - " \
     ansible-playbook junit-callback-test-prefix.yml -i inventory "$@"
 # # Compare with expected result
-mv $(ls -t $JUNIT_OUTPUT_DIR/junit-callback-test-prefix-[0-9]* | head -1) reports
+mv "$(find "$JUNIT_OUTPUT_DIR" -name "junit-callback-test-prefix-[0-9]*" | sort -r | head -1)" reports
 # Remove classname and time
 cat reports/junit-callback-test-prefix-[0-9]* | sed -e 's/time=".*"//' | sed -e 's/classname=".*"//' > reports/junit-callback-test-prefix.xml
 
@@ -24,7 +24,7 @@ JUNIT_TEST_CASE_PREFIX="JUNIT TASK PREFIX - " \
 JUNIT_TEST_CASE_IGNORE_TEXT="JUNIT IGNORE THIS TASK" \
     ansible-playbook junit-callback-test-ignore.yml -i inventory "$@"
 # Compare with expected result
-mv $(ls -t $JUNIT_OUTPUT_DIR/junit-callback-test-ignore-[0-9]* | head -1) reports
+mv "$(find "$JUNIT_OUTPUT_DIR" -name "junit-callback-test-ignore-[0-9]*" | sort -r | head -1)" reports
 # Remove classname and time
 cat reports/junit-callback-test-ignore-[0-9]* | sed -e 's/time=".*"//' | sed -e 's/classname=".*"//' > reports/junit-callback-test-ignore.xml
 

--- a/test/integration/targets/callback_junit/runme.sh
+++ b/test/integration/targets/callback_junit/runme.sh
@@ -11,14 +11,14 @@ ansible-playbook junit-callback-test.yml -i inventory "$@"
 # Copy report to local directory
 mv "$(find "$JUNIT_OUTPUT_DIR" -name "junit-callback-test-[0-9]*" | sort -r | head -1)" reports
 # Remove classname and time
-cat reports/junit-callback-test-[0-9]* | sed -e 's/time=".*"//' | sed -e 's/classname=".*"//' > reports/junit-callback-test.xml
+cat reports/junit-callback-test-[0-9]* | sed 's/[ ]\{1,\}time="[0-9.]\{1,\}"//' | sed 's/[ ]\{1,\}classname="[^"]\{1,\}"//' > reports/junit-callback-test.xml
 
 JUNIT_TEST_CASE_PREFIX="JUNIT TASK PREFIX - " \
     ansible-playbook junit-callback-test-prefix.yml -i inventory "$@"
 # # Compare with expected result
 mv "$(find "$JUNIT_OUTPUT_DIR" -name "junit-callback-test-prefix-[0-9]*" | sort -r | head -1)" reports
 # Remove classname and time
-cat reports/junit-callback-test-prefix-[0-9]* | sed -e 's/time=".*"//' | sed -e 's/classname=".*"//' > reports/junit-callback-test-prefix.xml
+cat reports/junit-callback-test-prefix-[0-9]* | sed 's/[ ]\{1,\}time="[0-9.]\{1,\}"//' | sed 's/[ ]\{1,\}classname="[^"]\{1,\}"//' > reports/junit-callback-test-prefix.xml
 
 JUNIT_TEST_CASE_PREFIX="JUNIT TASK PREFIX - " \
 JUNIT_TEST_CASE_IGNORE_TEXT="JUNIT IGNORE THIS TASK" \
@@ -26,7 +26,7 @@ JUNIT_TEST_CASE_IGNORE_TEXT="JUNIT IGNORE THIS TASK" \
 # Compare with expected result
 mv "$(find "$JUNIT_OUTPUT_DIR" -name "junit-callback-test-ignore-[0-9]*" | sort -r | head -1)" reports
 # Remove classname and time
-cat reports/junit-callback-test-ignore-[0-9]* | sed -e 's/time=".*"//' | sed -e 's/classname=".*"//' > reports/junit-callback-test-ignore.xml
+cat reports/junit-callback-test-ignore-[0-9]* | sed 's/[ ]\{1,\}time="[0-9.]\{1,\}"//' | sed 's/[ ]\{1,\}classname="[^"]\{1,\}"//' > reports/junit-callback-test-ignore.xml
 
 diff --ignore-space-change expected_reports/junit-callback-test.xml reports/junit-callback-test.xml
 diff --ignore-space-change expected_reports/junit-callback-test-prefix.xml reports/junit-callback-test-prefix.xml

--- a/test/integration/targets/callback_junit/runme.sh
+++ b/test/integration/targets/callback_junit/runme.sh
@@ -11,14 +11,18 @@ ansible-playbook junit-callback-test.yml -i inventory "$@"
 # Copy report to local directory
 mv "$(find "$JUNIT_OUTPUT_DIR" -name "junit-callback-test-[0-9]*" | sort -r | head -1)" reports
 # Remove classname and time
-cat reports/junit-callback-test-[0-9]* | sed 's/[ ]\{1,\}time="[0-9.]\{1,\}"//' | sed 's/[ ]\{1,\}classname="[^"]\{1,\}"//' > reports/junit-callback-test.xml
+cat reports/junit-callback-test-[0-9]* | sed 's/[ ]\{1,\}time="[0-9.]\{1,\}"//' | sed 's/[ ]\{1,\}classname="[^"]\{1,\}"//' | sed 's/>{/>\
+{/' | sed 's/}</}\
+</' > reports/junit-callback-test.xml
 
 JUNIT_TEST_CASE_PREFIX="JUNIT TASK PREFIX - " \
     ansible-playbook junit-callback-test-prefix.yml -i inventory "$@"
 # # Compare with expected result
 mv "$(find "$JUNIT_OUTPUT_DIR" -name "junit-callback-test-prefix-[0-9]*" | sort -r | head -1)" reports
 # Remove classname and time
-cat reports/junit-callback-test-prefix-[0-9]* | sed 's/[ ]\{1,\}time="[0-9.]\{1,\}"//' | sed 's/[ ]\{1,\}classname="[^"]\{1,\}"//' > reports/junit-callback-test-prefix.xml
+cat reports/junit-callback-test-prefix-[0-9]* | sed 's/[ ]\{1,\}time="[0-9.]\{1,\}"//' | sed 's/[ ]\{1,\}classname="[^"]\{1,\}"//' | sed 's/>{/>\
+{/' | sed 's/}</}\
+</' > reports/junit-callback-test-prefix.xml
 
 JUNIT_TEST_CASE_PREFIX="JUNIT TASK PREFIX - " \
 JUNIT_TEST_CASE_IGNORE_TEXT="JUNIT IGNORE THIS TASK" \
@@ -26,7 +30,9 @@ JUNIT_TEST_CASE_IGNORE_TEXT="JUNIT IGNORE THIS TASK" \
 # Compare with expected result
 mv "$(find "$JUNIT_OUTPUT_DIR" -name "junit-callback-test-ignore-[0-9]*" | sort -r | head -1)" reports
 # Remove classname and time
-cat reports/junit-callback-test-ignore-[0-9]* | sed 's/[ ]\{1,\}time="[0-9.]\{1,\}"//' | sed 's/[ ]\{1,\}classname="[^"]\{1,\}"//' > reports/junit-callback-test-ignore.xml
+cat reports/junit-callback-test-ignore-[0-9]* | sed 's/[ ]\{1,\}time="[0-9.]\{1,\}"//' | sed 's/[ ]\{1,\}classname="[^"]\{1,\}"//' | sed 's/>{/>\
+{/' | sed 's/}</}\
+</' > reports/junit-callback-test-ignore.xml
 
 diff --ignore-space-change expected_reports/junit-callback-test.xml reports/junit-callback-test.xml
 diff --ignore-space-change expected_reports/junit-callback-test-prefix.xml reports/junit-callback-test-prefix.xml

--- a/test/integration/targets/callback_junit/runme.sh
+++ b/test/integration/targets/callback_junit/runme.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# export JUNIT_OUTPUT_DIR="$PWD/reports"
+
+rm -rf reports
+mkdir reports
+
+ansible-playbook junit-callback-test.yml -i inventory "$@"
+# Copy report to local directory
+mv $(ls -t $JUNIT_OUTPUT_DIR/junit-callback-test-[0-9]* | head -1) reports
+# Remove classname and time
+cat reports/junit-callback-test-[0-9]* | sed -e 's/time=".*"//' | sed -e 's/classname=".*"//' > reports/junit-callback-test.xml
+
+JUNIT_TEST_CASE_PREFIX="JUNIT TASK PREFIX - " \
+    ansible-playbook junit-callback-test-prefix.yml -i inventory "$@"
+# # Compare with expected result
+mv $(ls -t $JUNIT_OUTPUT_DIR/junit-callback-test-prefix-[0-9]* | head -1) reports
+# Remove classname and time
+cat reports/junit-callback-test-prefix-[0-9]* | sed -e 's/time=".*"//' | sed -e 's/classname=".*"//' > reports/junit-callback-test-prefix.xml
+
+JUNIT_TEST_CASE_PREFIX="JUNIT TASK PREFIX - " \
+JUNIT_TEST_CASE_IGNORE_TEXT="JUNIT IGNORE THIS TASK" \
+    ansible-playbook junit-callback-test-ignore.yml -i inventory "$@"
+# Compare with expected result
+mv $(ls -t $JUNIT_OUTPUT_DIR/junit-callback-test-ignore-[0-9]* | head -1) reports
+# Remove classname and time
+cat reports/junit-callback-test-ignore-[0-9]* | sed -e 's/time=".*"//' | sed -e 's/classname=".*"//' > reports/junit-callback-test-ignore.xml
+
+diff --ignore-space-change expected_reports/junit-callback-test.xml reports/junit-callback-test.xml
+diff --ignore-space-change expected_reports/junit-callback-test-prefix.xml reports/junit-callback-test-prefix.xml
+diff --ignore-space-change expected_reports/junit-callback-test-ignore.xml reports/junit-callback-test-ignore.xml

--- a/test/integration/targets/callback_junit/tasks/tasks.yml
+++ b/test/integration/targets/callback_junit/tasks/tasks.yml
@@ -1,0 +1,12 @@
+---
+- name: "A task in a file"
+  debug:
+    msg: This is a task with no prefix
+
+- name: "JUNIT TASK PREFIX - A task in a file"
+  debug:
+    msg: This is a task with a prefix
+
+- name: "A task in a file JUNIT IGNORE THIS TASK"
+  debug:
+    msg: This is a task with an ignore string

--- a/test/integration/targets/callback_junit/tasks/tasks.yml
+++ b/test/integration/targets/callback_junit/tasks/tasks.yml
@@ -10,3 +10,9 @@
 - name: "A task in a file JUNIT IGNORE THIS TASK"
   debug:
     msg: This is a task with an ignore string
+
+- name: "JUNIT TASK PREFIX - A task with a variable in the task name {{ something }}"
+  debug:
+    msg: This is a task with a variable in the task name
+  vars:
+    something: some-string


### PR DESCRIPTION
##### SUMMARY
Currently the JUNIT callback plugin has two issues:
1. JUNIT_TEST_CASE_PREFIX does not work for tasks that are in roles
2. There is no way to exclude a test case completely from the report. (Which is useful when running negative test cases)

A new ENVIRONMENT VARIABLE is introduced to control the text used to exclude a test case from the report (JUNIT_TEST_CASE_IGNORE_TEXT)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
junit

##### ADDITIONAL INFORMATION
Integration tests have also been added
