### PR TITLE
ansible-test - skip installing reqs if they are already installed

### DIFF
--- a/changelogs/fragments/ps-sanity-requirements.yml
+++ b/changelogs/fragments/ps-sanity-requirements.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-test - Skip installing requirements if they are already installed.

--- a/test/lib/ansible_test/_data/requirements/sanity.ps1
+++ b/test/lib/ansible_test/_data/requirements/sanity.ps1
@@ -10,8 +10,27 @@ Set-StrictMode -Version 2.0
 $ErrorActionPreference = "Stop"
 $ProgressPreference = 'SilentlyContinue'
 
+Function Install-PSModule {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [String]
+        $Name,
+
+        [Parameter(Mandatory=$true)]
+        [Version]
+        $RequiredVersion
+    )
+
+    # In case PSGallery is down we check if the module is already installed.
+    $installedModule = Get-Module -Name $Name -ListAvailable | Where-Object Version -eq $RequiredVersion
+    if (-not $installedModule) {
+        Install-Module -Name $Name -RequiredVersion $RequiredVersion -Scope CurrentUser
+   }
+}
+
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.18.0 -Scope CurrentUser
+Install-PSModule -Name PSScriptAnalyzer -RequiredVersion 1.18.0
 
 if ($IsContainer) {
     # PSScriptAnalyzer contain lots of json files for the UseCompatibleCommands check. We don't use this rule so by
@@ -23,4 +42,4 @@ if ($IsContainer) {
 }
 
 # Installed the PSCustomUseLiteralPath rule
-Install-Module -Name PSSA-PSCustomUseLiteralPath -RequiredVersion 0.1.1 -Scope CurrentUser
+Install-PSModule -Name PSSA-PSCustomUseLiteralPath -RequiredVersion 0.1.1


### PR DESCRIPTION
##### SUMMARY
The `Install-Module` function still tries to access PSGallery even if the module is already installed at the version requested. This is an issue if PSGallery is down as it will break our sanity run for the default test container that already has the reqs installed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test