### PR TITLE
Update intro_installation.rst  with missing step of ansible installation on centos

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -103,10 +103,17 @@ On Fedora:
 
     $ sudo dnf install ansible
 
-On RHEL and CentOS:
+On RHEL:
 
 .. code-block:: bash
 
+    $ sudo yum install ansible
+
+On CentOS:
+
+.. code-block:: bash
+
+    $ sudo yum install epel-release
     $ sudo yum install ansible
 
 RPMs for RHEL 7 and RHEL 8 are available from the `Ansible Engine repository <https://access.redhat.com/articles/3174981>`_.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
"No package ansible available.
Error: Nothing to do"
To fix following issue while installing ansible on centos, We need to install epel-release.
Added this missing step in documentation 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
