### PR TITLE
Fix FreeBSD HTTP Kerberos setup

### DIFF
--- a/test/integration/targets/get_url/tasks/use_gssapi.yml
+++ b/test/integration/targets/get_url/tasks/use_gssapi.yml
@@ -1,37 +1,22 @@
-- name: Skip explicit auth tests on FreeBSD as Heimdal there does not have gss_acquire_cred_with_password
-  when: ansible_facts.os_family != 'FreeBSD'
-  block:
-  - name: test Negotiate auth over HTTP with explicit credentials
-    get_url:
-      url: http://{{ httpbin_host }}/gssapi
-      dest: '{{ remote_tmp_dir }}/gssapi_explicit.txt'
-      use_gssapi: yes
-      url_username: '{{ krb5_username }}'
-      url_password: '{{ krb5_password }}'
-    register: http_explicit
-
-  - name: get result of test Negotiate auth over HTTP with explicit credentials
-    slurp:
-      path: '{{ remote_tmp_dir }}/gssapi_explicit.txt'
-    register: http_explicit_actual
-
-  - name: assert test Negotiate auth with implicit credentials
-    assert:
-      that:
-      - http_explicit.status_code == 200
-      - http_explicit_actual.content | b64decode | trim == 'Microsoft Rulz'
-
-- name: FreeBSD - verify it fails with explicit credential
+- name: test Negotiate auth over HTTP with explicit credentials
   get_url:
     url: http://{{ httpbin_host }}/gssapi
     dest: '{{ remote_tmp_dir }}/gssapi_explicit.txt'
     use_gssapi: yes
     url_username: '{{ krb5_username }}'
     url_password: '{{ krb5_password }}'
-  register: explicit_failure
-  when: ansible_facts.os_family == 'FreeBSD'
-  failed_when:
-  - '"Platform GSSAPI library does not support gss_acquire_cred_with_password, cannot acquire GSSAPI credential with explicit username and password" not in explicit_failure.msg'
+  register: http_explicit
+
+- name: get result of test Negotiate auth over HTTP with explicit credentials
+  slurp:
+    path: '{{ remote_tmp_dir }}/gssapi_explicit.txt'
+  register: http_explicit_actual
+
+- name: assert test Negotiate auth with implicit credentials
+  assert:
+    that:
+    - http_explicit.status_code == 200
+    - http_explicit_actual.content | b64decode | trim == 'Microsoft Rulz'
 
 - name: skip tests on macOS, I cannot seem to get it to read a credential from a custom ccache
   when: ansible_facts.distribution != 'MacOSX'

--- a/test/integration/targets/prepare_http_tests/tasks/kerberos.yml
+++ b/test/integration/targets/prepare_http_tests/tasks/kerberos.yml
@@ -43,8 +43,10 @@
     state: present
     extra_args: '-c {{ remote_constraints }}'
   environment:
-    # Need this custom path for OpenSUSE as krb5-config is placed there
-    PATH: '{{ ansible_facts.env.PATH }}:/usr/lib/mit/bin'
+    # Put /usr/local/bin for FreeBSD as we need to use the heimdal port over the builtin version
+    # https://github.com/pythongssapi/python-gssapi/issues/228
+    # Need the /usr/lib/mit/bin custom path for OpenSUSE as krb5-config is placed there
+    PATH: '/usr/local/bin:{{ ansible_facts.env.PATH }}:/usr/lib/mit/bin'
   notify: Remove python gssapi
 
 - name: test the environment to make sure Kerberos is working properly

--- a/test/integration/targets/uri/tasks/use_gssapi.yml
+++ b/test/integration/targets/uri/tasks/use_gssapi.yml
@@ -5,45 +5,31 @@
   register: no_auth_failure
   failed_when: no_auth_failure.www_authenticate != 'Negotiate'
 
-- name: Skip explicit auth tests on FreeBSD as Heimdal there does not have gss_acquire_cred_with_password
-  when: ansible_facts.os_family != 'FreeBSD'
-  block:
-  - name: test Negotiate auth over HTTP with explicit credentials
-    uri:
-      url: http://{{ httpbin_host }}/gssapi
-      use_gssapi: yes
-      url_username: '{{ krb5_username }}'
-      url_password: '{{ krb5_password }}'
-      return_content: yes
-    register: http_explicit
+- name: test Negotiate auth over HTTP with explicit credentials
+  uri:
+    url: http://{{ httpbin_host }}/gssapi
+    use_gssapi: yes
+    url_username: '{{ krb5_username }}'
+    url_password: '{{ krb5_password }}'
+    return_content: yes
+  register: http_explicit
 
-  - name: test Negotiate auth over HTTPS with explicit credentials
-    uri:
-      url: https://{{ httpbin_host }}/gssapi
-      use_gssapi: yes
-      url_username: '{{ krb5_username }}'
-      url_password: '{{ krb5_password }}'
-      return_content: yes
-    register: https_explicit
-
-  - name: assert test Negotiate auth with implicit credentials
-    assert:
-      that:
-      - http_explicit.status == 200
-      - http_explicit.content | trim == 'Microsoft Rulz'
-      - https_explicit.status == 200
-      - https_explicit.content | trim == 'Microsoft Rulz'
-
-- name: FreeBSD - verify it fails with explicit credential
+- name: test Negotiate auth over HTTPS with explicit credentials
   uri:
     url: https://{{ httpbin_host }}/gssapi
     use_gssapi: yes
     url_username: '{{ krb5_username }}'
     url_password: '{{ krb5_password }}'
-  register: explicit_failure
-  when: ansible_facts.os_family == 'FreeBSD'
-  failed_when:
-  - '"Platform GSSAPI library does not support gss_acquire_cred_with_password, cannot acquire GSSAPI credential with explicit username and password" not in explicit_failure.msg'
+    return_content: yes
+  register: https_explicit
+
+- name: assert test Negotiate auth with implicit credentials
+  assert:
+    that:
+    - http_explicit.status == 200
+    - http_explicit.content | trim == 'Microsoft Rulz'
+    - https_explicit.status == 200
+    - https_explicit.content | trim == 'Microsoft Rulz'
 
 - name: skip tests on macOS, I cannot seem to get it to read a credential from a custom ccache
   when: ansible_facts.distribution != 'MacOSX'


### PR DESCRIPTION
##### SUMMARY
The [gssapi](https://pypi.org/project/gssapi/) Python library just released version 1.6.10 which causes issues with our FreeBSD instance in CI. The current setup code installs the `heimdal` port but it turns out FreeBSD already ships with an older version of Heimdal which is what the existing setup code was compiling against. Because the new `gssapi` release relies on a new identifier that isn't present in the base Heimdal release on FreeBSD it fails to compile.

What this change does is ensures `gssapi` is built against the Heimdal port which contains the identifiers and methods that are required. We can also simplify our tests now that this newer port includes the cred extension which implements `gss_acquire_cred_with_password`.

Further background info can be found at https://github.com/pythongssapi/python-gssapi/issues/228.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test