### PR TITLE
Add context to inventory plugins documentation

### DIFF
--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -97,7 +97,7 @@ You can create dynamic groups using host variables with the constructed ``keyed_
       private_only: "public_ip_address is not defined"
     compose:
       # use a private address where a public one isn't assigned
-      ansible_host: ((network_interfaces[0].association | default({}) ).public_ip | default('') != '') | ternary((network_interfaces[0].association | default({}) ).public_ip, private_ip_address)
+      ansible_host: public_ip_address is defined | ternary(public_ip_address, private_ip_address)
       # alternatively, set the ansible_host variable to connect with the private IP address without changing the hostname
       # ansible_host: private_ip_address
       # if you *must* set a string here (perhaps to identify the inventory source if you have multiple

--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -31,7 +31,7 @@ If the plugin is in a collection, and isn't being picked up by the `auto` statem
    [inventory]
    enable_plugins = host_list, script, auto, yaml, ini, toml, namespace.collection_name.inventory_plugin_name
 
-Or, if it's a local plugin, perhaps stored in `plugins/inventory/my_plugin.py`, you could reference it like this:
+Or, if it's a local plugin, perhaps stored in `~/.ansible/plugins/inventory/my_plugin.py`, you could reference it like this:
 
 .. code-block:: ini
 

--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -94,7 +94,7 @@ You can create dynamic groups using host variables with the constructed ``keyed_
       # add hosts to the group development if any of the dictionary's keys or values is the word 'devel'
       development: "'devel' in (tags|list)"
       # add hosts to the "private_only" group if the host doesn't have a public IP associated to it
-      private_only: "(network_interfaces[0].association | default({}) ).public_ip | default('') != ''"
+      private_only: "public_ip_address is not defined"
     compose:
       # use a private address where a public one isn't assigned
       ansible_host: ((network_interfaces[0].association | default({}) ).public_ip | default('') != '') | ternary((network_interfaces[0].association | default({}) ).public_ip, private_ip_address)

--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -31,6 +31,12 @@ If the plugin is in a collection, use the fully qualified name:
    [inventory]
    enable_plugins = namespace.collection_name.inventory_plugin_name
 
+If you want to be able to add a plugin from a collection to your other inventory methods, add it into the existing list:
+
+.. code-block:: ini
+
+   [inventory]
+   enable_plugins = host_list, script, auto, yaml, ini, toml, namespace.collection_name.inventory_plugin_name
 
 .. _using_inventory:
 
@@ -80,12 +86,24 @@ You can create dynamic groups using host variables with the constructed ``keyed_
       - key: tags.Name
         prefix: tag_Name_
         separator: ""
+      # If you have a tag called "Role" which has the value "Webserver", this will add the group
+      # Role_Webserver and add any hosts that have that tag assigned to it.
+      - key: tags.Role
+        prefix: role
     groups:
       # add hosts to the group development if any of the dictionary's keys or values is the word 'devel'
       development: "'devel' in (tags|list)"
+      # add hosts to the "private_only" group if the host doesn't have a public IP associated to it
+      private_only: "(network_interfaces[0].association | default({}) ).public_ip | default('') != ''"
     compose:
-      # set the ansible_host variable to connect with the private IP address without changing the hostname
-      ansible_host: private_ip_address
+      # use a private address where a public one isn't assigned
+      ansible_host: ((network_interfaces[0].association | default({}) ).public_ip | default('') != '') | ternary((network_interfaces[0].association | default({}) ).public_ip, private_ip_address)
+      # alternatively, set the ansible_host variable to connect with the private IP address without changing the hostname
+      # ansible_host: private_ip_address
+      # if you *must* set a string here (perhaps to identify the inventory source if you have multiple
+      # accounts you want to use as sources), you need to wrap this in two sets of quotes, either ' then "
+      # or " then '
+      some_inventory_wide_string: '"Yes, you need both types of quotes here"'
 
 Now the output of ``ansible-inventory -i demo.aws_ec2.yml --graph``:
 
@@ -99,6 +117,8 @@ Now the output of ``ansible-inventory -i demo.aws_ec2.yml --graph``:
       |--@development:
       |  |--ec2-12-345-678-901.compute-1.amazonaws.com
       |  |--ec2-98-765-432-10.compute-1.amazonaws.com
+      |--@role_Webserver
+      |  |--ec2-12-345-678-901.compute-1.amazonaws.com
       |--@tag_Name_ECS_Instance:
       |  |--ec2-98-765-432-10.compute-1.amazonaws.com
       |--@tag_Name_Test_Server:

--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -87,7 +87,7 @@ You can create dynamic groups using host variables with the constructed ``keyed_
         prefix: tag_Name_
         separator: ""
       # If you have a tag called "Role" which has the value "Webserver", this will add the group
-      # Role_Webserver and add any hosts that have that tag assigned to it.
+      # role_Webserver and add any hosts that have that tag assigned to it.
       - key: tags.Role
         prefix: role
     groups:

--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -24,19 +24,19 @@ In some circumstances, for example, if the inventory plugin does not use a YAML 
    [inventory]
    enable_plugins = host_list, script, auto, yaml, ini, toml
 
-If the plugin is in a collection, use the fully qualified name:
-
-.. code-block:: ini
-
-   [inventory]
-   enable_plugins = namespace.collection_name.inventory_plugin_name
-
-If you want to be able to add a plugin from a collection to your other inventory methods, add it into the existing list:
+If the plugin is in a collection, and isn't being picked up by the `auto` statement, you can append the fully qualified name:
 
 .. code-block:: ini
 
    [inventory]
    enable_plugins = host_list, script, auto, yaml, ini, toml, namespace.collection_name.inventory_plugin_name
+
+Or, if it's a local plugin, perhaps stored in `plugins/inventory/my_plugin.py`, you could reference it like this:
+
+.. code-block:: ini
+
+   [inventory]
+   enable_plugins = host_list, script, auto, yaml, ini, toml, my_plugin
 
 .. _using_inventory:
 

--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -24,7 +24,7 @@ In some circumstances, for example, if the inventory plugin does not use a YAML 
    [inventory]
    enable_plugins = host_list, script, auto, yaml, ini, toml
 
-If the plugin is in a collection, and isn't being picked up by the `auto` statement, you can append the fully qualified name:
+If the plugin is in a collection and is not being picked up by the `auto` statement, you can append the fully qualified name:
 
 .. code-block:: ini
 

--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -31,7 +31,7 @@ If the plugin is in a collection and is not being picked up by the `auto` statem
    [inventory]
    enable_plugins = host_list, script, auto, yaml, ini, toml, namespace.collection_name.inventory_plugin_name
 
-Or, if it's a local plugin, perhaps stored in `~/.ansible/plugins/inventory/my_plugin.py`, you could reference it like this:
+Or, if it is a local plugin, perhaps stored in `~/.ansible/plugins/inventory/my_plugin.py`, you could reference it like this:
 
 .. code-block:: ini
 

--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -31,7 +31,7 @@ If the plugin is in a collection and is not being picked up by the `auto` statem
    [inventory]
    enable_plugins = host_list, script, auto, yaml, ini, toml, namespace.collection_name.inventory_plugin_name
 
-Or, if it is a local plugin, perhaps stored in `~/.ansible/plugins/inventory/my_plugin.py`, you could reference it like this:
+Or, if it is a local plugin, perhaps stored in the path set by :ref:`DEFAULT_INVENTORY_PLUGIN_PATH`, you could reference it as follows:
 
 .. code-block:: ini
 


### PR DESCRIPTION
##### SUMMARY
* Show how to add the inventory plugin to the `enable_plugins` configuration item - not just replace it.
* Show adding tags to `keyed_groups` without specifying the separator.
* Show adding more complex `groups` and `compose` statements, including using the ternary filter.
* As I added an additional group, I've updated the resulting `ansible-inventory` output accordingly.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ansible.builtin.constructed_inventory

##### ADDITIONAL INFORMATION
This has been raised in response to confusion I had, which was cleared up during conversations with @s-hertel and @flowerysong in the Ansible-AWS IRC channel.