### PR TITLE
Change apt-add-repository to add-apt-repository

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -151,7 +151,7 @@ To configure the PPA on your machine and install Ansible run these commands:
 
     $ sudo apt update
     $ sudo apt install software-properties-common
-    $ sudo apt-add-repository --yes --update ppa:ansible/ansible
+    $ sudo add-apt-repository --yes --update ppa:ansible/ansible
     $ sudo apt install ansible
 
 .. note:: On older Ubuntu distributions, "software-properties-common" is called "python-software-properties". You may want to use ``apt-get`` instead of ``apt`` in older versions. Also, be aware that only newer distributions (in other words, 18.04, 18.10, and so on) have a ``-u`` or ``--update`` flag, so adjust your script accordingly.


### PR DESCRIPTION
##### SUMMARY
<!--- Your description here -->
Bash command apt-add-repository was incorrect. Updated to correct command for adding apt repository.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`apt-add-repository` is a symlink to `add-apt-repository`
`apt-add-repository` is not available is the base Ubuntu docker image and causes confusion
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Ubuntu install docs
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1. create a VS Code remote container installation of Ubuntu bionic
1. apt-add-repository is not a valid command in Ubuntu

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Hit:1 http://archive.ubuntu.com/ubuntu bionic InRelease
Hit:2 http://ppa.launchpad.net/ansible/ansible/ubuntu bionic InRelease
Hit:3 http://security.ubuntu.com/ubuntu bionic-security InRelease       
Hit:4 http://archive.ubuntu.com/ubuntu bionic-updates InRelease         
Hit:5 http://archive.ubuntu.com/ubuntu bionic-backports InRelease
Reading package lists... Done
```
