### PR TITLE
Fix super annoying Python 2.6 multiprocessing.Queue stack trace in CI

### DIFF
--- a/changelogs/fragments/py26-multiprocess-queue-bug.yml
+++ b/changelogs/fragments/py26-multiprocess-queue-bug.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - account for bug in Python 2.6 that occurs during interpreter shutdown to avoid stack trace

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -339,7 +339,7 @@ class TaskQueueManager:
         #     Fix:   https://hg.python.org/cpython/rev/d316315a8781
         #
         try:
-            if (2, 6) == (sys.version[0], sys.version[1]):
+            if (2, 6) == (sys.version_info[0:2]):
                 time.sleep(0.0001)
         except (IndexError, AttributeError):
             # In case there is an issue getting the version info, don't raise an Exception

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -20,6 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
+import sys
 import tempfile
 import threading
 import time
@@ -327,6 +328,22 @@ class TaskQueueManager:
         self.terminate()
         self._final_q.close()
         self._cleanup_processes()
+
+        # A bug exists in Python 2.6 that causes an exception to be raised during
+        # interpreter shutdown. This is only an issue in our CI testing but we
+        # hit it frequently enough to add a small sleep to avoid the issue.
+        # This can be removed once we have split controller available in CI.
+        #
+        # Further information:
+        #     Issue: https://bugs.python.org/issue4106
+        #     Fix:   https://hg.python.org/cpython/rev/d316315a8781
+        #
+        try:
+            if (2, 6) == (sys.version[0], sys.version[1]):
+                time.sleep(0.0001)
+        except (IndexError, AttributeError):
+            # In case there is an issue getting the version info, don't raise an Exception
+            pass
 
     def _cleanup_processes(self):
         if hasattr(self, '_workers'):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

A bug exists in Python 2.6 that sometimes raises an exception during interpreter shutdown. We encounter this frequently in our CI since we run tests on CentOS 6 as the control node, which has Python 2.6.6 with this bug.

This PR adds a very minor sleep only on Python 2.6 which gets around this issue. I did a lot of testing using a standalone script I found that easily duplicated the issue to find the minimum sleep value needed to avoid this issue.

CPython issue: https://bugs.python.org/issue4106
Fix in CPython: https://hg.python.org/cpython/rev/d316315a8781<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/executor/task_queue_manager.py`

##### ADDITIONAL INFORMATION

Here is the test script I used in our [CentOS 6 test container](https://quay.io/repository/ansible/centos6-test-container):

```python
#!/usr/bin/env python
#
# This code is from
# https://groups.google.com/g/comp.lang.python/c/QUSUhGMLdv8/m/crEsBKYMxlgJ

# Shell command to test. This needs to be done in a script because it's the
# interpreter shutdown that triggers the race condition.
#
# export i=1; while true; do printf "%-'6d:" "${i}";  python queue-test.py ; let "i+=1" ; done

import sys
import time
from multiprocessing import Process, Queue


def listTest(q):
    print(q.get())


def queueTest():
    q = Queue()
    q.put([1, 2, 3, 4, 5, 6])
    p = Process(target=listTest, args=(q,))
    p.start()
    p.join()


if __name__ == '__main__':
    queueTest()
    # Adding this sleep prevents the traceback
    if (2, 6) == (sys.version_info[0:2]):
        time.sleep(0.0001)
```

I'm not sure about adding tests for this since I haven't found a way to reliably duplicate it running Ansible.