### PR TITLE
Return xmit_hash_policy for bonding interfaces

### DIFF
--- a/changelogs/fragments/72388-return-xmit-hash-policy-for-bonding-interfaces.yml
+++ b/changelogs/fragments/72388-return-xmit-hash-policy-for-bonding-interfaces.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - facts - add `xmit_hash_policy` fact for Linux bonding interfaces, which returns its setting. (https://github.com/ansible/ansible/issues/72388)

--- a/lib/ansible/module_utils/facts/network/linux.py
+++ b/lib/ansible/module_utils/facts/network/linux.py
@@ -137,6 +137,7 @@ class LinuxNetwork(Network):
                 interfaces[device]['mode'] = get_file_content(os.path.join(path, 'bonding', 'mode'), default='').split()[0]
                 interfaces[device]['miimon'] = get_file_content(os.path.join(path, 'bonding', 'miimon'), default='').split()[0]
                 interfaces[device]['lacp_rate'] = get_file_content(os.path.join(path, 'bonding', 'lacp_rate'), default='').split()[0]
+                interfaces[device]['xmit_hash_policy'] = get_file_content(os.path.join(path, 'bonding', 'xmit_hash_policy'), default='').split()[0]
                 primary = get_file_content(os.path.join(path, 'bonding', 'primary'))
                 if primary:
                     interfaces[device]['primary'] = primary


### PR DESCRIPTION
##### SUMMARY
Return `xmit_hash_policy` fact for bonding interfaces, as returned by `/sys/class/net/{interface}/bonding/xmit_hash_policy`.
<!--- Describe the change below, including rationale and design decisions -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/facts/network/linux.py

##### ADDITIONAL INFORMATION
Before:

```json
"ansible_bond0": {
...
              "lacp_rate": "fast",
              "macaddress": "<redacted>",
              "miimon": "100",
              "mode": "802.3ad",
              "mtu": 1500,
              "promisc": false,
              "slaves": [ 
                  "eth0", 
                  "eth1"  
              ],          
              "speed": 2000,
              "timestamping": [
                  "rx_software",
                  "software"
              ],          
              "type": "bonding",
},
```

After:
```json
"ansible_bond0": {
...
              "lacp_rate": "fast",
              "macaddress": "<redacted>",
              "miimon": "100",
              "mode": "802.3ad",
              "mtu": 1500,
              "promisc": false,
              "slaves": [ 
                  "eth0", 
                  "eth1"  
              ],          
              "speed": 2000,
              "timestamping": [
                  "rx_software",
                  "software"
              ],          
              "type": "bonding",
              "xmit_hash_policy": "layer3+4"
},
```