### PR TITLE
Ensure that the configured role skeleton does not apply to collection init

### DIFF
--- a/changelogs/fragments/66255-default-collection-skel.yml
+++ b/changelogs/fragments/66255-default-collection-skel.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- ansible-galaxy - Ensure that the configured role skeleton does not apply to collection init
+  (https://github.com/ansible/ansible/issues/66255)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -237,7 +237,7 @@ class GalaxyCLI(CLI):
                                  help='The path in which the skeleton {0} will be created. The default is the '
                                       'current working directory.'.format(galaxy_type))
         init_parser.add_argument('--{0}-skeleton'.format(galaxy_type), dest='{0}_skeleton'.format(galaxy_type),
-                                 default=C.GALAXY_ROLE_SKELETON,
+                                 default=C.GALAXY_ROLE_SKELETON if galaxy_type == 'role' else None,
                                  help='The path to a {0} skeleton that the new {0} should be based '
                                       'upon.'.format(galaxy_type))
 


### PR DESCRIPTION
##### SUMMARY
Ensure that the configured role skeleton does not apply to collection init

Fixes #66255
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/cli/galaxy.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
