### PR TITLE
Added option to display dynamic includes

### DIFF
--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -36,6 +36,7 @@ from ansible.utils.color import colorize, hostcolor
 # TODO: Change the default of check_mode_markers to True in a future release (2.13)
 COMPAT_OPTIONS = (('display_skipped_hosts', C.DISPLAY_SKIPPED_HOSTS),
                   ('display_ok_hosts', True),
+                  ('display_includes', True),
                   ('show_custom_stats', C.SHOW_CUSTOM_STATS),
                   ('display_failed_stderr', False),
                   ('check_mode_markers', False),
@@ -335,11 +336,12 @@ class CallbackModule(CallbackBase):
             self._display.display(msg, color=C.COLOR_SKIP)
 
     def v2_playbook_on_include(self, included_file):
-        msg = 'included: %s for %s' % (included_file._filename, ", ".join([h.name for h in included_file._hosts]))
-        label = self._get_item_label(included_file._vars)
-        if label:
-            msg += " => (item=%s)" % label
-        self._display.display(msg, color=C.COLOR_SKIP)
+        if self.display_includes:
+            msg = 'included: %s for %s' % (included_file._filename, ", ".join([h.name for h in included_file._hosts]))
+            label = self._get_item_label(included_file._vars)
+            if label:
+                msg += " => (item=%s)" % label
+            self._display.display(msg, color=C.COLOR_SKIP)
 
     def v2_playbook_on_stats(self, stats):
         self._display.banner("PLAY RECAP")

--- a/lib/ansible/plugins/doc_fragments/default_callback.py
+++ b/lib/ansible/plugins/doc_fragments/default_callback.py
@@ -36,6 +36,16 @@ class ModuleDocFragment(object):
           - key: display_ok_hosts
             section: defaults
         version_added: '2.7'
+      display_includes:
+        name: Show dynamicly included tasks
+        description: "Toggle to control displaying dynamicly included task/host results in a task"
+        type: bool
+        default: yes
+        env:
+          - name: ANSIBLE_DISPLAY_INCLUDES
+        ini:
+          - key: display_includes
+            section: defaults
       display_failed_stderr:
         name: Use STDERR for failed and unreachable tasks
         description: "Toggle to control whether failed and unreachable tasks are displayed to STDERR (vs. STDOUT)"

--- a/test/integration/targets/callback_default/runme.sh
+++ b/test/integration/targets/callback_default/runme.sh
@@ -119,6 +119,7 @@ export ANSIBLE_NOCOLOR=1
 # Default settings
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS=1
 export ANSIBLE_DISPLAY_OK_HOSTS=1
+export ANSIBLE_DISPLAY_INCLUDES=1
 export ANSIBLE_DISPLAY_FAILED_STDERR=0
 export ANSIBLE_CHECK_MODE_MARKERS=0
 
@@ -132,18 +133,21 @@ run_test hide_skipped
 # Hide skipped/ok
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS=0
 export ANSIBLE_DISPLAY_OK_HOSTS=0
+export ANSIBLE_DISPLAY_INCLUDES=0
 
 run_test hide_skipped_ok
 
 # Hide ok
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS=1
 export ANSIBLE_DISPLAY_OK_HOSTS=0
+export ANSIBLE_DISPLAY_INCLUDES=0
 
 run_test hide_ok
 
 # Failed to stderr
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS=1
 export ANSIBLE_DISPLAY_OK_HOSTS=1
+export ANSIBLE_DISPLAY_INCLUDES=1
 export ANSIBLE_DISPLAY_FAILED_STDERR=1
 
 run_test failed_to_stderr
@@ -151,6 +155,7 @@ run_test failed_to_stderr
 # Default settings with unreachable tasks
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS=1
 export ANSIBLE_DISPLAY_OK_HOSTS=1
+export ANSIBLE_DISPLAY_INCLUDES=1
 export ANSIBLE_DISPLAY_FAILED_STDERR=1
 export ANSIBLE_TIMEOUT=1
 
@@ -168,6 +173,7 @@ fi
 # Default settings with dry run tasks
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS=1
 export ANSIBLE_DISPLAY_OK_HOSTS=1
+export ANSIBLE_DISPLAY_INCLUDES=1
 export ANSIBLE_DISPLAY_FAILED_STDERR=1
 # Enable Check mode markers
 export ANSIBLE_CHECK_MODE_MARKERS=1

--- a/test/integration/targets/callback_default/runme.sh
+++ b/test/integration/targets/callback_default/runme.sh
@@ -133,14 +133,14 @@ run_test hide_skipped
 # Hide skipped/ok
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS=0
 export ANSIBLE_DISPLAY_OK_HOSTS=0
-export ANSIBLE_DISPLAY_INCLUDES=0
+export ANSIBLE_DISPLAY_INCLUDES=1
 
 run_test hide_skipped_ok
 
 # Hide ok
 export ANSIBLE_DISPLAY_SKIPPED_HOSTS=1
 export ANSIBLE_DISPLAY_OK_HOSTS=0
-export ANSIBLE_DISPLAY_INCLUDES=0
+export ANSIBLE_DISPLAY_INCLUDES=1
 
 run_test hide_ok
 


### PR DESCRIPTION
##### SUMMARY
Adds an option to display or hide dynamic includes for the default callback plugin. Referencing to #72752.

##### ISSUE TYPE
Based on issue #72752

##### COMPONENT NAME
Default callback plugin

