### PR TITLE
[stable-2.9] AnsibleModule.set_mode_if_different: handle symlink is in a sticky directory (#45198)

### DIFF
--- a/changelogs/fragments/set_mode_if_different-symlink-sticky-dir.yml
+++ b/changelogs/fragments/set_mode_if_different-symlink-sticky-dir.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >
+    set_mode_if_different - handle symlink if it is inside a directory with
+    sticky bit set (https://github.com/ansible/ansible/pull/45198)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1210,7 +1210,11 @@ class AnsibleModule(object):
                         if underlying_stat.st_mode != new_underlying_stat.st_mode:
                             os.chmod(b_path, stat.S_IMODE(underlying_stat.st_mode))
             except OSError as e:
-                if os.path.islink(b_path) and e.errno in (errno.EPERM, errno.EROFS):  # Can't set mode on symbolic links
+                if os.path.islink(b_path) and e.errno in (
+                    errno.EACCES,  # can't access symlink in sticky directory (stat)
+                    errno.EPERM,  # can't set mode on symbolic links (chmod)
+                    errno.EROFS,  # can't set mode on read-only filesystem
+                ):
                     pass
                 elif e.errno in (errno.ENOENT, errno.ELOOP):  # Can't set mode on broken symbolic links
                     pass

--- a/test/integration/targets/file/defaults/main.yml
+++ b/test/integration/targets/file/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+remote_unprivileged_user: tmp_ansible_test_user

--- a/test/integration/targets/file/tasks/state_link.yml
+++ b/test/integration/targets/file/tasks/state_link.yml
@@ -116,6 +116,88 @@
     that:
       - "file6a_result.changed == false"
 
+# In order for a symlink in a sticky world writable directory to be followed, it must
+# either be owned by the follower,
+# or the directory and symlink must have the same owner.
+- name: symlink in sticky directory
+  block:
+    - name: Create remote unprivileged remote user
+      user:
+        name: '{{ remote_unprivileged_user }}'
+      register: user
+
+    - name: Create a local temporary directory
+      tempfile:
+        state: directory
+      register: tempdir
+
+    - name: Set sticky bit
+      file:
+        path: '{{ tempdir.path }}'
+        mode: o=rwXt
+
+    - name: 'Check mode: force creation soft link in sticky directory owned by another user (mode is used)'
+      file:
+        src: '{{ user.home }}/nonexistent'
+        dest: '{{ tempdir.path }}/soft3.txt'
+        mode: 0640
+        state: 'link'
+        owner: '{{ remote_unprivileged_user }}'
+        force: true
+        follow: false
+      check_mode: true
+      register: missing_dst_no_follow_enable_force_use_mode1
+
+    - name: force creation soft link in sticky directory owned by another user (mode is used)
+      file:
+        src: '{{ user.home }}/nonexistent'
+        dest: '{{ tempdir.path }}/soft3.txt'
+        mode: 0640
+        state: 'link'
+        owner: '{{ remote_unprivileged_user }}'
+        force: true
+        follow: false
+      register: missing_dst_no_follow_enable_force_use_mode2
+
+    - name: Get stat info for the link
+      stat:
+        path: '{{ tempdir.path }}/soft3.txt'
+        follow: false
+      register: soft3_result
+
+    - name: 'Idempotence: force creation soft link in sticky directory owned by another user (mode is used)'
+      file:
+        src: '{{ user.home }}/nonexistent'
+        dest: '{{ tempdir.path }}/soft3.txt'
+        mode: 0640
+        state: 'link'
+        owner: '{{ remote_unprivileged_user }}'
+        force: yes
+        follow: false
+      register: missing_dst_no_follow_enable_force_use_mode3
+  always:
+    - name: Delete remote unprivileged remote user
+      user:
+        name: '{{ remote_unprivileged_user }}'
+        state: absent
+
+    - name: Delete unprivileged user home and tempdir
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - '{{ tempdir.path }}'
+        - '{{ user.home }}'
+
+- name: verify that link was created
+  assert:
+    that:
+      - "missing_dst_no_follow_enable_force_use_mode1 is changed"
+      - "missing_dst_no_follow_enable_force_use_mode2 is changed"
+      - "missing_dst_no_follow_enable_force_use_mode3 is not changed"
+      - "soft3_result['stat'].islnk"
+      - "soft3_result['stat'].lnk_target == '{{ user.home }}/nonexistent'"
+
 #
 # Test creating a link to a directory https://github.com/ansible/ansible/issues/1369
 #


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #45198 for Ansible 2.9
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/basic.py`