### PR TITLE
[packaging/rpm] %{python_sitelib} breaks RHEL8

### DIFF
--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -35,8 +35,8 @@ Url: http://ansible.com
 BuildArch: noarch
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
-%{!?python2_sitelib: %global python_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
-%{!?python3_sitelib: %global python_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
+%{!?python2_sitelib: %global _python_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
+%{!?python3_sitelib: %global _python_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 
 # Bundled provides
 Provides: bundled(python-backports-ssl_match_hostname) = 3.7.0.1
@@ -219,8 +219,8 @@ done
 
 # Amazon Linux doesn't install to dist-packages but python_sitelib expands to
 # that location and the python interpreter expects things to be there.
-if expr x'%{python_sitelib}' : 'x.*dist-packages/\?' ; then
-    DEST_DIR='%{buildroot}%{python_sitelib}'
+if expr x'%{_python_sitelib}' : 'x.*dist-packages/\?' ; then
+    DEST_DIR='%{buildroot}%{_python_sitelib}'
     SOURCE_DIR=$(echo "$DEST_DIR" | sed 's/dist-packages/site-packages/g')
     if test -d "$SOURCE_DIR" -a ! -d "$DEST_DIR" ; then
         mv $SOURCE_DIR $DEST_DIR


### PR DESCRIPTION

##### SUMMARY

Change:
Modern RHEL8 dislikes unversioned python macros, and will error on them:

Start: rpmbuild -bs
error: attempt to use unversioned python, define %__python to /usr/bin/python2 or /usr/bin/python3 explicitly
error: line 222: if expr x'%{python_sitelib}' : 'x.*dist-packages/\?' ; then

We actually work around this earlier in the spec file, but the static
analysis that rpmbuild does is not smart enough to realize that we're
using our custom %{python_sitelib} global here.

So this PR just renames it to %{_python_sitelib} instead to sate
rpmbuild and get the spec file working on el8.

Test Plan:
Built on RHEL8 VM successfully.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

packaging/rpm