### PR TITLE
Add Python 3.10 to ansible-test

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -21,6 +21,7 @@ matrix:
     - env: T=units/3.7
     - env: T=units/3.8
     - env: T=units/3.9
+    - env: T=units/3.10
 
     - env: T=windows/2012/1
     - env: T=windows/2012-R2/1

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,5 +1,5 @@
-default name=quay.io/ansible/default-test-container:2.9.0 python=3.6,2.6,2.7,3.5,3.7,3.8,3.9 seccomp=unconfined context=collection
-default name=quay.io/ansible/ansible-base-test-container:1.7.0 python=3.6,2.6,2.7,3.5,3.7,3.8,3.9 seccomp=unconfined context=ansible-core
+default name=quay.io/ansible/default-test-container:2.9.1 python=3.6,2.6,2.7,3.5,3.7,3.8,3.9,3.10 seccomp=unconfined context=collection
+default name=quay.io/ansible/ansible-base-test-container:1.7.1 python=3.6,2.6,2.7,3.5,3.7,3.8,3.9,3.10 seccomp=unconfined context=ansible-core
 alpine3 name=quay.io/ansible/alpine3-test-container:1.19.0 python=3.8
 centos6 name=quay.io/ansible/centos6-test-container:1.26.0 python=2.6 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.17.0 python=2.7 seccomp=unconfined

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -116,6 +116,7 @@ SUPPORTED_PYTHON_VERSIONS = (
     '3.7',
     '3.8',
     '3.9',
+    '3.10',
 )
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add Python 3.10 to ansible-test.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-test
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
With this PR ansible builds in our Python 3.10 testing COPR.
https://copr.fedorainfracloud.org/coprs/g/python/python3.10/build/1810564/
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
