### PR TITLE
Fix BaseFileCacheModule#keys to respect prefix

### DIFF
--- a/changelogs/fragments/ansible-test-cache-plugin.yml
+++ b/changelogs/fragments/ansible-test-cache-plugin.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fix ``keys()`` implementation of ``BaseFileCacheModule`` to strip the prefix
+    from the key and only return keys that share the same prefix as the cache.

--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -207,10 +207,20 @@ class BaseFileCacheModule(BaseCacheModule):
         return True
 
     def keys(self):
+        # When using a prefix we must remove it from the key name before
+        # checking the expiry and returning it to the caller. Keys that do not
+        # share the same prefix cannot be fetched from the cache.
+        prefix = self.get_option('_prefix')
+        prefix_length = len(prefix)
         keys = []
         for k in os.listdir(self._cache_dir):
-            if not (k.startswith('.') or self.has_expired(k)):
+            if k.startswith('.') or not k.startswith(prefix):
+                continue
+
+            k = k[prefix_length:]
+            if not self.has_expired(k):
                 keys.append(k)
+
         return keys
 
     def contains(self, key):


### PR DESCRIPTION
##### SUMMARY
Previously BaseFileCacheModule#keys would return keys with the cache prefix. These keys are impossible to retrieve from the cache without removing the prefix or using the cache without a prefix. Now it removes the prefix from the key and only returns keys that share the same prefix as the cache.

##### ISSUE TYPE
- Bugfix Pull Request
- Test Pull Request

##### COMPONENT NAME
cache

##### ADDITIONAL INFORMATION
New tests without the fix for all BaseFileCacheModule based caches.

```
$ ansible-test units --docker -v --python 3.9 test/units/plugins/cache/test_cache.py
=================================== FAILURES ===================================
______________________ TestJsonFileCachePrefix.test_flush ______________________
[gw1] linux -- Python 3.9.0 /tmp/python-yclxd6af-ansible/python
self = <units.plugins.cache.test_cache.TestJsonFileCachePrefix testMethod=test_flush>

    def test_flush(self):
        # Fake that the cache already has some data in it but the adjudicator
        # hasn't loaded it in.
        self.cache._plugin.set('monkey', 'animal')
        self.cache._plugin.set('wolf', 'animal')
        self.cache._plugin.set('another wolf', 'another animal')
    
        # The adjudicator does't know about the new entries
        assert len(self.cache.keys()) == 2
        # But the cache itself does
        assert len(self.cache._plugin.keys()) == 3
    
        # If we call flush, both the adjudicator and the cache should flush
        self.cache.flush()
        assert len(self.cache.keys()) == 0
>       assert len(self.cache._plugin.keys()) == 0
E       AssertionError: assert 3 == 0
E         +3
E         -0

test/units/plugins/cache/test_cache.py:108: AssertionError
```
