### PR TITLE
Emit warning when running on the controller with a Python older than 3.8

### DIFF
--- a/changelogs/fragments/controller-python-warning.yml
+++ b/changelogs/fragments/controller-python-warning.yml
@@ -1,3 +1,4 @@
 minor_changes:
 - Controller - Add warning for Ansible 2.11 when running a Python version older than Python 3.8
-  to inform users that 2.12 will only support Python 3.8 and newer on the controller
+  to inform users that 2.12 will only support Python 3.8 and newer on the controller. Starting
+  with Ansible 2.11, the project will only be packaged for Python 3.8 and newer.

--- a/changelogs/fragments/controller-python-warning.yml
+++ b/changelogs/fragments/controller-python-warning.yml
@@ -1,3 +1,3 @@
 minor_changes:
-- Controller - Add warning for Ansible 2.11 when running a Python version older than Python3.8
-  to inform users that 2.12 will only support Python3.8 and newer on the controller
+- Controller - Add warning for Ansible 2.11 when running a Python version older than Python 3.8
+  to inform users that 2.12 will only support Python 3.8 and newer on the controller

--- a/changelogs/fragments/controller-python-warning.yml
+++ b/changelogs/fragments/controller-python-warning.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- Controller - Add warning for Ansible 2.11 when running a Python version older than Python3.8
+  to inform users that 2.12 will only support Python3.8 and newer on the controller

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -22,7 +22,7 @@ You install Ansible on a control node, which then uses SSH (by default) to commu
 Control node requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Currently Ansible can be run from any machine with Python 2 (version 2.7) or Python 3 (versions 3.5 and higher) installed. Ansible 2.11 will make Python 3.8 a soft dependency for the control node, but will function with the aforementioned requirements. Ansible 2.12 will require Python3.8 or newer to function on the control node.
+Currently Ansible can be run from any machine with Python 2 (version 2.7) or Python 3 (versions 3.5 and higher) installed. Ansible 2.11 will make Python 3.8 a soft dependency for the control node, but will function with the aforementioned requirements. Ansible 2.12 will require Python 3.8 or newer to function on the control node. Starting with Ansible 2.11, the project will only be packaged for Python 3.8 and newer.
 This includes Red Hat, Debian, CentOS, macOS, any of the BSDs, and so on.
 Windows is not supported for the control node, read more about this in `Matt Davis's blog post <http://blog.rolpdog.com/2020/03/why-no-ansible-controller-for-windows.html>`_.
 
@@ -35,7 +35,7 @@ When choosing a control node, bear in mind that any management system benefits f
 
 .. warning::
 
-    Ansible 2.11 will make Python 3.8 a soft dependency for the control node, but will function with the aforementioned requirements. Ansible 2.12 will require Python 3.8 or newer to function on the control node.
+    Ansible 2.11 will make Python 3.8 a soft dependency for the control node, but will function with the aforementioned requirements. Ansible 2.12 will require Python 3.8 or newer to function on the control node. Starting with Ansible 2.11, the project will only be packaged for Python 3.8 and newer.
 
 .. warning::
 

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -22,7 +22,7 @@ You install Ansible on a control node, which then uses SSH (by default) to commu
 Control node requirements
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Currently Ansible can be run from any machine with Python 2 (version 2.7) or Python 3 (versions 3.5 and higher) installed.
+Currently Ansible can be run from any machine with Python 2 (version 2.7) or Python 3 (versions 3.5 and higher) installed. Ansible 2.11 will make Python 3.8 a soft dependency for the control node, but will function with the aforementioned requirements. Ansible 2.12 will require Python3.8 or newer to function on the control node.
 This includes Red Hat, Debian, CentOS, macOS, any of the BSDs, and so on.
 Windows is not supported for the control node, read more about this in `Matt Davis's blog post <http://blog.rolpdog.com/2020/03/why-no-ansible-controller-for-windows.html>`_.
 
@@ -32,6 +32,10 @@ When choosing a control node, bear in mind that any management system benefits f
 
     macOS by default is configured for a small number of file handles, so if you want to use 15 or more forks you'll need to raise the ulimit with ``sudo launchctl limit maxfiles unlimited``. This command can also fix any "Too many open files" error.
 
+
+.. warning::
+
+    Ansible 2.11 will make Python 3.8 a soft dependency for the control node, but will function with the aforementioned requirements. Ansible 2.12 will require Python3.8 or newer to function on the control node.
 
 .. warning::
 

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -35,7 +35,7 @@ When choosing a control node, bear in mind that any management system benefits f
 
 .. warning::
 
-    Ansible 2.11 will make Python 3.8 a soft dependency for the control node, but will function with the aforementioned requirements. Ansible 2.12 will require Python3.8 or newer to function on the control node.
+    Ansible 2.11 will make Python 3.8 a soft dependency for the control node, but will function with the aforementioned requirements. Ansible 2.12 will require Python 3.8 or newer to function on the control node.
 
 .. warning::
 

--- a/lib/ansible/cli/scripts/ansible_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_cli_stub.py
@@ -38,6 +38,7 @@ from ansible.module_utils._text import to_text
 
 # Used for determining if the system is running a new enough python version
 # and should only restrict on our documented minimum versions
+_PY38_MIN = sys.version_info[:2] >= (3, 8)
 _PY3_MIN = sys.version_info[:2] >= (3, 5)
 _PY2_MIN = (2, 6) <= sys.version_info[:2] < (3,)
 _PY_MIN = _PY3_MIN or _PY2_MIN
@@ -72,6 +73,14 @@ if __name__ == '__main__':
 
     try:
         display = Display()
+        if C.CONTROLLER_PYTHON_WARNING and not _PY38_MIN:
+            display.deprecated(
+                (
+                    'Ansible will require Python3.8 or newer on the controller starting with Ansible 2.12. '
+                    'Current version: %s' % ''.join(sys.version.splitlines())
+                ),
+                version='2.12',
+            )
         display.debug("starting run")
 
         sub = None

--- a/lib/ansible/cli/scripts/ansible_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_cli_stub.py
@@ -76,7 +76,7 @@ if __name__ == '__main__':
         if C.CONTROLLER_PYTHON_WARNING and not _PY38_MIN:
             display.deprecated(
                 (
-                    'Ansible will require Python3.8 or newer on the controller starting with Ansible 2.12. '
+                    'Ansible will require Python 3.8 or newer on the controller starting with Ansible 2.12. '
                     'Current version: %s' % ''.join(sys.version.splitlines())
                 ),
                 version='2.12',

--- a/lib/ansible/cli/scripts/ansible_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_cli_stub.py
@@ -80,6 +80,7 @@ if __name__ == '__main__':
                     'Current version: %s' % ''.join(sys.version.splitlines())
                 ),
                 version='2.12',
+                collection_name='ansible.builtin',
             )
         display.debug("starting run")
 

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -585,6 +585,15 @@ CALLABLE_ACCEPT_LIST:
     section: defaults
     version_added: '2.11'
   type: list
+CONTROLLER_PYTHON_WARNING:
+  name: Running Older than Py3.8 Warning
+  default: True
+  description: Toggle to control showing warnings related to running a Python version
+               older than Python 3.8 on the controller
+  env: [{name: ANSIBLE_CONTROLLER_PYTHON_WARNING}]
+  ini:
+  - {key: controller_python_warning, section: defaults}
+  type: boolean
 DEFAULT_CALLBACK_PLUGIN_PATH:
   name: Callback Plugins Path
   default: ~/.ansible/plugins/callback:/usr/share/ansible/plugins/callback

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -586,7 +586,7 @@ CALLABLE_ACCEPT_LIST:
     version_added: '2.11'
   type: list
 CONTROLLER_PYTHON_WARNING:
-  name: Running Older than Py3.8 Warning
+  name: Running Older than Python 3.8 Warning
   default: True
   description: Toggle to control showing warnings related to running a Python version
                older than Python 3.8 on the controller

--- a/test/lib/ansible_test/_internal/ansible_util.py
+++ b/test/lib/ansible_test/_internal/ansible_util.py
@@ -74,6 +74,7 @@ def ansible_environment(args, color=True, ansible_config=None):
         ANSIBLE_CONFIG=ansible_config,
         ANSIBLE_LIBRARY='/dev/null',
         ANSIBLE_DEVEL_WARNING='false',  # Don't show warnings that CI is running devel
+        ANSIBLE_CONTROLLER_PYTHON_WARNING='false',  # Don't show warnings in CI for old controller Python
         PYTHONPATH=get_ansible_python_path(),
         PAGER='/bin/cat',
         PATH=path,


### PR DESCRIPTION
##### SUMMARY
Emit warning when running on the controller with a Python older than 3.8

Ansible 2.11 will make Python 3.8 a soft dependency for the controller. Ansible 2.12 will _require_ Python3.8 or newer to function on the controller.

This deprecation warning will help inform users of this change.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
