### PR TITLE
ansible-galaxy - source deps from all servers and not just parent

### DIFF
--- a/changelogs/fragments/galaxy-servers.yml
+++ b/changelogs/fragments/galaxy-servers.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- >
+  ansible-galaxy - find any collection dependencies in the globally configured Galaxy servers and not just the server
+  the parent collection is from.

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1189,7 +1189,7 @@ def _build_dependency_map(collections, existing_collections, b_temp_path, apis, 
                     deps_exhausted = False
                     for dep_name, dep_requirement in parent_info.dependencies.items():
                         _get_collection_info(dependency_map, existing_collections, dep_name, dep_requirement,
-                                             parent_info.api, b_temp_path, apis, validate_certs, force_deps,
+                                             source, b_temp_path, apis, validate_certs, force_deps,
                                              parent=parent, allow_pre_release=allow_pre_release)
 
                     checked_parents.add(parent)

--- a/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
@@ -62,9 +62,9 @@
     vX: '{{ "v3/" if item.v3|default(false) else "v2/" }}'
   loop:
   - name: pulp_v2
-    server: '{{ pulp_v2_server }}'
+    server: '{{ pulp_server }}published/api/'
   - name: pulp_v3
-    server: '{{ pulp_v3_server }}'
+    server: '{{ pulp_server }}published/api/'
     v3: true
   - name: galaxy_ng
     server: '{{ galaxy_ng_server }}'
@@ -103,10 +103,56 @@
     v3: true
     requires_auth: true
   - name: pulp_v2
-    server: '{{ pulp_v2_server }}'
+    server: '{{ pulp_server }}published/api/'
   - name: pulp_v3
-    server: '{{ pulp_v3_server }}'
+    server: '{{ pulp_server }}published/api/'
     v3: true
+
+- name: publish collection with a dep on another server
+  setup_collections:
+    server: secondary
+    collections:
+    - namespace: secondary
+      name: name
+      # parent_dep.parent_collection does not exist on the secondary server
+      dependencies:
+        parent_dep.parent_collection: '*'
+  environment:
+    ANSIBLE_CONFIG: '{{ galaxy_dir }}/ansible.cfg'
+
+- name: install collection with dep on another server
+  command: ansible-galaxy collection install secondary.name -vvv  # 3 -v's will show the source in the stdout
+  register: install_cross_dep
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
+    ANSIBLE_CONFIG: '{{ galaxy_dir }}/ansible.cfg'
+
+- name: get result of install collection with dep on another server
+  slurp:
+    path: '{{ galaxy_dir }}/ansible_collections/{{ item.namespace }}/{{ item.name }}/MANIFEST.json'
+  register: install_cross_dep_actual
+  loop:
+  - namespace: secondary
+    name: name
+  - namespace: parent_dep
+    name: parent_collection
+  - namespace: child_dep
+    name: child_collection
+  - namespace: child_dep
+    name: child_dep2
+
+- name: assert result of install collection with dep on another server
+  assert:
+    that:
+    - '"''secondary.name'' obtained from server secondary" in install_cross_dep.stdout'
+    # pulp_v2 is highest in the list so it will find it there first
+    - '"''parent_dep.parent_collection'' obtained from server pulp_v2" in install_cross_dep.stdout'
+    - '"''child_dep.child_collection'' obtained from server pulp_v2" in install_cross_dep.stdout'
+    - '"''child_dep.child_dep2'' obtained from server pulp_v2" in install_cross_dep.stdout'
+    - (install_cross_dep_actual.results[0].content | b64decode | from_json).collection_info.version == '1.0.0'
+    - (install_cross_dep_actual.results[1].content | b64decode | from_json).collection_info.version == '1.0.0'
+    - (install_cross_dep_actual.results[2].content | b64decode | from_json).collection_info.version == '0.9.9'
+    - (install_cross_dep_actual.results[3].content | b64decode | from_json).collection_info.version == '1.2.2'
 
 # fake.fake does not exist but we check the output to ensure it checked all 3
 # servers defined in the config. We hardcode to -vvv as that's what level the

--- a/test/integration/targets/ansible-galaxy-collection/tasks/pulp.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/pulp.yml
@@ -7,5 +7,5 @@
     galaxy_ng_server: '{{ galaxy_ng_server }}'
     url_username: '{{ pulp_user }}'
     url_password: '{{ pulp_password }}'
-    repository: published
+    repositories: '{{ pulp_repositories }}'
     namespaces: '{{ collection_list|map(attribute="namespace")|unique + publish_namespaces }}'

--- a/test/integration/targets/ansible-galaxy-collection/templates/ansible.cfg.j2
+++ b/test/integration/targets/ansible-galaxy-collection/templates/ansible.cfg.j2
@@ -1,15 +1,15 @@
 [galaxy]
 # Ensures subsequent unstable reruns don't use the cached information causing another failure
 cache_dir={{ remote_tmp_dir }}/galaxy_cache
-server_list=pulp_v2,pulp_v3,galaxy_ng
+server_list=pulp_v2,pulp_v3,galaxy_ng,secondary
 
 [galaxy_server.pulp_v2]
-url={{ pulp_v2_server }}
+url={{ pulp_server }}published/api/
 username={{ pulp_user }}
 password={{ pulp_password }}
 
 [galaxy_server.pulp_v3]
-url={{ pulp_v3_server }}
+url={{ pulp_server }}published/api/
 v3=true
 username={{ pulp_user }}
 password={{ pulp_password }}
@@ -17,3 +17,9 @@ password={{ pulp_password }}
 [galaxy_server.galaxy_ng]
 url={{ galaxy_ng_server }}
 token={{ galaxy_ng_token.json.token }}
+
+[galaxy_server.secondary]
+url={{ pulp_server }}secondary/api/
+v3=true
+username={{ pulp_user }}
+password={{ pulp_password }}

--- a/test/integration/targets/ansible-galaxy-collection/vars/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/vars/main.yml
@@ -1,5 +1,9 @@
 galaxy_verbosity: "{{ '' if not ansible_verbosity else '-' ~ ('v' * ansible_verbosity) }}"
 
+pulp_repositories:
+  - published
+  - secondary
+
 publish_namespaces:
   - ansible_test
 

--- a/test/lib/ansible_test/_internal/cloud/galaxy.py
+++ b/test/lib/ansible_test/_internal/cloud/galaxy.py
@@ -238,16 +238,14 @@ class GalaxyEnvironment(CloudEnvironment):
             ansible_vars=dict(
                 pulp_user=pulp_user,
                 pulp_password=pulp_password,
-                pulp_v2_server='http://%s:%s/pulp_ansible/galaxy/published/api/' % (pulp_host, pulp_port),
-                pulp_v3_server='http://%s:%s/pulp_ansible/galaxy/published/api/' % (pulp_host, pulp_port),
                 pulp_api='http://%s:%s' % (pulp_host, pulp_port),
+                pulp_server='http://%s:%s/pulp_ansible/galaxy/' % (pulp_host, pulp_port),
                 galaxy_ng_server='http://%s:%s/api/galaxy/' % (pulp_host, galaxy_port),
             ),
             env_vars=dict(
                 PULP_USER=pulp_user,
                 PULP_PASSWORD=pulp_password,
-                PULP_V2_SERVER='http://%s:%s/pulp_ansible/galaxy/published/api/' % (pulp_host, pulp_port),
-                PULP_V3_SERVER='http://%s:%s/pulp_ansible/galaxy/published/api/' % (pulp_host, pulp_port),
+                PULP_SERVER='http://%s:%s/pulp_ansible/galaxy/api/' % (pulp_host, pulp_port),
                 GALAXY_NG_SERVER='http://%s:%s/api/galaxy/' % (pulp_host, galaxy_port),
             ),
         )


### PR DESCRIPTION
##### SUMMARY
The current logic when coming across a collection dependency is to only search the server that collection was from for that dependency. The upcoming work with Private Automation Hub (Galaxy NG) uses multiple endpoints to sync upstream content and a use case is for end users to upload a collection in their internal repository that can depend on an upstream one. This means we need to change the logic to search for collections in all the user configured servers. This enables a collection in server 1 to have a dependency collection on server 2 and so on.

This code is expected to change in devel at some point in the future with the upcoming refactor but we need to backport this change to stable-2.9 hence why it's being done here as well.

TODO:

- [x] Add integration tests for this scenario

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-galaxy