### PR TITLE
[stable-2.9] Fix super annoying Python 2.6 multiprocessing.Queue stack trace in CI (#72604)

### DIFF
--- a/changelogs/fragments/py26-multiprocess-queue-bug.yml
+++ b/changelogs/fragments/py26-multiprocess-queue-bug.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - account for bug in Python 2.6 that occurs during interpreter shutdown to avoid stack trace

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -20,7 +20,9 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
+import sys
 import tempfile
+import time
 
 from ansible import constants as C
 from ansible import context
@@ -256,6 +258,22 @@ class TaskQueueManager:
         self.terminate()
         self._final_q.close()
         self._cleanup_processes()
+
+        # A bug exists in Python 2.6 that causes an exception to be raised during
+        # interpreter shutdown. This is only an issue in our CI testing but we
+        # hit it frequently enough to add a small sleep to avoid the issue.
+        # This can be removed once we have split controller available in CI.
+        #
+        # Further information:
+        #     Issue: https://bugs.python.org/issue4106
+        #     Fix:   https://hg.python.org/cpython/rev/d316315a8781
+        #
+        try:
+            if (2, 6) == (sys.version_info[0:2]):
+                time.sleep(0.0001)
+        except (IndexError, AttributeError):
+            # In case there is an issue getting the version info, don't raise an Exception
+            pass
 
     def _cleanup_processes(self):
         if hasattr(self, '_workers'):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #72604 for Ansible 2.9
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/executor/task_queue_manager.py`