### PR TITLE
Fixed typo in yum package

### DIFF
--- a/changelogs/fragments/72964-fixed-typo-in-yum-failure-message.yml
+++ b/changelogs/fragments/72964-fixed-typo-in-yum-failure-message.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - yum - Fixed typo in failure message (https://github.com/ansible/ansible/pull/72964).

--- a/lib/ansible/modules/yum.py
+++ b/lib/ansible/modules/yum.py
@@ -1006,7 +1006,7 @@ class YumModule(YumDnf):
                 # most common case is the pkg is already installed
                 envra = self.local_envra(package)
                 if envra is None:
-                    self.module.fail_json(msg="Failed to get nevra information from RPM package: %s" % spec)
+                    self.module.fail_json(msg="Failed to get envra information from RPM package: %s" % spec)
                 installed_pkgs = self.is_installed(repoq, envra)
                 if installed_pkgs:
                     res['results'].append('%s providing %s is already installed' % (installed_pkgs[0], package))
@@ -1322,7 +1322,7 @@ class YumModule(YumDnf):
                     envra = self.local_envra(spec)
 
                     if envra is None:
-                        self.module.fail_json(msg="Failed to get nevra information from RPM package: %s" % spec)
+                        self.module.fail_json(msg="Failed to get envra information from RPM package: %s" % spec)
 
                     # local rpm files can't be updated
                     if self.is_installed(repoq, envra):
@@ -1339,7 +1339,7 @@ class YumModule(YumDnf):
                     envra = self.local_envra(package)
 
                     if envra is None:
-                        self.module.fail_json(msg="Failed to get nevra information from RPM package: %s" % spec)
+                        self.module.fail_json(msg="Failed to get envra information from RPM package: %s" % spec)
 
                     # local rpm files can't be updated
                     if self.is_installed(repoq, envra):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I noticed in the output of a a failing yum installation that it was mentioning nevra.
(name-epoch:version-release.architecture output format ) 
However I believe in this case it is referring to something very similar: envra.
(epoch:name-version-release.architecture output format)

The variables are also called envra. So I fixed the typo.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
