### PR TITLE
Add link to all module and plugin indexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ docs/docsite/rst/dev_guide/collections_galaxy_meta.rst
 docs/docsite/rst/dev_guide/testing/sanity/index.rst.new
 docs/docsite/rst/modules/*.rst
 docs/docsite/rst/collections/*.rst
+!docs/docsite/rst/collections/all_plugins.rst
 docs/docsite/rst/collections/*/*.rst
 docs/docsite/rst/playbooks_directives.rst
 docs/docsite/rst/plugins_by_category.rst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,6 @@ include SYMLINK_CACHE.json
 include requirements.txt
 include shippable.yml
 recursive-include docs *
-include docs/docsite/rst/collections/all_plugins.rst
 exclude docs/docsite/rst_warnings
 recursive-exclude docs/docsite/_build *
 recursive-exclude docs/docsite/_extensions *.pyc *.pyo

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include SYMLINK_CACHE.json
 include requirements.txt
 include shippable.yml
 recursive-include docs *
+include docs/docsite/rst/collections/all_plugins.rst
 exclude docs/docsite/rst_warnings
 recursive-exclude docs/docsite/_build *
 recursive-exclude docs/docsite/_extensions *.pyc *.pyo

--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -94,7 +94,11 @@ clean:
 	rm -f rst/reference_appendices/playbooks_keywords.rst
 	rm -f rst/dev_guide/collections_galaxy_meta.rst
 	rm -f rst/cli/*.rst
-	rm -rf rst/collections/*
+	for filename in `ls rst/collections/` ; do \
+		if test x"$$filename" != x'all_plugins.rst' ; then \
+			rm -rf "rst/collections/$$filename"; \
+		fi \
+	done
 	@echo "Cleaning up legacy generated rst locations"
 	rm -rf rst/modules
 	rm -f rst/plugins/*/*.rst

--- a/docs/docsite/rst/all_plugins.rst
+++ b/docs/docsite/rst/all_plugins.rst
@@ -8,4 +8,4 @@ Indexes of all modules and plugins
    :caption: Plugin indexes
    :glob:
 
-   index_*
+   collections/index_*

--- a/docs/docsite/rst/collections/all_plugins.rst
+++ b/docs/docsite/rst/collections/all_plugins.rst
@@ -6,17 +6,6 @@ Indexes of all modules and plugins
 .. toctree::
    :maxdepth: 1
    :caption: Plugin indexes
+   :glob:
 
-   index_module
-   index_become
-   index_cache
-   index_callback
-   index_cliconf
-   index_connection
-   index_httpapi
-   index_inventory
-   index_lookup
-   index_netconf
-   index_shell
-   index_strategy
-   index_vars
+   index_*

--- a/docs/docsite/rst/collections/all_plugins.rst
+++ b/docs/docsite/rst/collections/all_plugins.rst
@@ -8,4 +8,4 @@ Indexes of all modules and plugins
    :caption: Plugin indexes
    :glob:
 
-   collections/index_*
+   index_*

--- a/docs/docsite/rst/collections/all_plugins.rst
+++ b/docs/docsite/rst/collections/all_plugins.rst
@@ -1,0 +1,22 @@
+.. _all_modules_and_plugins:
+
+Indexes of all modules and plugins
+----------------------------------
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Plugin indexes
+
+   index_module
+   index_become
+   index_cache
+   index_callback
+   index_cliconf
+   index_connection
+   index_httpapi
+   index_inventory
+   index_lookup
+   index_netconf
+   index_shell
+   index_strategy
+   index_vars

--- a/docs/docsite/rst/index.rst
+++ b/docs/docsite/rst/index.rst
@@ -75,6 +75,7 @@ Ansible releases a new major release of Ansible approximately three to four time
    :caption: Reference & Appendices
 
    collections/index
+   collections/all_plugins
    reference_appendices/playbooks_keywords
    reference_appendices/common_return_values
    reference_appendices/config

--- a/docs/docsite/rst/index.rst
+++ b/docs/docsite/rst/index.rst
@@ -75,7 +75,7 @@ Ansible releases a new major release of Ansible approximately three to four time
    :caption: Reference & Appendices
 
    collections/index
-   collections/all_plugins
+   all_plugins
    reference_appendices/playbooks_keywords
    reference_appendices/common_return_values
    reference_appendices/config

--- a/docs/docsite/rst/index.rst
+++ b/docs/docsite/rst/index.rst
@@ -75,7 +75,7 @@ Ansible releases a new major release of Ansible approximately three to four time
    :caption: Reference & Appendices
 
    collections/index
-   all_plugins
+   collections/all_plugins
    reference_appendices/playbooks_keywords
    reference_appendices/common_return_values
    reference_appendices/config


### PR DESCRIPTION
##### SUMMARY
The indexes are already there (https://docs.ansible.com/ansible/latest/collections/index_module.html, https://docs.ansible.com/ansible/latest/collections/index_lookup.html, ...), but right now impossible to find since nobody links to them.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docsite
