### PR TITLE
document that handler can not run include_role and import_role

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_handlers.rst
+++ b/docs/docsite/rst/user_guide/playbooks_handlers.rst
@@ -140,6 +140,7 @@ a shared source like Galaxy).
    * Use unique handler names. If you trigger more than one handler with the same name, the first one(s) get overwritten. Only the last one defined will run.
    * You can notify a handler defined inside a static include.
    * You cannot notify a handler defined inside a dynamic include.
+   * A handler can not run import_role or include_role.
 
 When using handlers within roles, note that:
 

--- a/lib/ansible/modules/import_role.py
+++ b/lib/ansible/modules/import_role.py
@@ -17,6 +17,7 @@ description:
     between other tasks of the play.
   - Most keywords, loops and conditionals will only be applied to the imported tasks, not to this statement itself. If
     you want the opposite behavior, use M(ansible.builtin.include_role) instead.
+  - Does not work in handlers.
 version_added: '2.4'
 options:
   name:

--- a/lib/ansible/modules/include_role.py
+++ b/lib/ansible/modules/include_role.py
@@ -20,6 +20,7 @@ description:
   - To apply keywords to the tasks within the role, pass them using the C(apply) option or use M(ansible.builtin.import_role) instead.
   - Ignores some keywords, like C(until) and C(retries).
   - This module is also supported for Windows targets.
+  - Does not work in handlers.
 version_added: "2.2"
 options:
   apply:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Document that handler can not run `include_role` and `import_role`.

Warn the users until issue #20493 is fixed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
import_role
include_role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Better warn the user about a thing which may be fixed than let him fail.