### PR TITLE
ExecutionPolicy default value is RemoteSigned

### DIFF
--- a/changelogs/fragments/72993-ansible-doc-has_action.yml
+++ b/changelogs/fragments/72993-ansible-doc-has_action.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "ansible-doc - In Windows setup steps, ``ExecutionPolicy`` should be restored to default value ``RemoteSigned`` (https://github.com/ansible/ansible/pull/72993)."

--- a/docs/docsite/rst/user_guide/windows_setup.rst
+++ b/docs/docsite/rst/user_guide/windows_setup.rst
@@ -49,7 +49,7 @@ This is an example of how to run this script from PowerShell:
     &$file -Version 5.1 -Username $username -Password $password -Verbose
 
 Once completed, you will need to remove auto logon
-and set the execution policy back to the default of ``RemoteSigned``. You can
+and set the execution policy back to the default (``Restricted `` for Windows clients, or ``RemoteSigned`` for Windows servers). You can
 do this with the following PowerShell commands:
 
 .. code-block:: powershell

--- a/docs/docsite/rst/user_guide/windows_setup.rst
+++ b/docs/docsite/rst/user_guide/windows_setup.rst
@@ -49,13 +49,13 @@ This is an example of how to run this script from PowerShell:
     &$file -Version 5.1 -Username $username -Password $password -Verbose
 
 Once completed, you will need to remove auto logon
-and set the execution policy back to the default of ``Restricted``. You can
+and set the execution policy back to the default of ``RemoteSigned``. You can
 do this with the following PowerShell commands:
 
 .. code-block:: powershell
 
     # This isn't needed but is a good security practice to complete
-    Set-ExecutionPolicy -ExecutionPolicy Restricted -Force
+    Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Force
 
     $reg_winlogon_path = "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\Winlogon"
     Set-ItemProperty -Path $reg_winlogon_path -Name AutoAdminLogon -Value 0


### PR DESCRIPTION
##### SUMMARY
In Windows setup steps, settings `ExecutionPolicy` is restored to value `Restricted`. But actually default value for Windows server is not `Restricted` but `RemoteSigned` ([source](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7.1#default)).

I have got issue with `win_dsc` because `ExecutionPolicy` was `Restricted`.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr
