### PR TITLE
[stable-2.10] ansible-test - skip installing PowerShell sanity test reqs if they are already installed (#72423)

### DIFF
--- a/changelogs/fragments/ps-sanity-requirements.yml
+++ b/changelogs/fragments/ps-sanity-requirements.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-test - Skip installing requirements if they are already installed.

--- a/test/lib/ansible_test/_data/requirements/sanity.ps1
+++ b/test/lib/ansible_test/_data/requirements/sanity.ps1
@@ -10,8 +10,27 @@ Set-StrictMode -Version 2.0
 $ErrorActionPreference = "Stop"
 $ProgressPreference = 'SilentlyContinue'
 
+Function Install-PSModule {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [String]
+        $Name,
+
+        [Parameter(Mandatory=$true)]
+        [Version]
+        $RequiredVersion
+    )
+
+    # In case PSGallery is down we check if the module is already installed.
+    $installedModule = Get-Module -Name $Name -ListAvailable | Where-Object Version -eq $RequiredVersion
+    if (-not $installedModule) {
+        Install-Module -Name $Name -RequiredVersion $RequiredVersion -Scope CurrentUser
+   }
+}
+
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.18.0 -Scope CurrentUser
+Install-PSModule -Name PSScriptAnalyzer -RequiredVersion 1.18.0
 
 if ($IsContainer) {
     # PSScriptAnalyzer contain lots of json files for the UseCompatibleCommands check. We don't use this rule so by
@@ -23,4 +42,4 @@ if ($IsContainer) {
 }
 
 # Installed the PSCustomUseLiteralPath rule
-Install-Module -Name PSSA-PSCustomUseLiteralPath -RequiredVersion 0.1.1 -Scope CurrentUser
+Install-PSModule -Name PSSA-PSCustomUseLiteralPath -RequiredVersion 0.1.1


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #72423 for Ansible 2.10
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/lib/ansible_test/_data/requirements/sanity.ps1`