### PR TITLE
[2.9] Improve ansible-test classifications for collections

### DIFF
--- a/changelogs/fragments/ansible-test-collection-classification.yml
+++ b/changelogs/fragments/ansible-test-collection-classification.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-test - improve classification of changes to ``.gitignore``, ``COPYING``, ``LICENSE``, ``Makefile``, and all files ending with one of ``.in`, ``.md`, ``.rst``, ``.toml``, ``.txt`` in the collection root directory (https://github.com/ansible/ansible/pull/72353)."

--- a/test/lib/ansible_test/_internal/classification.py
+++ b/test/lib/ansible_test/_internal/classification.py
@@ -651,6 +651,9 @@ class PathMapper:
         if result is not None:
             return result
 
+        filename = os.path.basename(path)
+        dummy, ext = os.path.splitext(filename)
+
         minimal = {}
 
         if path.startswith('changelogs/'):
@@ -658,6 +661,24 @@ class PathMapper:
 
         if path.startswith('docs/'):
             return minimal
+
+        if '/' not in path:
+            if path in (
+                    '.gitignore',
+                    'COPYING',
+                    'LICENSE',
+                    'Makefile',
+            ):
+                return minimal
+
+            if ext in (
+                    '.in',
+                    '.md',
+                    '.rst',
+                    '.toml',
+                    '.txt',
+            ):
+                return minimal
 
         return None
 


### PR DESCRIPTION
##### SUMMARY
Backport of #72353 to stable-2.9.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/lib/ansible_test/_internal/classification.py
