### PR TITLE
[centos6] update container for EOL

### DIFF
--- a/changelogs/fragments/ansible-test-centos6-eol.yml
+++ b/changelogs/fragments/ansible-test-centos6-eol.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - centos6 end of life - container image updated to point to vault base repository (https://github.com/ansible/distro-test-containers/pull/54)

--- a/test/integration/targets/yum_repository/vars/CentOS.yml
+++ b/test/integration/targets/yum_repository/vars/CentOS.yml
@@ -2,7 +2,7 @@ yum_repository_test_package: sl
 yum_repository_test_repo:
   name: epel
   description: EPEL yum repo
-  baseurl: http://download.fedoraproject.org/pub/epel/{{ ansible_facts.distribution_major_version }}/$basearch
+  baseurl: https://archives.fedoraproject.org/pub/archive/epel/{{ ansible_facts.distribution_major_version }}/$basearch
 
 yum_repository_epel:
   description: Extra Packages for Enterprise Linux {{ ansible_facts.distribution_major_version }} - $basearch

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,5 +1,5 @@
 default name=quay.io/ansible/default-test-container:1.10.1 python=3.6,2.6,2.7,3.5,3.7,3.8 seccomp=unconfined
-centos6 name=quay.io/ansible/centos6-test-container:1.25.0 python=2.6 seccomp=unconfined
+centos6 name=quay.io/ansible/centos6-test-container:1.26.0 python=2.6 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.8.0 python=2.7 seccomp=unconfined
 centos8 name=quay.io/ansible/centos8-test-container:1.10.0 python=3.6 seccomp=unconfined
 fedora30 name=quay.io/ansible/fedora30-test-container:1.9.2 python=3.7

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,5 +1,5 @@
 default name=quay.io/ansible/default-test-container:1.10.1 python=3.6,2.6,2.7,3.5,3.7,3.8 seccomp=unconfined
-centos6 name=quay.io/ansible/centos6-test-container:1.8.0 python=2.6 seccomp=unconfined
+centos6 name=quay.io/ansible/centos6-test-container:1.25.0 python=2.6 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.8.0 python=2.7 seccomp=unconfined
 centos8 name=quay.io/ansible/centos8-test-container:1.10.0 python=3.6 seccomp=unconfined
 fedora30 name=quay.io/ansible/fedora30-test-container:1.9.2 python=3.7


### PR DESCRIPTION

##### SUMMARY
Change:
- Reference:
  https://lists.centos.org/pipermail/centos-devel/2020-December/056208.html
- Bump centos6 container to 1.25.0

Test Plan:
- ci_complete

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Test Pull Request

##### COMPONENT NAME

ansible-test, centos6