### PR TITLE
Use is_boto3_error_code in 'standard' example

### DIFF
--- a/docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst
@@ -286,7 +286,8 @@ amounts of exception handling to existing modules, we recommend migrating the mo
 Note that it should normally be acceptable to catch all normal exceptions here, however if you
 expect anything other than botocore exceptions you should test everything works as expected.
 
-If you need to perform an action based on the error boto3 returned, use the error code.
+If you need to perform an action based on the error boto3 returned, use the error code and the
+``is_boto3_error_code()`` helper
 
 .. code-block:: python
 
@@ -294,12 +295,9 @@ If you need to perform an action based on the error boto3 returned, use the erro
    name = module.params.get['name']
    try:
        result = connection.describe_frooble(FroobleName=name)
-   except botocore.exceptions.ClientError as e:
-       if e.response['Error']['Code'] == 'FroobleNotFound':
-           workaround_failure()  # This is an error that we can work around
-       else:
-           module.fail_json_aws(e, msg="Couldn't obtain frooble %s" % name)
-   except botocore.exceptions.BotoCoreError as e:
+   except is_boto3_error_code('FroobleNotFound'):
+       workaround_failure()  # This is an error that we can work around
+   except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
        module.fail_json_aws(e, msg="Couldn't obtain frooble %s" % name)
 
 using fail_json() and avoiding ansible.module_utils.aws.core

--- a/docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst
@@ -287,7 +287,7 @@ Note that it should normally be acceptable to catch all normal exceptions here, 
 expect anything other than botocore exceptions you should test everything works as expected.
 
 If you need to perform an action based on the error boto3 returned, use the error code and the
-``is_boto3_error_code()`` helper
+``is_boto3_error_code()`` helper.
 
 .. code-block:: python
 
@@ -297,7 +297,7 @@ If you need to perform an action based on the error boto3 returned, use the erro
        result = connection.describe_frooble(FroobleName=name)
    except is_boto3_error_code('FroobleNotFound'):
        workaround_failure()  # This is an error that we can work around
-   except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
+   except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:  # pylint: disable=duplicate-except
        module.fail_json_aws(e, msg="Couldn't obtain frooble %s" % name)
 
 using fail_json() and avoiding ansible.module_utils.aws.core


### PR DESCRIPTION
##### SUMMARY

It looks like we didn't update some of our examples in the  AWS Guidelines to recommend is_boto3_error_code when working around a specific error is possible

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst

##### ADDITIONAL INFORMATION

CC: @jillr @s-hertel 