### PR TITLE
backport support for python-kubernetes v12 to ansible 2.9

### DIFF
--- a/changelogs/fragments/k8s-support-kubernetes-v12.yml
+++ b/changelogs/fragments/k8s-support-kubernetes-v12.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - k8s - add support for python-kubernetes v12 and later - backport of
+    support in community.kubernetes

--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -188,7 +188,12 @@ class K8sAnsibleMixin(object):
                 kubernetes.config.load_kube_config(auth.get('kubeconfig'), auth.get('context'))
 
         # Override any values in the default configuration with Ansible parameters
-        configuration = kubernetes.client.Configuration()
+        # As of kubernetes-client v12.0.0, get_default_copy() is required here
+        try:
+            configuration = kubernetes.client.Configuration().get_default_copy()
+        except AttributeError:
+            configuration = kubernetes.client.Configuration()
+
         for key, value in iteritems(auth):
             if key in AUTH_ARG_MAP.keys() and value is not None:
                 if key == 'api_key':

--- a/test/integration/targets/k8s/tasks/basic_validation.yml
+++ b/test/integration/targets/k8s/tasks/basic_validation.yml
@@ -1,0 +1,8 @@
+---
+
+# just test that authentication works
+- name: Ensure testing1 namespace exists
+  k8s:
+    api_version: v1
+    kind: Namespace
+    name: testing1

--- a/test/integration/targets/k8s/tasks/main.yml
+++ b/test/integration/targets/k8s/tasks/main.yml
@@ -70,6 +70,40 @@
     state: absent
   no_log: yes
 
+# Test works with kubernetes==11.* and kubernetes>11
+
+- pip:
+    name:
+      - openshift
+      - kubernetes==11.*
+      - coverage
+    virtualenv: "{{ virtualenv }}"
+    virtualenv_command: "{{ virtualenv_command }}"
+    virtualenv_site_packages: no
+
+- include_tasks: basic_validation.yml
+
+- file:
+    path: "{{ virtualenv }}"
+    state: absent
+  no_log: yes
+
+- pip:
+    name:
+      - openshift
+      - kubernetes>11
+      - coverage
+    virtualenv: "{{ virtualenv }}"
+    virtualenv_command: "{{ virtualenv_command }}"
+    virtualenv_site_packages: no
+
+- include_tasks: basic_validation.yml
+
+- file:
+    path: "{{ virtualenv }}"
+    state: absent
+  no_log: yes
+
 # Run full test suite
 
 - pip:


### PR DESCRIPTION
Support for using python-kubernetes v12 has been added to the
new upstream repo:
https://github.com/ansible-collections/community.kubernetes/blob/main/plugins/module_utils/common.py#L256-L261
This PR backports that support to ansible 2.9

##### SUMMARY
When using python-kubernetes v12, the k8s module does not read the configuration from `~/.kube/config` correctly - attempts to use the module will give some odd error because it will default to localhost.
```
ansible -m k8s -u root -a 'name=my-namespace api_version=v1 kind=Namespace state=present validate_certs=no' localhost 
localhost | FAILED! => {
    "changed": false,
    "msg": "Failed to get client due to HTTPConnectionPool(host='localhost', port=80): Max retries exceeded with url: /version (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f1a3a04d1f0>: Failed to establish a new connection: [Errno 111] Connection refused'))"
}
```
When using python-kubernetes v11, it works as expected - it correctly looks up the current context and configuration and uses it.

This has already been fixed upstream in https://github.com/ansible-collections/community.kubernetes/blob/main/plugins/module_utils/common.py#L256-L261
This is a request to backport the fix to ansible 2.9.  This is needed because
many platforms that distribute ansible 2.9 also distribute python-kubernetes
version 12 (e.g. Fedora).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
k8s

##### ADDITIONAL INFORMATION