### PR TITLE
apply owner/group permissions to top folder with unarchive module

### DIFF
--- a/changelogs/fragments/73024-unarchive-apply-permissions-top-folder.yml
+++ b/changelogs/fragments/73024-unarchive-apply-permissions-top-folder.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - unarchive - apply ``owner`` and ``group`` permissions to top folder (https://github.com/ansible/ansible/issues/35426)

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -1038,7 +1038,7 @@ def main():
             res_args['changed'] = True
 
     top_folder_name = handler.files_in_archive[0].split('/')[0]
-    file_args['path'] = "{0}/{1}".format(dest, top_folder_name)
+    file_args['path'] = "%s/%s" % (dest, top_folder_name)
     res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'], expand=False)
 
     # Get diff if required

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -1038,7 +1038,7 @@ def main():
             res_args['changed'] = True
 
     top_folder_name = handler.files_in_archive[0].split('/')[0]
-    file_args['path'] = "{}/{}".format(dest,top_folder_name)
+    file_args['path'] = "{}/{}".format(dest, top_folder_name)
     res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'], expand=False)
 
     # Get diff if required

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -1037,10 +1037,6 @@ def main():
         else:
             res_args['changed'] = True
 
-    top_folder_name = handler.files_in_archive[0].split('/')[0]
-    file_args['path'] = "%s/%s" % (dest, top_folder_name)
-    res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'], expand=False)
-
     # Get diff if required
     if check_results.get('diff', False):
         res_args['diff'] = {'prepared': check_results['diff']}

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -1037,6 +1037,10 @@ def main():
         else:
             res_args['changed'] = True
 
+    top_folder_name = handler.files_in_archive[0].split('/')[0]
+    file_args['path'] = "{}/{}".format(dest,top_folder_name)
+    res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'], expand=False)
+
     # Get diff if required
     if check_results.get('diff', False):
         res_args['diff'] = {'prepared': check_results['diff']}

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -1038,7 +1038,7 @@ def main():
             res_args['changed'] = True
 
     top_folder_name = handler.files_in_archive[0].split('/')[0]
-    file_args['path'] = "{}/{}".format(dest, top_folder_name)
+    file_args['path'] = "{0}/{1}".format(dest, top_folder_name)
     res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'], expand=False)
 
     # Get diff if required

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -1037,10 +1037,6 @@ def main():
         else:
             res_args['changed'] = True
 
-    top_folder_name = handler.files_in_archive[0].split('/')[0]
-    file_args['path'] = "%s/%s" % (dest, top_folder_name)
-    res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'], expand=False)
-
     # Get diff if required
     if check_results.get('diff', False):
         res_args['diff'] = {'prepared': check_results['diff']}
@@ -1048,6 +1044,10 @@ def main():
     # Run only if we found differences (idempotence) or diff was missing
     if res_args.get('diff', True) and not module.check_mode:
         # do we need to change perms?
+        if handler.files_in_archive and '/' in handler.files_in_archive[0]:
+            top_folder_name = handler.files_in_archive[0].split('/')[0]
+            file_args['path'] = "%s/%s" % (dest, top_folder_name)
+            res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'], expand=False)
         for filename in handler.files_in_archive:
             file_args['path'] = os.path.join(b_dest, to_bytes(filename, errors='surrogate_or_strict'))
 

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -1044,10 +1044,6 @@ def main():
     # Run only if we found differences (idempotence) or diff was missing
     if res_args.get('diff', True) and not module.check_mode:
         # do we need to change perms?
-        if handler.files_in_archive and '/' in handler.files_in_archive[0]:
-            top_folder_name = handler.files_in_archive[0].split('/')[0]
-            file_args['path'] = "%s/%s" % (dest, top_folder_name)
-            res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'], expand=False)
         for filename in handler.files_in_archive:
             file_args['path'] = os.path.join(b_dest, to_bytes(filename, errors='surrogate_or_strict'))
 

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -19,3 +19,4 @@
 - import_tasks: test_unprivileged_user.yml
 - import_tasks: test_different_language_var.yml
 - import_tasks: test_invalid_options.yml
+- import_tasks: test_ownership_top_folder.yml

--- a/test/integration/targets/unarchive/tasks/test_ownership_top_folder.yml
+++ b/test/integration/targets/unarchive/tasks/test_ownership_top_folder.yml
@@ -1,0 +1,75 @@
+- name: Create unarchivetest3 user
+  user:
+    name: unarchivetest3
+    group: "{{ group_table[ansible_facts['distribution']] | default(omit) }}"
+  register: user
+  vars:
+    group_table:
+      MacOSX: staff
+
+- name: Test unarchiving as root and apply different ownership to top folder
+  become: yes
+  become_user: root
+  block:
+
+    - name: Create top folder owned by root
+      file:
+        path: "{{ user.home }}/tarball-top-folder"
+        state: directory
+        owner: root
+        group: root
+
+    - name: Add a file owned by root
+      copy:
+        src: foo.txt
+        dest: "{{ user.home }}/tarball-top-folder/foo-unarchive.txt"
+        mode: preserve
+
+    - name: Create a tarball as root
+      shell: tar -czf test-tarball.tar.gz tarball-top-folder/
+      args:
+        chdir: "{{ user.home }}"
+        creates: "{{ user.home }}/test-tarball.tar.gz"
+
+    - name: Create unarchive destination folder in /home/unarchivetest3/unarchivetest3-unarchive
+      file:
+        path: "{{ user.home }}/unarchivetest3-unarchive"
+        state: directory
+        owner: unarchivetest3
+        group: "{{ user.group }}"
+
+    - name: unarchive the tarball as root. apply ownership for unarchivetest3
+      unarchive:
+        src: "{{ user.home }}/test-tarball.tar.gz"
+        dest: "{{ user.home }}/unarchivetest3-unarchive"
+        remote_src: yes
+        list_files: True
+        owner: unarchivetest3
+        group: "{{ user.group }}"
+      register: unarchive30
+
+    - name: Stat the extracted top folder
+      stat:
+        path: "{{ user.home }}/unarchivetest3-unarchive/tarball-top-folder"
+      register: top_folder_info
+
+    - name: verify that extracted top folder is owned by unarchivetest3
+      assert:
+        that:
+          - top_folder_info.stat.pw_name == "unarchivetest3"
+          - top_folder_info.stat.gid == {{ user.group }}
+
+  always:
+    - name: remove our unarchivetest3 user and files
+      user:
+        name: unarchivetest3
+        state: absent
+        remove: yes
+      become: no
+
+    - name: Remove user home directory on macOS
+      file:
+        path: /Users/unarchivetest3
+        state: absent
+      become: no
+      when: ansible_facts.distribution == 'MacOSX'

--- a/test/integration/targets/unarchive/tasks/test_ownership_top_folder.yml
+++ b/test/integration/targets/unarchive/tasks/test_ownership_top_folder.yml
@@ -17,7 +17,6 @@
         path: "{{ user.home }}/tarball-top-folder"
         state: directory
         owner: root
-        group: root
 
     - name: Add a file owned by root
       copy:

--- a/test/integration/targets/unarchive/tasks/test_ownership_top_folder.yml
+++ b/test/integration/targets/unarchive/tasks/test_ownership_top_folder.yml
@@ -45,7 +45,6 @@
         list_files: True
         owner: unarchivetest3
         group: "{{ user.group }}"
-      register: unarchive30
 
     - name: Stat the extracted top folder
       stat:

--- a/test/integration/targets/unarchive/tasks/test_ownership_top_folder.yml
+++ b/test/integration/targets/unarchive/tasks/test_ownership_top_folder.yml
@@ -17,6 +17,7 @@
         path: "{{ user.home }}/tarball-top-folder"
         state: directory
         owner: root
+        group: root
 
     - name: Add a file owned by root
       copy:
@@ -45,6 +46,7 @@
         list_files: True
         owner: unarchivetest3
         group: "{{ user.group }}"
+      register: unarchive30
 
     - name: Stat the extracted top folder
       stat:

--- a/test/integration/targets/unarchive/tasks/test_ownership_top_folder.yml
+++ b/test/integration/targets/unarchive/tasks/test_ownership_top_folder.yml
@@ -24,8 +24,8 @@
         dest: "{{ user.home }}/tarball-top-folder/foo-unarchive.txt"
         mode: preserve
 
-    - name: Create a tarball as root
-      shell: tar -czf test-tarball.tar.gz tarball-top-folder/
+    - name: Create a tarball as root. This tarball won't list the top folder when doing "tar tvf test-tarball.tar.gz"
+      shell: tar -czf test-tarball.tar.gz tarball-top-folder/foo-unarchive.txt
       args:
         chdir: "{{ user.home }}"
         creates: "{{ user.home }}/test-tarball.tar.gz"


### PR DESCRIPTION
##### SUMMARY

Quick&dirty PoC to fix https://github.com/ansible/ansible/issues/35426

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
unarchive

##### ADDITIONAL INFORMATION

Module `unarchive` doesn't apply the `owner` and `group` permissions to the extracted **top** folder. The issue is described in https://github.com/ansible/ansible/issues/35426

This is a quick&dirty PoC to apply the same owner/group to the top folder. I am aware this is not ready to be merged (I have only tested with a tar.gz in linux) but before investing more time on it I would like to ask the maintainers if this can be merged if it's improved.

I attach a playbook to test it:

With the current `unarchive` module the extracted top folder `/tmp/apache-tomcat-8.5.27` will be owned by root. Using this patch the top folder is owned by the owner/group arguments passed to the unarchive module (user `pablo` in this example, adapt to a existing user in your system for testing) . You should execute this playbook as a regular non-root user doing: `ansible-playbook -K unarchive-test-playbook.yml`

```yaml

---

- name: Test the unarchive owner/group permissions for top folder
  hosts: localhost
  gather_facts: True
  become: true

  vars:

    file_to_download: https://archive.apache.org/dist/tomcat/tomcat-8/v8.5.27/bin/apache-tomcat-8.5.27.tar.gz
    file_checksum: sha256:ad78d0908a5dabf722cd378364ba02b1cbd58f3515ba2f1833f334bf6dcec448
    destination_folder: /tmp
    owner_user: pablo
    owner_group: pablo

  tasks:

    - name: Download the compressed file
      get_url:
        url: "{{ file_to_download }}"
        dest: "{{ destination_folder }}"
        checksum: "{{ file_checksum }}"
      register: download

    - name: set a variable with the full path of the downloaded file
      set_fact:
        tarball_path: "{{ download.dest }}"

    - name: Uncompress the file to {{ destination_folder }}
      unarchive:
        src: "{{ tarball_path }}"
        dest: "{{ destination_folder }}"
        remote_src: yes
        owner: "{{ owner_user }}"
        group: "{{ owner_group }}"

    - name: Find the folder where the tomcat tarball has been uncompressed
      find:
        paths: "{{ destination_folder }}"
        patterns: 'apache-tomcat*'
        file_type: directory
      register: find_result

     # [files] is a list of dicts with the info of all the directories starting by apache-tomcat*
     # we fetch the path of last element in the list
    - name: set a variable with the path where the tarball has been uncompressed
      set_fact:
        tomcat_path: "{{ find_result['files'][-1]['path'] }}"

    - name: List the contents of the tomcat folder
      shell: "ls -la {{ tomcat_path }}"
      register: ls_output
      changed_when: false

    - name: print the output of shell. Check owner of folder "."
      debug:
        var: ls_output.stdout_lines
```
