### PR TITLE
The implicit default for type=bool options is not 'false', but 'none'

### DIFF
--- a/changelogs/fragments/72699-validate-modules-default-for-bools.yml
+++ b/changelogs/fragments/72699-validate-modules-default-for-bools.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "ansible-test validate-modules - no longer assume that ``default`` for ``type=bool`` options is ``false``, as the default is ``none`` and for some modules, ``none`` and ``false`` mean different things (https://github.com/ansible/ansible/issues/69561)."

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -36,9 +36,9 @@ options:
   update_cache:
     description:
       - Run the equivalent of C(apt-get update) before the operation. Can be run as part of the package installation or as a separate step.
+      - Default is not to update the cache.
     aliases: [ update-cache ]
     type: bool
-    default: 'no'
   update_cache_retries:
     description:
       - Amount of retries if the cache update fails. Also see I(update_cache_retry_max_delay).

--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -123,7 +123,7 @@ options:
       - New variables are added on top of crontab.
       - C(name) and C(value) parameters are the name and the value of environment variable.
     type: bool
-    default: no
+    default: false
     version_added: "2.1"
   insertafter:
     description:
@@ -572,7 +572,7 @@ def main():
             reboot=dict(type='bool', default=False),
             special_time=dict(type='str', choices=["reboot", "yearly", "annually", "monthly", "weekly", "daily", "hourly"]),
             disabled=dict(type='bool', default=False),
-            env=dict(type='bool'),
+            env=dict(type='bool', default=False),
             insertafter=dict(type='str'),
             insertbefore=dict(type='str'),
         ),

--- a/lib/ansible/modules/debconf.py
+++ b/lib/ansible/modules/debconf.py
@@ -54,7 +54,7 @@ options:
     description:
       - Do not set 'seen' flag when pre-seeding.
     type: bool
-    default: no
+    default: false
 author:
 - Brian Coca (@bcoca)
 '''
@@ -137,7 +137,7 @@ def main():
             question=dict(type='str', aliases=['selection', 'setting']),
             vtype=dict(type='str', choices=['boolean', 'error', 'multiselect', 'note', 'password', 'seen', 'select', 'string', 'text', 'title']),
             value=dict(type='str', aliases=['answer']),
-            unseen=dict(type='bool'),
+            unseen=dict(type='bool', default=False),
         ),
         required_together=(['question', 'vtype', 'value'],),
         supports_check_mode=True,

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -449,7 +449,7 @@ def main():
     argument_spec.update(
         url=dict(type='str', required=True),
         dest=dict(type='path', required=True),
-        backup=dict(type='bool'),
+        backup=dict(type='bool', default=False),
         sha256sum=dict(type='str', default=''),
         checksum=dict(type='str', default=''),
         timeout=dict(type='int', default=10),

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -326,6 +326,7 @@ options:
       - If no chain is specified then the entire table is purged.
       - Ignores all other parameters.
     type: bool
+    default: false
     version_added: "2.2"
   policy:
     description:

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -1734,8 +1734,6 @@ class ModuleValidator(Validator):
                         msg=msg
                     )
                     continue
-            elif data.get('default') is None and _type == 'bool' and 'options' not in data:
-                arg_default = False
 
             doc_options_args = []
             for alias in sorted(set([arg] + list(aliases))):
@@ -1765,8 +1763,6 @@ class ModuleValidator(Validator):
                 if 'default' in doc_options_arg and not is_empty(doc_options_arg['default']):
                     with CaptureStd():
                         doc_default = _type_checker(doc_options_arg['default'])
-                elif doc_options_arg.get('default') is None and _type == 'bool' and 'suboptions' not in doc_options_arg:
-                    doc_default = False
             except (Exception, SystemExit):
                 msg = "Argument '%s' in documentation" % arg
                 if context:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -85,6 +85,7 @@ lib/ansible/modules/async_wrapper.py pylint:ansible-bad-function # ignore, requi
 lib/ansible/modules/async_wrapper.py use-argspec-type-path
 lib/ansible/modules/blockinfile.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/blockinfile.py validate-modules:doc-default-does-not-match-spec
+lib/ansible/modules/command.py validate-modules:doc-default-does-not-match-spec  # _uses_shell is undocumented
 lib/ansible/modules/command.py validate-modules:doc-missing-type
 lib/ansible/modules/command.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/command.py validate-modules:undocumented-parameter
@@ -112,6 +113,7 @@ lib/ansible/modules/pip.py validate-modules:invalid-ansiblemodule-schema
 lib/ansible/modules/replace.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/service.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/service.py validate-modules:use-run-command-not-popen
+lib/ansible/modules/stat.py validate-modules:doc-default-does-not-match-spec  # get_md5 is undocumented
 lib/ansible/modules/stat.py validate-modules:parameter-invalid
 lib/ansible/modules/stat.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/stat.py validate-modules:undocumented-parameter


### PR DESCRIPTION
##### SUMMARY
Right now validate-modules complains when a `default` specified in argument spec not has a matching `default` in the documentation. The only case where this doesn't happen is if `type=bool`: in that case, `default=False` in the argument spec does not require `default: false` in the documentation, despite `false` and `none` (implicit default) are two different values.

(There are modules for which `false` and `none` / not specified are different values, and in some cases their documentation could be wrong because of this.)

Fixes #69561.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test validate-modules
