### PR TITLE
Disable win_rds* tests in CI

### DIFF
--- a/test/integration/targets/win_rds/aliases
+++ b/test/integration/targets/win_rds/aliases
@@ -4,3 +4,4 @@ skip/windows/2008  # win_feature is required to install the RDS feature and that
 win_rds_cap
 win_rds_rap
 win_rds_settings
+disable  # Test takes too long to run in CI and any backports will be tested by community.windows first


### PR DESCRIPTION
##### SUMMARY
These tests take a long time to run in CI, ~12 minutes, and causes a group to get near the 55 minute limit. Because this is a community module that's no longer in devel there's not much point in running it in the backport PRs. Any changes to this module should come from `community.windows` where it is tested.

The modules affected are also quite static, I don't think there's been a change since they were merged in.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
win_rds