### PR TITLE
Add filter dict

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -98,6 +98,11 @@ def to_datetime(string, format="%Y-%m-%d %H:%M:%S"):
     return datetime.datetime.strptime(string, format)
 
 
+def make_dict(value, key):
+    '''Return a dictionary with a single key-value pair'''
+    return {key: value}
+
+
 def strftime(string_format, second=None):
     ''' return a date string using string. See https://docs.python.org/2/library/time.html#time.strftime for format '''
     if second is not None:
@@ -662,4 +667,5 @@ class FilterModule(object):
             'dict2items': dict_to_list_of_dict_key_value_elements,
             'items2dict': list_of_dict_key_value_elements_to_dict,
             'subelements': subelements,
+            'dict': make_dict,
         }


### PR DESCRIPTION
Add dict filter which returns a single key-value pair from two arguments. Useful for generating complex dictionaries without using loops.

Example 1

```
- hosts: localhost
  gather_facts: false
  vars:
    myvar: myvalue
  tasks:
  - debug:
      msg: "{{ myvar | dict('thatsmyvar') }}"

OUTPUT:
ok: [localhost] => {
    "msg": {
        "thatsmyvar": "myvalue"
    }
}
```

Example 2

```
- hosts: localhost
  gather_facts: false
  vars:
    myservers:
    - server1
    - server2
  tasks:
  - debug:
      msg: "{{ myservers | map('dict', 'server') }}"

OUTPUT:
ok: [localhost] => {
    "msg": [
        {
            "server": "server1"
        },
        {
            "server": "server2"
        }
    ]
}
```

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
core

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
