### PR TITLE
Unarchive timeout parameter and RETURN documentation.

### DIFF
--- a/changelogs/fragments/72530-unarchive-timeout.yml
+++ b/changelogs/fragments/72530-unarchive-timeout.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - Added a timeout parameter to the unarchive module so that a value other than the default 10 seconds may be given for fetching from remote web sources.
+  - Added a timeout parameter to the unarchive module so that a value other than the default 10 seconds may be given for fetching from remote web sources. (https://github.com/ansible/ansible/pull/72530)
   - Added 'RETURN' documentation (https://github.com/ansible/ansible/issues/67445)

--- a/changelogs/fragments/72530-unarchive-timeout.yml
+++ b/changelogs/fragments/72530-unarchive-timeout.yml
@@ -1,3 +1,5 @@
 minor_changes:
-  - Added a timeout parameter to the unarchive module so that a value other than the default 10 seconds may be given for fetching from remote web sources. (https://github.com/ansible/ansible/pull/72530)
-  - Added 'RETURN' documentation (https://github.com/ansible/ansible/issues/67445)
+  - unarchive - added a timeout parameter to the unarchive module so
+    that a value other than the default 10 seconds may be given for
+    fetching from remote web sources. (https://github.com/ansible/ansible/pull/72530)
+  - unarchive - added 'RETURN' documentation (https://github.com/ansible/ansible/issues/67445)

--- a/changelogs/fragments/72530-unarchive-timeout.yml
+++ b/changelogs/fragments/72530-unarchive-timeout.yml
@@ -1,5 +1,5 @@
 minor_changes:
-  - unarchive - added a timeout parameter to the unarchive module so
+  - unarchive - add ``timeout`` option to the unarchive module so
     that a value other than the default 10 seconds may be given for
-    fetching from remote web sources. (https://github.com/ansible/ansible/pull/72530)
-  - unarchive - added 'RETURN' documentation (https://github.com/ansible/ansible/issues/67445)
+    fetching from remote web sources (https://github.com/ansible/ansible/pull/72530).
+  - unarchive - add ``RETURN`` documentation (https://github.com/ansible/ansible/issues/67445).

--- a/changelogs/fragments/72530-unarchive-timeout.yml
+++ b/changelogs/fragments/72530-unarchive-timeout.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Added a timeout parameter to the unarchive module so that a value other than the default 10 seconds may be given for fetching from remote web sources.
+  - Added 'RETURN' documentation.

--- a/changelogs/fragments/72530-unarchive-timeout.yml
+++ b/changelogs/fragments/72530-unarchive-timeout.yml
@@ -1,3 +1,3 @@
 minor_changes:
   - Added a timeout parameter to the unarchive module so that a value other than the default 10 seconds may be given for fetching from remote web sources.
-  - Added 'RETURN' documentation.
+  - Added 'RETURN' documentation (https://github.com/ansible/ansible/issues/67445)

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -160,7 +160,7 @@ files:
   description: List of all the file in the archive.
   returned: When I(list_files) is True
   type: list
-  sample: \["file1", "file2"\]
+  sample: '["file1", "file2"]'
 gid:
   description: numerical id of the group that owns the destination directory.
   returned: always

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -192,7 +192,7 @@ size:
   type: int
   sample: 36
 src:
-  description: 
+  description:
     - The source archive's path.
     - If I(src) was a remote web URL, or from the local ansible controller, this shows the temporary location where the download was stored.
   returned: always

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -154,7 +154,7 @@ RETURN = r'''
 dest:
   description: Path to the destination directory
   returned: always
-  type: string
+  type: str
   sample: /opt/software
 files:
   description: List of all the file in the archive.
@@ -169,22 +169,22 @@ gid:
 group:
   description: name of the group that owns the destination directory.
   returned: always
-  type: string
+  type: str
   sample: "paul"
 handler:
   description: which archive software handler was used to extract and decompress the archive.
   returned: always
-  type: string
+  type: str
   sample: "TgzArchive"
 mode:
   description: string that represents the octal permissions of the destination directory.
   returned: always
-  type: string
+  type: str
   sample: "0755"
 owner:
   description: name of the user that owns the destination directory.
   returned: always
-  type: string
+  type: str
   sample: "paul"
 size:
   description: The size of destination directory.
@@ -196,12 +196,12 @@ src:
     - The source archive's path.
     - If I(src) was a remote web URL, or from the local ansible controller, this shows the temporary location where the download was stored.
   returned: always
-  type: string
+  type: str
   sample: "/home/paul/test.tar.gz"
 state:
   description: State of the destination. Effectively always "directory".
   returned: always
-  type: string
+  type: str
   sample: "directory"
 uid:
   description: numerical id of the user that owns the destination directory.

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -177,7 +177,7 @@ handler:
   type: string
   sample: "TgzArchive"
 mode:
-  description: string that represents the octal permissions applied to extracted files.
+  description: string that represents the octal permissions of the destination directory.
   returned: always
   type: string
   sample: "0755"

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -6,6 +6,7 @@
 # Copyright: (c) 2015, Toshio Kuratomi <tkuratomi@ansible.com>
 # Copyright: (c) 2016, Dag Wieers <dag@wieers.com>
 # Copyright: (c) 2017, Ansible Project
+# Copyright: (c) 2020, Paul Aiton <@paultaiton>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -147,6 +148,66 @@ EXAMPLES = r'''
     extra_opts:
     - --transform
     - s/^xxx/yyy/
+'''
+
+RETURN = r'''
+dest:
+  description: Path to the destination directory
+  returned: always
+  type: string
+  sample: /opt/software
+files:
+  description: List of all the file in the archive.
+  returned: When I(list_files) is True
+  type: list
+  sample: \["file1", "file2"\]
+gid:
+  description: numerical id of the group that owns the destination directory.
+  returned: always
+  type: int
+  sample: 1000
+group:
+  description: name of the group that owns the destination directory.
+  returned: always
+  type: string
+  sample: "paul"
+handler:
+  description: which archive software handler was used to extract and decompress the archive.
+  returned: always
+  type: string
+  sample: "TgzArchive"
+mode:
+  description: string that represents the octal permissions applied to extracted files.
+  returned: always
+  type: string
+  sample: "0755"
+owner:
+  description: name of the user that owns the destination directory.
+  returned: always
+  type: string
+  sample: "paul"
+size:
+  description: The size of destination directory.
+  returned: always
+  type: int
+  sample: 36
+src:
+  description: 
+    - The source archive's path.
+    - If I(src) was a remote web URL, or from the local ansible controller, this shows the temporary location where the download was stored.
+  returned: always
+  type: string
+  sample: "/home/paul/test.tar.gz"
+state:
+  description: State of the destination. Effectively always "directory".
+  returned: always
+  type: string
+  sample: "directory"
+uid:
+  description: numerical id of the user that owns the destination directory.
+  returned: always
+  type: int
+  sample: 1000
 '''
 
 import binascii

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -90,7 +90,7 @@ options:
       - This option is silently ignored if I(src) is not a web URL.
     type: int
     default: 10
-    version_added: '1.11'
+    version_added: '2.11'
   validate_certs:
     description:
       - This only applies if using a https URL as the source of the file.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added the "timeout" parameter that is passed to "fetch_file" utility function. This will allow specifying a value other than the default 10 seconds so that it doesn't fail for big files or slow connections.

I've also added documentation for all the return values, which fixes #67445

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
unarchive

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
