### PR TITLE
Remove incorrect changelog

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -802,7 +802,6 @@ releases:
       - ansible-galaxy - Requirement entries for collections now support a 'type'
         key to indicate whether the collection is a galaxy artifact, file, url, or
         git repo.
-      - ansible-galaxy - Support both 'galaxy.yml' and 'galaxy.yaml' files for collections.
       - ansible-galaxy - add ``--token`` argument which is the same as ``--api-key``
         (https://github.com/ansible/ansible/issues/65955)
       - ansible-galaxy - add ``collection list`` command for listing installed collections

--- a/changelogs/fragments/69154-install-collection-from-git-repo.yml
+++ b/changelogs/fragments/69154-install-collection-from-git-repo.yml
@@ -1,4 +1,3 @@
 minor_changes:
   - ansible-galaxy - Allow installing collections from git repositories.
   - ansible-galaxy - Requirement entries for collections now support a 'type' key to indicate whether the collection is a galaxy artifact, file, url, or git repo.
-  - ansible-galaxy - Support both 'galaxy.yml' and 'galaxy.yaml' files for collections.

--- a/lib/ansible/galaxy/collection.py
+++ b/lib/ansible/galaxy/collection.py
@@ -1548,10 +1548,4 @@ def _consume_file(read_from, write_to=None):
 
 
 def get_galaxy_metadata_path(b_path):
-    b_default_path = os.path.join(b_path, b'galaxy.yml')
-    candidate_names = [b'galaxy.yml', b'galaxy.yaml']
-    for b_name in candidate_names:
-        b_path = os.path.join(b_path, b_name)
-        if os.path.exists(b_path):
-            return b_path
-    return b_default_path
+    return os.path.join(b_path, b'galaxy.yml')


### PR DESCRIPTION
##### SUMMARY
I have no idea anymore what happened here, but this didn't ever work and it won't work in the future.

```python
for b_name in candidate_names:
    b_path = os.path.join(b_path, b_name)
```
ends up with a path like `/.../.../galaxy.yml/galaxy.yaml`

Related: https://github.com/ansible/ansible/pull/72665

##### ISSUE TYPE
- Docs Pull Request
