### PR TITLE
Improve check_mutually_exclusive

### DIFF
--- a/changelogs/fragments/72110-mutually-exclusive-math-check.yml
+++ b/changelogs/fragments/72110-mutually-exclusive-math-check.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - >
+    mutually exclusive module parameters are now evaluated for their truthiness
+    in addition to checking for the presence of mutually excluse keys
+    (https://github.com/ansible/ansible/issues/72110)

--- a/test/units/module_utils/common/validation/test_check_mutually_exclusive.py
+++ b/test/units/module_utils/common/validation/test_check_mutually_exclusive.py
@@ -42,6 +42,35 @@ def test_check_mutually_exclusive_found(mutually_exclusive_terms):
     assert to_native(e.value) == expected
 
 
+@pytest.mark.parametrize(
+    'params',
+    (
+        {'string1': 'cat', 'string2': None},
+        {'fox': 'blue', 'box': False},
+        {'fox': 'blue', 'box': '', 'socks': None},
+    )
+)
+def test_check_mutually_exclusive_mathematical_pass(mutually_exclusive_terms, params):
+    check_mutually_exclusive(mutually_exclusive_terms, params)
+
+
+@pytest.mark.parametrize(
+    ('params', 'expected'),
+    (
+        ({'fox': 'blue', 'box': 'large'}, 'box|fox|socks'),
+        ({'fox': 'blue', 'box': '', 'socks': 'blue'}, 'box|fox|socks'),
+        ({'string1': 'cat', 'string2': None, 'fox': 'blue', 'box': 'large'}, 'box|fox|socks'),
+        ({'string1': 'cat', 'string2': 'bat', 'fox': 'blue', 'box': 'large'}, 'string1|string2, box|fox|socks'),
+        ({'string1': 'cat', 'string2': 'bat', 'fox': '', 'box': 'large', 'socks': 0}, 'string1|string2'),
+    )
+)
+def test_check_mutually_exclusive_mathematical_fail(mutually_exclusive_terms, params, expected):
+    with pytest.raises(TypeError) as e:
+        check_mutually_exclusive(mutually_exclusive_terms, params)
+
+    assert to_native(e.value) == 'parameters are mutually exclusive: {0}'.format(expected)
+
+
 def test_check_mutually_exclusive_none():
     terms = None
     params = {


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

In addition to looking for the presence of mutually exclusive keys, evaluate the given values of mutually exclusive parameters. If any combination of two parameters evaluates to `True`, then the mutually exclusive check fails.

Fixes #72110

I filed this is a minor change/feature PR since this is a change in behavior. I'm not sure this should be backported if we decide to even merge this at all. There may be problems with changing this behavior that I am no thinking of.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/common/validation.py`