### PR TITLE
Update developing_plugins.rst

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -130,7 +130,7 @@ For example, if you wanted to check the time difference between your Ansible con
 
             if remote_date:
                 remote_date_obj = datetime.strptime(remote_date, '%Y-%m-%dT%H:%M:%SZ')
-                time_delta = datetime.now() - remote_date_obj
+                time_delta = datetime.utcnow() - remote_date_obj
                 ret['delta_seconds'] = time_delta.seconds
                 ret['delta_days'] = time_delta.days
                 ret['delta_microseconds'] = time_delta.microseconds


### PR DESCRIPTION
##### SUMMARY
ansible_date_time returns utc time. datetime.utcnow() rather than datetime.now()

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
