### PR TITLE
Fix parsing of values when using an empty string as key (#57132)

### DIFF
--- a/changelogs/fragments/72545_fix_facts_value_empty_key.yml
+++ b/changelogs/fragments/72545_fix_facts_value_empty_key.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix parsing of values when using empty string as a key (https://github.com/ansible/ansible/issues/57132)

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -797,7 +797,7 @@ class Templar:
         set to True, the given data will be wrapped as a jinja2 variable ('{{foo}}')
         before being sent through the template engine.
         '''
-        static_vars = [''] if static_vars is None else static_vars
+        static_vars = [] if static_vars is None else static_vars
 
         # Don't template unsafe variables, just return them.
         if hasattr(variable, '__UNSAFE__'):

--- a/test/integration/targets/set_fact/runme.sh
+++ b/test/integration/targets/set_fact/runme.sh
@@ -28,3 +28,6 @@ ansible-playbook -i inventory --flush-cache "$@" set_fact_no_cache.yml
 # Test boolean conversions in set_fact
 ANSIBLE_JINJA2_NATIVE=0 ansible-playbook -v set_fact_bool_conv.yml
 ANSIBLE_JINJA2_NATIVE=1 ansible-playbook -v set_fact_bool_conv_jinja2_native.yml
+
+# Test parsing of values when using an empty string as a key
+ansible-playbook -i inventory set_fact_empty_str_key.yml

--- a/test/integration/targets/set_fact/set_fact_empty_str_key.yml
+++ b/test/integration/targets/set_fact/set_fact_empty_str_key.yml
@@ -1,0 +1,15 @@
+- name: Test set_fact for empty string as a key
+  hosts: testhost
+  gather_facts: no
+  vars:
+    value: 1
+  tasks:
+    - name: Define fact with key as an empty string
+      set_fact:
+        foo:
+          "": "bar{{ value }}"
+
+    - name: Verify the parsed value of the key
+      assert:
+        that:
+          - foo == {"":"bar1"}


### PR DESCRIPTION
Signed-off-by: Yadnesh Kulkarni <ykulkarn@redhat.com>

##### SUMMARY
Fixes #57132 

Works fine after removing the empty string element from static_vars list
```
TASK [debug] *********************************************************************************************************************************
ok: [kube-pnq] => {
    "bar": {
        "": "bla1"
    }
}

TASK [debug] *********************************************************************************************************************************
ok: [kube-pnq] => {
    "baz": {
        "qux": "ble1"
    }
}
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
template

