### PR TITLE
document what the name of a play is

### DIFF
--- a/docs/docsite/rst/reference_appendices/special_variables.rst
+++ b/docs/docsite/rst/reference_appendices/special_variables.rst
@@ -116,7 +116,7 @@ play_hosts
     Deprecated, the same as ansible_play_batch
 
 ansible_play_name
-    The name of the currently executed play. Added in ``2.8``.
+    The name of the currently executed play. Added in ``2.8``. (`name` attribute of the play, not file name of the playbook.)
 
 playbook_dir
     The path to the directory of the playbook that was passed to the ``ansible-playbook`` command line.


### PR DESCRIPTION
##### SUMMARY

Make clear that `ansible_play_name` is the name attribute from the play and not the file name of the playbook.

improves #57361

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION

I was fooled by this today. Because I was not the first one, I suggest to update the doc.
