### PR TITLE
Rollback pulp container to stabilise CI

### DIFF
--- a/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
@@ -301,38 +301,39 @@
     - (install_req_actual.results[0].content | b64decode | from_json).collection_info.version == '1.0.0'
     - (install_req_actual.results[1].content | b64decode | from_json).collection_info.version == '1.0.0'
 
-- name: install cache.cache at the current latest version
-  command: ansible-galaxy collection install cache.cache -s '{{ test_name }}' -vvv
-  environment:
-    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
-
-- set_fact:
-    cache_version_build: '{{ (cache_version_build | int) + 1 }}'
-
-- name: publish update for cache.cache test
-  setup_collections:
-    server: galaxy_ng
-    collections:
-    - namespace: cache
-      name: cache
-      version: 1.0.{{ cache_version_build }}
-
-- name: make sure the cache version list is ignored on a collection version change
-  command: ansible-galaxy collection install cache.cache -s '{{ test_name }}' --force -vvv
-  register: install_cached_update
-  environment:
-    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
-
-- name: get result of install collections with ansible-galaxy install - {{ test_name }}
-  slurp:
-    path: '{{ galaxy_dir }}/ansible_collections/cache/cache/MANIFEST.json'
-  register: install_cached_update_actual
-
-- name: assert install collections with ansible-galaxy install - {{ test_name }}
-  assert:
-    that:
-    - '"Installing ''cache.cache:1.0.{{ cache_version_build }}'' to" in install_cached_update.stdout'
-    - (install_cached_update_actual.content | b64decode | from_json).collection_info.version == '1.0.' ~ cache_version_build
+# Uncomment once pulp container is at pulp>=0.5.0
+#- name: install cache.cache at the current latest version
+#  command: ansible-galaxy collection install cache.cache -s '{{ test_name }}' -vvv
+#  environment:
+#    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
+#
+#- set_fact:
+#    cache_version_build: '{{ (cache_version_build | int) + 1 }}'
+#
+#- name: publish update for cache.cache test
+#  setup_collections:
+#    server: galaxy_ng
+#    collections:
+#    - namespace: cache
+#      name: cache
+#      version: 1.0.{{ cache_version_build }}
+#
+#- name: make sure the cache version list is ignored on a collection version change - {{ test_name }}
+#  command: ansible-galaxy collection install cache.cache -s '{{ test_name }}' --force -vvv
+#  register: install_cached_update
+#  environment:
+#    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
+#
+#- name: get result of cache version list is ignored on a collection version change - {{ test_name }}
+#  slurp:
+#    path: '{{ galaxy_dir }}/ansible_collections/cache/cache/MANIFEST.json'
+#  register: install_cached_update_actual
+#
+#- name: assert cache version list is ignored on a collection version change - {{ test_name }}
+#  assert:
+#    that:
+#    - '"Installing ''cache.cache:1.0.{{ cache_version_build }}'' to" in install_cached_update.stdout'
+#    - (install_cached_update_actual.content | b64decode | from_json).collection_info.version == '1.0.' ~ cache_version_build
 
 - name: remove test collection install directory - {{ test_name }}
   file:

--- a/test/lib/ansible_test/_internal/cloud/galaxy.py
+++ b/test/lib/ansible_test/_internal/cloud/galaxy.py
@@ -94,9 +94,13 @@ class GalaxyProvider(CloudProvider):
         """
         super(GalaxyProvider, self).__init__(args)
 
+        # Cannot use the latest container image as either galaxy_ng 4.2.0rc2 or pulp 0.5.0 has sporatic issues with
+        # dropping published collections in CI. Try running the tests multiple times when updating. Will also need to
+        # comment out the cache tests in 'test/integration/targets/ansible-galaxy-collection/tasks/install.yml' when
+        # the newer update is available.
         self.pulp = os.environ.get(
             'ANSIBLE_PULP_CONTAINER',
-            'docker.io/pulp/pulp-galaxy-ng@sha256:263282d364e2c996f5e0740e85bbfb685bcc602bce1ab2c4f5af702fe46f9b20'
+            'docker.io/pulp/pulp-galaxy-ng@sha256:b79a7be64eff86d8f58db9ca83ed4967bd8b4e45c99addb17a91d11926480cf1'
         )
 
         self.containers = []


### PR DESCRIPTION
##### SUMMARY
Downgrading the pulp container used for Galaxy CI. There are sporatic issues with 4.2.0rc2 that is used in the latest image where collections that have been published are no longer available. While we can't run the full tests on these older versions we at least make the remaining tests stable until a newer version is ready.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy-collection