### PR TITLE
ansible-test - add cryptography constraint for cffi

### DIFF
--- a/changelogs/fragments/cffi-constraint.yml
+++ b/changelogs/fragments/cffi-constraint.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >
+    ansible-test - add constraint for ``cffi`` to prevent failure on systems with
+    older versions of ``gcc`` (https://foss.heptapod.net/pypy/cffi/-/issues/480)

--- a/test/lib/ansible_test/_data/cryptography-constraints.txt
+++ b/test/lib/ansible_test/_data/cryptography-constraints.txt
@@ -1,1 +1,2 @@
 idna < 2.8 ; python_version < '2.7' # idna 2.8+ requires python 2.7+
+cffi != 1.14.4 # Fails on systems with older gcc. Should be fixed in the next release. https://foss.heptapod.net/pypy/cffi/-/issues/480


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The recently released version of `cffi` fails to install on systems with an older version of `gcc`. In our case, this in the CentOS 6 test image. There is a fix but it has not yet been released. Skipping the failing version fixes tests. If the next release does not in fact fix the issue, we will have adjust this constraint.

https://foss.heptapod.net/pypy/cffi/-/issues/480<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/lib/ansible_test/_data/cryptography-constraints.txt`