### PR TITLE
[2.9] postgresql_pg_hba: fix a crash when a new rule with an 'options' field replaces a rule without or vice versa

### DIFF
--- a/changelogs/fragments/1124-pg_hba-dictkey_bugfix.yaml
+++ b/changelogs/fragments/1124-pg_hba-dictkey_bugfix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - postgresql_pg_hba - fix a crash when a new rule with an 'options' field replaces a rule without or vice versa (https://github.com/ansible-collections/community.general/issues/1108).

--- a/lib/ansible/modules/database/postgresql/postgresql_pg_hba.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_pg_hba.py
@@ -342,7 +342,7 @@ class PgHba(object):
             ekeys = set(list(oldrule.keys()) + list(rule.keys()))
             ekeys.remove('line')
             for k in ekeys:
-                if oldrule[k] != rule[k]:
+                if oldrule.get(k) != rule.get(k):
                     raise PgHbaRuleChanged('{0} changes {1}'.format(rule, oldrule))
         except PgHbaRuleChanged:
             self.rules[key] = rule

--- a/test/integration/targets/postgresql/tasks/postgresql_pg_hba.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_pg_hba.yml
@@ -58,6 +58,20 @@
   register: pg_hba_change
   with_items: "{{pg_hba_test_ips}}"
 
+- name: Able to add options on rule without
+  postgresql_pg_hba:
+    dest: "/tmp/pg_hba.conf"
+    users: "+some"
+    order: "sud"
+    state: "present"
+    contype: "local"
+    method: "cert"
+    options: "{{ item }}"
+    address: ""
+  with_items:
+  - ""
+  - "clientcert=1"
+
 - name: Retain options even if they contain spaces
   postgresql_pg_hba:
     dest: "/tmp/pg_hba.conf"


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible-collections/community.general/pull/1124
postgresql_pg_hba: fix a crash when a new rule with an 'options' field replaces a rule without or vice versa

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/modules/database/postgresql/postgresql_pg_hba.py`