### PR TITLE
Allow using galaxy.yml as a requirements file

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -608,8 +608,9 @@ class GalaxyCLI(CLI):
 
         else:
             # Newer format with a collections and/or roles key
-            extra_keys = set(file_requirements.keys()).difference(set(['roles', 'collections']))
-            if extra_keys:
+            is_galaxy_yml = set(file_requirements.keys()).issuperset(['name', 'namespace'])
+            extra_keys = set(file_requirements.keys()).difference(['roles', 'collections'])
+            if extra_keys and not is_galaxy_yml:
                 raise AnsibleError("Expecting only 'roles' and/or 'collections' as base keys in the requirements "
                                    "file. Found: %s" % (to_native(", ".join(extra_keys))))
 
@@ -640,6 +641,10 @@ class GalaxyCLI(CLI):
                     requirements['collections'].append((req_name, req_version, req_source, req_type))
                 else:
                     requirements['collections'].append((collection_req, '*', None, None))
+
+            if is_galaxy_yml:
+                for req_name, req_version in (file_requirements.get('dependencies') or {}).items():
+                    requirements['collections'].append((req_name, req_version, None, None))
 
         return requirements
 


### PR DESCRIPTION
##### SUMMARY
Allow using galaxy.yml as a requirements file

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/cli/galaxy.py

##### ADDITIONAL INFORMATION
We had discussed this previously, but didn't pursue it.  This may be useful for https://github.com/ansible/ansible/issues/72634 whether ansible-test supports it natively or not.

Just a potential option.