### PR TITLE
catch the case that cowsay is broken

### DIFF
--- a/changelogs/fragments/72592-catch-broken-cowsay.yaml
+++ b/changelogs/fragments/72592-catch-broken-cowsay.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - catch the case that cowsay is broken which would lead to missing output

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -225,6 +225,8 @@ class Display(with_metaclass(Singleton, object)):
             try:
                 cmd = subprocess.Popen([self.b_cowsay, "-l"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 (out, err) = cmd.communicate()
+                if cmd.returncode:
+                    raise Exception
                 self.cows_available = set([to_text(c) for c in out.split()])
                 if C.ANSIBLE_COW_ACCEPTLIST and any(C.ANSIBLE_COW_ACCEPTLIST):
                     self.cows_available = set(C.ANSIBLE_COW_ACCEPTLIST).intersection(self.cows_available)

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -226,7 +226,7 @@ class Display(with_metaclass(Singleton, object)):
                 cmd = subprocess.Popen([self.b_cowsay, "-l"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 (out, err) = cmd.communicate()
                 if cmd.returncode:
-                    raise Exception
+                    raise AnsibleError(f"cowsay returned exit code {cmd.returncode}. stderr was {err}")
                 self.cows_available = set([to_text(c) for c in out.split()])
                 if C.ANSIBLE_COW_ACCEPTLIST and any(C.ANSIBLE_COW_ACCEPTLIST):
                     self.cows_available = set(C.ANSIBLE_COW_ACCEPTLIST).intersection(self.cows_available)

--- a/test/units/utils/display/test_broken_cowsay.py
+++ b/test/units/utils/display/test_broken_cowsay.py
@@ -21,7 +21,7 @@ def test_display_with_fake_cowsay_binary(capsys, mocker):
     mock_popen.return_value.communicate = mock_communicate
     mock_popen.return_value.returncode = 1
     mocker.patch("subprocess.Popen", mock_popen)
-    
+
     display = Display()
     assert not hasattr(display, "cows_available")
     assert display.b_cowsay is False

--- a/test/units/utils/display/test_broken_cowsay.py
+++ b/test/units/utils/display/test_broken_cowsay.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+from ansible.utils.display import Display
+from mock import MagicMock
+
+
+def test_display_with_fake_cowsay_binary(capsys, mocker):
+    mocker.patch("ansible.constants.ANSIBLE_COW_PATH", "./cowsay.sh")
+
+    def mock_communicate(input=None, timeout=None):
+        return b"", b""
+
+    mock_popen = MagicMock()
+    mock_popen.return_value.communicate = mock_communicate
+    mock_popen.return_value.returncode = 1
+    mocker.patch("subprocess.Popen", mock_popen)
+    
+    display = Display()
+    assert not hasattr(display, "cows_available")
+    assert display.b_cowsay is False


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #72582

Catch the unlikely (but possible) case that `cowsay` is broken which leads to missing output (and is hard to debug in particular for non power users and beginners)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

ansible

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```

I'm happy to include some form of warning or error message telling that cowsay seems to be broken and ansible is backing up to normal output.

