### PR TITLE
Update local_mods in git.py to show destination of conflict

### DIFF
--- a/changelogs/fragments/72405-git-module-local_mods-show-conflict-destination-directory.yml
+++ b/changelogs/fragments/72405-git-module-local_mods-show-conflict-destination-directory.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - git - display the destination directory path in error msg when local_mods detects local modifications conflict so that users see the exact location

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -1249,11 +1249,11 @@ def main():
         if local_mods:
             # failure should happen regardless of check mode
             if not force:
-                module.fail_json(msg="Local modifications exist in repository (force=no).", **result)
+                module.fail_json(msg="Local modifications exist in the destination directory (force=no).", **result)
             # if force and in non-check mode, do a reset
             if not module.check_mode:
                 reset(git_path, module, dest)
-                result.update(changed=True, msg='Local modifications exist.')
+                result.update(changed=True, msg='Local modifications exist in the destination directory.')
 
         # exit if already at desired sha version
         if module.check_mode:

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -1249,11 +1249,11 @@ def main():
         if local_mods:
             # failure should happen regardless of check mode
             if not force:
-                module.fail_json(msg="Local modifications exist in the destination directory (force=no).", **result)
+                module.fail_json(msg="Local modifications exist in the destination: " + dest + " (force=no).", **result)
             # if force and in non-check mode, do a reset
             if not module.check_mode:
                 reset(git_path, module, dest)
-                result.update(changed=True, msg='Local modifications exist in the destination directory.')
+                result.update(changed=True, msg='Local modifications exist in the destination: ' + dest)
 
         # exit if already at desired sha version
         if module.check_mode:


### PR DESCRIPTION
specify that the local modification is in the destination directory so that some of the users clearly understand this..

##### SUMMARY

some of our users (https://github.com/Screenly/screenly-ose) a lot of times run into this error because by default ansible no longer forces the destination directory files to be replaced with the source repo which is perfectly fine, but the error message sometimes goes over their head and I couldn't find very layman's terms documentation literally saying to the users something like "you have files in the destination directory that are different than those being pulled by git from the repo you are using, please either merge your local changes with your upstream repo or backup those changes somewhere else so that it does not conflict with the current pull of files"... something like that.. I mean this is just adding one or two words to the error message that's all, it will probably go a long way saving some beginner users some headache when they make one change in their local directory and forgot that they did it and try to run ansible git and all of a sudden keep getting this local modifications error...

thanks..

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

git module


