### PR TITLE
[stable-2.10] Fix async interpreter parsing (#72636)

### DIFF
--- a/changelogs/fragments/70690-async-interpreter.yml
+++ b/changelogs/fragments/70690-async-interpreter.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- async - Fix Python 3 interpreter parsing from module by comparing with bytes
+  (https://github.com/ansible/ansible/issues/70690)

--- a/test/integration/targets/noexec/aliases
+++ b/test/integration/targets/noexec/aliases
@@ -1,0 +1,3 @@
+shippable/posix/group2
+skip/docker
+skip/macos

--- a/test/integration/targets/noexec/inventory
+++ b/test/integration/targets/noexec/inventory
@@ -1,0 +1,1 @@
+not_empty  # avoid empty empty hosts list warning without defining explicit localhost

--- a/test/integration/targets/noexec/runme.sh
+++ b/test/integration/targets/noexec/runme.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -eux
+
+trap 'umount "${OUTPUT_DIR}/ramdisk"' EXIT
+
+mkdir "${OUTPUT_DIR}/ramdisk"
+mount -t tmpfs -o size=32m,noexec,rw tmpfs "${OUTPUT_DIR}/ramdisk"
+ANSIBLE_REMOTE_TMP="${OUTPUT_DIR}/ramdisk" ansible-playbook -i inventory "$@" test-noexec.yml

--- a/test/integration/targets/noexec/test-noexec.yml
+++ b/test/integration/targets/noexec/test-noexec.yml
@@ -1,0 +1,8 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - ping:
+
+    - command: sleep 1
+      async: 2
+      poll: 1


### PR DESCRIPTION
* Fix async interpreter parsing. Fixes #70690

* Target localhost instead of remote host

* Don't forget inventory

* Address shellcheck issue
(cherry picked from commit 83764ad)


Co-authored-by: Matt Martz <matt@sivel.net>