### PR TITLE
remove redundant remote_user for local setting

### DIFF
--- a/changelogs/fragments/ensure_local_user_correctness.yml
+++ b/changelogs/fragments/ensure_local_user_correctness.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ensure 'local' connection always has the correct default user for actions to consume.

--- a/changelogs/fragments/play_context_remove_redundant_pwd.yml
+++ b/changelogs/fragments/play_context_remove_redundant_pwd.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - remove redundant remote_user setting in play_context for local as plugin already does it, also removes fork/thread issue from use of pwd library.

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -22,7 +22,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-import pwd
 import sys
 
 from ansible import constants as C
@@ -313,15 +312,11 @@ class PlayContext(Base):
                 elif getattr(new_info, 'connection', None) == 'local' and (not remote_addr_local or not inv_hostname_local):
                     setattr(new_info, 'connection', C.DEFAULT_TRANSPORT)
 
-        # if the final connection type is local, reset the remote_user value to that of the currently logged in user
-        # this ensures any become settings are obeyed correctly
         # we store original in 'connection_user' for use of network/other modules that fallback to it as login user
-        # connection_user to be deprecated once connection=local is removed for
-        # network modules
+        # connection_user to be deprecated once connection=local is removed for, as local resets remote_user
         if new_info.connection == 'local':
             if not new_info.connection_user:
                 new_info.connection_user = new_info.remote_user
-            new_info.remote_user = pwd.getpwuid(os.getuid()).pw_name
 
         # set no_log to default if it was not previously set
         if new_info.no_log is None:

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -44,13 +44,14 @@ class Connection(ConnectionBase):
 
         super(Connection, self).__init__(*args, **kwargs)
         self.cwd = None
+        self.default_user = getpass.getuser()
 
     def _connect(self):
         ''' connect to the local host; nothing to do here '''
 
         # Because we haven't made any remote connection we're running as
         # the local user, rather than as whatever is configured in remote_user.
-        self._play_context.remote_user = getpass.getuser()
+        self._play_context.remote_user = self.default_user
 
         if not self._connected:
             display.vvv(u"ESTABLISH LOCAL CONNECTION FOR USER: {0}".format(self._play_context.remote_user), host=self._play_context.remote_addr)

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -49,8 +49,7 @@ class Connection(ConnectionBase):
         ''' connect to the local host; nothing to do here '''
 
         # Because we haven't made any remote connection we're running as
-        # the local user, rather than as whatever is configured in
-        # remote_user.
+        # the local user, rather than as whatever is configured in remote_user.
         self._play_context.remote_user = getpass.getuser()
 
         if not self._connected:

--- a/test/integration/targets/delegate_to/delegate_local_from_root.yml
+++ b/test/integration/targets/delegate_to/delegate_local_from_root.yml
@@ -1,0 +1,10 @@
+- name: handle case from issue 72541
+  hosts: testhost
+  gather_facts: false
+  remote_user: root
+  tasks:
+  - name: ensure we copy w/o errors due to remote user not being overriden
+    copy:
+      src: testfile
+      dest: "{{ playbook_dir }}"
+    delegate_to: localhost

--- a/test/integration/targets/delegate_to/files/testfile
+++ b/test/integration/targets/delegate_to/files/testfile
@@ -1,0 +1,1 @@
+nothing special

--- a/test/integration/targets/delegate_to/runme.sh
+++ b/test/integration/targets/delegate_to/runme.sh
@@ -71,3 +71,4 @@ ln -s python secondpython
 )
 ansible-playbook verify_interpreter.yml -i inventory_interpreters -v "$@"
 ansible-playbook discovery_applied.yml -i inventory -v "$@"
+ansible-playbook delegate_local_from_root.yml -i inventory -v "$@" -e 'ansible_user=root'


### PR DESCRIPTION
  local action plugin already does and this also should fix
  fork/thread issue by removing use of pwd library

  fixes #59642

(cherry picked from commit 488b9d6c35b22205522c964182480e398e2cf4bc)
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
play_context