### PR TITLE
[stable-2.9] Add coverage exporting to ansible-test

### DIFF
--- a/changelogs/fragments/ansible-test-coverage-combine-export.yml
+++ b/changelogs/fragments/ansible-test-coverage-combine-export.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Added a ``--export`` option to the ``ansible-test coverage combine`` command to facilitate multi-stage aggregation of coverage in CI pipelines.

--- a/changelogs/fragments/ansible-test-venv-system-site-packages.yml
+++ b/changelogs/fragments/ansible-test-venv-system-site-packages.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "ansible-test - added a ``--venv-system-site-packages`` option for use with the ``--venv`` option"

--- a/test/lib/ansible_test/_internal/cli.py
+++ b/test/lib/ansible_test/_internal/cli.py
@@ -654,6 +654,12 @@ def add_environments(parser, tox_version=False, tox_only=False):
                               action='store_true',
                               help='run from ansible-test managed virtual environments')
 
+    venv = parser.add_argument_group(title='venv arguments')
+
+    venv.add_argument('--venv-system-site-packages',
+                      action='store_true',
+                      help='enable system site packages')
+
     if data_context().content.is_ansible:
         if tox_version:
             environments.add_argument('--tox',

--- a/test/lib/ansible_test/_internal/cli.py
+++ b/test/lib/ansible_test/_internal/cli.py
@@ -760,6 +760,9 @@ def add_extra_coverage_options(parser):
                         action='store_true',
                         help='generate empty report of all python/powershell source files')
 
+    parser.add_argument('--export',
+                        help='directory to export combined coverage files to')
+
 
 def add_httptester_options(parser, argparse):
     """

--- a/test/lib/ansible_test/_internal/config.py
+++ b/test/lib/ansible_test/_internal/config.py
@@ -320,6 +320,7 @@ class CoverageConfig(EnvironmentConfig):
         self.group_by = frozenset(args.group_by) if 'group_by' in args and args.group_by else set()  # type: t.FrozenSet[str]
         self.all = args.all if 'all' in args else False  # type: bool
         self.stub = args.stub if 'stub' in args else False  # type: bool
+        self.export = args.export if 'export' in args else None  # type: str
         self.coverage = False  # temporary work-around to support intercept_command in cover.py
 
 

--- a/test/lib/ansible_test/_internal/config.py
+++ b/test/lib/ansible_test/_internal/config.py
@@ -44,6 +44,7 @@ class EnvironmentConfig(CommonConfig):
 
         self.local = args.local is True
         self.venv = args.venv
+        self.venv_system_site_packages = args.venv_system_site_packages
 
         if args.tox is True or args.tox is False or args.tox is None:
             self.tox = args.tox is True

--- a/test/lib/ansible_test/_internal/delegation.py
+++ b/test/lib/ansible_test/_internal/delegation.py
@@ -245,14 +245,20 @@ def delegate_venv(args,  # type: EnvironmentConfig
         if needs_httptester:
             display.warning('Use --docker or --remote to enable httptester for tests marked "needs/httptester": %s' % ', '.join(needs_httptester))
 
-    venvs = dict((version, os.path.join(ResultType.TMP.path, 'delegation', 'python%s' % version)) for version in versions)
-    venvs = dict((version, path) for version, path in venvs.items() if create_virtual_environment(args, version, path))
+    if args.venv_system_site_packages:
+        suffix = '-ssp'
+    else:
+        suffix = ''
+
+    venvs = dict((version, os.path.join(ResultType.TMP.path, 'delegation', 'python%s%s' % (version, suffix))) for version in versions)
+    venvs = dict((version, path) for version, path in venvs.items() if create_virtual_environment(args, version, path, args.venv_system_site_packages))
 
     if not venvs:
         raise ApplicationError('No usable virtual environment support found.')
 
     options = {
         '--venv': 0,
+        '--venv-system-site-packages': 0,
     }
 
     with tempdir() as inject_path:


### PR DESCRIPTION
##### SUMMARY

A new `--export` option for `ansible-test coverage combine` allows multi-step aggregation of code coverage for CI pipelines.

(cherry picked from commit fa2be89cd44f0c867f24351c3ba73d5e849cb507)

Backport of https://github.com/ansible/ansible/pull/72563

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

This allows use of code coverage on Azure Pipelines, which requires a separate aggregation step.