### PR TITLE
When retrieving the IP of containers for Docker's default network, fall back to NetworkSettings.IPAddress

### DIFF
--- a/changelogs/fragments/ansible-test-docker-network.yml
+++ b/changelogs/fragments/ansible-test-docker-network.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-test - when retrieving the IP of containers for Docker's default network, use ``NetworkSettings.IPAddress`` instead of crashing (https://github.com/ansible/ansible/issues/72528)."

--- a/test/lib/ansible_test/_internal/docker_util.py
+++ b/test/lib/ansible_test/_internal/docker_util.py
@@ -111,7 +111,11 @@ def get_docker_container_ip(args, container_id):
 
     if networks:
         network_name = get_docker_preferred_network_name(args)
-        ipaddress = networks[network_name]['IPAddress']
+        if network_name is None:
+            # Docker default network: fall back to NetworkSettings.IPAddress
+            ipaddress = network_settings['IPAddress']
+        else:
+            ipaddress = networks[network_name]['IPAddress']
     else:
         # podman doesn't provide Networks, fall back to using IPAddress
         ipaddress = network_settings['IPAddress']


### PR DESCRIPTION
##### SUMMARY
Fixes #72528.

Instead of my first fix in #72528 doesn't assume that `bridge` is the default network, but falls back to `NetworkSettings.IPAddress`. This shouldn't affect current behavior and does fix the problem for me. Having a proper detection for Docker's default network would be even better, but I'm not sure how to do that (or whether it's possible at all).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test
