### PR TITLE
[stable-2.9] lvol: Fix idempotency when size uses  %VG or %PVS

### DIFF
--- a/changelogs/fragments/72569-lvol_percentage_fix.yml
+++ b/changelogs/fragments/72569-lvol_percentage_fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+ - lvol - fix idempotency issue when using lvol with ``%VG`` or ``%PVS`` size options and VG is fully allocated (https://github.com/ansible-collections/community.general/pull/229).

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -477,6 +477,10 @@ def main():
                 size_requested = size_percent * this_vg['size'] / 100
             else:  # size_whole == 'FREE':
                 size_requested = size_percent * this_vg['free'] / 100
+
+            # Round down to the next lowest whole physical extent
+            size_requested -= (size_requested % this_vg['ext_size'])
+
             if '+' in size:
                 size_requested += this_lv['size']
             if this_lv['size'] < size_requested:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Change the behavior when using %VG or %PVS to make the `size_requested` an even
modulus of the VG's physical extents by rounding down.

This makes the usage of %VG or %PVS idempotent when the calculated
`size_requested` does not end on a physical extent boundary.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Backport of ansible-collections/community.general#229.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

`lvol`
