### PR TITLE
[stable-2.10] Fix reset_connection paramiko, winrm, psrp (#72688)

### DIFF
--- a/changelogs/fragments/65812-paramiko-attribute-error.yml
+++ b/changelogs/fragments/65812-paramiko-attribute-error.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- paramiko connection plugin - Ensure we only reset the connection when one has been
+  previously established (https://github.com/ansible/ansible/issues/65812)

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -536,6 +536,8 @@ class Connection(ConnectionBase):
                         f.write("%s %s %s\n" % (hostname, keytype, key.get_base64()))
 
     def reset(self):
+        if not self._connected:
+            return
         self.close()
         self._connect()
 

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -407,6 +407,8 @@ class Connection(ConnectionBase):
         return self
 
     def reset(self):
+        if not self._connected:
+            return
         display.vvvvv("PSRP: Reset Connection", host=self._psrp_host)
         self.runspace = None
         self._connect()

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -520,6 +520,8 @@ class Connection(ConnectionBase):
         return self
 
     def reset(self):
+        if not self._connected:
+            return
         self.protocol = None
         self.shell_id = None
         self._connect()

--- a/test/integration/targets/connection/test.sh
+++ b/test/integration/targets/connection/test.sh
@@ -21,3 +21,5 @@ then
 else
     echo "SUCCESS: Connection vars not found"
 fi
+
+ansible-playbook test_reset_connection.yml -i "${INVENTORY}" "$@"

--- a/test/integration/targets/connection/test_reset_connection.yml
+++ b/test/integration/targets/connection/test_reset_connection.yml
@@ -1,0 +1,5 @@
+- hosts: "{{ target_hosts }}"
+  gather_facts: no
+  tasks:
+    # https://github.com/ansible/ansible/issues/65812
+    - meta: reset_connection


### PR DESCRIPTION
* Ensure we only reset the connection when one has been previously established. Fixes #65812

* Ensure psrp doesn't trace

* winrm too

* Indentation fix
(cherry picked from commit a3b6485)


Co-authored-by: Matt Martz <matt@sivel.net>