### PR TITLE
Show ZFS mounts in ansible_mounts for Linux

### DIFF
--- a/changelogs/fragments/72658-show-zfs-mounts-in-ansible-mounts-for-linux.yml
+++ b/changelogs/fragments/72658-show-zfs-mounts-in-ansible-mounts-for-linux.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hardware facts - Return info about ZFS mounts on Linux hosts in `ansible_mounts` (https://github.com/ansible/ansible/pull/72659).

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -540,8 +540,8 @@ class LinuxHardware(Hardware):
             'zfs'
         ]
         if device.startswith(('/', '\\')) or fstype in regular_filesystems:
-            return True
-        return False
+            return False
+        return True
 
     def get_mount_facts(self):
 

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -545,7 +545,7 @@ class LinuxHardware(Hardware):
 
             device, mount, fstype, options = fields[0], fields[1], fields[2], fields[3]
 
-            if not device.startswith(('/', '\\')) and ':/' not in device or fstype == 'none':
+            if not device.startswith(('/', '\\')) and ':/' not in device and fstype != 'zfs' or fstype == 'none':
                 continue
 
             mount_info = {'mount': mount,

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -539,7 +539,9 @@ class LinuxHardware(Hardware):
             'nfs',
             'zfs'
         ]
-        if device.startswith(('/', '\\')) or fstype in regular_filesystems:
+        if device.startswith(('/', '\\')) and fstype != 'none':
+            return False
+        if fstype in regular_filesystems:
             return False
         return True
 

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -526,6 +526,15 @@ class LinuxHardware(Hardware):
 
         return mount_size, uuid
 
+    @staticmethod
+    def _is_blocking_mount(device, fstype):
+        # The only mounts starting without slashes should be network mounts and ZFS
+        if not device.startswith(('/', '\\')) and fstype != 'zfs':
+            return True
+        if fstype == 'none':
+            return True
+        return False
+
     def get_mount_facts(self):
 
         mounts = []
@@ -545,7 +554,7 @@ class LinuxHardware(Hardware):
 
             device, mount, fstype, options = fields[0], fields[1], fields[2], fields[3]
 
-            if not device.startswith(('/', '\\')) and ':/' not in device and fstype != 'zfs' or fstype == 'none':
+            if self._is_blocking_mount(device, fstype):
                 continue
 
             mount_info = {'mount': mount,

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -515,6 +515,7 @@ class LinuxHardware(Hardware):
     def _replace_octal_escapes(self, value):
         return self.OCTAL_ESCAPE_RE.sub(self._replace_octal_escapes_helper, value)
 
+    @timeout.timeout(15)
     def get_mount_info(self, mount, device, uuids):
 
         mount_size = get_mount_size(mount)

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -528,7 +528,8 @@ class LinuxHardware(Hardware):
 
     @staticmethod
     def _is_blocking_mount(device, fstype):
-        # The only mounts starting without slashes should be network mounts and ZFS
+        # The only mounts starting without slashes should be network mounts, special filesystems
+        # and ZFS (which we want to keep)
         if not device.startswith(('/', '\\')) and fstype != 'zfs':
             return True
         if fstype == 'none':

--- a/test/units/module_utils/facts/hardware/linux_data.py
+++ b/test/units/module_utils/facts/hardware/linux_data.py
@@ -93,7 +93,7 @@ cgroup /sys/fs/cgroup/hugetlb cgroup rw,nosuid,nodev,noexec,relatime,hugetlb 0 0
 cgroup /sys/fs/cgroup/perf_event cgroup rw,nosuid,nodev,noexec,relatime,perf_event 0 0
 cgroup /sys/fs/cgroup/net_cls,net_prio cgroup rw,nosuid,nodev,noexec,relatime,net_cls,net_prio 0 0
 configfs /sys/kernel/config configfs rw,relatime 0 0
-pool1/root / zfs rw,relatime,xattr,noacl 0 0
+pool1/m.e-d_i:a /mnt/media zfs rw,relatime,xattr,noacl 0 0
 pool1/root:/var /var zfs rw,noatime,xattr,posixacl 0 0
 /dev/mapper/fedora_dhcp129--186-root / ext4 rw,seclabel,relatime,data=ordered 0 0
 selinuxfs /sys/fs/selinux selinuxfs rw,relatime 0 0
@@ -256,8 +256,8 @@ MTAB_ENTRIES = [
     ],
     ['configfs', '/sys/kernel/config', 'configfs', 'rw,relatime', '0', '0'],
     [
-        'pool1/root',
-        '/',
+        'pool1/m.e-d_i:a',
+        '/mnt/media',
         'zfs',
         'rw,relatime,xattr,noacl',
         '0',
@@ -337,6 +337,16 @@ MTAB_ENTRIES = [
         '0'
     ],
     ['fusectl', '/sys/fs/fuse/connections', 'fusectl', 'rw,relatime', '0', '0']]
+
+VALID_MOUNTS = [
+    'pool1/m.e-d_i:a',
+    'pool1/root:/var',
+    '/dev/mapper/fedora_dhcp129--186-root',
+    '/dev/loop0',
+    '/dev/sda1',
+    '/dev/sdz4',
+    '/dev/mapper/fedora_dhcp129--186-home'
+]
 
 STATVFS_INFO = {'/': {'block_available': 10192323,
                       'block_size': 4096,

--- a/test/units/module_utils/facts/hardware/linux_data.py
+++ b/test/units/module_utils/facts/hardware/linux_data.py
@@ -94,6 +94,7 @@ cgroup /sys/fs/cgroup/perf_event cgroup rw,nosuid,nodev,noexec,relatime,perf_eve
 cgroup /sys/fs/cgroup/net_cls,net_prio cgroup rw,nosuid,nodev,noexec,relatime,net_cls,net_prio 0 0
 configfs /sys/kernel/config configfs rw,relatime 0 0
 pool1/root / zfs rw,relatime,xattr,noacl 0 0
+pool1/root:/var /var zfs rw,noatime,xattr,posixacl 0 0
 /dev/mapper/fedora_dhcp129--186-root / ext4 rw,seclabel,relatime,data=ordered 0 0
 selinuxfs /sys/fs/selinux selinuxfs rw,relatime 0 0
 systemd-1 /proc/sys/fs/binfmt_misc autofs rw,relatime,fd=24,pgrp=1,timeout=0,minproto=5,maxproto=5,direct 0 0
@@ -255,10 +256,18 @@ MTAB_ENTRIES = [
     ],
     ['configfs', '/sys/kernel/config', 'configfs', 'rw,relatime', '0', '0'],
     [
-        'pool1/system/root',
+        'pool1/root',
         '/',
         'zfs',
         'rw,relatime,xattr,noacl',
+        '0',
+        '0'
+    ],
+    [
+        'pool1/root:/var',
+        '/var',
+        'zfs',
+        'rw,relatime,xattr,posixacl',
         '0',
         '0'
     ],

--- a/test/units/module_utils/facts/hardware/linux_data.py
+++ b/test/units/module_utils/facts/hardware/linux_data.py
@@ -93,6 +93,7 @@ cgroup /sys/fs/cgroup/hugetlb cgroup rw,nosuid,nodev,noexec,relatime,hugetlb 0 0
 cgroup /sys/fs/cgroup/perf_event cgroup rw,nosuid,nodev,noexec,relatime,perf_event 0 0
 cgroup /sys/fs/cgroup/net_cls,net_prio cgroup rw,nosuid,nodev,noexec,relatime,net_cls,net_prio 0 0
 configfs /sys/kernel/config configfs rw,relatime 0 0
+pool1/root / zfs rw,relatime,xattr,noacl 0 0
 /dev/mapper/fedora_dhcp129--186-root / ext4 rw,seclabel,relatime,data=ordered 0 0
 selinuxfs /sys/fs/selinux selinuxfs rw,relatime 0 0
 systemd-1 /proc/sys/fs/binfmt_misc autofs rw,relatime,fd=24,pgrp=1,timeout=0,minproto=5,maxproto=5,direct 0 0
@@ -253,6 +254,14 @@ MTAB_ENTRIES = [
         '0'
     ],
     ['configfs', '/sys/kernel/config', 'configfs', 'rw,relatime', '0', '0'],
+    [
+        'pool1/system/root',
+        '/',
+        'zfs',
+        'rw,relatime,xattr,noacl',
+        '0',
+        '0'
+    ],
     [
         '/dev/mapper/fedora_dhcp129--186-root',
         '/',

--- a/test/units/module_utils/facts/hardware/test_linux.py
+++ b/test/units/module_utils/facts/hardware/test_linux.py
@@ -95,7 +95,7 @@ class TestFactsLinuxHardwareGetMountFacts(unittest.TestCase):
         mtab_entries = lh._mtab_entries()
         self.assertIsInstance(mtab_entries, list)
         self.assertIsInstance(mtab_entries[0], list)
-        self.assertEqual(len(mtab_entries), 39)
+        self.assertEqual(len(mtab_entries), 40)
 
     @patch('ansible.module_utils.facts.hardware.linux.LinuxHardware._run_findmnt', return_value=(0, FINDMNT_OUTPUT, ''))
     def test_find_bind_mounts(self, mock_run_findmnt):

--- a/test/units/module_utils/facts/hardware/test_linux.py
+++ b/test/units/module_utils/facts/hardware/test_linux.py
@@ -89,7 +89,7 @@ class TestFactsLinuxHardwareGetMountFacts(unittest.TestCase):
 
         # Check that all mounts points were parsed correctly
         parsed_mounts = [m['device'] for m in mount_facts['mounts']]
-        self.assertListEqual(VALID_MOUNTS, parsed_mounts)
+        self.assertListEqual(sorted(VALID_MOUNTS), sorted(parsed_mounts))
 
     @patch('ansible.module_utils.facts.hardware.linux.get_file_content', return_value=MTAB)
     def test_get_mtab_entries(self, mock_get_file_content):

--- a/test/units/module_utils/facts/hardware/test_linux.py
+++ b/test/units/module_utils/facts/hardware/test_linux.py
@@ -95,7 +95,7 @@ class TestFactsLinuxHardwareGetMountFacts(unittest.TestCase):
         mtab_entries = lh._mtab_entries()
         self.assertIsInstance(mtab_entries, list)
         self.assertIsInstance(mtab_entries[0], list)
-        self.assertEqual(len(mtab_entries), 38)
+        self.assertEqual(len(mtab_entries), 39)
 
     @patch('ansible.module_utils.facts.hardware.linux.LinuxHardware._run_findmnt', return_value=(0, FINDMNT_OUTPUT, ''))
     def test_find_bind_mounts(self, mock_run_findmnt):

--- a/test/units/module_utils/facts/hardware/test_linux.py
+++ b/test/units/module_utils/facts/hardware/test_linux.py
@@ -25,7 +25,9 @@ from ansible.module_utils.facts import timeout
 
 from ansible.module_utils.facts.hardware import linux
 
-from . linux_data import LSBLK_OUTPUT, LSBLK_OUTPUT_2, LSBLK_UUIDS, MTAB, MTAB_ENTRIES, VALID_MOUNTS, BIND_MOUNTS, STATVFS_INFO, UDEVADM_UUID, UDEVADM_OUTPUT, SG_INQ_OUTPUTS
+from . linux_data import (
+    LSBLK_OUTPUT, LSBLK_OUTPUT_2, LSBLK_UUIDS, MTAB, MTAB_ENTRIES, VALID_MOUNTS, BIND_MOUNTS, STATVFS_INFO, UDEVADM_UUID, UDEVADM_OUTPUT, SG_INQ_OUTPUTS
+)
 
 with open(os.path.join(os.path.dirname(__file__), '../fixtures/findmount_output.txt')) as f:
     FINDMNT_OUTPUT = f.read()

--- a/test/units/module_utils/facts/hardware/test_linux.py
+++ b/test/units/module_utils/facts/hardware/test_linux.py
@@ -25,7 +25,7 @@ from ansible.module_utils.facts import timeout
 
 from ansible.module_utils.facts.hardware import linux
 
-from . linux_data import LSBLK_OUTPUT, LSBLK_OUTPUT_2, LSBLK_UUIDS, MTAB, MTAB_ENTRIES, BIND_MOUNTS, STATVFS_INFO, UDEVADM_UUID, UDEVADM_OUTPUT, SG_INQ_OUTPUTS
+from . linux_data import LSBLK_OUTPUT, LSBLK_OUTPUT_2, LSBLK_UUIDS, MTAB, MTAB_ENTRIES, VALID_MOUNTS, BIND_MOUNTS, STATVFS_INFO, UDEVADM_UUID, UDEVADM_OUTPUT, SG_INQ_OUTPUTS
 
 with open(os.path.join(os.path.dirname(__file__), '../fixtures/findmount_output.txt')) as f:
     FINDMNT_OUTPUT = f.read()
@@ -86,6 +86,10 @@ class TestFactsLinuxHardwareGetMountFacts(unittest.TestCase):
 
         self.maxDiff = 4096
         self.assertDictEqual(home_info, home_expected)
+
+        # Check that all mounts points were parsed correctly
+        parsed_mounts = [m['device'] for m in mount_facts['mounts']]
+        self.assertListEqual(VALID_MOUNTS, parsed_mounts)
 
     @patch('ansible.module_utils.facts.hardware.linux.get_file_content', return_value=MTAB)
     def test_get_mtab_entries(self, mock_get_file_content):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Show ZFS mounts in ansible_mounts for Linux.

Fixes #72658
Fixes #24644
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
`lib/ansible/module_utils/facts/hardware/linux.py`

##### ADDITIONAL INFORMATION
Before:
```
linux-zfs-host | SUCCESS => {                              
    "ansible_facts": {  
        "ansible_mounts": []
    },
    "changed": false
}
```    

After:
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
```
linux-zfs-host | SUCCESS => {                                         
    "ansible_facts": {
        "ansible_mounts": [
            {
                "block_available": 97982,
                "block_size": 131072,                                                           
                "block_total": 107498,                                                 
                "block_used": 9516,                                    
                "device": "pool1/root",                             
                "fstype": "zfs",                   
                "inode_available": 25083461,           
                "inode_total": 25170040,                                             
                "inode_used": 86579,           
                "mount": "/",                        
                "options": "rw,relatime,xattr,noacl",                                       
                "size_available": 12842696704,                                 
                "size_total": 14089977856,
                "uuid": "N/A"                         
            }
        ]
    },
    "changed": false
}
```                                                                                                                                                                                                                                                             