### PR TITLE
Update mongodb replicaset check_compatibility function

### DIFF
--- a/changelogs/fragments/72299-fix-check-compatibility.yaml
+++ b/changelogs/fragments/72299-fix-check-compatibility.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - mongodb_replicaset - fixes check_compatibility function (https://github.com/ansible-collections/community.mongodb/issues/230).

--- a/lib/ansible/modules/database/mongodb/mongodb_replicaset.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_replicaset.py
@@ -180,29 +180,43 @@ from ansible.module_utils._text import to_native
 # MongoDB module specific support methods.
 #
 
-def check_compatibility(module, client):
+def check_compatibility(module, srv_version, driver_version):
     """Check the compatibility between the driver and the database.
-
-       See: https://docs.mongodb.com/ecosystem/drivers/driver-compatibility-reference/#python-driver-compatibility
-
+    See: https://docs.mongodb.com/ecosystem/drivers/driver-compatibility-reference/#python-driver-compatibility
     Args:
         module: Ansible module.
-        client (cursor): Mongodb cursor on admin database.
+        srv_version (LooseVersion): MongoDB server version.
+        driver_version (LooseVersion): Pymongo version.
     """
-    loose_srv_version = LooseVersion(client.server_info()['version'])
-    loose_driver_version = LooseVersion(PyMongoVersion)
+    msg = 'pymongo driver version and MongoDB version are incompatible: '
 
-    if loose_srv_version >= LooseVersion('3.2') and loose_driver_version < LooseVersion('3.2'):
-        module.fail_json(msg=' (Note: you must use pymongo 3.2+ with MongoDB >= 3.2)')
+    if srv_version >= LooseVersion('4.2') and driver_version < LooseVersion('3.9'):
+        msg += 'you must use pymongo 3.9+ with MongoDB >= 4.2'
+        module.fail_json(msg=msg)
 
-    elif loose_srv_version >= LooseVersion('3.0') and loose_driver_version <= LooseVersion('2.8'):
-        module.fail_json(msg=' (Note: you must use pymongo 2.8+ with MongoDB 3.0)')
+    elif srv_version >= LooseVersion('4.0') and driver_version < LooseVersion('3.7'):
+        msg += 'you must use pymongo 3.7+ with MongoDB >= 4.0'
+        module.fail_json(msg=msg)
 
-    elif loose_srv_version >= LooseVersion('2.6') and loose_driver_version <= LooseVersion('2.7'):
-        module.fail_json(msg=' (Note: you must use pymongo 2.7+ with MongoDB 2.6)')
+    elif srv_version >= LooseVersion('3.6') and driver_version < LooseVersion('3.6'):
+        msg += 'you must use pymongo 3.6+ with MongoDB >= 3.6'
+        module.fail_json(msg=msg)
 
-    elif LooseVersion(PyMongoVersion) <= LooseVersion('2.5'):
-        module.fail_json(msg=' (Note: you must be on mongodb 2.4+ and pymongo 2.5+ to use the roles param)')
+    elif srv_version >= LooseVersion('3.4') and driver_version < LooseVersion('3.4'):
+        msg += 'you must use pymongo 3.4+ with MongoDB >= 3.4'
+        module.fail_json(msg=msg)
+
+    elif srv_version >= LooseVersion('3.2') and driver_version < LooseVersion('3.2'):
+        msg += 'you must use pymongo 3.2+ with MongoDB >= 3.2'
+        module.fail_json(msg=msg)
+
+    elif srv_version >= LooseVersion('3.0') and driver_version <= LooseVersion('2.8'):
+        msg += 'you must use pymongo 2.8+ with MongoDB 3.0'
+        module.fail_json(msg=msg)
+
+    elif srv_version >= LooseVersion('2.6') and driver_version <= LooseVersion('2.7'):
+        msg += 'you must use pymongo 2.7+ with MongoDB 2.6'
+        module.fail_json(msg=msg)
 
 
 def replicaset_find(client):
@@ -394,6 +408,7 @@ def main():
                         # Get driver version::
                         driver_version = LooseVersion(PyMongoVersion)
                         # Check driver and server version compatibility:
+
                         check_compatibility(module, srv_version, driver_version)
                     except Exception as excep:
                         module.fail_json(msg='Unable to authenticate with MongoDB: %s' % to_native(excep))

--- a/test/integration/targets/mongodb_replicaset/aliases
+++ b/test/integration/targets/mongodb_replicaset/aliases
@@ -3,5 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
-linux/centos8/1
 needs/root

--- a/test/integration/targets/mongodb_replicaset/aliases
+++ b/test/integration/targets/mongodb_replicaset/aliases
@@ -3,5 +3,5 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
-skip/linux/centos8
+linux/centos8/1
 needs/root

--- a/test/integration/targets/mongodb_replicaset/aliases
+++ b/test/integration/targets/mongodb_replicaset/aliases
@@ -3,5 +3,5 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
-skip/centos8
+skip/linux/centos8
 needs/root

--- a/test/integration/targets/mongodb_replicaset/aliases
+++ b/test/integration/targets/mongodb_replicaset/aliases
@@ -3,4 +3,5 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+skip/centos8
 needs/root

--- a/test/integration/targets/setup_mongodb/defaults/main.yml
+++ b/test/integration/targets/setup_mongodb/defaults/main.yml
@@ -21,7 +21,7 @@ yum:
   baseurl: https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/{{mongodb_version}}/x86_64/
   gpgcheck: 1
   gpgkey: https://www.mongodb.org/static/pgp/server-{{mongodb_version}}.asc
-  redhat8url: https://repo.mongodb.org/yum/redhat/7/mongodb-org/{{mongodb_version}}/x86_64/
+  redhat8url: https://repo.mongodb.org/yum/redhat/8/mongodb-org/{{mongodb_version}}/x86_64/
   fedoraurl: https://repo.mongodb.org/yum/amazon/2013.03/mongodb-org/{{mongodb_version}}/x86_64/
 
 debian_packages_py2:

--- a/test/integration/targets/setup_mongodb/tasks/main.yml
+++ b/test/integration/targets/setup_mongodb/tasks/main.yml
@@ -129,12 +129,12 @@
   when:
     - ansible_distribution == "Fedora"
 
-- name: Fix corrupted yum db in Redhat 8 Shippable
-  shell: rm -rf /var/lib/rpm/ && yum clean all
-  when:
-    - ansible_os_family == "RedHat"
-    - ansible_distribution_version.split('.')[0]|int == 8
-    - not ansible_distribution == "Fedora"
+#- name: Fix corrupted yum db in Redhat 8 Shippable
+#  shell: rm -rf /var/lib/rpm/ && yum clean all
+#  when:
+#    - ansible_os_family == "RedHat"
+#    - ansible_distribution_version.split('.')[0]|int == 8
+#    - not ansible_distribution == "Fedora"
 
 - name: Ensure epel package is installed
   package:

--- a/test/integration/targets/setup_mongodb/tasks/main.yml
+++ b/test/integration/targets/setup_mongodb/tasks/main.yml
@@ -129,7 +129,7 @@
   when:
     - ansible_distribution == "Fedora"
 
-- name: Fix cirrupted yum db in Redhat 8 Shippable
+- name: Fix corrupted yum db in Redhat 8 Shippable
   shell: rm -rf /var/lib/rpm/ && yum clean all
   when:
     - ansible_os_family == "RedHat"
@@ -137,7 +137,7 @@
     - not ansible_distribution == "Fedora"
 
 - name: Ensure epel package is installed
-  yum:
+  package:
     name: epel-release
     state: present
   when: ansible_os_family == "RedHat"

--- a/test/integration/targets/setup_mongodb/tasks/main.yml
+++ b/test/integration/targets/setup_mongodb/tasks/main.yml
@@ -129,13 +129,6 @@
   when:
     - ansible_distribution == "Fedora"
 
-#- name: Fix corrupted yum db in Redhat 8 Shippable
-#  shell: rm -rf /var/lib/rpm/ && yum clean all
-#  when:
-#    - ansible_os_family == "RedHat"
-#    - ansible_distribution_version.split('.')[0]|int == 8
-#    - not ansible_distribution == "Fedora"
-
 - name: Ensure epel package is installed
   package:
     name: epel-release

--- a/test/integration/targets/setup_mongodb/tasks/main.yml
+++ b/test/integration/targets/setup_mongodb/tasks/main.yml
@@ -26,6 +26,7 @@
     or ansible_os_family == "Suse"
     or ansible_distribution == 'Fedora'
     or (ansible_distribution == 'CentOS' and ansible_distribution_version == '7')
+    or (ansible_distribution == 'CentOS' and ansible_distribution_version == '8')
 
 # Ubuntu
 - name: Import MongoDB public GPG Key xenial

--- a/test/integration/targets/setup_mongodb/tasks/main.yml
+++ b/test/integration/targets/setup_mongodb/tasks/main.yml
@@ -129,12 +129,6 @@
   when:
     - ansible_distribution == "Fedora"
 
-- name: Ensure epel package is installed
-  package:
-    name: epel-release
-    state: present
-  when: ansible_os_family == "RedHat"
-
 - name: Ensure mongod package is installed
   yum:
     name: "{{ mongodb_packages.mongod }}"

--- a/test/integration/targets/setup_mongodb/tasks/main.yml
+++ b/test/integration/targets/setup_mongodb/tasks/main.yml
@@ -128,6 +128,13 @@
   when:
     - ansible_distribution == "Fedora"
 
+- name: Fix cirrupted yum db in Redhat 8 Shippable
+  shell: rm -rf /var/lib/rpm/ && yum clean all
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_version.split('.')[0]|int == 8
+    - not ansible_distribution == "Fedora"
+
 - name: Ensure mongod package is installed
   yum:
     name: "{{ mongodb_packages.mongod }}"

--- a/test/integration/targets/setup_mongodb/tasks/main.yml
+++ b/test/integration/targets/setup_mongodb/tasks/main.yml
@@ -129,12 +129,12 @@
   when:
     - ansible_distribution == "Fedora"
 
-#- name: Fix cirrupted yum db in Redhat 8 Shippable
-#  shell: rm -rf /var/lib/rpm/ && yum clean all
-#  when:
-#    - ansible_os_family == "RedHat"
-#    - ansible_distribution_version.split('.')[0]|int == 8
-#    - not ansible_distribution == "Fedora"
+- name: Fix cirrupted yum db in Redhat 8 Shippable
+  shell: rm -rf /var/lib/rpm/ && yum clean all
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_version.split('.')[0]|int == 8
+    - not ansible_distribution == "Fedora"
 
 - name: Ensure epel package is installed
   yum:

--- a/test/integration/targets/setup_mongodb/tasks/main.yml
+++ b/test/integration/targets/setup_mongodb/tasks/main.yml
@@ -136,6 +136,12 @@
 #    - ansible_distribution_version.split('.')[0]|int == 8
 #    - not ansible_distribution == "Fedora"
 
+- name: Ensure epel package is installed
+  yum:
+    name: epel-release
+    state: present
+  when: ansible_os_family == "RedHat"
+
 - name: Ensure mongod package is installed
   yum:
     name: "{{ mongodb_packages.mongod }}"

--- a/test/integration/targets/setup_mongodb/tasks/main.yml
+++ b/test/integration/targets/setup_mongodb/tasks/main.yml
@@ -128,12 +128,12 @@
   when:
     - ansible_distribution == "Fedora"
 
-- name: Fix cirrupted yum db in Redhat 8 Shippable
-  shell: rm -rf /var/lib/rpm/ && yum clean all
-  when:
-    - ansible_os_family == "RedHat"
-    - ansible_distribution_version.split('.')[0]|int == 8
-    - not ansible_distribution == "Fedora"
+#- name: Fix cirrupted yum db in Redhat 8 Shippable
+#  shell: rm -rf /var/lib/rpm/ && yum clean all
+#  when:
+#    - ansible_os_family == "RedHat"
+#    - ansible_distribution_version.split('.')[0]|int == 8
+#    - not ansible_distribution == "Fedora"
 
 - name: Ensure mongod package is installed
   yum:


### PR DESCRIPTION
##### SUMMARY

Update the check_compatibility function so the module actually works. In this PR https://github.com/ansible/ansible/pull/71393 I failed to update the function called check_compatibility that has three parameters. The odd thing here is that the integrations tests ran fine (locally and in the CI). I've just tested this locally as follows..

```
virtualenv venv
. venv/bin/activate
pip install -r requirements.txt
. hacking/env-setup
ansible-test integration --docker -v mongodb_replicaset
```

These tests do not run with the local copy of the module. I'm not sure if I'm doing something wrong here but ansible-test certainly doesn't include this in the docker image to be tested. I added a module.fail_json call somewhere to check this (it was never called). I originally submitted these modules before the collection split and this way of testing modules used to work as expected. This other error (or mistake) explains how this slipped through.

A user reported this over at the MongoDB collection repo https://github.com/ansible-collections/community.mongodb/issues/230

I have updated this module with the three-parameter version of the function.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
mongodb_replicaset
