### PR TITLE
2.10: Use _wrap_native_text only for builtin STRING_TYPE_FILTERS (#71801)

### DIFF
--- a/changelogs/fragments/wrap_native_text-non-collections-only.yml
+++ b/changelogs/fragments/wrap_native_text-non-collections-only.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Apply ``_wrap_native_text`` only for builtin filters specified in STRING_TYPE_FILTERS.

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -510,7 +510,8 @@ class JinjaPluginIntercept(MutableMapping):
                 for func_name, func in iteritems(method_map()):
                     fq_name = '.'.join((parent_prefix, func_name))
                     # FIXME: detect/warn on intra-collection function name collisions
-                    if USE_JINJA2_NATIVE and func_name in C.STRING_TYPE_FILTERS:
+                    if USE_JINJA2_NATIVE and fq_name.startswith(('ansible.builtin.', 'ansible.legacy.')) and \
+                            func_name in C.STRING_TYPE_FILTERS:
                         self._collection_jinja_func_cache[fq_name] = _wrap_native_text(func)
                     else:
                         self._collection_jinja_func_cache[fq_name] = _unroll_iterator(func)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of https://github.com/ansible/ansible/pull/71801
(cherry picked from commit 252685092cacdd0f8b485ed6f105ec7acc29c7a4)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
``lib/ansible/template/__init__.py``