### PR TITLE
correct the reST rendering of the R() note

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -253,8 +253,8 @@ content in a uniform way:
 .. note::
     - To refer to a group of modules in a collection, use ``R()``.  When a collection is not the right granularity, use ``C(..)``:
 
-        -``Refer to the R(community.kubernetes collection, plugins_in_community.kubernetes) for information on managing kubernetes clusters.``
-        -``The C(win_*) modules (spread across several collections) allow you to manage various aspects of windows hosts.``
+        - ``Refer to the R(community.kubernetes collection, plugins_in_community.kubernetes) for information on managing kubernetes clusters.``
+        - ``The C(win_*) modules (spread across several collections) allow you to manage various aspects of windows hosts.``
 
 
 .. note::


### PR DESCRIPTION
##### SUMMARY
without the space, it's not rendered as a list


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
