### PR TITLE
more explicit documentation about role variables

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
@@ -256,7 +256,7 @@ You can pass other keywords, including variables and tags, when importing roles:
             app_port: 5000
       ...
 
-Variables of the role (from section `vars:` and from `roles/x/vars/main.yml`) are available to all tasks and all roles of the play.
+Variables of the role (from `vars:` in task and from `roles/x/vars/main.yml`) are available to all tasks and all roles of the play.
 
 When you add a tag to an ``import_role`` statement, Ansible applies the tag to `all` tasks within the role. See :ref:`tag_inheritance` for details.
 

--- a/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
@@ -122,7 +122,7 @@ When you use the ``roles`` option at the play level, for each role 'x':
 
 - If roles/x/tasks/main.yml exists, Ansible adds the tasks in that file to the play.
 - If roles/x/handlers/main.yml exists, Ansible adds the handlers in that file to the play.
-- If roles/x/vars/main.yml exists, Ansible adds the variables in that file to the play.
+- If roles/x/vars/main.yml exists, Ansible adds the variables in that file to the play (available to all tasks and all roles).
 - If roles/x/defaults/main.yml exists, Ansible adds the variables in that file to the play.
 - If roles/x/meta/main.yml exists, Ansible adds any role dependencies in that file to the list of roles.
 - Any copy, script, template or include tasks (in the role) can reference files in roles/x/{files,templates,tasks}/ (dir depends on task) without having to path them relatively or absolutely.
@@ -161,7 +161,7 @@ You can pass other keywords to the ``roles`` option:
 
 When you add a tag to the ``role`` option, Ansible applies the tag to ALL tasks within the role.
 
-When using ``vars:`` within the ``roles:`` section of a playbook, the variables are added to the play variables, making them available to all tasks within the play before and after the role. This behavior can be changed by :ref:`DEFAULT_PRIVATE_ROLE_VARS`.
+When using ``vars:`` within the ``roles:`` section of a playbook, the variables are added to the play variables, making them available to all tasks within the play before and after the role. (This is the same as for variables from roles/x/vars/main.yml) This behavior can be changed by :ref:`DEFAULT_PRIVATE_ROLE_VARS`.
 
 Including roles: dynamic reuse
 ------------------------------
@@ -217,6 +217,8 @@ You can conditionally include a role:
             name: some_role
           when: "ansible_facts['os_family'] == 'RedHat'"
 
+Variables of the role are only available to the role (except if option `public: true` is set, see :ref:`ansible.builtin.include_role_module`).
+
 Importing roles: static reuse
 -----------------------------
 
@@ -253,6 +255,8 @@ You can pass other keywords, including variables and tags, when importing roles:
             dir: '/opt/a'
             app_port: 5000
       ...
+
+Variables of the role (from section `vars:` and from `roles/x/vars/main.yml`) are available to all tasks and all roles of the play.
 
 When you add a tag to an ``import_role`` statement, Ansible applies the tag to `all` tasks within the role. See :ref:`tag_inheritance` for details.
 

--- a/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
@@ -462,15 +462,12 @@ Role dependencies are stored in the ``meta/main.yml`` file within the role direc
     ---
     dependencies:
       - role: common
-        vars:
-          some_parameter: 3
+        some_parameter_var: 3
       - role: apache
-        vars:
-          apache_port: 80
+        apache_port: 80
       - role: postgres
-        vars:
-          dbname: blarg
-          other_parameter: 12
+        dbname: blarg
+        other_parameter_var: 12
 
 Ansible always executes roles listed in ``dependencies`` before the role that lists them. Ansible executes this pattern recursively when you use the ``roles`` keyword. For example, if you list role ``foo`` under ``roles:``, role ``foo`` lists role ``bar`` under ``dependencies`` in its meta/main.yml file, and role ``bar`` lists role ``baz`` under ``dependencies`` in its meta/main.yml, Ansible executes ``baz``, then ``bar``, then ``foo``.
 

--- a/lib/ansible/modules/import_role.py
+++ b/lib/ansible/modules/import_role.py
@@ -59,7 +59,7 @@ options:
     version_added: '2.11'
 notes:
   - Handlers are made available to the whole play.
-  - Since Ansible 2.7 variables defined in C(vars) (from `vars:` in task and roles/x/vars/main.yml) and C(defaults) for the role are exposed at playbook parsing time.
+  - Since Ansible 2.7 variables defined in C(vars) (from `vars:` in task and from `roles/x/vars/main.yml`) and C(defaults) for the role are exposed at playbook parsing time.
     Due to this, these variables will be accessible to roles and tasks executed before the location of the
     M(ansible.builtin.import_role) task.
   - Unlike M(ansible.builtin.include_role) variable exposure is not configurable, and will always be exposed.

--- a/lib/ansible/modules/import_role.py
+++ b/lib/ansible/modules/import_role.py
@@ -59,7 +59,7 @@ options:
     version_added: '2.11'
 notes:
   - Handlers are made available to the whole play.
-  - Since Ansible 2.7 variables defined in C(vars) and C(defaults) for the role are exposed to the play at playbook parsing time.
+  - Since Ansible 2.7 variables defined in C(vars) (from `vars:` in task and roles/x/vars/main.yml) and C(defaults) for the role are exposed at playbook parsing time.
     Due to this, these variables will be accessible to roles and tasks executed before the location of the
     M(ansible.builtin.import_role) task.
   - Unlike M(ansible.builtin.include_role) variable exposure is not configurable, and will always be exposed.

--- a/lib/ansible/modules/include_role.py
+++ b/lib/ansible/modules/include_role.py
@@ -54,7 +54,7 @@ options:
     default: yes
   public:
     description:
-      - This option dictates whether the role's C(vars) and C(defaults) are exposed to the play. If set to C(yes)
+      - This option dictates whether the role's C(vars) (from `vars:` of the task and roles/x/vars/main.yml) and C(defaults) are exposed to the playbook. If set to C(yes)
         the variables will be available to tasks following the C(include_role) task. This functionality differs from
         standard variable exposure for roles listed under the C(roles) header or C(import_role) as they are exposed
         to the play at playbook parsing time, and available to earlier roles and tasks as well.

--- a/lib/ansible/modules/include_role.py
+++ b/lib/ansible/modules/include_role.py
@@ -54,7 +54,7 @@ options:
     default: yes
   public:
     description:
-      - This option dictates whether the role's C(vars) (from `vars:` of the task and roles/x/vars/main.yml) and C(defaults) are exposed to the playbook. If set to C(yes)
+      - This option dictates whether the role's C(vars) (from `vars:` of the task and from `roles/x/vars/main.yml`) and C(defaults) are exposed to the playbook. If set to C(yes)
         the variables will be available to tasks following the C(include_role) task. This functionality differs from
         standard variable exposure for roles listed under the C(roles) header or C(import_role) as they are exposed
         to the play at playbook parsing time, and available to earlier roles and tasks as well.


### PR DESCRIPTION
##### SUMMARY
Documentation is more explicit
about variables of roles being accessible in all tasks of the play,
about from which places the variables are affected (`var:` of task and roles/x/vars/main.yml) and
in which cases this happens (`roles:` of play and module `import_role`).
And avoid the term `role parameter` when variables are used (because role parameters behave different than role variables).

improves #55942 and #50278

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
import_role
include_role
