### PR TITLE
systemd - use list-unit-files rather than list-units

### DIFF
--- a/changelogs/fragments/71528-systemd-list-unit-files.yml
+++ b/changelogs/fragments/71528-systemd-list-unit-files.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - >
+    systemd - follow up fix to https://github.com/ansible/ansible/issues/72338
+    to use ``list-unit-files`` rather than ``list-units`` in order to show
+    all units files on the system.

--- a/lib/ansible/modules/systemd.py
+++ b/lib/ansible/modules/systemd.py
@@ -405,7 +405,7 @@ def main():
         elif err and rc == 1 and 'Failed to parse bus message' in err:
             result['status'] = parse_systemctl_show(to_native(out).split('\n'))
 
-            (rc, out, err) = module.run_command("{systemctl} list-units '{unit}*'".format(systemctl=systemctl, unit=unit))
+            (rc, out, err) = module.run_command("{systemctl} list-unit-files '{unit}*'".format(systemctl=systemctl, unit=unit))
             is_systemd = unit in out
 
             (rc, out, err) = module.run_command("{systemctl} is-active '{unit}'".format(systemctl=systemctl, unit=unit))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Follow up fix for #71528 per [this feedback](https://github.com/ansible/ansible/pull/72348#issuecomment-717374249) from @ktdreyer.

`list-units` only displays units that are active, have pending jobs, or have failed. If a unit exists but is not enabled, it won't show up and the `systemd` module will not properly manage it.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/systemd.py`