### PR TITLE
ansible-test: support both venv and virtualenv in virtualenv.sh

### DIFF
--- a/test/lib/ansible_test/_data/injector/virtualenv.sh
+++ b/test/lib/ansible_test/_data/injector/virtualenv.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
 # Create and activate a fresh virtual environment with `source virtualenv.sh`.
 
+# Privilege venv if it is available but fallback to virtualenv
+# https://github.com/ansible/ansible/issues/72738
+"${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m venv &> /dev/null
+if [ $? -eq 2 ]; then
+    module="venv"
+else
+    module="virtualenv"
+fi
+
 rm -rf "${OUTPUT_DIR}/venv"
-"${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m virtualenv --system-site-packages --python "${ANSIBLE_TEST_PYTHON_INTERPRETER}" "${OUTPUT_DIR}/venv"
+"${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m $module --system-site-packages --python "${ANSIBLE_TEST_PYTHON_INTERPRETER}" "${OUTPUT_DIR}/venv"
 set +ux
 source "${OUTPUT_DIR}/venv/bin/activate"
 set -ux


### PR DESCRIPTION
Fixes: https://github.com/ansible/ansible/issues/72738

##### SUMMARY
The ``virtualenv`` python module is not necessarily installed if ``venv`` is. We should support both.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test