### PR TITLE
Fix async interpreter parsing

### DIFF
--- a/changelogs/fragments/70690-async-interpreter.yml
+++ b/changelogs/fragments/70690-async-interpreter.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- async - Fix Python 3 interpreter parsing from module by comparing with bytes
+  (https://github.com/ansible/ansible/issues/70690)

--- a/test/integration/targets/noexec/aliases
+++ b/test/integration/targets/noexec/aliases
@@ -1,0 +1,3 @@
+shippable/posix/group2
+skip/docker
+skip/macos

--- a/test/integration/targets/noexec/inventory
+++ b/test/integration/targets/noexec/inventory
@@ -1,0 +1,1 @@
+not_empty  # avoid empty empty hosts list warning without defining explicit localhost

--- a/test/integration/targets/noexec/runme.sh
+++ b/test/integration/targets/noexec/runme.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -eux
+
+trap 'umount "${OUTPUT_DIR}/ramdisk"' EXIT
+
+mkdir "${OUTPUT_DIR}/ramdisk"
+mount -t tmpfs -o size=32m,noexec,rw tmpfs "${OUTPUT_DIR}/ramdisk"
+ANSIBLE_REMOTE_TMP="${OUTPUT_DIR}/ramdisk" ansible-playbook -i ../../inventory "$@" test-noexec.yml

--- a/test/integration/targets/noexec/runme.sh
+++ b/test/integration/targets/noexec/runme.sh
@@ -2,8 +2,8 @@
 
 set -eux
 
-trap 'umount "${OUTPUT_DIR}/ramdisk"' EXIT
+trap "umount '${OUTPUT_DIR}/ramdisk'" EXIT
 
 mkdir "${OUTPUT_DIR}/ramdisk"
 mount -t tmpfs -o size=32m,noexec,rw tmpfs "${OUTPUT_DIR}/ramdisk"
-ANSIBLE_REMOTE_TMP="${OUTPUT_DIR}/ramdisk" ansible-playbook -i ../../inventory "$@" test-noexec.yml
+ANSIBLE_REMOTE_TMP="${OUTPUT_DIR}/ramdisk" ansible-playbook -i inventory "$@" test-noexec.yml

--- a/test/integration/targets/noexec/runme.sh
+++ b/test/integration/targets/noexec/runme.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-trap "umount '${OUTPUT_DIR}/ramdisk'" EXIT
+trap 'umount "${OUTPUT_DIR}/ramdisk"' EXIT
 
 mkdir "${OUTPUT_DIR}/ramdisk"
 mount -t tmpfs -o size=32m,noexec,rw tmpfs "${OUTPUT_DIR}/ramdisk"

--- a/test/integration/targets/noexec/test-noexec.yml
+++ b/test/integration/targets/noexec/test-noexec.yml
@@ -1,0 +1,8 @@
+- hosts: all
+  gather_facts: false
+  tasks:
+    - ping:
+
+    - command: sleep 1
+      async: 2
+      poll: 1

--- a/test/integration/targets/noexec/test-noexec.yml
+++ b/test/integration/targets/noexec/test-noexec.yml
@@ -1,4 +1,4 @@
-- hosts: all
+- hosts: localhost
   gather_facts: false
   tasks:
     - ping:


### PR DESCRIPTION
##### SUMMARY
Fix async interpreter parsing. Fixes #70690

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/async_wrapper.py

##### ADDITIONAL INFORMATION
Without fix:

```
TASK [command] *******************************************************************************************************
fatal: [testhost]: FAILED! => {"ansible_job_id": "331694001241.14647", "changed": false, "cmd": "/root/ansible/test/results/.tmp/output_dir/ramdisk/ansible-tmp-1605544005.5060177-14636-38834302060190/AnsiballZ_command.py", "finished": 1, "msg": "[Errno 13] Permission denied: b'/root/ansible/test/results/.tmp/output_dir/ramdisk/ansible-tmp-1605544005.5060177-14636-38834302060190/AnsiballZ_command.py'", "outdata": "", "stderr": "", "stderr_lines": []}
```
