### PR TITLE
Add orig_exc context to error messages

### DIFF
--- a/changelogs/fragments/68605-ansible-error-orig-exc-context.yml
+++ b/changelogs/fragments/68605-ansible-error-orig-exc-context.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- Errors - Ensure that errors passed with ``orig_exc`` include the context of that exception
+  (https://github.com/ansible/ansible/issues/68605)

--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -70,7 +70,7 @@ class AnsibleError(Exception):
             extended_error = self._get_extended_error()
             if extended_error and not self._suppress_extended_error:
                 message.append(
-                    '\n\n%s' % (self._message, to_native(extended_error))
+                    '\n\n%s' % to_native(extended_error)
                 )
         elif self.orig_exc:
             message.append('. %s' % to_native(self.orig_exc))

--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -57,9 +57,7 @@ class AnsibleError(Exception):
         self._suppress_extended_error = suppress_extended_error
         self._message = to_native(message)
         self.obj = obj
-
-        if orig_exc:
-            self.orig_exc = orig_exc
+        self.orig_exc = orig_exc
 
     @property
     def message(self):
@@ -67,11 +65,17 @@ class AnsibleError(Exception):
         # since the objects code also imports ansible.errors
         from ansible.parsing.yaml.objects import AnsibleBaseYAMLObject
 
+        message = [self._message]
         if isinstance(self.obj, AnsibleBaseYAMLObject):
             extended_error = self._get_extended_error()
             if extended_error and not self._suppress_extended_error:
-                return '%s\n\n%s' % (self._message, to_native(extended_error))
-        return self._message
+                message.append(
+                    '\n\n%s' % (self._message, to_native(extended_error))
+                )
+        elif self.orig_exc:
+            message.append('. %s' % to_native(self.orig_exc))
+
+        return ''.join(message)
 
     @message.setter
     def message(self, val):


### PR DESCRIPTION
##### SUMMARY
Add orig_exc context to error messages. Fixes #68605

In https://github.com/ansible/ansible/commit/4befefd78c2a19c21e0252860f389d5bb7274eb0 we added support for displaying extra context of the original exception. That change was too verbose, and we limited how and when `orig_exc` was used in https://github.com/ansible/ansible/commit/9c6d7ddeb50eb1d0568d6c5b2f286991772b0396, which ended up removing useful information.

This PR, adds some of that back slightly, to use the original message and the original exception to build a simple message

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
```
lib/ansible/errors/__init__.py
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
