### PR TITLE
[stable-2.9] iptables: Reorder comment postition (#71496)

### DIFF
--- a/changelogs/fragments/71496-iptables-reorder-comment-position.yml
+++ b/changelogs/fragments/71496-iptables-reorder-comment-position.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - iptables - reorder comment postition to be at the end (https://github.com/ansible/ansible/issues/71444).

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -541,8 +541,6 @@ def construct_rule(params):
         '--set-dscp-class',
         False)
     append_match_flag(rule, params['syn'], '--syn', True)
-    append_match(rule, params['comment'], 'comment')
-    append_param(rule, params['comment'], '--comment', False)
     if 'conntrack' in params['match']:
         append_csv(rule, params['ctstate'], '--ctstate')
     elif 'state' in params['match']:
@@ -574,6 +572,8 @@ def construct_rule(params):
         params['icmp_type'],
         ICMP_TYPE_OPTIONS[params['ip_version']],
         False)
+    append_match(rule, params['comment'], 'comment')
+    append_param(rule, params['comment'], '--comment', False)
     return rule
 
 

--- a/test/units/modules/system/test_iptables.py
+++ b/test/units/modules/system/test_iptables.py
@@ -828,3 +828,44 @@ class TestIptables(ModuleTestCase):
             '--dst-range',
             '10.0.0.50-10.0.0.100'
         ])
+
+    def test_comment_position_at_end(self):
+        """Test flush without parameters"""
+        set_module_args({
+            'chain': 'INPUT',
+            'jump': 'ACCEPT',
+            'action': 'insert',
+            'ctstate': ['NEW'],
+            'comment': 'this is a comment',
+            '_ansible_check_mode': True,
+        })
+
+        commands_results = [
+            (0, '', ''),
+        ]
+
+        with patch.object(basic.AnsibleModule, 'run_command') as run_command:
+            run_command.side_effect = commands_results
+            with self.assertRaises(AnsibleExitJson) as result:
+                iptables.main()
+                self.assertTrue(result.exception.args[0]['changed'])
+
+        self.assertEqual(run_command.call_count, 1)
+        self.assertEqual(run_command.call_args_list[0][0][0], [
+            '/sbin/iptables',
+            '-t',
+            'filter',
+            '-C',
+            'INPUT',
+            '-j',
+            'ACCEPT',
+            '-m',
+            'conntrack',
+            '--ctstate',
+            'NEW',
+            '-m',
+            'comment',
+            '--comment',
+            'this is a comment'
+        ])
+        self.assertEqual(run_command.call_args[0][0][14], 'this is a comment')


### PR DESCRIPTION
##### SUMMARY

Backport of #71496 for Ansible 2.9
##### ISSUE TYPE

* Bugfix Pull Request


##### COMPONENT NAME

`lib/ansible/modules/system/iptables.py`

