### PR TITLE
[2.10] [ansible-test] use newer container images (#72126)

### DIFF
--- a/changelogs/fragments/ansible-base-update-containers.yml
+++ b/changelogs/fragments/ansible-base-update-containers.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - ansible-test - OpenSuse container now uses Leap 15.2 (https://github.com/ansible/distro-test-containers/pull/48).
+  - ansible-test - Ubuntu containers as well as ``default-test-container`` and ``ansible-base-test-container`` are now slightly smaller due to apt cleanup (https://github.com/ansible/distro-test-containers/pull/46).
+  - ansible-test - CentOS 8 container is now 8.2.2004 (https://github.com/ansible/distro-test-containers/pull/45).
+  - ansible-test - ``default-test-container`` and ``ansible-base-test-container`` now use Python 3.9.0 instead of 3.9.0rc1.

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,12 +1,12 @@
-default name=quay.io/ansible/default-test-container:2.7.0 python=3.6,2.6,2.7,3.5,3.7,3.8,3.9 seccomp=unconfined context=collection
-default name=quay.io/ansible/ansible-base-test-container:1.6.0 python=3.6,2.6,2.7,3.5,3.7,3.8,3.9 seccomp=unconfined context=ansible-base
+default name=quay.io/ansible/default-test-container:2.9.0 python=3.6,2.6,2.7,3.5,3.7,3.8,3.9 seccomp=unconfined context=collection
+default name=quay.io/ansible/ansible-base-test-container:1.7.0 python=3.6,2.6,2.7,3.5,3.7,3.8,3.9 seccomp=unconfined context=ansible-base
 centos6 name=quay.io/ansible/centos6-test-container:1.17.0 python=2.6 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.17.0 python=2.7 seccomp=unconfined
-centos8 name=quay.io/ansible/centos8-test-container:1.17.0 python=3.6 seccomp=unconfined
+centos8 name=quay.io/ansible/centos8-test-container:1.21.0 python=3.6 seccomp=unconfined
 fedora30 name=quay.io/ansible/fedora30-test-container:1.17.0 python=3.7
 fedora31 name=quay.io/ansible/fedora31-test-container:1.17.0 python=3.7
 fedora32 name=quay.io/ansible/fedora32-test-container:1.17.0 python=3.8
-opensuse15py2 name=quay.io/ansible/opensuse15py2-test-container:1.17.0 python=2.7
-opensuse15 name=quay.io/ansible/opensuse15-test-container:1.17.0 python=3.6
-ubuntu1604 name=quay.io/ansible/ubuntu1604-test-container:1.17.0 python=2.7 seccomp=unconfined
-ubuntu1804 name=quay.io/ansible/ubuntu1804-test-container:1.17.0 python=3.6 seccomp=unconfined
+opensuse15py2 name=quay.io/ansible/opensuse15py2-test-container:1.21.0 python=2.7
+opensuse15 name=quay.io/ansible/opensuse15-test-container:1.21.0 python=3.6
+ubuntu1604 name=quay.io/ansible/ubuntu1604-test-container:1.21.0 python=2.7 seccomp=unconfined
+ubuntu1804 name=quay.io/ansible/ubuntu1804-test-container:1.21.0 python=3.6 seccomp=unconfined


### PR DESCRIPTION


##### SUMMARY

Change:
- Bump default, ansible-base, distro containers
- We do NOT add fedora33 yet, because it doesn't work right on Shippable
  due to an old kernel. This will be added post-AZP.

Test Plan:
- CI

Signed-off-by: Rick Elrod <rick@elrod.me>
(cherry picked from commit e7bf0696efc39e6704312f1518c9033e0edc8e35)

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Test Pull Request

##### COMPONENT NAME

tests