### PR TITLE
fix(hostvars): change templating behaviour (#72829)

### DIFF
--- a/lib/ansible/vars/hostvars.py
+++ b/lib/ansible/vars/hostvars.py
@@ -136,7 +136,7 @@ class HostVarsVars(Mapping):
 
     def __getitem__(self, var):
         templar = Templar(variables=self._vars, loader=self._loader)
-        foo = templar.template(self._vars[var], fail_on_undefined=False, static_vars=STATIC_VARS)
+        foo = templar.template(self._vars[var], fail_on_undefined=True, static_vars=STATIC_VARS)
         return foo
 
     def __contains__(self, var):
@@ -151,4 +151,4 @@ class HostVarsVars(Mapping):
 
     def __repr__(self):
         templar = Templar(variables=self._vars, loader=self._loader)
-        return repr(templar.template(self._vars, fail_on_undefined=False, static_vars=STATIC_VARS))
+        return repr(templar.template(self._vars, fail_on_undefined=True, static_vars=STATIC_VARS))


### PR DESCRIPTION
##### SUMMARY
Changes the templating behaviour of hostvars to default to automatically failing if the template is unresolvable.

Fixes #72829

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
[vars/hostvars](https://github.com/ansible/ansible/blob/devel/lib/ansible/vars/hostvars.py)

##### ADDITIONAL INFORMATION
[Meeting](https://meetbot.fedoraproject.org/ansible-meeting/2020-12-08/ansible_core_public_irc_meeting.2020-12-08-19.00.log.html)