### PR TITLE
Improve ansible-test classifications for collections

### DIFF
--- a/changelogs/fragments/ansible-test-collection-classification.yml
+++ b/changelogs/fragments/ansible-test-collection-classification.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- "ansible-test - improve classification of changes to ``README.md``, ``CHANGELOG.rst``, ``COPYING`` and ``LICENSE`` (https://github.com/ansible/ansible/pull/72353)."
+- "ansible-test - improve classification of changes to ``.gitignore``, ``COPYING``, ``LICENSE``, ``Makefile``, and all files ending with one of ``.in`, ``.md`, ``.rst``, ``.toml``, ``.txt`` in the collection root directory (https://github.com/ansible/ansible/pull/72353)."

--- a/changelogs/fragments/ansible-test-collection-classification.yml
+++ b/changelogs/fragments/ansible-test-collection-classification.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-test - improve classification of changes to ``changelogs/``, ``README.md``, ``CHANGELOG.rst``, ``COPYING`` and ``LICENSE`` (https://github.com/ansible/ansible/pull/72353)."

--- a/changelogs/fragments/ansible-test-collection-classification.yml
+++ b/changelogs/fragments/ansible-test-collection-classification.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- "ansible-test - improve classification of changes to ``changelogs/``, ``README.md``, ``CHANGELOG.rst``, ``COPYING`` and ``LICENSE`` (https://github.com/ansible/ansible/pull/72353)."
+- "ansible-test - improve classification of changes to ``README.md``, ``CHANGELOG.rst``, ``COPYING`` and ``LICENSE`` (https://github.com/ansible/ansible/pull/72353)."

--- a/test/lib/ansible_test/_internal/classification.py
+++ b/test/lib/ansible_test/_internal/classification.py
@@ -660,6 +660,9 @@ class PathMapper:
         if result is not None:
             return result
 
+        filename = os.path.basename(path)
+        dummy, ext = os.path.splitext(filename)
+
         minimal = {}
 
         if path.startswith('changelogs/'):

--- a/test/lib/ansible_test/_internal/classification.py
+++ b/test/lib/ansible_test/_internal/classification.py
@@ -663,9 +663,7 @@ class PathMapper:
         minimal = {}
 
         if path.startswith('changelogs/'):
-            return {
-                'sanity': 'changelog',
-            }
+            return minimal
 
         if path.startswith('docs/'):
             return minimal

--- a/test/lib/ansible_test/_internal/classification.py
+++ b/test/lib/ansible_test/_internal/classification.py
@@ -668,8 +668,23 @@ class PathMapper:
         if path.startswith('docs/'):
             return minimal
 
-        if path in ('README.md', 'CHANGELOG.rst', 'COPYING', 'LICENSE'):
-            return minimal
+        if '/' not in path:
+            if path in (
+                    '.gitignore',
+                    'COPYING',
+                    'LICENSE',
+                    'Makefile',
+            ):
+                return minimal
+
+            if ext in (
+                    '.in',
+                    '.md',
+                    '.rst',
+                    '.toml',
+                    '.txt',
+            ):
+                return minimal
 
         return None
 

--- a/test/lib/ansible_test/_internal/classification.py
+++ b/test/lib/ansible_test/_internal/classification.py
@@ -663,9 +663,14 @@ class PathMapper:
         minimal = {}
 
         if path.startswith('changelogs/'):
-            return minimal
+            return {
+                'sanity': 'changelog',
+            }
 
         if path.startswith('docs/'):
+            return minimal
+
+        if path in ('README.md', 'CHANGELOG.rst', 'COPYING', 'LICENSE'):
             return minimal
 
         return None


### PR DESCRIPTION
##### SUMMARY
Imrove classification for changes to `README.md`, `CHANGELOG.rst`, `COPYING` and `LICENSE`: run nothing instead of all tests.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/lib/ansible_test/_internal/classification.py
