### PR TITLE
systemd - fix issue with unknown capabilities in newer kernel

### DIFF
--- a/changelogs/fragments/71528-systemd-capbpf-workaround.yml
+++ b/changelogs/fragments/71528-systemd-capbpf-workaround.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >
+    systemd - work around bug with ``systemd`` 245 and 5.8 kernel that does not correctly
+    report service state (https://github.com/ansible/ansible/issues/71528)

--- a/lib/ansible/modules/systemd.py
+++ b/lib/ansible/modules/systemd.py
@@ -400,6 +400,17 @@ def main():
                 # Check for loading error
                 if is_systemd and not is_masked and 'LoadError' in result['status']:
                     module.fail_json(msg="Error loading unit file '%s': %s" % (unit, result['status']['LoadError']))
+
+        # Workaround for https://github.com/ansible/ansible/issues/71528
+        elif err and rc == 1 and 'Failed to parse bus message' in err:
+            result['status'] = parse_systemctl_show(to_native(out).split('\n'))
+
+            (rc, out, err) = module.run_command("{systemctl} list-units '{unit}*'".format(systemctl=systemctl, unit=unit))
+            is_systemd = unit in out
+
+            (rc, out, err) = module.run_command("{systemctl} is-active '{unit}'".format(systemctl=systemctl, unit=unit))
+            result['status']['ActiveState'] = out.rstrip('\n')
+
         else:
             # list taken from man systemctl(1) for systemd 244
             valid_enabled_states = [


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A [bug](https://github.com/systemd/systemd/pull/16424) existed in `systemd` 245 that did not properly handle unknown kernel capabilities gracefully. This resulted in incomplete output and an `rc` of 1 when querying for the service status. It is possible to get service status by other means. This PR works around this issue by getting service status using other commands in the event of a failure due to this bug.

Fixes #71528
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/systemd.py`
##### ADDITIONAL INFORMATION

I'm not sure of a good way to test this. I setup a Fedora 32 VM running the 5.8 kernel and `systemd-245.4-1.fc32.src.rpm`. Our Fedora 32 test image has `systemd-245.6-2.fc32.x86_64` but the kernel version of the Docker host would need to be 5.8 in order to invoke the failure.

Since this is a very specific workaround to a bug that is already fixed, it _may_ be ok to not have tests for this PR.
