### PR TITLE
Compare the whole HostState in lockstep

### DIFF
--- a/changelogs/fragments/lineary-strategy-lockstep-fix.yml
+++ b/changelogs/fragments/lineary-strategy-lockstep-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix for linear strategy when tasks were executed in incorrect order or even removed from execution. (https://github.com/ansible/ansible/issues/64611, https://github.com/ansible/ansible/issues/64999, https://github.com/ansible/ansible/issues/72725, https://github.com/ansible/ansible/issues/72781)

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -106,15 +106,18 @@ class HostState:
         if self.run_state == IteratingStates.TASKS:
             if self.cur_regular_task != other.cur_regular_task:
                 return False
-            s = self.tasks_child_state; o = other.tasks_child_state
+            s = self.tasks_child_state
+            o = other.tasks_child_state
         elif self.run_state == IteratingStates.RESCUE:
             if self.cur_rescue_task != other.cur_rescue_task:
                 return False
-            s = self.rescue_child_state; o = other.rescue_child_state
+            s = self.rescue_child_state
+            o = other.rescue_child_state
         elif self.run_state == IteratingStates.ALWAYS:
             if self.cur_always_task != other.cur_always_task:
                 return False
-            s = self.always_child_state; o = other.always_child_state
+            s = self.always_child_state
+            o = other.always_child_state
 
         if (s is not None and o is not None) or (s is None and o is None):
             return s == o
@@ -141,15 +144,18 @@ class HostState:
         if self.run_state == IteratingStates.TASKS:
             if self.cur_regular_task != other.cur_regular_task:
                 return self.cur_regular_task < other.cur_regular_task
-            s = self.tasks_child_state; o = other.tasks_child_state
+            s = self.tasks_child_state
+            o = other.tasks_child_state
         elif self.run_state == IteratingStates.RESCUE:
             if self.cur_rescue_task != other.cur_rescue_task:
                 return self.cur_rescue_task < other.cur_rescue_task
-            s = self.rescue_child_state; o = other.rescue_child_state
+            s = self.rescue_child_state
+            o = other.rescue_child_state
         elif self.run_state == IteratingStates.ALWAYS:
             if self.cur_always_task != other.cur_always_task:
                 return self.cur_always_task < other.cur_always_task
-            s = self.always_child_state; o = other.always_child_state
+            s = self.always_child_state
+            o = other.always_child_state
 
         if s is not None and o is not None:
             return s < o

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -91,6 +91,9 @@ class HostState:
                 ))
 
     def __eq__(self, other):
+        """Compare two HostStates whether they are at the same point of execution.
+        Used in the linear strategy for lockstep.
+        """
         if not isinstance(other, HostState):
             raise AnsibleAssertionError(f'HostState can be compared only to another HostState, got {type(other)}')
 

--- a/test/integration/targets/blocks/72725.yml
+++ b/test/integration/targets/blocks/72725.yml
@@ -1,0 +1,24 @@
+- hosts: host1,host2
+  gather_facts: no
+  tasks:
+    - block:
+        - block:
+          - name: EXPECTED FAILURE host1 fails
+            fail:
+            when: inventory_hostname == 'host1'
+
+          - set_fact:
+               only_host2_fact: yes
+
+        - name: should not fail
+          fail:
+          when: only_host2_fact is not defined
+      always:
+        - block:
+          - meta: clear_host_errors
+
+    - assert:
+        that:
+          - only_host2_fact is defined
+      when:
+        - inventory_hostname == 'host2'

--- a/test/integration/targets/blocks/72781.yml
+++ b/test/integration/targets/blocks/72781.yml
@@ -1,0 +1,13 @@
+- hosts: all
+  gather_facts: no
+  any_errors_fatal: true
+  tasks:
+    - block:
+      - block:
+          - fail:
+            when: inventory_hostname == 'host1'
+        rescue:
+          - fail:
+      - block:
+        - debug:
+            msg: "SHOULD NOT HAPPEN"

--- a/test/integration/targets/blocks/runme.sh
+++ b/test/integration/targets/blocks/runme.sh
@@ -107,3 +107,14 @@ ansible-playbook inherit_notify.yml "$@"
 ansible-playbook unsafe_failed_task.yml "$@"
 
 ansible-playbook finalized_task.yml "$@"
+
+# https://github.com/ansible/ansible/issues/72725
+ansible-playbook -i host1,host2 -vv 72725.yml
+
+# https://github.com/ansible/ansible/issues/72781
+set +e
+ansible-playbook -i host1,host2 -vv 72781.yml > 72781.out
+set -e
+cat 72781.out
+[ "$(grep -c 'SHOULD NOT HAPPEN' 72781.out)" -eq 0 ]
+rm -f 72781.out

--- a/test/units/plugins/strategy/test_linear.py
+++ b/test/units/plugins/strategy/test_linear.py
@@ -175,3 +175,147 @@ class TestStrategyLinear(unittest.TestCase):
         host2_task = hosts_tasks[1][1]
         self.assertIsNone(host1_task)
         self.assertIsNone(host2_task)
+
+    def test_noop_64999(self):
+        fake_loader = DictDataLoader({
+            "test_play.yml": """
+            - hosts: all
+              gather_facts: no
+              tasks:
+                - name: block1
+                  block:
+                    - name: block2
+                      block:
+                        - name: block3
+                          block:
+                          - name: task1
+                            debug:
+                            failed_when: inventory_hostname == 'host01'
+                          rescue:
+                            - name: rescue1
+                              debug:
+                                msg: "rescue"
+
+                        - name: after_rescue1
+                          debug:
+                            msg: "after_rescue1"
+            """,
+        })
+
+        mock_var_manager = MagicMock()
+        mock_var_manager._fact_cache = dict()
+        mock_var_manager.get_vars.return_value = dict()
+
+        p = Playbook.load('test_play.yml', loader=fake_loader, variable_manager=mock_var_manager)
+
+        inventory = MagicMock()
+        inventory.hosts = {}
+        hosts = []
+        for i in range(0, 2):
+            host = MagicMock()
+            host.name = host.get_name.return_value = 'host%02d' % i
+            hosts.append(host)
+            inventory.hosts[host.name] = host
+        inventory.get_hosts.return_value = hosts
+        inventory.filter_hosts.return_value = hosts
+
+        mock_var_manager._fact_cache['host00'] = dict()
+
+        play_context = PlayContext(play=p._entries[0])
+
+        itr = PlayIterator(
+            inventory=inventory,
+            play=p._entries[0],
+            play_context=play_context,
+            variable_manager=mock_var_manager,
+            all_vars=dict(),
+        )
+
+        tqm = TaskQueueManager(
+            inventory=inventory,
+            variable_manager=mock_var_manager,
+            loader=fake_loader,
+            passwords=None,
+            forks=5,
+        )
+        tqm._initialize_processes(3)
+        strategy = StrategyModule(tqm)
+        strategy._hosts_cache = [h.name for h in hosts]
+        strategy._hosts_cache_all = [h.name for h in hosts]
+
+        # implicit meta: flush_handlers
+        hosts_left = strategy.get_hosts_left(itr)
+        hosts_tasks = strategy._get_next_task_lockstep(hosts_left, itr)
+        host1_task = hosts_tasks[0][1]
+        host2_task = hosts_tasks[1][1]
+        self.assertIsNotNone(host1_task)
+        self.assertIsNotNone(host2_task)
+        self.assertEqual(host1_task.action, 'meta')
+        self.assertEqual(host2_task.action, 'meta')
+
+        # debug: task1, debug: task1
+        hosts_left = strategy.get_hosts_left(itr)
+        hosts_tasks = strategy._get_next_task_lockstep(hosts_left, itr)
+        host1_task = hosts_tasks[0][1]
+        host2_task = hosts_tasks[1][1]
+        self.assertIsNotNone(host1_task)
+        self.assertIsNotNone(host2_task)
+        self.assertEqual(host1_task.action, 'debug')
+        self.assertEqual(host2_task.action, 'debug')
+        self.assertEqual(host1_task.name, 'task1')
+        self.assertEqual(host2_task.name, 'task1')
+
+        # mark the second host failed
+        itr.mark_host_failed(hosts[1])
+
+        # meta: noop, debug: rescue1
+        hosts_left = strategy.get_hosts_left(itr)
+        hosts_tasks = strategy._get_next_task_lockstep(hosts_left, itr)
+        host1_task = hosts_tasks[0][1]
+        host2_task = hosts_tasks[1][1]
+        self.assertIsNotNone(host1_task)
+        self.assertIsNotNone(host2_task)
+        self.assertEqual(host1_task.action, 'meta')
+        self.assertEqual(host2_task.action, 'debug')
+        self.assertEqual(host1_task.name, '')
+        self.assertEqual(host2_task.name, 'rescue1')
+
+        # debug: after_rescue1, debug: after_rescue1
+        hosts_left = strategy.get_hosts_left(itr)
+        hosts_tasks = strategy._get_next_task_lockstep(hosts_left, itr)
+        host1_task = hosts_tasks[0][1]
+        host2_task = hosts_tasks[1][1]
+        self.assertIsNotNone(host1_task)
+        self.assertIsNotNone(host2_task)
+        self.assertEqual(host1_task.action, 'debug')
+        self.assertEqual(host2_task.action, 'debug')
+        self.assertEqual(host1_task.name, 'after_rescue1')
+        self.assertEqual(host2_task.name, 'after_rescue1')
+
+        # implicit meta: flush_handlers
+        hosts_left = strategy.get_hosts_left(itr)
+        hosts_tasks = strategy._get_next_task_lockstep(hosts_left, itr)
+        host1_task = hosts_tasks[0][1]
+        host2_task = hosts_tasks[1][1]
+        self.assertIsNotNone(host1_task)
+        self.assertIsNotNone(host2_task)
+        self.assertEqual(host1_task.action, 'meta')
+        self.assertEqual(host2_task.action, 'meta')
+
+        # implicit meta: flush_handlers
+        hosts_left = strategy.get_hosts_left(itr)
+        hosts_tasks = strategy._get_next_task_lockstep(hosts_left, itr)
+        host1_task = hosts_tasks[0][1]
+        host2_task = hosts_tasks[1][1]
+        self.assertIsNotNone(host1_task)
+        self.assertIsNotNone(host2_task)
+        self.assertEqual(host1_task.action, 'meta')
+        self.assertEqual(host2_task.action, 'meta')
+
+        # end of iteration
+        hosts_left = strategy.get_hosts_left(itr)
+        hosts_tasks = strategy._get_next_task_lockstep(hosts_left, itr)
+        host1_task = hosts_tasks[0][1]
+        host2_task = hosts_tasks[1][1]
+        self.assertIsNone(host1_task)
+        self.assertIsNone(host2_task)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Compare the whole HostState in lockstep as opposed to just current block
and run state. We need to take all nested HostStates into account as
well to ensure tasks are executed in lockstep in the linear strategy.

Fixes #64611
Fixes #64999
Fixes #68312
Fixes #72725
Fixes #72781 

ci_complete
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/executor/play_iterator.py`
`lib/ansible/plugins/strategy/linear.py`