### PR TITLE
Provide better decryption errors for single vault values

### DIFF
--- a/changelogs/fragments/72276-provide-better-vault-error.yml
+++ b/changelogs/fragments/72276-provide-better-vault-error.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- vault - Provide better error for single value encrypted values to indicate the file, line, and column of
+  the errant vault (https://github.com/ansible/ansible/issues/72276)

--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -73,6 +73,10 @@ class AnsibleError(Exception):
                 return '%s\n\n%s' % (self._message, to_native(extended_error))
         return self._message
 
+    @message.setter
+    def message(self, val):
+        self._message = val
+
     def __str__(self):
         return self.message
 

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -649,7 +649,7 @@ class VaultLib:
                                                 vault_id=vault_id)
         return b_vaulttext
 
-    def decrypt(self, vaulttext, filename=None):
+    def decrypt(self, vaulttext, filename=None, obj=None):
         '''Decrypt a piece of vault encrypted data.
 
         :arg vaulttext: a string to decrypt.  Since vault encrypted data is an
@@ -660,10 +660,10 @@ class VaultLib:
         :returns: a byte string containing the decrypted data and the vault-id that was used
 
         '''
-        plaintext, vault_id, vault_secret = self.decrypt_and_get_vault_id(vaulttext, filename=filename)
+        plaintext, vault_id, vault_secret = self.decrypt_and_get_vault_id(vaulttext, filename=filename, obj=obj)
         return plaintext
 
-    def decrypt_and_get_vault_id(self, vaulttext, filename=None):
+    def decrypt_and_get_vault_id(self, vaulttext, filename=None, obj=None):
         """Decrypt a piece of vault encrypted data.
 
         :arg vaulttext: a string to decrypt.  Since vault encrypted data is an
@@ -750,11 +750,12 @@ class VaultLib:
                     )
                     break
             except AnsibleVaultFormatError as exc:
+                exc.obj = obj
                 msg = u"There was a vault format error"
                 if filename:
                     msg += u' in %s' % (to_text(filename))
-                msg += u': %s' % exc
-                display.warning(msg)
+                msg += u': %s' % to_text(exc)
+                display.warning(msg, formatted=True)
                 raise
             except AnsibleError as e:
                 display.vvvv(u'Tried to use the vault secret (%s) to decrypt (%s) but it failed. Error: %s' %

--- a/lib/ansible/parsing/yaml/constructor.py
+++ b/lib/ansible/parsing/yaml/constructor.py
@@ -112,6 +112,7 @@ class AnsibleConstructor(SafeConstructor):
                                    note=None)
         ret = AnsibleVaultEncryptedUnicode(b_ciphertext_data)
         ret.vault = vault
+        ret.ansible_pos = self._node_position_info(node)
         return ret
 
     def construct_yaml_seq(self, node):

--- a/lib/ansible/parsing/yaml/objects.py
+++ b/lib/ansible/parsing/yaml/objects.py
@@ -25,7 +25,6 @@ import sys as _sys
 import sys
 import yaml
 
-from ansible.errors import AnsibleError
 from ansible.module_utils.common._collections_compat import Sequence
 from ansible.module_utils.six import text_type
 from ansible.module_utils._text import to_bytes, to_text, to_native

--- a/lib/ansible/parsing/yaml/objects.py
+++ b/lib/ansible/parsing/yaml/objects.py
@@ -25,6 +25,7 @@ import sys as _sys
 import sys
 import yaml
 
+from ansible.errors import AnsibleError
 from ansible.module_utils.common._collections_compat import Sequence
 from ansible.module_utils.six import text_type
 from ansible.module_utils._text import to_bytes, to_text, to_native
@@ -117,7 +118,7 @@ class AnsibleVaultEncryptedUnicode(Sequence, AnsibleBaseYAMLObject):
     def data(self):
         if not self.vault:
             return to_text(self._ciphertext)
-        return to_text(self.vault.decrypt(self._ciphertext))
+        return to_text(self.vault.decrypt(self._ciphertext, obj=self))
 
     @data.setter
     def data(self, value):

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -123,7 +123,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
             except AnsibleParserError as e:
                 # if the raises exception was created with obj=ds args, then it includes the detail
                 # so we dont need to add it so we can just re raise.
-                if e._obj:
+                if e.obj:
                     raise
                 # But if it wasn't, we can add the yaml object now to get more detail
                 raise AnsibleParserError(to_native(e), obj=task_ds, orig_exc=e)

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -221,7 +221,7 @@ class Task(Base, Conditional, Taggable, CollectionSearch):
         except AnsibleParserError as e:
             # if the raises exception was created with obj=ds args, then it includes the detail
             # so we dont need to add it so we can just re raise.
-            if e._obj:
+            if e.obj:
                 raise
             # But if it wasn't, we can add the yaml object now to get more detail
             raise AnsibleParserError(to_native(e), obj=ds, orig_exc=e)

--- a/test/units/config/test_manager.py
+++ b/test/units/config/test_manager.py
@@ -134,7 +134,7 @@ class TestConfigManager:
     def test_entry_as_vault_var(self):
         class MockVault:
 
-            def decrypt(self, value):
+            def decrypt(self, value, filename=None, obj=None):
                 return value
 
         vault_var = AnsibleVaultEncryptedUnicode(b"vault text")
@@ -147,7 +147,7 @@ class TestConfigManager:
     @pytest.mark.parametrize("value_type", ("str", "string", None))
     def test_ensure_type_with_vaulted_str(self, value_type):
         class MockVault:
-            def decrypt(self, value):
+            def decrypt(self, value, filename=None, obj=None):
                 return value
 
         vault_var = AnsibleVaultEncryptedUnicode(b"vault text")

--- a/test/units/playbook/test_task.py
+++ b/test/units/playbook/test_task.py
@@ -82,8 +82,8 @@ class TestTask(unittest.TestCase):
             Task.load(ds)
 
         self.assertIsInstance(cm.exception, errors.AnsibleParserError)
-        self.assertEqual(cm.exception._obj, ds)
-        self.assertEqual(cm.exception._obj, kv_bad_args_ds)
+        self.assertEqual(cm.exception.obj, ds)
+        self.assertEqual(cm.exception.obj, kv_bad_args_ds)
         self.assertIn("The error appears to be in 'test_task_faux_playbook.yml", cm.exception.message)
         self.assertIn(kv_bad_args_str, cm.exception.message)
         self.assertIn('apk', cm.exception.message)


### PR DESCRIPTION
##### SUMMARY
Provides more context on decryption errors for single vault values

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
Before:
```
[WARNING]: There was a vault format error: Vault format unhexlify error: Odd-length string
fatal: [localhost]: FAILED! => {"msg": "Vault format unhexlify error: Odd-length string"}
```

After:
```
[WARNING]:
There was a vault format error: Vault format unhexlify error: Odd-length string

The error appears to be in '/Users/matt/projects/ansibledev/playbooks/72276/72276.yml': line 11, column 10, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

          6134
    bad: !vault |
         ^ here
fatal: [localhost]: FAILED! => {"msg": "Vault format unhexlify error: Odd-length string\n\nThe error appears to be in '/Users/matt/projects/ansibledev/playbooks/72276/72276.yml': line 11, column 10, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n          6134\n    bad: !vault |\n         ^ here\n"}
```