### PR TITLE
[2.8] Remove ansible-galaxy login (#72288)

### DIFF
--- a/changelogs/fragments/galaxy_login_bye.yml
+++ b/changelogs/fragments/galaxy_login_bye.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- ansible-galaxy login command has been removed (see https://github.com/ansible/ansible/issues/71560)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -555,28 +555,9 @@ class GalaxyCLI(CLI):
         """
         verify user's identify via GitHub and retrieve an auth token from Ansible Galaxy.
         """
-        # Authenticate with github and retrieve a token
-        if context.CLIARGS['token'] is None:
-            if C.GALAXY_TOKEN:
-                github_token = C.GALAXY_TOKEN
-            else:
-                login = GalaxyLogin(self.galaxy)
-                github_token = login.create_github_token()
-        else:
-            github_token = context.CLIARGS['token']
-
-        galaxy_response = self.api.authenticate(github_token)
-
-        if context.CLIARGS['token'] is None and C.GALAXY_TOKEN is None:
-            # Remove the token we created
-            login.remove_github_token()
-
-        # Store the Galaxy token
-        token = GalaxyToken()
-        token.set(galaxy_response['token'])
-
-        display.display("Successfully logged into Galaxy as %s" % galaxy_response['username'])
-        return 0
+        display.error("The login command was removed in late 2020. To continue importing roles to Galaxy, upgrade to "
+                      "ansible >= 2.9 or use the Web UI to import manually.")
+        return 1
 
     def execute_import(self):
         """ used to import a role into Ansible Galaxy """

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1413,13 +1413,6 @@ GALAXY_SERVER:
   ini:
   - {key: server, section: galaxy}
   yaml: {key: galaxy.server}
-GALAXY_TOKEN:
-  default: null
-  description: "GitHub personal access token"
-  env: [{name: ANSIBLE_GALAXY_TOKEN}]
-  ini:
-  - {key: token, section: galaxy}
-  yaml: {key: galaxy.token}
 HOST_KEY_CHECKING:
   name: Check host keys
   default: True


### PR DESCRIPTION
##### SUMMARY
* GitHub is removing the underlying API used to implement the `login` command. Since the general consensus seems to be that relatively nobody currently uses this command (in favor of explicit token passing), support was simply removed for interactive login. If a future need arises, this command should be reimplemented via OAuth Device Auth Grants.
* login or role login commands now produce a fatal error with a descriptive message
 
(cherry picked from commit 83909bfa22573777e3db5688773bda59721962ad)

NB: the 2.8 backport is a subset that merely removes login and recommends upgrading or using the web UI for publishing without an active token, since the token functionality changed significantly between 2.8 and 2.9, and 2.8 is very near EOL

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
