### PR TITLE
[2.10] validate-modules: fix processing of add_file_common_args=True when argument_spec is not specified as kwarg

### DIFF
--- a/changelogs/fragments/ansible-test-validate-modules-file-common-args.yml
+++ b/changelogs/fragments/ansible-test-validate-modules-file-common-args.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-test validate-modules - when a module uses ``add_file_common_args=True`` and does not use a keyword argument for ``argument_spec`` in ``AnsibleModule()``, the common file arguments were not considered added during validation (https://github.com/ansible/ansible/pull/72334)."

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/module_args.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/module_args.py
@@ -146,19 +146,19 @@ def get_py_argument_spec(filename, collection):
             raise AnsibleModuleNotInitialized()
 
     try:
-        try:
-            # for ping kwargs == {'argument_spec':{'data':{'type':'str','default':'pong'}}, 'supports_check_mode':True}
+        # for ping kwargs == {'argument_spec':{'data':{'type':'str','default':'pong'}}, 'supports_check_mode':True}
+        if 'argument_spec' in fake.kwargs:
             argument_spec = fake.kwargs['argument_spec']
-            # If add_file_common_args is truish, add options from FILE_COMMON_ARGUMENTS when not present.
-            # This is the only modification to argument_spec done by AnsibleModule itself, and which is
-            # not caught by setup_env's AnsibleModule replacement
-            if fake.kwargs.get('add_file_common_args'):
-                for k, v in FILE_COMMON_ARGUMENTS.items():
-                    if k not in argument_spec:
-                        argument_spec[k] = v
-            return argument_spec, fake.args, fake.kwargs
-        except KeyError:
-            return fake.args[0], fake.args, fake.kwargs
+        else:
+            argument_spec = fake.args[0]
+        # If add_file_common_args is truish, add options from FILE_COMMON_ARGUMENTS when not present.
+        # This is the only modification to argument_spec done by AnsibleModule itself, and which is
+        # not caught by setup_env's AnsibleModule replacement
+        if fake.kwargs.get('add_file_common_args'):
+            for k, v in FILE_COMMON_ARGUMENTS.items():
+                if k not in argument_spec:
+                    argument_spec[k] = v
+        return argument_spec, fake.args, fake.kwargs
     except (TypeError, IndexError):
         return {}, (), {}
 


### PR DESCRIPTION
##### SUMMARY
Backport of #72334 to stable-2.10.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test validate-modules
