### PR TITLE
Backport/2.10/72390

### DIFF
--- a/changelogs/fragments/72390-return-error-if-cwd-directory-does-not-exist.yml
+++ b/changelogs/fragments/72390-return-error-if-cwd-directory-does-not-exist.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - basic.AnsibleModule - AnsibleModule.run_command silently ignores a non-existent directory in the ``cwd`` argument (https://github.com/ansible/ansible/pull/72390).

--- a/changelogs/fragments/run-command-cwd.yml
+++ b/changelogs/fragments/run-command-cwd.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - AnsibleModule - added arg ``ignore_invalid_cwd`` to ``AnsibleModule.run_command()``, to control its behaviour when ``cwd`` is invalid. (https://github.com/ansible/ansible/pull/72390)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2527,7 +2527,7 @@ class AnsibleModule(object):
 
     def run_command(self, args, check_rc=False, close_fds=True, executable=None, data=None, binary_data=False, path_prefix=None, cwd=None,
                     use_unsafe_shell=False, prompt_regex=None, environ_update=None, umask=None, encoding='utf-8', errors='surrogate_or_strict',
-                    expand_user_and_vars=True, pass_fds=None, before_communicate_callback=None):
+                    expand_user_and_vars=True, pass_fds=None, before_communicate_callback=None, ignore_invalid_cwd=True):
         '''
         Execute a command, returns rc, stdout, and stderr.
 
@@ -2578,6 +2578,9 @@ class AnsibleModule(object):
             after ``Popen`` object will be created
             but before communicating to the process.
             (``Popen`` object will be passed to callback as a first argument)
+        :kw ignore_invalid_cwd: This flag indicates whether an invalid ``cwd``
+            (non-existent or not a directory) should be ignored or should raise
+            an exception.
         :returns: A 3-tuple of return code (integer), stdout (native string),
             and stderr (native string).  On python2, stdout and stderr are both
             byte strings.  On python3, stdout and stderr are text strings converted
@@ -2691,14 +2694,17 @@ class AnsibleModule(object):
         prev_dir = os.getcwd()
 
         # make sure we're in the right working directory
-        if cwd and os.path.isdir(cwd):
-            cwd = to_bytes(os.path.abspath(os.path.expanduser(cwd)), errors='surrogate_or_strict')
-            kwargs['cwd'] = cwd
-            try:
-                os.chdir(cwd)
-            except (OSError, IOError) as e:
-                self.fail_json(rc=e.errno, msg="Could not open %s, %s" % (cwd, to_native(e)),
-                               exception=traceback.format_exc())
+        if cwd:
+            if os.path.isdir(cwd):
+                cwd = to_bytes(os.path.abspath(os.path.expanduser(cwd)), errors='surrogate_or_strict')
+                kwargs['cwd'] = cwd
+                try:
+                    os.chdir(cwd)
+                except (OSError, IOError) as e:
+                    self.fail_json(rc=e.errno, msg="Could not chdir to %s, %s" % (cwd, to_native(e)),
+                                   exception=traceback.format_exc())
+            elif not ignore_invalid_cwd:
+                self.fail_json(msg="Provided cwd is not a valid directory: %s" % cwd)
 
         old_umask = None
         if umask:

--- a/test/units/module_utils/basic/test_run_command.py
+++ b/test/units/module_utils/basic/test_run_command.py
@@ -180,6 +180,14 @@ class TestRunCommandCwd:
         rc_am.run_command('/bin/ls', cwd='/not-a-dir')
         assert rc_am._os.chdir.mock_calls == [mocker.call('/old'), ]
 
+    @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
+    def test_cwd_not_a_dir_noignore(self, rc_am):
+        rc_am._os.getcwd.return_value = '/old'
+        rc_am._os.path.isdir.side_effect = lambda d: d != '/not-a-dir'
+        with pytest.raises(SystemExit):
+            rc_am.run_command('/bin/ls', cwd='/not-a-dir', ignore_invalid_cwd=False)
+        assert rc_am.fail_json.called
+
 
 class TestRunCommandPrompt:
     @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])


### PR DESCRIPTION
##### SUMMARY
Backporting #72390

The method `AnsibleModule.run_command()` silently ignores the `cwd` parameter if the specified directory does not exist.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py

##### ADDITIONAL INFORMATION
This PR derives from the issue raised in the community.general repository:
https://github.com/ansible-collections/community.general/issues/630

The problem is in this part:
```python
        # make sure we're in the right working directory
        if cwd and os.path.isdir(cwd):
            cwd = to_bytes(os.path.abspath(os.path.expanduser(cwd)), errors='surrogate_or_strict')
            kwargs['cwd'] = cwd
            try:
                os.chdir(cwd)
            except (OSError, IOError) as e:
                self.fail_json(rc=e.errno, msg="Could not open %s, %s" % (cwd, to_native(e)),
                               exception=traceback.format_exc())

        old_umask = None
```
if `cwd` exists but it is not a valid directory, it silently moves on, eventually executing the command on the directory where the ansible process was before.