### PR TITLE
add a --dot option so we can get an actual graph

### DIFF
--- a/changelogs/fragments/72426-inventory-add-dot-option.yaml
+++ b/changelogs/fragments/72426-inventory-add-dot-option.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - ansible-inventory - add a --dot option so we can generate a graphviz diagram of the inventory

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -99,6 +99,17 @@ class InventoryCLI(CLI):
         # self.parser.add_argument("--ignore-vars-plugins", action="store_true", default=False, dest='ignore_vars_plugins',
         #                          help="When doing an --list, skip vars data from vars plugins, by default, this would include group_vars/ and host_vars/")
 
+        # dot color options
+        self.parser.add_argument("--dot-bg", default='white', dest='dot_bg',
+                                 help='Specify the background color of the dot graph (default : white)')
+        self.parser.add_argument("--dot-node-bg", default='grey', dest='dot_node_bg',
+                                 help='Specify the background color of the dot graph (default : grey)')
+        self.parser.add_argument("--dot-fg", default='black', dest='dot_fg',
+                                 help='Specify the text and frame color of the dot graph (default : black)')
+        self.parser.add_argument("--dot-edge-fg", default='darkgrey', dest='dot_edge_fg',
+                                 help='Specify the arrow color of the dot graph (default : darkgrey)')
+
+
     def post_process_args(self, options):
         options = super(InventoryCLI, self).post_process_args(options)
 
@@ -311,9 +322,10 @@ class InventoryCLI(CLI):
 
         output = [
             'digraph G {',
-            'graph [rankdir="LR" bgcolor="#F6F6F6"];',
-            'node [shape="record" color="#D3D3D3" style="filled" fillcolor="#AAAAAA" contraint="false"];',
-            'edge [color="#4284F3"];',
+            'graph [rankdir="LR" bgcolor="%s"];' % (context.CLIARGS['dot_bg']),
+            'node [shape="record" color="%s" fontcolor="%s" style="filled" fillcolor="%s" contraint="false"];' % (
+                context.CLIARGS['dot_fg'], context.CLIARGS['dot_fg'], context.CLIARGS['dot_node_bg']),
+            'edge [color="%s"];' % (context.CLIARGS['dot_edge_fg']),
         ]
         output.extend(self._graph_group_dot(start_at))
         output.append('}')

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -109,7 +109,6 @@ class InventoryCLI(CLI):
         self.parser.add_argument("--dot-edge-fg", default='darkgrey', dest='dot_edge_fg',
                                  help='Specify the arrow color of the dot graph (default : darkgrey)')
 
-
     def post_process_args(self, options):
         options = super(InventoryCLI, self).post_process_args(options)
 
@@ -317,9 +316,6 @@ class InventoryCLI(CLI):
     def inventory_graph_dot(self):
 
         start_at = self._get_group(context.CLIARGS['pattern'])
-        if context.CLIARGS['show_vars']:
-            raise AnsibleOptionsError("This would be graphic")
-
         output = [
             'digraph G {',
             'graph [rankdir="LR" bgcolor="%s"];' % (context.CLIARGS['dot_bg']),

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -125,6 +125,9 @@ class InventoryCLI(CLI):
         elif used > 1:
             raise AnsibleOptionsError("Conflicting options used, only one of --host, --graph, --dot or --list can be used at the same time.")
 
+        if options.graph_dot and options.show_vars:
+            raise AnsibleOptionsError("Variable display is not support in dot diagrams.")
+
         # set host pattern to default if not supplied
         if options.args:
             options.pattern = options.args

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -286,21 +286,21 @@ class InventoryCLI(CLI):
         from hashlib import sha1
         depth = depth + 1
         hashed_group_name = sha1(group.name.encode()).hexdigest()
-        result = ["%s\"%s\" [label=\"%s\"];" % (' ' * depth*4, hashed_group_name, group.name)]
+        result = ["%s\"%s\" [label=\"%s\"];" % (' ' * depth * 4, hashed_group_name, group.name)]
         for kid in sorted(group.child_groups, key=attrgetter('name')):
             hashed_kid_name = sha1(kid.name.encode()).hexdigest()
             result.extend(self._graph_group_dot(kid, depth))
             new_group = '%s"%s" -> "%s";' % (
-                    ' ' * depth*2, hashed_group_name, hashed_kid_name)
+                ' ' * depth * 4, hashed_group_name, hashed_kid_name)
             result.append(new_group)
 
         if group.name != 'all':
             for host in sorted(group.hosts, key=attrgetter('name')):
                 hashed_host_name = sha1(host.name.encode()).hexdigest()
-                new_host = '%s"%s" [label="%s"];' % (' ' * depth*4, hashed_host_name, host.name)
+                new_host = '%s"%s" [label="%s"];' % (' ' * depth * 4, hashed_host_name, host.name)
                 result.append(new_host)
                 new_parent_group = '%s"%s" -> "%s";' % (
-                        ' ' * depth*2, hashed_group_name, hashed_host_name)
+                    ' ' * depth * 2, hashed_group_name, hashed_host_name)
                 result.append(new_parent_group)
         return result
 
@@ -311,11 +311,11 @@ class InventoryCLI(CLI):
             raise AnsibleOptionsError("This would be graphic")
 
         output = [
-                'digraph G {',
-                'graph [rankdir="LR" bgcolor="#F6F6F6"];',
-                'node [shape="record" color="#D3D3D3" style="filled" fillcolor="#AAAAAA" contraint="false"];',
-                'edge [color="#4284F3"];',
-            ]
+            'digraph G {',
+            'graph [rankdir="LR" bgcolor="#F6F6F6"];',
+            'node [shape="record" color="#D3D3D3" style="filled" fillcolor="#AAAAAA" contraint="false"];',
+            'edge [color="#4284F3"];',
+        ]
         output.extend(self._graph_group_dot(start_at))
         output.append('}')
         if start_at:

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -88,7 +88,7 @@ class InventoryCLI(CLI):
         self.parser.add_argument('--toml', action='store_true', default=False, dest='toml',
                                  help='Use TOML format instead of default JSON, ignored for --graph and --dot')
         self.parser.add_argument("--vars", action="store_true", default=False, dest='show_vars',
-                                 help='Add vars to graph display, ignored unless used with --graph and --dot')
+                                 help='Add vars to graph display, ignored unless used with --graph')
 
         # list
         self.parser.add_argument("--export", action="store_true", default=C.INVENTORY_EXPORT, dest='export',
@@ -320,6 +320,8 @@ class InventoryCLI(CLI):
 
         start_at = self._get_group(context.CLIARGS['pattern'])
         output = [
+            '// diagram generated ansible-inventory for %s group' % (start_at),
+            '// this file is meant to be compiled with the graphviz toolchain',
             'digraph G {',
             'graph [rankdir="LR" bgcolor="%s"];' % (context.CLIARGS['dot_bg']),
             'node [shape="record" color="%s" fontcolor="%s" style="filled" fillcolor="%s" contraint="false"];' % (

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -9,7 +9,6 @@ import sys
 
 import argparse
 from operator import attrgetter
-from hashlib import sha1
 
 from ansible import constants as C
 from ansible import context


### PR DESCRIPTION
##### SUMMARY

This implement a "dot graphviz" output for `ansible-inventory`. This is very similar to "`terraform graph`" command.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME

ansible-inventory

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

I wonder if the vars options is relevant here, they are hard to make it pleasing in a usable graphic as soon as you go beyond really trivial inventory (we use _huge_ ones here).
Also my color choices are probably not so good.
Please advise.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
# consider this inventory
$ cat /tmp/trivial_inventory
[group1]
host1
host2

[group2]
host3

[group3]
host3
host4

[machines:children]
group1
group2
# the basic graph option
$ ansible-inventory -i /tmp/trivial_inventory --graph                           
@all:
  |--@group3:
  |  |--host3
[...]
  |  |--@group2:
  |  |  |--host3
  |--@ungrouped:
# the new --dot option
$ ansible-inventory -i /tmp/trivial_inventory --dot | dot -T svg -o inv.svg -x

 [attachment converted to png below this code block, because github can't embed svg]

$ ansible-inventory -i /tmp/trivial_inventory --dot
digraph G {
graph [rankdir="LR" bgcolor="#F6F6F6"];
node [shape="record" color="#D3D3D3" style="filled" fillcolor="#AAAAAA" contraint="false"];
edge [color="#4284F3"];
    "d87c448044defb778f33158d8ccf94a20531d600" [label="all"];
        "e157bec2c6b2adc3ce70aca06ae4f6dfc1ee91ee" [label="group3"];
        "3b39992c0b1a539a76f9b80752690a1ca0b77c59" [label="host3"];
    "e157bec2c6b2adc3ce70aca06ae4f6dfc1ee91ee" -> "3b39992c0b1a539a76f9b80752690a1ca0b77c59";
        "abf67cf30541723b65dd6b9fc7c0b1caf0101fcf" [label="host4"];
    "e157bec2c6b2adc3ce70aca06ae4f6dfc1ee91ee" -> "abf67cf30541723b65dd6b9fc7c0b1caf0101fcf";
  "d87c448044defb778f33158d8ccf94a20531d600" -> "e157bec2c6b2adc3ce70aca06ae4f6dfc1ee91ee";
        "6516c232528481e757d3d0eec7e42b291b27aca6" [label="machines"];
            "be4f69bf25177a377d20437445e49a13cf3c65d5" [label="group1"];
            "e5e2a9518607915ae99ab77d575bfe7a7dcf2a99" [label="host1"];
      "be4f69bf25177a377d20437445e49a13cf3c65d5" -> "e5e2a9518607915ae99ab77d575bfe7a7dcf2a99";
            "e0d87a849f5a1e3d140e8b666446536edfe92089" [label="host2"];
      "be4f69bf25177a377d20437445e49a13cf3c65d5" -> "e0d87a849f5a1e3d140e8b666446536edfe92089";
    "6516c232528481e757d3d0eec7e42b291b27aca6" -> "be4f69bf25177a377d20437445e49a13cf3c65d5";
            "ca5ff4060839997ae17316da3095bc65d342f828" [label="group2"];
            "3b39992c0b1a539a76f9b80752690a1ca0b77c59" [label="host3"];
      "ca5ff4060839997ae17316da3095bc65d342f828" -> "3b39992c0b1a539a76f9b80752690a1ca0b77c59";
    "6516c232528481e757d3d0eec7e42b291b27aca6" -> "ca5ff4060839997ae17316da3095bc65d342f828";
  "d87c448044defb778f33158d8ccf94a20531d600" -> "6516c232528481e757d3d0eec7e42b291b27aca6";
        "3b36d99c7304a08a5a24f247f2e47e6b283f147e" [label="ungrouped"];
  "d87c448044defb778f33158d8ccf94a20531d600" -> "3b36d99c7304a08a5a24f247f2e47e6b283f147e";
}
```
![example_inv](https://user-images.githubusercontent.com/12843753/97784166-e07bf400-1b9c-11eb-8eae-ffb19762f431.png)
