### PR TITLE
galaxy: Handle mtime for symlinks in collection build

### DIFF
--- a/changelogs/fragments/galaxy_build_symlnk_mtime.yml
+++ b/changelogs/fragments/galaxy_build_symlnk_mtime.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- galaxy - fix mtime for symlink files in tar file (https://github.com/ansible-collections/community.kubernetes/issues/288).

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1083,6 +1083,7 @@ def _build_collection_tar(b_collection_path, b_tar_path, collection_manifest, fi
                         tarinfo.mode = 0o0755 if existing_is_exec or tarinfo.isdir() else 0o0644
                     tarinfo.uid = tarinfo.gid = 0
                     tarinfo.uname = tarinfo.gname = ''
+                    tarinfo.mtime = time.time()
 
                     return tarinfo
 


### PR DESCRIPTION
##### SUMMARY

While building collection, mtime for symlinks are
reset to 'Jan 1, 1970'.
This fixes the mtime for symlinks.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/galaxy_build_symlnk_mtime.yml
lib/ansible/galaxy/collection/__init__.py
