### PR TITLE
[stable-2.10]: Fix AIX networks facts when nestat is either missing or has incorrect permissions

### DIFF
--- a/changelogs/fragments/72516-fix-aix-network-facts.yml
+++ b/changelogs/fragments/72516-fix-aix-network-facts.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - Fixed issue when `netstat` is either missing or doesn't have execution permissions leading to incorrect command being executed. 

--- a/lib/ansible/module_utils/facts/network/aix.py
+++ b/lib/ansible/module_utils/facts/network/aix.py
@@ -30,22 +30,23 @@ class AIXNetwork(GenericBsdIfconfigNetwork):
     platform = 'AIX'
 
     def get_default_interfaces(self, route_path):
-        netstat_path = self.module.get_bin_path('netstat')
-
-        rc, out, err = self.module.run_command([netstat_path, '-nr'])
-
         interface = dict(v4={}, v6={})
 
-        lines = out.splitlines()
-        for line in lines:
-            words = line.split()
-            if len(words) > 1 and words[0] == 'default':
-                if '.' in words[1]:
-                    interface['v4']['gateway'] = words[1]
-                    interface['v4']['interface'] = words[5]
-                elif ':' in words[1]:
-                    interface['v6']['gateway'] = words[1]
-                    interface['v6']['interface'] = words[5]
+        netstat_path = self.module.get_bin_path('netstat')
+
+        if netstat_path:
+            rc, out, err = self.module.run_command([netstat_path, '-nr'])
+
+            lines = out.splitlines()
+            for line in lines:
+                words = line.split()
+                if len(words) > 1 and words[0] == 'default':
+                    if '.' in words[1]:
+                        interface['v4']['gateway'] = words[1]
+                        interface['v4']['interface'] = words[5]
+                    elif ':' in words[1]:
+                        interface['v6']['gateway'] = words[1]
+                        interface['v6']['interface'] = words[5]
 
         return interface['v4'], interface['v6']
 


### PR DESCRIPTION
##### SUMMARY

Backport of #72516

<!--- Describe the change below, including rationale and design decisions -->
Ansible `gather_facts` on AIX uses `netstat -nr` to collect information about default interfaces. While it normally works, there might be situations when `netstat` is either unavailable or missing execute permissions. This PR adds a check to ensure the `nestat -nr` command is executed only if `netstat` exists or has execute permissions (as per `get_bin_path` logic).

Other commands in same file have this check already.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`module_utils/facts/network/aix.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
In current state, if `netstat` is missing execution permissions, following will be the result of executing a playbook with `gather_facts` enabled

```json
{
    "_ansible_no_log": false,
    "failed_modules": {
        "setup": {
            "failed": true,
            "rc": 2,
            "invocation": {
                "module_args": {
                    "filter": "*",
                    "gather_subset": [
                        "all"
                    ],
                    "fact_path": "/etc/ansible/facts.d",
                    "gather_timeout": 10
                }
            },
            "cmd": "-nr",
            "msg": "[Errno 2] A file or directory in the path name does not exist.: b'-nr'"
        }
    },
    "msg": "The following modules failed to execute: setup\n",
    "changed": false,
    "_ansible_verbose_override": true,
    "ansible_facts": {}
}
```