### PR TITLE
Clarify CLI version number as core version

### DIFF
--- a/changelogs/fragments/core_version.yml
+++ b/changelogs/fragments/core_version.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- CLI version displays clarified as core version

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -157,7 +157,7 @@ def _gitinfo():
 def version(prog=None):
     """ return ansible version """
     if prog:
-        result = [" ".join((prog, __version__))]
+        result = ["{0} [core {1}] ".format(prog, __version__)]
     else:
         result = [__version__]
 

--- a/test/units/cli/arguments/test_optparse_helpers.py
+++ b/test/units/cli/arguments/test_optparse_helpers.py
@@ -25,7 +25,7 @@ VERSION_OUTPUT = opt_help.version(prog=FAKE_PROG)
 
 @pytest.mark.parametrize(
     'must_have', [
-        FAKE_PROG + u' %s' % ansible_version,
+        FAKE_PROG + u' [core %s]' % ansible_version,
         u'config file = %s' % C.CONFIG_FILE,
         u'configured module search path = %s' % cpath,
         u'ansible python module location = %s' % ':'.join(ansible_path),

--- a/test/units/cli/test_adhoc.py
+++ b/test/units/cli/test_adhoc.py
@@ -105,7 +105,7 @@ def test_ansible_version(capsys, mocker):
         version_lines = version[0].splitlines()
 
     assert len(version_lines) == 9, 'Incorrect number of lines in "ansible --version" output'
-    assert re.match('ansible [0-9.a-z]+(?: .*)?$', version_lines[0]), 'Incorrect ansible version line in "ansible --version" output'
+    assert re.match(r'ansible \[core [0-9.a-z]+\]', version_lines[0]), 'Incorrect ansible version line in "ansible --version" output'
     assert re.match('  config file = .*$', version_lines[1]), 'Incorrect config file line in "ansible --version" output'
     assert re.match('  configured module search path = .*$', version_lines[2]), 'Incorrect module search path in "ansible --version" output'
     assert re.match('  ansible python module location = .*$', version_lines[3]), 'Incorrect python module location in "ansible --version" output'


### PR DESCRIPTION
##### SUMMARY
With the `ansible` PyPI package versions drifting from the core engine version, users have requested clarification of the CLI version output that it's the core version.

* reduce confusion with `ansible` PyPI package >= 2.10 drifting from core version

(sample new output)
```
ansible-playbook [core 2.11.0.dev0]  (core_version_msg c20329a0f6) last updated 2020/10/21 15:10:16 (GMT -700)
  config file = None
  configured module search path = ['/home/mdavis/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mdavis/projects/ansible/lib/ansible
  ansible collection location = /home/mdavis/.ansible/collections:/usr/share/ansible/collections
  executable location = /home/mdavis/projects/ansible/bin/ansible-playbook
  python version = 3.8.5 (default, Jul 20 2020, 00:00:00) [GCC 10.1.1 20200507 (Red Hat 10.1.1-1)]
  libyaml = True

```

(needs backport to 2.10)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
