### PR TITLE
Fixing the creation of a disk on a second datastore 

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_disk.py
@@ -320,7 +320,10 @@ class PyVmomiHelper(PyVmomi):
                     disk_spec.device.backing.thinProvisioned = True
                 elif disk['disk_type'] == 'eagerzeroedthick':
                     disk_spec.device.backing.eagerlyScrub = True
-                disk_spec.device.backing.fileName = "[%s] %s/%s_%s_%s.vmdk" % (disk['datastore'].name,
+                if not self.is_vcenter():
+                    disk_spec.device.backing.fileName = "[%s] " % (disk['datastore'].name)
+                else:
+                    disk_spec.device.backing.fileName = "[%s] %s/%s_%s_%s.vmdk" % (disk['datastore'].name,
                                                                                vm_name, vm_name,
                                                                                str(scsi_controller),
                                                                                str(disk['disk_unit_number']))


### PR DESCRIPTION
##### SUMMARY
Fixing the creation of a second disk on a second datastore when directly connected to a standalone ESXi.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_disk

##### ADDITIONAL INFORMATION
Relates to a difference in the API between vCenter and ESXi connections - https://kb.vmware.com/s/article/1030790

Has to be cherry picked also for version 2.9

