### PR TITLE
blockinfile: add feature insert newlines before or after

### DIFF
--- a/changelogs/fragments/70427-blockinfile-newlines-succeeding-preceding.yml
+++ b/changelogs/fragments/70427-blockinfile-newlines-succeeding-preceding.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "``blockinfile`` - add parameter ``newlines_preceding`` and ``newlines_succeeding`` (both default to ``0``) to insert newlines before and/or after the block of lines to be inserted (https://github.com/ansible/ansible/issues/70427)."

--- a/changelogs/fragments/70427-blockinfile-newlines-succeeding-preceding.yml
+++ b/changelogs/fragments/70427-blockinfile-newlines-succeeding-preceding.yml
@@ -1,2 +1,3 @@
+# -*- coding: utf-8 -*-
 minor_changes:
   - "``blockinfile`` - add parameter ``newlines_preceding`` and ``newlines_succeeding`` (both default to ``0``) to insert newlines before and/or after the block of lines to be inserted (https://github.com/ansible/ansible/issues/70427)."

--- a/changelogs/fragments/72869-blockinfile-newlines-succeeding-preceding.yml
+++ b/changelogs/fragments/72869-blockinfile-newlines-succeeding-preceding.yml
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+minor_changes:
+  - "``blockinfile`` - add parameters ``newlines_before`` and ``newlines_after`` (both default to ``0``) to insert empty newlines before and/or after the block of lines to be inserted for increased readability (feature request: https://github.com/ansible/ansible/issues/70427)."
+


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allow insertion of empty new lines before or after the block of lines to be inserted (with `blockinfile` module). The number of empty lines is provided by the parameters `newlines_before` and/or `newlines_after` (integer values, such as 0 (=default), 1, 2, ...).

This allows blocks of lines maintained by Ansible to be more clearly distinguished in the concerned files: improves readability of maintained files. The feature removes the need to manually add empty lines before or after such blocks. Does not affect existing code.

This seems to be a sought-after feature, with no proper solution that doesn't involve multiple tasks (see issue with using `\n` in marker: [feature request](https://github.com/ansible/ansible/issues/70427)):
- https://www.reddit.com/r/ansible/comments/8m3auz/blockinfile_module_add_a_new_line_before_marker/
- http://mrtango.planetcrazy.de/ansible-add-an-empty-line-before-a-blockinfile.html

In terms of design, the code appends empty lines to the block of lines immediately before (as a location in `blockinfile.py`) the block is inserted at its insertion point `n0`, ie. line 309:

https://github.com/ansible/ansible/blob/6608f3aab338f9e4e871afe77ded7b69e50f23f6/lib/ansible/modules/blockinfile.py#L304-L314

Two optional parameters are provided:
- `newlines_before`: takes an integer above or equal to 0 (default is 0)
- `newlines_after`: same.

This feature will insert the number of additional empty lines fed to these parameters before (in the case of `newlines_before`) or after (in the case of `newlines_after`) the block of lines to be inserted.

If there already exist empty lines before the block, then those empty lines are deducted from the number of empty lines that were set to be added via `newlines_before`. The same applies for `newlines_after`. In order to calculate the number of existing empty lines, lines that only contain spaces or tabs (`\t`) are considered to be empty (and thus deducted from the number of additional lines to be added before or after the block accordingly).

Conversely, if there already exists an excess number of empty lines before or after the block, those existing empty lines will remain untouched (ie. the feature does _not_ delete any _excess_ empty lines).

Furthermore, `newlines_before` will not add newlines if the block is inserted at the beginning of the file. Similarly, no additional empty lines will be inserted before the block if there exist only empty lines between the beginning of the file and the insert point `n0`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

Feature discussed here:
- Fixes #70427

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

Blockinfile:
- https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/blockinfile.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
  - name: Test blockinfile 'newlines_before' and 'newlines_after' features
    blockinfile:
      path: ./somefile.txt
      block: |
        Blabla line 1
        blabla line 4
        Blablaa line 5
      marker: "# {mark} ANSIBLE MANAGED BLOCK {{ lookup('pipe','date +%Y-%m-%d') }}"
      newlines_before: 1
      newlines_after: 3
      create: yes
    register: testout
```

```
...> Some preceding content here.
   > If no preceding content (ie this is the beginning of the file)
     or only empty lines between the beginning of the file and the managed block,
     the following empty line would not be added.
==> 1st empty line before the inserted block
# BEGIN ANSIBLE MANAGED BLOCK 2020-12-05      # <== this is the managed block
Blabla line 1
blabla line 4
Blablaa line 5
# END ANSIBLE MANAGED BLOCK 2020-12-05
==> 1st empty line after the inserted block
==> 2nd empty line after the inserted block
==> 3rd empty line after the inserted block
...> Some succeeding content here, if any, or EOF
```
