### PR TITLE
ansible-test ansible-doc sanity test: disable vars plugins for collections

### DIFF
--- a/changelogs/fragments/ansible-test-ansible-doc-vars-collections.yml
+++ b/changelogs/fragments/ansible-test-ansible-doc-vars-collections.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-test - disable ansible-doc sanity test for vars plugins in collections, which are not supported by Ansible 2.9 (https://github.com/ansible/ansible/pull/72336)."

--- a/test/lib/ansible_test/_internal/sanity/ansible_doc.py
+++ b/test/lib/ansible_test/_internal/sanity/ansible_doc.py
@@ -61,6 +61,9 @@ class AnsibleDocTest(SanitySingleVersion):
             'terminal',
             'test',
         ])
+        if data_context().content.collection:
+            # Ansible 2.9 does not support var plugins in collections
+            plugin_type_blacklist.add('vars')
 
         plugin_paths = [plugin_path for plugin_type, plugin_path in data_context().content.plugin_paths.items() if plugin_type not in plugin_type_blacklist]
 


### PR DESCRIPTION
##### SUMMARY
This is NOT a backport!

Ansible 2.9 does not support vars plugins in collections. Unfortunately, the ansible-doc sanity test still is still ran for vars plugins.

This makes that sanity test skips vars plugins in collections (but not in ansible/ansible).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test
