### PR TITLE
Handle TemplateSyntaxErrors when fail on undefined is false

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -1098,7 +1098,10 @@ class Templar:
             try:
                 t = myenv.from_string(data)
             except TemplateSyntaxError as e:
-                raise AnsibleError("template error while templating string: %s. String: %s" % (to_native(e), to_native(data)))
+                if fail_on_undefined:
+                    raise AnsibleError("template error while templating string: %s. String: %s" % (to_native(e), to_native(data)))
+                else:
+                    return data
             except Exception as e:
                 if 'recursion' in to_native(e):
                     raise AnsibleError("recursive loop detected in template string: %s" % to_native(data))


### PR DESCRIPTION
##### SUMMARY

Prometheus rules (for example) use jinja syntax e.g.
`{{ some_prometheus_value }}`

One way to handle these rules is to set `error_on_undefined_vars`
to False and then these template strings get rendered as is.

However, other prometheus rules have a `$` prefix e.g.

`some text {{ $labels.service }}`

These cause jinja to raise a TemplateSyntaxError which then causes
an Ansible error.

By returning the original text when `error_on_undefined_vars` is
False, these rules then get rendered correctly (at the cost of
missing some jinja syntax errors in this circumstance).


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
template

##### ADDITIONAL INFORMATION

Before: (warnings removed for brevity)
```
ansible -m debug -a msg='{{ some_prometheus_value }}' localhost
[WARNING]: No inventory was parsed, only implicit localhost is available
localhost | SUCCESS => {
    "msg": "{{ some_prometheus_value }}"
}
ansible -m debug -a msg='{{ $labels.namespace }}' localhost
[WARNING]: No inventory was parsed, only implicit localhost is available
localhost | FAILED! => {
    "msg": "template error while templating string: unexpected char '$' at 3. String: {{ $labels.namespace }}"
}
```

After: (warnings removed)
```paste below
ansible -m debug -a msg='{{ some_prometheus_value }}' localhost
localhost | SUCCESS => {
    "msg": "{{ some_prometheus_value }}"
}
ansible -m debug -a msg='{{ $labels.namespace }}' localhost    
localhost | SUCCESS => {
    "msg": "{{ $labels.namespace }}"
}
```
