### PR TITLE
ansible-test - prefer venv over virtualenv on Python 3

### DIFF
--- a/changelogs/fragments/ansible-test-venv-virtualenv-fallback.yml
+++ b/changelogs/fragments/ansible-test-venv-virtualenv-fallback.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ansible-test - virtualenv helper scripts now prefer ``venv`` on Python 3 over ``virtualenv``
+  - ansible-test - remote macOS instances no longer install ``virtualenv`` during provisioning

--- a/test/lib/ansible_test/_data/injector/virtualenv-isolated.sh
+++ b/test/lib/ansible_test/_data/injector/virtualenv-isolated.sh
@@ -2,7 +2,13 @@
 # Create and activate a fresh virtual environment with `source virtualenv-isolated.sh`.
 
 rm -rf "${OUTPUT_DIR}/venv"
-"${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m virtualenv --python "${ANSIBLE_TEST_PYTHON_INTERPRETER}" "${OUTPUT_DIR}/venv"
+
+# Try to use 'venv' if it is available, then fallback to 'virtualenv' since some systems provide 'venv' although it is non-functional.
+if [[ "${ANSIBLE_TEST_PYTHON_VERSION}" =~ ^2\. ]] || ! "${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m venv "${OUTPUT_DIR}/venv" > /dev/null 2>&1; then
+    rm -rf "${OUTPUT_DIR}/venv"
+    "${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m virtualenv --python "${ANSIBLE_TEST_PYTHON_INTERPRETER}" "${OUTPUT_DIR}/venv"
+fi
+
 set +ux
 source "${OUTPUT_DIR}/venv/bin/activate"
 set -ux

--- a/test/lib/ansible_test/_data/injector/virtualenv.sh
+++ b/test/lib/ansible_test/_data/injector/virtualenv.sh
@@ -2,7 +2,13 @@
 # Create and activate a fresh virtual environment with `source virtualenv.sh`.
 
 rm -rf "${OUTPUT_DIR}/venv"
-"${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m virtualenv --system-site-packages --python "${ANSIBLE_TEST_PYTHON_INTERPRETER}" "${OUTPUT_DIR}/venv"
+
+# Try to use 'venv' if it is available, then fallback to 'virtualenv' since some systems provide 'venv' although it is non-functional.
+if [[ "${ANSIBLE_TEST_PYTHON_VERSION}" =~ ^2\. ]] || ! "${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m venv --system-site-packages "${OUTPUT_DIR}/venv" > /dev/null 2>&1; then
+    rm -rf "${OUTPUT_DIR}/venv"
+    "${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m virtualenv --system-site-packages --python "${ANSIBLE_TEST_PYTHON_INTERPRETER}" "${OUTPUT_DIR}/venv"
+fi
+
 set +ux
 source "${OUTPUT_DIR}/venv/bin/activate"
 set -ux

--- a/test/lib/ansible_test/_data/setup/remote.sh
+++ b/test/lib/ansible_test/_data/setup/remote.sh
@@ -88,18 +88,10 @@ elif [ "${platform}" = "centos" ]; then
     done
 
     install_pip
-elif [ "${platform}" = "macos" ]; then
-    while true; do
-        pip3 install --disable-pip-version-check --quiet \
-            'virtualenv<20' \
-        && break
-        echo "Failed to install packages. Sleeping before trying again..."
-        sleep 10
-    done
 elif [ "${platform}" = "osx" ]; then
     while true; do
         pip install --disable-pip-version-check --quiet \
-            'virtualenv<20' \
+            'virtualenv==16.7.10' \
         && break
         echo "Failed to install packages. Sleeping before trying again..."
         sleep 10


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Also pin `virtualenv` to 16.7.10 for older Mac OS X systems. This was the version being installed anway with the previous constraint (<20).

On systems with Python 3, now prefer `venv` over `virtualenv`. Test to see if `venv` is functional since some systems have a non-functional `venv` installation (such as Debian).

Supersedes #72778
Fixes: #72738
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`changelogs/fragments/ansible-test-venv-virtualenv-fallback.yml`
`test/lib/ansible_test/_data/injector/virtualenv-isolated.sh`
`test/lib/ansible_test/_data/injector/virtualenv.sh`
`test/lib/ansible_test/_data/setup/remote.sh`
