### PR TITLE
[stable-2.9] Update pip tests to omit install dev extras to avoid dep issues (#72436)

### DIFF
--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -487,7 +487,8 @@
 
 - name: try install package with setuptools extras
   pip:
-    name: "{{pip_test_package}}[dev,test]"
+    name:
+      - "{{pip_test_package}}[test]"
 
 - name: clean up
   pip:


### PR DESCRIPTION
(cherry picked from commit 2ee5af5)


Co-authored-by: Matt Martz <matt@sivel.net>