### PR TITLE
[facts] Differentiate CentOS vs CentOS Stream

### DIFF
--- a/changelogs/fragments/73027-differentiate-centos-stream.yml
+++ b/changelogs/fragments/73027-differentiate-centos-stream.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - distribution facts - ``distribution_release`` is now ``"Stream"`` on CentOS Stream (https://github.com/ansible/ansible/issues/73027).

--- a/hacking/tests/gen_distribution_version_testcase.py
+++ b/hacking/tests/gen_distribution_version_testcase.py
@@ -25,6 +25,7 @@ from ansible.module_utils._text import to_text
 filelist = [
     '/etc/oracle-release',
     '/etc/slackware-version',
+    '/etc/centos-release',
     '/etc/redhat-release',
     '/etc/vmware-release',
     '/etc/openwrt_release',

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -55,6 +55,7 @@ class DistributionFiles:
         {'path': '/etc/altlinux-release', 'name': 'Altlinux'},
         {'path': '/etc/oracle-release', 'name': 'OracleLinux'},
         {'path': '/etc/slackware-version', 'name': 'Slackware'},
+        {'path': '/etc/centos-release', 'name': 'CentOS'},
         {'path': '/etc/redhat-release', 'name': 'RedHat'},
         {'path': '/etc/vmware-release', 'name': 'VMwareESX', 'allowempty': True},
         {'path': '/etc/openwrt_release', 'name': 'OpenWrt'},
@@ -440,6 +441,15 @@ class DistributionFiles:
             clear_facts['distribution_release'] = release.groups()[0]
         return True, clear_facts
 
+    def parse_distribution_file_CentOS(self, name, data, path, collected_facts):
+        centos_facts = {}
+
+        if 'CentOS Stream' in data:
+            centos_facts['distribution_release'] = 'Stream'
+            return True, centos_facts
+
+        return False, centos_facts
+
 
 class Distribution(object):
     """
@@ -449,40 +459,6 @@ class Distribution(object):
 
     This is unit tested. Please extend the tests to cover all distributions if you have them available.
     """
-
-    # every distribution name mentioned here, must have one of
-    #  - allowempty == True
-    #  - be listed in SEARCH_STRING
-    #  - have a function get_distribution_DISTNAME implemented
-    OSDIST_LIST = (
-        {'path': '/etc/oracle-release', 'name': 'OracleLinux'},
-        {'path': '/etc/slackware-version', 'name': 'Slackware'},
-        {'path': '/etc/redhat-release', 'name': 'RedHat'},
-        {'path': '/etc/vmware-release', 'name': 'VMwareESX', 'allowempty': True},
-        {'path': '/etc/openwrt_release', 'name': 'OpenWrt'},
-        {'path': '/etc/system-release', 'name': 'Amazon'},
-        {'path': '/etc/alpine-release', 'name': 'Alpine'},
-        {'path': '/etc/arch-release', 'name': 'Archlinux', 'allowempty': True},
-        {'path': '/etc/os-release', 'name': 'SUSE'},
-        {'path': '/etc/SuSE-release', 'name': 'SUSE'},
-        {'path': '/etc/gentoo-release', 'name': 'Gentoo'},
-        {'path': '/etc/os-release', 'name': 'Debian'},
-        {'path': '/etc/lsb-release', 'name': 'Mandriva'},
-        {'path': '/etc/altlinux-release', 'name': 'Altlinux'},
-        {'path': '/etc/sourcemage-release', 'name': 'SMGL'},
-        {'path': '/usr/lib/os-release', 'name': 'ClearLinux'},
-        {'path': '/etc/coreos/update.conf', 'name': 'Coreos'},
-        {'path': '/etc/flatcar/update.conf', 'name': 'Flatcar'},
-        {'path': '/etc/os-release', 'name': 'NA'},
-    )
-
-    SEARCH_STRING = {
-        'OracleLinux': 'Oracle Linux',
-        'RedHat': 'Red Hat',
-        'Altlinux': 'ALT Linux',
-        'ClearLinux': 'Clear Linux Software for Intel Architecture',
-        'SMGL': 'Source Mage GNU/Linux',
-    }
 
     # keep keys in sync with Conditionals page of docs
     OS_FAMILY_MAP = {'RedHat': ['RedHat', 'Fedora', 'CentOS', 'Scientific', 'SLC',

--- a/test/units/module_utils/facts/system/distribution/fixtures/centos_8_1.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/centos_8_1.json
@@ -1,0 +1,54 @@
+{
+    "name": "CentOS 8.1",
+    "distro": {
+        "codename": "Core",
+        "id": "centos",
+        "name": "CentOS Linux",
+        "version": "8",
+        "version_best": "8.1.1911",
+        "lsb_release_info": {
+            "lsb_version": ":core-4.1-amd64:core-4.1-noarch:cxx-4.1-amd64:cxx-4.1-noarch:desktop-4.1-amd64:desktop-4.1-noarch:languages-4.1-amd64:languages-4.1-noarch:printing-4.1-amd64:printing-4.1-noarch",
+            "distributor_id": "CentOS",
+            "description": "CentOS Linux release 8.1.1911 (Core)",
+            "release": "8.1.1911",
+            "codename": "Core"
+        },
+        "os_release_info": {
+            "name": "CentOS Linux",
+            "version": "8 (Core)",
+            "id": "centos",
+            "id_like": "rhel fedora",
+            "version_id": "8",
+            "platform_id": "platform:el8",
+            "pretty_name": "CentOS Linux 8 (Core)",
+            "ansi_color": "0;31",
+            "cpe_name": "cpe:/o:centos:centos:8",
+            "home_url": "https://www.centos.org/",
+            "bug_report_url": "https://bugs.centos.org/",
+            "centos_mantisbt_project": "CentOS-8",
+            "centos_mantisbt_project_version": "8",
+            "redhat_support_product": "centos",
+            "redhat_support_product_version": "8",
+            "codename": "Core"
+        }
+    },
+    "input": {
+        "/etc/centos-release": "CentOS Linux release 8.1.1911 (Core) \n",
+        "/etc/redhat-release": "CentOS Linux release 8.1.1911 (Core) \n",
+        "/etc/system-release": "CentOS Linux release 8.1.1911 (Core) \n",
+        "/etc/os-release": "NAME=\"CentOS Linux\"\nVERSION=\"8 (Core)\"\nID=\"centos\"\nID_LIKE=\"rhel fedora\"\nVERSION_ID=\"8\"\nPLATFORM_ID=\"platform:el8\"\nPRETTY_NAME=\"CentOS Linux 8 (Core)\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:centos:centos:8\"\nHOME_URL=\"https://www.centos.org/\"\nBUG_REPORT_URL=\"https://bugs.centos.org/\"\n\nCENTOS_MANTISBT_PROJECT=\"CentOS-8\"\nCENTOS_MANTISBT_PROJECT_VERSION=\"8\"\nREDHAT_SUPPORT_PRODUCT=\"centos\"\nREDHAT_SUPPORT_PRODUCT_VERSION=\"8\"\n\n"
+    },
+    "platform.dist": [
+        "centos",
+        "8",
+        "Core"
+    ],
+    "result": {
+        "distribution": "CentOS",
+        "distribution_version": "8.1",
+        "distribution_release": "Core",
+        "distribution_major_version": "8",
+        "os_family": "RedHat"
+    },
+    "platform.release": "4.18.0-147.el8.x86_64"
+}

--- a/test/units/module_utils/facts/system/distribution/fixtures/centos_stream_8.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/centos_stream_8.json
@@ -1,0 +1,46 @@
+{
+    "name": "CentOS 8",
+    "distro": {
+        "codename": "",
+        "id": "centos",
+        "name": "CentOS Stream",
+        "version": "8",
+        "version_best": "8",
+        "lsb_release_info": {},
+        "os_release_info": {
+            "name": "CentOS Stream",
+            "version": "8",
+            "id": "centos",
+            "id_like": "rhel fedora",
+            "version_id": "8",
+            "platform_id": "platform:el8",
+            "pretty_name": "CentOS Stream 8",
+            "ansi_color": "0;31",
+            "cpe_name": "cpe:/o:centos:centos:8",
+            "home_url": "https://centos.org/",
+            "bug_report_url": "https://bugzilla.redhat.com/",
+            "redhat_support_product": "Red Hat Enterprise Linux 8",
+            "redhat_support_product_version": "CentOS Stream"
+        }
+    },
+    "input": {
+        "/etc/centos-release": "CentOS Stream release 8\n",
+        "/etc/redhat-release": "CentOS Stream release 8\n",
+        "/etc/system-release": "CentOS Stream release 8\n",
+        "/etc/os-release": "NAME=\"CentOS Stream\"\nVERSION=\"8\"\nID=\"centos\"\nID_LIKE=\"rhel fedora\"\nVERSION_ID=\"8\"\nPLATFORM_ID=\"platform:el8\"\nPRETTY_NAME=\"CentOS Stream 8\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:centos:centos:8\"\nHOME_URL=\"https://centos.org/\"\nBUG_REPORT_URL=\"https://bugzilla.redhat.com/\"\nREDHAT_SUPPORT_PRODUCT=\"Red Hat Enterprise Linux 8\"\nREDHAT_SUPPORT_PRODUCT_VERSION=\"CentOS Stream\"\n",
+        "/usr/lib/os-release": "NAME=\"CentOS Stream\"\nVERSION=\"8\"\nID=\"centos\"\nID_LIKE=\"rhel fedora\"\nVERSION_ID=\"8\"\nPLATFORM_ID=\"platform:el8\"\nPRETTY_NAME=\"CentOS Stream 8\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:centos:centos:8\"\nHOME_URL=\"https://centos.org/\"\nBUG_REPORT_URL=\"https://bugzilla.redhat.com/\"\nREDHAT_SUPPORT_PRODUCT=\"Red Hat Enterprise Linux 8\"\nREDHAT_SUPPORT_PRODUCT_VERSION=\"CentOS Stream\"\n"
+    },
+    "platform.dist": [
+        "centos",
+        "8",
+        ""
+    ],
+    "result": {
+        "distribution": "CentOS",
+        "distribution_version": "8",
+        "distribution_release": "Stream",
+        "distribution_major_version": "8",
+        "os_family": "RedHat"
+    },
+    "platform.release": "4.18.0-257.el8.x86_64"
+}


### PR DESCRIPTION
##### SUMMARY

Change:
- On CentOS Stream, make distribution_release be "Stream"
- On CentOS Core, it continues to be "Core"
- Implement custom distribution file parser for CentOS, so we can look
  for "CentOS Linux" and "CentOS Stream"
- Two new fixtures introduced (CentOS Linux 8.1 and CentOS Stream 8)
- Removed two dicts from `Distribution` class that were seemingly not
  used anywhere.

Test Plan:
- ci_complete
- New test fixtures

Tickets:
- Fixes #73027

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

distribution facts