### PR TITLE
Use type 'path' for fact_caching_connection in jsonfile plugin

### DIFF
--- a/changelogs/fragments/72315-fact-caching-relative-to-config.yml
+++ b/changelogs/fragments/72315-fact-caching-relative-to-config.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix jsonfile cache plugin option '_uri' to be a type path instead of a string. (https://github.com/ansible/ansible/issues/38002)

--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -23,6 +23,7 @@ DOCUMENTATION = '''
         ini:
           - key: fact_caching_connection
             section: defaults
+        type: path
       _prefix:
         description: User defined prefix to use when creating the JSON files
         env:


### PR DESCRIPTION
##### SUMMARY
This is something that needs to be fixed in individual plugins, because fact_caching_connection should not always be a path.

Fixes #38002

##### ISSUE TYPE
- Bugfix Pull Request
