### PR TITLE
Replace `exit` with `sys.exit` in Galaxy CLI.

### DIFF
--- a/changelogs/fragments/galaxy-sys-exit.yml
+++ b/changelogs/fragments/galaxy-sys-exit.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - Use ``sys.exit`` instead of ``exit`` when reporting an error for the removed login command.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -8,6 +8,7 @@ __metaclass__ = type
 import os.path
 import re
 import shutil
+import sys
 import textwrap
 import time
 import yaml
@@ -119,7 +120,7 @@ class GalaxyCLI(CLI):
                     "to Galaxy. The key can be found at https://galaxy.ansible.com/me/preferences, and passed to the "
                     "ansible-galaxy CLI via a file at {0} or (insecurely) via the `--token` "
                     "command-line argument.".format(to_text(C.GALAXY_TOKEN_PATH)))
-                exit(1)
+                sys.exit(1)
 
         self.api_servers = []
         self.galaxy = None


### PR DESCRIPTION
##### SUMMARY

Replace `exit` with `sys.exit` in Galaxy CLI.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-galaxy
