### PR TITLE
docs: Transpose two words to correct a sentence.

### DIFF
--- a/docs/docsite/keyword_desc.yml
+++ b/docs/docsite/keyword_desc.yml
@@ -48,7 +48,7 @@ loop_control: |
 
 max_fail_percentage: can be used to abort the run after a given percentage of hosts in the current batch has failed.
 module_defaults: Specifies default parameter values for modules.
-name: "Identifier. Can be used for documentation, in or tasks/handlers."
+name: "Identifier. Can be used for documentation, or in tasks/handlers."
 no_log: Boolean that controls information disclosure.
 notify: "List of handlers to notify when the task returns a 'changed=True' status."
 order: Controls the sorting of hosts as they are used for executing the play. Possible values are inventory (default), sorted, reverse_sorted, reverse_inventory and shuffle.


### PR DESCRIPTION
So that 'for documentation, in or tasks/handlers' becomes 'for documentation, or in tasks/handlers'.
