### PR TITLE
[facts] fix version facts on FreeBSD RC/PRERELEASE

### DIFF
--- a/changelogs/fragments/72331-truenas-rc-major-version.yml
+++ b/changelogs/fragments/72331-truenas-rc-major-version.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - distribution facts - Allow ``distribution_major_version`` and ``distribution_version`` to work for RC and PRERELEASE versions of FreeBSD (and derived distributions) (https://github.com/ansible/ansible/issues/72331).

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -586,7 +586,7 @@ class Distribution(object):
     def get_distribution_FreeBSD(self):
         freebsd_facts = {}
         freebsd_facts['distribution_release'] = platform.release()
-        data = re.search(r'(\d+)\.(\d+)-(RELEASE|STABLE|CURRENT).*', freebsd_facts['distribution_release'])
+        data = re.search(r'(\d+)\.(\d+)-(RELEASE|STABLE|CURRENT|RC|PRERELEASE).*', freebsd_facts['distribution_release'])
         if 'trueos' in platform.version():
             freebsd_facts['distribution'] = 'TrueOS'
         if data:

--- a/test/units/module_utils/facts/system/distribution/fixtures/truenas_12.0rc1.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/truenas_12.0rc1.json
@@ -1,0 +1,39 @@
+{
+    "name": "FreeBSD 12.2",
+    "distro": {
+        "codename": "",
+        "id": "freebsd",
+        "name": "FreeBSD",
+        "version": "12.2",
+        "version_best": "12.2",
+        "lsb_release_info": {},
+        "os_release_info": {
+            "name": "FreeBSD",
+            "version": "12.2-PRERELEASE",
+            "version_id": "12.2",
+            "id": "freebsd",
+            "ansi_color": "0;31",
+            "pretty_name": "FreeBSD 12.2-PRERELEASE",
+            "cpe_name": "cpe:/o:freebsd:freebsd:12.2",
+            "home_url": "https://FreeBSD.org/",
+            "bug_report_url": "https://bugs.FreeBSD.org/"
+        }
+    },
+    "input": {
+        "/etc/os-release": "NAME=FreeBSD\nVERSION=12.2-PRERELEASE\nVERSION_ID=12.2\nID=freebsd\nANSI_COLOR=\"0;31\"\nPRETTY_NAME=\"FreeBSD 12.2-PRERELEASE\"\nCPE_NAME=cpe:/o:freebsd:freebsd:12.2\nHOME_URL=https://FreeBSD.org/\nBUG_REPORT_URL=https://bugs.FreeBSD.org/\n"
+    },
+    "platform.dist": [
+        "freebsd",
+        "12.2",
+        ""
+    ],
+    "result": {
+        "distribution": "FreeBSD",
+        "distribution_version": "12.2",
+        "distribution_release": "12.2-PRERELEASE",
+        "distribution_major_version": "12",
+        "os_family": "FreeBSD"
+    },
+    "platform.system": "FreeBSD",
+    "platform.release": "12.2-PRERELEASE"
+}


### PR DESCRIPTION

##### SUMMARY

Change:
- The FreeBSD release can contain -RC or -PRERELEASE in addition to
  -RELEASE, -STABLE, or -CURRENT.

Test Plan:
- Added new fixed from an RC version of TrueNAS which uses a -PRERELEASE
  version of FreeBSD.

Tickets:
- Fixes #72331

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

distribution facts