### PR TITLE
Fixing "infinite recursion in template" from issue#8603 and #58952

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -1190,7 +1190,9 @@ class Templar:
             return res
         except (UndefinedError, AnsibleUndefinedVariable) as e:
             if fail_on_undefined:
-                raise AnsibleUndefinedVariable(e)
+                if isinstance(e, AnsibleUndefinedVariable):
+                    raise
+                raise AnsibleUndefinedVariable('Error while rendering template "{0}": "{1}"'.format(data, e))
             else:
                 display.debug("Ignoring undefined failure: %s" % to_text(e))
                 return data

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -29,6 +29,7 @@ import time
 
 from contextlib import contextmanager
 from distutils.version import LooseVersion
+from functools import wraps
 from numbers import Number
 from traceback import format_exc
 
@@ -603,6 +604,66 @@ if USE_JINJA2_NATIVE:
             self.tests = JinjaPluginIntercept(self.tests, test_loader, jinja2_native=True)
 
 
+def templar_template_decorator(method):
+    """
+    Decorator, dedicated to "template" method in Templar.
+    This method has multiple return points, and we want this specific logic for return:
+    If (and only if) we provide "path_to_variable" argument for the method, we want to save
+    it's result to "_known_variables" attribute.
+    This could speed up our templating and will help us find the way out of infinite recursive loop
+    in some special cases (see #8603)
+    """
+    @wraps(method)
+    def _impl(self, *method_args, **method_kwargs):
+        path_to_variable = method_kwargs.get('path_to_variable')
+        if path_to_variable and path_to_variable in self._known_variables:
+            return self._known_variables[path_to_variable]
+        result = method(self, *method_args, **method_kwargs)
+        if path_to_variable:
+            self._known_variables[path_to_variable] = result
+        return result
+    return _impl
+
+
+class KnownVariablesDict(dict):
+    """
+    Special dict for special needs. The idea is simple:
+    dict["variable_root.sub_variable.sub_sub_variable"]
+    transforms into:
+    dict["variable_root"]["sub_variable"]["sub_sub_variable"]
+
+    This will work too:
+    a = dict["variable_root"]["sub_variable"]
+    a = dict["variable_root"]["sub_variable.sub_sub_variable"]
+    a = dict["variable_root"]["sub_variable"]["sub_sub_variable"]
+
+    """
+    @classmethod
+    def from_dict(cls, d):
+        return cls(**d)
+
+    def __setitem__(self, key, value):
+        if isinstance(value, dict):
+            value = self.from_dict(value)
+        if "." in key:
+            subdict_name, subitem = key.split(".", 1)
+            subdict = self.setdefault(subdict_name, KnownVariablesDict())
+            if isinstance(subdict, KnownVariablesDict):
+                self[subdict_name][subitem] = value
+            else:
+                self[subdict_name] = KnownVariablesDict(**{subitem: value})
+
+        else:
+            super(KnownVariablesDict, self).__setitem__(key, value)
+
+    def __getitem__(self, key):
+        if '.' in key:
+            subdict, subitem = key.split(".", 1)
+            return self[subdict][subitem]
+        else:
+            return super(KnownVariablesDict, self).__getitem__(key)
+
+
 class Templar:
     '''
     The main class for templating, with the main entry-point of template().
@@ -615,6 +676,7 @@ class Templar:
         self._filters = None
         self._tests = None
         self._available_variables = {} if variables is None else variables
+        self._known_variables = KnownVariablesDict()
         self._cached_result = {}
         self._basedir = loader.get_basedir() if loader else './'
 
@@ -722,6 +784,7 @@ class Templar:
         if not isinstance(variables, Mapping):
             raise AnsibleAssertionError("the type of 'variables' should be a Mapping but was a %s" % (type(variables)))
         self._available_variables = variables
+        self._known_variables = KnownVariablesDict()
         self._cached_result = {}
 
     def set_available_variables(self, variables):
@@ -761,8 +824,9 @@ class Templar:
             obj = mapping.get(key, self.environment)
             setattr(obj, key, original[key])
 
+    @templar_template_decorator
     def template(self, variable, convert_bare=False, preserve_trailing_newlines=True, escape_backslashes=True, fail_on_undefined=None, overrides=None,
-                 convert_data=True, static_vars=None, cache=True, disable_lookups=False):
+                 convert_data=True, static_vars=None, cache=True, disable_lookups=False, path_to_variable=None):
         '''
         Templates (possibly recursively) any given data as input. If convert_bare is
         set to True, the given data will be wrapped as a jinja2 variable ('{{foo}}')
@@ -859,6 +923,16 @@ class Templar:
                 # we don't use iteritems() here to avoid problems if the underlying dict
                 # changes sizes due to the templating, which can happen with hostvars
                 for k in variable.keys():
+                    try:
+                        k_path_to_variable = "{0}.{1}".format(path_to_variable, k)
+                    except Exception:
+                        # Sometimes this fails for python2 because of weird UnicodeDecode/UnicodeEncode errors.
+                        # I can't figure out why it fails yet, probably some weird variable name.
+                        # But ansible seems to be dropping python2 support soon enough, so this problem doesn't seem
+                        # to be worth of investigation... unless we receive explicit bugreport.
+                        # This also does nothing for "regular" variable parsing, so only variables with "recursion"
+                        # are affected. And they didn't work anyway, even without this patch.
+                        k_path_to_variable = None
                     if k not in static_vars:
                         d[k] = self.template(
                             variable[k],
@@ -866,6 +940,7 @@ class Templar:
                             fail_on_undefined=fail_on_undefined,
                             overrides=overrides,
                             disable_lookups=disable_lookups,
+                            path_to_variable=k_path_to_variable,
                         )
                     else:
                         d[k] = variable[k]
@@ -1074,7 +1149,7 @@ class Templar:
 
             jvars = AnsibleJ2Vars(self, t.globals)
 
-            self.cur_context = new_context = t.new_context(jvars, shared=True)
+            self.cur_context = new_context = t.new_context(jvars, shared=True, locals=self._known_variables)
             rf = t.root_render_func(new_context)
 
             try:

--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -95,7 +95,7 @@ class AnsibleJ2Vars(Mapping):
         else:
             value = None
             try:
-                value = self._templar.template(variable)
+                value = self._templar.template(variable, path_to_variable=varname)
             except AnsibleUndefinedVariable as e:
                 raise AnsibleUndefinedVariable("%s: %s" % (to_native(variable), e.message))
             except Exception as e:

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -493,10 +493,18 @@ class TestKnownVariablesDict(unittest.TestCase):
     def test_assign_dict(self):
         kvd = KnownVariablesDict()
         kvd['a'] = {'b': 'c'}
+        self.assertIsInstance(kvd['a'], KnownVariablesDict)
         self.assertEqual(kvd['a.b'], 'c')
         self.assertIsInstance(kvd['a.b'], str)
         kvd['a.b.c'] = 'd'
-        self.assertIsInstance(kvd['a.b'], KnownVariablesDict)
+        self.assertIsInstance(kvd['a.b'], KnownVariablesDict, msg="At this point 'c' rewritten and becomes "
+                                                                  "KnownVariablesDict")
         self.assertEqual(kvd['a.b.c'], 'd')
         b = kvd['a.b']
         self.assertEqual(b['c'], 'd')
+
+    def test_path(self):
+        kvd = KnownVariablesDict()
+        kvd['a.b.c'] = 'd'
+        self.assertEqual(kvd['a']['__path'], 'a')
+        self.assertEqual(kvd['a.b']['__path'], 'a.b')


### PR DESCRIPTION
##### SUMMARY
This fixes issue #8603 and #58952. Fixing "infinite recursion in template" for variables like this:

```yaml
my_vars:
  path: "/path/to/project/"
  content: "{{ config.path }}/content_folder/"
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible/template

##### ADDITIONAL INFORMATION
Beforehand: this is my first PR to opensource ever, feel free to point me into some guideline- or other "protocol-violations" etc, will fix :)

So, about the issue, fixed in this PR.

Links to read about problem:
issue #8603
https://stackoverflow.com/questions/22027902/keep-ansible-dry-how-to-avoid-repeating-variables

How to reproduce on v2.10 (and earlier):

First, make simple variable structure like this:
```yaml
my_vars:
  path: "/path/to/project/"
  content: "{{ config.path }}/content_folder/"
```
Then try to use in playbook.

Expected result for ansible v2.10: the thing will explode and you will see - "infinite recursion in template" in the end.

My playbook for testing:
```yaml
- name: "Debug"
  hosts: localhost
  tasks:
    - name: "debug prints"
      debug:
        msg: "{{ item }}"
      with_items: "{{ my_vars.values() }}"
```