### PR TITLE
[2.9] [cloud_init_data_facts tests] fix for centos8

### DIFF
--- a/test/integration/targets/cloud_init_data_facts/tasks/main.yml
+++ b/test/integration/targets/cloud_init_data_facts/tasks/main.yml
@@ -11,11 +11,23 @@
   - not (ansible_distribution == "Ubuntu" and ansible_distribution_major_version|int == 14)
   - not (ansible_os_family == "Suse" and ansible_distribution_major_version|int != 42 and ansible_python.version.major != 3)
   block:
+  - name: Include distribution specific variables
+    include_vars: "{{ lookup('first_found', params) }}"
+    vars:
+      params:
+        files:
+        - "{{ ansible_facts.distribution }}-{{ ansible_facts.distribution_major_version }}.yml"
+        - "{{ ansible_facts.os_family }}.yml"
+        - default.yml
+        paths:
+        - "{{ role_path }}/vars"
+
+  - debug:
+      var: pkgs_required
+
   - name: setup install cloud-init
     package:
-      name:
-      - cloud-init
-      - "{{ 'systemd-udev' if ansible_os_family == 'RedHat' else 'udev' }}"
+      name: "{{ pkgs_required }}"
 
   - name: setup run cloud-init
     service:

--- a/test/integration/targets/cloud_init_data_facts/tasks/main.yml
+++ b/test/integration/targets/cloud_init_data_facts/tasks/main.yml
@@ -15,7 +15,7 @@
     package:
       name:
       - cloud-init
-      - udev
+      - "{{ 'systemd-udev' if ansible_os_family == 'RedHat' else 'udev' }}"
 
   - name: setup run cloud-init
     service:

--- a/test/integration/targets/cloud_init_data_facts/vars/CentOS-7.yml
+++ b/test/integration/targets/cloud_init_data_facts/vars/CentOS-7.yml
@@ -1,0 +1,3 @@
+pkgs_required:
+  - cloud-init
+  - systemd # This provides 'udev' as a virtual pkg

--- a/test/integration/targets/cloud_init_data_facts/vars/CentOS-8.yml
+++ b/test/integration/targets/cloud_init_data_facts/vars/CentOS-8.yml
@@ -1,0 +1,3 @@
+pkgs_required:
+  - cloud-init
+  - systemd-udev

--- a/test/integration/targets/cloud_init_data_facts/vars/default.yml
+++ b/test/integration/targets/cloud_init_data_facts/vars/default.yml
@@ -1,0 +1,3 @@
+pkgs_required:
+  - cloud-init
+  - udev


### PR DESCRIPTION

##### SUMMARY

Change:
- `udev` is provided by `systemd-udev`, which our `state=present` check
  doesn't match. For now, work around this so we don't end up trying to
  upgrade all of systemd.
- In the future, we should discuss if the `yum` module does the right
  thing here.

Test Plan:
- Locally in docker
- CI

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Test Pull Request

##### COMPONENT NAME

cloud_init_data_facts tests