### PR TITLE
Change package name from ansible_base to ansible_core in cli scripts

### DIFF
--- a/lib/ansible/cli/scripts/ansible_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_cli_stub.py
@@ -22,7 +22,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-__requires__ = ['ansible_base']
+__requires__ = ['ansible_core']
 
 
 import errno

--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -4,7 +4,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
-__requires__ = ['ansible_base']
+__requires__ = ['ansible_core']
 
 
 import fcntl


### PR DESCRIPTION
##### SUMMARY
To fix https://github.com/ansible/ansible/issues/72900

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-inventory

##### ADDITIONAL INFORMATION
This is just doing exactly what @sivel said, but I had to make the branch in order to actually test. I wanted to make the PR to document with the exact environment that I filed the issue with.

```
pip uninstall -y ansible-core
pip install git+https://github.com/AlanCoding/ansible.git@base_to_core
ansible-inventory -i ~/repos/test-playbooks/inventories/linode_fqcn.linode.yml --list -vvv
```

That produces the expected error, showing the code from the external library is running.

```
[WARNING]:  * Failed to parse /home/alancoding/repos/test-playbooks/inventories/linode_fqcn.linode.yml with auto plugin: No
setting was provided for required configuration plugin_type: inventory plugin:
ansible_collections.community.general.plugins.inventory.linode setting: access_token
  File "/home/alancoding/test/my_linode/lib64/python3.9/site-packages/ansible/inventory/manager.py", line 290, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/home/alancoding/test/my_linode/lib64/python3.9/site-packages/ansible/plugins/inventory/auto.py", line 58, in parse
    plugin.parse(inventory, loader, path, cache=cache)
  File "/home/alancoding/.ansible/collections/ansible_collections/community/general/plugins/inventory/linode.py", line 201, in parse
    config_data = self._read_config_data(path)
  File "/home/alancoding/test/my_linode/lib64/python3.9/site-packages/ansible/plugins/inventory/__init__.py", line 234, in _read_config_data
    self.set_options(direct=config, var_options=self._vars)
  File "/home/alancoding/test/my_linode/lib64/python3.9/site-packages/ansible/plugins/__init__.py", line 75, in set_options
    self._options = C.config.get_plugin_options(get_plugin_class(self), self._load_name, keys=task_keys, variables=var_options, direct=direct)
  File "/home/alancoding/test/my_linode/lib64/python3.9/site-packages/ansible/config/manager.py", line 362, in get_plugin_options
    options[option] = self.get_config_value(option, plugin_type=plugin_type, plugin_name=name, keys=keys, variables=variables, direct=direct)
  File "/home/alancoding/test/my_linode/lib64/python3.9/site-packages/ansible/config/manager.py", line 430, in get_config_value
    value, _drop = self.get_config_value_and_origin(config, cfile=cfile, plugin_type=plugin_type, plugin_name=plugin_name,
  File "/home/alancoding/test/my_linode/lib64/python3.9/site-packages/ansible/config/manager.py", line 518, in get_config_value_and_origin
    raise AnsibleError("No setting was provided for required configuration %s" %
```
