### PR TITLE
Galaxy - make versions list consistent across versions

### DIFF
--- a/changelogs/fragments/ansible-galaxy-version-response.yml
+++ b/changelogs/fragments/ansible-galaxy-version-response.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- >-
+  ansible-galaxy - Ensure ``get_collection_versions`` returns an empty list when a collection does
+  not exist for consistency across API versions.

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -511,29 +511,26 @@ class CollectionRequirement:
         galaxy_meta = None
 
         for api in apis:
-            try:
-                if not (requirement == '*' or requirement.startswith('<') or requirement.startswith('>') or
-                        requirement.startswith('!=')):
-                    # Exact requirement
-                    allow_pre_release = True
+            if not (requirement == '*' or requirement.startswith('<') or requirement.startswith('>') or
+                    requirement.startswith('!=')):
+                # Exact requirement
+                allow_pre_release = True
 
-                    if requirement.startswith('='):
-                        requirement = requirement.lstrip('=')
+                if requirement.startswith('='):
+                    requirement = requirement.lstrip('=')
 
+                try:
                     resp = api.get_collection_version_metadata(namespace, name, requirement)
-
+                except GalaxyError as err:
+                    if err.http_code != 404:
+                        raise
+                    versions = []
+                else:
                     galaxy_meta = resp
                     versions = [resp.version]
-                else:
-                    versions = api.get_collection_versions(namespace, name)
-            except GalaxyError as err:
-                if err.http_code != 404:
-                    raise
+            else:
+                versions = api.get_collection_versions(namespace, name)
 
-                versions = []
-
-            # Automation Hub doesn't return a 404 but an empty version list so we check that to align both AH and
-            # Galaxy when the collection is not available on that server.
             if not versions:
                 display.vvv("Collection '%s' is not available from server %s %s" % (collection, api.name,
                                                                                     api.api_server))

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -403,10 +403,9 @@ def test_build_requirement_from_name_second_server(galaxy_server, monkeypatch):
 
     broken_server = copy.copy(galaxy_server)
     broken_server.api_server = 'https://broken.com/'
-    mock_404 = MagicMock()
-    mock_404.side_effect = api.GalaxyError(urllib_error.HTTPError('https://galaxy.server.com', 404, 'msg', {},
-                                                                  StringIO()), "custom msg")
-    monkeypatch.setattr(broken_server, 'get_collection_versions', mock_404)
+    mock_version_list = MagicMock()
+    mock_version_list.return_value = []
+    monkeypatch.setattr(broken_server, 'get_collection_versions', mock_version_list)
 
     actual = collection.CollectionRequirement.from_name('namespace.collection', [broken_server, galaxy_server],
                                                         '>1.0.1', False, True)
@@ -420,8 +419,8 @@ def test_build_requirement_from_name_second_server(galaxy_server, monkeypatch):
     assert actual.latest_version == u'1.0.3'
     assert actual.dependencies == {}
 
-    assert mock_404.call_count == 1
-    assert mock_404.mock_calls[0][1] == ('namespace', 'collection')
+    assert mock_version_list.call_count == 1
+    assert mock_version_list.mock_calls[0][1] == ('namespace', 'collection')
 
     assert mock_get_versions.call_count == 1
     assert mock_get_versions.mock_calls[0][1] == ('namespace', 'collection')
@@ -429,8 +428,7 @@ def test_build_requirement_from_name_second_server(galaxy_server, monkeypatch):
 
 def test_build_requirement_from_name_missing(galaxy_server, monkeypatch):
     mock_open = MagicMock()
-    mock_open.side_effect = api.GalaxyError(urllib_error.HTTPError('https://galaxy.server.com', 404, 'msg', {},
-                                                                   StringIO()), "")
+    mock_open.return_value = []
 
     monkeypatch.setattr(galaxy_server, 'get_collection_versions', mock_open)
 


### PR DESCRIPTION
##### SUMMARY
The API `{root}/collections/{namespace}/{name}/versions/` on Galaxy will return a 404 if the collection does not exist on v2 endpoints and an empty dataset on v3 endpoints. The logic to handle this was in the collection code but to make the method consistent from the API stub this PR ensures the return value is always an empty list.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-galaxy