### PR TITLE
Switch to hashlib.sha256() for ansible-test

### DIFF
--- a/changelogs/fragments/72411-fips-mode-ansible-test.yml
+++ b/changelogs/fragments/72411-fips-mode-ansible-test.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Switch to hashlib.sha256() for ansible-test to allow for FIPs mode.

--- a/test/lib/ansible_test/_internal/executor.py
+++ b/test/lib/ansible_test/_internal/executor.py
@@ -2118,7 +2118,7 @@ class EnvironmentDescription:
         if not os.path.exists(path):
             return None
 
-        file_hash = hashlib.md5()
+        file_hash = hashlib.sha256()
 
         file_hash.update(read_binary_file(path))
 


### PR DESCRIPTION
When FIPs mode is enable on centos-8, we are not able to load md5
functions.

    Traceback (most recent call last):
      File "/home/zuul/venv/bin/ansible-test", line 28, in <module>
        main()
      File "/home/zuul/venv/bin/ansible-test", line 24, in main
        cli_main()
      File "/home/zuul/venv/lib/python3.6/site-packages/ansible_test/_internal/cli.py", line 173, in main
        args.func(config)
      File "/home/zuul/venv/lib/python3.6/site-packages/ansible_test/_internal/executor.py", line 570, in command_network_integration
        command_integration_filtered(args, internal_targets, all_targets, inventory_path)
      File "/home/zuul/venv/lib/python3.6/site-packages/ansible_test/_internal/executor.py", line 1105, in command_integration_filtered
        original_environment = current_environment if current_environment else EnvironmentDescription(args)
      File "/home/zuul/venv/lib/python3.6/site-packages/ansible_test/_internal/executor.py", line 1930, in __init__
        known_hosts_hash = self.get_hash(os.path.expanduser('~/.ssh/known_hosts'))
      File "/home/zuul/venv/lib/python3.6/site-packages/ansible_test/_internal/executor.py", line 2087, in get_hash
        file_hash = hashlib.md5()
    ValueError: [digital envelope routines: EVP_DigestInit_ex] disabled for FIPS

Signed-off-by: Paul Belanger <pabelanger@redhat.com>