### PR TITLE
json_query: Add examples for starts_with and contains

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -234,7 +234,7 @@ If you are reading in some already formatted data::
 for example::
 
   tasks:
-    - name: Register JSON output as a variable 
+    - name: Register JSON output as a variable
       ansible.builtin.shell: cat /some/path/to/file.json
       register: result
 
@@ -749,8 +749,8 @@ To extract all server names::
 
 To extract ports from cluster1::
 
-    - ansible.builtin.name: Display all ports from cluster1
-      debug:
+    - name: Display all ports from cluster1
+      ansible.builtin.debug:
         var: item
       loop: "{{ domain_definition | community.general.json_query(server_name_cluster1_query) }}"
       vars:
@@ -783,6 +783,24 @@ To get a hash map with all ports and names of a cluster::
       loop: "{{ domain_definition | community.general.json_query(server_name_cluster1_query) }}"
       vars:
         server_name_cluster1_query: "domain.server[?cluster=='cluster2'].{name: name, port: port}"
+
+To extract ports from all clusters with name starting with 'server1'::
+
+    - name: Display all ports from cluster1
+      ansible.builtin.debug:
+        msg: "{{ domain_definition | to_json | from_json | community.general.json_query(server_name_query) }}"
+      vars:
+        server_name_query: "domain.server[?starts_with(name,'server1')].port"
+
+To extract ports from all clusters with name containing 'server1'::
+
+    - name: Display all ports from cluster1
+      ansible.builtin.debug:
+        msg: "{{ domain_definition | to_json | from_json | community.general.json_query(server_name_query) }}"
+      vars:
+        server_name_query: "domain.server[?contains(name,'server1')].port"
+
+.. note:: while using ``starts_with`` and ``contains``, you have to use `` to_json | from_json `` filter for correct parsing of data structure.
 
 
 Randomizing data


### PR DESCRIPTION
##### SUMMARY

* Add a note about - data structure returned from register variables
needs to be parsed using ``to_json | from_json`` in order to
get correct result.
* Add examples for starts_with and contains

Fixes: https://github.com/ansible-collections/community.general/issues/320

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/user_guide/playbooks_filters.rst
