### PR TITLE
[2.9] Fix freeform actions with FQCN

### DIFF
--- a/changelogs/fragments/72958-fix-freeform-actions.yml
+++ b/changelogs/fragments/72958-fix-freeform-actions.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Freeform actions did not work with ``ansible.builtin.`` or ``ansible.legacy.`` FQCN (https://github.com/ansible/ansible/pull/72958).

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -30,14 +30,14 @@ from ansible.utils.sentinel import Sentinel
 
 
 # For filtering out modules correctly below
-FREEFORM_ACTIONS = frozenset((
+FREEFORM_ACTIONS = frozenset(add_internal_fqcns((
     'command',
     'win_command',
     'shell',
     'win_shell',
     'script',
     'raw'
-))
+)))
 
 RAW_PARAM_MODULES = FREEFORM_ACTIONS.union(add_internal_fqcns((
     'include',

--- a/test/integration/targets/command_shell/tasks/main.yml
+++ b/test/integration/targets/command_shell/tasks/main.yml
@@ -32,6 +32,12 @@
       - tar.warnings | length() == 1
       - '"Consider using the unarchive module rather than running ''tar''" in tar.warnings[0]'
 
+- name: use command with `ansible.builtin.` FQCN
+  ansible.builtin.command: /bin/ls
+
+- name: use command with `ansible.legacy.` FQCN
+  ansible.legacy.command: /bin/ls
+
 - name: use command to execute chown
   command: chown -h
   register: chown


### PR DESCRIPTION
##### SUMMARY
Unfortunately I missed something in backport #72458, namely that parsing/mod_args.py had its `FREEFORM_ACTIONS` set not from a set already containing FQCNs as in stable-2.10 and devel, but specified it explicitly, and thus also needed a `add_internal_fqcns()`.

With this PR, also
```.yaml
- ansible.builtin.command: /bin/ls
```
will work. Without it, the above fails.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/parsing/mod_args.py
