### PR TITLE
[reboot] allow filtering boot time command output

### DIFF
--- a/changelogs/fragments/reboot-filter-boot-time.yml
+++ b/changelogs/fragments/reboot-filter-boot-time.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - reboot - now accepts a ``boot_time_filter_regex`` option which can be used to limit the boot time command's output to relevant lines before seeing if they changed.

--- a/lib/ansible/modules/reboot.py
+++ b/lib/ansible/modules/reboot.py
@@ -68,8 +68,21 @@ options:
       - Command to run that returns a unique string indicating the last time the system was booted.
       - Setting this to a command that has different output each time it is run will cause the task to fail.
     type: str
-    default: 'cat /proc/sys/kernel/random/boot_id'
+    default: '[determined based on target OS]'
     version_added: '2.10'
+
+  boot_time_filter_regex:
+    description:
+      - Filters stdout lines from the result of C(boot_time_command).
+      - Some systems will inject shutdown warnings into the result of the command if the reboot
+        triggers too quickly. Using this option allows you to filter to lines that contain the
+        relevant information (boot time).
+      - This regex is applied in multiline mode to the stdout of C(boot_time_command). If multiple
+        lines match, they will all be used (any of them changing will cause the module to assume
+        the reboot has been successful).
+    type: str
+    default: '[determined based on target OS]'
+    version_added: '2.11'
 
   reboot_command:
     description:

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -247,11 +247,14 @@ class ActionModule(ActionBase):
         if filter_re:
             matches = re.findall(filter_re, command_result['stdout'], re.MULTILINE)
             if not matches:
-                raise AnsibleError("{action}: failed to get host boot time info, filter regex did not match result of boot time check command. rc: {rc}, stdout: {out}, stderr: {err}".format(
-                    action=self._task.action,
-                    rc=command_result['rc'],
-                    out=to_native(stdout),
-                    err=to_native(stderr)))
+                raise AnsibleError(
+                    "{action}: failed to get host boot time info, filter regex "
+                    "did not match result of boot time check command. rc: {rc}, "
+                    "stdout: {out}, stderr: {err}".format(
+                        action=self._task.action,
+                        rc=command_result['rc'],
+                        out=to_native(stdout),
+                        err=to_native(stderr)))
 
             # If there are multiple matches, munge them together into a string
             # We could return a list, but we don't actually use the data IN the

--- a/test/integration/targets/reboot/tasks/main.yml
+++ b/test/integration/targets/reboot/tasks/main.yml
@@ -36,6 +36,7 @@
 
     - import_tasks: test_standard_scenarios.yml
     - import_tasks: test_reboot_command.yml
+    - import_tasks: test_invalid_filter_regex.yml
     - import_tasks: test_invalid_parameter.yml
     - import_tasks: test_invalid_test_command.yml
     - import_tasks: test_molly_guard.yml

--- a/test/integration/targets/reboot/tasks/test_invalid_filter_regex.yml
+++ b/test/integration/targets/reboot/tasks/test_invalid_filter_regex.yml
@@ -1,0 +1,8 @@
+- name: Reboot with boot time command regex filter that fails
+  reboot:
+    reboot_timeout: "{{ timeout }}"
+    boot_time_filter_regex: ^thislinewillneverexist$
+  register: regex_fail
+  failed_when: "regex_fail is success or 'filter regex did not match' not in regex_fail.msg"
+  vars:
+    timeout: "{{ _timeout_value[ansible_facts['distribution'] | lower] | default(60) }}"


### PR DESCRIPTION

##### SUMMARY

Change:
- Some systems inject system reboot messages into command stdout. This
  previously broke our detection logic and caused the reboot action to
  think that the boot time changed. We now allow filtering for specific
  lines.
- Small docs fix to update a default.

Test Plan:
- local VMs

Tickets:
- Refs #72629 - trying to repro that is where I originally found this
  issue. This also contains a small docs fix relevant to that ticket.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME

reboot