### PR TITLE
[ansible-test] Limit cryptography to <3.2

### DIFF
--- a/changelogs/fragments/ansible-test-constraints-cryptography-old-openssl.yml
+++ b/changelogs/fragments/ansible-test-constraints-cryptography-old-openssl.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - python-cryptography is now bounded at <3.2, as 3.2 drops support for OpenSSL 1.0.2 upon which some of our CI infrastructure still depends.

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -2,6 +2,7 @@ coverage >= 4.5.1, < 5.0.0 ; python_version <  '3.7' # coverage 4.4 required for
 coverage >= 4.5.2, < 5.0.0 ; python_version == '3.7' # coverage 4.5.2 fixes bugs in support for python 3.7, coverage 5.0+ incompatible
 coverage >= 4.5.4, < 5.0.0 ; python_version >  '3.7' # coverage had a bug in < 4.5.4 that would cause unit tests to hang in Python 3.8, coverage 5.0+ incompatible
 cryptography < 2.2 ; python_version < '2.7' # cryptography 2.2 drops support for python 2.6
+cryptography < 3.2 ; python_version >= 2.7  # cryptography 3.2 drops support for OpenSSL 1.0.2 which some of our CI hosts (FreeBSD) still use
 deepdiff < 4.0.0 ; python_version < '3' # deepdiff 4.0.0 and later require python 3
 jinja2 < 2.11 ; python_version < '2.7' # jinja2 2.11 and later require python 2.7 or later
 urllib3 < 1.24 ; python_version < '2.7' # urllib3 1.24 and later require python 2.7 or later

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -2,7 +2,7 @@ coverage >= 4.5.1, < 5.0.0 ; python_version <  '3.7' # coverage 4.4 required for
 coverage >= 4.5.2, < 5.0.0 ; python_version == '3.7' # coverage 4.5.2 fixes bugs in support for python 3.7, coverage 5.0+ incompatible
 coverage >= 4.5.4, < 5.0.0 ; python_version >  '3.7' # coverage had a bug in < 4.5.4 that would cause unit tests to hang in Python 3.8, coverage 5.0+ incompatible
 cryptography < 2.2 ; python_version < '2.7' # cryptography 2.2 drops support for python 2.6
-cryptography < 3.2 ; python_version >= 2.7  # cryptography 3.2 drops support for OpenSSL 1.0.2 which some of our CI hosts (FreeBSD) still use
+cryptography < 3.2 ; python_version >= '2.7'  # cryptography 3.2 drops support for OpenSSL 1.0.2 which some of our CI hosts (FreeBSD) still use
 deepdiff < 4.0.0 ; python_version < '3' # deepdiff 4.0.0 and later require python 3
 jinja2 < 2.11 ; python_version < '2.7' # jinja2 2.11 and later require python 2.7 or later
 urllib3 < 1.24 ; python_version < '2.7' # urllib3 1.24 and later require python 2.7 or later


### PR DESCRIPTION

##### SUMMARY
Change:
- Cryptography 3.2 drops support for OpenSSL 1.0.2. Some of our CI
  infrastructure still uses this version (FreeBSD, namely). For now,
  just add a constraint to use old cryptography.

Test Plan:
- ci_complete

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Test Pull Request

##### COMPONENT NAME

tests