### PR TITLE
Adjust is_collection_path path detection with CLI

### DIFF
--- a/lib/ansible/collections/__init__.py
+++ b/lib/ansible/collections/__init__.py
@@ -8,7 +8,7 @@ import os
 
 from ansible.module_utils._text import to_bytes
 
-B_FLAG_FILES = frozenset([b'MANIFEST.json', b'galaxy.yml'])
+B_FLAG_FILES = frozenset([b'MANIFEST.json', b'galaxy.yml', b'galaxy.yaml'])
 
 
 def is_collection_path(path):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change essentially aligns what Galaxy CLI treats as a folder with a collection
with what `ansible.collections.is_collection_path()` does.

I originally spotted the difference while working on #72591.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Refactoring Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A