### PR TITLE
[stable-2.10] systemd - use list-unit-files rather than list-units (#72363)

### DIFF
--- a/changelogs/fragments/71528-systemd-list-unit-files.yml
+++ b/changelogs/fragments/71528-systemd-list-unit-files.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - >
+    systemd - follow up fix to https://github.com/ansible/ansible/issues/72338
+    to use ``list-unit-files`` rather than ``list-units`` in order to show
+    all units files on the system.

--- a/lib/ansible/modules/systemd.py
+++ b/lib/ansible/modules/systemd.py
@@ -414,6 +414,17 @@ def main():
                 # Check for loading error
                 if is_systemd and not is_masked and 'LoadError' in result['status']:
                     module.fail_json(msg="Error loading unit file '%s': %s" % (unit, result['status']['LoadError']))
+
+        # Workaround for https://github.com/ansible/ansible/issues/71528
+        elif err and rc == 1 and 'Failed to parse bus message' in err:
+            result['status'] = parse_systemctl_show(to_native(out).split('\n'))
+
+            (rc, out, err) = module.run_command("{systemctl} list-unit-files '{unit}*'".format(systemctl=systemctl, unit=unit))
+            is_systemd = unit in out
+
+            (rc, out, err) = module.run_command("{systemctl} is-active '{unit}'".format(systemctl=systemctl, unit=unit))
+            result['status']['ActiveState'] = out.rstrip('\n')
+
         else:
             # list taken from man systemctl(1) for systemd 244
             valid_enabled_states = [


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #72363 for Ansible 2.10
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/systemd.py`