### PR TITLE
Add version_sort filter to sort e.g. package lists

### DIFF
--- a/changelogs/fragments/72711-version-sort-filter.yml
+++ b/changelogs/fragments/72711-version-sort-filter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - add a version_sort filter which allows to sort list of version strings e.g. of package names with their versions

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -35,6 +35,7 @@ import uuid
 import yaml
 
 import datetime
+from distutils.version import LooseVersion
 from functools import partial
 from random import Random, SystemRandom, shuffle
 
@@ -113,6 +114,11 @@ def quote(a):
     if a is None:
         a = u''
     return shlex_quote(to_text(a))
+
+
+def version_sort(value, reverse=False):
+    '''Sort a list according to loose versions so that e.g. 2.9 is smaller than 2.10'''
+    return sorted(value, key=LooseVersion, reverse=reverse)
 
 
 def fileglob(pathname):
@@ -621,6 +627,9 @@ class FilterModule(object):
 
             # quote string for shell usage
             'quote': quote,
+
+            # version sort for e.g. package versions sorting
+            'version_sort': version_sort,
 
             # hash filters
             # md5 hex digest of string

--- a/test/integration/targets/filter_core/files/foo.txt
+++ b/test/integration/targets/filter_core/files/foo.txt
@@ -67,3 +67,6 @@ regex_replace = bar
 regex_search = 0001
 regex_findall = ["car", "tar", "bar"]
 regex_escape = \^f\.\*o\(\.\*\)\$
+
+# check that version_sort sorts versions correctly and in a stable manner
+sorted_versions = ['a-1.9.rpm', 'a-1.09.rpm', 'a-1.10-0.rpm', 'a-1.10-1.rpm', 'a-2.1-0.rpm', 'b-1.01.rpm']

--- a/test/integration/targets/filter_core/templates/foo.j2
+++ b/test/integration/targets/filter_core/templates/foo.j2
@@ -60,3 +60,6 @@ regex_replace = {{ 'foo' | regex_replace('^foo', 'bar') }}
 regex_search = {{ 'test_value_0001' | regex_search('([0-9]+)$')}}
 regex_findall = {{ 'car\ntar\nfoo\nbar\n' | regex_findall('^.ar$', multiline=True)|to_json }}
 regex_escape = {{ '^f.*o(.*)$' | regex_escape() }}
+
+# check that version_sort sorts versions correctly and in a stable manner
+sorted_versions = {{ ['a-1.9.rpm', 'a-1.10-1.rpm', 'a-1.09.rpm', 'b-1.01.rpm', 'a-2.1-0.rpm', 'a-1.10-0.rpm'] | version_sort }}


### PR DESCRIPTION
##### SUMMARY

The standard sort filter doesn't properly sort versions e.g. 2.9 is _after_ 2.10 hence this filter.

##### ISSUE TYPE

- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME

version_sort

##### ADDITIONAL INFORMATION

I think the test added explains it pretty much:
`sorted_versions = {{ ['a-1.9.rpm', 'a-1.10-1.rpm', 'a-1.09.rpm', 'b-1.01.rpm', 'a-2.1-0.rpm', 'a-1.10-0.rpm'] | version_sort }}` becomes `sorted_versions = ['a-1.9.rpm', 'a-1.09.rpm', 'a-1.10-0.rpm', 'a-1.10-1.rpm', 'a-2.1-0.rpm', 'b-1.01.rpm']`.

