### PR TITLE
vmware: Using env variable for custom SSL path

### DIFF
--- a/docs/docsite/rst/scenario_guides/vmware_scenarios/vmware_requirements.rst
+++ b/docs/docsite/rst/scenario_guides/vmware_scenarios/vmware_requirements.rst
@@ -42,3 +42,21 @@ Installing ESXi SSL certificates for Ansible
 * Secure copy (SCP) ``rui.crt`` located in ``/etc/vmware/ssl`` directory to Ansible control node.
 
 * Install the certificate file by the process that is appropriate for your operating system.
+
+Using custom path for SSL certificates
+--------------------------------------
+
+If you need to use a custom path for SSL certificates, you can set the ``REQUESTS_CA_BUNDLE`` environment variable in your playbook.
+
+For example, if ``/var/vmware/certs/vcenter1.crt`` is the SSL certificate for your vCenter Server, you can use the :ref:`environment <playbooks_environment>` keyword to pass it to the modules:
+
+.. code-block:: yaml
+
+   - name: Gather all tags from vCenter
+     community.vmware.vmware_tag_info:
+       validate_certs: True
+       hostname: '{{ vcenter_hostname }}'
+       username: '{{ vcenter_username }}'
+       password: '{{ vcenter_password }}'
+     environment:
+       REQUESTS_CA_BUNDLE: /var/vmware/certs/vcenter1.crt


### PR DESCRIPTION
##### SUMMARY

When validate_certs is True and user has custom SSL
certificate path, user can use ``REQUESTS_CA_PATH``
in ``environment`` parameter of task to specify this path.

Fixes: https://github.com/ansible-collections/community.vmware/issues/49

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/scenario_guides/vmware_scenarios/vmware_requirements.rst
