### PR TITLE
[2.9] ansible-doc: export has_action when --json is used

### DIFF
--- a/changelogs/fragments/ansible-doc-has_action.yml
+++ b/changelogs/fragments/ansible-doc-has_action.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "ansible-doc - provide ``has_action`` field in JSON output for modules. That information is currently only available in the text view (https://github.com/ansible/ansible/pull/72359)."


### PR DESCRIPTION
##### SUMMARY
Improve feature parity between `ansible-doc` and `ansible-doc --json`. Needed to include this information in the docs build.

Backport of #72359 to stable-2.9.

Not sure if this should really be backported to stable-2.9.

CC @bcoca @abadger 

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
ansible-doc
