### PR TITLE
Use a pty for local connections

### DIFF
--- a/changelogs/fragments/enable_su_on_local.yaml
+++ b/changelogs/fragments/enable_su_on_local.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - allow become method 'su' to work on 'local' connection by allocating a fake tty.

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -17,6 +17,7 @@ DOCUMENTATION = '''
 '''
 
 import os
+import pty
 import shutil
 import subprocess
 import fcntl
@@ -79,15 +80,29 @@ class Connection(ConnectionBase):
         else:
             cmd = map(to_bytes, cmd)
 
+        # Create a pty. Fallback to using a standard pipe if this fails (which may
+        # cause the command to fail in certain situations where we are escalating
+        # privileges or the command otherwise needs a pty)
+        try:
+            master, stdin = pty.openpty()
+        except:
+            master = None
+            stdin = subprocess.PIPE
+
         p = subprocess.Popen(
             cmd,
             shell=isinstance(cmd, (text_type, binary_type)),
             executable=executable,
             cwd=self.cwd,
-            stdin=subprocess.PIPE,
+            stdin=stdin,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
+
+        # if we created a master, we can close the other half of the pty now
+        if master:
+            os.close(stdin)
+
         display.debug("done running command with Popen()")
 
         if self.become and self.become.expect_prompt() and sudoable:
@@ -120,13 +135,18 @@ class Connection(ConnectionBase):
 
             if not self.become.check_success(become_output):
                 become_pass = self.become.get_option('become_pass', playcontext=self._play_context)
-                p.stdin.write(to_bytes(become_pass, errors='surrogate_or_strict') + b'\n')
+                os.write(master, to_bytes(become_pass, errors='surrogate_or_strict') + b'\n')
+
             fcntl.fcntl(p.stdout, fcntl.F_SETFL, fcntl.fcntl(p.stdout, fcntl.F_GETFL) & ~os.O_NONBLOCK)
             fcntl.fcntl(p.stderr, fcntl.F_SETFL, fcntl.fcntl(p.stderr, fcntl.F_GETFL) & ~os.O_NONBLOCK)
 
         display.debug("getting output with communicate()")
         stdout, stderr = p.communicate(in_data)
         display.debug("done communicating")
+
+        # finally, close the other half of the pty, if it was created
+        if master:
+            os.close(master)
 
         display.debug("done with local.exec_command()")
         return (p.returncode, stdout, stderr)

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -85,7 +85,8 @@ class Connection(ConnectionBase):
         # privileges or the command otherwise needs a pty)
         try:
             master, stdin = pty.openpty()
-        except:
+        except (IOError, OSError) as e:
+            display.debug("Unable to open pty: %s" % to_native(e))
             master = None
             stdin = subprocess.PIPE
 

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -39,7 +39,7 @@ class Connection(ConnectionBase):
     ''' Local based connections '''
 
     transport = 'local'
-    has_pipelining = True
+    has_pipelining = False
 
     def __init__(self, *args, **kwargs):
 

--- a/test/integration/targets/become_su/aliases
+++ b/test/integration/targets/become_su/aliases
@@ -1,0 +1,3 @@
+destructive
+shippable/posix/group1
+skip/aix

--- a/test/integration/targets/become_su/runme.sh
+++ b/test/integration/targets/become_su/runme.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# ensure we execute su with a pseudo terminal
+[ "$(ansible -a whoami --become-method=su localhost --become)" != "su: requires a terminal to execute" ]


### PR DESCRIPTION
Fixes #38696
rebase of #39024

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
connection/local

#### ADDITIONAL INFO
test:
```
notroot#>ansible -a whoami --become-method=su localhost --become
```

Error w/o patch
```
localhost | FAILED | rc=-1 >>
privilege output closed while waiting for password prompt:\
su: requires a terminal to execute
```

After patch:
```
localhost | CHANGED | rc=0 >>
root
```