### PR TITLE
[POC] play_iterator.py: Introduce is_in_rescue and is_in_always methods

### DIFF
--- a/changelogs/fragments/43191-ansible_failed_task-always_outer_rescue.yml
+++ b/changelogs/fragments/43191-ansible_failed_task-always_outer_rescue.yml
@@ -1,0 +1,2 @@
+bugfixes:
+   - Fix an issue when ``ansible_failed_task`` was not defined when a failure was followed by an always section and the rescue section was in an outer block. (https://github.com/ansible/ansible/issues/43191)

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -541,12 +541,18 @@ class PlayIterator(metaclass=MetaPlayIterator):
     def is_any_block_rescuing(self, state):
         '''
         Given the current HostState state, determines if the current block, or any child blocks,
-        are in rescue mode.
+        has a rescue section.
         '''
-        if state.run_state == IteratingStates.RESCUE:
+        if state is None:
+            return False
+        if state._blocks[state.cur_block].rescue:
             return True
         if state.tasks_child_state is not None:
             return self.is_any_block_rescuing(state.tasks_child_state)
+        elif state.rescue_child_state is not None:
+            return self.is_any_block_rescuing(state.rescue_child_state)
+        elif state.always_child_state is not None:
+            return self.is_any_block_rescuing(state.always_child_state)
         return False
 
     def get_original_task(self, host, task):

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -538,7 +538,7 @@ class PlayIterator(metaclass=MetaPlayIterator):
             return self.get_active_state(state.always_child_state)
         return state
 
-    def is_any_block_rescuing(self, state):
+    def is_in_rescue(self, state):
         '''
         Given the current HostState state, determines if the current block, or any child blocks,
         has a rescue section.
@@ -548,11 +548,28 @@ class PlayIterator(metaclass=MetaPlayIterator):
         if state._blocks[state.cur_block].rescue:
             return True
         if state.tasks_child_state is not None:
-            return self.is_any_block_rescuing(state.tasks_child_state)
+            return self.is_in_rescue(state.tasks_child_state)
         elif state.rescue_child_state is not None:
-            return self.is_any_block_rescuing(state.rescue_child_state)
+            return self.is_in_rescue(state.rescue_child_state)
         elif state.always_child_state is not None:
-            return self.is_any_block_rescuing(state.always_child_state)
+            return self.is_in_rescue(state.always_child_state)
+        return False
+
+    def is_in_always(self, state):
+        '''
+        Given the current HostState state, determines if the current block, or any child blocks,
+        has a always section.
+        '''
+        if state is None:
+            return False
+        if state._blocks[state.cur_block].always:
+            return True
+        if state.tasks_child_state is not None:
+            return self.is_in_always(state.tasks_child_state)
+        elif state.rescue_child_state is not None:
+            return self.is_in_always(state.rescue_child_state)
+        elif state.always_child_state is not None:
+            return self.is_in_always(state.always_child_state)
         return False
 
     def get_original_task(self, host, task):

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -570,7 +570,7 @@ class StrategyBase:
                     # we save the failed task in a special var for use
                     # within the rescue/always
                     state = iterator._host_states[original_host.name]
-                    if iterator.is_any_block_rescuing(state):
+                    if iterator.is_in_rescue(state):
                         self._tqm._stats.increment('rescued', original_host.name)
                         self._variable_manager.set_nonpersistent_facts(
                             original_host.name,

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -561,20 +561,16 @@ class StrategyBase:
                     else:
                         iterator.mark_host_failed(original_host)
 
-                    # grab the current state and if we're iterating on the rescue portion
-                    # of a block then we save the failed task in a special var for use
-                    # within the rescue/always
                     state, _ = iterator.get_next_task_for_host(original_host, peek=True)
 
                     if iterator.is_failed(original_host) and state and state.run_state == IteratingStates.COMPLETE:
                         self._tqm._failed_hosts[original_host.name] = True
 
-                    # Use of get_active_state() here helps detect proper state if, say, we are in a rescue
-                    # block from an included file (include_tasks). In a non-included rescue case, a rescue
-                    # that starts with a new 'block' will have an active state of IteratingStates.TASKS, so we also
-                    # check the current state block tree to see if any blocks are rescuing.
-                    if state and (iterator.get_active_state(state).run_state == IteratingStates.RESCUE or
-                                  iterator.is_any_block_rescuing(state)):
+                    # If we're iterating on the rescue portion of a block then
+                    # we save the failed task in a special var for use
+                    # within the rescue/always
+                    state = iterator._host_states[original_host.name]
+                    if iterator.is_any_block_rescuing(state):
                         self._tqm._stats.increment('rescued', original_host.name)
                         self._variable_manager.set_nonpersistent_facts(
                             original_host.name,

--- a/test/integration/targets/blocks/73246.yml
+++ b/test/integration/targets/blocks/73246.yml
@@ -1,0 +1,11 @@
+- hosts: host1
+  gather_facts: no
+  any_errors_fatal: yes
+  tasks:
+    - block:
+        - block:
+          - fail:
+      always:
+        - block:
+          - debug:
+              msg: "Always starts with a new block"

--- a/test/integration/targets/blocks/always_outer_rescue.yml
+++ b/test/integration/targets/blocks/always_outer_rescue.yml
@@ -1,0 +1,20 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - block:
+        - debug:
+      always:
+        - block:
+          - block:
+              - name: EXPECTED FAILURE ansible_failed_task works
+                fail:
+            always:
+              - name: second inner block
+                block:
+                  - debug: msg="In 1st always"
+                always:
+                  - debug: msg="In 2nd always"
+          rescue:
+            - name: Rescue message
+              debug:
+                msg: "{{ ansible_failed_task.action }}"

--- a/test/integration/targets/blocks/always_outer_rescue.yml
+++ b/test/integration/targets/blocks/always_outer_rescue.yml
@@ -1,4 +1,4 @@
-- hosts: localhost
+- hosts: host1
   gather_facts: no
   tasks:
     - block:

--- a/test/integration/targets/blocks/runme.sh
+++ b/test/integration/targets/blocks/runme.sh
@@ -107,3 +107,12 @@ ansible-playbook inherit_notify.yml "$@"
 ansible-playbook unsafe_failed_task.yml "$@"
 
 ansible-playbook finalized_task.yml "$@"
+
+# https://github.com/ansible/ansible/issues/43191
+ansible-playbook always_outer_rescue.yml > always_outer_rescue_test.out
+cat always_outer_rescue_test.out
+[ "$(grep -c 'rescued=1' always_outer_rescue_test.out)" -eq 1 ]
+[ "$(grep -c 'failed=0' always_outer_rescue_test.out)" -eq 1 ]
+[ "$(grep -c 'VARIABLE IS NOT DEFINED!' always_outer_rescue_test.out)" -eq 0 ]
+[ "$(grep -c 'ansible_failed_task works' always_outer_rescue_test.out)" -eq 1 ]
+rm -f always_outer_rescue_test.out

--- a/test/integration/targets/blocks/runme.sh
+++ b/test/integration/targets/blocks/runme.sh
@@ -109,10 +109,18 @@ ansible-playbook unsafe_failed_task.yml "$@"
 ansible-playbook finalized_task.yml "$@"
 
 # https://github.com/ansible/ansible/issues/43191
-ansible-playbook always_outer_rescue.yml > always_outer_rescue_test.out
+ansible-playbook -i host1, -vv always_outer_rescue.yml > always_outer_rescue_test.out
 cat always_outer_rescue_test.out
 [ "$(grep -c 'rescued=1' always_outer_rescue_test.out)" -eq 1 ]
 [ "$(grep -c 'failed=0' always_outer_rescue_test.out)" -eq 1 ]
 [ "$(grep -c 'VARIABLE IS NOT DEFINED!' always_outer_rescue_test.out)" -eq 0 ]
 [ "$(grep -c 'ansible_failed_task works' always_outer_rescue_test.out)" -eq 1 ]
 rm -f always_outer_rescue_test.out
+
+# https://github.com/ansible/ansible/issues/73246
+set +e
+ansible-playbook -i host1, -vv 73246.yml > 73246.out
+set -e
+cat 73246.out
+[ "$(grep -c 'Always starts with a new block' 73246.out)" -eq 1 ]
+rm -f 73246.out


### PR DESCRIPTION
##### SUMMARY

Rather then trying to iterate states to figure out whether the next task
will be in a rescue portion of the block and if so set
ansible_failed_task/ansible_failed_result variables, we could just look
if rescue portion of the block exists in any block from top down to the
most nested one. That way we do not have to handle various corner cases
where iterating to next task would end up in an always section but
rescue section would be in an outer block and we would fail to set the
variable.

Fixes #43191
Fixes #73246

ci_complete

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/executor/play_iterator.py`
`lib/ansible/plugins/strategy/__init__.py`