### PR TITLE
wait_for - ignore psutil related errors

### DIFF
--- a/changelogs/fragments/72322-wait-for-handle-errors.yml
+++ b/changelogs/fragments/72322-wait-for-handle-errors.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - wait_for - catch and ignore errors when getting active connections with psutil (https://github.com/ansible/ansible/issues/72322)

--- a/lib/ansible/modules/wait_for.py
+++ b/lib/ansible/modules/wait_for.py
@@ -289,10 +289,13 @@ class TCPConnectionInfo(object):
     def get_active_connections_count(self):
         active_connections = 0
         for p in psutil.process_iter():
-            if hasattr(p, 'get_connections'):
-                connections = p.get_connections(kind='inet')
-            else:
-                connections = p.connections(kind='inet')
+            try:
+                if hasattr(p, 'get_connections'):
+                    connections = p.get_connections(kind='inet')
+                else:
+                    connections = p.connections(kind='inet')
+            except psutil.Error:
+                continue
             for conn in connections:
                 if conn.status not in self.module.params['active_connection_states']:
                     continue

--- a/lib/ansible/modules/wait_for.py
+++ b/lib/ansible/modules/wait_for.py
@@ -295,6 +295,7 @@ class TCPConnectionInfo(object):
                 else:
                     connections = p.connections(kind='inet')
             except psutil.Error:
+                # Process is Zombie or other error state
                 continue
             for conn in connections:
                 if conn.status not in self.module.params['active_connection_states']:

--- a/test/integration/targets/wait_for/files/zombie.py
+++ b/test/integration/targets/wait_for/files/zombie.py
@@ -1,0 +1,12 @@
+#!/bin/env python
+
+import os
+import sys
+import time
+
+child_pid = os.fork()
+
+if child_pid > 0:
+    time.sleep(60)
+else:
+    sys.exit()

--- a/test/integration/targets/wait_for/files/zombie.py
+++ b/test/integration/targets/wait_for/files/zombie.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 

--- a/test/integration/targets/wait_for/files/zombie.py
+++ b/test/integration/targets/wait_for/files/zombie.py
@@ -1,4 +1,7 @@
-#!/bin/env python
+#!/usr/bin/python
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 import os
 import sys

--- a/test/integration/targets/wait_for/tasks/main.yml
+++ b/test/integration/targets/wait_for/tasks/main.yml
@@ -153,6 +153,16 @@
     name: psutil
   when: ansible_system != 'Linux'
 
+- name: Copy zombie.py
+  copy:
+    src: zombie.py
+    dest: "{{ output_dir }}"
+
+- name: Create zombie process
+  shell: "{{ output_dir }}/zombie"
+  async: 90
+  poll: 0
+
 - name: test wait for port drained
   wait_for:
     port: "{{ http_port }}"

--- a/test/integration/targets/wait_for/tasks/main.yml
+++ b/test/integration/targets/wait_for/tasks/main.yml
@@ -159,7 +159,7 @@
     dest: "{{ output_dir }}"
 
 - name: Create zombie process
-  shell: "{{ output_dir }}/zombie"
+  shell: "{{ ansible_python.executable }} {{ output_dir }}/zombie"
   async: 90
   poll: 0
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When enumerating connections with psutil, catch and ignore errors to avoid returning a stack trace.

Fixes #72322


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/wait_for.py`