### PR TITLE
[stable-2.10] Update pip tests to omit install dev extras to avoid dep issues (#72436)

### DIFF
--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -479,7 +479,8 @@
 
 - name: try install package with setuptools extras
   pip:
-    name: "{{pip_test_package}}[dev,test]"
+    name:
+      - "{{pip_test_package}}[test]"
 
 - name: clean up
   pip:


### PR DESCRIPTION
(cherry picked from commit 2ee5af5)


Co-authored-by: Matt Martz <matt@sivel.net>