### PR TITLE
Update ansible-test pylint Python support.

### DIFF
--- a/changelogs/fragments/ansible-test-pylint-python-3.8-3.9.yml
+++ b/changelogs/fragments/ansible-test-pylint-python-3.8-3.9.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ansible-test - The ``pylint`` sanity test is now supported on Python 3.8.
+  - ansible-test - The ``pylint`` sanity test is now skipped with a warning on Python 3.9 due to unresolved regressions.

--- a/changelogs/fragments/ansible-test-pylint-python-3.8-3.9.yml
+++ b/changelogs/fragments/ansible-test-pylint-python-3.8-3.9.yml
@@ -1,3 +1,3 @@
 minor_changes:
   - ansible-test - The ``pylint`` sanity test is now supported on Python 3.8.
-  - ansible-test - The ``pylint`` sanity test is now skipped with a warning on Python 3.9 due to unresolved regressions.
+  - ansible-test - The ``pylint`` sanity test is now skipped with a warning on Python 3.9 due to unresolved upstream regressions.

--- a/test/integration/targets/ansible-test/ansible_collections/ns/col/plugins/filter/check_pylint.py
+++ b/test/integration/targets/ansible-test/ansible_collections/ns/col/plugins/filter/check_pylint.py
@@ -1,0 +1,21 @@
+"""
+These test cases verify ansible-test version constraints for pylint and its dependencies across Python versions.
+The initial test cases were discovered while testing various Python versions against ansible/ansible.
+"""
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+# Python 3.8 fails with astroid 2.2.5 but works on 2.3.3
+#   syntax-error: Cannot import 'string' due to syntax error 'invalid syntax (&lt;unknown&gt;, line 109)'
+# Python 3.9 fails with astroid 2.2.5 but works on 2.3.3
+#   syntax-error: Cannot import 'string' due to syntax error 'invalid syntax (&lt;unknown&gt;, line 104)'
+import string
+
+# Python 3.9 fails with pylint 2.3.1 or 2.4.4 with astroid 2.3.3 but works with pylint 2.5.0 and astroid 2.4.0
+#   'Call' object has no attribute 'value'
+result = {}[{}.get('something')]
+
+# pylint 2.3.1 and 2.4.4 report the following error but 2.5.0 and 2.6.0 do not
+#   blacklisted-name: Black listed name "foo"
+# see: https://github.com/PyCQA/pylint/issues/3701
+foo = {}.keys()

--- a/test/integration/targets/ansible-test/ansible_collections/ns/col/tests/sanity/ignore.txt
+++ b/test/integration/targets/ansible-test/ansible_collections/ns/col/tests/sanity/ignore.txt
@@ -1,3 +1,4 @@
+plugins/filter/check_pylint.py pylint:blacklisted-name
 plugins/modules/bad.py import
 plugins/modules/bad.py pylint:ansible-bad-module-import
 tests/integration/targets/hello/files/bad.py pylint:ansible-bad-function

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -53,12 +53,12 @@ antsibull-changelog == 0.7.0
 antsibull >= 0.21.0
 
 # freeze pylint and its requirements for consistent test results
-astroid == 2.2.5
+astroid == 2.3.3
 isort == 4.3.15
-lazy-object-proxy == 1.3.1
+lazy-object-proxy == 1.4.3
 mccabe == 0.6.1
 pylint == 2.3.1
-typed-ast == 1.4.0  # 1.4.0 is required to compile on Python 3.8
+typed-ast == 1.4.1
 wrapt == 1.11.1
 
 # freeze pycodestyle for consistent test results

--- a/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
@@ -1,3 +1,3 @@
-pylint ; python_version < '3.9'  # installation fails on python 3.9.0b1
+pylint
 pyyaml  # needed for collection_detail.py
 mccabe  # pylint complexity testing

--- a/test/lib/ansible_test/_internal/sanity/pylint.py
+++ b/test/lib/ansible_test/_internal/sanity/pylint.py
@@ -64,6 +64,14 @@ class PylintTest(SanitySingleVersion):
         """Error code for ansible-test matching the format used by the underlying test program, or None if the program does not use error codes."""
         return 'ansible-test'
 
+    @property
+    def supported_python_versions(self):  # type: () -> t.Optional[t.Tuple[str, ...]]
+        """A tuple of supported Python versions or None if the test does not depend on specific Python versions."""
+        # Python 3.9 is not supported on pylint < 2.5.0.
+        # Unfortunately pylint 2.5.0 and later include an unfixed regression.
+        # See: https://github.com/PyCQA/pylint/issues/3701
+        return tuple(python_version for python_version in super(PylintTest, self).supported_python_versions if python_version not in ('3.9',))
+
     def filter_targets(self, targets):  # type: (t.List[TestTarget]) -> t.List[TestTarget]
         """Return the given list of test targets, filtered to include only those relevant for the test."""
         return [target for target in targets if os.path.splitext(target.path)[1] == '.py' or is_subdir(target.path, 'bin')]

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -142,6 +142,7 @@ lib/ansible/plugins/lookup/sequence.py pylint:blacklisted-name
 lib/ansible/plugins/strategy/__init__.py pylint:blacklisted-name
 lib/ansible/plugins/strategy/linear.py pylint:blacklisted-name
 lib/ansible/vars/hostvars.py pylint:blacklisted-name
+test/integration/targets/ansible-test/ansible_collections/ns/col/plugins/filter/check_pylint.py pylint:blacklisted-name
 test/integration/targets/ansible-test-docker/ansible_collections/ns/col/plugins/modules/hello.py pylint:relative-beyond-top-level
 test/integration/targets/ansible-test-docker/ansible_collections/ns/col/tests/unit/plugins/module_utils/test_my_util.py pylint:relative-beyond-top-level
 test/integration/targets/ansible-test-docker/ansible_collections/ns/col/tests/unit/plugins/modules/test_hello.py pylint:relative-beyond-top-level


### PR DESCRIPTION
##### SUMMARY

Update ansible-test pylint Python support.

* Python 3.8 is now officially supported.
* Python 3.9 is now skipped with a warning.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

Replaces https://github.com/ansible/ansible/pull/72970
Resolves https://github.com/ansible/ansible/issues/67118
Resolves https://github.com/ansible/ansible/issues/72854
