### PR TITLE
[2.9] [zypper_repository test] Use repo that doesn't 404

### DIFF
--- a/test/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/test/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -121,7 +121,7 @@
 - name: "Test adding a repo with custom GPG key"
   zypper_repository:
     name: "Apache_Modules"
-    repo: "http://download.opensuse.org/repositories/Apache:/Modules/openSUSE_Tumbleweed/"
+    repo: "http://download.opensuse.org/repositories/Apache:/Modules/openSUSE_Leap_{{ ansible_distribution_version }}/"
     priority: 100
     auto_import_keys: true
     state: "present"


### PR DESCRIPTION

##### SUMMARY

Change:
- The repo we were testing with no longer seems to exist. Point to one
  that does.

Test Plan:
- local test in docker
- CI

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Test Pull Request

##### COMPONENT NAME

zypper_repository