### PR TITLE
[stable-2.9] Pull images from Quay to avoid Docker Hub limits

### DIFF
--- a/test/integration/targets/docker-registry/tasks/main.yml
+++ b/test/integration/targets/docker-registry/tasks/main.yml
@@ -37,7 +37,7 @@
     docker_container:
       state: stopped
       name: "{{ nginx_name }}"
-      image: nginx:alpine
+      image: quay.io/ansible/nga
       ports: 5000
       links:
         - "{{ registry_name }}:real-registry"

--- a/test/integration/targets/docker-registry/tasks/main.yml
+++ b/test/integration/targets/docker-registry/tasks/main.yml
@@ -37,7 +37,7 @@
     docker_container:
       state: stopped
       name: "{{ nginx_name }}"
-      image: quay.io/ansible/nga
+      image: quay.io/ansible/docker-test-containers:nginx-alpine
       ports: 5000
       links:
         - "{{ registry_name }}:real-registry"

--- a/test/integration/targets/docker-registry/tasks/tests/docker_image.yml
+++ b/test/integration/targets/docker-registry/tasks/tests/docker_image.yml
@@ -5,7 +5,7 @@
 
 - name: Determining pushed image names
   set_fact:
-    hello_world_image_base: "{{ registry_address }}/test/hello-world"
+    hello_world_image_base: "{{ registry_address }}/test/quay.io/ansible/hey"
     test_image_base: "{{ registry_address }}/test/{{ iname }}"
 
 - name: Registering image name
@@ -24,12 +24,12 @@
 
 - name: Make sure we have hello-world:latest
   docker_image:
-    name: hello-world:latest
+    name: quay.io/ansible/hey:latest
     source: pull
 
 - name: Push image to test registry
   docker_image:
-    name: "hello-world:latest"
+    name: "quay.io/ansible/hey:latest"
     repository: "{{ hello_world_image_base }}"
     push: yes
     source: local
@@ -37,7 +37,7 @@
 
 - name: Push image to test registry (idempotent)
   docker_image:
-    name: "hello-world:latest"
+    name: "quay.io/ansible/hey:latest"
     repository: "{{ hello_world_image_base }}"
     push: yes
     source: local
@@ -45,7 +45,7 @@
 
 - name: Push image to test registry (force, still idempotent)
   docker_image:
-    name: "hello-world:latest"
+    name: "quay.io/ansible/hey:latest"
     repository: "{{ hello_world_image_base }}"
     push: yes
     source: local

--- a/test/integration/targets/docker-registry/tasks/tests/docker_image.yml
+++ b/test/integration/targets/docker-registry/tasks/tests/docker_image.yml
@@ -5,7 +5,7 @@
 
 - name: Determining pushed image names
   set_fact:
-    hello_world_image_base: "{{ registry_address }}/test/quay.io/ansible/hey"
+    hello_world_image_base: "{{ registry_address }}/test/quay.io/ansible/docker-test-containers"
     test_image_base: "{{ registry_address }}/test/{{ iname }}"
 
 - name: Registering image name
@@ -22,14 +22,14 @@
     state: absent
     force_absent: yes
 
-- name: Make sure we have hello-world:latest
+- name: Make sure we have quay.io/ansible/docker-test-containers:hello-world
   docker_image:
-    name: quay.io/ansible/hey:latest
+    name: quay.io/ansible/docker-test-containers:hello-world
     source: pull
 
 - name: Push image to test registry
   docker_image:
-    name: "quay.io/ansible/hey:latest"
+    name: "quay.io/ansible/docker-test-containers:hello-world"
     repository: "{{ hello_world_image_base }}"
     push: yes
     source: local
@@ -37,7 +37,7 @@
 
 - name: Push image to test registry (idempotent)
   docker_image:
-    name: "quay.io/ansible/hey:latest"
+    name: "quay.io/ansible/docker-test-containers:hello-world"
     repository: "{{ hello_world_image_base }}"
     push: yes
     source: local
@@ -45,7 +45,7 @@
 
 - name: Push image to test registry (force, still idempotent)
   docker_image:
-    name: "quay.io/ansible/hey:latest"
+    name: "quay.io/ansible/docker-test-containers:hello-world"
     repository: "{{ hello_world_image_base }}"
     push: yes
     source: local

--- a/test/integration/targets/docker-registry/tasks/tests/docker_image.yml
+++ b/test/integration/targets/docker-registry/tasks/tests/docker_image.yml
@@ -5,7 +5,7 @@
 
 - name: Determining pushed image names
   set_fact:
-    hello_world_image_base: "{{ registry_address }}/test/quay.io/ansible/docker-test-containers"
+    hello_world_image_base: "{{ registry_address }}/test/hello-world"
     test_image_base: "{{ registry_address }}/test/{{ iname }}"
 
 - name: Registering image name
@@ -30,7 +30,7 @@
 - name: Push image to test registry
   docker_image:
     name: "quay.io/ansible/docker-test-containers:hello-world"
-    repository: "{{ hello_world_image_base }}"
+    repository: "{{ hello_world_image_base }}:latest"
     push: yes
     source: local
   register: push_1
@@ -38,7 +38,7 @@
 - name: Push image to test registry (idempotent)
   docker_image:
     name: "quay.io/ansible/docker-test-containers:hello-world"
-    repository: "{{ hello_world_image_base }}"
+    repository: "{{ hello_world_image_base }}:latest"
     push: yes
     source: local
   register: push_2
@@ -46,7 +46,7 @@
 - name: Push image to test registry (force, still idempotent)
   docker_image:
     name: "quay.io/ansible/docker-test-containers:hello-world"
-    repository: "{{ hello_world_image_base }}"
+    repository: "{{ hello_world_image_base }}:latest"
     push: yes
     source: local
     force_tag: yes

--- a/test/integration/targets/docker_container/tasks/tests/comparisons.yml
+++ b/test/integration/targets/docker_container/tasks/tests/comparisons.yml
@@ -12,7 +12,7 @@
 
 - name: value
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -21,7 +21,7 @@
 
 - name: value (change, ignore)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -33,7 +33,7 @@
 
 - name: value (change, strict)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -62,7 +62,7 @@
 
 - name: list
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -73,7 +73,7 @@
 
 - name: list (change, ignore)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -86,7 +86,7 @@
 
 - name: list (change, strict)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -116,7 +116,7 @@
 
 - name: set
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -127,7 +127,7 @@
 
 - name: set (change, ignore)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -142,7 +142,7 @@
 
 - name: set (change, allow_more_present)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -157,7 +157,7 @@
 
 - name: set (change, allow_more_present)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -171,7 +171,7 @@
 
 - name: set (change, strict)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -204,7 +204,7 @@
 
 - name: set(dict)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -215,7 +215,7 @@
 
 - name: set(dict) (change, ignore)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -230,7 +230,7 @@
 
 - name: set(dict) (change, allow_more_present)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -245,7 +245,7 @@
 
 - name: set(dict) (change, allow_more_present)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -259,7 +259,7 @@
 
 - name: set(dict) (change, strict)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -292,7 +292,7 @@
 
 - name: dict
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -303,7 +303,7 @@
 
 - name: dict (change, ignore)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -318,7 +318,7 @@
 
 - name: dict (change, allow_more_present)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -333,7 +333,7 @@
 
 - name: dict (change, allow_more_present)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -347,7 +347,7 @@
 
 - name: dict (change, strict)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -381,12 +381,12 @@
 - name: Pull hello-world image to make sure wildcard_2 test succeeds
   # If the image isn't there, it will pull it and return 'changed'.
   docker_image:
-    name: hello-world
+    name: quay.io/redhattraining/hello-world-nginx
     pull: true
 
 - name: wildcard
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -400,7 +400,7 @@
 
 - name: wildcard (change, ignore)
   docker_container:
-    image: hello-world
+    image: quay.io/redhattraining/hello-world-nginx
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -416,7 +416,7 @@
 
 - name: wildcard (change, strict)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -433,7 +433,7 @@
 
 - name: wildcard (no change, strict)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started

--- a/test/integration/targets/docker_container/tasks/tests/comparisons.yml
+++ b/test/integration/targets/docker_container/tasks/tests/comparisons.yml
@@ -12,7 +12,7 @@
 
 - name: value
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -21,7 +21,7 @@
 
 - name: value (change, ignore)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -33,7 +33,7 @@
 
 - name: value (change, strict)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -62,7 +62,7 @@
 
 - name: list
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -73,7 +73,7 @@
 
 - name: list (change, ignore)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -86,7 +86,7 @@
 
 - name: list (change, strict)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -116,7 +116,7 @@
 
 - name: set
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -127,7 +127,7 @@
 
 - name: set (change, ignore)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -142,7 +142,7 @@
 
 - name: set (change, allow_more_present)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -157,7 +157,7 @@
 
 - name: set (change, allow_more_present)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -171,7 +171,7 @@
 
 - name: set (change, strict)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -204,7 +204,7 @@
 
 - name: set(dict)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -215,7 +215,7 @@
 
 - name: set(dict) (change, ignore)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -230,7 +230,7 @@
 
 - name: set(dict) (change, allow_more_present)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -245,7 +245,7 @@
 
 - name: set(dict) (change, allow_more_present)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -259,7 +259,7 @@
 
 - name: set(dict) (change, strict)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -292,7 +292,7 @@
 
 - name: dict
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -303,7 +303,7 @@
 
 - name: dict (change, ignore)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -318,7 +318,7 @@
 
 - name: dict (change, allow_more_present)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -333,7 +333,7 @@
 
 - name: dict (change, allow_more_present)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -347,7 +347,7 @@
 
 - name: dict (change, strict)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -381,12 +381,12 @@
 - name: Pull hello-world image to make sure wildcard_2 test succeeds
   # If the image isn't there, it will pull it and return 'changed'.
   docker_image:
-    name: quay.io/redhattraining/hello-world-nginx
+    name: quay.io/ansible/hey
     pull: true
 
 - name: wildcard
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -400,7 +400,7 @@
 
 - name: wildcard (change, ignore)
   docker_container:
-    image: quay.io/redhattraining/hello-world-nginx
+    image: quay.io/ansible/hey
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -416,7 +416,7 @@
 
 - name: wildcard (change, strict)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -433,7 +433,7 @@
 
 - name: wildcard (no change, strict)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started

--- a/test/integration/targets/docker_container/tasks/tests/comparisons.yml
+++ b/test/integration/targets/docker_container/tasks/tests/comparisons.yml
@@ -12,7 +12,7 @@
 
 - name: value
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -21,7 +21,7 @@
 
 - name: value (change, ignore)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -33,7 +33,7 @@
 
 - name: value (change, strict)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -62,7 +62,7 @@
 
 - name: list
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -73,7 +73,7 @@
 
 - name: list (change, ignore)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -86,7 +86,7 @@
 
 - name: list (change, strict)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -116,7 +116,7 @@
 
 - name: set
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -127,7 +127,7 @@
 
 - name: set (change, ignore)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -142,7 +142,7 @@
 
 - name: set (change, allow_more_present)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -157,7 +157,7 @@
 
 - name: set (change, allow_more_present)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -171,7 +171,7 @@
 
 - name: set (change, strict)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -204,7 +204,7 @@
 
 - name: set(dict)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -215,7 +215,7 @@
 
 - name: set(dict) (change, ignore)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -230,7 +230,7 @@
 
 - name: set(dict) (change, allow_more_present)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -245,7 +245,7 @@
 
 - name: set(dict) (change, allow_more_present)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -259,7 +259,7 @@
 
 - name: set(dict) (change, strict)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -292,7 +292,7 @@
 
 - name: dict
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -303,7 +303,7 @@
 
 - name: dict (change, ignore)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -318,7 +318,7 @@
 
 - name: dict (change, allow_more_present)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -333,7 +333,7 @@
 
 - name: dict (change, allow_more_present)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -347,7 +347,7 @@
 
 - name: dict (change, strict)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -381,12 +381,12 @@
 - name: Pull hello-world image to make sure wildcard_2 test succeeds
   # If the image isn't there, it will pull it and return 'changed'.
   docker_image:
-    name: quay.io/ansible/hey
+    name: quay.io/ansible/docker-test-containers:hello-world
     pull: true
 
 - name: wildcard
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -400,7 +400,7 @@
 
 - name: wildcard (change, ignore)
   docker_container:
-    image: quay.io/ansible/hey
+    image: quay.io/ansible/docker-test-containers:hello-world
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -416,7 +416,7 @@
 
 - name: wildcard (change, strict)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -433,7 +433,7 @@
 
 - name: wildcard (no change, strict)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started

--- a/test/integration/targets/docker_container/tasks/tests/image-ids.yml
+++ b/test/integration/targets/docker_container/tasks/tests/image-ids.yml
@@ -106,7 +106,7 @@
 - name: set Digests
   set_fact:
     digest_hello_world_v1_29: e004c2cc521c95383aebb1fb5893719aa7a8eae2e7a71f316a4410784edb00a9
-    digest_hello_world_v1_32: c9249fdf56138f0d929e2080ae98ee9cb2946f71498fc1484288e6a935b5e5bc
+    digest_hello_world_v1_32: ee44b399df993016003bf5466bd3eeb221305e9d0fa831606bc7902d149c775b
 
 - name: Create container with busybox image via old digest
   docker_container:

--- a/test/integration/targets/docker_container/tasks/tests/image-ids.yml
+++ b/test/integration/targets/docker_container/tasks/tests/image-ids.yml
@@ -11,16 +11,16 @@
     name: "{{ image }}"
     source: pull
   loop:
-    - "quay.io/app-sre/busybox:latest"
-    - "quay.io/app-sre/alpine:3.8"
+    - "quay.io/ansible/bb:latest"
+    - "quay.io/ansible/mountainous:3.8"
   loop_control:
     loop_var: image
 
 - name: Get image ID of busybox and alpine images
   docker_image_info:
     name:
-    - "quay.io/app-sre/busybox:latest"
-    - "quay.io/app-sre/alpine:3.8"
+    - "quay.io/ansible/bb:latest"
+    - "quay.io/ansible/mountainous:3.8"
   register: image_info
 
 - assert:
@@ -29,7 +29,7 @@
 
 - name: Print image IDs
   debug:
-    msg: "busybox: {{ image_info.images[0].Id }}; alpine: {{ image_info.images[1].Id }}"
+    msg: "busybox: {{ image_info.images[0].Id }}; quay.io/ansible/mountainous {{ image_info.images[1].Id }}"
 
 - name: Create container with busybox image via ID
   docker_container:
@@ -66,13 +66,13 @@
 - name: Untag image
   # Image will not be deleted since the container still uses it
   docker_image:
-    name: quay.io/app-sre/alpine:3.8
+    name: quay.io/ansible/mountainous:3.8
     force_absent: yes
     state: absent
 
 - name: Create container with alpine image via name (check mode, will pull, same image)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     name: "{{ cname }}"
     state: present
   register: create_5
@@ -80,7 +80,7 @@
 
 - name: Create container with alpine image via name (will pull, same image)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     name: "{{ cname }}"
     state: present
   register: create_6
@@ -110,7 +110,7 @@
 
 - name: Create container with busybox image via old digest
   docker_container:
-    image: "quay.io/app-sre/busybox@sha256:{{ digest_hello_world_v1_29 }}"
+    image: "quay.io/ansible/bb@sha256:{{ digest_hello_world_v1_29 }}"
     name: "{{ cname }}"
     state: present
     force_kill: yes
@@ -118,7 +118,7 @@
 
 - name: Create container with busybox image via old digest (idempotent)
   docker_container:
-    image: "quay.io/app-sre/busybox@sha256:{{ digest_hello_world_v1_29 }}"
+    image: "quay.io/ansible/bb@sha256:{{ digest_hello_world_v1_29 }}"
     name: "{{ cname }}"
     state: present
     force_kill: yes
@@ -126,7 +126,7 @@
 
 - name: Update container with busybox image via new digest
   docker_container:
-    image: "quay.io/app-sre/busybox@sha256:{{ digest_hello_world_v1_32 }}"
+    image: "quay.io/ansible/bb@sha256:{{ digest_hello_world_v1_32 }}"
     name: "{{ cname }}"
     state: present
     force_kill: yes

--- a/test/integration/targets/docker_container/tasks/tests/image-ids.yml
+++ b/test/integration/targets/docker_container/tasks/tests/image-ids.yml
@@ -11,15 +11,15 @@
     name: "{{ image }}"
     source: pull
   loop:
-    - "quay.io/redhattraining/hello-world-nginx:latest"
+    - "quay.io/app-sre/busybox:latest"
     - "quay.io/app-sre/alpine:3.8"
   loop_control:
     loop_var: image
 
-- name: Get image ID of hello-world and alpine images
+- name: Get image ID of busybox and alpine images
   docker_image_info:
     name:
-    - "quay.io/redhattraining/hello-world-nginx:latest"
+    - "quay.io/app-sre/busybox:latest"
     - "quay.io/app-sre/alpine:3.8"
   register: image_info
 
@@ -29,9 +29,9 @@
 
 - name: Print image IDs
   debug:
-    msg: "hello-world: {{ image_info.images[0].Id }}; alpine: {{ image_info.images[1].Id }}"
+    msg: "busybox: {{ image_info.images[0].Id }}; alpine: {{ image_info.images[1].Id }}"
 
-- name: Create container with hello-world image via ID
+- name: Create container with busybox image via ID
   docker_container:
     image: "{{ image_info.images[0].Id }}"
     name: "{{ cname }}"
@@ -39,7 +39,7 @@
     force_kill: yes
   register: create_1
 
-- name: Create container with hello-world image via ID (idempotent)
+- name: Create container with busybox image via ID (idempotent)
   docker_container:
     image: "{{ image_info.images[0].Id }}"
     name: "{{ cname }}"
@@ -105,28 +105,28 @@
 
 - name: set Digests
   set_fact:
-    digest_hello_world_v1: 941928d702a2f08c986017b1eed3417d83952f05de55d657787512e82714dd89
-    digest_hello_world_latest: 7f99ece5f39bf8d5d76a43cd9104a8d0a39f7135821b94bc1ebdc39cdc6dd63b
+    digest_hello_world_v1_29: e004c2cc521c95383aebb1fb5893719aa7a8eae2e7a71f316a4410784edb00a9
+    digest_hello_world_v1_32: c9249fdf56138f0d929e2080ae98ee9cb2946f71498fc1484288e6a935b5e5bc
 
-- name: Create container with hello-world image via old digest
+- name: Create container with busybox image via old digest
   docker_container:
-    image: "quay.io/redhattraining/hello-world-nginx@sha256:{{ digest_hello_world_v1 }}"
+    image: "quay.io/app-sre/busybox@sha256:{{ digest_hello_world_v1_29 }}"
     name: "{{ cname }}"
     state: present
     force_kill: yes
   register: digest_1
 
-- name: Create container with hello-world image via old digest (idempotent)
+- name: Create container with busybox image via old digest (idempotent)
   docker_container:
-    image: "quay.io/redhattraining/hello-world-nginx@sha256:{{ digest_hello_world_v1 }}"
+    image: "quay.io/app-sre/busybox@sha256:{{ digest_hello_world_v1_29 }}"
     name: "{{ cname }}"
     state: present
     force_kill: yes
   register: digest_2
 
-- name: Update container with hello-world image via new digest
+- name: Update container with busybox image via new digest
   docker_container:
-    image: "quay.io/redhattraining/hello-world-nginx@sha256:{{ digest_hello_world_latest }}"
+    image: "quay.io/app-sre/busybox@sha256:{{ digest_hello_world_v1_32 }}"
     name: "{{ cname }}"
     state: present
     force_kill: yes

--- a/test/integration/targets/docker_container/tasks/tests/image-ids.yml
+++ b/test/integration/targets/docker_container/tasks/tests/image-ids.yml
@@ -11,16 +11,16 @@
     name: "{{ image }}"
     source: pull
   loop:
-    - "quay.io/ansible/bb:latest"
-    - "quay.io/ansible/mountainous:3.8"
+    - "quay.io/ansible/docker-test-containers:busybox"
+    - "quay.io/ansible/docker-test-containers:alpine3.8"
   loop_control:
     loop_var: image
 
 - name: Get image ID of busybox and alpine images
   docker_image_info:
     name:
-    - "quay.io/ansible/bb:latest"
-    - "quay.io/ansible/mountainous:3.8"
+    - "quay.io/ansible/docker-test-containers:busybox"
+    - "quay.io/ansible/docker-test-containers:alpine3.8"
   register: image_info
 
 - assert:
@@ -66,13 +66,13 @@
 - name: Untag image
   # Image will not be deleted since the container still uses it
   docker_image:
-    name: quay.io/ansible/mountainous:3.8
+    name: quay.io/ansible/docker-test-containers:alpine3.8
     force_absent: yes
     state: absent
 
 - name: Create container with alpine image via name (check mode, will pull, same image)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     name: "{{ cname }}"
     state: present
   register: create_5
@@ -80,7 +80,7 @@
 
 - name: Create container with alpine image via name (will pull, same image)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     name: "{{ cname }}"
     state: present
   register: create_6
@@ -105,12 +105,12 @@
 
 - name: set Digests
   set_fact:
-    digest_hello_world_v1_29: e004c2cc521c95383aebb1fb5893719aa7a8eae2e7a71f316a4410784edb00a9
-    digest_hello_world_v1_32: ee44b399df993016003bf5466bd3eeb221305e9d0fa831606bc7902d149c775b
+    digest_busybox_v1_29: e004c2cc521c95383aebb1fb5893719aa7a8eae2e7a71f316a4410784edb00a9
+    digest_busybox_v1_32: ee44b399df993016003bf5466bd3eeb221305e9d0fa831606bc7902d149c775b
 
 - name: Create container with busybox image via old digest
   docker_container:
-    image: "quay.io/ansible/bb@sha256:{{ digest_hello_world_v1_29 }}"
+    image: "quay.io/ansible/docker-test-containers@sha256:{{ digest_busybox_v1_29 }}"
     name: "{{ cname }}"
     state: present
     force_kill: yes
@@ -118,7 +118,7 @@
 
 - name: Create container with busybox image via old digest (idempotent)
   docker_container:
-    image: "quay.io/ansible/bb@sha256:{{ digest_hello_world_v1_29 }}"
+    image: "quay.io/ansible/docker-test-containers@sha256:{{ digest_busybox_v1_29 }}"
     name: "{{ cname }}"
     state: present
     force_kill: yes
@@ -126,7 +126,7 @@
 
 - name: Update container with busybox image via new digest
   docker_container:
-    image: "quay.io/ansible/bb@sha256:{{ digest_hello_world_v1_32 }}"
+    image: "quay.io/ansible/docker-test-containers@sha256:{{ digest_busybox_v1_32 }}"
     name: "{{ cname }}"
     state: present
     force_kill: yes

--- a/test/integration/targets/docker_container/tasks/tests/image-ids.yml
+++ b/test/integration/targets/docker_container/tasks/tests/image-ids.yml
@@ -29,7 +29,7 @@
 
 - name: Print image IDs
   debug:
-    msg: "busybox: {{ image_info.images[0].Id }}; quay.io/ansible/mountainous {{ image_info.images[1].Id }}"
+    msg: "busybox: {{ image_info.images[0].Id }}; alpine {{ image_info.images[1].Id }}"
 
 - name: Create container with busybox image via ID
   docker_container:

--- a/test/integration/targets/docker_container/tasks/tests/image-ids.yml
+++ b/test/integration/targets/docker_container/tasks/tests/image-ids.yml
@@ -105,8 +105,8 @@
 
 - name: set Digests
   set_fact:
-    digest_hello_world_v1: 4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
-    digest_hello_world_latest: 4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
+    digest_hello_world_v1: 941928d702a2f08c986017b1eed3417d83952f05de55d657787512e82714dd89
+    digest_hello_world_latest: 7f99ece5f39bf8d5d76a43cd9104a8d0a39f7135821b94bc1ebdc39cdc6dd63b
 
 - name: Create container with hello-world image via old digest
   docker_container:

--- a/test/integration/targets/docker_container/tasks/tests/image-ids.yml
+++ b/test/integration/targets/docker_container/tasks/tests/image-ids.yml
@@ -11,16 +11,16 @@
     name: "{{ image }}"
     source: pull
   loop:
-    - "hello-world:latest"
-    - "alpine:3.8"
+    - "quay.io/redhattraining/hello-world-nginx:latest"
+    - "quay.io/app-sre/alpine:3.8"
   loop_control:
     loop_var: image
 
 - name: Get image ID of hello-world and alpine images
   docker_image_info:
     name:
-    - "hello-world:latest"
-    - "alpine:3.8"
+    - "quay.io/redhattraining/hello-world-nginx:latest"
+    - "quay.io/app-sre/alpine:3.8"
   register: image_info
 
 - assert:
@@ -66,13 +66,13 @@
 - name: Untag image
   # Image will not be deleted since the container still uses it
   docker_image:
-    name: alpine:3.8
+    name: quay.io/app-sre/alpine:3.8
     force_absent: yes
     state: absent
 
 - name: Create container with alpine image via name (check mode, will pull, same image)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     name: "{{ cname }}"
     state: present
   register: create_5
@@ -80,7 +80,7 @@
 
 - name: Create container with alpine image via name (will pull, same image)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     name: "{{ cname }}"
     state: present
   register: create_6
@@ -105,12 +105,12 @@
 
 - name: set Digests
   set_fact:
-    digest_hello_world_2016: 0256e8a36e2070f7bf2d0b0763dbabdd67798512411de4cdcf9431a1feb60fd9
-    digest_hello_world_2019: 2557e3c07ed1e38f26e389462d03ed943586f744621577a99efb77324b0fe535
+    digest_hello_world_v1: 4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
+    digest_hello_world_latest: 4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
 
 - name: Create container with hello-world image via old digest
   docker_container:
-    image: "hello-world@sha256:{{ digest_hello_world_2016 }}"
+    image: "quay.io/redhattraining/hello-world-nginx@sha256:{{ digest_hello_world_v1 }}"
     name: "{{ cname }}"
     state: present
     force_kill: yes
@@ -118,7 +118,7 @@
 
 - name: Create container with hello-world image via old digest (idempotent)
   docker_container:
-    image: "hello-world@sha256:{{ digest_hello_world_2016 }}"
+    image: "quay.io/redhattraining/hello-world-nginx@sha256:{{ digest_hello_world_v1 }}"
     name: "{{ cname }}"
     state: present
     force_kill: yes
@@ -126,7 +126,7 @@
 
 - name: Update container with hello-world image via new digest
   docker_container:
-    image: "hello-world@sha256:{{ digest_hello_world_2019 }}"
+    image: "quay.io/redhattraining/hello-world-nginx@sha256:{{ digest_hello_world_latest }}"
     name: "{{ cname }}"
     state: present
     force_kill: yes

--- a/test/integration/targets/docker_container/tasks/tests/mounts-volumes.yml
+++ b/test/integration/targets/docker_container/tasks/tests/mounts-volumes.yml
@@ -20,7 +20,7 @@
 
 - name: mounts
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -37,7 +37,7 @@
 
 - name: mounts (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -54,7 +54,7 @@
 
 - name: mounts (less mounts)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -67,7 +67,7 @@
 
 - name: mounts (more mounts)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -85,7 +85,7 @@
 
 - name: mounts (different modes)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -103,7 +103,7 @@
 
 - name: mounts (endpoint collision)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -149,7 +149,7 @@
 
 - name: mounts + volumes
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -165,7 +165,7 @@
 
 - name: mounts + volumes (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -181,7 +181,7 @@
 
 - name: mounts + volumes (switching)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -198,7 +198,7 @@
 
 - name: mounts + volumes (collision, should fail)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -241,7 +241,7 @@
 
 - name: volume_driver
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     volume_driver: local
@@ -250,7 +250,7 @@
 
 - name: volume_driver (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     volume_driver: local
@@ -259,7 +259,7 @@
 
 - name: volume_driver (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     volume_driver: /
@@ -286,7 +286,7 @@
 
 - name: volumes
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -297,7 +297,7 @@
 
 - name: volumes (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -308,7 +308,7 @@
 
 - name: volumes (less volumes)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -318,7 +318,7 @@
 
 - name: volumes (more volumes)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -330,7 +330,7 @@
 
 - name: volumes (different modes)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -342,7 +342,7 @@
 
 - name: volumes (collision)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -376,7 +376,7 @@
 
 - name: start helpers
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ container_name }}"
     state: started
@@ -390,7 +390,7 @@
 
 - name: volumes_from
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -399,7 +399,7 @@
 
 - name: volumes_from (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -408,7 +408,7 @@
 
 - name: volumes_from (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started

--- a/test/integration/targets/docker_container/tasks/tests/mounts-volumes.yml
+++ b/test/integration/targets/docker_container/tasks/tests/mounts-volumes.yml
@@ -20,7 +20,7 @@
 
 - name: mounts
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -37,7 +37,7 @@
 
 - name: mounts (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -54,7 +54,7 @@
 
 - name: mounts (less mounts)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -67,7 +67,7 @@
 
 - name: mounts (more mounts)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -85,7 +85,7 @@
 
 - name: mounts (different modes)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -103,7 +103,7 @@
 
 - name: mounts (endpoint collision)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -149,7 +149,7 @@
 
 - name: mounts + volumes
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -165,7 +165,7 @@
 
 - name: mounts + volumes (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -181,7 +181,7 @@
 
 - name: mounts + volumes (switching)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -198,7 +198,7 @@
 
 - name: mounts + volumes (collision, should fail)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -241,7 +241,7 @@
 
 - name: volume_driver
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     volume_driver: local
@@ -250,7 +250,7 @@
 
 - name: volume_driver (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     volume_driver: local
@@ -259,7 +259,7 @@
 
 - name: volume_driver (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     volume_driver: /
@@ -286,7 +286,7 @@
 
 - name: volumes
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -297,7 +297,7 @@
 
 - name: volumes (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -308,7 +308,7 @@
 
 - name: volumes (less volumes)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -318,7 +318,7 @@
 
 - name: volumes (more volumes)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -330,7 +330,7 @@
 
 - name: volumes (different modes)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -342,7 +342,7 @@
 
 - name: volumes (collision)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -376,7 +376,7 @@
 
 - name: start helpers
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ container_name }}"
     state: started
@@ -390,7 +390,7 @@
 
 - name: volumes_from
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -399,7 +399,7 @@
 
 - name: volumes_from (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -408,7 +408,7 @@
 
 - name: volumes_from (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started

--- a/test/integration/targets/docker_container/tasks/tests/mounts-volumes.yml
+++ b/test/integration/targets/docker_container/tasks/tests/mounts-volumes.yml
@@ -20,7 +20,7 @@
 
 - name: mounts
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -37,7 +37,7 @@
 
 - name: mounts (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -54,7 +54,7 @@
 
 - name: mounts (less mounts)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -67,7 +67,7 @@
 
 - name: mounts (more mounts)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -85,7 +85,7 @@
 
 - name: mounts (different modes)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -103,7 +103,7 @@
 
 - name: mounts (endpoint collision)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -149,7 +149,7 @@
 
 - name: mounts + volumes
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -165,7 +165,7 @@
 
 - name: mounts + volumes (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -181,7 +181,7 @@
 
 - name: mounts + volumes (switching)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -198,7 +198,7 @@
 
 - name: mounts + volumes (collision, should fail)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -241,7 +241,7 @@
 
 - name: volume_driver
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     volume_driver: local
@@ -250,7 +250,7 @@
 
 - name: volume_driver (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     volume_driver: local
@@ -259,7 +259,7 @@
 
 - name: volume_driver (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     volume_driver: /
@@ -286,7 +286,7 @@
 
 - name: volumes
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -297,7 +297,7 @@
 
 - name: volumes (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -308,7 +308,7 @@
 
 - name: volumes (less volumes)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -318,7 +318,7 @@
 
 - name: volumes (more volumes)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -330,7 +330,7 @@
 
 - name: volumes (different modes)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -342,7 +342,7 @@
 
 - name: volumes (collision)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -376,7 +376,7 @@
 
 - name: start helpers
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ container_name }}"
     state: started
@@ -390,7 +390,7 @@
 
 - name: volumes_from
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -399,7 +399,7 @@
 
 - name: volumes_from (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -408,7 +408,7 @@
 
 - name: volumes_from (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started

--- a/test/integration/targets/docker_container/tasks/tests/network.yml
+++ b/test/integration/targets/docker_container/tasks/tests/network.yml
@@ -54,7 +54,7 @@
 
 - name: network_mode
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -63,7 +63,7 @@
 
 - name: network_mode (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -72,7 +72,7 @@
 
 - name: network_mode (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -82,7 +82,7 @@
 
 - name: network_mode (container mode setup)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname_h1 }}"
     state: started
@@ -90,7 +90,7 @@
 
 - name: network_mode (container mode)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -100,7 +100,7 @@
 
 - name: network_mode (container mode idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -139,7 +139,7 @@
 - block:
   - name: networks_cli_compatible=no, networks w/o purge_networks
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -151,7 +151,7 @@
 
   - name: networks_cli_compatible=no, networks w/o purge_networks
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -163,7 +163,7 @@
 
   - name: networks_cli_compatible=no, networks, purge_networks
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -177,7 +177,7 @@
 
   - name: networks_cli_compatible=no, networks, purge_networks (idempotency)
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -190,7 +190,7 @@
 
   - name: networks_cli_compatible=no, networks (less networks)
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -201,7 +201,7 @@
 
   - name: networks_cli_compatible=no, networks, purge_networks (less networks)
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -214,7 +214,7 @@
 
   - name: networks_cli_compatible=no, networks, purge_networks (more networks)
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -281,7 +281,7 @@
 - block:
   - name: networks_cli_compatible=yes, networks specified
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -296,7 +296,7 @@
 
   - name: networks_cli_compatible=yes, networks specified
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -315,7 +315,7 @@
 
   - name: networks_cli_compatible=yes, empty networks list specified
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -325,7 +325,7 @@
 
   - name: networks_cli_compatible=yes, empty networks list specified
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -335,7 +335,7 @@
 
   - name: networks_cli_compatible=yes, empty networks list specified, purge_networks
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -354,7 +354,7 @@
 
   - name: networks_cli_compatible=yes, networks not specified
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -364,7 +364,7 @@
 
   - name: networks_cli_compatible=yes, networks not specified
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -373,7 +373,7 @@
 
   - name: networks_cli_compatible=yes, networks not specified, purge_networks
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -435,7 +435,7 @@
 - block:
   - name: create container with one network
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -446,7 +446,7 @@
 
   - name: different networks, comparisons=ignore
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -459,7 +459,7 @@
 
   - name: less networks, comparisons=ignore
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -471,7 +471,7 @@
 
   - name: less networks, comparisons=allow_more_present
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -483,7 +483,7 @@
 
   - name: different networks, comparisons=allow_more_present
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -497,7 +497,7 @@
 
   - name: different networks, comparisons=strict
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -511,7 +511,7 @@
 
   - name: less networks, comparisons=strict
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -569,7 +569,7 @@
 - block:
   - name: create container (stopped) with one network and fixed IP
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: stopped
@@ -582,7 +582,7 @@
 
   - name: create container (stopped) with one network and fixed IP (idempotent)
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: stopped
@@ -595,7 +595,7 @@
 
   - name: create container (stopped) with one network and fixed IP (different IPv4)
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: stopped
@@ -608,7 +608,7 @@
 
   - name: create container (stopped) with one network and fixed IP (different IPv6)
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: stopped
@@ -627,7 +627,7 @@
 
   - name: create container (started) with one network and fixed IP (different IPv4)
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -641,7 +641,7 @@
 
   - name: create container (started) with one network and fixed IP (different IPv6)
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -655,7 +655,7 @@
 
   - name: create container (started) with one network and fixed IP (idempotent)
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started

--- a/test/integration/targets/docker_container/tasks/tests/network.yml
+++ b/test/integration/targets/docker_container/tasks/tests/network.yml
@@ -54,7 +54,7 @@
 
 - name: network_mode
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -63,7 +63,7 @@
 
 - name: network_mode (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -72,7 +72,7 @@
 
 - name: network_mode (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -82,7 +82,7 @@
 
 - name: network_mode (container mode setup)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname_h1 }}"
     state: started
@@ -90,7 +90,7 @@
 
 - name: network_mode (container mode)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -100,7 +100,7 @@
 
 - name: network_mode (container mode idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -139,7 +139,7 @@
 - block:
   - name: networks_cli_compatible=no, networks w/o purge_networks
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -151,7 +151,7 @@
 
   - name: networks_cli_compatible=no, networks w/o purge_networks
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -163,7 +163,7 @@
 
   - name: networks_cli_compatible=no, networks, purge_networks
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -177,7 +177,7 @@
 
   - name: networks_cli_compatible=no, networks, purge_networks (idempotency)
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -190,7 +190,7 @@
 
   - name: networks_cli_compatible=no, networks (less networks)
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -201,7 +201,7 @@
 
   - name: networks_cli_compatible=no, networks, purge_networks (less networks)
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -214,7 +214,7 @@
 
   - name: networks_cli_compatible=no, networks, purge_networks (more networks)
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -281,7 +281,7 @@
 - block:
   - name: networks_cli_compatible=yes, networks specified
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -296,7 +296,7 @@
 
   - name: networks_cli_compatible=yes, networks specified
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -315,7 +315,7 @@
 
   - name: networks_cli_compatible=yes, empty networks list specified
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -325,7 +325,7 @@
 
   - name: networks_cli_compatible=yes, empty networks list specified
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -335,7 +335,7 @@
 
   - name: networks_cli_compatible=yes, empty networks list specified, purge_networks
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -354,7 +354,7 @@
 
   - name: networks_cli_compatible=yes, networks not specified
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -364,7 +364,7 @@
 
   - name: networks_cli_compatible=yes, networks not specified
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -373,7 +373,7 @@
 
   - name: networks_cli_compatible=yes, networks not specified, purge_networks
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -435,7 +435,7 @@
 - block:
   - name: create container with one network
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -446,7 +446,7 @@
 
   - name: different networks, comparisons=ignore
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -459,7 +459,7 @@
 
   - name: less networks, comparisons=ignore
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -471,7 +471,7 @@
 
   - name: less networks, comparisons=allow_more_present
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -483,7 +483,7 @@
 
   - name: different networks, comparisons=allow_more_present
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -497,7 +497,7 @@
 
   - name: different networks, comparisons=strict
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -511,7 +511,7 @@
 
   - name: less networks, comparisons=strict
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -569,7 +569,7 @@
 - block:
   - name: create container (stopped) with one network and fixed IP
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: stopped
@@ -582,7 +582,7 @@
 
   - name: create container (stopped) with one network and fixed IP (idempotent)
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: stopped
@@ -595,7 +595,7 @@
 
   - name: create container (stopped) with one network and fixed IP (different IPv4)
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: stopped
@@ -608,7 +608,7 @@
 
   - name: create container (stopped) with one network and fixed IP (different IPv6)
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: stopped
@@ -627,7 +627,7 @@
 
   - name: create container (started) with one network and fixed IP (different IPv4)
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -641,7 +641,7 @@
 
   - name: create container (started) with one network and fixed IP (different IPv6)
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -655,7 +655,7 @@
 
   - name: create container (started) with one network and fixed IP (idempotent)
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started

--- a/test/integration/targets/docker_container/tasks/tests/network.yml
+++ b/test/integration/targets/docker_container/tasks/tests/network.yml
@@ -54,7 +54,7 @@
 
 - name: network_mode
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -63,7 +63,7 @@
 
 - name: network_mode (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -72,7 +72,7 @@
 
 - name: network_mode (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -82,7 +82,7 @@
 
 - name: network_mode (container mode setup)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname_h1 }}"
     state: started
@@ -90,7 +90,7 @@
 
 - name: network_mode (container mode)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -100,7 +100,7 @@
 
 - name: network_mode (container mode idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -139,7 +139,7 @@
 - block:
   - name: networks_cli_compatible=no, networks w/o purge_networks
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -151,7 +151,7 @@
 
   - name: networks_cli_compatible=no, networks w/o purge_networks
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -163,7 +163,7 @@
 
   - name: networks_cli_compatible=no, networks, purge_networks
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -177,7 +177,7 @@
 
   - name: networks_cli_compatible=no, networks, purge_networks (idempotency)
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -190,7 +190,7 @@
 
   - name: networks_cli_compatible=no, networks (less networks)
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -201,7 +201,7 @@
 
   - name: networks_cli_compatible=no, networks, purge_networks (less networks)
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -214,7 +214,7 @@
 
   - name: networks_cli_compatible=no, networks, purge_networks (more networks)
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -281,7 +281,7 @@
 - block:
   - name: networks_cli_compatible=yes, networks specified
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -296,7 +296,7 @@
 
   - name: networks_cli_compatible=yes, networks specified
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -315,7 +315,7 @@
 
   - name: networks_cli_compatible=yes, empty networks list specified
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -325,7 +325,7 @@
 
   - name: networks_cli_compatible=yes, empty networks list specified
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -335,7 +335,7 @@
 
   - name: networks_cli_compatible=yes, empty networks list specified, purge_networks
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -354,7 +354,7 @@
 
   - name: networks_cli_compatible=yes, networks not specified
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -364,7 +364,7 @@
 
   - name: networks_cli_compatible=yes, networks not specified
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -373,7 +373,7 @@
 
   - name: networks_cli_compatible=yes, networks not specified, purge_networks
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -435,7 +435,7 @@
 - block:
   - name: create container with one network
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -446,7 +446,7 @@
 
   - name: different networks, comparisons=ignore
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -459,7 +459,7 @@
 
   - name: less networks, comparisons=ignore
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -471,7 +471,7 @@
 
   - name: less networks, comparisons=allow_more_present
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -483,7 +483,7 @@
 
   - name: different networks, comparisons=allow_more_present
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -497,7 +497,7 @@
 
   - name: different networks, comparisons=strict
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -511,7 +511,7 @@
 
   - name: less networks, comparisons=strict
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -569,7 +569,7 @@
 - block:
   - name: create container (stopped) with one network and fixed IP
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: stopped
@@ -582,7 +582,7 @@
 
   - name: create container (stopped) with one network and fixed IP (idempotent)
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: stopped
@@ -595,7 +595,7 @@
 
   - name: create container (stopped) with one network and fixed IP (different IPv4)
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: stopped
@@ -608,7 +608,7 @@
 
   - name: create container (stopped) with one network and fixed IP (different IPv6)
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: stopped
@@ -627,7 +627,7 @@
 
   - name: create container (started) with one network and fixed IP (different IPv4)
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -641,7 +641,7 @@
 
   - name: create container (started) with one network and fixed IP (different IPv6)
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started
@@ -655,7 +655,7 @@
 
   - name: create container (started) with one network and fixed IP (idempotent)
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -15,7 +15,7 @@
 
 - name: auto_remove
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "echo"'
     name: "{{ cname }}"
     state: started
@@ -52,7 +52,7 @@
 
 - name: blkio_weight
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -61,7 +61,7 @@
 
 - name: blkio_weight (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -70,7 +70,7 @@
 
 - name: blkio_weight (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -97,7 +97,7 @@
 
 - name: capabilities, cap_drop
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -109,7 +109,7 @@
 
 - name: capabilities, cap_drop (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -121,7 +121,7 @@
 
 - name: capabilities, cap_drop (less)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -132,7 +132,7 @@
 
 - name: capabilities, cap_drop (changed)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -163,7 +163,7 @@
 
 - name: command
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -171,7 +171,7 @@
 
 - name: command (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -179,7 +179,7 @@
 
 - name: command (less parameters)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -205,7 +205,7 @@
 
 - name: cpu_period
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_period: 90000
@@ -214,7 +214,7 @@
 
 - name: cpu_period (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_period: 90000
@@ -223,7 +223,7 @@
 
 - name: cpu_period (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_period: 50000
@@ -250,7 +250,7 @@
 
 - name: cpu_quota
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_quota: 150000
@@ -259,7 +259,7 @@
 
 - name: cpu_quota (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_quota: 150000
@@ -268,7 +268,7 @@
 
 - name: cpu_quota (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_quota: 50000
@@ -295,7 +295,7 @@
 
 - name: cpu_shares
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_shares: 900
@@ -304,7 +304,7 @@
 
 - name: cpu_shares (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_shares: 900
@@ -313,7 +313,7 @@
 
 - name: cpu_shares (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_shares: 1100
@@ -340,7 +340,7 @@
 
 - name: cpuset_cpus
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_cpus: "0"
@@ -349,7 +349,7 @@
 
 - name: cpuset_cpus (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_cpus: "0"
@@ -358,7 +358,7 @@
 
 - name: cpuset_cpus (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_cpus: "1"
@@ -388,7 +388,7 @@
 
 - name: cpuset_mems
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_mems: "0"
@@ -397,7 +397,7 @@
 
 - name: cpuset_mems (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_mems: "0"
@@ -406,7 +406,7 @@
 
 - name: cpuset_mems (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_mems: "1"
@@ -436,7 +436,7 @@
 
 - name: debug (create)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -452,7 +452,7 @@
 
 - name: debug (stop)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     name: "{{ cname }}"
     state: stopped
     force_kill: yes
@@ -481,7 +481,7 @@
 - name: detach without cleanup
   docker_container:
     name: "{{ cname }}"
-    image: quay.io/redhattraining/hello-world-nginx
+    image: quay.io/ansible/hey
     detach: no
   register: detach_no_cleanup
 
@@ -495,7 +495,7 @@
 - name: detach with cleanup
   docker_container:
     name: "{{ cname }}"
-    image: quay.io/redhattraining/hello-world-nginx
+    image: quay.io/ansible/hey
     detach: no
     cleanup: yes
   register: detach_cleanup
@@ -510,7 +510,7 @@
 - name: detach with auto_remove and cleanup
   docker_container:
     name: "{{ cname }}"
-    image: quay.io/redhattraining/hello-world-nginx
+    image: quay.io/ansible/hey
     detach: no
     auto_remove: yes
     cleanup: yes
@@ -548,7 +548,7 @@
 
 - name: devices
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -559,7 +559,7 @@
 
 - name: devices (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -570,7 +570,7 @@
 
 - name: devices (less)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -580,7 +580,7 @@
 
 - name: devices (changed)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -610,7 +610,7 @@
 
 - name: device_read_bps
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -624,7 +624,7 @@
 
 - name: device_read_bps (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -638,7 +638,7 @@
 
 - name: device_read_bps (lesser entries)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -650,7 +650,7 @@
 
 - name: device_read_bps (changed)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -690,7 +690,7 @@
 
 - name: device_read_iops
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -704,7 +704,7 @@
 
 - name: device_read_iops (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -718,7 +718,7 @@
 
 - name: device_read_iops (less)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -730,7 +730,7 @@
 
 - name: device_read_iops (changed)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -770,7 +770,7 @@
 
 - name: device_write_bps and device_write_iops
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -785,7 +785,7 @@
 
 - name: device_write_bps and device_write_iops (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -800,7 +800,7 @@
 
 - name: device_write_bps device_write_iops (changed)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -840,7 +840,7 @@
 
 - name: dns_opts
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -852,7 +852,7 @@
 
 - name: dns_opts (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -864,7 +864,7 @@
 
 - name: dns_opts (less resolv.conf options)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -875,7 +875,7 @@
 
 - name: dns_opts (more resolv.conf options)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -913,7 +913,7 @@
 
 - name: dns_search_domains
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -924,7 +924,7 @@
 
 - name: dns_search_domains (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -935,7 +935,7 @@
 
 - name: dns_search_domains (different order)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -947,7 +947,7 @@
 
 - name: dns_search_domains (changed elements)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -977,7 +977,7 @@
 
 - name: dns_servers
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -988,7 +988,7 @@
 
 - name: dns_servers (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -999,7 +999,7 @@
 
 - name: dns_servers (changed order)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1011,7 +1011,7 @@
 
 - name: dns_servers (changed elements)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1041,7 +1041,7 @@
 
 - name: domainname
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     domainname: example.com
@@ -1050,7 +1050,7 @@
 
 - name: domainname (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     domainname: example.com
@@ -1059,7 +1059,7 @@
 
 - name: domainname (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     domainname: example.org
@@ -1086,7 +1086,7 @@
 
 - name: entrypoint
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     entrypoint:
     - /bin/sh
     - "-v"
@@ -1098,7 +1098,7 @@
 
 - name: entrypoint (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     entrypoint:
     - /bin/sh
     - "-v"
@@ -1110,7 +1110,7 @@
 
 - name: entrypoint (change order, should not be idempotent)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     entrypoint:
     - /bin/sh
     - "-c"
@@ -1123,7 +1123,7 @@
 
 - name: entrypoint (less parameters)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     entrypoint:
     - /bin/sh
     - "-c"
@@ -1135,7 +1135,7 @@
 
 - name: entrypoint (other parameters)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     entrypoint:
     - /bin/sh
     - "-c"
@@ -1166,7 +1166,7 @@
 
 - name: env
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1180,7 +1180,7 @@
 
 - name: env (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1194,7 +1194,7 @@
 
 - name: env (less environment variables)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1204,7 +1204,7 @@
 
 - name: env (more environment variables)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1216,7 +1216,7 @@
 
 - name: env (fail unwrapped values)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1248,7 +1248,7 @@
 
 - name: env_file
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1257,7 +1257,7 @@
 
 - name: env_file (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1282,7 +1282,7 @@
 
 - name: etc_hosts
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1293,7 +1293,7 @@
 
 - name: etc_hosts (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1304,7 +1304,7 @@
 
 - name: etc_hosts (less hosts)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1314,7 +1314,7 @@
 
 - name: etc_hosts (more hosts)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1344,7 +1344,7 @@
 
 - name: exposed_ports
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1355,7 +1355,7 @@
 
 - name: exposed_ports (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1366,7 +1366,7 @@
 
 - name: exposed_ports (less ports)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1376,7 +1376,7 @@
 
 - name: exposed_ports (more ports)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1412,7 +1412,7 @@
 
 - name: groups
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1423,7 +1423,7 @@
 
 - name: groups (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1434,7 +1434,7 @@
 
 - name: groups (less groups)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1444,7 +1444,7 @@
 
 - name: groups (more groups)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1474,7 +1474,7 @@
 
 - name: healthcheck
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1492,7 +1492,7 @@
 
 - name: healthcheck (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1510,7 +1510,7 @@
 
 - name: healthcheck (changed)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1528,7 +1528,7 @@
 
 - name: healthcheck (no change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1538,7 +1538,7 @@
 
 - name: healthcheck (disabled)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1551,7 +1551,7 @@
 
 - name: healthcheck (disabled, idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1564,7 +1564,7 @@
 
 - name: healthcheck (string in healthcheck test, changed)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1576,7 +1576,7 @@
 
 - name: healthcheck (string in healthcheck test, idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1617,7 +1617,7 @@
 
 - name: hostname
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     hostname: me.example.com
@@ -1626,7 +1626,7 @@
 
 - name: hostname (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     hostname: me.example.com
@@ -1635,7 +1635,7 @@
 
 - name: hostname (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     hostname: me.example.org
@@ -1662,7 +1662,7 @@
 
 - name: init
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     init: yes
@@ -1672,7 +1672,7 @@
 
 - name: init (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     init: yes
@@ -1682,7 +1682,7 @@
 
 - name: init (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     init: no
@@ -1717,7 +1717,7 @@
 
 - name: interactive
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     interactive: yes
@@ -1726,7 +1726,7 @@
 
 - name: interactive (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     interactive: yes
@@ -1735,7 +1735,7 @@
 
 - name: interactive (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     interactive: no
@@ -1763,12 +1763,12 @@
 - name: Pull hello-world image to make sure ignore_image test succeeds
   # If the image isn't there, it will pull it and return 'changed'.
   docker_image:
-    name: hello-world
+    name: quay.io/ansible/hey
     pull: true
 
 - name: image
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1776,7 +1776,7 @@
 
 - name: image (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1784,7 +1784,7 @@
 
 - name: ignore_image
   docker_container:
-    image: quay.io/redhattraining/hello-world-nginx
+    image: quay.io/ansible/hey
     ignore_image: yes
     name: "{{ cname }}"
     state: started
@@ -1792,7 +1792,7 @@
 
 - name: image change
   docker_container:
-    image: quay.io/redhattraining/hello-world-nginx
+    image: quay.io/ansible/hey
     name: "{{ cname }}"
     state: started
     force_kill: yes
@@ -1818,7 +1818,7 @@
 
 - name: start helpers
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ container_name }}"
     state: started
@@ -1830,7 +1830,7 @@
 
 - name: ipc_mode
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1840,7 +1840,7 @@
 
 - name: ipc_mode (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1850,7 +1850,7 @@
 
 - name: ipc_mode (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1882,7 +1882,7 @@
 
 - name: kernel_memory
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     kernel_memory: 8M
@@ -1892,7 +1892,7 @@
 
 - name: kernel_memory (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     kernel_memory: 8M
@@ -1902,7 +1902,7 @@
 
 - name: kernel_memory (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     kernel_memory: 6M
@@ -1938,7 +1938,7 @@
 
 - name: labels
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1949,7 +1949,7 @@
 
 - name: labels (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1960,7 +1960,7 @@
 
 - name: labels (less labels)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1970,7 +1970,7 @@
 
 - name: labels (more labels)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2000,7 +2000,7 @@
 
 - name: start helpers
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ container_name }}"
     state: started
@@ -2013,7 +2013,7 @@
 
 - name: links
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2024,7 +2024,7 @@
 
 - name: links (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2035,7 +2035,7 @@
 
 - name: links (less links)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2045,7 +2045,7 @@
 
 - name: links (more links)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2082,7 +2082,7 @@
 
 - name: log_driver
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2091,7 +2091,7 @@
 
 - name: log_driver (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2100,7 +2100,7 @@
 
 - name: log_driver (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2127,7 +2127,7 @@
 
 - name: log_options
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2140,7 +2140,7 @@
 
 - name: log_options (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2153,7 +2153,7 @@
 
 - name: log_options (less log options)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2164,7 +2164,7 @@
 
 - name: log_options (more log options)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2197,7 +2197,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: mac_address
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     mac_address: 92:d0:c6:0a:29:33
@@ -2206,7 +2206,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: mac_address (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     mac_address: 92:d0:c6:0a:29:33
@@ -2215,7 +2215,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: mac_address (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     mac_address: 92:d0:c6:0a:29:44
@@ -2242,7 +2242,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory: 64M
@@ -2251,7 +2251,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory: 64M
@@ -2260,7 +2260,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory: 48M
@@ -2287,7 +2287,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_reservation
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_reservation: 64M
@@ -2296,7 +2296,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_reservation (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_reservation: 64M
@@ -2305,7 +2305,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_reservation (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_reservation: 48M
@@ -2332,7 +2332,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_swap
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     # Docker daemon does not accept memory_swap if memory is not specified
@@ -2344,7 +2344,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_swap (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     # Docker daemon does not accept memory_swap if memory is not specified
@@ -2356,7 +2356,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_swap (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     # Docker daemon does not accept memory_swap if memory is not specified
@@ -2395,7 +2395,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_swappiness
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_swappiness: 40
@@ -2404,7 +2404,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_swappiness (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_swappiness: 40
@@ -2413,7 +2413,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_swappiness (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_swappiness: 60
@@ -2440,7 +2440,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: oom_killer
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_killer: yes
@@ -2449,7 +2449,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: oom_killer (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_killer: yes
@@ -2458,7 +2458,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: oom_killer (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_killer: no
@@ -2485,7 +2485,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: oom_score_adj
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_score_adj: 5
@@ -2494,7 +2494,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: oom_score_adj (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_score_adj: 5
@@ -2503,7 +2503,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: oom_score_adj (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_score_adj: 7
@@ -2536,7 +2536,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: paused
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: "/bin/sh -c 'sleep 10m'"
     name: "{{ cname }}"
     state: started
@@ -2550,7 +2550,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: paused (idempotent)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: "/bin/sh -c 'sleep 10m'"
     name: "{{ cname }}"
     state: started
@@ -2560,7 +2560,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: paused (continue)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: "/bin/sh -c 'sleep 10m'"
     name: "{{ cname }}"
     state: started
@@ -2593,7 +2593,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: start helpers
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname_h1 }}"
     state: started
@@ -2601,7 +2601,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: pid_mode
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2612,7 +2612,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: pid_mode (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2623,7 +2623,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: pid_mode (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2662,7 +2662,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: pids_limit
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2672,7 +2672,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: pids_limit (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2682,7 +2682,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: pids_limit (changed)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2717,7 +2717,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: privileged
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     privileged: yes
@@ -2726,7 +2726,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: privileged (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     privileged: yes
@@ -2735,7 +2735,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: privileged (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     privileged: no
@@ -2762,7 +2762,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: published_ports
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2773,7 +2773,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: published_ports (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2784,7 +2784,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: published_ports (less published_ports)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2794,7 +2794,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: published_ports (more published_ports)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2806,7 +2806,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: published_ports (ports with IP addresses)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2843,7 +2843,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: read_only
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     read_only: yes
@@ -2852,7 +2852,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: read_only (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     read_only: yes
@@ -2861,7 +2861,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: read_only (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     read_only: no
@@ -2888,7 +2888,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: restart_policy
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: always
@@ -2897,7 +2897,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: restart_policy (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: always
@@ -2906,7 +2906,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: restart_policy (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: unless-stopped
@@ -2933,7 +2933,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: restart_retries
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: on-failure
@@ -2943,7 +2943,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: restart_retries (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: on-failure
@@ -2953,7 +2953,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: restart_retries (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: on-failure
@@ -2981,7 +2981,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: runtime
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     runtime: runc
@@ -2991,7 +2991,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: runtime (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     runtime: runc
@@ -3040,7 +3040,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: security_opts
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3051,7 +3051,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: security_opts (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3062,7 +3062,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: security_opts (less security options)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3072,7 +3072,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: security_opts (more security options)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3102,7 +3102,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: shm_size
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     shm_size: 96M
@@ -3111,7 +3111,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: shm_size (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     shm_size: 96M
@@ -3120,7 +3120,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: shm_size (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     shm_size: 75M
@@ -3147,7 +3147,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: stop_signal
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     stop_signal: "30"
@@ -3156,7 +3156,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: stop_signal (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     stop_signal: "30"
@@ -3165,7 +3165,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: stop_signal (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     stop_signal: "9"
@@ -3192,7 +3192,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: stop_timeout
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     stop_timeout: 2
@@ -3201,7 +3201,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: stop_timeout (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     stop_timeout: 2
@@ -3211,7 +3211,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 - name: stop_timeout (no change)
   # stop_timeout changes are ignored by default
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     stop_timeout: 1
@@ -3247,7 +3247,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: sysctls
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3259,7 +3259,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: sysctls (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3271,7 +3271,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: sysctls (less sysctls)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3282,7 +3282,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: sysctls (more sysctls)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3320,7 +3320,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tmpfs
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3331,7 +3331,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tmpfs (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3342,7 +3342,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tmpfs (less tmpfs)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3352,7 +3352,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tmpfs (more tmpfs)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3388,7 +3388,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tty
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     tty: yes
@@ -3397,7 +3397,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tty (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     tty: yes
@@ -3406,7 +3406,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tty (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     tty: no
@@ -3433,7 +3433,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: ulimits
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3444,7 +3444,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: ulimits (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3455,7 +3455,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: ulimits (less ulimits)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3465,7 +3465,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: ulimits (more ulimits)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3495,7 +3495,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: user
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     user: nobody
@@ -3504,7 +3504,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: user (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     user: nobody
@@ -3513,7 +3513,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: user (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     user: root
@@ -3540,7 +3540,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: userns_mode
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     userns_mode: host
@@ -3550,7 +3550,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: userns_mode (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     userns_mode: host
@@ -3560,7 +3560,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: userns_mode (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     userns_mode: ""
@@ -3595,7 +3595,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: uts
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     uts: host
@@ -3605,7 +3605,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: uts (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     uts: host
@@ -3615,7 +3615,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: uts (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     uts: ""
@@ -3650,7 +3650,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: working_dir
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     working_dir: /tmp
@@ -3659,7 +3659,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: working_dir (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     working_dir: /tmp
@@ -3668,7 +3668,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: working_dir (change)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     working_dir: /

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -15,7 +15,7 @@
 
 - name: auto_remove
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "echo"'
     name: "{{ cname }}"
     state: started
@@ -52,7 +52,7 @@
 
 - name: blkio_weight
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -61,7 +61,7 @@
 
 - name: blkio_weight (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -70,7 +70,7 @@
 
 - name: blkio_weight (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -97,7 +97,7 @@
 
 - name: capabilities, cap_drop
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -109,7 +109,7 @@
 
 - name: capabilities, cap_drop (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -121,7 +121,7 @@
 
 - name: capabilities, cap_drop (less)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -132,7 +132,7 @@
 
 - name: capabilities, cap_drop (changed)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -163,7 +163,7 @@
 
 - name: command
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -v -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -171,7 +171,7 @@
 
 - name: command (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -v -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -179,7 +179,7 @@
 
 - name: command (less parameters)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -205,7 +205,7 @@
 
 - name: cpu_period
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_period: 90000
@@ -214,7 +214,7 @@
 
 - name: cpu_period (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_period: 90000
@@ -223,7 +223,7 @@
 
 - name: cpu_period (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_period: 50000
@@ -250,7 +250,7 @@
 
 - name: cpu_quota
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_quota: 150000
@@ -259,7 +259,7 @@
 
 - name: cpu_quota (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_quota: 150000
@@ -268,7 +268,7 @@
 
 - name: cpu_quota (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_quota: 50000
@@ -295,7 +295,7 @@
 
 - name: cpu_shares
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_shares: 900
@@ -304,7 +304,7 @@
 
 - name: cpu_shares (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_shares: 900
@@ -313,7 +313,7 @@
 
 - name: cpu_shares (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_shares: 1100
@@ -340,7 +340,7 @@
 
 - name: cpuset_cpus
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_cpus: "0"
@@ -349,7 +349,7 @@
 
 - name: cpuset_cpus (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_cpus: "0"
@@ -358,7 +358,7 @@
 
 - name: cpuset_cpus (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_cpus: "1"
@@ -388,7 +388,7 @@
 
 - name: cpuset_mems
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_mems: "0"
@@ -397,7 +397,7 @@
 
 - name: cpuset_mems (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_mems: "0"
@@ -406,7 +406,7 @@
 
 - name: cpuset_mems (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_mems: "1"
@@ -436,7 +436,7 @@
 
 - name: debug (create)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -452,7 +452,7 @@
 
 - name: debug (stop)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     name: "{{ cname }}"
     state: stopped
     force_kill: yes
@@ -481,7 +481,7 @@
 - name: detach without cleanup
   docker_container:
     name: "{{ cname }}"
-    image: quay.io/ansible/hey
+    image: quay.io/ansible/docker-test-containers:hello-world
     detach: no
   register: detach_no_cleanup
 
@@ -495,7 +495,7 @@
 - name: detach with cleanup
   docker_container:
     name: "{{ cname }}"
-    image: quay.io/ansible/hey
+    image: quay.io/ansible/docker-test-containers:hello-world
     detach: no
     cleanup: yes
   register: detach_cleanup
@@ -510,7 +510,7 @@
 - name: detach with auto_remove and cleanup
   docker_container:
     name: "{{ cname }}"
-    image: quay.io/ansible/hey
+    image: quay.io/ansible/docker-test-containers:hello-world
     detach: no
     auto_remove: yes
     cleanup: yes
@@ -548,7 +548,7 @@
 
 - name: devices
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -559,7 +559,7 @@
 
 - name: devices (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -570,7 +570,7 @@
 
 - name: devices (less)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -580,7 +580,7 @@
 
 - name: devices (changed)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -610,7 +610,7 @@
 
 - name: device_read_bps
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -624,7 +624,7 @@
 
 - name: device_read_bps (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -638,7 +638,7 @@
 
 - name: device_read_bps (lesser entries)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -650,7 +650,7 @@
 
 - name: device_read_bps (changed)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -690,7 +690,7 @@
 
 - name: device_read_iops
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -704,7 +704,7 @@
 
 - name: device_read_iops (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -718,7 +718,7 @@
 
 - name: device_read_iops (less)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -730,7 +730,7 @@
 
 - name: device_read_iops (changed)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -770,7 +770,7 @@
 
 - name: device_write_bps and device_write_iops
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -785,7 +785,7 @@
 
 - name: device_write_bps and device_write_iops (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -800,7 +800,7 @@
 
 - name: device_write_bps device_write_iops (changed)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -840,7 +840,7 @@
 
 - name: dns_opts
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -852,7 +852,7 @@
 
 - name: dns_opts (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -864,7 +864,7 @@
 
 - name: dns_opts (less resolv.conf options)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -875,7 +875,7 @@
 
 - name: dns_opts (more resolv.conf options)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -913,7 +913,7 @@
 
 - name: dns_search_domains
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -924,7 +924,7 @@
 
 - name: dns_search_domains (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -935,7 +935,7 @@
 
 - name: dns_search_domains (different order)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -947,7 +947,7 @@
 
 - name: dns_search_domains (changed elements)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -977,7 +977,7 @@
 
 - name: dns_servers
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -988,7 +988,7 @@
 
 - name: dns_servers (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -999,7 +999,7 @@
 
 - name: dns_servers (changed order)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1011,7 +1011,7 @@
 
 - name: dns_servers (changed elements)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1041,7 +1041,7 @@
 
 - name: domainname
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     domainname: example.com
@@ -1050,7 +1050,7 @@
 
 - name: domainname (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     domainname: example.com
@@ -1059,7 +1059,7 @@
 
 - name: domainname (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     domainname: example.org
@@ -1086,7 +1086,7 @@
 
 - name: entrypoint
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     entrypoint:
     - /bin/sh
     - "-v"
@@ -1098,7 +1098,7 @@
 
 - name: entrypoint (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     entrypoint:
     - /bin/sh
     - "-v"
@@ -1110,7 +1110,7 @@
 
 - name: entrypoint (change order, should not be idempotent)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     entrypoint:
     - /bin/sh
     - "-c"
@@ -1123,7 +1123,7 @@
 
 - name: entrypoint (less parameters)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     entrypoint:
     - /bin/sh
     - "-c"
@@ -1135,7 +1135,7 @@
 
 - name: entrypoint (other parameters)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     entrypoint:
     - /bin/sh
     - "-c"
@@ -1166,7 +1166,7 @@
 
 - name: env
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1180,7 +1180,7 @@
 
 - name: env (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1194,7 +1194,7 @@
 
 - name: env (less environment variables)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1204,7 +1204,7 @@
 
 - name: env (more environment variables)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1216,7 +1216,7 @@
 
 - name: env (fail unwrapped values)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1248,7 +1248,7 @@
 
 - name: env_file
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1257,7 +1257,7 @@
 
 - name: env_file (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1282,7 +1282,7 @@
 
 - name: etc_hosts
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1293,7 +1293,7 @@
 
 - name: etc_hosts (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1304,7 +1304,7 @@
 
 - name: etc_hosts (less hosts)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1314,7 +1314,7 @@
 
 - name: etc_hosts (more hosts)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1344,7 +1344,7 @@
 
 - name: exposed_ports
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1355,7 +1355,7 @@
 
 - name: exposed_ports (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1366,7 +1366,7 @@
 
 - name: exposed_ports (less ports)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1376,7 +1376,7 @@
 
 - name: exposed_ports (more ports)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1412,7 +1412,7 @@
 
 - name: groups
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1423,7 +1423,7 @@
 
 - name: groups (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1434,7 +1434,7 @@
 
 - name: groups (less groups)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1444,7 +1444,7 @@
 
 - name: groups (more groups)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1474,7 +1474,7 @@
 
 - name: healthcheck
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1492,7 +1492,7 @@
 
 - name: healthcheck (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1510,7 +1510,7 @@
 
 - name: healthcheck (changed)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1528,7 +1528,7 @@
 
 - name: healthcheck (no change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1538,7 +1538,7 @@
 
 - name: healthcheck (disabled)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1551,7 +1551,7 @@
 
 - name: healthcheck (disabled, idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1564,7 +1564,7 @@
 
 - name: healthcheck (string in healthcheck test, changed)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1576,7 +1576,7 @@
 
 - name: healthcheck (string in healthcheck test, idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1617,7 +1617,7 @@
 
 - name: hostname
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     hostname: me.example.com
@@ -1626,7 +1626,7 @@
 
 - name: hostname (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     hostname: me.example.com
@@ -1635,7 +1635,7 @@
 
 - name: hostname (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     hostname: me.example.org
@@ -1662,7 +1662,7 @@
 
 - name: init
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     init: yes
@@ -1672,7 +1672,7 @@
 
 - name: init (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     init: yes
@@ -1682,7 +1682,7 @@
 
 - name: init (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     init: no
@@ -1717,7 +1717,7 @@
 
 - name: interactive
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     interactive: yes
@@ -1726,7 +1726,7 @@
 
 - name: interactive (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     interactive: yes
@@ -1735,7 +1735,7 @@
 
 - name: interactive (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     interactive: no
@@ -1763,12 +1763,12 @@
 - name: Pull hello-world image to make sure ignore_image test succeeds
   # If the image isn't there, it will pull it and return 'changed'.
   docker_image:
-    name: quay.io/ansible/hey
+    name: quay.io/ansible/docker-test-containers:hello-world
     pull: true
 
 - name: image
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1776,7 +1776,7 @@
 
 - name: image (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1784,7 +1784,7 @@
 
 - name: ignore_image
   docker_container:
-    image: quay.io/ansible/hey
+    image: quay.io/ansible/docker-test-containers:hello-world
     ignore_image: yes
     name: "{{ cname }}"
     state: started
@@ -1792,7 +1792,7 @@
 
 - name: image change
   docker_container:
-    image: quay.io/ansible/hey
+    image: quay.io/ansible/docker-test-containers:hello-world
     name: "{{ cname }}"
     state: started
     force_kill: yes
@@ -1818,7 +1818,7 @@
 
 - name: start helpers
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ container_name }}"
     state: started
@@ -1830,7 +1830,7 @@
 
 - name: ipc_mode
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1840,7 +1840,7 @@
 
 - name: ipc_mode (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1850,7 +1850,7 @@
 
 - name: ipc_mode (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1882,7 +1882,7 @@
 
 - name: kernel_memory
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     kernel_memory: 8M
@@ -1892,7 +1892,7 @@
 
 - name: kernel_memory (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     kernel_memory: 8M
@@ -1902,7 +1902,7 @@
 
 - name: kernel_memory (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     kernel_memory: 6M
@@ -1938,7 +1938,7 @@
 
 - name: labels
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1949,7 +1949,7 @@
 
 - name: labels (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1960,7 +1960,7 @@
 
 - name: labels (less labels)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1970,7 +1970,7 @@
 
 - name: labels (more labels)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2000,7 +2000,7 @@
 
 - name: start helpers
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ container_name }}"
     state: started
@@ -2013,7 +2013,7 @@
 
 - name: links
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2024,7 +2024,7 @@
 
 - name: links (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2035,7 +2035,7 @@
 
 - name: links (less links)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2045,7 +2045,7 @@
 
 - name: links (more links)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2082,7 +2082,7 @@
 
 - name: log_driver
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2091,7 +2091,7 @@
 
 - name: log_driver (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2100,7 +2100,7 @@
 
 - name: log_driver (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2127,7 +2127,7 @@
 
 - name: log_options
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2140,7 +2140,7 @@
 
 - name: log_options (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2153,7 +2153,7 @@
 
 - name: log_options (less log options)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2164,7 +2164,7 @@
 
 - name: log_options (more log options)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2197,7 +2197,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: mac_address
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     mac_address: 92:d0:c6:0a:29:33
@@ -2206,7 +2206,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: mac_address (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     mac_address: 92:d0:c6:0a:29:33
@@ -2215,7 +2215,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: mac_address (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     mac_address: 92:d0:c6:0a:29:44
@@ -2242,7 +2242,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory: 64M
@@ -2251,7 +2251,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory: 64M
@@ -2260,7 +2260,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory: 48M
@@ -2287,7 +2287,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_reservation
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_reservation: 64M
@@ -2296,7 +2296,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_reservation (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_reservation: 64M
@@ -2305,7 +2305,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_reservation (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_reservation: 48M
@@ -2332,7 +2332,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_swap
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     # Docker daemon does not accept memory_swap if memory is not specified
@@ -2344,7 +2344,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_swap (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     # Docker daemon does not accept memory_swap if memory is not specified
@@ -2356,7 +2356,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_swap (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     # Docker daemon does not accept memory_swap if memory is not specified
@@ -2395,7 +2395,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_swappiness
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_swappiness: 40
@@ -2404,7 +2404,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_swappiness (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_swappiness: 40
@@ -2413,7 +2413,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_swappiness (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_swappiness: 60
@@ -2440,7 +2440,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: oom_killer
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_killer: yes
@@ -2449,7 +2449,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: oom_killer (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_killer: yes
@@ -2458,7 +2458,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: oom_killer (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_killer: no
@@ -2485,7 +2485,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: oom_score_adj
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_score_adj: 5
@@ -2494,7 +2494,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: oom_score_adj (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_score_adj: 5
@@ -2503,7 +2503,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: oom_score_adj (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_score_adj: 7
@@ -2536,7 +2536,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: paused
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: "/bin/sh -c 'sleep 10m'"
     name: "{{ cname }}"
     state: started
@@ -2550,7 +2550,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: paused (idempotent)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: "/bin/sh -c 'sleep 10m'"
     name: "{{ cname }}"
     state: started
@@ -2560,7 +2560,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: paused (continue)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: "/bin/sh -c 'sleep 10m'"
     name: "{{ cname }}"
     state: started
@@ -2593,7 +2593,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: start helpers
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname_h1 }}"
     state: started
@@ -2601,7 +2601,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: pid_mode
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2612,7 +2612,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: pid_mode (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2623,7 +2623,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: pid_mode (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2662,7 +2662,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: pids_limit
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2672,7 +2672,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: pids_limit (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2682,7 +2682,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: pids_limit (changed)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2717,7 +2717,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: privileged
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     privileged: yes
@@ -2726,7 +2726,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: privileged (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     privileged: yes
@@ -2735,7 +2735,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: privileged (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     privileged: no
@@ -2762,7 +2762,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: published_ports
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2773,7 +2773,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: published_ports (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2784,7 +2784,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: published_ports (less published_ports)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2794,7 +2794,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: published_ports (more published_ports)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2806,7 +2806,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: published_ports (ports with IP addresses)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2843,7 +2843,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: read_only
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     read_only: yes
@@ -2852,7 +2852,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: read_only (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     read_only: yes
@@ -2861,7 +2861,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: read_only (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     read_only: no
@@ -2888,7 +2888,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: restart_policy
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: always
@@ -2897,7 +2897,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: restart_policy (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: always
@@ -2906,7 +2906,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: restart_policy (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: unless-stopped
@@ -2933,7 +2933,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: restart_retries
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: on-failure
@@ -2943,7 +2943,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: restart_retries (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: on-failure
@@ -2953,7 +2953,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: restart_retries (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: on-failure
@@ -2981,7 +2981,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: runtime
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     runtime: runc
@@ -2991,7 +2991,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: runtime (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     runtime: runc
@@ -3040,7 +3040,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: security_opts
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3051,7 +3051,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: security_opts (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3062,7 +3062,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: security_opts (less security options)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3072,7 +3072,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: security_opts (more security options)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3102,7 +3102,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: shm_size
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     shm_size: 96M
@@ -3111,7 +3111,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: shm_size (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     shm_size: 96M
@@ -3120,7 +3120,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: shm_size (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     shm_size: 75M
@@ -3147,7 +3147,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: stop_signal
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     stop_signal: "30"
@@ -3156,7 +3156,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: stop_signal (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     stop_signal: "30"
@@ -3165,7 +3165,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: stop_signal (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     stop_signal: "9"
@@ -3192,7 +3192,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: stop_timeout
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     stop_timeout: 2
@@ -3201,7 +3201,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: stop_timeout (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     stop_timeout: 2
@@ -3211,7 +3211,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 - name: stop_timeout (no change)
   # stop_timeout changes are ignored by default
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     stop_timeout: 1
@@ -3247,7 +3247,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: sysctls
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3259,7 +3259,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: sysctls (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3271,7 +3271,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: sysctls (less sysctls)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3282,7 +3282,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: sysctls (more sysctls)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3320,7 +3320,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tmpfs
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3331,7 +3331,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tmpfs (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3342,7 +3342,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tmpfs (less tmpfs)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3352,7 +3352,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tmpfs (more tmpfs)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3388,7 +3388,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tty
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     tty: yes
@@ -3397,7 +3397,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tty (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     tty: yes
@@ -3406,7 +3406,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tty (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     tty: no
@@ -3433,7 +3433,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: ulimits
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3444,7 +3444,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: ulimits (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3455,7 +3455,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: ulimits (less ulimits)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3465,7 +3465,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: ulimits (more ulimits)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3495,7 +3495,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: user
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     user: nobody
@@ -3504,7 +3504,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: user (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     user: nobody
@@ -3513,7 +3513,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: user (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     user: root
@@ -3540,7 +3540,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: userns_mode
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     userns_mode: host
@@ -3550,7 +3550,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: userns_mode (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     userns_mode: host
@@ -3560,7 +3560,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: userns_mode (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     userns_mode: ""
@@ -3595,7 +3595,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: uts
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     uts: host
@@ -3605,7 +3605,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: uts (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     uts: host
@@ -3615,7 +3615,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: uts (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     uts: ""
@@ -3650,7 +3650,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: working_dir
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     working_dir: /tmp
@@ -3659,7 +3659,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: working_dir (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     working_dir: /tmp
@@ -3668,7 +3668,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: working_dir (change)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     working_dir: /

--- a/test/integration/targets/docker_container/tasks/tests/options.yml
+++ b/test/integration/targets/docker_container/tasks/tests/options.yml
@@ -15,7 +15,7 @@
 
 - name: auto_remove
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "echo"'
     name: "{{ cname }}"
     state: started
@@ -52,7 +52,7 @@
 
 - name: blkio_weight
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -61,7 +61,7 @@
 
 - name: blkio_weight (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -70,7 +70,7 @@
 
 - name: blkio_weight (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -97,7 +97,7 @@
 
 - name: capabilities, cap_drop
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -109,7 +109,7 @@
 
 - name: capabilities, cap_drop (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -121,7 +121,7 @@
 
 - name: capabilities, cap_drop (less)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -132,7 +132,7 @@
 
 - name: capabilities, cap_drop (changed)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -163,7 +163,7 @@
 
 - name: command
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -171,7 +171,7 @@
 
 - name: command (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -179,7 +179,7 @@
 
 - name: command (less parameters)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -205,7 +205,7 @@
 
 - name: cpu_period
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_period: 90000
@@ -214,7 +214,7 @@
 
 - name: cpu_period (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_period: 90000
@@ -223,7 +223,7 @@
 
 - name: cpu_period (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_period: 50000
@@ -250,7 +250,7 @@
 
 - name: cpu_quota
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_quota: 150000
@@ -259,7 +259,7 @@
 
 - name: cpu_quota (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_quota: 150000
@@ -268,7 +268,7 @@
 
 - name: cpu_quota (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_quota: 50000
@@ -295,7 +295,7 @@
 
 - name: cpu_shares
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_shares: 900
@@ -304,7 +304,7 @@
 
 - name: cpu_shares (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_shares: 900
@@ -313,7 +313,7 @@
 
 - name: cpu_shares (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpu_shares: 1100
@@ -340,7 +340,7 @@
 
 - name: cpuset_cpus
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_cpus: "0"
@@ -349,7 +349,7 @@
 
 - name: cpuset_cpus (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_cpus: "0"
@@ -358,7 +358,7 @@
 
 - name: cpuset_cpus (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_cpus: "1"
@@ -388,7 +388,7 @@
 
 - name: cpuset_mems
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_mems: "0"
@@ -397,7 +397,7 @@
 
 - name: cpuset_mems (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_mems: "0"
@@ -406,7 +406,7 @@
 
 - name: cpuset_mems (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     cpuset_mems: "1"
@@ -436,7 +436,7 @@
 
 - name: debug (create)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -452,7 +452,7 @@
 
 - name: debug (stop)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     name: "{{ cname }}"
     state: stopped
     force_kill: yes
@@ -481,7 +481,7 @@
 - name: detach without cleanup
   docker_container:
     name: "{{ cname }}"
-    image: hello-world
+    image: quay.io/redhattraining/hello-world-nginx
     detach: no
   register: detach_no_cleanup
 
@@ -495,7 +495,7 @@
 - name: detach with cleanup
   docker_container:
     name: "{{ cname }}"
-    image: hello-world
+    image: quay.io/redhattraining/hello-world-nginx
     detach: no
     cleanup: yes
   register: detach_cleanup
@@ -510,7 +510,7 @@
 - name: detach with auto_remove and cleanup
   docker_container:
     name: "{{ cname }}"
-    image: hello-world
+    image: quay.io/redhattraining/hello-world-nginx
     detach: no
     auto_remove: yes
     cleanup: yes
@@ -548,7 +548,7 @@
 
 - name: devices
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -559,7 +559,7 @@
 
 - name: devices (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -570,7 +570,7 @@
 
 - name: devices (less)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -580,7 +580,7 @@
 
 - name: devices (changed)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -610,7 +610,7 @@
 
 - name: device_read_bps
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -624,7 +624,7 @@
 
 - name: device_read_bps (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -638,7 +638,7 @@
 
 - name: device_read_bps (lesser entries)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -650,7 +650,7 @@
 
 - name: device_read_bps (changed)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -690,7 +690,7 @@
 
 - name: device_read_iops
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -704,7 +704,7 @@
 
 - name: device_read_iops (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -718,7 +718,7 @@
 
 - name: device_read_iops (less)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -730,7 +730,7 @@
 
 - name: device_read_iops (changed)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -770,7 +770,7 @@
 
 - name: device_write_bps and device_write_iops
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -785,7 +785,7 @@
 
 - name: device_write_bps and device_write_iops (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -800,7 +800,7 @@
 
 - name: device_write_bps device_write_iops (changed)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -840,7 +840,7 @@
 
 - name: dns_opts
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -852,7 +852,7 @@
 
 - name: dns_opts (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -864,7 +864,7 @@
 
 - name: dns_opts (less resolv.conf options)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -875,7 +875,7 @@
 
 - name: dns_opts (more resolv.conf options)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -913,7 +913,7 @@
 
 - name: dns_search_domains
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -924,7 +924,7 @@
 
 - name: dns_search_domains (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -935,7 +935,7 @@
 
 - name: dns_search_domains (different order)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -947,7 +947,7 @@
 
 - name: dns_search_domains (changed elements)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -977,7 +977,7 @@
 
 - name: dns_servers
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -988,7 +988,7 @@
 
 - name: dns_servers (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -999,7 +999,7 @@
 
 - name: dns_servers (changed order)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1011,7 +1011,7 @@
 
 - name: dns_servers (changed elements)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1041,7 +1041,7 @@
 
 - name: domainname
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     domainname: example.com
@@ -1050,7 +1050,7 @@
 
 - name: domainname (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     domainname: example.com
@@ -1059,7 +1059,7 @@
 
 - name: domainname (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     domainname: example.org
@@ -1086,7 +1086,7 @@
 
 - name: entrypoint
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     entrypoint:
     - /bin/sh
     - "-v"
@@ -1098,7 +1098,7 @@
 
 - name: entrypoint (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     entrypoint:
     - /bin/sh
     - "-v"
@@ -1110,7 +1110,7 @@
 
 - name: entrypoint (change order, should not be idempotent)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     entrypoint:
     - /bin/sh
     - "-c"
@@ -1123,7 +1123,7 @@
 
 - name: entrypoint (less parameters)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     entrypoint:
     - /bin/sh
     - "-c"
@@ -1135,7 +1135,7 @@
 
 - name: entrypoint (other parameters)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     entrypoint:
     - /bin/sh
     - "-c"
@@ -1166,7 +1166,7 @@
 
 - name: env
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1180,7 +1180,7 @@
 
 - name: env (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1194,7 +1194,7 @@
 
 - name: env (less environment variables)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1204,7 +1204,7 @@
 
 - name: env (more environment variables)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1216,7 +1216,7 @@
 
 - name: env (fail unwrapped values)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1248,7 +1248,7 @@
 
 - name: env_file
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1257,7 +1257,7 @@
 
 - name: env_file (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1282,7 +1282,7 @@
 
 - name: etc_hosts
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1293,7 +1293,7 @@
 
 - name: etc_hosts (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1304,7 +1304,7 @@
 
 - name: etc_hosts (less hosts)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1314,7 +1314,7 @@
 
 - name: etc_hosts (more hosts)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1344,7 +1344,7 @@
 
 - name: exposed_ports
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1355,7 +1355,7 @@
 
 - name: exposed_ports (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1366,7 +1366,7 @@
 
 - name: exposed_ports (less ports)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1376,7 +1376,7 @@
 
 - name: exposed_ports (more ports)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1412,7 +1412,7 @@
 
 - name: groups
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1423,7 +1423,7 @@
 
 - name: groups (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1434,7 +1434,7 @@
 
 - name: groups (less groups)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1444,7 +1444,7 @@
 
 - name: groups (more groups)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1474,7 +1474,7 @@
 
 - name: healthcheck
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1492,7 +1492,7 @@
 
 - name: healthcheck (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1510,7 +1510,7 @@
 
 - name: healthcheck (changed)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1528,7 +1528,7 @@
 
 - name: healthcheck (no change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1538,7 +1538,7 @@
 
 - name: healthcheck (disabled)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1551,7 +1551,7 @@
 
 - name: healthcheck (disabled, idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1564,7 +1564,7 @@
 
 - name: healthcheck (string in healthcheck test, changed)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1576,7 +1576,7 @@
 
 - name: healthcheck (string in healthcheck test, idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1617,7 +1617,7 @@
 
 - name: hostname
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     hostname: me.example.com
@@ -1626,7 +1626,7 @@
 
 - name: hostname (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     hostname: me.example.com
@@ -1635,7 +1635,7 @@
 
 - name: hostname (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     hostname: me.example.org
@@ -1662,7 +1662,7 @@
 
 - name: init
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     init: yes
@@ -1672,7 +1672,7 @@
 
 - name: init (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     init: yes
@@ -1682,7 +1682,7 @@
 
 - name: init (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     init: no
@@ -1717,7 +1717,7 @@
 
 - name: interactive
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     interactive: yes
@@ -1726,7 +1726,7 @@
 
 - name: interactive (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     interactive: yes
@@ -1735,7 +1735,7 @@
 
 - name: interactive (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     interactive: no
@@ -1768,7 +1768,7 @@
 
 - name: image
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1776,7 +1776,7 @@
 
 - name: image (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1784,7 +1784,7 @@
 
 - name: ignore_image
   docker_container:
-    image: hello-world
+    image: quay.io/redhattraining/hello-world-nginx
     ignore_image: yes
     name: "{{ cname }}"
     state: started
@@ -1792,7 +1792,7 @@
 
 - name: image change
   docker_container:
-    image: hello-world
+    image: quay.io/redhattraining/hello-world-nginx
     name: "{{ cname }}"
     state: started
     force_kill: yes
@@ -1818,7 +1818,7 @@
 
 - name: start helpers
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ container_name }}"
     state: started
@@ -1830,7 +1830,7 @@
 
 - name: ipc_mode
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1840,7 +1840,7 @@
 
 - name: ipc_mode (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1850,7 +1850,7 @@
 
 - name: ipc_mode (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1882,7 +1882,7 @@
 
 - name: kernel_memory
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     kernel_memory: 8M
@@ -1892,7 +1892,7 @@
 
 - name: kernel_memory (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     kernel_memory: 8M
@@ -1902,7 +1902,7 @@
 
 - name: kernel_memory (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     kernel_memory: 6M
@@ -1938,7 +1938,7 @@
 
 - name: labels
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1949,7 +1949,7 @@
 
 - name: labels (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1960,7 +1960,7 @@
 
 - name: labels (less labels)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -1970,7 +1970,7 @@
 
 - name: labels (more labels)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2000,7 +2000,7 @@
 
 - name: start helpers
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ container_name }}"
     state: started
@@ -2013,7 +2013,7 @@
 
 - name: links
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2024,7 +2024,7 @@
 
 - name: links (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2035,7 +2035,7 @@
 
 - name: links (less links)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2045,7 +2045,7 @@
 
 - name: links (more links)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2082,7 +2082,7 @@
 
 - name: log_driver
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2091,7 +2091,7 @@
 
 - name: log_driver (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2100,7 +2100,7 @@
 
 - name: log_driver (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2127,7 +2127,7 @@
 
 - name: log_options
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2140,7 +2140,7 @@
 
 - name: log_options (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2153,7 +2153,7 @@
 
 - name: log_options (less log options)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2164,7 +2164,7 @@
 
 - name: log_options (more log options)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2197,7 +2197,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: mac_address
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     mac_address: 92:d0:c6:0a:29:33
@@ -2206,7 +2206,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: mac_address (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     mac_address: 92:d0:c6:0a:29:33
@@ -2215,7 +2215,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: mac_address (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     mac_address: 92:d0:c6:0a:29:44
@@ -2242,7 +2242,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory: 64M
@@ -2251,7 +2251,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory: 64M
@@ -2260,7 +2260,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory: 48M
@@ -2287,7 +2287,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_reservation
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_reservation: 64M
@@ -2296,7 +2296,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_reservation (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_reservation: 64M
@@ -2305,7 +2305,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_reservation (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_reservation: 48M
@@ -2332,7 +2332,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_swap
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     # Docker daemon does not accept memory_swap if memory is not specified
@@ -2344,7 +2344,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_swap (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     # Docker daemon does not accept memory_swap if memory is not specified
@@ -2356,7 +2356,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_swap (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     # Docker daemon does not accept memory_swap if memory is not specified
@@ -2395,7 +2395,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_swappiness
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_swappiness: 40
@@ -2404,7 +2404,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_swappiness (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_swappiness: 40
@@ -2413,7 +2413,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: memory_swappiness (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     memory_swappiness: 60
@@ -2440,7 +2440,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: oom_killer
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_killer: yes
@@ -2449,7 +2449,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: oom_killer (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_killer: yes
@@ -2458,7 +2458,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: oom_killer (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_killer: no
@@ -2485,7 +2485,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: oom_score_adj
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_score_adj: 5
@@ -2494,7 +2494,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: oom_score_adj (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_score_adj: 5
@@ -2503,7 +2503,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: oom_score_adj (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     oom_score_adj: 7
@@ -2536,7 +2536,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: paused
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: "/bin/sh -c 'sleep 10m'"
     name: "{{ cname }}"
     state: started
@@ -2550,7 +2550,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: paused (idempotent)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: "/bin/sh -c 'sleep 10m'"
     name: "{{ cname }}"
     state: started
@@ -2560,7 +2560,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: paused (continue)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: "/bin/sh -c 'sleep 10m'"
     name: "{{ cname }}"
     state: started
@@ -2593,7 +2593,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: start helpers
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname_h1 }}"
     state: started
@@ -2601,7 +2601,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: pid_mode
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2612,7 +2612,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: pid_mode (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2623,7 +2623,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: pid_mode (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2662,7 +2662,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: pids_limit
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2672,7 +2672,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: pids_limit (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2682,7 +2682,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: pids_limit (changed)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2717,7 +2717,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: privileged
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     privileged: yes
@@ -2726,7 +2726,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: privileged (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     privileged: yes
@@ -2735,7 +2735,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: privileged (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     privileged: no
@@ -2762,7 +2762,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: published_ports
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2773,7 +2773,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: published_ports (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2784,7 +2784,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: published_ports (less published_ports)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2794,7 +2794,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: published_ports (more published_ports)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2806,7 +2806,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: published_ports (ports with IP addresses)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -2843,7 +2843,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: read_only
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     read_only: yes
@@ -2852,7 +2852,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: read_only (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     read_only: yes
@@ -2861,7 +2861,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: read_only (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     read_only: no
@@ -2888,7 +2888,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: restart_policy
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: always
@@ -2897,7 +2897,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: restart_policy (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: always
@@ -2906,7 +2906,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: restart_policy (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: unless-stopped
@@ -2933,7 +2933,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: restart_retries
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: on-failure
@@ -2943,7 +2943,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: restart_retries (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: on-failure
@@ -2953,7 +2953,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: restart_retries (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart_policy: on-failure
@@ -2981,7 +2981,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: runtime
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     runtime: runc
@@ -2991,7 +2991,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: runtime (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     runtime: runc
@@ -3040,7 +3040,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: security_opts
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3051,7 +3051,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: security_opts (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3062,7 +3062,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: security_opts (less security options)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3072,7 +3072,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: security_opts (more security options)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3102,7 +3102,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: shm_size
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     shm_size: 96M
@@ -3111,7 +3111,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: shm_size (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     shm_size: 96M
@@ -3120,7 +3120,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: shm_size (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     shm_size: 75M
@@ -3147,7 +3147,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: stop_signal
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     stop_signal: "30"
@@ -3156,7 +3156,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: stop_signal (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     stop_signal: "30"
@@ -3165,7 +3165,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: stop_signal (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     stop_signal: "9"
@@ -3192,7 +3192,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: stop_timeout
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     stop_timeout: 2
@@ -3201,7 +3201,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: stop_timeout (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     stop_timeout: 2
@@ -3211,7 +3211,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 - name: stop_timeout (no change)
   # stop_timeout changes are ignored by default
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     stop_timeout: 1
@@ -3247,7 +3247,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: sysctls
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3259,7 +3259,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: sysctls (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3271,7 +3271,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: sysctls (less sysctls)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3282,7 +3282,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: sysctls (more sysctls)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3320,7 +3320,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tmpfs
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3331,7 +3331,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tmpfs (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3342,7 +3342,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tmpfs (less tmpfs)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3352,7 +3352,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tmpfs (more tmpfs)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3388,7 +3388,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tty
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     tty: yes
@@ -3397,7 +3397,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tty (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     tty: yes
@@ -3406,7 +3406,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: tty (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     tty: no
@@ -3433,7 +3433,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: ulimits
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3444,7 +3444,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: ulimits (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3455,7 +3455,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: ulimits (less ulimits)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3465,7 +3465,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: ulimits (more ulimits)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -3495,7 +3495,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: user
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     user: nobody
@@ -3504,7 +3504,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: user (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     user: nobody
@@ -3513,7 +3513,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: user (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     user: root
@@ -3540,7 +3540,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: userns_mode
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     userns_mode: host
@@ -3550,7 +3550,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: userns_mode (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     userns_mode: host
@@ -3560,7 +3560,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: userns_mode (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     userns_mode: ""
@@ -3595,7 +3595,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: uts
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     uts: host
@@ -3605,7 +3605,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: uts (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     uts: host
@@ -3615,7 +3615,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: uts (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     uts: ""
@@ -3650,7 +3650,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: working_dir
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     working_dir: /tmp
@@ -3659,7 +3659,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: working_dir (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     working_dir: /tmp
@@ -3668,7 +3668,7 @@ avoid such warnings, please quote the value.' in log_options_2.warnings"
 
 - name: working_dir (change)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     working_dir: /

--- a/test/integration/targets/docker_container/tasks/tests/ports.yml
+++ b/test/integration/targets/docker_container/tasks/tests/ports.yml
@@ -9,7 +9,7 @@
 
 - name: published_ports -- all
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -23,7 +23,7 @@
 
 - name: published_ports -- all (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -37,7 +37,7 @@
 
 - name: published_ports -- all (writing out 'all')
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -52,7 +52,7 @@
 
 - name: published_ports -- all (idempotency 2)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -67,7 +67,7 @@
 
 - name: published_ports -- all (switching back to 'all')
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -100,7 +100,7 @@
 
 - name: published_ports -- port range
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -115,7 +115,7 @@
 
 - name: published_ports -- port range (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -130,7 +130,7 @@
 
 - name: published_ports -- port range (different range)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -162,7 +162,7 @@
 
 - name: published_ports -- IPv6
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -173,7 +173,7 @@
 
 - name: published_ports -- IPv6 (idempotency)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -184,7 +184,7 @@
 
 - name: published_ports -- IPv6 (different IP)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -195,7 +195,7 @@
 
 - name: published_ports -- IPv6 (hostname)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started

--- a/test/integration/targets/docker_container/tasks/tests/ports.yml
+++ b/test/integration/targets/docker_container/tasks/tests/ports.yml
@@ -9,7 +9,7 @@
 
 - name: published_ports -- all
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -23,7 +23,7 @@
 
 - name: published_ports -- all (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -37,7 +37,7 @@
 
 - name: published_ports -- all (writing out 'all')
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -52,7 +52,7 @@
 
 - name: published_ports -- all (idempotency 2)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -67,7 +67,7 @@
 
 - name: published_ports -- all (switching back to 'all')
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -100,7 +100,7 @@
 
 - name: published_ports -- port range
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -115,7 +115,7 @@
 
 - name: published_ports -- port range (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -130,7 +130,7 @@
 
 - name: published_ports -- port range (different range)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -162,7 +162,7 @@
 
 - name: published_ports -- IPv6
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -173,7 +173,7 @@
 
 - name: published_ports -- IPv6 (idempotency)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -184,7 +184,7 @@
 
 - name: published_ports -- IPv6 (different IP)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -195,7 +195,7 @@
 
 - name: published_ports -- IPv6 (hostname)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started

--- a/test/integration/targets/docker_container/tasks/tests/ports.yml
+++ b/test/integration/targets/docker_container/tasks/tests/ports.yml
@@ -9,7 +9,7 @@
 
 - name: published_ports -- all
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -23,7 +23,7 @@
 
 - name: published_ports -- all (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -37,7 +37,7 @@
 
 - name: published_ports -- all (writing out 'all')
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -52,7 +52,7 @@
 
 - name: published_ports -- all (idempotency 2)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -67,7 +67,7 @@
 
 - name: published_ports -- all (switching back to 'all')
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -100,7 +100,7 @@
 
 - name: published_ports -- port range
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -115,7 +115,7 @@
 
 - name: published_ports -- port range (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -130,7 +130,7 @@
 
 - name: published_ports -- port range (different range)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -162,7 +162,7 @@
 
 - name: published_ports -- IPv6
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -173,7 +173,7 @@
 
 - name: published_ports -- IPv6 (idempotency)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -184,7 +184,7 @@
 
 - name: published_ports -- IPv6 (different IP)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -195,7 +195,7 @@
 
 - name: published_ports -- IPv6 (hostname)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started

--- a/test/integration/targets/docker_container/tasks/tests/regression-45700-dont-parse-on-absent.yml
+++ b/test/integration/targets/docker_container/tasks/tests/regression-45700-dont-parse-on-absent.yml
@@ -9,7 +9,7 @@
 
 - name: Start container
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started

--- a/test/integration/targets/docker_container/tasks/tests/regression-45700-dont-parse-on-absent.yml
+++ b/test/integration/targets/docker_container/tasks/tests/regression-45700-dont-parse-on-absent.yml
@@ -9,7 +9,7 @@
 
 - name: Start container
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started

--- a/test/integration/targets/docker_container/tasks/tests/regression-45700-dont-parse-on-absent.yml
+++ b/test/integration/targets/docker_container/tasks/tests/regression-45700-dont-parse-on-absent.yml
@@ -9,7 +9,7 @@
 
 - name: Start container
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started

--- a/test/integration/targets/docker_container/tasks/tests/start-stop.yml
+++ b/test/integration/targets/docker_container/tasks/tests/start-stop.yml
@@ -12,7 +12,7 @@
 
 - name: Create container (check)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -21,7 +21,7 @@
 
 - name: Create container
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -29,7 +29,7 @@
 
 - name: Create container (idempotent)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -37,7 +37,7 @@
 
 - name: Create container (idempotent check)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -94,7 +94,7 @@
 
 - name: Present check for running container (check)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -103,7 +103,7 @@
 
 - name: Present check for running container
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -126,7 +126,7 @@
 
 - name: Start container from scratch (check)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     stop_timeout: 1
     name: "{{ cname }}"
@@ -136,7 +136,7 @@
 
 - name: Start container from scratch
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     stop_timeout: 1
     name: "{{ cname }}"
@@ -145,7 +145,7 @@
 
 - name: Start container from scratch (idempotent)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     stop_timeout: 1
     name: "{{ cname }}"
@@ -154,7 +154,7 @@
 
 - name: Start container from scratch (idempotent check)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     stop_timeout: 1
     name: "{{ cname }}"
@@ -175,7 +175,7 @@
 
 - name: Recreating container (created)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -184,7 +184,7 @@
 
 - name: Recreating container (created, recreate)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     recreate: yes
@@ -194,7 +194,7 @@
 
 - name: Recreating container (started)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -203,7 +203,7 @@
 
 - name: Recreating container (started, recreate)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     recreate: yes
@@ -238,7 +238,7 @@
 
 - name: Restarting
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -249,7 +249,7 @@
 
 - name: Restarting (restart)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart: yes
@@ -260,7 +260,7 @@
 
 - name: Restarting (verify volumes)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -289,7 +289,7 @@
 
 - name: Stop container (check)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     name: "{{ cname }}"
     state: stopped
     stop_timeout: 1
@@ -298,7 +298,7 @@
 
 - name: Stop container
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     name: "{{ cname }}"
     state: stopped
     stop_timeout: 1
@@ -306,7 +306,7 @@
 
 - name: Stop container (idempotent)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     name: "{{ cname }}"
     state: stopped
     stop_timeout: 1
@@ -314,7 +314,7 @@
 
 - name: Stop container (idempotent check)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     name: "{{ cname }}"
     state: stopped
     stop_timeout: 1
@@ -371,7 +371,7 @@
 
 - name: Start container (setup for removing from running)
   docker_container:
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started

--- a/test/integration/targets/docker_container/tasks/tests/start-stop.yml
+++ b/test/integration/targets/docker_container/tasks/tests/start-stop.yml
@@ -12,7 +12,7 @@
 
 - name: Create container (check)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -21,7 +21,7 @@
 
 - name: Create container
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -29,7 +29,7 @@
 
 - name: Create container (idempotent)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -37,7 +37,7 @@
 
 - name: Create container (idempotent check)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -94,7 +94,7 @@
 
 - name: Present check for running container (check)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -103,7 +103,7 @@
 
 - name: Present check for running container
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -126,7 +126,7 @@
 
 - name: Start container from scratch (check)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     stop_timeout: 1
     name: "{{ cname }}"
@@ -136,7 +136,7 @@
 
 - name: Start container from scratch
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     stop_timeout: 1
     name: "{{ cname }}"
@@ -145,7 +145,7 @@
 
 - name: Start container from scratch (idempotent)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     stop_timeout: 1
     name: "{{ cname }}"
@@ -154,7 +154,7 @@
 
 - name: Start container from scratch (idempotent check)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     stop_timeout: 1
     name: "{{ cname }}"
@@ -175,7 +175,7 @@
 
 - name: Recreating container (created)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -184,7 +184,7 @@
 
 - name: Recreating container (created, recreate)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     recreate: yes
@@ -194,7 +194,7 @@
 
 - name: Recreating container (started)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -203,7 +203,7 @@
 
 - name: Recreating container (started, recreate)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     recreate: yes
@@ -238,7 +238,7 @@
 
 - name: Restarting
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -249,7 +249,7 @@
 
 - name: Restarting (restart)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart: yes
@@ -260,7 +260,7 @@
 
 - name: Restarting (verify volumes)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -289,7 +289,7 @@
 
 - name: Stop container (check)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     name: "{{ cname }}"
     state: stopped
     stop_timeout: 1
@@ -298,7 +298,7 @@
 
 - name: Stop container
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     name: "{{ cname }}"
     state: stopped
     stop_timeout: 1
@@ -306,7 +306,7 @@
 
 - name: Stop container (idempotent)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     name: "{{ cname }}"
     state: stopped
     stop_timeout: 1
@@ -314,7 +314,7 @@
 
 - name: Stop container (idempotent check)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     name: "{{ cname }}"
     state: stopped
     stop_timeout: 1
@@ -371,7 +371,7 @@
 
 - name: Start container (setup for removing from running)
   docker_container:
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started

--- a/test/integration/targets/docker_container/tasks/tests/start-stop.yml
+++ b/test/integration/targets/docker_container/tasks/tests/start-stop.yml
@@ -12,7 +12,7 @@
 
 - name: Create container (check)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -21,7 +21,7 @@
 
 - name: Create container
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -29,7 +29,7 @@
 
 - name: Create container (idempotent)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -37,7 +37,7 @@
 
 - name: Create container (idempotent check)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -94,7 +94,7 @@
 
 - name: Present check for running container (check)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -103,7 +103,7 @@
 
 - name: Present check for running container
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -126,7 +126,7 @@
 
 - name: Start container from scratch (check)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     stop_timeout: 1
     name: "{{ cname }}"
@@ -136,7 +136,7 @@
 
 - name: Start container from scratch
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     stop_timeout: 1
     name: "{{ cname }}"
@@ -145,7 +145,7 @@
 
 - name: Start container from scratch (idempotent)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     stop_timeout: 1
     name: "{{ cname }}"
@@ -154,7 +154,7 @@
 
 - name: Start container from scratch (idempotent check)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     stop_timeout: 1
     name: "{{ cname }}"
@@ -175,7 +175,7 @@
 
 - name: Recreating container (created)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: present
@@ -184,7 +184,7 @@
 
 - name: Recreating container (created, recreate)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     recreate: yes
@@ -194,7 +194,7 @@
 
 - name: Recreating container (started)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -203,7 +203,7 @@
 
 - name: Recreating container (started, recreate)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     recreate: yes
@@ -238,7 +238,7 @@
 
 - name: Restarting
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -249,7 +249,7 @@
 
 - name: Restarting (restart)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     restart: yes
@@ -260,7 +260,7 @@
 
 - name: Restarting (verify volumes)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started
@@ -289,7 +289,7 @@
 
 - name: Stop container (check)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     name: "{{ cname }}"
     state: stopped
     stop_timeout: 1
@@ -298,7 +298,7 @@
 
 - name: Stop container
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     name: "{{ cname }}"
     state: stopped
     stop_timeout: 1
@@ -306,7 +306,7 @@
 
 - name: Stop container (idempotent)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     name: "{{ cname }}"
     state: stopped
     stop_timeout: 1
@@ -314,7 +314,7 @@
 
 - name: Stop container (idempotent check)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     name: "{{ cname }}"
     state: stopped
     stop_timeout: 1
@@ -371,7 +371,7 @@
 
 - name: Start container (setup for removing from running)
   docker_container:
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -c "sleep 10m"'
     name: "{{ cname }}"
     state: started

--- a/test/integration/targets/docker_container_info/tasks/main.yml
+++ b/test/integration/targets/docker_container_info/tasks/main.yml
@@ -24,7 +24,7 @@
   - name: Make sure container exists
     docker_container:
       name: "{{ cname }}"
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       state: started
       force_kill: yes

--- a/test/integration/targets/docker_container_info/tasks/main.yml
+++ b/test/integration/targets/docker_container_info/tasks/main.yml
@@ -24,7 +24,7 @@
   - name: Make sure container exists
     docker_container:
       name: "{{ cname }}"
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       state: started
       force_kill: yes

--- a/test/integration/targets/docker_container_info/tasks/main.yml
+++ b/test/integration/targets/docker_container_info/tasks/main.yml
@@ -24,7 +24,7 @@
   - name: Make sure container exists
     docker_container:
       name: "{{ cname }}"
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       state: started
       force_kill: yes

--- a/test/integration/targets/docker_host_info/tasks/test_host_info.yml
+++ b/test/integration/targets/docker_host_info/tasks/test_host_info.yml
@@ -28,7 +28,7 @@
 # * network list is always non-empty (default networks).
   - name: Create container
     docker_container:
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started

--- a/test/integration/targets/docker_host_info/tasks/test_host_info.yml
+++ b/test/integration/targets/docker_host_info/tasks/test_host_info.yml
@@ -28,7 +28,7 @@
 # * network list is always non-empty (default networks).
   - name: Create container
     docker_container:
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started

--- a/test/integration/targets/docker_host_info/tasks/test_host_info.yml
+++ b/test/integration/targets/docker_host_info/tasks/test_host_info.yml
@@ -28,7 +28,7 @@
 # * network list is always non-empty (default networks).
   - name: Create container
     docker_container:
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
       command: '/bin/sh -c "sleep 10m"'
       name: "{{ cname }}"
       state: started

--- a/test/integration/targets/docker_image/files/Dockerfile
+++ b/test/integration/targets/docker_image/files/Dockerfile
@@ -1,3 +1,3 @@
-FROM quay.io/ansible/bb
+FROM quay.io/ansible/docker-test-containers:busybox
 ENV foo /bar
 WORKDIR ${foo}

--- a/test/integration/targets/docker_image/files/Dockerfile
+++ b/test/integration/targets/docker_image/files/Dockerfile
@@ -1,3 +1,3 @@
-FROM busybox
+FROM quay.io/ansible/bb
 ENV foo /bar
 WORKDIR ${foo}

--- a/test/integration/targets/docker_image/files/EtcHostsDockerfile
+++ b/test/integration/targets/docker_image/files/EtcHostsDockerfile
@@ -1,3 +1,3 @@
-FROM busybox
+FROM quay.io/ansible/bb
 # This should fail building if docker cannot resolve some-custom-host
 RUN ping -c1 some-custom-host

--- a/test/integration/targets/docker_image/files/EtcHostsDockerfile
+++ b/test/integration/targets/docker_image/files/EtcHostsDockerfile
@@ -1,3 +1,3 @@
-FROM quay.io/ansible/bb
+FROM quay.io/ansible/docker-test-containers:busybox
 # This should fail building if docker cannot resolve some-custom-host
 RUN ping -c1 some-custom-host

--- a/test/integration/targets/docker_image/files/MyDockerfile
+++ b/test/integration/targets/docker_image/files/MyDockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ansible/mountainous:3.7
+FROM quay.io/ansible/docker-test-containers:alpine3.7
 ENV INSTALL_PATH /newdata
 RUN mkdir -p $INSTALL_PATH
 

--- a/test/integration/targets/docker_image/files/MyDockerfile
+++ b/test/integration/targets/docker_image/files/MyDockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM quay.io/ansible/mountainous:3.7
 ENV INSTALL_PATH /newdata
 RUN mkdir -p $INSTALL_PATH
 

--- a/test/integration/targets/docker_image/files/StagedDockerfile
+++ b/test/integration/targets/docker_image/files/StagedDockerfile
@@ -1,7 +1,7 @@
-FROM busybox AS first
+FROM quay.io/ansible/bb AS first
 ENV dir /first
 WORKDIR ${dir}
 
-FROM busybox AS second
+FROM quay.io/ansible/bb AS second
 ENV dir /second
 WORKDIR ${dir}

--- a/test/integration/targets/docker_image/files/StagedDockerfile
+++ b/test/integration/targets/docker_image/files/StagedDockerfile
@@ -1,7 +1,7 @@
-FROM quay.io/ansible/bb AS first
+FROM quay.io/ansible/docker-test-containers:busybox AS first
 ENV dir /first
 WORKDIR ${dir}
 
-FROM quay.io/ansible/bb AS second
+FROM quay.io/ansible/docker-test-containers:busybox AS second
 ENV dir /second
 WORKDIR ${dir}

--- a/test/integration/targets/docker_image/tasks/tests/basic.yml
+++ b/test/integration/targets/docker_image/tasks/tests/basic.yml
@@ -5,14 +5,14 @@
 
 - name: Make sure image is not there
   docker_image:
-    name: "hello-world:latest"
+    name: "quay.io/ansible/hey:latest"
     state: absent
     force_absent: yes
   register: absent_1
 
 - name: Make sure image is not there (idempotency)
   docker_image:
-    name: "hello-world:latest"
+    name: "quay.io/ansible/hey:latest"
     state: absent
   register: absent_2
 
@@ -22,14 +22,14 @@
 
 - name: Make sure image is there
   docker_image:
-    name: "hello-world:latest"
+    name: "quay.io/ansible/hey:latest"
     state: present
     source: pull
   register: present_1
 
 - name: Make sure image is there (idempotent)
   docker_image:
-    name: "hello-world:latest"
+    name: "quay.io/ansible/hey:latest"
     state: present
     source: pull
   register: present_2
@@ -41,28 +41,28 @@
 
 - name: Make sure tag is not there
   docker_image:
-    name: "hello-world:alias"
+    name: "quay.io/ansible/hey:alias"
     state: absent
 
 - name: Tag image with alias
   docker_image:
     source: local
-    name: "hello-world:latest"
-    repository: "hello-world:alias"
+    name: "quay.io/ansible/hey:latest"
+    repository: "quay.io/ansible/hey:alias"
   register: tag_1
 
 - name: Tag image with alias (idempotent)
   docker_image:
     source: local
-    name: "hello-world:latest"
-    repository: "hello-world:alias"
+    name: "quay.io/ansible/hey:latest"
+    repository: "quay.io/ansible/hey:alias"
   register: tag_2
 
 - name: Tag image with alias (force, still idempotent)
   docker_image:
     source: local
-    name: "hello-world:latest"
-    repository: "hello-world:alias"
+    name: "quay.io/ansible/hey:latest"
+    repository: "quay.io/ansible/hey:alias"
     force_tag: yes
   register: tag_3
 
@@ -74,5 +74,5 @@
 
 - name: Cleanup alias tag
   docker_image:
-    name: "hello-world:alias"
+    name: "quay.io/ansible/hey:alias"
     state: absent

--- a/test/integration/targets/docker_image/tasks/tests/basic.yml
+++ b/test/integration/targets/docker_image/tasks/tests/basic.yml
@@ -5,14 +5,14 @@
 
 - name: Make sure image is not there
   docker_image:
-    name: "quay.io/ansible/hey:latest"
+    name: "quay.io/ansible/docker-test-containers:hello-world"
     state: absent
     force_absent: yes
   register: absent_1
 
 - name: Make sure image is not there (idempotency)
   docker_image:
-    name: "quay.io/ansible/hey:latest"
+    name: "quay.io/ansible/docker-test-containers:hello-world"
     state: absent
   register: absent_2
 
@@ -22,14 +22,14 @@
 
 - name: Make sure image is there
   docker_image:
-    name: "quay.io/ansible/hey:latest"
+    name: "quay.io/ansible/docker-test-containers:hello-world"
     state: present
     source: pull
   register: present_1
 
 - name: Make sure image is there (idempotent)
   docker_image:
-    name: "quay.io/ansible/hey:latest"
+    name: "quay.io/ansible/docker-test-containers:hello-world"
     state: present
     source: pull
   register: present_2
@@ -41,28 +41,28 @@
 
 - name: Make sure tag is not there
   docker_image:
-    name: "quay.io/ansible/hey:alias"
+    name: "quay.io/ansible/docker-test-containers:alias"
     state: absent
 
 - name: Tag image with alias
   docker_image:
     source: local
-    name: "quay.io/ansible/hey:latest"
-    repository: "quay.io/ansible/hey:alias"
+    name: "quay.io/ansible/docker-test-containers:hello-world"
+    repository: "quay.io/ansible/docker-test-containers:alias"
   register: tag_1
 
 - name: Tag image with alias (idempotent)
   docker_image:
     source: local
-    name: "quay.io/ansible/hey:latest"
-    repository: "quay.io/ansible/hey:alias"
+    name: "quay.io/ansible/docker-test-containers:hello-world"
+    repository: "quay.io/ansible/docker-test-containers:alias"
   register: tag_2
 
 - name: Tag image with alias (force, still idempotent)
   docker_image:
     source: local
-    name: "quay.io/ansible/hey:latest"
-    repository: "quay.io/ansible/hey:alias"
+    name: "quay.io/ansible/docker-test-containers:hello-world"
+    repository: "quay.io/ansible/docker-test-containers:alias"
     force_tag: yes
   register: tag_3
 
@@ -74,5 +74,5 @@
 
 - name: Cleanup alias tag
   docker_image:
-    name: "quay.io/ansible/hey:alias"
+    name: "ansible/docker-test-containers:alias"
     state: absent

--- a/test/integration/targets/docker_image/tasks/tests/options.yml
+++ b/test/integration/targets/docker_image/tasks/tests/options.yml
@@ -177,27 +177,27 @@
 
 - name: Archive image
   docker_image:
-    name: "quay.io/ansible/hey:latest"
+    name: "quay.io/ansible/docker-test-containers:hello-world"
     archive_path: "{{ output_dir }}/image.tar"
     source: pull
   register: archive_image
 
 - name: remove image
   docker_image:
-    name: "quay.io/ansible/hey:latest"
+    name: "quay.io/ansible/docker-test-containers:hello-world"
     state: absent
     force_absent: yes
 
 - name: load image (changed)
   docker_image:
-    name: "quay.io/ansible/hey:latest"
+    name: "quay.io/ansible/docker-test-containers:hello-world"
     load_path: "{{ output_dir }}/image.tar"
     source: load
   register: load_image
 
 - name: load image (idempotency)
   docker_image:
-    name: "quay.io/ansible/hey:latest"
+    name: "quay.io/ansible/docker-test-containers:hello-world"
     load_path: "{{ output_dir }}/image.tar"
     source: load
   register: load_image_1

--- a/test/integration/targets/docker_image/tasks/tests/options.yml
+++ b/test/integration/targets/docker_image/tasks/tests/options.yml
@@ -177,27 +177,27 @@
 
 - name: Archive image
   docker_image:
-    name: "hello-world:latest"
+    name: "quay.io/ansible/hey:latest"
     archive_path: "{{ output_dir }}/image.tar"
     source: pull
   register: archive_image
 
 - name: remove image
   docker_image:
-    name: "hello-world:latest"
+    name: "quay.io/ansible/hey:latest"
     state: absent
     force_absent: yes
 
 - name: load image (changed)
   docker_image:
-    name: "hello-world:latest"
+    name: "quay.io/ansible/hey:latest"
     load_path: "{{ output_dir }}/image.tar"
     source: load
   register: load_image
 
 - name: load image (idempotency)
   docker_image:
-    name: "hello-world:latest"
+    name: "quay.io/ansible/hey:latest"
     load_path: "{{ output_dir }}/image.tar"
     source: load
   register: load_image_1

--- a/test/integration/targets/docker_image_info/tasks/main.yml
+++ b/test/integration/targets/docker_image_info/tasks/main.yml
@@ -2,12 +2,12 @@
 - block:
   - name: Make sure image is not there
     docker_image:
-      name: alpine:3.7
+      name: quay.io/ansible/mountainous:3.7
       state: absent
 
   - name: Inspect a non-available image
     docker_image_info:
-      name: alpine:3.7
+      name: quay.io/ansible/mountainous:3.7
     register: result
 
   - assert:
@@ -20,24 +20,24 @@
       source: pull
       state: present
     loop:
-    - "hello-world:latest"
-    - "alpine:3.8"
+    - "quay.io/ansible/hey:latest"
+    - "quay.io/ansible/mountainous:3.8"
 
   - name: Inspect an available image
     docker_image_info:
-      name: hello-world:latest
+      name: quay.io/ansible/hey:latest
     register: result
 
   - assert:
       that:
       - "result.images|length == 1"
-      - "'hello-world:latest' in result.images[0].RepoTags"
+      - "'quay.io/ansible/hey:latest' in result.images[0].RepoTags"
 
   - name: Inspect multiple images
     docker_image_info:
       name:
-      - "hello-world:latest"
-      - "alpine:3.8"
+      - "quay.io/ansible/hey:latest"
+      - "quay.io/ansible/mountainous:3.8"
     register: result
 
   - debug: var=result
@@ -45,8 +45,8 @@
   - assert:
       that:
       - "result.images|length == 2"
-      - "'hello-world:latest' in result.images[0].RepoTags"
-      - "'alpine:3.8' in result.images[1].RepoTags"
+      - "'quay.io/ansible/hey:latest' in result.images[0].RepoTags"
+      - "'quay.io/ansible/mountainous:3.8' in result.images[1].RepoTags"
 
   when: docker_py_version is version('1.8.0', '>=') and docker_api_version is version('1.20', '>=')
 

--- a/test/integration/targets/docker_image_info/tasks/main.yml
+++ b/test/integration/targets/docker_image_info/tasks/main.yml
@@ -2,12 +2,12 @@
 - block:
   - name: Make sure image is not there
     docker_image:
-      name: quay.io/ansible/mountainous:3.7
+      name: quay.io/ansible/docker-test-containers:alpine3.7
       state: absent
 
   - name: Inspect a non-available image
     docker_image_info:
-      name: quay.io/ansible/mountainous:3.7
+      name: quay.io/ansible/docker-test-containers:alpine3.7
     register: result
 
   - assert:
@@ -20,24 +20,24 @@
       source: pull
       state: present
     loop:
-    - "quay.io/ansible/hey:latest"
-    - "quay.io/ansible/mountainous:3.8"
+    - "quay.io/ansible/docker-test-containers:hello-world"
+    - "quay.io/ansible/docker-test-containers:alpine3.8"
 
   - name: Inspect an available image
     docker_image_info:
-      name: quay.io/ansible/hey:latest
+      name: quay.io/ansible/docker-test-containers:hello-world
     register: result
 
   - assert:
       that:
       - "result.images|length == 1"
-      - "'quay.io/ansible/hey:latest' in result.images[0].RepoTags"
+      - "'quay.io/ansible/docker-test-containers:hello-world' in result.images[0].RepoTags"
 
   - name: Inspect multiple images
     docker_image_info:
       name:
-      - "quay.io/ansible/hey:latest"
-      - "quay.io/ansible/mountainous:3.8"
+      - "quay.io/ansible/docker-test-containers:hello-world"
+      - "quay.io/ansible/docker-test-containers:alpine3.8"
     register: result
 
   - debug: var=result
@@ -45,8 +45,8 @@
   - assert:
       that:
       - "result.images|length == 2"
-      - "'quay.io/ansible/hey:latest' in result.images[0].RepoTags"
-      - "'quay.io/ansible/mountainous:3.8' in result.images[1].RepoTags"
+      - "'quay.io/ansible/docker-test-containers:hello-world' in result.images[0].RepoTags"
+      - "'quay.io/ansible/docker-test-containers:alpine3.8' in result.images[1].RepoTags"
 
   when: docker_py_version is version('1.8.0', '>=') and docker_api_version is version('1.20', '>=')
 

--- a/test/integration/targets/docker_network/tasks/tests/basic.yml
+++ b/test/integration/targets/docker_network/tasks/tests/basic.yml
@@ -14,7 +14,7 @@
 - name: Create containers
   docker_container:
     name: "{{ container_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: /bin/sleep 10m
     state: started
   loop:

--- a/test/integration/targets/docker_network/tasks/tests/basic.yml
+++ b/test/integration/targets/docker_network/tasks/tests/basic.yml
@@ -14,7 +14,7 @@
 - name: Create containers
   docker_container:
     name: "{{ container_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: /bin/sleep 10m
     state: started
   loop:

--- a/test/integration/targets/docker_network/tasks/tests/basic.yml
+++ b/test/integration/targets/docker_network/tasks/tests/basic.yml
@@ -14,7 +14,7 @@
 - name: Create containers
   docker_container:
     name: "{{ container_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: /bin/sleep 10m
     state: started
   loop:

--- a/test/integration/targets/docker_prune/tasks/main.yml
+++ b/test/integration/targets/docker_prune/tasks/main.yml
@@ -9,7 +9,7 @@
   # Create objects to be pruned
   - docker_container:
       name: "{{ cname }}"
-      image: hello-world
+      image: quay.io/redhattraining/hello-world-nginx
       state: present
     register: container
   - docker_network:

--- a/test/integration/targets/docker_prune/tasks/main.yml
+++ b/test/integration/targets/docker_prune/tasks/main.yml
@@ -9,7 +9,7 @@
   # Create objects to be pruned
   - docker_container:
       name: "{{ cname }}"
-      image: quay.io/redhattraining/hello-world-nginx
+      image: quay.io/ansible/hey
       state: present
     register: container
   - docker_network:

--- a/test/integration/targets/docker_prune/tasks/main.yml
+++ b/test/integration/targets/docker_prune/tasks/main.yml
@@ -9,7 +9,7 @@
   # Create objects to be pruned
   - docker_container:
       name: "{{ cname }}"
-      image: quay.io/ansible/hey
+      image: quay.io/ansible/docker-test-containers:hello-world
       state: present
     register: container
   - docker_network:

--- a/test/integration/targets/docker_stack/files/stack_compose_base.yml
+++ b/test/integration/targets/docker_stack/files/stack_compose_base.yml
@@ -1,5 +1,5 @@
 version: '3'
 services:
     busybox:
-        image: quay.io/quay/busybox:latest
+        image: quay.io/ansible/docker-test-containers:busybox
         command: sleep 3600

--- a/test/integration/targets/docker_stack/files/stack_compose_base.yml
+++ b/test/integration/targets/docker_stack/files/stack_compose_base.yml
@@ -1,5 +1,5 @@
 version: '3'
 services:
     busybox:
-        image: busybox:latest
+        image: quay.io/quay/busybox:latest
         command: sleep 3600

--- a/test/integration/targets/docker_stack/vars/main.yml
+++ b/test/integration/targets/docker_stack/vars/main.yml
@@ -2,7 +2,7 @@ stack_compose_base:
     version: '3'
     services:
         busybox:
-            image: busybox:latest
+            image: quay.io/quay/busybox:latest
             command: sleep 3600
 
 stack_compose_overrides:

--- a/test/integration/targets/docker_stack/vars/main.yml
+++ b/test/integration/targets/docker_stack/vars/main.yml
@@ -2,7 +2,7 @@ stack_compose_base:
     version: '3'
     services:
         busybox:
-            image: quay.io/quay/busybox:latest
+            image: quay.io/ansible/docker-test-containers:busybox
             command: sleep 3600
 
 stack_compose_overrides:

--- a/test/integration/targets/docker_swarm_service/tasks/main.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/main.yml
@@ -20,9 +20,7 @@
       state: present
       advertise_addr: "{{ansible_default_ipv4.address | default('127.0.0.1')}}"
 
-  - include_tasks: run-test.yml
-    with_fileglob:
-      - "tests/*.yml"
+  - import_tasks: tests/options.yml
 
   always:
     - name: Make sure all services are removed

--- a/test/integration/targets/docker_swarm_service/tasks/tests/configs.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/configs.yml
@@ -31,7 +31,7 @@
 - name: configs
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -44,7 +44,7 @@
 - name: configs (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -56,7 +56,7 @@
 - name: configs (add)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -71,7 +71,7 @@
 - name: configs (add idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -86,7 +86,7 @@
 - name: configs (add idempotency no id)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -100,7 +100,7 @@
 - name: configs (add idempotency no id and re-ordered)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -114,7 +114,7 @@
 - name: configs (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs: []
@@ -124,7 +124,7 @@
 - name: configs (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs: []
@@ -162,7 +162,7 @@
 - name: configs (uid int)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -175,7 +175,7 @@
 - name: configs (uid int idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -188,7 +188,7 @@
 - name: configs (uid int change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -201,7 +201,7 @@
 - name: configs (uid str)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -214,7 +214,7 @@
 - name: configs (uid str idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -252,7 +252,7 @@
 - name: configs (gid int)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -265,7 +265,7 @@
 - name: configs (gid int idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -278,7 +278,7 @@
 - name: configs (gid int change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -291,7 +291,7 @@
 - name: configs (gid str)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -304,7 +304,7 @@
 - name: configs (gid str idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -341,7 +341,7 @@
 - name: configs (mode)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -354,7 +354,7 @@
 - name: configs (mode idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -367,7 +367,7 @@
 - name: configs (mode change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/configs.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/configs.yml
@@ -31,7 +31,7 @@
 - name: configs
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -44,7 +44,7 @@
 - name: configs (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -56,7 +56,7 @@
 - name: configs (add)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -71,7 +71,7 @@
 - name: configs (add idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -86,7 +86,7 @@
 - name: configs (add idempotency no id)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -100,7 +100,7 @@
 - name: configs (add idempotency no id and re-ordered)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -114,7 +114,7 @@
 - name: configs (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs: []
@@ -124,7 +124,7 @@
 - name: configs (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs: []
@@ -162,7 +162,7 @@
 - name: configs (uid int)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -175,7 +175,7 @@
 - name: configs (uid int idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -188,7 +188,7 @@
 - name: configs (uid int change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -201,7 +201,7 @@
 - name: configs (uid str)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -214,7 +214,7 @@
 - name: configs (uid str idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -252,7 +252,7 @@
 - name: configs (gid int)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -265,7 +265,7 @@
 - name: configs (gid int idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -278,7 +278,7 @@
 - name: configs (gid int change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -291,7 +291,7 @@
 - name: configs (gid str)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -304,7 +304,7 @@
 - name: configs (gid str idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -341,7 +341,7 @@
 - name: configs (mode)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -354,7 +354,7 @@
 - name: configs (mode idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -367,7 +367,7 @@
 - name: configs (mode change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/configs.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/configs.yml
@@ -31,7 +31,7 @@
 - name: configs
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -44,7 +44,7 @@
 - name: configs (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -56,7 +56,7 @@
 - name: configs (add)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -71,7 +71,7 @@
 - name: configs (add idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -86,7 +86,7 @@
 - name: configs (add idempotency no id)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -100,7 +100,7 @@
 - name: configs (add idempotency no id and re-ordered)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -114,7 +114,7 @@
 - name: configs (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs: []
@@ -124,7 +124,7 @@
 - name: configs (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs: []
@@ -162,7 +162,7 @@
 - name: configs (uid int)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -175,7 +175,7 @@
 - name: configs (uid int idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -188,7 +188,7 @@
 - name: configs (uid int change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -201,7 +201,7 @@
 - name: configs (uid str)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -214,7 +214,7 @@
 - name: configs (uid str idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -252,7 +252,7 @@
 - name: configs (gid int)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -265,7 +265,7 @@
 - name: configs (gid int idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -278,7 +278,7 @@
 - name: configs (gid int change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -291,7 +291,7 @@
 - name: configs (gid str)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -304,7 +304,7 @@
 - name: configs (gid str idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -341,7 +341,7 @@
 - name: configs (mode)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -354,7 +354,7 @@
 - name: configs (mode idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:
@@ -367,7 +367,7 @@
 - name: configs (mode change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     configs:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/logging.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/logging.yml
@@ -15,7 +15,7 @@
 - name: logging.driver
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -25,7 +25,7 @@
 - name: logging.driver (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -35,7 +35,7 @@
 - name: log_driver (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     log_driver: json-file
@@ -44,7 +44,7 @@
 - name: logging.driver (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -71,7 +71,7 @@
 - name: logging_options
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -84,7 +84,7 @@
 - name: logging_options (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -97,7 +97,7 @@
 - name: log_driver_options (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     log_driver: json-file
@@ -109,7 +109,7 @@
 - name: logging_options (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -123,7 +123,7 @@
 - name: logging_options (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -134,7 +134,7 @@
 - name: logging_options (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/logging.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/logging.yml
@@ -15,7 +15,7 @@
 - name: logging.driver
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -25,7 +25,7 @@
 - name: logging.driver (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -35,7 +35,7 @@
 - name: log_driver (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     log_driver: json-file
@@ -44,7 +44,7 @@
 - name: logging.driver (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -71,7 +71,7 @@
 - name: logging_options
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -84,7 +84,7 @@
 - name: logging_options (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -97,7 +97,7 @@
 - name: log_driver_options (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     log_driver: json-file
@@ -109,7 +109,7 @@
 - name: logging_options (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -123,7 +123,7 @@
 - name: logging_options (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -134,7 +134,7 @@
 - name: logging_options (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/logging.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/logging.yml
@@ -15,7 +15,7 @@
 - name: logging.driver
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -25,7 +25,7 @@
 - name: logging.driver (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -35,7 +35,7 @@
 - name: log_driver (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     log_driver: json-file
@@ -44,7 +44,7 @@
 - name: logging.driver (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -71,7 +71,7 @@
 - name: logging_options
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -84,7 +84,7 @@
 - name: logging_options (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -97,7 +97,7 @@
 - name: log_driver_options (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     log_driver: json-file
@@ -109,7 +109,7 @@
 - name: logging_options (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -123,7 +123,7 @@
 - name: logging_options (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:
@@ -134,7 +134,7 @@
 - name: logging_options (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     logging:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/misc.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/misc.yml
@@ -28,7 +28,7 @@
       docker_swarm_service:
         name: test_service
         endpoint_mode: dnsrr
-        image: quay.io/quay/busybox
+        image: quay.io/ansible/docker-test-containers:busybox
         resolve_image: no
         args:
           - sleep
@@ -43,7 +43,7 @@
       register: output
       docker_swarm_service:
         name: test_service
-        image: quay.io/quay/busybox
+        image: quay.io/ansible/docker-test-containers:busybox
         resolve_image: no
         args:
           - sleep
@@ -58,7 +58,7 @@
       register: output
       docker_swarm_service:
         name: test_service
-        image: quay.io/quay/busybox
+        image: quay.io/ansible/docker-test-containers:busybox
         resolve_image: no
         endpoint_mode: vip
         mode: global
@@ -75,7 +75,7 @@
       register: output
       docker_swarm_service:
         name: test_service
-        image: quay.io/quay/busybox
+        image: quay.io/ansible/docker-test-containers:busybox
         resolve_image: no
         mode: global
         args:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/misc.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/misc.yml
@@ -28,7 +28,7 @@
       docker_swarm_service:
         name: test_service
         endpoint_mode: dnsrr
-        image: busybox
+        image: quay.io/quay/busybox
         resolve_image: no
         args:
           - sleep
@@ -43,7 +43,7 @@
       register: output
       docker_swarm_service:
         name: test_service
-        image: busybox
+        image: quay.io/quay/busybox
         resolve_image: no
         args:
           - sleep
@@ -58,7 +58,7 @@
       register: output
       docker_swarm_service:
         name: test_service
-        image: busybox
+        image: quay.io/quay/busybox
         resolve_image: no
         endpoint_mode: vip
         mode: global
@@ -75,7 +75,7 @@
       register: output
       docker_swarm_service:
         name: test_service
-        image: busybox
+        image: quay.io/quay/busybox
         resolve_image: no
         mode: global
         args:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/mounts.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/mounts.yml
@@ -25,7 +25,7 @@
 - name: mounts
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -37,7 +37,7 @@
 - name: mounts (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -49,7 +49,7 @@
 - name: mounts (add)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -64,7 +64,7 @@
 - name: mounts (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -79,7 +79,7 @@
 - name: mounts (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts: []
@@ -88,7 +88,7 @@
 - name: mounts (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts: []
@@ -116,7 +116,7 @@
 - name: mounts.readonly
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -129,7 +129,7 @@
 - name: mounts.readonly (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -141,7 +141,7 @@
 - name: mounts.readonly (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -169,7 +169,7 @@
 - name: mounts.propagation
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -183,7 +183,7 @@
 - name: mounts.propagation (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -196,7 +196,7 @@
 - name: mounts.propagation (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -225,7 +225,7 @@
 - name: mounts.labels
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -241,7 +241,7 @@
 - name: mounts.labels (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -256,7 +256,7 @@
 - name: mounts.labels (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -286,7 +286,7 @@
 - name: mounts.no_copy
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -300,7 +300,7 @@
 - name: mounts.no_copy (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -313,7 +313,7 @@
 - name: mounts.no_copy (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -342,7 +342,7 @@
 - name: mounts.driver_config
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -358,7 +358,7 @@
 - name: mounts.driver_config
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -374,7 +374,7 @@
 - name: mounts.driver_config
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -404,7 +404,7 @@
 - name: mounts.tmpfs_size
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -418,7 +418,7 @@
 - name: mounts.tmpfs_size (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -432,7 +432,7 @@
 - name: mounts.tmpfs_size (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -468,7 +468,7 @@
 - name: mounts.tmpfs_mode
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -482,7 +482,7 @@
 - name: mounts.tmpfs_mode (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -496,7 +496,7 @@
 - name: mounts.tmpfs_mode (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -532,7 +532,7 @@
 - name: mounts.source (empty for tmpfs)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -545,7 +545,7 @@
 - name: mounts.source (empty for tmpfs idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -558,7 +558,7 @@
 - name: mounts.source (not specified for tmpfs idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/mounts.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/mounts.yml
@@ -25,7 +25,7 @@
 - name: mounts
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -37,7 +37,7 @@
 - name: mounts (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -49,7 +49,7 @@
 - name: mounts (add)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -64,7 +64,7 @@
 - name: mounts (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -79,7 +79,7 @@
 - name: mounts (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts: []
@@ -88,7 +88,7 @@
 - name: mounts (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts: []
@@ -116,7 +116,7 @@
 - name: mounts.readonly
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -129,7 +129,7 @@
 - name: mounts.readonly (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -141,7 +141,7 @@
 - name: mounts.readonly (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -169,7 +169,7 @@
 - name: mounts.propagation
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -183,7 +183,7 @@
 - name: mounts.propagation (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -196,7 +196,7 @@
 - name: mounts.propagation (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -225,7 +225,7 @@
 - name: mounts.labels
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -241,7 +241,7 @@
 - name: mounts.labels (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -256,7 +256,7 @@
 - name: mounts.labels (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -286,7 +286,7 @@
 - name: mounts.no_copy
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -300,7 +300,7 @@
 - name: mounts.no_copy (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -313,7 +313,7 @@
 - name: mounts.no_copy (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -342,7 +342,7 @@
 - name: mounts.driver_config
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -358,7 +358,7 @@
 - name: mounts.driver_config
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -374,7 +374,7 @@
 - name: mounts.driver_config
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -404,7 +404,7 @@
 - name: mounts.tmpfs_size
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -418,7 +418,7 @@
 - name: mounts.tmpfs_size (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -432,7 +432,7 @@
 - name: mounts.tmpfs_size (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -468,7 +468,7 @@
 - name: mounts.tmpfs_mode
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -482,7 +482,7 @@
 - name: mounts.tmpfs_mode (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -496,7 +496,7 @@
 - name: mounts.tmpfs_mode (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -532,7 +532,7 @@
 - name: mounts.source (empty for tmpfs)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -545,7 +545,7 @@
 - name: mounts.source (empty for tmpfs idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -558,7 +558,7 @@
 - name: mounts.source (not specified for tmpfs idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/mounts.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/mounts.yml
@@ -25,7 +25,7 @@
 - name: mounts
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -37,7 +37,7 @@
 - name: mounts (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -49,7 +49,7 @@
 - name: mounts (add)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -64,7 +64,7 @@
 - name: mounts (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -79,7 +79,7 @@
 - name: mounts (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts: []
@@ -88,7 +88,7 @@
 - name: mounts (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts: []
@@ -116,7 +116,7 @@
 - name: mounts.readonly
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -129,7 +129,7 @@
 - name: mounts.readonly (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -141,7 +141,7 @@
 - name: mounts.readonly (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -169,7 +169,7 @@
 - name: mounts.propagation
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -183,7 +183,7 @@
 - name: mounts.propagation (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -196,7 +196,7 @@
 - name: mounts.propagation (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -225,7 +225,7 @@
 - name: mounts.labels
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -241,7 +241,7 @@
 - name: mounts.labels (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -256,7 +256,7 @@
 - name: mounts.labels (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -286,7 +286,7 @@
 - name: mounts.no_copy
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -300,7 +300,7 @@
 - name: mounts.no_copy (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -313,7 +313,7 @@
 - name: mounts.no_copy (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -342,7 +342,7 @@
 - name: mounts.driver_config
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -358,7 +358,7 @@
 - name: mounts.driver_config
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -374,7 +374,7 @@
 - name: mounts.driver_config
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -404,7 +404,7 @@
 - name: mounts.tmpfs_size
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -418,7 +418,7 @@
 - name: mounts.tmpfs_size (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -432,7 +432,7 @@
 - name: mounts.tmpfs_size (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -468,7 +468,7 @@
 - name: mounts.tmpfs_mode
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -482,7 +482,7 @@
 - name: mounts.tmpfs_mode (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -496,7 +496,7 @@
 - name: mounts.tmpfs_mode (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -532,7 +532,7 @@
 - name: mounts.source (empty for tmpfs)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -545,7 +545,7 @@
 - name: mounts.source (empty for tmpfs idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:
@@ -558,7 +558,7 @@
 - name: mounts.source (not specified for tmpfs idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mounts:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/networks.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/networks.yml
@@ -28,7 +28,7 @@
 - name: networks
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -38,7 +38,7 @@
 - name: networks (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -48,7 +48,7 @@
 - name: networks (dict idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -58,7 +58,7 @@
 - name: networks (change more)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -69,7 +69,7 @@
 - name: networks (change more idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -80,7 +80,7 @@
 - name: networks (change more dict idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -91,7 +91,7 @@
 - name: networks (change more mixed idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -102,7 +102,7 @@
 - name: networks (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -113,7 +113,7 @@
 - name: networks (change less)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -123,7 +123,7 @@
 - name: networks (change less idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -133,7 +133,7 @@
 - name: networks (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks: []
@@ -142,7 +142,7 @@
 - name: networks (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks: []
@@ -151,7 +151,7 @@
 - name: networks (unknown network)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -162,7 +162,7 @@
 - name: networks (missing dict key name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -173,7 +173,7 @@
 - name: networks (invalid list type)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -227,7 +227,7 @@
 - name: networks.aliases
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -240,7 +240,7 @@
 - name: networks.aliases (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -253,7 +253,7 @@
 - name: networks.aliases (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -266,7 +266,7 @@
 - name: networks.aliases (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -278,7 +278,7 @@
 - name: networks.aliases (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -289,7 +289,7 @@
 - name: networks.aliases (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -300,7 +300,7 @@
 - name: networks.aliases (invalid type)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -334,7 +334,7 @@
 - name: networks.options
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -347,7 +347,7 @@
 - name: networks.options (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -360,7 +360,7 @@
 - name: networks.options (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -373,7 +373,7 @@
 - name: networks.options (change less)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -385,7 +385,7 @@
 - name: networks.options (invalid type)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -397,7 +397,7 @@
 - name: networks.options (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -408,7 +408,7 @@
 - name: networks.options (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/networks.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/networks.yml
@@ -28,7 +28,7 @@
 - name: networks
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -38,7 +38,7 @@
 - name: networks (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -48,7 +48,7 @@
 - name: networks (dict idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -58,7 +58,7 @@
 - name: networks (change more)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -69,7 +69,7 @@
 - name: networks (change more idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -80,7 +80,7 @@
 - name: networks (change more dict idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -91,7 +91,7 @@
 - name: networks (change more mixed idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -102,7 +102,7 @@
 - name: networks (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -113,7 +113,7 @@
 - name: networks (change less)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -123,7 +123,7 @@
 - name: networks (change less idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -133,7 +133,7 @@
 - name: networks (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks: []
@@ -142,7 +142,7 @@
 - name: networks (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks: []
@@ -151,7 +151,7 @@
 - name: networks (unknown network)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -162,7 +162,7 @@
 - name: networks (missing dict key name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -173,7 +173,7 @@
 - name: networks (invalid list type)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -227,7 +227,7 @@
 - name: networks.aliases
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -240,7 +240,7 @@
 - name: networks.aliases (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -253,7 +253,7 @@
 - name: networks.aliases (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -266,7 +266,7 @@
 - name: networks.aliases (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -278,7 +278,7 @@
 - name: networks.aliases (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -289,7 +289,7 @@
 - name: networks.aliases (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -300,7 +300,7 @@
 - name: networks.aliases (invalid type)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -334,7 +334,7 @@
 - name: networks.options
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -347,7 +347,7 @@
 - name: networks.options (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -360,7 +360,7 @@
 - name: networks.options (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -373,7 +373,7 @@
 - name: networks.options (change less)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -385,7 +385,7 @@
 - name: networks.options (invalid type)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -397,7 +397,7 @@
 - name: networks.options (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -408,7 +408,7 @@
 - name: networks.options (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/networks.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/networks.yml
@@ -28,7 +28,7 @@
 - name: networks
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -38,7 +38,7 @@
 - name: networks (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -48,7 +48,7 @@
 - name: networks (dict idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -58,7 +58,7 @@
 - name: networks (change more)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -69,7 +69,7 @@
 - name: networks (change more idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -80,7 +80,7 @@
 - name: networks (change more dict idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -91,7 +91,7 @@
 - name: networks (change more mixed idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -102,7 +102,7 @@
 - name: networks (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -113,7 +113,7 @@
 - name: networks (change less)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -123,7 +123,7 @@
 - name: networks (change less idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -133,7 +133,7 @@
 - name: networks (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks: []
@@ -142,7 +142,7 @@
 - name: networks (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks: []
@@ -151,7 +151,7 @@
 - name: networks (unknown network)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -162,7 +162,7 @@
 - name: networks (missing dict key name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -173,7 +173,7 @@
 - name: networks (invalid list type)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -227,7 +227,7 @@
 - name: networks.aliases
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -240,7 +240,7 @@
 - name: networks.aliases (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -253,7 +253,7 @@
 - name: networks.aliases (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -266,7 +266,7 @@
 - name: networks.aliases (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -278,7 +278,7 @@
 - name: networks.aliases (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -289,7 +289,7 @@
 - name: networks.aliases (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -300,7 +300,7 @@
 - name: networks.aliases (invalid type)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -334,7 +334,7 @@
 - name: networks.options
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -347,7 +347,7 @@
 - name: networks.options (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -360,7 +360,7 @@
 - name: networks.options (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -373,7 +373,7 @@
 - name: networks.options (change less)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -385,7 +385,7 @@
 - name: networks.options (invalid type)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -397,7 +397,7 @@
 - name: networks.options (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:
@@ -408,7 +408,7 @@
 - name: networks.options (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     networks:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -15,7 +15,7 @@
 - name: args
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     args:
       - sleep
@@ -25,7 +25,7 @@
 - name: args (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     args:
       - sleep
@@ -35,7 +35,7 @@
 - name: args (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     args:
       - sleep
@@ -45,7 +45,7 @@
 - name: args (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     args: []
   register: args_4
@@ -53,7 +53,7 @@
 - name: args (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     args: []
   register: args_5
@@ -79,7 +79,7 @@
 - name: command
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
   register: command_1
@@ -87,7 +87,7 @@
 - name: command (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
   register: command_2
@@ -95,7 +95,7 @@
 - name: command (less parameters)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -c "sleep 10m"'
   register: command_3
@@ -103,7 +103,7 @@
 - name: command (as list)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command:
       - "/bin/sh"
@@ -114,7 +114,7 @@
 - name: command (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: []
   register: command_5
@@ -122,7 +122,7 @@
 - name: command (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: []
   register: command_6
@@ -130,7 +130,7 @@
 - name: command (string failure)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: yes
   register: command_7
@@ -139,7 +139,7 @@
 - name: command (list failure)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command:
       - "/bin/sh"
@@ -171,7 +171,7 @@
 - name: container_labels
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     container_labels:
@@ -182,7 +182,7 @@
 - name: container_labels (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     container_labels:
@@ -193,7 +193,7 @@
 - name: container_labels (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     container_labels:
@@ -204,7 +204,7 @@
 - name: container_labels (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     container_labels: {}
@@ -213,7 +213,7 @@
 - name: container_labels (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     container_labels: {}
@@ -240,7 +240,7 @@
 - name: dns
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns:
@@ -252,7 +252,7 @@
 - name: dns (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns:
@@ -264,7 +264,7 @@
 - name: dns_servers (changed order)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns:
@@ -276,7 +276,7 @@
 - name: dns_servers (changed elements)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns:
@@ -288,7 +288,7 @@
 - name: dns_servers (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns: []
@@ -298,7 +298,7 @@
 - name: dns_servers (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns: []
@@ -333,7 +333,7 @@
 - name: dns_options
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options:
@@ -345,7 +345,7 @@
 - name: dns_options (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options:
@@ -357,7 +357,7 @@
 - name: dns_options (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options:
@@ -369,7 +369,7 @@
 - name: dns_options (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options:
@@ -381,7 +381,7 @@
 - name: dns_options (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options: []
@@ -391,7 +391,7 @@
 - name: dns_options (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options: []
@@ -426,7 +426,7 @@
 - name: dns_search
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search:
@@ -438,7 +438,7 @@
 - name: dns_search (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search:
@@ -450,7 +450,7 @@
 - name: dns_search (different order)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search:
@@ -462,7 +462,7 @@
 - name: dns_search (changed elements)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search:
@@ -474,7 +474,7 @@
 - name: dns_search (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search: []
@@ -484,7 +484,7 @@
 - name: dns_search (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search: []
@@ -519,7 +519,7 @@
 - name: endpoint_mode
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     endpoint_mode: "dnsrr"
@@ -529,7 +529,7 @@
 - name: endpoint_mode (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     endpoint_mode: "dnsrr"
@@ -539,7 +539,7 @@
 - name: endpoint_mode (changes)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     endpoint_mode: "vip"
@@ -571,7 +571,7 @@
 - name: env
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env:
@@ -582,7 +582,7 @@
 - name: env (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env:
@@ -593,7 +593,7 @@
 - name: env (changes)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env:
@@ -604,7 +604,7 @@
 - name: env (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env:
@@ -615,7 +615,7 @@
 - name: env (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env: []
@@ -624,7 +624,7 @@
 - name: env (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env: []
@@ -633,7 +633,7 @@
 - name: env (fail unwrapped values)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     env:
       TEST1: true
@@ -643,7 +643,7 @@
 - name: env (fail invalid formatted string)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     env:
       - "TEST1=val3"
@@ -675,7 +675,7 @@
 - name: env_files
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     env_files:
       - "{{ role_path }}/files/env-file-1"
@@ -684,7 +684,7 @@
 - name: env_files (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     env_files:
       - "{{ role_path }}/files/env-file-1"
@@ -693,7 +693,7 @@
 - name: env_files (more items)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     env_files:
       - "{{ role_path }}/files/env-file-1"
@@ -703,7 +703,7 @@
 - name: env_files (order)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     env_files:
       - "{{ role_path }}/files/env-file-2"
@@ -713,7 +713,7 @@
 - name: env_files (multiple idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     env_files:
       - "{{ role_path }}/files/env-file-2"
@@ -723,7 +723,7 @@
 - name: env_files (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     env_files: []
   register: env_file_6
@@ -731,7 +731,7 @@
 - name: env_files (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     env_files: []
   register: env_file_7
@@ -759,7 +759,7 @@
 - name: force_update
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     args:
@@ -772,7 +772,7 @@
 - name: force_update (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     args:
@@ -806,7 +806,7 @@
 - name: groups
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups:
@@ -818,7 +818,7 @@
 - name: groups (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups:
@@ -830,7 +830,7 @@
 - name: groups (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups:
@@ -842,7 +842,7 @@
 - name: groups (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups:
@@ -853,7 +853,7 @@
 - name: groups (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups: []
@@ -863,7 +863,7 @@
 - name: groups (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups: []
@@ -898,7 +898,7 @@
 - name: healthcheck
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -916,7 +916,7 @@
 - name: healthcheck (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -934,7 +934,7 @@
 - name: healthcheck (changed)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -951,7 +951,7 @@
 - name: healthcheck (disabled)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -963,7 +963,7 @@
 - name: healthcheck (disabled, idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -975,7 +975,7 @@
 - name: healthcheck (string in healthcheck test, changed)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -986,7 +986,7 @@
 - name: healthcheck (string in healthcheck test, idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -997,7 +997,7 @@
 - name: healthcheck (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck: {}
@@ -1007,7 +1007,7 @@
 - name: healthcheck (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck: {}
@@ -1045,7 +1045,7 @@
 - name: hostname
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hostname: me.example.com
@@ -1055,7 +1055,7 @@
 - name: hostname (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hostname: me.example.com
@@ -1065,7 +1065,7 @@
 - name: hostname (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hostname: me.example.org
@@ -1097,7 +1097,7 @@
 - name: hosts
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hosts:
@@ -1109,7 +1109,7 @@
 - name: hosts (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hosts:
@@ -1121,7 +1121,7 @@
 - name: hosts (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hosts:
@@ -1155,7 +1155,7 @@
 - name: image
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
   register: image_1
@@ -1163,7 +1163,7 @@
 - name: image (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
   register: image_2
@@ -1171,7 +1171,7 @@
 - name: image (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.7
+    image: quay.io/ansible/mountainous:3.7
   register: image_3
 
 - name: cleanup
@@ -1193,7 +1193,7 @@
 - name: labels
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels:
@@ -1204,7 +1204,7 @@
 - name: labels (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels:
@@ -1215,7 +1215,7 @@
 - name: labels (changes)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels:
@@ -1227,7 +1227,7 @@
 - name: labels (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels: {}
@@ -1236,7 +1236,7 @@
 - name: labels (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels: {}
@@ -1263,7 +1263,7 @@
 - name: mode
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mode: "replicated"
@@ -1273,7 +1273,7 @@
 - name: mode (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mode: "replicated"
@@ -1283,7 +1283,7 @@
 - name: mode (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mode: "global"
@@ -1309,7 +1309,7 @@
 - name: stop_grace_period
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_grace_period: 60s
@@ -1318,7 +1318,7 @@
 - name: stop_grace_period (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_grace_period: 60s
@@ -1327,7 +1327,7 @@
 - name: stop_grace_period (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_grace_period: 1m30s
@@ -1352,7 +1352,7 @@
 - name: stop_signal
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_signal: "30"
@@ -1362,7 +1362,7 @@
 - name: stop_signal (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_signal: "30"
@@ -1372,7 +1372,7 @@
 - name: stop_signal (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_signal: "9"
@@ -1404,7 +1404,7 @@
 - name: publish
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
@@ -1420,7 +1420,7 @@
 - name: publish (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
@@ -1435,7 +1435,7 @@
 - name: publish (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
@@ -1451,7 +1451,7 @@
 - name: publish (mode)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
@@ -1469,7 +1469,7 @@
 - name: publish (mode idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
@@ -1487,7 +1487,7 @@
 - name: publish (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish: []
@@ -1497,7 +1497,7 @@
 - name: publish (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish: []
@@ -1507,7 +1507,7 @@
 - name: publish (publishes the same port with both protocols)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
@@ -1557,7 +1557,7 @@
 - name: read_only
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     read_only: true
@@ -1567,7 +1567,7 @@
 - name: read_only (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     read_only: true
@@ -1577,7 +1577,7 @@
 - name: read_only (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     read_only: false
@@ -1609,7 +1609,7 @@
 - name: replicas
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     replicas: 2
@@ -1618,7 +1618,7 @@
 - name: replicas (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     replicas: 2
@@ -1627,7 +1627,7 @@
 - name: replicas (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     replicas: 3
@@ -1652,7 +1652,7 @@
 - name: resolve_image (false)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     resolve_image: false
   register: resolve_image_1
@@ -1660,7 +1660,7 @@
 - name: resolve_image (false idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     resolve_image: false
   register: resolve_image_2
@@ -1668,7 +1668,7 @@
 - name: resolve_image (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     resolve_image: true
   register: resolve_image_3
@@ -1702,7 +1702,7 @@
 # - name: tty
 #   docker_swarm_service:
 #     name: "{{ service_name }}"
-#     image: quay.io/app-sre/alpine:3.8
+#     image: quay.io/ansible/mountainous:3.8
 #     resolve_image: no
 #     command: '/bin/sh -v -c "sleep 10m"'
 #     tty: yes
@@ -1712,7 +1712,7 @@
 # - name: tty (idempotency)
 #   docker_swarm_service:
 #     name: "{{ service_name }}"
-#     image: quay.io/app-sre/alpine:3.8
+#     image: quay.io/ansible/mountainous:3.8
 #     resolve_image: no
 #     command: '/bin/sh -v -c "sleep 10m"'
 #     tty: yes
@@ -1722,7 +1722,7 @@
 # - name: tty (change)
 #   docker_swarm_service:
 #     name: "{{ service_name }}"
-#     image: quay.io/app-sre/alpine:3.8
+#     image: quay.io/ansible/mountainous:3.8
 #     resolve_image: no
 #     command: '/bin/sh -v -c "sleep 10m"'
 #     tty: no
@@ -1754,7 +1754,7 @@
 # - name: user
 #   docker_swarm_service:
 #     name: "{{ service_name }}"
-#     image: quay.io/app-sre/alpine:3.8
+#     image: quay.io/ansible/mountainous:3.8
 #     resolve_image: no
 #     command: '/bin/sh -v -c "sleep 10m"'
 #     user: "operator"
@@ -1763,7 +1763,7 @@
 # - name: user (idempotency)
 #   docker_swarm_service:
 #     name: "{{ service_name }}"
-#     image: quay.io/app-sre/alpine:3.8
+#     image: quay.io/ansible/mountainous:3.8
 #     resolve_image: no
 #     command: '/bin/sh -v -c "sleep 10m"'
 #     user: "operator"
@@ -1772,7 +1772,7 @@
 # - name: user (change)
 #   docker_swarm_service:
 #     name: "{{ service_name }}"
-#     image: quay.io/app-sre/alpine:3.8
+#     image: quay.io/ansible/mountainous:3.8
 #     resolve_image: no
 #     command: '/bin/sh -v -c "sleep 10m"'
 #     user: "root"
@@ -1797,7 +1797,7 @@
 # - name: working_dir
 #   docker_swarm_service:
 #     name: "{{ service_name }}"
-#     image: quay.io/app-sre/alpine:3.8
+#     image: quay.io/ansible/mountainous:3.8
 #     resolve_image: no
 #     working_dir: /tmp
 #   register: working_dir_1
@@ -1805,7 +1805,7 @@
 # - name: working_dir (idempotency)
 #   docker_swarm_service:
 #     name: "{{ service_name }}"
-#     image: quay.io/app-sre/alpine:3.8
+#     image: quay.io/ansible/mountainous:3.8
 #     resolve_image: no
 #     working_dir: /tmp
 #   register: working_dir_2
@@ -1813,7 +1813,7 @@
 # - name: working_dir (change)
 #   docker_swarm_service:
 #     name: "{{ service_name }}"
-#     image: quay.io/app-sre/alpine:3.8
+#     image: quay.io/ansible/mountainous:3.8
 #     resolve_image: no
 #     working_dir: /
 #   register: working_dir_3

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -15,7 +15,7 @@
 - name: args
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     args:
       - sleep
@@ -25,7 +25,7 @@
 - name: args (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     args:
       - sleep
@@ -35,7 +35,7 @@
 - name: args (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     args:
       - sleep
@@ -45,7 +45,7 @@
 - name: args (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     args: []
   register: args_4
@@ -53,7 +53,7 @@
 - name: args (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     args: []
   register: args_5
@@ -79,7 +79,7 @@
 - name: command
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
   register: command_1
@@ -87,7 +87,7 @@
 - name: command (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
   register: command_2
@@ -95,7 +95,7 @@
 - name: command (less parameters)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -c "sleep 10m"'
   register: command_3
@@ -103,7 +103,7 @@
 - name: command (as list)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command:
       - "/bin/sh"
@@ -114,7 +114,7 @@
 - name: command (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: []
   register: command_5
@@ -122,7 +122,7 @@
 - name: command (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: []
   register: command_6
@@ -130,7 +130,7 @@
 - name: command (string failure)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: yes
   register: command_7
@@ -139,7 +139,7 @@
 - name: command (list failure)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command:
       - "/bin/sh"
@@ -171,7 +171,7 @@
 - name: container_labels
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     container_labels:
@@ -182,7 +182,7 @@
 - name: container_labels (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     container_labels:
@@ -193,7 +193,7 @@
 - name: container_labels (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     container_labels:
@@ -204,7 +204,7 @@
 - name: container_labels (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     container_labels: {}
@@ -213,7 +213,7 @@
 - name: container_labels (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     container_labels: {}
@@ -240,7 +240,7 @@
 - name: dns
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns:
@@ -252,7 +252,7 @@
 - name: dns (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns:
@@ -264,7 +264,7 @@
 - name: dns_servers (changed order)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns:
@@ -276,7 +276,7 @@
 - name: dns_servers (changed elements)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns:
@@ -288,7 +288,7 @@
 - name: dns_servers (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns: []
@@ -298,7 +298,7 @@
 - name: dns_servers (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns: []
@@ -333,7 +333,7 @@
 - name: dns_options
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options:
@@ -345,7 +345,7 @@
 - name: dns_options (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options:
@@ -357,7 +357,7 @@
 - name: dns_options (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options:
@@ -369,7 +369,7 @@
 - name: dns_options (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options:
@@ -381,7 +381,7 @@
 - name: dns_options (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options: []
@@ -391,7 +391,7 @@
 - name: dns_options (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options: []
@@ -426,7 +426,7 @@
 - name: dns_search
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search:
@@ -438,7 +438,7 @@
 - name: dns_search (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search:
@@ -450,7 +450,7 @@
 - name: dns_search (different order)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search:
@@ -462,7 +462,7 @@
 - name: dns_search (changed elements)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search:
@@ -474,7 +474,7 @@
 - name: dns_search (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search: []
@@ -484,7 +484,7 @@
 - name: dns_search (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search: []
@@ -519,7 +519,7 @@
 - name: endpoint_mode
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     endpoint_mode: "dnsrr"
@@ -529,7 +529,7 @@
 - name: endpoint_mode (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     endpoint_mode: "dnsrr"
@@ -539,7 +539,7 @@
 - name: endpoint_mode (changes)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     endpoint_mode: "vip"
@@ -571,7 +571,7 @@
 - name: env
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env:
@@ -582,7 +582,7 @@
 - name: env (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env:
@@ -593,7 +593,7 @@
 - name: env (changes)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env:
@@ -604,7 +604,7 @@
 - name: env (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env:
@@ -615,7 +615,7 @@
 - name: env (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env: []
@@ -624,7 +624,7 @@
 - name: env (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env: []
@@ -633,7 +633,7 @@
 - name: env (fail unwrapped values)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     env:
       TEST1: true
@@ -643,7 +643,7 @@
 - name: env (fail invalid formatted string)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     env:
       - "TEST1=val3"
@@ -675,7 +675,7 @@
 - name: env_files
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     env_files:
       - "{{ role_path }}/files/env-file-1"
@@ -684,7 +684,7 @@
 - name: env_files (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     env_files:
       - "{{ role_path }}/files/env-file-1"
@@ -693,7 +693,7 @@
 - name: env_files (more items)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     env_files:
       - "{{ role_path }}/files/env-file-1"
@@ -703,7 +703,7 @@
 - name: env_files (order)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     env_files:
       - "{{ role_path }}/files/env-file-2"
@@ -713,7 +713,7 @@
 - name: env_files (multiple idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     env_files:
       - "{{ role_path }}/files/env-file-2"
@@ -723,7 +723,7 @@
 - name: env_files (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     env_files: []
   register: env_file_6
@@ -731,7 +731,7 @@
 - name: env_files (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     env_files: []
   register: env_file_7
@@ -759,7 +759,7 @@
 - name: force_update
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     args:
@@ -772,7 +772,7 @@
 - name: force_update (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     args:
@@ -806,7 +806,7 @@
 - name: groups
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups:
@@ -818,7 +818,7 @@
 - name: groups (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups:
@@ -830,7 +830,7 @@
 - name: groups (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups:
@@ -842,7 +842,7 @@
 - name: groups (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups:
@@ -853,7 +853,7 @@
 - name: groups (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups: []
@@ -863,7 +863,7 @@
 - name: groups (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups: []
@@ -898,7 +898,7 @@
 - name: healthcheck
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -916,7 +916,7 @@
 - name: healthcheck (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -934,7 +934,7 @@
 - name: healthcheck (changed)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -951,7 +951,7 @@
 - name: healthcheck (disabled)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -963,7 +963,7 @@
 - name: healthcheck (disabled, idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -975,7 +975,7 @@
 - name: healthcheck (string in healthcheck test, changed)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -986,7 +986,7 @@
 - name: healthcheck (string in healthcheck test, idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -997,7 +997,7 @@
 - name: healthcheck (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck: {}
@@ -1007,7 +1007,7 @@
 - name: healthcheck (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck: {}
@@ -1045,7 +1045,7 @@
 - name: hostname
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hostname: me.example.com
@@ -1055,7 +1055,7 @@
 - name: hostname (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hostname: me.example.com
@@ -1065,7 +1065,7 @@
 - name: hostname (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hostname: me.example.org
@@ -1097,7 +1097,7 @@
 - name: hosts
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hosts:
@@ -1109,7 +1109,7 @@
 - name: hosts (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hosts:
@@ -1121,7 +1121,7 @@
 - name: hosts (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hosts:
@@ -1155,7 +1155,7 @@
 - name: image
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
   register: image_1
@@ -1163,7 +1163,7 @@
 - name: image (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
   register: image_2
@@ -1171,7 +1171,7 @@
 - name: image (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.7
+    image: quay.io/app-sre/alpine:3.7
   register: image_3
 
 - name: cleanup
@@ -1193,7 +1193,7 @@
 - name: labels
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels:
@@ -1204,7 +1204,7 @@
 - name: labels (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels:
@@ -1215,7 +1215,7 @@
 - name: labels (changes)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels:
@@ -1227,7 +1227,7 @@
 - name: labels (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels: {}
@@ -1236,7 +1236,7 @@
 - name: labels (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels: {}
@@ -1263,7 +1263,7 @@
 - name: mode
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mode: "replicated"
@@ -1273,7 +1273,7 @@
 - name: mode (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mode: "replicated"
@@ -1283,7 +1283,7 @@
 - name: mode (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mode: "global"
@@ -1309,7 +1309,7 @@
 - name: stop_grace_period
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_grace_period: 60s
@@ -1318,7 +1318,7 @@
 - name: stop_grace_period (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_grace_period: 60s
@@ -1327,7 +1327,7 @@
 - name: stop_grace_period (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_grace_period: 1m30s
@@ -1352,7 +1352,7 @@
 - name: stop_signal
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_signal: "30"
@@ -1362,7 +1362,7 @@
 - name: stop_signal (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_signal: "30"
@@ -1372,7 +1372,7 @@
 - name: stop_signal (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_signal: "9"
@@ -1404,7 +1404,7 @@
 - name: publish
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
@@ -1420,7 +1420,7 @@
 - name: publish (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
@@ -1435,7 +1435,7 @@
 - name: publish (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
@@ -1451,7 +1451,7 @@
 - name: publish (mode)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
@@ -1469,7 +1469,7 @@
 - name: publish (mode idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
@@ -1487,7 +1487,7 @@
 - name: publish (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish: []
@@ -1497,7 +1497,7 @@
 - name: publish (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish: []
@@ -1507,7 +1507,7 @@
 - name: publish (publishes the same port with both protocols)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
@@ -1557,7 +1557,7 @@
 - name: read_only
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     read_only: true
@@ -1567,7 +1567,7 @@
 - name: read_only (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     read_only: true
@@ -1577,7 +1577,7 @@
 - name: read_only (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     read_only: false
@@ -1609,7 +1609,7 @@
 - name: replicas
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     replicas: 2
@@ -1618,7 +1618,7 @@
 - name: replicas (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     replicas: 2
@@ -1627,7 +1627,7 @@
 - name: replicas (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     replicas: 3
@@ -1652,7 +1652,7 @@
 - name: resolve_image (false)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     resolve_image: false
   register: resolve_image_1
@@ -1660,7 +1660,7 @@
 - name: resolve_image (false idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     resolve_image: false
   register: resolve_image_2
@@ -1668,7 +1668,7 @@
 - name: resolve_image (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     command: '/bin/sh -v -c "sleep 10m"'
     resolve_image: true
   register: resolve_image_3
@@ -1699,133 +1699,133 @@
 # tty #############################################################
 ###################################################################
 
-- name: tty
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    tty: yes
-  register: tty_1
-  ignore_errors: yes
-
-- name: tty (idempotency)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    tty: yes
-  register: tty_2
-  ignore_errors: yes
-
-- name: tty (change)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    tty: no
-  register: tty_3
-  ignore_errors: yes
-
-- name: cleanup
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    state: absent
-  diff: no
-
-- assert:
-    that:
-      - tty_1 is changed
-      - tty_2 is not changed
-      - tty_3 is changed
-  when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.4.0', '>=')
-- assert:
-    that:
-    - tty_1 is failed
-    - "'Minimum version required' in tty_1.msg"
-  when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.4.0', '<')
-
-###################################################################
-## user ###########################################################
-###################################################################
-
-- name: user
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    user: "operator"
-  register: user_1
-
-- name: user (idempotency)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    user: "operator"
-  register: user_2
-
-- name: user (change)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    command: '/bin/sh -v -c "sleep 10m"'
-    user: "root"
-  register: user_3
-
-- name: cleanup
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    state: absent
-  diff: no
-
-- assert:
-    that:
-      - user_1 is changed
-      - user_2 is not changed
-      - user_3 is changed
-
-####################################################################
-## working_dir #####################################################
-####################################################################
-
-- name: working_dir
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    working_dir: /tmp
-  register: working_dir_1
-
-- name: working_dir (idempotency)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    working_dir: /tmp
-  register: working_dir_2
-
-- name: working_dir (change)
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    image: alpine:3.8
-    resolve_image: no
-    working_dir: /
-  register: working_dir_3
-
-- name: cleanup
-  docker_swarm_service:
-    name: "{{ service_name }}"
-    state: absent
-  diff: no
-
-- assert:
-    that:
-    - working_dir_1 is changed
-    - working_dir_2 is not changed
-    - working_dir_3 is changed
+# - name: tty
+#   docker_swarm_service:
+#     name: "{{ service_name }}"
+#     image: quay.io/app-sre/alpine:3.8
+#     resolve_image: no
+#     command: '/bin/sh -v -c "sleep 10m"'
+#     tty: yes
+#   register: tty_1
+#   ignore_errors: yes
+#
+# - name: tty (idempotency)
+#   docker_swarm_service:
+#     name: "{{ service_name }}"
+#     image: quay.io/app-sre/alpine:3.8
+#     resolve_image: no
+#     command: '/bin/sh -v -c "sleep 10m"'
+#     tty: yes
+#   register: tty_2
+#   ignore_errors: yes
+#
+# - name: tty (change)
+#   docker_swarm_service:
+#     name: "{{ service_name }}"
+#     image: quay.io/app-sre/alpine:3.8
+#     resolve_image: no
+#     command: '/bin/sh -v -c "sleep 10m"'
+#     tty: no
+#   register: tty_3
+#   ignore_errors: yes
+#
+# - name: cleanup
+#   docker_swarm_service:
+#     name: "{{ service_name }}"
+#     state: absent
+#   diff: no
+#
+# - assert:
+#     that:
+#       - tty_1 is changed
+#       - tty_2 is not changed
+#       - tty_3 is changed
+#   when: docker_api_version is version('1.25', '>=') and docker_py_version is version('2.4.0', '>=')
+# - assert:
+#     that:
+#     - tty_1 is failed
+#     - "'Minimum version required' in tty_1.msg"
+#   when: docker_api_version is version('1.25', '<') or docker_py_version is version('2.4.0', '<')
+#
+# ###################################################################
+# ## user ###########################################################
+# ###################################################################
+#
+# - name: user
+#   docker_swarm_service:
+#     name: "{{ service_name }}"
+#     image: quay.io/app-sre/alpine:3.8
+#     resolve_image: no
+#     command: '/bin/sh -v -c "sleep 10m"'
+#     user: "operator"
+#   register: user_1
+#
+# - name: user (idempotency)
+#   docker_swarm_service:
+#     name: "{{ service_name }}"
+#     image: quay.io/app-sre/alpine:3.8
+#     resolve_image: no
+#     command: '/bin/sh -v -c "sleep 10m"'
+#     user: "operator"
+#   register: user_2
+#
+# - name: user (change)
+#   docker_swarm_service:
+#     name: "{{ service_name }}"
+#     image: quay.io/app-sre/alpine:3.8
+#     resolve_image: no
+#     command: '/bin/sh -v -c "sleep 10m"'
+#     user: "root"
+#   register: user_3
+#
+# - name: cleanup
+#   docker_swarm_service:
+#     name: "{{ service_name }}"
+#     state: absent
+#   diff: no
+#
+# - assert:
+#     that:
+#       - user_1 is changed
+#       - user_2 is not changed
+#       - user_3 is changed
+#
+# ####################################################################
+# ## working_dir #####################################################
+# ####################################################################
+#
+# - name: working_dir
+#   docker_swarm_service:
+#     name: "{{ service_name }}"
+#     image: quay.io/app-sre/alpine:3.8
+#     resolve_image: no
+#     working_dir: /tmp
+#   register: working_dir_1
+#
+# - name: working_dir (idempotency)
+#   docker_swarm_service:
+#     name: "{{ service_name }}"
+#     image: quay.io/app-sre/alpine:3.8
+#     resolve_image: no
+#     working_dir: /tmp
+#   register: working_dir_2
+#
+# - name: working_dir (change)
+#   docker_swarm_service:
+#     name: "{{ service_name }}"
+#     image: quay.io/app-sre/alpine:3.8
+#     resolve_image: no
+#     working_dir: /
+#   register: working_dir_3
+#
+# - name: cleanup
+#   docker_swarm_service:
+#     name: "{{ service_name }}"
+#     state: absent
+#   diff: no
+#
+# - assert:
+#     that:
+#     - working_dir_1 is changed
+#     - working_dir_2 is not changed
+#     - working_dir_3 is changed

--- a/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/options.yml
@@ -15,7 +15,7 @@
 - name: args
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     args:
       - sleep
@@ -25,7 +25,7 @@
 - name: args (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     args:
       - sleep
@@ -35,7 +35,7 @@
 - name: args (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     args:
       - sleep
@@ -45,7 +45,7 @@
 - name: args (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     args: []
   register: args_4
@@ -53,7 +53,7 @@
 - name: args (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     args: []
   register: args_5
@@ -79,7 +79,7 @@
 - name: command
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
   register: command_1
@@ -87,7 +87,7 @@
 - name: command (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
   register: command_2
@@ -95,7 +95,7 @@
 - name: command (less parameters)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -c "sleep 10m"'
   register: command_3
@@ -103,7 +103,7 @@
 - name: command (as list)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command:
       - "/bin/sh"
@@ -114,7 +114,7 @@
 - name: command (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: []
   register: command_5
@@ -122,7 +122,7 @@
 - name: command (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: []
   register: command_6
@@ -130,7 +130,7 @@
 - name: command (string failure)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: yes
   register: command_7
@@ -139,7 +139,7 @@
 - name: command (list failure)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command:
       - "/bin/sh"
@@ -171,7 +171,7 @@
 - name: container_labels
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     container_labels:
@@ -182,7 +182,7 @@
 - name: container_labels (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     container_labels:
@@ -193,7 +193,7 @@
 - name: container_labels (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     container_labels:
@@ -204,7 +204,7 @@
 - name: container_labels (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     container_labels: {}
@@ -213,7 +213,7 @@
 - name: container_labels (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     container_labels: {}
@@ -240,7 +240,7 @@
 - name: dns
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns:
@@ -252,7 +252,7 @@
 - name: dns (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns:
@@ -264,7 +264,7 @@
 - name: dns_servers (changed order)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns:
@@ -276,7 +276,7 @@
 - name: dns_servers (changed elements)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns:
@@ -288,7 +288,7 @@
 - name: dns_servers (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns: []
@@ -298,7 +298,7 @@
 - name: dns_servers (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns: []
@@ -333,7 +333,7 @@
 - name: dns_options
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options:
@@ -345,7 +345,7 @@
 - name: dns_options (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options:
@@ -357,7 +357,7 @@
 - name: dns_options (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options:
@@ -369,7 +369,7 @@
 - name: dns_options (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options:
@@ -381,7 +381,7 @@
 - name: dns_options (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options: []
@@ -391,7 +391,7 @@
 - name: dns_options (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_options: []
@@ -426,7 +426,7 @@
 - name: dns_search
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search:
@@ -438,7 +438,7 @@
 - name: dns_search (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search:
@@ -450,7 +450,7 @@
 - name: dns_search (different order)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search:
@@ -462,7 +462,7 @@
 - name: dns_search (changed elements)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search:
@@ -474,7 +474,7 @@
 - name: dns_search (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search: []
@@ -484,7 +484,7 @@
 - name: dns_search (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     dns_search: []
@@ -519,7 +519,7 @@
 - name: endpoint_mode
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     endpoint_mode: "dnsrr"
@@ -529,7 +529,7 @@
 - name: endpoint_mode (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     endpoint_mode: "dnsrr"
@@ -539,7 +539,7 @@
 - name: endpoint_mode (changes)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     endpoint_mode: "vip"
@@ -571,7 +571,7 @@
 - name: env
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env:
@@ -582,7 +582,7 @@
 - name: env (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env:
@@ -593,7 +593,7 @@
 - name: env (changes)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env:
@@ -604,7 +604,7 @@
 - name: env (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env:
@@ -615,7 +615,7 @@
 - name: env (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env: []
@@ -624,7 +624,7 @@
 - name: env (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     env: []
@@ -633,7 +633,7 @@
 - name: env (fail unwrapped values)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     env:
       TEST1: true
@@ -643,7 +643,7 @@
 - name: env (fail invalid formatted string)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     env:
       - "TEST1=val3"
@@ -675,7 +675,7 @@
 - name: env_files
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     env_files:
       - "{{ role_path }}/files/env-file-1"
@@ -684,7 +684,7 @@
 - name: env_files (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     env_files:
       - "{{ role_path }}/files/env-file-1"
@@ -693,7 +693,7 @@
 - name: env_files (more items)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     env_files:
       - "{{ role_path }}/files/env-file-1"
@@ -703,7 +703,7 @@
 - name: env_files (order)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     env_files:
       - "{{ role_path }}/files/env-file-2"
@@ -713,7 +713,7 @@
 - name: env_files (multiple idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     env_files:
       - "{{ role_path }}/files/env-file-2"
@@ -723,7 +723,7 @@
 - name: env_files (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     env_files: []
   register: env_file_6
@@ -731,7 +731,7 @@
 - name: env_files (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     env_files: []
   register: env_file_7
@@ -759,7 +759,7 @@
 - name: force_update
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     args:
@@ -772,7 +772,7 @@
 - name: force_update (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     args:
@@ -806,7 +806,7 @@
 - name: groups
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups:
@@ -818,7 +818,7 @@
 - name: groups (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups:
@@ -830,7 +830,7 @@
 - name: groups (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups:
@@ -842,7 +842,7 @@
 - name: groups (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups:
@@ -853,7 +853,7 @@
 - name: groups (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups: []
@@ -863,7 +863,7 @@
 - name: groups (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     groups: []
@@ -898,7 +898,7 @@
 - name: healthcheck
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -916,7 +916,7 @@
 - name: healthcheck (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -934,7 +934,7 @@
 - name: healthcheck (changed)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -951,7 +951,7 @@
 - name: healthcheck (disabled)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -963,7 +963,7 @@
 - name: healthcheck (disabled, idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -975,7 +975,7 @@
 - name: healthcheck (string in healthcheck test, changed)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -986,7 +986,7 @@
 - name: healthcheck (string in healthcheck test, idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck:
@@ -997,7 +997,7 @@
 - name: healthcheck (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck: {}
@@ -1007,7 +1007,7 @@
 - name: healthcheck (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     healthcheck: {}
@@ -1045,7 +1045,7 @@
 - name: hostname
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hostname: me.example.com
@@ -1055,7 +1055,7 @@
 - name: hostname (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hostname: me.example.com
@@ -1065,7 +1065,7 @@
 - name: hostname (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hostname: me.example.org
@@ -1097,7 +1097,7 @@
 - name: hosts
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hosts:
@@ -1109,7 +1109,7 @@
 - name: hosts (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hosts:
@@ -1121,7 +1121,7 @@
 - name: hosts (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     hosts:
@@ -1155,7 +1155,7 @@
 - name: image
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
   register: image_1
@@ -1163,7 +1163,7 @@
 - name: image (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
   register: image_2
@@ -1171,7 +1171,7 @@
 - name: image (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.7
+    image: quay.io/ansible/docker-test-containers:alpine3.7
   register: image_3
 
 - name: cleanup
@@ -1193,7 +1193,7 @@
 - name: labels
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels:
@@ -1204,7 +1204,7 @@
 - name: labels (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels:
@@ -1215,7 +1215,7 @@
 - name: labels (changes)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels:
@@ -1227,7 +1227,7 @@
 - name: labels (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels: {}
@@ -1236,7 +1236,7 @@
 - name: labels (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     labels: {}
@@ -1263,7 +1263,7 @@
 - name: mode
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mode: "replicated"
@@ -1273,7 +1273,7 @@
 - name: mode (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mode: "replicated"
@@ -1283,7 +1283,7 @@
 - name: mode (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     mode: "global"
@@ -1309,7 +1309,7 @@
 - name: stop_grace_period
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_grace_period: 60s
@@ -1318,7 +1318,7 @@
 - name: stop_grace_period (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_grace_period: 60s
@@ -1327,7 +1327,7 @@
 - name: stop_grace_period (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_grace_period: 1m30s
@@ -1352,7 +1352,7 @@
 - name: stop_signal
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_signal: "30"
@@ -1362,7 +1362,7 @@
 - name: stop_signal (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_signal: "30"
@@ -1372,7 +1372,7 @@
 - name: stop_signal (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     stop_signal: "9"
@@ -1404,7 +1404,7 @@
 - name: publish
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
@@ -1420,7 +1420,7 @@
 - name: publish (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
@@ -1435,7 +1435,7 @@
 - name: publish (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
@@ -1451,7 +1451,7 @@
 - name: publish (mode)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
@@ -1469,7 +1469,7 @@
 - name: publish (mode idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
@@ -1487,7 +1487,7 @@
 - name: publish (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish: []
@@ -1497,7 +1497,7 @@
 - name: publish (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish: []
@@ -1507,7 +1507,7 @@
 - name: publish (publishes the same port with both protocols)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     publish:
@@ -1557,7 +1557,7 @@
 - name: read_only
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     read_only: true
@@ -1567,7 +1567,7 @@
 - name: read_only (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     read_only: true
@@ -1577,7 +1577,7 @@
 - name: read_only (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     read_only: false
@@ -1609,7 +1609,7 @@
 - name: replicas
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     replicas: 2
@@ -1618,7 +1618,7 @@
 - name: replicas (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     replicas: 2
@@ -1627,7 +1627,7 @@
 - name: replicas (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     replicas: 3
@@ -1652,7 +1652,7 @@
 - name: resolve_image (false)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -v -c "sleep 10m"'
     resolve_image: false
   register: resolve_image_1
@@ -1660,7 +1660,7 @@
 - name: resolve_image (false idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -v -c "sleep 10m"'
     resolve_image: false
   register: resolve_image_2
@@ -1668,7 +1668,7 @@
 - name: resolve_image (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     command: '/bin/sh -v -c "sleep 10m"'
     resolve_image: true
   register: resolve_image_3
@@ -1702,7 +1702,7 @@
 # - name: tty
 #   docker_swarm_service:
 #     name: "{{ service_name }}"
-#     image: quay.io/ansible/mountainous:3.8
+#     image: quay.io/ansible/docker-test-containers:alpine3.8
 #     resolve_image: no
 #     command: '/bin/sh -v -c "sleep 10m"'
 #     tty: yes
@@ -1712,7 +1712,7 @@
 # - name: tty (idempotency)
 #   docker_swarm_service:
 #     name: "{{ service_name }}"
-#     image: quay.io/ansible/mountainous:3.8
+#     image: quay.io/ansible/docker-test-containers:alpine3.8
 #     resolve_image: no
 #     command: '/bin/sh -v -c "sleep 10m"'
 #     tty: yes
@@ -1722,7 +1722,7 @@
 # - name: tty (change)
 #   docker_swarm_service:
 #     name: "{{ service_name }}"
-#     image: quay.io/ansible/mountainous:3.8
+#     image: quay.io/ansible/docker-test-containers:alpine3.8
 #     resolve_image: no
 #     command: '/bin/sh -v -c "sleep 10m"'
 #     tty: no
@@ -1754,7 +1754,7 @@
 # - name: user
 #   docker_swarm_service:
 #     name: "{{ service_name }}"
-#     image: quay.io/ansible/mountainous:3.8
+#     image: quay.io/ansible/docker-test-containers:alpine3.8
 #     resolve_image: no
 #     command: '/bin/sh -v -c "sleep 10m"'
 #     user: "operator"
@@ -1763,7 +1763,7 @@
 # - name: user (idempotency)
 #   docker_swarm_service:
 #     name: "{{ service_name }}"
-#     image: quay.io/ansible/mountainous:3.8
+#     image: quay.io/ansible/docker-test-containers:alpine3.8
 #     resolve_image: no
 #     command: '/bin/sh -v -c "sleep 10m"'
 #     user: "operator"
@@ -1772,7 +1772,7 @@
 # - name: user (change)
 #   docker_swarm_service:
 #     name: "{{ service_name }}"
-#     image: quay.io/ansible/mountainous:3.8
+#     image: quay.io/ansible/docker-test-containers:alpine3.8
 #     resolve_image: no
 #     command: '/bin/sh -v -c "sleep 10m"'
 #     user: "root"
@@ -1797,7 +1797,7 @@
 # - name: working_dir
 #   docker_swarm_service:
 #     name: "{{ service_name }}"
-#     image: quay.io/ansible/mountainous:3.8
+#     image: quay.io/ansible/docker-test-containers:alpine3.8
 #     resolve_image: no
 #     working_dir: /tmp
 #   register: working_dir_1
@@ -1805,7 +1805,7 @@
 # - name: working_dir (idempotency)
 #   docker_swarm_service:
 #     name: "{{ service_name }}"
-#     image: quay.io/ansible/mountainous:3.8
+#     image: quay.io/ansible/docker-test-containers:alpine3.8
 #     resolve_image: no
 #     working_dir: /tmp
 #   register: working_dir_2
@@ -1813,7 +1813,7 @@
 # - name: working_dir (change)
 #   docker_swarm_service:
 #     name: "{{ service_name }}"
-#     image: quay.io/ansible/mountainous:3.8
+#     image: quay.io/ansible/docker-test-containers:alpine3.8
 #     resolve_image: no
 #     working_dir: /
 #   register: working_dir_3

--- a/test/integration/targets/docker_swarm_service/tasks/tests/placement.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/placement.yml
@@ -16,7 +16,7 @@
 - name: placement.preferences
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -28,7 +28,7 @@
 - name: placement.preferences (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -40,7 +40,7 @@
 - name: placement.preferences (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -52,7 +52,7 @@
 - name: placement.preferences (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -63,7 +63,7 @@
 - name: placement.preferences (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -98,7 +98,7 @@
 - name: placement.constraints
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -110,7 +110,7 @@
 - name: placement.constraints (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -122,7 +122,7 @@
 - name: constraints (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     constraints:
@@ -133,7 +133,7 @@
 - name: placement.constraints (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -145,7 +145,7 @@
 - name: placement.constraints (add)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -158,7 +158,7 @@
 - name: placement.constraints (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -171,7 +171,7 @@
 - name: placement.constraints (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -182,7 +182,7 @@
 - name: placement.constraints (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/placement.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/placement.yml
@@ -16,7 +16,7 @@
 - name: placement.preferences
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -28,7 +28,7 @@
 - name: placement.preferences (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -40,7 +40,7 @@
 - name: placement.preferences (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -52,7 +52,7 @@
 - name: placement.preferences (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -63,7 +63,7 @@
 - name: placement.preferences (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -98,7 +98,7 @@
 - name: placement.constraints
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -110,7 +110,7 @@
 - name: placement.constraints (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -122,7 +122,7 @@
 - name: constraints (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     constraints:
@@ -133,7 +133,7 @@
 - name: placement.constraints (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -145,7 +145,7 @@
 - name: placement.constraints (add)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -158,7 +158,7 @@
 - name: placement.constraints (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -171,7 +171,7 @@
 - name: placement.constraints (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -182,7 +182,7 @@
 - name: placement.constraints (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/placement.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/placement.yml
@@ -16,7 +16,7 @@
 - name: placement.preferences
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -28,7 +28,7 @@
 - name: placement.preferences (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -40,7 +40,7 @@
 - name: placement.preferences (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -52,7 +52,7 @@
 - name: placement.preferences (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -63,7 +63,7 @@
 - name: placement.preferences (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -98,7 +98,7 @@
 - name: placement.constraints
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -110,7 +110,7 @@
 - name: placement.constraints (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -122,7 +122,7 @@
 - name: constraints (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     constraints:
@@ -133,7 +133,7 @@
 - name: placement.constraints (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -145,7 +145,7 @@
 - name: placement.constraints (add)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -158,7 +158,7 @@
 - name: placement.constraints (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -171,7 +171,7 @@
 - name: placement.constraints (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:
@@ -182,7 +182,7 @@
 - name: placement.constraints (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     placement:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/resources.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/resources.yml
@@ -15,7 +15,7 @@
 - name: limits.cpus
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
@@ -25,7 +25,7 @@
 - name: limits.cpus (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
@@ -35,7 +35,7 @@
 - name: limit_cpu (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limit_cpu: 1
@@ -44,7 +44,7 @@
 - name: limits.cpus (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
@@ -71,7 +71,7 @@
 - name: limits.memory
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
@@ -81,7 +81,7 @@
 - name: limits.memory (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
@@ -91,7 +91,7 @@
 - name: limit_memory (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limit_memory: "67108864"
@@ -100,7 +100,7 @@
 - name: limits.memory (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limit_memory: 32M
@@ -126,7 +126,7 @@
 - name: reserve_cpu
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reservations:
@@ -136,7 +136,7 @@
 - name: reserve_cpu (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reservations:
@@ -146,7 +146,7 @@
 - name: reserve_cpu (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reserve_cpu: 1
@@ -155,7 +155,7 @@
 - name: reserve_cpu (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reservations:
@@ -182,7 +182,7 @@
 - name: reservations.memory
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reservations:
@@ -192,7 +192,7 @@
 - name: reservations.memory (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reserve_memory: 64M
@@ -201,7 +201,7 @@
 - name: reserve_memory (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reserve_memory: "67108864"
@@ -210,7 +210,7 @@
 - name: reservations.memory (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reserve_memory: 32M

--- a/test/integration/targets/docker_swarm_service/tasks/tests/resources.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/resources.yml
@@ -15,7 +15,7 @@
 - name: limits.cpus
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
@@ -25,7 +25,7 @@
 - name: limits.cpus (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
@@ -35,7 +35,7 @@
 - name: limit_cpu (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limit_cpu: 1
@@ -44,7 +44,7 @@
 - name: limits.cpus (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
@@ -71,7 +71,7 @@
 - name: limits.memory
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
@@ -81,7 +81,7 @@
 - name: limits.memory (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
@@ -91,7 +91,7 @@
 - name: limit_memory (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limit_memory: "67108864"
@@ -100,7 +100,7 @@
 - name: limits.memory (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limit_memory: 32M
@@ -126,7 +126,7 @@
 - name: reserve_cpu
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reservations:
@@ -136,7 +136,7 @@
 - name: reserve_cpu (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reservations:
@@ -146,7 +146,7 @@
 - name: reserve_cpu (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reserve_cpu: 1
@@ -155,7 +155,7 @@
 - name: reserve_cpu (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reservations:
@@ -182,7 +182,7 @@
 - name: reservations.memory
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reservations:
@@ -192,7 +192,7 @@
 - name: reservations.memory (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reserve_memory: 64M
@@ -201,7 +201,7 @@
 - name: reserve_memory (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reserve_memory: "67108864"
@@ -210,7 +210,7 @@
 - name: reservations.memory (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reserve_memory: 32M

--- a/test/integration/targets/docker_swarm_service/tasks/tests/resources.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/resources.yml
@@ -15,7 +15,7 @@
 - name: limits.cpus
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
@@ -25,7 +25,7 @@
 - name: limits.cpus (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
@@ -35,7 +35,7 @@
 - name: limit_cpu (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limit_cpu: 1
@@ -44,7 +44,7 @@
 - name: limits.cpus (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
@@ -71,7 +71,7 @@
 - name: limits.memory
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
@@ -81,7 +81,7 @@
 - name: limits.memory (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limits:
@@ -91,7 +91,7 @@
 - name: limit_memory (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limit_memory: "67108864"
@@ -100,7 +100,7 @@
 - name: limits.memory (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     limit_memory: 32M
@@ -126,7 +126,7 @@
 - name: reserve_cpu
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reservations:
@@ -136,7 +136,7 @@
 - name: reserve_cpu (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reservations:
@@ -146,7 +146,7 @@
 - name: reserve_cpu (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reserve_cpu: 1
@@ -155,7 +155,7 @@
 - name: reserve_cpu (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reservations:
@@ -182,7 +182,7 @@
 - name: reservations.memory
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reservations:
@@ -192,7 +192,7 @@
 - name: reservations.memory (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reserve_memory: 64M
@@ -201,7 +201,7 @@
 - name: reserve_memory (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reserve_memory: "67108864"
@@ -210,7 +210,7 @@
 - name: reservations.memory (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     reserve_memory: 32M

--- a/test/integration/targets/docker_swarm_service/tasks/tests/restart_config.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/restart_config.yml
@@ -15,7 +15,7 @@
 - name: restart_config.condition
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -25,7 +25,7 @@
 - name: restart_config.condition (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -35,7 +35,7 @@
 - name: restart_policy (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_policy: "on-failure"
@@ -44,7 +44,7 @@
 - name: restart_config.condition (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -71,7 +71,7 @@
 - name: restart_config.max_attempts
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -81,7 +81,7 @@
 - name: restart_config.max_attempts (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -91,7 +91,7 @@
 - name: restart_policy_attempts (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_policy_attempts: 1
@@ -100,7 +100,7 @@
 - name: restart_config.max_attempts (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -127,7 +127,7 @@
 - name: restart_config.delay
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -137,7 +137,7 @@
 - name: restart_config.delay (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -147,7 +147,7 @@
 - name: restart_policy_delay (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_policy_delay: 5000000000
@@ -156,7 +156,7 @@
 - name: restart_config.delay (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -183,7 +183,7 @@
 - name: restart_config.window
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -193,7 +193,7 @@
 - name: restart_config.window (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -203,7 +203,7 @@
 - name: restart_policy_window (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_policy_window: 10000000000
@@ -212,7 +212,7 @@
 - name: restart_config.window (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/restart_config.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/restart_config.yml
@@ -15,7 +15,7 @@
 - name: restart_config.condition
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -25,7 +25,7 @@
 - name: restart_config.condition (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -35,7 +35,7 @@
 - name: restart_policy (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_policy: "on-failure"
@@ -44,7 +44,7 @@
 - name: restart_config.condition (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -71,7 +71,7 @@
 - name: restart_config.max_attempts
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -81,7 +81,7 @@
 - name: restart_config.max_attempts (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -91,7 +91,7 @@
 - name: restart_policy_attempts (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_policy_attempts: 1
@@ -100,7 +100,7 @@
 - name: restart_config.max_attempts (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -127,7 +127,7 @@
 - name: restart_config.delay
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -137,7 +137,7 @@
 - name: restart_config.delay (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -147,7 +147,7 @@
 - name: restart_policy_delay (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_policy_delay: 5000000000
@@ -156,7 +156,7 @@
 - name: restart_config.delay (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -183,7 +183,7 @@
 - name: restart_config.window
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -193,7 +193,7 @@
 - name: restart_config.window (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -203,7 +203,7 @@
 - name: restart_policy_window (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_policy_window: 10000000000
@@ -212,7 +212,7 @@
 - name: restart_config.window (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/restart_config.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/restart_config.yml
@@ -15,7 +15,7 @@
 - name: restart_config.condition
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -25,7 +25,7 @@
 - name: restart_config.condition (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -35,7 +35,7 @@
 - name: restart_policy (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_policy: "on-failure"
@@ -44,7 +44,7 @@
 - name: restart_config.condition (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -71,7 +71,7 @@
 - name: restart_config.max_attempts
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -81,7 +81,7 @@
 - name: restart_config.max_attempts (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -91,7 +91,7 @@
 - name: restart_policy_attempts (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_policy_attempts: 1
@@ -100,7 +100,7 @@
 - name: restart_config.max_attempts (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -127,7 +127,7 @@
 - name: restart_config.delay
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -137,7 +137,7 @@
 - name: restart_config.delay (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -147,7 +147,7 @@
 - name: restart_policy_delay (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_policy_delay: 5000000000
@@ -156,7 +156,7 @@
 - name: restart_config.delay (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -183,7 +183,7 @@
 - name: restart_config.window
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -193,7 +193,7 @@
 - name: restart_config.window (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:
@@ -203,7 +203,7 @@
 - name: restart_policy_window (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_policy_window: 10000000000
@@ -212,7 +212,7 @@
 - name: restart_config.window (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     restart_config:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/rollback_config.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/rollback_config.yml
@@ -15,7 +15,7 @@
 - name: rollback_config.delay
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -26,7 +26,7 @@
 - name: rollback_config.delay (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -37,7 +37,7 @@
 - name: rollback_config.delay (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -70,7 +70,7 @@
 - name: rollback_config.failure_action
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -81,7 +81,7 @@
 - name: rollback_config.failure_action (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -92,7 +92,7 @@
 - name: rollback_config.failure_action (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -125,7 +125,7 @@
 - name: rollback_config.max_failure_ratio
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -136,7 +136,7 @@
 - name: rollback_config.max_failure_ratio (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -147,7 +147,7 @@
 - name: rollback_config.max_failure_ratio (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -180,7 +180,7 @@
 - name: rollback_config.monitor
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -191,7 +191,7 @@
 - name: rollback_config.monitor (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -202,7 +202,7 @@
 - name: rollback_config.monitor (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -235,7 +235,7 @@
 - name: rollback_config.order
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -246,7 +246,7 @@
 - name: rollback_config.order (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -257,7 +257,7 @@
 - name: rollback_config.order (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -290,7 +290,7 @@
 - name: rollback_config.parallelism
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -301,7 +301,7 @@
 - name: rollback_config.parallelism (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -312,7 +312,7 @@
 - name: rollback_config.parallelism (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/rollback_config.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/rollback_config.yml
@@ -15,7 +15,7 @@
 - name: rollback_config.delay
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -26,7 +26,7 @@
 - name: rollback_config.delay (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -37,7 +37,7 @@
 - name: rollback_config.delay (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -70,7 +70,7 @@
 - name: rollback_config.failure_action
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -81,7 +81,7 @@
 - name: rollback_config.failure_action (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -92,7 +92,7 @@
 - name: rollback_config.failure_action (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -125,7 +125,7 @@
 - name: rollback_config.max_failure_ratio
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -136,7 +136,7 @@
 - name: rollback_config.max_failure_ratio (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -147,7 +147,7 @@
 - name: rollback_config.max_failure_ratio (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -180,7 +180,7 @@
 - name: rollback_config.monitor
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -191,7 +191,7 @@
 - name: rollback_config.monitor (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -202,7 +202,7 @@
 - name: rollback_config.monitor (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -235,7 +235,7 @@
 - name: rollback_config.order
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -246,7 +246,7 @@
 - name: rollback_config.order (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -257,7 +257,7 @@
 - name: rollback_config.order (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -290,7 +290,7 @@
 - name: rollback_config.parallelism
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -301,7 +301,7 @@
 - name: rollback_config.parallelism (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -312,7 +312,7 @@
 - name: rollback_config.parallelism (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/rollback_config.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/rollback_config.yml
@@ -15,7 +15,7 @@
 - name: rollback_config.delay
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -26,7 +26,7 @@
 - name: rollback_config.delay (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -37,7 +37,7 @@
 - name: rollback_config.delay (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -70,7 +70,7 @@
 - name: rollback_config.failure_action
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -81,7 +81,7 @@
 - name: rollback_config.failure_action (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -92,7 +92,7 @@
 - name: rollback_config.failure_action (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -125,7 +125,7 @@
 - name: rollback_config.max_failure_ratio
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -136,7 +136,7 @@
 - name: rollback_config.max_failure_ratio (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -147,7 +147,7 @@
 - name: rollback_config.max_failure_ratio (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -180,7 +180,7 @@
 - name: rollback_config.monitor
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -191,7 +191,7 @@
 - name: rollback_config.monitor (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -202,7 +202,7 @@
 - name: rollback_config.monitor (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -235,7 +235,7 @@
 - name: rollback_config.order
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -246,7 +246,7 @@
 - name: rollback_config.order (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -257,7 +257,7 @@
 - name: rollback_config.order (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -290,7 +290,7 @@
 - name: rollback_config.parallelism
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -301,7 +301,7 @@
 - name: rollback_config.parallelism (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:
@@ -312,7 +312,7 @@
 - name: rollback_config.parallelism (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     rollback_config:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/secrets.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/secrets.yml
@@ -31,7 +31,7 @@
 - name: secrets
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -44,7 +44,7 @@
 - name: secrets (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -56,7 +56,7 @@
 - name: secrets (add)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -71,7 +71,7 @@
 - name: secrets (add idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -86,7 +86,7 @@
 - name: secrets (add idempotency no id)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -100,7 +100,7 @@
 - name: secrets (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -114,7 +114,7 @@
 - name: secrets (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets: []
@@ -124,7 +124,7 @@
 - name: secrets (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets: []
@@ -161,7 +161,7 @@
 - name: secrets (uid int)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -174,7 +174,7 @@
 - name: secrets (uid int idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -187,7 +187,7 @@
 - name: secrets (uid int change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -200,7 +200,7 @@
 - name: secrets (uid str)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -213,7 +213,7 @@
 - name: secrets (uid str idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -250,7 +250,7 @@
 - name: secrets (gid int)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -263,7 +263,7 @@
 - name: secrets (gid int idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -276,7 +276,7 @@
 - name: secrets (gid int change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -289,7 +289,7 @@
 - name: secrets (gid str)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -302,7 +302,7 @@
 - name: secrets (gid str idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -339,7 +339,7 @@
 - name: secrets (mode)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -352,7 +352,7 @@
 - name: secrets (mode idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -365,7 +365,7 @@
 - name: secrets (mode change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/secrets.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/secrets.yml
@@ -31,7 +31,7 @@
 - name: secrets
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -44,7 +44,7 @@
 - name: secrets (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -56,7 +56,7 @@
 - name: secrets (add)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -71,7 +71,7 @@
 - name: secrets (add idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -86,7 +86,7 @@
 - name: secrets (add idempotency no id)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -100,7 +100,7 @@
 - name: secrets (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -114,7 +114,7 @@
 - name: secrets (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets: []
@@ -124,7 +124,7 @@
 - name: secrets (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets: []
@@ -161,7 +161,7 @@
 - name: secrets (uid int)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -174,7 +174,7 @@
 - name: secrets (uid int idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -187,7 +187,7 @@
 - name: secrets (uid int change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -200,7 +200,7 @@
 - name: secrets (uid str)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -213,7 +213,7 @@
 - name: secrets (uid str idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -250,7 +250,7 @@
 - name: secrets (gid int)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -263,7 +263,7 @@
 - name: secrets (gid int idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -276,7 +276,7 @@
 - name: secrets (gid int change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -289,7 +289,7 @@
 - name: secrets (gid str)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -302,7 +302,7 @@
 - name: secrets (gid str idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -339,7 +339,7 @@
 - name: secrets (mode)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -352,7 +352,7 @@
 - name: secrets (mode idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -365,7 +365,7 @@
 - name: secrets (mode change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/secrets.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/secrets.yml
@@ -31,7 +31,7 @@
 - name: secrets
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -44,7 +44,7 @@
 - name: secrets (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -56,7 +56,7 @@
 - name: secrets (add)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -71,7 +71,7 @@
 - name: secrets (add idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -86,7 +86,7 @@
 - name: secrets (add idempotency no id)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -100,7 +100,7 @@
 - name: secrets (order idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -114,7 +114,7 @@
 - name: secrets (empty)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets: []
@@ -124,7 +124,7 @@
 - name: secrets (empty idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets: []
@@ -161,7 +161,7 @@
 - name: secrets (uid int)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -174,7 +174,7 @@
 - name: secrets (uid int idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -187,7 +187,7 @@
 - name: secrets (uid int change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -200,7 +200,7 @@
 - name: secrets (uid str)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -213,7 +213,7 @@
 - name: secrets (uid str idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -250,7 +250,7 @@
 - name: secrets (gid int)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -263,7 +263,7 @@
 - name: secrets (gid int idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -276,7 +276,7 @@
 - name: secrets (gid int change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -289,7 +289,7 @@
 - name: secrets (gid str)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -302,7 +302,7 @@
 - name: secrets (gid str idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -339,7 +339,7 @@
 - name: secrets (mode)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -352,7 +352,7 @@
 - name: secrets (mode idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:
@@ -365,7 +365,7 @@
 - name: secrets (mode change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     secrets:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/update_config.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/update_config.yml
@@ -15,7 +15,7 @@
 - name: update_config.delay
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -25,7 +25,7 @@
 - name: update_config.delay (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -35,7 +35,7 @@
 - name: update_delay (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_delay: 5000000000
@@ -44,7 +44,7 @@
 - name: update_config.delay (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -71,7 +71,7 @@
 - name: update_config.failure_action
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -81,7 +81,7 @@
 - name: update_config.failure_action (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -91,7 +91,7 @@
 - name: update_failure_action (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_failure_action: "pause"
@@ -100,7 +100,7 @@
 - name: update_config.failure_action (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -110,7 +110,7 @@
 - name: update_config.failure_action (rollback)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -121,7 +121,7 @@
 - name: update_config.failure_action (rollback idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_failure_action: "rollback"
@@ -160,7 +160,7 @@
 - name: update_config.max_failure_ratio
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -171,7 +171,7 @@
 - name: update_config.max_failure_ratio (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -182,7 +182,7 @@
 - name: update_max_failure_ratio (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_max_failure_ratio: 0.25
@@ -192,7 +192,7 @@
 - name: update_config.max_failure_ratio (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -226,7 +226,7 @@
 - name: update_config.monitor
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -237,7 +237,7 @@
 - name: update_config.monitor (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -248,7 +248,7 @@
 - name: update_monitor (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_monitor: 10s
@@ -258,7 +258,7 @@
 - name: update_config.monitor (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -292,7 +292,7 @@
 - name: update_config.order
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -303,7 +303,7 @@
 - name: update_config.order (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -314,7 +314,7 @@
 - name: update_order (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_order: "start-first"
@@ -324,7 +324,7 @@
 - name: update_config.order (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -358,7 +358,7 @@
 - name: update_config.parallelism
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -368,7 +368,7 @@
 - name: update_config.parallelism (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -378,7 +378,7 @@
 - name: update_parallelism (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_parallelism: 2
@@ -387,7 +387,7 @@
 - name: update_config.parallelism (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/app-sre/alpine:3.8
+    image: quay.io/ansible/mountainous:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/update_config.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/update_config.yml
@@ -15,7 +15,7 @@
 - name: update_config.delay
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -25,7 +25,7 @@
 - name: update_config.delay (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -35,7 +35,7 @@
 - name: update_delay (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_delay: 5000000000
@@ -44,7 +44,7 @@
 - name: update_config.delay (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -71,7 +71,7 @@
 - name: update_config.failure_action
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -81,7 +81,7 @@
 - name: update_config.failure_action (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -91,7 +91,7 @@
 - name: update_failure_action (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_failure_action: "pause"
@@ -100,7 +100,7 @@
 - name: update_config.failure_action (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -110,7 +110,7 @@
 - name: update_config.failure_action (rollback)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -121,7 +121,7 @@
 - name: update_config.failure_action (rollback idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_failure_action: "rollback"
@@ -160,7 +160,7 @@
 - name: update_config.max_failure_ratio
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -171,7 +171,7 @@
 - name: update_config.max_failure_ratio (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -182,7 +182,7 @@
 - name: update_max_failure_ratio (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_max_failure_ratio: 0.25
@@ -192,7 +192,7 @@
 - name: update_config.max_failure_ratio (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -226,7 +226,7 @@
 - name: update_config.monitor
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -237,7 +237,7 @@
 - name: update_config.monitor (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -248,7 +248,7 @@
 - name: update_monitor (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_monitor: 10s
@@ -258,7 +258,7 @@
 - name: update_config.monitor (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -292,7 +292,7 @@
 - name: update_config.order
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -303,7 +303,7 @@
 - name: update_config.order (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -314,7 +314,7 @@
 - name: update_order (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_order: "start-first"
@@ -324,7 +324,7 @@
 - name: update_config.order (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -358,7 +358,7 @@
 - name: update_config.parallelism
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -368,7 +368,7 @@
 - name: update_config.parallelism (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -378,7 +378,7 @@
 - name: update_parallelism (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_parallelism: 2
@@ -387,7 +387,7 @@
 - name: update_config.parallelism (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: alpine:3.8
+    image: quay.io/app-sre/alpine:3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:

--- a/test/integration/targets/docker_swarm_service/tasks/tests/update_config.yml
+++ b/test/integration/targets/docker_swarm_service/tasks/tests/update_config.yml
@@ -15,7 +15,7 @@
 - name: update_config.delay
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -25,7 +25,7 @@
 - name: update_config.delay (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -35,7 +35,7 @@
 - name: update_delay (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_delay: 5000000000
@@ -44,7 +44,7 @@
 - name: update_config.delay (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -71,7 +71,7 @@
 - name: update_config.failure_action
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -81,7 +81,7 @@
 - name: update_config.failure_action (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -91,7 +91,7 @@
 - name: update_failure_action (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_failure_action: "pause"
@@ -100,7 +100,7 @@
 - name: update_config.failure_action (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -110,7 +110,7 @@
 - name: update_config.failure_action (rollback)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -121,7 +121,7 @@
 - name: update_config.failure_action (rollback idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_failure_action: "rollback"
@@ -160,7 +160,7 @@
 - name: update_config.max_failure_ratio
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -171,7 +171,7 @@
 - name: update_config.max_failure_ratio (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -182,7 +182,7 @@
 - name: update_max_failure_ratio (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_max_failure_ratio: 0.25
@@ -192,7 +192,7 @@
 - name: update_config.max_failure_ratio (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -226,7 +226,7 @@
 - name: update_config.monitor
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -237,7 +237,7 @@
 - name: update_config.monitor (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -248,7 +248,7 @@
 - name: update_monitor (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_monitor: 10s
@@ -258,7 +258,7 @@
 - name: update_config.monitor (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -292,7 +292,7 @@
 - name: update_config.order
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -303,7 +303,7 @@
 - name: update_config.order (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -314,7 +314,7 @@
 - name: update_order (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_order: "start-first"
@@ -324,7 +324,7 @@
 - name: update_config.order (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -358,7 +358,7 @@
 - name: update_config.parallelism
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -368,7 +368,7 @@
 - name: update_config.parallelism (idempotency)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:
@@ -378,7 +378,7 @@
 - name: update_parallelism (idempotency, old name)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_parallelism: 2
@@ -387,7 +387,7 @@
 - name: update_config.parallelism (change)
   docker_swarm_service:
     name: "{{ service_name }}"
-    image: quay.io/ansible/mountainous:3.8
+    image: quay.io/ansible/docker-test-containers:alpine3.8
     resolve_image: no
     command: '/bin/sh -v -c "sleep 10m"'
     update_config:

--- a/test/integration/targets/docker_swarm_service/vars/main.yml
+++ b/test/integration/targets/docker_swarm_service/vars/main.yml
@@ -17,7 +17,7 @@ service_expected_output:
   healthcheck_disabled: null
   hostname: null
   hosts: null
-  image: busybox
+  image: quay.io/quay/busybox
   labels: null
   limit_cpu: null
   limit_memory: null

--- a/test/integration/targets/docker_swarm_service/vars/main.yml
+++ b/test/integration/targets/docker_swarm_service/vars/main.yml
@@ -17,7 +17,7 @@ service_expected_output:
   healthcheck_disabled: null
   hostname: null
   hosts: null
-  image: quay.io/quay/busybox
+  image: quay.io/ansible/docker-test-containers:busybox
   labels: null
   limit_cpu: null
   limit_memory: null

--- a/test/integration/targets/docker_swarm_service_info/tasks/test_docker_swarm_service_info.yml
+++ b/test/integration/targets/docker_swarm_service_info/tasks/test_docker_swarm_service_info.yml
@@ -35,7 +35,7 @@
   - name: Create services
     docker_swarm_service:
       name: "{{ service_name }}"
-      image: quay.io/app-sre/alpine:3.8
+      image: quay.io/ansible/mountainous:3.8
 
   - name: Try to get docker_swarm_service_info for a single service
     docker_swarm_service_info:

--- a/test/integration/targets/docker_swarm_service_info/tasks/test_docker_swarm_service_info.yml
+++ b/test/integration/targets/docker_swarm_service_info/tasks/test_docker_swarm_service_info.yml
@@ -35,7 +35,7 @@
   - name: Create services
     docker_swarm_service:
       name: "{{ service_name }}"
-      image: alpine:3.8
+      image: quay.io/app-sre/alpine:3.8
 
   - name: Try to get docker_swarm_service_info for a single service
     docker_swarm_service_info:

--- a/test/integration/targets/docker_swarm_service_info/tasks/test_docker_swarm_service_info.yml
+++ b/test/integration/targets/docker_swarm_service_info/tasks/test_docker_swarm_service_info.yml
@@ -35,7 +35,7 @@
   - name: Create services
     docker_swarm_service:
       name: "{{ service_name }}"
-      image: quay.io/ansible/mountainous:3.8
+      image: quay.io/ansible/docker-test-containers:alpine3.8
 
   - name: Try to get docker_swarm_service_info for a single service
     docker_swarm_service_info:

--- a/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
+++ b/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
@@ -47,4 +47,4 @@
   - name: run a Docker container on the target Docker Machine host to verify that Docker daemon connection settings from the docker-machine inventory plugin work as expected
     docker_container:
       name: test
-      image: quay.io/ansible/hey:latest
+      image: quay.io/ansible/docker-test-containers:hello-world

--- a/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
+++ b/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
@@ -47,4 +47,4 @@
   - name: run a Docker container on the target Docker Machine host to verify that Docker daemon connection settings from the docker-machine inventory plugin work as expected
     docker_container:
       name: test
-      image: quay.io/redhattraining/hello-world-nginx:latest
+      image: quay.io/ansible/hey:latest

--- a/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
+++ b/test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml
@@ -47,4 +47,4 @@
   - name: run a Docker container on the target Docker Machine host to verify that Docker daemon connection settings from the docker-machine inventory plugin work as expected
     docker_container:
       name: test
-      image: hello-world:latest
+      image: quay.io/redhattraining/hello-world-nginx:latest

--- a/test/integration/targets/k8s/tasks/waiter.yml
+++ b/test/integration/targets/k8s/tasks/waiter.yml
@@ -27,7 +27,7 @@
         wait: yes
       vars:
         k8s_pod_name: wait-pod
-        k8s_pod_image: quay.io/app-sre/alpine:3.8
+        k8s_pod_image: quay.io/ansible/docker-test-containers:alpine3.8
         k8s_pod_command:
           - sleep
           - "10000"
@@ -145,7 +145,7 @@
         wait_timeout: 30
       vars:
         k8s_pod_name: wait-crash-pod
-        k8s_pod_image: quay.io/app-sre/alpine:3.8
+        k8s_pod_image: quay.io/ansible/docker-test-containers:alpine3.8
         k8s_pod_command:
           - /bin/false
       register: crash_pod
@@ -316,7 +316,7 @@
         wait: yes
       vars:
         k8s_pod_name: wait-crash-deploy
-        k8s_pod_image: quay.io/app-sre/alpine:3.8
+        k8s_pod_image: quay.io/ansible/docker-test-containers:alpine3.8
         k8s_pod_command:
           - /bin/false
       register: wait_crash_deploy

--- a/test/integration/targets/k8s/tasks/waiter.yml
+++ b/test/integration/targets/k8s/tasks/waiter.yml
@@ -27,7 +27,7 @@
         wait: yes
       vars:
         k8s_pod_name: wait-pod
-        k8s_pod_image: alpine:3.8
+        k8s_pod_image: quay.io/app-sre/alpine:3.8
         k8s_pod_command:
           - sleep
           - "10000"
@@ -145,7 +145,7 @@
         wait_timeout: 30
       vars:
         k8s_pod_name: wait-crash-pod
-        k8s_pod_image: alpine:3.8
+        k8s_pod_image: quay.io/app-sre/alpine:3.8
         k8s_pod_command:
           - /bin/false
       register: crash_pod
@@ -316,7 +316,7 @@
         wait: yes
       vars:
         k8s_pod_name: wait-crash-deploy
-        k8s_pod_image: alpine:3.8
+        k8s_pod_image: quay.io/app-sre/alpine:3.8
         k8s_pod_command:
           - /bin/false
       register: wait_crash_deploy


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
CI tests are failing in certain situations due to the new Docker Hub limits on anonymous pulls. Switch to pulling an equivalent image from Quay.io.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/docker_container/tasks/tests/comparisons.yml`
`test/integration/targets/docker_container/tasks/tests/image-ids.yml`
`test/integration/targets/docker_container/tasks/tests/mounts-volumes.yml`
`test/integration/targets/docker_container/tasks/tests/network.yml`
`test/integration/targets/docker_container/tasks/tests/options.yml`
`test/integration/targets/docker_container/tasks/tests/ports.yml`
`test/integration/targets/docker_container/tasks/tests/regression-45700-dont-parse-on-absent.yml`
`test/integration/targets/docker_container/tasks/tests/start-stop.yml`
`test/integration/targets/docker_container_info/tasks/main.yml`
`test/integration/targets/docker_host_info/tasks/test_host_info.yml`
`test/integration/targets/docker_network/tasks/tests/basic.yml`
`test/integration/targets/docker_prune/tasks/main.yml`
`test/integration/targets/docker_stack/files/stack_compose_base.yml`
`test/integration/targets/docker_stack/vars/main.yml`
`test/integration/targets/docker_swarm_service/tasks/main.yml`
`test/integration/targets/docker_swarm_service/tasks/tests/configs.yml`
`test/integration/targets/docker_swarm_service/tasks/tests/logging.yml`
`test/integration/targets/docker_swarm_service/tasks/tests/misc.yml`
`test/integration/targets/docker_swarm_service/tasks/tests/mounts.yml`
`test/integration/targets/docker_swarm_service/tasks/tests/networks.yml`
`test/integration/targets/docker_swarm_service/tasks/tests/options.yml`
`test/integration/targets/docker_swarm_service/tasks/tests/placement.yml`
`test/integration/targets/docker_swarm_service/tasks/tests/resources.yml`
`test/integration/targets/docker_swarm_service/tasks/tests/restart_config.yml`
`test/integration/targets/docker_swarm_service/tasks/tests/rollback_config.yml`
`test/integration/targets/docker_swarm_service/tasks/tests/secrets.yml`
`test/integration/targets/docker_swarm_service/tasks/tests/update_config.yml`
`test/integration/targets/docker_swarm_service/vars/main.yml`
`test/integration/targets/docker_swarm_service_info/tasks/test_docker_swarm_service_info.yml`
`test/integration/targets/inventory_docker_machine/playbooks/test_inventory_1.yml`
test/integration/targets/k8s/tasks/waiter.yml