### PR TITLE
Add sles to INTERPRETER_PYTHON_DISTRO_MAP

### DIFF
--- a/changelogs/fragments/72498-sles-support-interpreter-python-map.yml
+++ b/changelogs/fragments/72498-sles-support-interpreter-python-map.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - config - add support for SLES to INTERPRETER_PYTHON_DISTRO_MAP, causing it to default to ``/usr/bin/python3`` starting with SLES 15.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1492,6 +1492,8 @@ INTERPRETER_PYTHON_DISTRO_MAP:
     oracle: *rhelish
     redhat: *rhelish
     rhel: *rhelish
+    sles:
+      '15': /usr/bin/python3
     ubuntu:
       '14': /usr/bin/python
       '16': /usr/bin/python3


### PR DESCRIPTION
Since SLES 15 SUSE recommends to use the Python 3 interpreter.

##### SUMMARY
Extend INTERPRETER_PYTHON_DISTRO_MAP with a default value for SLES 15 to ease transition to Ansible v2.10.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
config

##### ADDITIONAL INFORMATION
This change ensures that when running Ansible against SUSE Linux Enterprise Server 15 machines the correct Python interpreter is being used.
