### PR TITLE
rework some of ansible's inner templating

### DIFF
--- a/lib/ansible/parsing/yaml/dumper.py
+++ b/lib/ansible/parsing/yaml/dumper.py
@@ -26,6 +26,7 @@ from ansible.module_utils.common.yaml import SafeDumper
 from ansible.parsing.yaml.objects import AnsibleUnicode, AnsibleSequence, AnsibleMapping, AnsibleVaultEncryptedUnicode
 from ansible.utils.unsafe_proxy import AnsibleUnsafeText, AnsibleUnsafeBytes, NativeJinjaUnsafeText, NativeJinjaText
 from ansible.template import AnsibleUndefined
+from ansible.template.vars import AutoVars
 from ansible.vars.hostvars import HostVars, HostVarsVars
 from ansible.vars.manager import VarsWithSources
 
@@ -82,7 +83,7 @@ AnsibleDumper.add_representer(
 )
 
 AnsibleDumper.add_representer(
-    HostVarsVars,
+    AutoVars,
     represent_hostvars,
 )
 

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -51,7 +51,7 @@ from ansible.module_utils.common.collections import is_sequence
 from ansible.plugins.loader import filter_loader, lookup_loader, test_loader
 from ansible.template.native_helpers import ansible_native_concat, ansible_eval_concat, ansible_concat
 from ansible.template.template import AnsibleJ2Template
-from ansible.template.vars import AnsibleJ2Vars, AutoVars
+from ansible.template.vars import AnsibleJ2Vars, AutoVars, is_unsafe
 from ansible.utils.collection_loader import AnsibleCollectionRef
 from ansible.utils.display import Display
 from ansible.utils.listify import listify_lookup_plugin_terms
@@ -370,27 +370,8 @@ class AnsibleContext(Context):
         super(AnsibleContext, self).__init__(*args, **kwargs)
         self.unsafe = False
 
-    def _is_unsafe(self, val):
-        '''
-        Our helper function, which will also recursively check dict and
-        list entries due to the fact that they may be repr'd and contain
-        a key or value which contains jinja2 syntax and would otherwise
-        lose the AnsibleUnsafe value.
-        '''
-        if isinstance(val, dict):
-            for key in val.keys():
-                if self._is_unsafe(val[key]):
-                    return True
-        elif isinstance(val, list):
-            for item in val:
-                if self._is_unsafe(item):
-                    return True
-        elif getattr(val, '__UNSAFE__', False) is True:
-            return True
-        return False
-
     def _update_unsafe(self, val):
-        if val is not None and not self.unsafe and self._is_unsafe(val):
+        if val is not None and not self.unsafe and is_unsafe(val):
             self.unsafe = True
 
     def resolve_or_missing(self, key):

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -51,7 +51,8 @@ from ansible.module_utils.common.collections import is_sequence
 from ansible.plugins.loader import filter_loader, lookup_loader, test_loader
 from ansible.template.native_helpers import ansible_native_concat, ansible_eval_concat, ansible_concat
 from ansible.template.template import AnsibleJ2Template
-from ansible.template.vars import AnsibleJ2Vars
+from ansible.template.vars import AnsibleJ2Vars, AutoVars
+from ansible.utils.collection_loader import AnsibleCollectionRef
 from ansible.utils.display import Display
 from ansible.utils.listify import listify_lookup_plugin_terms
 from ansible.utils.native_jinja import NativeJinjaText
@@ -597,6 +598,7 @@ class Templar:
         self.environment.globals['query'] = self.environment.globals['q'] = self._query_lookup
         self.environment.globals['now'] = self._now_datetime
         self.environment.globals['undef'] = self._make_undefined
+        self.environment.globals['vars'] = AutoVars(self)
 
         # the current rendering context under which the templar class is working
         self.cur_context = None

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -953,7 +953,7 @@ class Templar:
             if disable_lookups:
                 t.globals['query'] = t.globals['q'] = t.globals['lookup'] = self._fail_lookup
 
-            jvars = AnsibleJ2Vars(self, t.globals)
+            jvars = AnsibleJ2Vars(self, t.globals, {'vars': AutoVars(self)})
 
             # In case this is a recursive call to do_template we need to
             # save/restore cur_context to prevent overriding __UNSAFE__.

--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -101,8 +101,7 @@ class AutoVars(Mapping):
         self._t = templar
 
     def __getitem__(self, var):
-        foo = self._t.template(self._t._available_variables[var], fail_on_undefined=False, static_vars=STATIC_VARS)
-        return foo
+        return self._t.template(self._t._available_variables[var], fail_on_undefined=False, static_vars=STATIC_VARS)
 
     def __contains__(self, var):
         return (var in self._t._available_variables)

--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -55,7 +55,7 @@ class AnsibleJ2Vars(ChainMap):
         variable = super().__getitem__(varname)
 
         from ansible.vars.hostvars import HostVars
-        if (varname == "vars" and isinstance(variable, dict)) or isinstance(variable, HostVars) or hasattr(variable, '__UNSAFE__'):
+        if (varname == "vars" and isinstance(variable, dict)) or isinstance(variable, AutoVars) or isinstance(variable, HostVars) or hasattr(variable, '__UNSAFE__'):
             return variable
 
         try:
@@ -98,7 +98,11 @@ class AutoVars(Mapping):
     ''' A special view of template vars on demand. '''
 
     def __init__(self, templar, myvars=None):
+
         self._t = templar
+
+        # this allows for vars that are part of this object to be
+        # resolved even if they depend on vars not contained within.
         if myvars is None:
             self._vars = self._t._available_variables
         else:

--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -100,7 +100,7 @@ class AutoVars(Mapping):
     def __init__(self, templar, myvars=None):
         self._t = templar
         if myvars is None:
-            self._vars = self._t.._available_variables
+            self._vars = self._t._available_variables
         else:
             self._vars = myvars
 

--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -27,7 +27,7 @@ STATIC_VARS = [
     'ungrouped',
 ]
 
-__all__ = ['AnsibleJ2Vars']
+__all__ = ['AnsibleJ2Vars', 'AutoVars']
 
 
 def _process_locals(_l):
@@ -115,4 +115,15 @@ class AutoVars(Mapping):
         return len(self._t._available_variables.keys())
 
     def __repr__(self):
-        return repr(templar.template(self._t._available_variables, fail_on_undefined=False, static_vars=STATIC_VARS))
+        return repr(self._t.template(self._t._available_variables, fail_on_undefined=False, static_vars=STATIC_VARS))
+
+    def __readonly__(self, *args, **kwargs):
+        raise RuntimeError("Cannot modify this variable, it is read only.")
+
+    __setitem__ = __readonly__
+    __delitem__ = __readonly__
+    pop = __readonly__
+    popitem = __readonly__
+    clear = __readonly__
+    update = __readonly__
+    setdefault = __readonly__

--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -97,24 +97,28 @@ class AnsibleJ2Vars(ChainMap):
 class AutoVars(Mapping):
     ''' A special view of template vars on demand. '''
 
-    def __init__(self, templar):
+    def __init__(self, templar, myvars=None):
         self._t = templar
+        if myvars is None:
+            self._vars = self._t.._available_variables
+        else:
+            self._vars = myvars
 
     def __getitem__(self, var):
-        return self._t.template(self._t._available_variables[var], fail_on_undefined=False, static_vars=STATIC_VARS)
+        return self._t.template(self._vars[var], fail_on_undefined=False, static_vars=STATIC_VARS)
 
     def __contains__(self, var):
-        return (var in self._t._available_variables)
+        return (var in self._vars)
 
     def __iter__(self):
-        for var in self._t._available_variables.keys():
+        for var in self._vars.keys():
             yield var
 
     def __len__(self):
-        return len(self._t._available_variables.keys())
+        return len(self._vars.keys())
 
     def __repr__(self):
-        return repr(self._t.template(self._t._available_variables, fail_on_undefined=False, static_vars=STATIC_VARS))
+        return repr(self._t.template(self._vars, fail_on_undefined=False, static_vars=STATIC_VARS))
 
     def __readonly__(self, *args, **kwargs):
         raise RuntimeError("Cannot modify this variable, it is read only.")

--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -54,8 +54,10 @@ class AnsibleJ2Vars(ChainMap):
     def __getitem__(self, varname):
         variable = super().__getitem__(varname)
 
+        # HostVars and AutoVars are special self templting returns.
+        # this is how 'vars' and 'hostvars' magic variables are implemented.
         from ansible.vars.hostvars import HostVars
-        if (varname == "vars" and isinstance(variable, dict)) or isinstance(variable, AutoVars) or isinstance(variable, HostVars) or hasattr(variable, '__UNSAFE__'):
+        if (varname == "vars" and isinstance(variable, dict)) or isinstance(variable, (AutoVars, HostVars)) or hasattr(variable, '__UNSAFE__'):
             return variable
 
         try:

--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -135,6 +135,7 @@ class AutoVars(Mapping):
             self._vars = myvars
 
     def __getitem__(self, var):
+        from ansible.vars.hostvars import HostVars
         if is_unsafe(self._vars[var]) or isinstance(self._vars[var], (HostVars, AnsibleJ2Vars, AutoVars)):
             res = self._vars[var]
         else:

--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -135,7 +135,7 @@ class AutoVars(Mapping):
             self._vars = myvars
 
     def __getitem__(self, var):
-        if is_unsafe(self._vars[var]):
+        if is_unsafe(self._vars[var]) or isinstance(self._vars[var], (HostVars, AnsibleJ2Vars, AutoVars)):
             res = self._vars[var]
         else:
             res = self._t.template(self._vars[var], fail_on_undefined=False, static_vars=STATIC_VARS)

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -438,6 +438,10 @@ class VariableManager:
         if task and host and task.delegate_to is not None and include_delegate_to:
             all_vars['ansible_delegated_vars'], all_vars['_ansible_loop_cache'] = self._get_delegated_vars(play, task, all_vars)
 
+
+        if 'hostvars' in all_vars:
+            all_vars['hostvars'].set_available_vars(all_vars)
+
         display.debug("done with get_vars()")
         if C.DEFAULT_DEBUG:
             # Use VarsWithSources wrapper class to display var sources

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -438,7 +438,6 @@ class VariableManager:
         if task and host and task.delegate_to is not None and include_delegate_to:
             all_vars['ansible_delegated_vars'], all_vars['_ansible_loop_cache'] = self._get_delegated_vars(play, task, all_vars)
 
-
         if 'hostvars' in all_vars:
             all_vars['hostvars'].set_available_vars(all_vars)
 

--- a/test/integration/targets/loops/tasks/main.yml
+++ b/test/integration/targets/loops/tasks/main.yml
@@ -388,8 +388,8 @@
 
 - assert:
     that:
-      - foo[0] != 'foo1.0'
-      - foo[0] == unsafe_value
+      - foo[0] != unsafe_value
+      - foo[0] == 'foo1.0'
   vars:
     unsafe_value: !unsafe 'foo{{ version_64169 }}'
 


### PR DESCRIPTION
  - vars is now a template object that is autosolvable
    also 'fixes' vars['varname'] not being templated.
  - avoid full vars dict copy now for every get_vars call.
  - moved to use common object for hostvarsvars as for vars.

related #72829
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vars