### PR TITLE
Update playbooks_filters_ipaddr.rst

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
@@ -504,7 +504,7 @@ The ``network_in_network`` filter returns whether an address or a network passed
 
 To check whether multiple addresses belong to a network, use the ``reduce_on_network`` filter::
 
-    # {{ '192.168.0.0/24' | ansible.netcommon.reduce_on_network( ['192.168.0.34', '10.3.0.3', '192.168.2.34'] ) }}
+    # {{ ['192.168.0.34', '10.3.0.3', '192.168.2.34'] | ansible.netcommon.reduce_on_network( '192.168.0.0/24' ) }}
     ['192.168.0.34']
 
 


### PR DESCRIPTION
##### SUMMARY
The order of the arguments for ansible.netcommon.reduce_on_network is wrong in the documentation, to make it work you need to pass the network as the argument and the list of IP addresses as the filter input.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
