### PR TITLE
ansible-test integration: allow tests to know which remote / docker container is used

### DIFF
--- a/changelogs/fragments/ansible-test-docker-remote-env.yml
+++ b/changelogs/fragments/ansible-test-docker-remote-env.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "ansible-test integration - exports ``ANSIBLE_TEST_DOCKER`` or ``ANSIBLE_TEST_REMOTE`` environment variables when the ``--docker`` resp. ``--remote`` options are used (https://github.com/ansible/ansible/pull/72430)."

--- a/test/lib/ansible_test/_internal/executor.py
+++ b/test/lib/ansible_test/_internal/executor.py
@@ -1441,6 +1441,12 @@ def integration_environment(args, target, test_dir, inventory_path, ansible_conf
         INVENTORY_PATH=os.path.abspath(inventory_path),
     )
 
+    if args.docker:
+        env.update(dict(ANSIBLE_TEST_DOCKER=args.docker_raw))
+
+    if args.remote:
+        env.update(dict(ANSIBLE_TEST_REMOTE=args.remote))
+
     if args.debug_strategy:
         env.update(dict(ANSIBLE_STRATEGY='debug'))
 


### PR DESCRIPTION
##### SUMMARY
I need that to be able to install OS-dependent packages for Python libraries such as pyOpenSSL and cryptography on OS images / remotes, while using `pip` on the `default` image. With this, hacks such as https://github.com/ansible-collections/community.crypto/pull/112/commits/740a74747d46fbe3d211907f11b1db676fb8d2e5 (first two changed files) could be avoided (in community.crypto, setup_acme is currently only used in 'cloud' tests, while setup_openssl only works for OS container/remote tests because it installs OS packages for `cryptography`).

It would be even better if this could be backported to stable-2.10 and stable-2.9, to allow unified testing for all supported Python versions.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test integration
