### PR TITLE
Compare removal and deprecation dates and versions in runtime metadata against current version and today

### DIFF
--- a/changelogs/fragments/ansible-test-runtime-dates-versions.yml
+++ b/changelogs/fragments/ansible-test-runtime-dates-versions.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- "ansible-test runtime-metadata - compare deprecation and tombstone versions to the current version to ensure that they are correct (https://github.com/ansible/ansible/pull/72625)."
+- "ansible-test runtime-metadata - ensure that the tombstone removal date is not in the future (https://github.com/ansible/ansible/pull/72625)."

--- a/test/lib/ansible_test/_data/sanity/code-smell/runtime-metadata.py
+++ b/test/lib/ansible_test/_data/sanity/code-smell/runtime-metadata.py
@@ -20,23 +20,37 @@ from ansible.module_utils.six import string_types
 from ansible.utils.version import SemanticVersion
 
 
-def isodate(value):
+def isodate(value, check_deprecation_date=False, is_tombstone=False):
     """Validate a datetime.date or ISO 8601 date string."""
     # datetime.date objects come from YAML dates, these are ok
     if isinstance(value, datetime.date):
-        return value
-    # make sure we have a string
-    msg = 'Expected ISO 8601 date string (YYYY-MM-DD), or YAML date'
-    if not isinstance(value, string_types):
-        raise Invalid(msg)
-    # From Python 3.7 in, there is datetime.date.fromisoformat(). For older versions,
-    # we have to do things manually.
-    if not re.match('^[0-9]{4}-[0-9]{2}-[0-9]{2}$', value):
-        raise Invalid(msg)
-    try:
-        datetime.datetime.strptime(value, '%Y-%m-%d').date()
-    except ValueError:
-        raise Invalid(msg)
+        removal_date = value
+    else:
+        # make sure we have a string
+        msg = 'Expected ISO 8601 date string (YYYY-MM-DD), or YAML date'
+        if not isinstance(value, string_types):
+            raise Invalid(msg)
+        # From Python 3.7 in, there is datetime.date.fromisoformat(). For older versions,
+        # we have to do things manually.
+        if not re.match('^[0-9]{4}-[0-9]{2}-[0-9]{2}$', value):
+            raise Invalid(msg)
+        try:
+            removal_date = datetime.datetime.strptime(value, '%Y-%m-%d').date()
+        except ValueError:
+            raise Invalid(msg)
+    # Make sure date is correct
+    today = datetime.date.today()
+    if is_tombstone:
+        # For a tombstone, the removal date must be in the past
+        if today < removal_date:
+            raise Invalid(
+                'The tombstone removal_date (%s) must not be after today (%s)' % (removal_date, today))
+    else:
+        # For a deprecation, the removal date must be in the future. Only test this if
+        # check_deprecation_date is truish, to avoid checks to suddenly start to fail.
+        if check_deprecation_date and today > removal_date:
+            raise Invalid(
+                'The deprecation removal_date (%s) must be after today (%s)' % (removal_date, today))
     return value
 
 
@@ -107,7 +121,7 @@ def get_collection_version():
         return None
 
 
-def validate_metadata_file(path, is_ansible):
+def validate_metadata_file(path, is_ansible, check_deprecation_dates=False):
     """Validate explicit runtime metadata file"""
     try:
         with open(path, 'r') as f_path:
@@ -151,7 +165,7 @@ def validate_metadata_file(path, is_ansible):
             {
                 'removal_version': partial(removal_version, is_ansible=is_ansible,
                                            current_version=current_version),
-                'removal_date': Any(isodate),
+                'removal_date': partial(isodate, check_deprecation_date=check_deprecation_dates),
                 'warning_text': Any(*string_types),
             }
         ),
@@ -164,7 +178,7 @@ def validate_metadata_file(path, is_ansible):
             {
                 'removal_version': partial(removal_version, is_ansible=is_ansible,
                                            current_version=current_version, is_tombstone=True),
-                'removal_date': Any(isodate),
+                'removal_date': partial(isodate, is_tombstone=True),
                 'warning_text': Any(*string_types),
             }
         ),
@@ -244,12 +258,20 @@ def main():
     collection_legacy_file = 'meta/routing.yml'
     collection_runtime_file = 'meta/runtime.yml'
 
+    # This is currently disabled, because if it is enabled this test can start failing
+    # at a random date. For this to be properly activated, we (a) need to be able to return
+    # codes for this test, and (b) make this error optional.
+    check_deprecation_dates = False
+
     for path in paths:
         if path == collection_legacy_file:
             print('%s:%d:%d: %s' % (path, 0, 0, ("Should be called '%s'" % collection_runtime_file)))
             continue
 
-        validate_metadata_file(path, is_ansible=path not in (collection_legacy_file, collection_runtime_file))
+        validate_metadata_file(
+            path,
+            is_ansible=path not in (collection_legacy_file, collection_runtime_file),
+            check_deprecation_dates=check_deprecation_dates)
 
 
 if __name__ == '__main__':

--- a/test/lib/ansible_test/_data/sanity/code-smell/runtime-metadata.py
+++ b/test/lib/ansible_test/_data/sanity/code-smell/runtime-metadata.py
@@ -98,7 +98,7 @@ def get_ansible_version():
     """Return current ansible-core version"""
     from ansible.release import __version__
 
-    return LooseVersion(__version__)
+    return LooseVersion('.'.join(__version__.split('.')[:3]))
 
 
 def get_collection_version():


### PR DESCRIPTION
##### SUMMARY
Adds more checks for removal and deprecation dates and versions in ansible_builtin_runtime.yml resp. collection's meta/runtime.yml.

The version checks make sure that tombstone removal_version values are not after the current version, and that deprecation removal_version values are not before the current version. (If the current version of a collection cannot be determined, these checks are not made.)

The date check ensures that tombstone removal_date values are not in the future.

(There's also a check that ensures that deprecation removal_date values are not in the past, but that is disabled, since it needs more infrastructure to be enabled, since this must be an optionally enabled error like the equivalent errors for deprecation versions everywhere else.)

These new validation checks will be very useful since we're releasing the last 1.x.0 release of community.general and community.network soon, and this check will flag all things we need to remove when bumping the version number to 2.0.0.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test runtime-metadata
