### PR TITLE
Import sanity test for plugins

### DIFF
--- a/changelogs/fragments/72497-ansible-test-import-plugins.yml
+++ b/changelogs/fragments/72497-ansible-test-import-plugins.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "ansible-test - the ``import`` sanity test now also tries to import all non-module and non-module_utils Python files in ``lib/ansible/`` resp. ``plugins/`` (https://github.com/ansible/ansible/pull/72497)."

--- a/docs/docsite/rst/dev_guide/testing/sanity/ansible-requirements.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/ansible-requirements.rst
@@ -1,0 +1,4 @@
+ansible-requirements
+====================
+
+``test/lib/ansible_test/_data/requirements/sanity.import-plugins.txt`` must be an identical copy of ``requirements.txt`` found in the project's root.

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -41,6 +41,8 @@ CRYPTOGRAPHY_BACKEND = None
 try:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
+        warnings.filterwarnings("ignore", "Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.")
+        warnings.filterwarnings("ignore", "Python 3.5 support will be dropped in the next release ofcryptography. Please upgrade your Python.")
         from cryptography.exceptions import InvalidSignature
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives import hashes, padding

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -41,8 +41,6 @@ CRYPTOGRAPHY_BACKEND = None
 try:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
-        warnings.filterwarnings("ignore", "Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.")
-        warnings.filterwarnings("ignore", "Python 3.5 support will be dropped in the next release ofcryptography. Please upgrade your Python.")
         from cryptography.exceptions import InvalidSignature
     from cryptography.hazmat.backends import default_backend
     from cryptography.hazmat.primitives import hashes, padding

--- a/test/lib/ansible_test/_data/requirements/sanity.import-plugins.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.import-plugins.txt
@@ -1,0 +1,9 @@
+# Note: this requirements.txt file is used to specify what dependencies are
+# needed to make the package run rather than for deployment of a tested set of
+# packages.  Thus, this should be the loosest set possible (only required
+# packages, not optional ones, and with the widest range of versions that could
+# be suitable)
+jinja2
+PyYAML
+cryptography
+packaging

--- a/test/lib/ansible_test/_data/requirements/sanity.import-plugins.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.import-plugins.txt
@@ -7,3 +7,7 @@ jinja2
 PyYAML
 cryptography
 packaging
+# NOTE: resolvelib 0.x version bumps should be considered major/breaking
+# NOTE: and we should update the upper cap with care, at least until 1.0
+# NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69
+resolvelib >= 0.5.3, < 0.6.0  # dependency resolver used by ansible-galaxy

--- a/test/lib/ansible_test/_data/sanity/import/importer.py
+++ b/test/lib/ansible_test/_data/sanity/import/importer.py
@@ -488,6 +488,10 @@ def main():
                 warnings.filterwarnings(
                     "ignore", 
                     "Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.")
+            warnings.filterwarnings(
+                "ignore",
+                "The _yaml extension module is now located at yaml._yaml and its location is subject to change.  To use the LibYAML-based parser and emitter, import from `yaml`: `from yaml import CLoader as Loader, CDumper as Dumper`.")
+
 
             try:
                 yield

--- a/test/lib/ansible_test/_data/sanity/import/importer.py
+++ b/test/lib/ansible_test/_data/sanity/import/importer.py
@@ -493,9 +493,15 @@ def main():
                     "ignore",
                     "Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography,"
                     " and will be removed in a future release.")
+                warnings.filterwarnings(
+                    "ignore",
+                    "Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography,"
+                    " and will be removed in the next release.")
             if sys.version_info[:2] == (3, 5):
                 warnings.filterwarnings(
                     "ignore", "Python 3.5 support will be dropped in the next release ofcryptography. Please upgrade your Python.")
+                warnings.filterwarnings(
+                    "ignore", "Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.")
 
             try:
                 yield

--- a/test/lib/ansible_test/_data/sanity/import/importer.py
+++ b/test/lib/ansible_test/_data/sanity/import/importer.py
@@ -441,11 +441,8 @@ def main():
             yield
         finally:
             if import_type == 'plugin':
-                # Remove collection loader from sys.meta_path
-                i = sys.meta_path.index(restricted_loader)
-                for entry in list(sys.meta_path[:i]):
-                    if 'ansible.utils.collection_loader._collection_finder._AnsibleCollectionFinder' in repr(entry):
-                        sys.meta_path.remove(entry)
+                from ansible.utils.collection_loader._collection_finder import _AnsibleCollectionFinder
+                _AnsibleCollectionFinder._remove()
 
             if sys.meta_path[0] != restricted_loader:
                 report_message(path, 0, 0, 'metapath', 'changes to sys.meta_path[0] are not permitted', messages)

--- a/test/lib/ansible_test/_data/sanity/import/importer.py
+++ b/test/lib/ansible_test/_data/sanity/import/importer.py
@@ -213,22 +213,14 @@ def main():
             self.loaded_modules.add(fullname)
             return import_module(fullname)
 
-    def run(args):
+    def run(restrict_to_module_paths):
         """Main program function."""
         base_dir = os.getcwd()
         messages = set()
 
-        if import_type == 'module':
-            for path in args or sys.stdin.read().splitlines():
-                name = convert_relative_path_to_name(path)
-                test_python_module(path, name, base_dir, messages, True)
-        elif import_type == 'plugin':
-            for path in args or sys.stdin.read().splitlines():
-                name = convert_relative_path_to_name(path)
-                test_python_module(path, name, base_dir, messages, False)
-        else:
-            print('Invalid import type!')
-            sys.exit(1)
+        for path in args or sys.stdin.read().splitlines():
+            name = convert_relative_path_to_name(path)
+            test_python_module(path, name, base_dir, messages, restrict_to_module_paths)
 
         if messages:
             sys.exit(10)
@@ -499,9 +491,11 @@ def main():
                     " and will be removed in the next release.")
             if sys.version_info[:2] == (3, 5):
                 warnings.filterwarnings(
-                    "ignore", "Python 3.5 support will be dropped in the next release ofcryptography. Please upgrade your Python.")
+                    "ignore", 
+                    "Python 3.5 support will be dropped in the next release ofcryptography. Please upgrade your Python.")
                 warnings.filterwarnings(
-                    "ignore", "Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.")
+                    "ignore", 
+                    "Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.")
 
             try:
                 yield
@@ -509,7 +503,7 @@ def main():
                 sys.stdout = old_stdout
                 sys.stderr = old_stderr
 
-    run(args)
+    run(import_type == 'module')
 
 
 if __name__ == '__main__':

--- a/test/lib/ansible_test/_data/sanity/import/importer.py
+++ b/test/lib/ansible_test/_data/sanity/import/importer.py
@@ -491,6 +491,10 @@ def main():
 
         with warnings.catch_warnings():
             warnings.simplefilter('error')
+            if sys.version_info[0] == 2:
+                warnings.filterwarnings("ignore", "Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.")
+            if sys.version_info[:2] == (3, 5):
+                warnings.filterwarnings("ignore", "Python 3.5 support will be dropped in the next release ofcryptography. Please upgrade your Python.")
 
             try:
                 yield

--- a/test/lib/ansible_test/_data/sanity/import/importer.py
+++ b/test/lib/ansible_test/_data/sanity/import/importer.py
@@ -492,9 +492,13 @@ def main():
         with warnings.catch_warnings():
             warnings.simplefilter('error')
             if sys.version_info[0] == 2:
-                warnings.filterwarnings("ignore", "Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in a future release.")
+                warnings.filterwarnings(
+                    "ignore",
+                    "Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography,"
+                    " and will be removed in a future release.")
             if sys.version_info[:2] == (3, 5):
-                warnings.filterwarnings("ignore", "Python 3.5 support will be dropped in the next release ofcryptography. Please upgrade your Python.")
+                warnings.filterwarnings(
+                    "ignore", "Python 3.5 support will be dropped in the next release ofcryptography. Please upgrade your Python.")
 
             try:
                 yield

--- a/test/lib/ansible_test/_data/sanity/import/importer.py
+++ b/test/lib/ansible_test/_data/sanity/import/importer.py
@@ -27,6 +27,7 @@ def main():
     external_python = os.environ.get('SANITY_EXTERNAL_PYTHON') or sys.executable
     collection_full_name = os.environ.get('SANITY_COLLECTION_FULL_NAME')
     collection_root = os.environ.get('ANSIBLE_COLLECTIONS_PATH')
+    import_type = os.environ.get('SANITY_IMPORTER_TYPE')
 
     try:
         # noinspection PyCompatibility
@@ -102,15 +103,6 @@ def main():
 
     # remove all modules under the ansible package
     list(map(sys.modules.pop, [m for m in sys.modules if m.partition('.')[0] == ansible.__name__]))
-
-    args = sys.argv[1:]
-    import_type = 'module'
-    try:
-        type_index = args.index('--type')
-        import_type = args[type_index + 1]
-        args = args[:type_index] + args[type_index + 2:]
-    except ValueError:
-        pass
 
     if import_type == 'module':
         # pre-load an empty ansible package to prevent unwanted code in __init__.py from loading
@@ -218,7 +210,7 @@ def main():
         base_dir = os.getcwd()
         messages = set()
 
-        for path in args or sys.stdin.read().splitlines():
+        for path in sys.argv[1:] or sys.stdin.read().splitlines():
             name = convert_relative_path_to_name(path)
             test_python_module(path, name, base_dir, messages, restrict_to_module_paths)
 

--- a/test/lib/ansible_test/_data/sanity/import/importer.py
+++ b/test/lib/ansible_test/_data/sanity/import/importer.py
@@ -483,15 +483,15 @@ def main():
                     " and will be removed in the next release.")
             if sys.version_info[:2] == (3, 5):
                 warnings.filterwarnings(
-                    "ignore", 
+                    "ignore",
                     "Python 3.5 support will be dropped in the next release ofcryptography. Please upgrade your Python.")
                 warnings.filterwarnings(
-                    "ignore", 
+                    "ignore",
                     "Python 3.5 support will be dropped in the next release of cryptography. Please upgrade your Python.")
             warnings.filterwarnings(
                 "ignore",
-                "The _yaml extension module is now located at yaml._yaml and its location is subject to change.  To use the LibYAML-based parser and emitter, import from `yaml`: `from yaml import CLoader as Loader, CDumper as Dumper`.")
-
+                "The _yaml extension module is now located at yaml._yaml and its location is subject to change.  To use the "
+                "LibYAML-based parser and emitter, import from `yaml`: `from yaml import CLoader as Loader, CDumper as Dumper`.")
 
             try:
                 yield

--- a/test/lib/ansible_test/_data/sanity/import/importer.py
+++ b/test/lib/ansible_test/_data/sanity/import/importer.py
@@ -442,7 +442,7 @@ def main():
         finally:
             if import_type == 'plugin':
                 from ansible.utils.collection_loader._collection_finder import _AnsibleCollectionFinder
-                _AnsibleCollectionFinder._remove()
+                _AnsibleCollectionFinder._remove()  # pylint: disable=protected-access
 
             if sys.meta_path[0] != restricted_loader:
                 report_message(path, 0, 0, 'metapath', 'changes to sys.meta_path[0] are not permitted', messages)

--- a/test/lib/ansible_test/_internal/executor.py
+++ b/test/lib/ansible_test/_internal/executor.py
@@ -2025,7 +2025,7 @@ class EnvironmentDescription:
         pip_paths = dict((v, find_executable('pip%s' % v, required=False)) for v in sorted(versions))
         program_versions = dict((v, self.get_version([python_paths[v], version_check], warnings)) for v in sorted(python_paths) if python_paths[v])
         pip_interpreters = dict((v, self.get_shebang(pip_paths[v])) for v in sorted(pip_paths) if pip_paths[v])
-        known_hosts_hash = self.get_hash(os.path.expanduser('~/.ssh/known_hosts'))
+        known_hosts_hash = get_hash(os.path.expanduser('~/.ssh/known_hosts'))
 
         for version in sorted(versions):
             self.check_python_pip_association(version, python_paths, pip_paths, pip_interpreters, warnings)
@@ -2164,14 +2164,6 @@ class EnvironmentDescription:
         """
         with open_text_file(path) as script_fd:
             return script_fd.readline().strip()
-
-    @staticmethod
-    def get_hash(path):
-        """
-        :type path: str
-        :rtype: str | None
-        """
-        return get_hash(path)
 
 
 class NoChangesDetected(ApplicationWarning):

--- a/test/lib/ansible_test/_internal/executor.py
+++ b/test/lib/ansible_test/_internal/executor.py
@@ -9,7 +9,6 @@ import re
 import time
 import textwrap
 import functools
-import hashlib
 import difflib
 import filecmp
 import random
@@ -44,7 +43,6 @@ from .cloud import (
 from .io import (
     make_dirs,
     open_text_file,
-    read_binary_file,
     read_text_file,
     write_text_file,
 )
@@ -70,6 +68,7 @@ from .util import (
     SUPPORTED_PYTHON_VERSIONS,
     str_to_version,
     version_to_str,
+    get_hash,
 )
 
 from .util_common import (
@@ -475,7 +474,7 @@ License: GPLv3+
     write_text_file(pkg_info_path, pkg_info.lstrip(), create_directories=True)
 
 
-def generate_pip_install(pip, command, packages=None, constraints=None, use_constraints=True, context=None):
+def generate_pip_install(pip, command, packages=None, constraints=None, use_constraints=True, context=None, requirements_file=None):
     """
     :type pip: list[str]
     :type command: str
@@ -483,10 +482,13 @@ def generate_pip_install(pip, command, packages=None, constraints=None, use_cons
     :type constraints: str | None
     :type use_constraints: bool
     :type context: str | None
+    :type requirements_file: str | None
     :rtype: list[str] | None
     """
     constraints = constraints or os.path.join(ANSIBLE_TEST_DATA_ROOT, 'requirements', 'constraints.txt')
     requirements = os.path.join(ANSIBLE_TEST_DATA_ROOT, 'requirements', '%s.txt' % ('%s.%s' % (command, context) if context else command))
+    if requirements_file:
+        requirements = requirements_file
     content_constraints = None
 
     options = []
@@ -2172,14 +2174,7 @@ class EnvironmentDescription:
         :type path: str
         :rtype: str | None
         """
-        if not os.path.exists(path):
-            return None
-
-        file_hash = hashlib.sha256()
-
-        file_hash.update(read_binary_file(path))
-
-        return file_hash.hexdigest()
+        return get_hash(path)
 
 
 class NoChangesDetected(ApplicationWarning):

--- a/test/lib/ansible_test/_internal/executor.py
+++ b/test/lib/ansible_test/_internal/executor.py
@@ -474,7 +474,7 @@ License: GPLv3+
     write_text_file(pkg_info_path, pkg_info.lstrip(), create_directories=True)
 
 
-def generate_pip_install(pip, command, packages=None, constraints=None, use_constraints=True, context=None, requirements_file=None):
+def generate_pip_install(pip, command, packages=None, constraints=None, use_constraints=True, context=None):
     """
     :type pip: list[str]
     :type command: str
@@ -482,13 +482,10 @@ def generate_pip_install(pip, command, packages=None, constraints=None, use_cons
     :type constraints: str | None
     :type use_constraints: bool
     :type context: str | None
-    :type requirements_file: str | None
     :rtype: list[str] | None
     """
     constraints = constraints or os.path.join(ANSIBLE_TEST_DATA_ROOT, 'requirements', 'constraints.txt')
     requirements = os.path.join(ANSIBLE_TEST_DATA_ROOT, 'requirements', '%s.txt' % ('%s.%s' % (command, context) if context else command))
-    if requirements_file:
-        requirements = requirements_file
     content_constraints = None
 
     options = []

--- a/test/lib/ansible_test/_internal/sanity/import.py
+++ b/test/lib/ansible_test/_internal/sanity/import.py
@@ -108,6 +108,9 @@ class ImportTest(SanityMultipleVersion):
                 ('module', _get_module_test(True), False),
                 ('plugin', _get_module_test(False), True),
         ):
+            if import_type == 'plugin' and python_version.startswith('2.6'):
+                continue
+
             data = '\n'.join([path for path in paths if test(path)])
             if not data:
                 continue

--- a/test/lib/ansible_test/_internal/sanity/import.py
+++ b/test/lib/ansible_test/_internal/sanity/import.py
@@ -64,7 +64,7 @@ from ..data import (
 )
 
 
-def _get_module_test(module_restrictions: bool) -> t.Callable[[str], bool]:
+def _get_module_test(module_restrictions):  # type: (bool) -> t.Callable[[str], bool]
     """Create a predicate which tests whether a path can be used by modules or not."""
     module_path = data_context().content.module_path
     module_utils_path = data_context().content.module_utils_path

--- a/test/lib/ansible_test/_internal/sanity/import.py
+++ b/test/lib/ansible_test/_internal/sanity/import.py
@@ -150,6 +150,7 @@ class ImportTest(SanityMultipleVersion):
                 env.update(
                     SANITY_COLLECTION_FULL_NAME=data_context().content.collection.full_name,
                     SANITY_EXTERNAL_PYTHON=python,
+                    SANITY_IMPORTER_TYPE=import_type,
                 )
 
             virtualenv_python = os.path.join(virtual_environment_bin, 'python')
@@ -181,7 +182,7 @@ class ImportTest(SanityMultipleVersion):
 
             display.info(import_type + ': ' + data, verbosity=4)
 
-            cmd = ['importer.py', '--type', import_type]
+            cmd = ['importer.py']
 
             messages = []
             try:

--- a/test/lib/ansible_test/_internal/sanity/import.py
+++ b/test/lib/ansible_test/_internal/sanity/import.py
@@ -153,7 +153,7 @@ class ImportTest(SanityMultipleVersion):
 
             # make sure requirements are installed if needed
             if requirements_file:
-                run_command(args, generate_pip_install(virtualenv_pip, '', requirements_file=requirements_file), env=env, capture=capture_pip)
+                run_command(args, generate_pip_install(virtualenv_pip, 'sanity', context='import-plugins'), env=env, capture=capture_pip)
 
             # make sure coverage is available in the virtual environment if needed
             if args.coverage:

--- a/test/lib/ansible_test/_internal/sanity/import.py
+++ b/test/lib/ansible_test/_internal/sanity/import.py
@@ -43,6 +43,7 @@ from ..ansible_util import (
 
 from ..executor import (
     generate_pip_install,
+    install_cryptography,
 )
 
 from ..config import (
@@ -156,6 +157,7 @@ class ImportTest(SanityMultipleVersion):
 
             # make sure requirements are installed if needed
             if requirements_file:
+                install_cryptography(args, virtualenv_python, python_version, virtualenv_pip)
                 run_command(args, generate_pip_install(virtualenv_pip, 'sanity', context='import-plugins'), env=env, capture=capture_pip)
 
             # make sure coverage is available in the virtual environment if needed

--- a/test/lib/ansible_test/_internal/sanity/import.py
+++ b/test/lib/ansible_test/_internal/sanity/import.py
@@ -29,6 +29,7 @@ from ..util import (
     generate_pip_command,
     find_python,
     get_hash,
+    REMOTE_ONLY_PYTHON_VERSIONS,
 )
 
 from ..util_common import (
@@ -63,7 +64,8 @@ from ..data import (
 )
 
 
-def _get_module_test(module_restrictions):
+def _get_module_test(module_restrictions: bool) -> t.Callable[[str], bool]:
+    """Create a predicate which tests whether a path can be used by modules or not."""
     module_path = data_context().content.module_path
     module_utils_path = data_context().content.module_utils_path
     if module_restrictions:
@@ -109,7 +111,7 @@ class ImportTest(SanityMultipleVersion):
                 ('module', _get_module_test(True), False),
                 ('plugin', _get_module_test(False), True),
         ):
-            if import_type == 'plugin' and python_version.startswith('2.6'):
+            if import_type == 'plugin' and python_version in REMOTE_ONLY_PYTHON_VERSIONS:
                 continue
 
             data = '\n'.join([path for path in paths if test(path)])

--- a/test/lib/ansible_test/_internal/sanity/import.py
+++ b/test/lib/ansible_test/_internal/sanity/import.py
@@ -20,6 +20,7 @@ from ..target import (
 )
 
 from ..util import (
+    ANSIBLE_ROOT,
     SubprocessError,
     remove_tree,
     display,
@@ -27,6 +28,7 @@ from ..util import (
     is_subdir,
     generate_pip_command,
     find_python,
+    get_hash,
 )
 
 from ..util_common import (
@@ -100,67 +102,77 @@ class ImportTest(SanityMultipleVersion):
 
         temp_root = os.path.join(ResultType.TMP.path, 'sanity', 'import')
 
-        # create a clean virtual environment to minimize the available imports beyond the python standard library
-        virtual_environment_path = os.path.join(temp_root, 'minimal-py%s' % python_version.replace('.', ''))
-        virtual_environment_bin = os.path.join(virtual_environment_path, 'bin')
-
-        remove_tree(virtual_environment_path)
-
-        if not create_virtual_environment(args, python_version, virtual_environment_path):
-            display.warning("Skipping sanity test '%s' on Python %s due to missing virtual environment support." % (self.name, python_version))
-            return SanitySkipped(self.name, python_version)
-
-        # add the importer to our virtual environment so it can be accessed through the coverage injector
-        importer_path = os.path.join(virtual_environment_bin, 'importer.py')
-        yaml_to_json_path = os.path.join(virtual_environment_bin, 'yaml_to_json.py')
-        if not args.explain:
-            os.symlink(os.path.abspath(os.path.join(SANITY_ROOT, 'import', 'importer.py')), importer_path)
-            os.symlink(os.path.abspath(os.path.join(SANITY_ROOT, 'import', 'yaml_to_json.py')), yaml_to_json_path)
-
-        # activate the virtual environment
-        env['PATH'] = '%s:%s' % (virtual_environment_bin, env['PATH'])
-
-        env.update(
-            SANITY_TEMP_PATH=ResultType.TMP.path,
-        )
-
-        if data_context().content.collection:
-            env.update(
-                SANITY_COLLECTION_FULL_NAME=data_context().content.collection.full_name,
-                SANITY_EXTERNAL_PYTHON=python,
-            )
-
-        virtualenv_python = os.path.join(virtual_environment_bin, 'python')
-        virtualenv_pip = generate_pip_command(virtualenv_python)
-
-        # make sure coverage is available in the virtual environment if needed
-        if args.coverage:
-            run_command(args, generate_pip_install(virtualenv_pip, '', packages=['setuptools']), env=env, capture=capture_pip)
-            run_command(args, generate_pip_install(virtualenv_pip, '', packages=['coverage']), env=env, capture=capture_pip)
-
-        try:
-            # In some environments pkg_resources is installed as a separate pip package which needs to be removed.
-            # For example, using Python 3.8 on Ubuntu 18.04 a virtualenv is created with only pip and setuptools.
-            # However, a venv is created with an additional pkg-resources package which is independent of setuptools.
-            # Making sure pkg-resources is removed preserves the import test consistency between venv and virtualenv.
-            # Additionally, in the above example, the pyparsing package vendored with pkg-resources is out-of-date and generates deprecation warnings.
-            # Thus it is important to remove pkg-resources to prevent system installed packages from generating deprecation warnings.
-            run_command(args, virtualenv_pip + ['uninstall', '--disable-pip-version-check', '-y', 'pkg-resources'], env=env, capture=capture_pip)
-        except SubprocessError:
-            pass
-
-        run_command(args, virtualenv_pip + ['uninstall', '--disable-pip-version-check', '-y', 'setuptools'], env=env, capture=capture_pip)
-        run_command(args, virtualenv_pip + ['uninstall', '--disable-pip-version-check', '-y', 'pip'], env=env, capture=capture_pip)
-
         results = []
 
-        for import_type, test in (
-                ('module', _get_module_test(True)),
-                ('plugin', _get_module_test(False)),
+        for import_type, test, add_ansible_requirements in (
+                ('module', _get_module_test(True), False),
+                ('plugin', _get_module_test(False), True),
         ):
             data = '\n'.join([path for path in paths if test(path)])
             if not data:
                 continue
+
+            requirements_file = None
+
+            # create a clean virtual environment to minimize the available imports beyond the python standard library
+            virtual_environment_dirname = 'minimal-py%s' % python_version.replace('.', '')
+            if add_ansible_requirements:
+                requirements_file = os.path.join(ANSIBLE_ROOT, 'requirements.txt')
+                virtual_environment_dirname += '-requirements-%s' % get_hash(requirements_file)
+            virtual_environment_path = os.path.join(temp_root, virtual_environment_dirname)
+            virtual_environment_bin = os.path.join(virtual_environment_path, 'bin')
+
+            remove_tree(virtual_environment_path)
+
+            if not create_virtual_environment(args, python_version, virtual_environment_path):
+                display.warning("Skipping sanity test '%s' on Python %s due to missing virtual environment support." % (self.name, python_version))
+                return SanitySkipped(self.name, python_version)
+
+            # add the importer to our virtual environment so it can be accessed through the coverage injector
+            importer_path = os.path.join(virtual_environment_bin, 'importer.py')
+            yaml_to_json_path = os.path.join(virtual_environment_bin, 'yaml_to_json.py')
+            if not args.explain:
+                os.symlink(os.path.abspath(os.path.join(SANITY_ROOT, 'import', 'importer.py')), importer_path)
+                os.symlink(os.path.abspath(os.path.join(SANITY_ROOT, 'import', 'yaml_to_json.py')), yaml_to_json_path)
+
+            # activate the virtual environment
+            env['PATH'] = '%s:%s' % (virtual_environment_bin, env['PATH'])
+
+            env.update(
+                SANITY_TEMP_PATH=ResultType.TMP.path,
+            )
+
+            if data_context().content.collection:
+                env.update(
+                    SANITY_COLLECTION_FULL_NAME=data_context().content.collection.full_name,
+                    SANITY_EXTERNAL_PYTHON=python,
+                )
+
+            virtualenv_python = os.path.join(virtual_environment_bin, 'python')
+            virtualenv_pip = generate_pip_command(virtualenv_python)
+
+            # make sure requirements are installed if needed
+            if requirements_file:
+                run_command(args, generate_pip_install(virtualenv_pip, '', requirements_file=requirements_file), env=env, capture=capture_pip)
+
+            # make sure coverage is available in the virtual environment if needed
+            if args.coverage:
+                run_command(args, generate_pip_install(virtualenv_pip, '', packages=['setuptools']), env=env, capture=capture_pip)
+                run_command(args, generate_pip_install(virtualenv_pip, '', packages=['coverage']), env=env, capture=capture_pip)
+
+            try:
+                # In some environments pkg_resources is installed as a separate pip package which needs to be removed.
+                # For example, using Python 3.8 on Ubuntu 18.04 a virtualenv is created with only pip and setuptools.
+                # However, a venv is created with an additional pkg-resources package which is independent of setuptools.
+                # Making sure pkg-resources is removed preserves the import test consistency between venv and virtualenv.
+                # Additionally, in the above example, the pyparsing package vendored with pkg-resources is out-of-date and generates deprecation warnings.
+                # Thus it is important to remove pkg-resources to prevent system installed packages from generating deprecation warnings.
+                run_command(args, virtualenv_pip + ['uninstall', '--disable-pip-version-check', '-y', 'pkg-resources'], env=env, capture=capture_pip)
+            except SubprocessError:
+                pass
+
+            run_command(args, virtualenv_pip + ['uninstall', '--disable-pip-version-check', '-y', 'setuptools'], env=env, capture=capture_pip)
+            run_command(args, virtualenv_pip + ['uninstall', '--disable-pip-version-check', '-y', 'pip'], env=env, capture=capture_pip)
 
             display.info(import_type + ': ' + data, verbosity=4)
 

--- a/test/lib/ansible_test/_internal/sanity/import.py
+++ b/test/lib/ansible_test/_internal/sanity/import.py
@@ -105,7 +105,7 @@ class ImportTest(SanityMultipleVersion):
 
         temp_root = os.path.join(ResultType.TMP.path, 'sanity', 'import')
 
-        results = []
+        messages = []
 
         for import_type, test, add_ansible_requirements in (
                 ('module', _get_module_test(True), False),
@@ -186,7 +186,6 @@ class ImportTest(SanityMultipleVersion):
 
             cmd = ['importer.py']
 
-            messages = []
             try:
                 with coverage_context(args):
                     stdout, stderr = intercept_command(args, cmd, self.name, env, capture=True, data=data, python_version=python_version,

--- a/test/lib/ansible_test/_internal/sanity/import.py
+++ b/test/lib/ansible_test/_internal/sanity/import.py
@@ -183,7 +183,7 @@ class ImportTest(SanityMultipleVersion):
 
             cmd = ['importer.py', '--type', import_type]
 
-            this_results = []
+            messages = []
             try:
                 with coverage_context(args):
                     stdout, stderr = intercept_command(args, cmd, self.name, env, capture=True, data=data, python_version=python_version,
@@ -197,18 +197,18 @@ class ImportTest(SanityMultipleVersion):
 
                 pattern = r'^(?P<path>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+): (?P<message>.*)$'
 
-                this_results = parse_to_list_of_dict(pattern, ex.stdout)
+                parsed = parse_to_list_of_dict(pattern, ex.stdout)
 
                 relative_temp_root = os.path.relpath(temp_root, data_context().content.root) + os.path.sep
 
-                this_results = [SanityMessage(
+                messages += [SanityMessage(
                     message=r['message'],
                     path=os.path.relpath(r['path'], relative_temp_root) if r['path'].startswith(relative_temp_root) else r['path'],
                     line=int(r['line']),
                     column=int(r['column']),
-                ) for r in this_results]
+                ) for r in parsed]
 
-            results.extend(settings.process_errors(this_results, paths))
+        results = settings.process_errors(messages, paths)
 
         if results:
             return SanityFailure(self.name, messages=results, python_version=python_version)

--- a/test/lib/ansible_test/_internal/sanity/import.py
+++ b/test/lib/ansible_test/_internal/sanity/import.py
@@ -146,13 +146,13 @@ class ImportTest(SanityMultipleVersion):
 
             env.update(
                 SANITY_TEMP_PATH=ResultType.TMP.path,
+                SANITY_IMPORTER_TYPE=import_type,
             )
 
             if data_context().content.collection:
                 env.update(
                     SANITY_COLLECTION_FULL_NAME=data_context().content.collection.full_name,
                     SANITY_EXTERNAL_PYTHON=python,
-                    SANITY_IMPORTER_TYPE=import_type,
                 )
 
             virtualenv_python = os.path.join(virtual_environment_bin, 'python')

--- a/test/lib/ansible_test/_internal/sanity/import.py
+++ b/test/lib/ansible_test/_internal/sanity/import.py
@@ -20,7 +20,7 @@ from ..target import (
 )
 
 from ..util import (
-    ANSIBLE_ROOT,
+    ANSIBLE_TEST_DATA_ROOT,
     SubprocessError,
     remove_tree,
     display,
@@ -120,7 +120,7 @@ class ImportTest(SanityMultipleVersion):
             # create a clean virtual environment to minimize the available imports beyond the python standard library
             virtual_environment_dirname = 'minimal-py%s' % python_version.replace('.', '')
             if add_ansible_requirements:
-                requirements_file = os.path.join(ANSIBLE_ROOT, 'requirements.txt')
+                requirements_file = os.path.join(ANSIBLE_TEST_DATA_ROOT, 'requirements', 'sanity.import-plugins.txt')
                 virtual_environment_dirname += '-requirements-%s' % get_hash(requirements_file)
             virtual_environment_path = os.path.join(temp_root, virtual_environment_dirname)
             virtual_environment_bin = os.path.join(virtual_environment_path, 'bin')

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -5,6 +5,7 @@ __metaclass__ = type
 import contextlib
 import errno
 import fcntl
+import hashlib
 import inspect
 import os
 import pkgutil
@@ -53,6 +54,7 @@ from .encoding import (
 
 from .io import (
     open_binary_file,
+    read_binary_file,
     read_text_file,
 )
 
@@ -855,6 +857,21 @@ def open_zipfile(path, mode='r'):
     zib_obj = zipfile.ZipFile(path, mode=mode)
     yield zib_obj
     zib_obj.close()
+
+
+def get_hash(path):
+    """
+    :type path: str
+    :rtype: str | None
+    """
+    if not os.path.exists(path):
+        return None
+
+    file_hash = hashlib.sha256()
+
+    file_hash.update(read_binary_file(path))
+
+    return file_hash.hexdigest()
 
 
 display = Display()  # pylint: disable=locally-disabled, invalid-name

--- a/test/sanity/code-smell/ansible-requirements.json
+++ b/test/sanity/code-smell/ansible-requirements.json
@@ -1,0 +1,7 @@
+{
+    "prefixes": [
+        "requirements.txt",
+        "test/lib/ansible_test/_data/requirements/sanity.import-plugins.txt"
+    ],
+    "output": "path-line-column-message"
+}

--- a/test/sanity/code-smell/ansible-requirements.py
+++ b/test/sanity/code-smell/ansible-requirements.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+import sys
+
+
+def read_file(path):
+    try:
+        with open(path, 'r') as f:
+            return f.read()
+    except Exception as ex:  # pylint: disable=broad-except
+        print('%s:%d:%d: Reading file failed: %s' % (path, 0, 0, re.sub(r'\s+', ' ', str(ex))))
+        return None
+
+
+def main():
+    ORIGINAL_FILE = 'requirements.txt'
+    VENDORED_COPY = 'test/lib/ansible_test/_data/requirements/sanity.import-plugins.txt'
+
+    requirements_1 = read_file(ORIGINAL_FILE)
+    requirements_2 = read_file(VENDORED_COPY)
+    if requirements_1 is not None and requirements_2 is not None:
+        if requirements_1 != requirements_2:
+            print('%s:%d:%d: Not identical to %s' % (VENDORED_COPY, 0, 0, ORIGINAL_FILE))
+            sys.exit()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/sanity/code-smell/ansible-requirements.py
+++ b/test/sanity/code-smell/ansible-requirements.py
@@ -11,7 +11,7 @@ def read_file(path):
         with open(path, 'r') as f:
             return f.read()
     except Exception as ex:  # pylint: disable=broad-except
-        print('%s:%d:%d: Reading file failed: %s' % (path, 0, 0, re.sub(r'\s+', ' ', str(ex))))
+        print('%s:%d:%d: unable to read required file %s' % (path, 0, 0, re.sub(r'\s+', ' ', str(ex))))
         return None
 
 
@@ -19,12 +19,12 @@ def main():
     ORIGINAL_FILE = 'requirements.txt'
     VENDORED_COPY = 'test/lib/ansible_test/_data/requirements/sanity.import-plugins.txt'
 
-    requirements_1 = read_file(ORIGINAL_FILE)
-    requirements_2 = read_file(VENDORED_COPY)
-    if requirements_1 is not None and requirements_2 is not None:
-        if requirements_1 != requirements_2:
-            print('%s:%d:%d: Not identical to %s' % (VENDORED_COPY, 0, 0, ORIGINAL_FILE))
-            sys.exit()
+    original_requirements = read_file(ORIGINAL_FILE)
+    vendored_requirements = read_file(VENDORED_COPY)
+
+    if original_requirements is not None and vendored_requirements is not None:
+        if original_requirements != vendored_requirements:
+            print('%s:%d:%d: must be identical to %s' % (VENDORED_COPY, 0, 0, ORIGINAL_FILE))
 
 
 if __name__ == '__main__':

--- a/test/sanity/code-smell/test-constraints.py
+++ b/test/sanity/code-smell/test-constraints.py
@@ -12,6 +12,12 @@ def main():
     requirements = {}
 
     for path in sys.argv[1:] or sys.stdin.read().splitlines():
+        if path == 'test/lib/ansible_test/_data/requirements/sanity.import-plugins.txt':
+            # This file is an exact copy of requirements.txt that is used in the import
+            # sanity test.  There is a code-smell test which ensures that the two files
+            # are identical, and it is only used inside an empty venv, so we can ignore
+            # it here.
+            continue
         with open(path, 'r') as path_fd:
             requirements[path] = parse_requirements(path_fd.read().splitlines())
 


### PR DESCRIPTION
##### SUMMARY
Right now the import sanity test only supports modules. Tries to see whether it can be extended to plugins as well.

First version works, but fails for all plugins as `jinja2` cannot be found. I guess the minimal venv is not the best place for this :)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test sanity
