### PR TITLE
Fix fileglob parameter order bug

### DIFF
--- a/changelogs/fragments/72873-fix-fileglob-ordering.yml
+++ b/changelogs/fragments/72873-fix-fileglob-ordering.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix fileglob bug where it could return different results for different order of parameters (https://github.com/ansible/ansible/issues/72873).

--- a/lib/ansible/plugins/lookup/fileglob.py
+++ b/lib/ansible/plugins/lookup/fileglob.py
@@ -59,7 +59,6 @@ class LookupModule(LookupBase):
 
         ret = []
         for term in terms:
-            term_results = []
             term_file = os.path.basename(term)
             found_paths = []
             if term_file != term:
@@ -77,8 +76,8 @@ class LookupModule(LookupBase):
             for dwimmed_path in found_paths:
                 if dwimmed_path:
                     globbed = glob.glob(to_bytes(os.path.join(dwimmed_path, term_file), errors='surrogate_or_strict'))
-                    term_results.extend(to_text(g, errors='surrogate_or_strict') for g in globbed if os.path.isfile(g))
+                    term_results = [to_text(g, errors='surrogate_or_strict') for g in globbed if os.path.isfile(g)]
                     if term_results:
+                        ret.extend(term_results)
                         break
-            ret.extend(term_results)
         return ret

--- a/lib/ansible/plugins/lookup/fileglob.py
+++ b/lib/ansible/plugins/lookup/fileglob.py
@@ -59,6 +59,7 @@ class LookupModule(LookupBase):
 
         ret = []
         for term in terms:
+            term_results = []
             term_file = os.path.basename(term)
             found_paths = []
             if term_file != term:
@@ -76,7 +77,8 @@ class LookupModule(LookupBase):
             for dwimmed_path in found_paths:
                 if dwimmed_path:
                     globbed = glob.glob(to_bytes(os.path.join(dwimmed_path, term_file), errors='surrogate_or_strict'))
-                    ret.extend(to_text(g, errors='surrogate_or_strict') for g in globbed if os.path.isfile(g))
-                    if ret:
+                    term_results.extend(to_text(g, errors='surrogate_or_strict') for g in globbed if os.path.isfile(g))
+                    if term_results:
                         break
+            ret.extend(term_results)
         return ret

--- a/test/integration/targets/lookup_fileglob/issue72873/test.yml
+++ b/test/integration/targets/lookup_fileglob/issue72873/test.yml
@@ -1,0 +1,31 @@
+- hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+     dir: files
+  tasks:
+  - file: path='{{ dir }}' state=directory
+  
+  - file: path='setvars.bat' state=touch  # in current directory!
+
+  - file: path='{{ dir }}/{{ item }}' state=touch
+    loop:
+        - json.c
+        - strlcpy.c
+        - base64.c
+        - json.h
+        - base64.h
+        - strlcpy.h
+        - jo.c
+
+  - name: Get working order results and sort them
+    set_fact:
+        working: '{{ query("fileglob", "setvars.bat", "{{ dir }}/*.[ch]") | sort }}'
+
+  - name: Get broken order results and sort them
+    set_fact:
+        broken: '{{ query("fileglob", "{{ dir }}/*.[ch]", "setvars.bat") | sort }}'
+
+  - assert:
+      that:
+        - working == broken

--- a/test/integration/targets/lookup_fileglob/runme.sh
+++ b/test/integration/targets/lookup_fileglob/runme.sh
@@ -13,3 +13,6 @@ for seed in foo foo/bar foo/bar/baz
 do
 	ansible-playbook non_existent/play.yml -e "seed='${seed}'" "$@"
 done
+
+# test for issue 72873 fix
+ansible-playbook issue72873/test.yml "$@"


### PR DESCRIPTION
##### SUMMARY

The order of the parameters given to `fileglob` can change the results.

Fixes #72873

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
fileglob

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
