### PR TITLE
Update pip tests to omit install dev extras to avoid dep issues

### DIFF
--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -479,7 +479,8 @@
 
 - name: try install package with setuptools extras
   pip:
-    name: "{{pip_test_package}}[dev,test]"
+    name:
+      - "{{pip_test_package}}[test]"
 
 - name: clean up
   pip:


### PR DESCRIPTION
##### SUMMARY
Update pip tests to omit install dev extras to avoid dep issues

The `dev` extra was bringing in an updated `check-manifest` which now has a dep on `build`.

`build` is bringing in a new `virtualenv` which has a dep on `importlib_metadata` and `zipp`, and `zipp` is failing to build on older `setuptools`, ultimately causing a traceback.

We'll just test against a single extra for now, until maybe we can create our own package that doesn't bring in so many deps.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/pip/tasks/pip.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
