### PR TITLE
ansible-doc: export has_action when --json is used

### DIFF
--- a/changelogs/fragments/ansible-doc-has_action.yml
+++ b/changelogs/fragments/ansible-doc-has_action.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "ansible-doc - provide ``has_action`` field in JSON output for modules. That information is currently only available in the text view (https://github.com/ansible/ansible/pull/72359)."

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -350,6 +350,7 @@ class DocCLI(CLI):
         if doc is None:
             raise ValueError('%s did not contain a DOCUMENTATION attribute' % plugin)
 
+        # generate extra data
         if plugin_type == 'module':
             # is there corresponding action plugin?
             if plugin in action_loader:

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -259,7 +259,7 @@ class DocCLI(CLI):
                     # The doc section existed but was empty
                     continue
 
-                plugin_docs[plugin] = {'doc': doc, 'examples': plainexamples, 'return': returndocs, 'metadata': metadata}
+                plugin_docs[plugin] = DocCLI._combine_plugin_doc(plugin, plugin_type, doc, plainexamples, returndocs, metadata)
 
             if do_json:
                 jdump(plugin_docs)
@@ -350,6 +350,12 @@ class DocCLI(CLI):
         if doc is None:
             raise ValueError('%s did not contain a DOCUMENTATION attribute' % plugin)
 
+        doc['filename'] = filename
+        doc['collection'] = collection_name
+        return doc, plainexamples, returndocs, metadata
+
+    @staticmethod
+    def _combine_plugin_doc(plugin, plugin_type, doc, plainexamples, returndocs, metadata):
         # generate extra data
         if plugin_type == 'module':
             # is there corresponding action plugin?
@@ -358,9 +364,8 @@ class DocCLI(CLI):
             else:
                 doc['has_action'] = False
 
-        doc['filename'] = filename
-        doc['collection'] = collection_name
-        return doc, plainexamples, returndocs, metadata
+        # return everything as one dictionary
+        return {'doc': doc, 'examples': plainexamples, 'return': returndocs, 'metadata': metadata}
 
     @staticmethod
     def format_plugin_doc(plugin, plugin_type, doc, plainexamples, returndocs, metadata):

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -350,6 +350,13 @@ class DocCLI(CLI):
         if doc is None:
             raise ValueError('%s did not contain a DOCUMENTATION attribute' % plugin)
 
+        if plugin_type == 'module':
+            # is there corresponding action plugin?
+            if plugin in action_loader:
+                doc['has_action'] = True
+            else:
+                doc['has_action'] = False
+
         doc['filename'] = filename
         doc['collection'] = collection_name
         return doc, plainexamples, returndocs, metadata
@@ -370,13 +377,6 @@ class DocCLI(CLI):
         doc['metadata'] = metadata
 
         # generate extra data
-        if plugin_type == 'module':
-            # is there corresponding action plugin?
-            if plugin in action_loader:
-                doc['action'] = True
-            else:
-                doc['action'] = False
-
         doc['now_date'] = datetime.date.today().strftime('%Y-%m-%d')
         if 'docuri' in doc:
             doc['docuri'] = doc[plugin_type].replace('_', '-')
@@ -658,7 +658,7 @@ class DocCLI(CLI):
                 text.append("%s" % doc.pop('deprecated'))
             text.append("\n")
 
-        if doc.pop('action', False):
+        if doc.pop('has_action', False):
             text.append("  * note: %s\n" % "This module has a corresponding action plugin.")
 
         if doc.get('options', False):

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -377,11 +377,6 @@ class DocCLI(CLI):
         doc['returndocs'] = returndocs
         doc['metadata'] = metadata
 
-        # generate extra data
-        doc['now_date'] = datetime.date.today().strftime('%Y-%m-%d')
-        if 'docuri' in doc:
-            doc['docuri'] = doc[plugin_type].replace('_', '-')
-
         if context.CLIARGS['show_snippet'] and plugin_type == 'module':
             text = DocCLI.get_snippet_text(doc)
         else:


### PR DESCRIPTION
##### SUMMARY
Improve feature parity between `ansible-doc` and `ansible-doc --json`. Needed to include this information in the docs build.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
ansible-doc
