### PR TITLE
Explicitly get the include task, and not assume it is the parent

### DIFF
--- a/changelogs/fragments/65710-find-include-parent.yml
+++ b/changelogs/fragments/65710-find-include-parent.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- Includes - Explicitly get the include task, and not assume it is the parent
+  (https://github.com/ansible/ansible/issues/65710)

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -259,7 +259,7 @@ class StrategyModule(StrategyBase):
                         continue
 
                     for new_block in new_blocks:
-                        task_vars = self._variable_manager.get_vars(play=iterator._play, task=new_block._parent,
+                        task_vars = self._variable_manager.get_vars(play=iterator._play, task=new_block.get_first_parent_include(),
                                                                     _hosts=self._hosts_cache,
                                                                     _hosts_all=self._hosts_cache_all)
                         final_block = new_block.filter_tagged_tasks(task_vars)

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -366,7 +366,7 @@ class StrategyModule(StrategyBase):
                             for new_block in new_blocks:
                                 task_vars = self._variable_manager.get_vars(
                                     play=iterator._play,
-                                    task=new_block._parent,
+                                    task=new_block.get_first_parent_include(),
                                     _hosts=self._hosts_cache,
                                     _hosts_all=self._hosts_cache_all,
                                 )

--- a/test/integration/targets/include_import/apply/include_apply_65710.yml
+++ b/test/integration/targets/include_import/apply/include_apply_65710.yml
@@ -1,0 +1,11 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - include_tasks:
+        file: include_tasks.yml
+        apply:
+          tags: always
+
+    - assert:
+        that:
+          - include_tasks_result is defined

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -81,6 +81,8 @@ if [[ -z "$OUT" ]]; then
     exit 1
 fi
 
+ANSIBLE_PLAYBOOK_VARS_ROOT=all ansible-playbook apply/include_apply_65710.yml -i inventory "$@"
+
 # Test that duplicate items in loop are not deduped
 ANSIBLE_STRATEGY='linear' ansible-playbook tasks/test_include_dupe_loop.yml -i inventory "$@" | tee test_include_dupe_loop.out
 test "$(grep -c '"item=foo"' test_include_dupe_loop.out)" = 3

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -81,7 +81,8 @@ if [[ -z "$OUT" ]]; then
     exit 1
 fi
 
-ANSIBLE_PLAYBOOK_VARS_ROOT=all ansible-playbook apply/include_apply_65710.yml -i inventory "$@"
+ANSIBLE_STRATEGY='linear' ANSIBLE_PLAYBOOK_VARS_ROOT=all ansible-playbook apply/include_apply_65710.yml -i inventory "$@"
+ANSIBLE_STRATEGY='free' ANSIBLE_PLAYBOOK_VARS_ROOT=all ansible-playbook apply/include_apply_65710.yml -i inventory "$@"
 
 # Test that duplicate items in loop are not deduped
 ANSIBLE_STRATEGY='linear' ansible-playbook tasks/test_include_dupe_loop.yml -i inventory "$@" | tee test_include_dupe_loop.out


### PR DESCRIPTION
##### SUMMARY
Explicitly get the include task, and not assume it is the parent

Fixes #65710

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/strategy/

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
