### PR TITLE
Add support for allow_change_held_packages

### DIFF
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -98,7 +98,7 @@ options:
     aliases: [ allow-change-held-packages ]
     type: bool
     default: 'no'
-    version_added: "2.4"
+    version_added: "2.11"
   upgrade:
     description:
       - If yes or safe, performs an aptitude safe-upgrade.
@@ -1198,7 +1198,9 @@ def main():
         force_yes = p['force']
 
         if p['upgrade']:
-            upgrade(module, p['upgrade'], force_yes, p['default_release'], use_apt_get, dpkg_options, autoremove, fail_on_autoremove, allow_unauthenticated, allow_change_held_packages)
+            upgrade(module, p['upgrade'], force_yes, p['default_release'],
+                    use_apt_get, dpkg_options, autoremove, fail_on_autoremove,
+                    allow_unauthenticated, allow_change_held_packages)
 
         if p['deb']:
             if p['state'] != 'present':
@@ -1219,7 +1221,9 @@ def main():
         if latest and all_installed:
             if packages:
                 module.fail_json(msg='unable to install additional packages when upgrading all installed packages')
-            upgrade(module, 'yes', force_yes, p['default_release'], use_apt_get, dpkg_options, autoremove, fail_on_autoremove, allow_unauthenticated, allow_change_held_packages)
+            upgrade(module, 'yes', force_yes, p['default_release'],
+                    use_apt_get, dpkg_options, autoremove, fail_on_autoremove,
+                    allow_unauthenticated, allow_change_held_packages)
 
         if packages:
             for package in packages:


### PR DESCRIPTION
##### SUMMARY
Currently, I can't upgrade a held package without either using `force: yes` (which allows more than I'd like to allow), or using manual logic with `dpkg_selections`. By using `--allow-change-held-packages`, I could upgrade held package in just one step with much cleaner change report.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
apt module

##### ADDITIONAL INFORMATION
.