### PR TITLE
ansible-doc: replace DataLoader with from_yaml

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -28,7 +28,6 @@ from ansible.module_utils.common._collections_compat import Container, Sequence
 from ansible.module_utils.common.json import AnsibleJSONEncoder
 from ansible.module_utils.compat import importlib
 from ansible.module_utils.six import iteritems, string_types
-from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.plugin_docs import read_docstub
 from ansible.parsing.utils.yaml import from_yaml
 from ansible.parsing.yaml.dumper import AnsibleDumper
@@ -89,8 +88,8 @@ class RoleMixin(object):
         else:
             raise AnsibleError("A path is required to load argument specs for role '%s'" % role_name)
 
-        loader = DataLoader()
-        return loader.load_from_file(path, cache=False, unsafe=True)
+        with open(path, 'r') as f:
+            return yaml.safe_load(f)
 
     def _find_all_normal_roles(self, role_paths, name_filters=None):
         """Find all non-collection roles that have an argument spec file.

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -90,7 +90,7 @@ class RoleMixin(object):
 
         try:
             with open(path, 'r') as f:
-               return from_yaml(f.read(), file_name=path)
+                return from_yaml(f.read(), file_name=path)
         except (IOError, OSError) as e:
             raise AnsibleParserError("An error occurred while trying to read the file '%s': %s" % (path, to_native(e)), orig_exc=e)
 

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -88,12 +88,8 @@ class RoleMixin(object):
         else:
             raise AnsibleError("A path is required to load argument specs for role '%s'" % role_name)
 
-        try:
-            with open(path, 'r') as f:
-                return yaml.safe_load(f)
-        except Exception as e:
-            display.vvvvv("Unable to load %s: %s" % (path, to_native(e)))
-            return {}
+        with open(path, 'r') as f:
+            return from_yaml(f.read(), file_name=path)
 
 
     def _find_all_normal_roles(self, role_paths, name_filters=None):

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -91,7 +91,6 @@ class RoleMixin(object):
         with open(path, 'r') as f:
             return from_yaml(f.read(), file_name=path)
 
-
     def _find_all_normal_roles(self, role_paths, name_filters=None):
         """Find all non-collection roles that have an argument spec file.
 

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -88,8 +88,13 @@ class RoleMixin(object):
         else:
             raise AnsibleError("A path is required to load argument specs for role '%s'" % role_name)
 
-        with open(path, 'r') as f:
-            return yaml.safe_load(f)
+        try:
+            with open(path, 'r') as f:
+                return yaml.safe_load(f)
+        except Exception as e:
+            display.vvvvv("Unable to load %s: %s" % (path, to_native(e)))
+            return {}
+
 
     def _find_all_normal_roles(self, role_paths, name_filters=None):
         """Find all non-collection roles that have an argument spec file.


### PR DESCRIPTION
##### SUMMARY

Use of DataLoader was heavy handed for this. Just use from_yaml().

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-doc

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
