### PR TITLE
[stable-2.9] Try to load action plugin from the same collection as the module (#66701)

### DIFF
--- a/changelogs/fragments/66701-action-plugin-load-network-modules.yaml
+++ b/changelogs/fragments/66701-action-plugin-load-network-modules.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Try to load action plugin from the same collection as the module (https://github.com/ansible/ansible/pull/66701)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -1046,16 +1046,26 @@ class TaskExecutor:
         Returns the correct action plugin to handle the requestion task action
         '''
 
-        module_prefix = self._task.action.split('.')[-1].split('_')[0]
+        module_collection, separator, module_name = self._task.action.rpartition(".")
+        module_prefix = module_name.split('_')[0]
+        if module_collection:
+            # For network modules, which look for one action plugin per platform, look for the
+            # action plugin in the same collection as the module by prefixing the action plugin
+            # with the same collection.
+            network_action = "{0}.{1}".format(module_collection, module_prefix)
+        else:
+            network_action = module_prefix
 
         collections = self._task.collections
 
         # let action plugin override module, fallback to 'normal' action plugin otherwise
         if self._shared_loader_obj.action_loader.has_plugin(self._task.action, collection_list=collections):
             handler_name = self._task.action
-        # FIXME: is this code path even live anymore? check w/ networking folks; it trips sometimes when it shouldn't
-        elif all((module_prefix in C.NETWORK_GROUP_MODULES, self._shared_loader_obj.action_loader.has_plugin(module_prefix, collection_list=collections))):
-            handler_name = module_prefix
+        elif all((module_prefix in C.NETWORK_GROUP_MODULES, self._shared_loader_obj.action_loader.has_plugin(network_action, collection_list=collections))):
+            handler_name = network_action
+            display.vvvv("Using network group action {handler} for {action}".format(handler=handler_name,
+                                                                                    action=self._task.action),
+                         host=self._play_context.remote_addr)
         else:
             # FUTURE: once we're comfortable with collections impl, preface this action with ansible.builtin so it can't be hijacked
             handler_name = 'normal'

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -399,7 +399,7 @@ class TestTaskExecutor(unittest.TestCase):
 
         mock_connection = MagicMock()
         mock_templar = MagicMock()
-        action = 'namespace.prefix_sufix'
+        action = 'namespace.prefix_suffix'
         te._task.action = action
 
         handler = te._get_action_handler(mock_connection, mock_templar)
@@ -434,8 +434,8 @@ class TestTaskExecutor(unittest.TestCase):
 
         mock_connection = MagicMock()
         mock_templar = MagicMock()
-        action = 'namespace.netconf_sufix'
-        module_prefix = action.split('.')[-1].split('_')[0]
+        action = 'namespace.netconf_suffix'
+        module_prefix = action.split('_')[0]
         te._task.action = action
 
         handler = te._get_action_handler(mock_connection, mock_templar)
@@ -445,7 +445,7 @@ class TestTaskExecutor(unittest.TestCase):
                                                    mock.call(module_prefix, collection_list=te._task.collections)])
 
         action_loader.get.assert_called_once_with(
-            'netconf', task=te._task, connection=mock_connection,
+            module_prefix, task=te._task, connection=mock_connection,
             play_context=te._play_context, loader=te._loader,
             templar=mock_templar, shared_loader_obj=te._shared_loader_obj,
             collection_list=te._task.collections)
@@ -469,8 +469,8 @@ class TestTaskExecutor(unittest.TestCase):
 
         mock_connection = MagicMock()
         mock_templar = MagicMock()
-        action = 'namespace.prefix_sufix'
-        module_prefix = action.split('.')[-1].split('_')[0]
+        action = 'namespace.prefix_suffix'
+        module_prefix = action.split('_')[0]
         te._task.action = action
         handler = te._get_action_handler(mock_connection, mock_templar)
 


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* Try to load network action plugin from the same collection as the module
* Alter tests to match

Just make sure the action plugin is as qualified as the module it is paired with

(cherry picked from commit 3dbc03d58a9dc17d3bb11873b026eeb3f001564b)

Merged in devel and stable-2.10 https://github.com/ansible/ansible/pull/66701
Add additional verbose logs https://github.com/ansible/ansible/pull/72408

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
executor/task_executor.py 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
