### PR TITLE
[2.10] Docsite: update complex_data_manipulation and playbooks_advanced_syntax rst files to use FQCNs

### DIFF
--- a/docs/docsite/rst/user_guide/complex_data_manipulation.rst
+++ b/docs/docsite/rst/user_guide/complex_data_manipulation.rst
@@ -47,7 +47,8 @@ There are several ways to do it in Ansible, this is just one example:
 
   tasks:
     - name: Show extracted list of keys from a list of dictionaries
-      debug: msg="{{ chains | map('extract', chains_config) | map(attribute='configs') | flatten | map(attribute='type') | flatten }}"
+      ansible.builtin.debug:
+        msg: "{{ chains | map('extract', chains_config) | map(attribute='configs') | flatten | map(attribute='type') | flatten }}"
       vars:
         chains: [1, 2]
         chains_config:
@@ -97,7 +98,8 @@ In this case, we want to find the mount point for a given path across our machin
         path: /var/lib/cache
      tasks:
      - name: The mount point for {{path}}, found using the Ansible mount facts, [-1] is the same as the 'last' filter
-       debug: msg="{{(ansible_facts.mounts | selectattr('mount', 'in', path) | list | sort(attribute='mount'))[-1]['mount']}}"
+       ansible.builtin.debug:
+        msg: "{{(ansible_facts.mounts | selectattr('mount', 'in', path) | list | sort(attribute='mount'))[-1]['mount']}}"
 
 
 
@@ -110,8 +112,8 @@ The special ``omit`` variable ONLY works with module options, but we can still u
  :caption: Inline list filtering when feeding a module option
  :emphasize-lines: 3, 7
 
-    - name: enable a list of Windows features, by name
-      set_fact:
+    - name: Enable a list of Windows features, by name
+      ansible.builtin.set_fact:
         win_feature_list: "{{ namestuff | reject('equalto', omit) | list }}"
       vars:
         namestuff:
@@ -126,8 +128,8 @@ Another way is to avoid adding elements to the list in the first place, so you c
  :caption: Using set_fact in a loop to increment a list conditionally
  :emphasize-lines: 3, 4, 6
 
-    - name: build unique list with some items conditionally omittted
-      set_fact:
+    - name: Build unique list with some items conditionally omitted
+      ansible.builtin.set_fact:
          namestuff: ' {{ (namestuff | default([])) | union([item]) }}'
       when: item != omit
       loop:
@@ -181,7 +183,7 @@ A bit more complex, using ``set_fact`` and a ``loop`` to create/update a diction
  :emphasize-lines: 3, 4
 
      - name: Uses 'combine' to update the dictionary and 'zip' to make pairs of both lists
-       set_fact:
+       ansible.builtin.set_fact:
          mydict: "{{ mydict | default({}) | combine({item[0]: item[1]}) }}"
        loop: "{{ (keys | zip(values)) | list }}"
        vars:
@@ -229,7 +231,8 @@ https://www.reddit.com/r/ansible/comments/gj5a93/trying_to_get_uptime_from_secon
 
 .. code-block:: YAML+Jinja
 
- - debug:
+ - name: Show the uptime in a certain format
+   ansible.builtin.debug:
     msg: Timedelta {{ now() - now().fromtimestamp(now(fmt='%s') | int - ansible_uptime_seconds) }}
 
 

--- a/docs/docsite/rst/user_guide/playbooks_advanced_syntax.rst
+++ b/docs/docsite/rst/user_guide/playbooks_advanced_syntax.rst
@@ -95,7 +95,7 @@ Now, you can re-use the value of ``app_version`` within the value of  ``custom_n
                 - *my_version
       tasks:
       - name: Using Anchor value
-        debug:
+        ansible.builtin.debug:
             msg: My app is called "{{ webapp.custom_name | join('-') }}".
 
 You've anchored the value of ``version`` with the ``&my_version`` anchor, and re-used it with the ``*my_version`` alias. Anchors and aliases let you access nested values inside dictionaries.


### PR DESCRIPTION
##### SUMMARY
Docsite: update complex_data_manipulation and playbooks_advanced_syntax rst files to use FQCNs

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`docs/docsite/rst/user_guide/complex_data_manipulation.rst`
`docs/docsite/rst/user_guide/playbooks_advanced_syntax.rst`