### PR TITLE
CLI - Specify jinja version in --version output

### DIFF
--- a/changelogs/fragments/version-jinja.yml
+++ b/changelogs/fragments/version-jinja.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - CLI - Specify jinja version in ``--version`` output

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -19,6 +19,8 @@ try:
 except ImportError:
     HAS_LIBYAML = False
 
+from jinja2 import __version__ as j2_version
+
 import ansible
 from ansible import constants as C
 from ansible.module_utils._text import to_native
@@ -172,6 +174,7 @@ def version(prog=None):
     result.append("  ansible collection location = %s" % ':'.join(C.COLLECTIONS_PATHS))
     result.append("  executable location = %s" % sys.argv[0])
     result.append("  python version = %s" % ''.join(sys.version.splitlines()))
+    result.append("  jinja version = %s" % j2_version)
     result.append("  libyaml = %s" % HAS_LIBYAML)
     return "\n".join(result)
 

--- a/test/units/cli/test_adhoc.py
+++ b/test/units/cli/test_adhoc.py
@@ -104,7 +104,7 @@ def test_ansible_version(capsys, mocker):
         # Python 2.6 does return a named tuple, so get the first item
         version_lines = version[0].splitlines()
 
-    assert len(version_lines) == 8, 'Incorrect number of lines in "ansible --version" output'
+    assert len(version_lines) == 9, 'Incorrect number of lines in "ansible --version" output'
     assert re.match('ansible [0-9.a-z]+$', version_lines[0]), 'Incorrect ansible version line in "ansible --version" output'
     assert re.match('  config file = .*$', version_lines[1]), 'Incorrect config file line in "ansible --version" output'
     assert re.match('  configured module search path = .*$', version_lines[2]), 'Incorrect module search path in "ansible --version" output'
@@ -112,4 +112,5 @@ def test_ansible_version(capsys, mocker):
     assert re.match('  ansible collection location = .*$', version_lines[4]), 'Incorrect collection location in "ansible --version" output'
     assert re.match('  executable location = .*$', version_lines[5]), 'Incorrect executable locaction in "ansible --version" output'
     assert re.match('  python version = .*$', version_lines[6]), 'Incorrect python version in "ansible --version" output'
-    assert re.match('  libyaml = .*$', version_lines[7]), 'Missing libyaml in "ansible --version" output'
+    assert re.match('  jinja version = .*$', version_lines[7]), 'Incorrect jinja version in "ansible --version" output'
+    assert re.match('  libyaml = .*$', version_lines[8]), 'Missing libyaml in "ansible --version" output'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
```
$ ansible --version
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can
become unstable at any point.
ansible 2.11.0.dev0 (cli-version-jinja 069fa223a2) last updated 2020/11/03 14:07:35 (GMT +200)
  config file = /home/mkrizek/src/ansible/ansible.cfg
  configured module search path = ['/home/mkrizek/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mkrizek/src/ansible/lib/ansible
  ansible collection location = /home/mkrizek/.ansible/collections:/usr/share/ansible/collections
  executable location = /home/mkrizek/.pyenv/versions/ansible-py382/bin/ansible
  python version = 3.8.2 (default, Apr  9 2020, 07:40:53) [GCC 9.3.1 20200317 (Red Hat 9.3.1-1)]
  jinja version = 3.0.0a1
  libyaml = False
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/cli/arguments/option_helpers.py`