### PR TITLE
Declare support for Python 3.9 in the metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -390,6 +390,7 @@ static_setup_params = dict(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: System :: Installation/Setup',
         'Topic :: System :: Systems Administration',
         'Topic :: Utilities',


### PR DESCRIPTION
##### SUMMARY

We run unit tests against Python 3.9 in the CI so we need to add a corresponding Trove classifier to the metadata.

##### ISSUE TYPE

- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME

setup.py

##### ADDITIONAL INFORMATION

N/A