### PR TITLE
Ensure that ansible-galaxy role init with custom role_skel does not overwrite files that got templated before

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -931,7 +931,11 @@ class GalaxyCLI(CLI):
                         df.write(b_rendered)
                 else:
                     f_rel_path = os.path.relpath(os.path.join(root, f), obj_skeleton)
-                    shutil.copyfile(os.path.join(root, f), os.path.join(obj_path, f_rel_path))
+                    check_path = os.path.join(obj_path, f_rel_path)
+                    if os.path.isfile(check_path) and os.access(check_path, os.R_OK):
+                        continue
+                    else:
+                        shutil.copyfile(os.path.join(root, f), os.path.join(obj_path, f_rel_path))
 
             for d in dirs:
                 b_dir_path = to_bytes(os.path.join(obj_path, rel_root, d), errors='surrogate_or_strict')


### PR DESCRIPTION
##### SUMMARY
I noted, that initializing a role via `ansible-galaxy role init --role-skel=<custom_role_skeleton>`, files that I wanted to have templated from `.j2` jinja templates would get overwritten by files with the same filename with "static" content. Most notable this will happen for `.gitlab-ci.yml.j2` files, if you have a `.gitlab-ci.yml` file in you custom role skeleton directory.

This fix will test if a file already exists before copying a files from the role_skeleton and thus ensure, that a file derived from a jinja2 template will not get overwritten by a file with the same name.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-galaxy (init role with custom role-skeleton)

##### ADDITIONAL INFORMATION
You can easily test the described bug:
1. create a new role via: `ansible-galaxy role init role_skel_test`
2. create a static file ".gitlab-ci.yml" in `role_skel_test` with static content
3. create a jinja2 template ".gitlab-ci.yml.j2" in `role_skel_test` that contains `{{ role_name }}`
4. create a new role based on the new template via: `ansible-galaxy role init --role-skeleton=role_skel_test role_from_custom_skel`
BUG : you will see that `role_from_custom_skel/.gitlab-ci.yml` is the same as `role_skel_test/.gitlab-ci.yml`
EXPECTED: I would expect that `role_from_custom_skel/.gitlab-ci.yml` contains the templated content based on `role_skel_test/.gitlab-ci.yml.j2".
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

