### PR TITLE
[2.9] ansible-test sanity: fix UnicodeDecodeError for `--python 2.7 --docker`

### DIFF
--- a/changelogs/fragments/72623-ansible-test-unicode-paths.yml
+++ b/changelogs/fragments/72623-ansible-test-unicode-paths.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-test - convert target paths to unicode on Python 2 to avoid ``UnicodeDecodeError`` (https://github.com/ansible/ansible/issues/68398, https://github.com/ansible/ansible/pull/72623)."

--- a/test/lib/ansible_test/_internal/target.py
+++ b/test/lib/ansible_test/_internal/target.py
@@ -144,7 +144,7 @@ def filter_targets(targets,  # type: t.Iterable[TCompletionTarget]
             continue
 
         if directories and matched_directories:
-            yield DirectoryTarget(sorted(matched_directories, key=len)[0], target.modules)
+            yield DirectoryTarget(to_text(sorted(matched_directories, key=len)[0]), target.modules)
         else:
             yield target
 
@@ -278,7 +278,7 @@ def walk_integration_targets():
         paths.append(os.path.sep.join(path_tuple))
 
     for path in paths:
-        yield IntegrationTarget(path, modules, prefixes)
+        yield IntegrationTarget(to_text(path), modules, prefixes)
 
 
 def load_integration_prefixes():
@@ -327,7 +327,7 @@ def walk_test_targets(path=None, module_path=None, extensions=None, prefix=None,
         if symlink and not include_symlinks:
             continue
 
-        yield TestTarget(file_path, module_path, prefix, path, symlink)
+        yield TestTarget(to_text(file_path), module_path, prefix, path, symlink)
 
     file_paths = []
 


### PR DESCRIPTION
##### SUMMARY
Backport of #72623 to stable-2.9.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test
