### PR TITLE
url lookup - add default user agent

### DIFF
--- a/changelogs/fragments/url-lookup-add-httpagent.yml
+++ b/changelogs/fragments/url-lookup-add-httpagent.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - url lookup - set default user agent to ``ansible-httpget``
+  - url lookup - set default user agent to ``ansible-httpget`` (https://github.com/ansible/ansible/pull/72324)

--- a/changelogs/fragments/url-lookup-add-httpagent.yml
+++ b/changelogs/fragments/url-lookup-add-httpagent.yml
@@ -1,2 +1,2 @@
 bugfixes:
-    - url lookup - set default user agent to ``ansible-httpget``
+  - url lookup - set default user agent to ``ansible-httpget``

--- a/changelogs/fragments/url-lookup-add-httpagent.yml
+++ b/changelogs/fragments/url-lookup-add-httpagent.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - url lookup - set default user agent to ``ansible-httpget``

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -64,7 +64,7 @@ options:
         - section: url_lookup
           key: timeout
   http_agent:
-    description: User-Agent to use in the request
+    description: User-Agent to use in the request. The default was changed in 2.11 to C(ansible-httpget).
     type: string
     version_added: "2.10"
     default: ansible-httpget

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -67,6 +67,7 @@ options:
     description: User-Agent to use in the request
     type: string
     version_added: "2.10"
+    default: ansible-httpget
     vars:
         - name: ansible_lookup_url_agent
     env:

--- a/test/units/plugins/lookup/test_url.py
+++ b/test/units/plugins/lookup/test_url.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2020, Sam Doran <sdoran@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible.plugins.loader import lookup_loader
+
+
+@pytest.mark.parametrize(
+    ('kwargs', 'agent'),
+    (
+        ({}, 'ansible-httpget'),
+        ({'http_agent': 'SuperFox'}, 'SuperFox'),
+    )
+)
+def test_user_agent(mocker, kwargs, agent):
+    mock_open_url = mocker.patch('ansible.plugins.lookup.url.open_url', side_effect=AttributeError('raised intentionally'))
+    url_lookup = lookup_loader.get('url')
+    with pytest.raises(AttributeError):
+        url_lookup.run(['https://nourl'], **kwargs)
+    assert 'http_agent' in mock_open_url.call_args.kwargs
+    assert mock_open_url.call_args.kwargs['http_agent'] == agent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `http_agent` option was added the `url` lookup in 2.10 (#64892). It should have set the default user agent value to `ansible-httpget` for consistency with other modules such as `uri`.

Related to #55733.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/lookup/url.py`

##### ADDITIONAL INFORMATION

This was originally supposed to get merged in #55733 but fell through the cracks. This is now a change in the default behavior for a shipped feature. I somewhat consider this a bug since the default Python user agent is blocked by a number of things. I would like to backport this change but that may be against our policies.