### PR TITLE
[2.9][backport] amazon.aws/211 - use fail_json_aws instead of fail_json

### DIFF
--- a/changelogs/fragments/211-fix-error-handling-during-tagging-failure.yaml
+++ b/changelogs/fragments/211-fix-error-handling-during-tagging-failure.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ec2_group - Fixes error handling during tagging failures (https://github.com/ansible-collections/amazon.aws/issues/210).

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -793,7 +793,7 @@ def update_tags(client, module, group_id, current_tags, tags, purge_tags):
             try:
                 client.create_tags(Resources=[group_id], Tags=ansible_dict_to_boto3_tag_list(tags_need_modify))
             except (BotoCoreError, ClientError) as e:
-                module.fail_json(e, msg="Unable to add tags {0}".format(tags_need_modify))
+                module.fail_json_aws(e, msg="Unable to add tags {0}".format(tags_need_modify))
 
     return bool(tags_need_modify or tags_to_delete)
 


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible-collections/amazon.aws/pull/211

A partial migration to fail_json_aws happened, resulting a TypeError while handling failures during tagging.

```
 TypeError: fail_json() takes exactly 1 argument (3 given)
```

This PR backports the fix from amazon.aws.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_group

##### ADDITIONAL INFORMATION

https://github.com/ansible-collections/amazon.aws/issues/210
