### PR TITLE
Update playbooks_tags.rst

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tags.rst
@@ -129,8 +129,9 @@ If you want to apply a tag to many, but not all, of the tasks in your play, use 
 
    # myrole/tasks/main.yml
    tasks:
-   - block:
+   - name: ntp tasks
      tags: ntp
+     block:
      - name: Install ntp
        ansible.builtin.yum:
          name: ntp


### PR DESCRIPTION
##### SUMMARY
The "Adding tags to blocks" example syntax is wrong (incorrect yaml). Tasks cannot immediately follow the `tags` keyword because yaml would think each task to be a tag. It seems `tags` needs to be defined above `block` or below all tasks. Defining `tags` below all tasks can make it hard to see, but defining `tags` above `block` may warrant a `name` for the block (as I proposed).


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
