### PR TITLE
Update pylint constraints for Python 3.9

### DIFF
--- a/changelogs/fragments/ansible-test-py39-constraints-update.yml
+++ b/changelogs/fragments/ansible-test-py39-constraints-update.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ansible-test - Depend on ``typed-ast`` 1.4.1 instead of 1.4.0, for Python 3.9 support (https://github.com/ansible/ansible/pull/72861).
+  - ansible-test - Allow ``pylint`` sanity dependency to be installed on Python 3.9 (https://github.com/ansible/ansible/pull/72861).

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -58,7 +58,7 @@ isort == 4.3.15
 lazy-object-proxy == 1.3.1
 mccabe == 0.6.1
 pylint == 2.3.1
-typed-ast == 1.4.0  # 1.4.0 is required to compile on Python 3.8
+typed-ast == 1.4.1  # 1.4.1 is required to compile on Python 3.9
 wrapt == 1.11.1
 
 # freeze pycodestyle for consistent test results

--- a/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
@@ -1,3 +1,3 @@
-pylint ; python_version < '3.9'  # installation fails on python 3.9.0b1
+pylint
 pyyaml  # needed for collection_detail.py
 mccabe  # pylint complexity testing


### PR DESCRIPTION

##### SUMMARY

Change:
- pylint now works on py39
- We need a newer typed-ast version for py39

Test Plan:
- Refs #72861 - which introduces Fedora 33.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Test Pull Request

##### COMPONENT NAME

ansible-test constraints