### PR TITLE
Fix documented type of mode field in copy module

### DIFF
--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -75,7 +75,7 @@ options:
     - As of Ansible 2.3, the mode may also be the special string C(preserve).
     - C(preserve) means that the file will be given the same permissions as the source file.
     - When doing a recursive copy, see also C(directory_mode).
-    type: path
+    type: str
   directory_mode:
     description:
     - When doing a recursive copy set the mode for the directories.

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -75,7 +75,7 @@ options:
     - As of Ansible 2.3, the mode may also be the special string C(preserve).
     - C(preserve) means that the file will be given the same permissions as the source file.
     - When doing a recursive copy, see also C(directory_mode).
-    type: str
+    type: raw
   directory_mode:
     description:
     - When doing a recursive copy set the mode for the directories.

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -75,7 +75,6 @@ options:
     - As of Ansible 2.3, the mode may also be the special string C(preserve).
     - C(preserve) means that the file will be given the same permissions as the source file.
     - When doing a recursive copy, see also C(directory_mode).
-    type: raw
   directory_mode:
     description:
     - When doing a recursive copy set the mode for the directories.

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -90,7 +90,6 @@ lib/ansible/modules/command.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/command.py validate-modules:undocumented-parameter
 lib/ansible/modules/copy.py pylint:blacklisted-name
 lib/ansible/modules/copy.py validate-modules:doc-default-does-not-match-spec
-lib/ansible/modules/copy.py validate-modules:doc-type-does-not-match-spec
 lib/ansible/modules/copy.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/copy.py validate-modules:undocumented-parameter
 lib/ansible/modules/dnf.py validate-modules:doc-required-mismatch


### PR DESCRIPTION
##### SUMMARY
Type of 'mode' field in Copy module is 'path' which is absolutely wrong. I changed it to 'str'.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
copy

