### PR TITLE
Document install_python_apt option of apt_repository

### DIFF
--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -81,11 +81,11 @@ options:
     install_python_apt:
         description:
             - Whether to automatically try to install Python apt or not, if it is not already installed.
-            - If python-apt Python library is not installed this module will not work.
+              Without this library, the module does not work.
             - Note that it is installed by running C(apt-get install python-apt) for Python 2, and C(apt-get install python3-apt) for Python 3.
-              If you are using a Python on the remote that is not the system Python, this will not work. In that case,
-              you should set I(install_python_apt=false) and need to ensure that the Python apt module for your
-              Python version is installed in another way.
+              If you are using a Python on the remote that is not the system Python 2 or Python 3, this will not work.
+              In that case, you should set I(install_python_apt=false) and you need to ensure that the Python apt library
+              for your Python version is installed some other way.
         type: bool
         default: true
 author:

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -80,12 +80,12 @@ options:
         version_added: '2.3'
     install_python_apt:
         description:
-            - Whether to automatically try to install Python apt or not, if it is not already installed.
+            - Whether to automatically try to install the Python apt library or not, if it is not already installed.
               Without this library, the module does not work.
-            - Note that it is installed by running C(apt-get install python-apt) for Python 2, and C(apt-get install python3-apt) for Python 3.
-              If you are using a Python on the remote that is not the system Python 2 or Python 3, this will not work.
-              In that case, you should set I(install_python_apt=false) and you need to ensure that the Python apt library
-              for your Python version is installed some other way.
+            - Runs C(apt-get install python-apt) for Python 2, and C(apt-get install python3-apt) for Python 3.
+            - Only works with the system Python 2 or Python 3. If you are using a Python on the remote that is not
+               the system Python, set I(install_python_apt=false) and ensure that the Python apt library
+               for your Python version is installed some other way.
         type: bool
         default: true
 author:

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -78,6 +78,12 @@ options:
               a non-Ubuntu target (for example, Debian or Mint).
         type: str
         version_added: '2.3'
+    install_python_apt:
+        description:
+            - Whether to install python apt or not, default is true
+            - If python-apt Python library is not installed this module will not work.
+        type: bool
+        default: true
 author:
 - Alexander Saltanov (@sashka)
 version_added: "0.7"

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -80,7 +80,7 @@ options:
         version_added: '2.3'
     install_python_apt:
         description:
-            - Whether to install python apt or not, default is true
+            - Whether to automatically install python apt or not, if it is not already installed.
             - If python-apt Python library is not installed this module will not work.
         type: bool
         default: true

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -80,8 +80,12 @@ options:
         version_added: '2.3'
     install_python_apt:
         description:
-            - Whether to automatically install python apt or not, if it is not already installed.
+            - Whether to automatically try to install Python apt or not, if it is not already installed.
             - If python-apt Python library is not installed this module will not work.
+            - Note that it is installed by running C(apt-get install python-apt) for Python 2, and C(apt-get install python3-apt) for Python 3.
+              If you are using a Python on the remote that is not the system Python, this will not work. In that case,
+              you should set I(install_python_apt=false) and need to ensure that the Python apt module for your
+              Python version is installed in another way.
         type: bool
         default: true
 author:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -73,10 +73,7 @@ lib/ansible/module_utils/urls.py pylint:blacklisted-name
 lib/ansible/module_utils/urls.py replace-urlopen
 lib/ansible/modules/apt.py validate-modules:parameter-invalid
 lib/ansible/modules/apt_key.py validate-modules:parameter-type-not-in-doc
-lib/ansible/modules/apt_repository.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/apt_repository.py validate-modules:parameter-invalid
-lib/ansible/modules/apt_repository.py validate-modules:parameter-type-not-in-doc
-lib/ansible/modules/apt_repository.py validate-modules:undocumented-parameter
 lib/ansible/modules/assemble.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/async_status.py use-argspec-type-path
 lib/ansible/modules/async_status.py validate-modules!skip


### PR DESCRIPTION
##### SUMMARY
This recovers the closed PR #70462.

Documenting this option a) reduces the number of ignore.txt entries, and b) allows users to make sure that no package is installed when not explicitly requested (in this case `python*-apt`).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
apt_repository
