### PR TITLE
[2.10] The implicit default for type=bool options is not 'false', but 'none'

### DIFF
--- a/changelogs/fragments/72699-validate-modules-default-for-bools.yml
+++ b/changelogs/fragments/72699-validate-modules-default-for-bools.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "ansible-test validate-modules - no longer assume that ``default`` for ``type=bool`` options is ``false``, as the default is ``none`` and for some modules, ``none`` and ``false`` mean different things (https://github.com/ansible/ansible/issues/69561)."

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -35,8 +35,8 @@ options:
   update_cache:
     description:
       - Run the equivalent of C(apt-get update) before the operation. Can be run as part of the package installation or as a separate step.
+      - Default is not to update the cache.
     type: bool
-    default: 'no'
   update_cache_retries:
     description:
       - Amount of retries if the cache update fails. Also see I(update_cache_retry_max_delay).

--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -123,7 +123,7 @@ options:
       - New variables are added on top of crontab.
       - C(name) and C(value) parameters are the name and the value of environment variable.
     type: bool
-    default: no
+    default: false
     version_added: "2.1"
   insertafter:
     description:
@@ -572,7 +572,7 @@ def main():
             reboot=dict(type='bool', default=False),
             special_time=dict(type='str', choices=["reboot", "yearly", "annually", "monthly", "weekly", "daily", "hourly"]),
             disabled=dict(type='bool', default=False),
-            env=dict(type='bool'),
+            env=dict(type='bool', default=False),
             insertafter=dict(type='str'),
             insertbefore=dict(type='str'),
         ),

--- a/lib/ansible/modules/debconf.py
+++ b/lib/ansible/modules/debconf.py
@@ -54,7 +54,7 @@ options:
     description:
       - Do not set 'seen' flag when pre-seeding.
     type: bool
-    default: no
+    default: false
 author:
 - Brian Coca (@bcoca)
 '''
@@ -137,7 +137,7 @@ def main():
             question=dict(type='str', aliases=['selection', 'setting']),
             vtype=dict(type='str', choices=['boolean', 'error', 'multiselect', 'note', 'password', 'seen', 'select', 'string', 'text', 'title']),
             value=dict(type='str', aliases=['answer']),
-            unseen=dict(type='bool'),
+            unseen=dict(type='bool', default=False),
         ),
         required_together=(['question', 'vtype', 'value'],),
         supports_check_mode=True,

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -429,7 +429,7 @@ def main():
     argument_spec.update(
         url=dict(type='str', required=True),
         dest=dict(type='path', required=True),
-        backup=dict(type='bool'),
+        backup=dict(type='bool', default=False),
         sha256sum=dict(type='str', default=''),
         checksum=dict(type='str', default=''),
         timeout=dict(type='int', default=10),

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -322,6 +322,7 @@ options:
       - If no chain is specified then the entire table is purged.
       - Ignores all other parameters.
     type: bool
+    default: false
     version_added: "2.2"
   policy:
     description:

--- a/lib/ansible/modules/systemd.py
+++ b/lib/ansible/modules/systemd.py
@@ -59,8 +59,8 @@ options:
             - (deprecated) run ``systemctl`` talking to the service manager of the calling user, rather than the service manager
               of the system.
             - This option is deprecated and will eventually be removed in 2.11. The ``scope`` option should be used instead.
+            - The default value is C(false).
         type: bool
-        default: no
     scope:
         description:
             - run systemctl within a given service manager scope, either as the default system scope (system),

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -1735,8 +1735,6 @@ class ModuleValidator(Validator):
                         msg=msg
                     )
                     continue
-            elif data.get('default') is None and _type == 'bool' and 'options' not in data:
-                arg_default = False
 
             doc_options_args = []
             for alias in sorted(set([arg] + list(aliases))):
@@ -1766,8 +1764,6 @@ class ModuleValidator(Validator):
                 if 'default' in doc_options_arg and not is_empty(doc_options_arg['default']):
                     with CaptureStd():
                         doc_default = _type_checker(doc_options_arg['default'])
-                elif doc_options_arg.get('default') is None and _type == 'bool' and 'suboptions' not in doc_options_arg:
-                    doc_default = False
             except (Exception, SystemExit):
                 msg = "Argument '%s' in documentation" % arg
                 if context:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -91,6 +91,7 @@ lib/ansible/module_utils/six/__init__.py no-dict-itervalues
 lib/ansible/module_utils/six/__init__.py replace-urlopen
 lib/ansible/module_utils/urls.py pylint:blacklisted-name
 lib/ansible/module_utils/urls.py replace-urlopen
+lib/ansible/modules/command.py validate-modules:doc-default-does-not-match-spec  # _uses_shell is undocumented
 lib/ansible/modules/command.py validate-modules:doc-missing-type
 lib/ansible/modules/command.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/command.py validate-modules:parameter-list-no-elements
@@ -114,6 +115,7 @@ lib/ansible/modules/lineinfile.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/lineinfile.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/lineinfile.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/replace.py validate-modules:nonexistent-parameter-documented
+lib/ansible/modules/stat.py validate-modules:doc-default-does-not-match-spec  # get_md5 is undocumented
 lib/ansible/modules/stat.py validate-modules:parameter-invalid
 lib/ansible/modules/stat.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/stat.py validate-modules:undocumented-parameter


### PR DESCRIPTION
##### SUMMARY
Backport of #72699 to stable-2.10.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test validate-modules
