### PR TITLE
[2.10][backport] Fix pip integration tests for pip 20.3

### DIFF
--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -100,7 +100,7 @@
 - name: create a requirement file with an vcs url
   copy:
     dest: "{{ output_dir }}/pipreq.txt"
-    content: "-e git+https://github.com/dvarrazzo/pyiso8601#egg=pyiso8601"
+    content: "-e git+https://github.com/dvarrazzo/pyiso8601#egg=iso8601"
 
 - name: install the requirement file in a virtualenv
   pip:
@@ -126,7 +126,7 @@
 
 - name: install the same module from url
   pip:
-    name: "git+https://github.com/dvarrazzo/pyiso8601#egg=pyiso8601"
+    name: "git+https://github.com/dvarrazzo/pyiso8601#egg=iso8601"
     virtualenv: "{{ output_dir }}/pipenv"
     editable: True
   register: url_installed
@@ -464,7 +464,7 @@
 - name: test module can parse the combination of multi-packages one line and git url
   pip:
     name:
-      - git+https://github.com/dvarrazzo/pyiso8601#egg=pyiso8601
+      - git+https://github.com/dvarrazzo/pyiso8601#egg=iso8601
       - "{{pip_test_pkg_ver[0]}},{{pip_test_pkg_ver[1]}}"
 
 - name: test the invalid package name


### PR DESCRIPTION
(cherry picked from commit 2eb97955437d33bd6b5f835a3233d88419518459)

##### SUMMARY
Newest pip release 20.3 seems to be more strict about egg name matching metadata.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
tests

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Was getting this error in tests:

```
"msg": "stdout: Obtaining pyiso8601 from git+https://github.com/dvarrazzo/pyiso8601#egg=pyiso8601 (from -r /root/ansible/test/results/.tmp/output_dir/pipreq.txt (line 1))
Cloning https://github.com/dvarrazzo/pyiso8601 to /root/ansible/test/results/.tmp/output_dir/pipenv/src/pyiso8601

:stderr:   WARNING: Generating metadata for package pyiso8601 produced metadata for project name iso8601. Fix your #egg=pyiso8601 fragments.
ERROR: Requested iso8601 from git+https://github.com/dvarrazzo/pyiso8601#egg=pyiso8601 (from -r /root/ansible/test/results/.tmp/output_dir/pipreq.txt (line 1)) has different name in metadata: 'iso8601'"
```