### PR TITLE
[dnf] Some fixes around filtering

### DIFF
--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -128,12 +128,14 @@ options:
   security:
     description:
       - If set to C(yes), and C(state=latest) then only installs updates that have been marked security related.
+      - Note that, similar to ``dnf upgrade-minimal``, this filter applies to dependencies as well.
     type: bool
     default: "no"
     version_added: "2.7"
   bugfix:
     description:
       - If set to C(yes), and C(state=latest) then only installs updates that have been marked bugfix related.
+      - Note that, similar to ``dnf upgrade-minimal``, this filter applies to dependencies as well.
     default: "no"
     type: bool
     version_added: "2.7"
@@ -674,10 +676,10 @@ class DnfModule(YumDnf):
         filters = []
         if self.bugfix:
             key = {'advisory_type__eq': 'bugfix'}
-            filters.append(base.sack.query().filter(**key))
+            filters.append(base.sack.query().upgrades().filter(**key))
         if self.security:
             key = {'advisory_type__eq': 'security'}
-            filters.append(base.sack.query().filter(**key))
+            filters.append(base.sack.query().upgrades().filter(**key))
         if filters:
             base._update_security_filters = filters
 

--- a/test/integration/targets/dnf/tasks/filters_check_mode.yml
+++ b/test/integration/targets/dnf/tasks/filters_check_mode.yml
@@ -20,7 +20,9 @@
 
     - name: Ask for pending updates (check_mode)
       dnf:
-        name: '*'
+        name:
+          - toaster
+          - oven
         state: latest
         update_only: true
         disable_gpg_check: true
@@ -38,7 +40,9 @@
 
     - name: Ask for pending updates with security=true (check_mode)
       dnf:
-        name: '*'
+        name:
+          - toaster
+          - oven
         state: latest
         update_only: true
         disable_gpg_check: true
@@ -57,7 +61,9 @@
 
     - name: Ask for pending updates with bugfix=true (check_mode)
       dnf:
-        name: '*'
+        name:
+          - toaster
+          - oven
         state: latest
         update_only: true
         disable_gpg_check: true
@@ -76,7 +82,9 @@
 
     - name: Ask for pending updates with bugfix=true and security=true (check_mode)
       dnf:
-        name: '*'
+        name:
+          - toaster
+          - oven
         state: latest
         update_only: true
         disable_gpg_check: true


### PR DESCRIPTION

##### SUMMARY

Change:
- Docs: Add note that security/bugfix apply to dependencies too, like
  the dnf command.

- dnf: security/bugfix only makes sense for updates, so limit the
  package query sack to available updates.

- tests: Limit tests to our known-good test packages, so that RHEL
  packages marked security/bugfix without similarly marked dependencies
  don't fail our tests.

Test Plan:
- Tested with `dnf upgrade-minimal --bugfix` and reproduced the same
  error currently seen in CI, showing that we are consistent with what
  dnf does.

Tickets:
- Likely fixes #72316

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Test Pull Request

##### COMPONENT NAME

dnf