### PR TITLE
Pass the top level dictionaries to combine_vars

### DIFF
--- a/changelogs/fragments/72979-fix-inventory-merge-hash-replace.yaml
+++ b/changelogs/fragments/72979-fix-inventory-merge-hash-replace.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - inventory - pass the vars dictionary to combine_vars instead of an individual key's value (https://github.com/ansible/ansible/issues/72975).

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -246,7 +246,7 @@ class Group:
         if key == 'ansible_group_priority':
             self.set_priority(int(value))
         else:
-            if key in self.vars:
+            if key in self.vars and isinstance(self.vars[key], MutableMapping) and isinstance(value, Mapping):
                 self.vars = combine_vars(self.vars, {key: value})
             else:
                 self.vars[key] = value

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -246,8 +246,8 @@ class Group:
         if key == 'ansible_group_priority':
             self.set_priority(int(value))
         else:
-            if key in self.vars and isinstance(self.vars[key], MutableMapping) and isinstance(value, Mapping):
-                self.vars[key] = combine_vars(self.vars[key], value)
+            if key in self.vars:
+                self.vars = combine_vars(self.vars, {key: value})
             else:
                 self.vars[key] = value
 

--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -142,7 +142,7 @@ class Host:
         return removed
 
     def set_variable(self, key, value):
-        if key in self.vars:
+        if key in self.vars and isinstance(self.vars[key], MutableMapping) and isinstance(value, Mapping):
             self.vars = combine_vars(self.vars, {key: value})
         else:
             self.vars[key] = value

--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -142,8 +142,8 @@ class Host:
         return removed
 
     def set_variable(self, key, value):
-        if key in self.vars and isinstance(self.vars[key], MutableMapping) and isinstance(value, Mapping):
-            self.vars[key] = combine_vars(self.vars[key], value)
+        if key in self.vars:
+            self.vars = combine_vars(self.vars, {key: value})
         else:
             self.vars[key] = value
 


### PR DESCRIPTION
##### SUMMARY
Fixes #72975

combine_vars uses dict.update() to replace keys

What we're doing now:
```
>>> vars1 = {'test_hash': {'key1': 'value1', 'key2': 'value2'}}
>>> vars2 = {'test_hash': {'key1': 'newvalue'}}
>>> vars1['test_hash'].update(vars2['test_hash'])
>>> vars1
{'test_hash': {'key1': 'newvalue', 'key2': 'value2'}}
```

What this change does:
```
>>> vars1 = {'test_hash': {'key1': 'value1', 'key2': 'value2'}}
>>> vars2 = {'test_hash': {'key1': 'newvalue'}}
>>> vars1.update(vars2)
>>> vars1
{'test_hash': {'key1': 'newvalue'}}
```

##### ISSUE TYPE
- Bugfix Pull Request
