### PR TITLE
Add alinux hostname module support

### DIFF
--- a/changelogs/fragments/72894-add-alinux-hostname-module-support.yml
+++ b/changelogs/fragments/72894-add-alinux-hostname-module-support.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hostname - Fixed an issue where the hostname on the alinux could not be set.

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -811,10 +811,12 @@ class CloudlinuxHostname(Hostname):
     distribution = 'Cloudlinux'
     strategy_class = RedHatStrategy
 
+
 class AlinuxHostname(Hostname):
     platform = 'Linux'
     distribution = 'Alinux'
     strategy_class = RedHatStrategy
+    
     
 class CoreosHostname(Hostname):
     platform = 'Linux'

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -811,7 +811,11 @@ class CloudlinuxHostname(Hostname):
     distribution = 'Cloudlinux'
     strategy_class = RedHatStrategy
 
-
+class AlinuxHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Alinux'
+    strategy_class = RedHatStrategy
+    
 class CoreosHostname(Hostname):
     platform = 'Linux'
     distribution = 'Coreos'

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -816,8 +816,8 @@ class AlinuxHostname(Hostname):
     platform = 'Linux'
     distribution = 'Alinux'
     strategy_class = RedHatStrategy
-    
-    
+
+
 class CoreosHostname(Hostname):
     platform = 'Linux'
     distribution = 'Coreos'


### PR DESCRIPTION
Add alinux hostname module support

##### SUMMARY
Add alinux support for hostname module,
![image](https://user-images.githubusercontent.com/31824303/101430271-a2ae8000-393f-11eb-9e41-e2f93bd00856.png)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`lib/ansible/modules/system/hostname.py`
