### PR TITLE
[WIP]Add use_cache option in cliconf base

### DIFF
--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -88,7 +88,7 @@ class CliconfBase(AnsiblePlugin):
         self._connection.queue_message('log', 'closing shell due to command timeout (%s seconds).' % self._connection._play_context.timeout)
         self.close()
 
-    def send_command(self, command=None, prompt=None, answer=None, sendonly=False, newline=True, prompt_retry_check=False, check_all=False):
+    def send_command(self, command=None, prompt=None, answer=None, sendonly=False, newline=True, prompt_retry_check=False, check_all=False, use_cache=False):
         """Executes a command over the device connection
 
         This method will execute a command over the device connection and

--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -110,7 +110,8 @@ class CliconfBase(AnsiblePlugin):
             'sendonly': sendonly,
             'newline': newline,
             'prompt_retry_check': prompt_retry_check,
-            'check_all': check_all
+            'check_all': check_all,
+            'use_cache': use_cache,
         }
 
         if prompt is not None:


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/ansible.netcommon/pull/120 

Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Add `use_cache` option in send_command()

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cliconf/__init__.py