### PR TITLE
[2.10] Fix task get_name to always prepend the role name (#72511)

### DIFF
--- a/changelogs/fragments/72511-always-prepend-role-to-task-name.yml
+++ b/changelogs/fragments/72511-always-prepend-role-to-task-name.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - 'Fix notifying handlers via `role_name : handler_name` when handler name contains the role name. (https://github.com/ansible/ansible/issues/70582)'
+  - 'Fix --list-tasks format `role_name : task_name` when task name contains the role name. (https://github.com/ansible/ansible/issues/72505)'

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -121,7 +121,7 @@ class Task(Base, Conditional, Taggable, CollectionSearch):
         if self._role:
             role_name = self._role.get_name(include_role_fqcn=include_role_fqcn)
 
-        if self._role and self.name and role_name not in self.name:
+        if self._role and self.name:
             return "%s : %s" % (role_name, self.name)
         elif self.name:
             return self.name

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -1015,10 +1015,7 @@ class StrategyBase:
         notified_hosts += failed_hosts
 
         if len(notified_hosts) > 0:
-            saved_name = handler.name
-            handler.name = handler_name
             self._tqm.send_callback('v2_playbook_on_handler_task_start', handler)
-            handler.name = saved_name
 
         bypass_host_loop = False
         try:

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/roles/common_handlers/handlers/main.yml
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/roles/common_handlers/handlers/main.yml
@@ -4,3 +4,24 @@
   set_fact:
     handler_counter: '{{ handler_counter|int + 1 }}'
   failed_when: handler_counter|int > 1
+
+# The following handler contains the role name and should be callable as:
+# 'common_handlers test_fqcn_handler'
+# 'common_handlers : common_handlers test_fqcn_handler`
+# 'testns.testcoll.common_handlers : common_handlers test_fqcn_handler'
+- name: common_handlers test_fqcn_handler
+  set_fact:
+    handler_counter: '{{ handler_counter|int + 1}}'
+  failed_when: handler_counter|int > 2
+
+# The following handler starts with 'role name : ' and should _not_ be listed as:
+# 'common_handlers : common_handlers : test_fqcn_handler`
+# 'testns.testcoll.common_handlers : common_handlers : test_fqcn_handler'
+- name: 'common_handlers : test_fqcn_handler'
+  meta: noop
+
+# The following handler starts with 'fqcn : ' and should _not_ be listed as:
+# 'common_handlers : testns.testcoll.common_handlers : test_fqcn_handler`
+# 'testns.testcoll.common_handlers : testns.testcoll.common_handlers : test_fqcn_handler'
+- name: 'testns.testcoll.common_handlers : test_fqcn_handler'
+  meta: noop

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/roles/test_fqcn_handlers/tasks/main.yml
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/roles/test_fqcn_handlers/tasks/main.yml
@@ -1,7 +1,16 @@
-- debug:
+- name: Fire fqcn handler 1
+  debug:
     msg: Fire fqcn handler
   changed_when: true
   notify:
     - 'testns.testcoll.common_handlers : test_fqcn_handler'
     - 'common_handlers : test_fqcn_handler'
     - 'test_fqcn_handler'
+
+- debug:
+    msg: Fire fqcn handler with role name
+  changed_when: true
+  notify:
+    - 'testns.testcoll.common_handlers : common_handlers test_fqcn_handler'
+    - 'common_handlers : common_handlers test_fqcn_handler'
+    - 'common_handlers test_fqcn_handler'


### PR DESCRIPTION
Backport of #72511

* Fix 'role_name : tast_name' notation if task contains role name

* Add tests for notifying handler names which contain the role name

Co-authored-by: Thomas Wouters <thomaswouters@gmail.com>
(cherry picked from commit 0ed7bfc694e5e2efe49fa0e1c8fea0a392c78c04)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
