### PR TITLE
Improve deprecations

### DIFF
--- a/changelogs/fragments/72697-improve-config-deprecations.yml
+++ b/changelogs/fragments/72697-improve-config-deprecations.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- "Improve Ansible config deprecations to show the source of the deprecation (ansible-core). Also remove space before a comma in config deprecations."
+- "Improve Ansible config deprecations to show the source of the deprecation (ansible-core). Also remove space before a comma in config deprecations (https://github.com/ansible/ansible/pull/72697)."

--- a/changelogs/fragments/72697-improve-config-deprecations.yml
+++ b/changelogs/fragments/72697-improve-config-deprecations.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "Improve Ansible config deprecations to show the source of the deprecation (ansible-core). Also remove space before a comma in config deprecations."

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -98,7 +98,7 @@ class CLI(with_metaclass(ABCMeta, object)):
             ver = deprecated[1].get('version')
             date = deprecated[1].get('date')
             collection_name = deprecated[1].get('collection_name')
-            display.deprecated("%s option, %s %s" % (name, why, alt),
+            display.deprecated("%s option, %s%s" % (name, why, alt),
                                version=ver, date=date, collection_name=collection_name)
 
     @staticmethod

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -4,7 +4,7 @@
 ALLOW_WORLD_READABLE_TMPFILES:
   name: Allow world-readable temporary files
   deprecated:
-    why: moved to a per plugin approach that is more flexible.
+    why: moved to a per plugin approach that is more flexible
     version: "2.14"
     alternatives: mostly the same config will work, but now controlled from the plugin itself and not using the general constant.
   default: False
@@ -438,7 +438,7 @@ COMMAND_WARNINGS:
   type: boolean
   version_added: "1.8"
   deprecated:
-    why: The command warnings feature is being removed.
+    why: the command warnings feature is being removed
     version: "2.14"
 LOCALHOST_WARNING:
   name: Warning when using implicit inventory with only localhost
@@ -1839,7 +1839,7 @@ PLUGIN_FILTERS_CFG:
   - key: plugin_filters_cfg
     section: default
     deprecated:
-      why: Specifying "plugin_filters_cfg" under the "default" section is deprecated
+      why: specifying "plugin_filters_cfg" under the "default" section is deprecated
       version: "2.12"
       alternatives: the "defaults" section instead
   - key: plugin_filters_cfg

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -43,7 +43,7 @@ ANSIBLE_COW_ACCEPTLIST:
   env:
   - name: ANSIBLE_COW_WHITELIST
     deprecated:
-      why: Normalizing names to new standard.
+      why: normalizing names to new standard
       version: "2.15"
       alternatives: 'ANSIBLE_COW_ACCEPTLIST'
   - name: ANSIBLE_COW_ACCEPTLIST
@@ -52,7 +52,7 @@ ANSIBLE_COW_ACCEPTLIST:
   - key: cow_whitelist
     section: defaults
     deprecated:
-      why: Normalizing names to new standard.
+      why: normalizing names to new standard
       version: "2.15"
       alternatives: 'cowsay_enabled_stencils'
   - key: cowsay_enabled_stencils
@@ -574,7 +574,7 @@ CALLABLE_ACCEPT_LIST:
   env:
   - name: ANSIBLE_CALLABLE_WHITELIST
     deprecated:
-      why: Normalizing names to new standard.
+      why: normalizing names to new standard
       version: "2.15"
       alternatives: 'ANSIBLE_CALLABLE_ENABLED'
   - name: ANSIBLE_CALLABLE_ENABLED
@@ -583,7 +583,7 @@ CALLABLE_ACCEPT_LIST:
   - key: callable_whitelist
     section: defaults
     deprecated:
-      why: Normalizing names to new standard.
+      why: normalizing names to new standard
       version: "2.15"
       alternatives: 'callable_enabled'
   - key: callable_enabled
@@ -617,7 +617,7 @@ CALLBACKS_ENABLED:
   env:
   - name: ANSIBLE_CALLBACK_WHITELIST
     deprecated:
-      why: Normalizing names to new standard.
+      why: normalizing names to new standard
       version: "2.15"
       alternatives: 'ANSIBLE_CALLBACKS_ENABLED'
   - name: ANSIBLE_CALLBACKS_ENABLED
@@ -626,7 +626,7 @@ CALLBACKS_ENABLED:
   - key: callback_whitelist
     section: defaults
     deprecated:
-      why: Normalizing names to new standard.
+      why: normalizing names to new standard
       version: "2.15"
       alternatives: 'callback_enabled'
   - key: callbacks_enabled
@@ -782,7 +782,7 @@ DEFAULT_HASH_BEHAVIOUR:
   ini:
   - {key: hash_behaviour, section: defaults}
   deprecated:
-    why: This feature is fragile and not portable, leading to continual confusion and misuse
+    why: this feature is fragile and not portable, leading to continual confusion and misuse
     version: "2.13"
     alternatives: the ``combine`` filter explicitly
 DEFAULT_HOST_LIST:

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -266,6 +266,20 @@ def find_ini_config_file(warnings=None):
     return path
 
 
+def _add_base_defs_deprecations(base_defs):
+    '''Add deprecation source 'ansible.builtin' to deprecations in base.yml'''
+    def process(entry):
+        if 'deprecated' in entry:
+            entry['deprecated']['collection_name'] = 'ansible.builtin'
+
+    for dummy, data in base_defs.items():
+        process(data)
+        for section in ('ini', 'env', 'vars'):
+            if section in data:
+                for entry in data[section]:
+                    process(entry)
+
+
 class ConfigManager(object):
 
     DEPRECATED = []
@@ -281,6 +295,7 @@ class ConfigManager(object):
         self.data = ConfigData()
 
         self._base_defs = self._read_config_yaml_file(defs_file or ('%s/base.yml' % os.path.dirname(__file__)))
+        _add_base_defs_deprecations(self._base_defs)
 
         if self._config_file is None:
             # set config using ini


### PR DESCRIPTION
##### SUMMARY
Right now, some deprecations coming from `lib/ansible/config/base.yml` are ugly and don't show where something is deprecated:
```
[DEPRECATION WARNING]: [defaults]callback_whitelist option, Normalizing names to new standard. , use callback_enabled instead. This feature will be removed 
in version 2.15. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: DEFAULT_HASH_BEHAVIOUR option, This feature is fragile and not portable, leading to continual confusion and misuse , use the 
``combine`` filter explicitly instead. This feature will be removed in version 2.13. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
```
This PR
 - adds source `ansible-core` (`collection_name: ansible.builtin`) to all deprecations in base.yml automatically;
 - removes the space before the comma of the `, use xxx instead` part;
 - adjusts some deprecation messages in base.yml to better fit in between two commas.

The above deprecation warnings will now be printed as:
```
[DEPRECATION WARNING]: [defaults]callback_whitelist option, normalizing names to new standard, use callback_enabled instead. This feature will be removed 
from ansible-core in version 2.15. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: DEFAULT_HASH_BEHAVIOUR option, this feature is fragile and not portable, leading to continual confusion and misuse, use the 
``combine`` filter explicitly instead. This feature will be removed from ansible-core in version 2.13. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
```

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
core
