### PR TITLE
[stable-2.10] Add coverage exporting to ansible-test

### DIFF
--- a/changelogs/fragments/ansible-test-coverage-combine-export.yml
+++ b/changelogs/fragments/ansible-test-coverage-combine-export.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Added a ``--export`` option to the ``ansible-test coverage combine`` command to facilitate multi-stage aggregation of coverage in CI pipelines.

--- a/test/lib/ansible_test/_internal/cli.py
+++ b/test/lib/ansible_test/_internal/cli.py
@@ -993,6 +993,9 @@ def add_extra_coverage_options(parser):
                         action='store_true',
                         help='generate empty report of all python/powershell source files')
 
+    parser.add_argument('--export',
+                        help='directory to export combined coverage files to')
+
 
 def add_httptester_options(parser, argparse):
     """

--- a/test/lib/ansible_test/_internal/coverage/__init__.py
+++ b/test/lib/ansible_test/_internal/coverage/__init__.py
@@ -61,6 +61,7 @@ class CoverageConfig(EnvironmentConfig):
         self.group_by = frozenset(args.group_by) if 'group_by' in args and args.group_by else set()  # type: t.FrozenSet[str]
         self.all = args.all if 'all' in args else False  # type: bool
         self.stub = args.stub if 'stub' in args else False  # type: bool
+        self.export = args.export if 'export' in args else None  # type: str
         self.coverage = False  # temporary work-around to support intercept_command in cover.py
 
 
@@ -208,6 +209,14 @@ def enumerate_powershell_lines(
         filename = sanitize_filename(filename, collection_search_re=collection_search_re, collection_sub_re=collection_sub_re)
 
         if not filename:
+            continue
+
+        if isinstance(hits, dict) and not hits.get('Line'):
+            # Input data was previously aggregated and thus uses the standard ansible-test output format for PowerShell coverage.
+            # This format differs from the more verbose format of raw coverage data from the remote Windows hosts.
+            hits = dict((int(key), value) for key, value in hits.items())
+
+            yield filename, hits
             continue
 
         # PowerShell unpacks arrays if there's only a single entry so this is a defensive check on that


### PR DESCRIPTION
##### SUMMARY

A new `--export` option for `ansible-test coverage combine` allows multi-step aggregation of code coverage for CI pipelines.

Backport of https://github.com/ansible/ansible/pull/72563

(cherry picked from commit fa2be89cd44f0c867f24351c3ba73d5e849cb507)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
