### PR TITLE
[yum/dnf] securely pass yum/dnf config env vars

### DIFF
--- a/changelogs/fragments/72916-yum-dnf-allow-config-env-vars.yml
+++ b/changelogs/fragments/72916-yum-dnf-allow-config-env-vars.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - dnf - Added ``config_environment`` parameter to module, to allow safely passing ``$DNF[0-9]`` and ``$DNF_VAR_<foo>`` environment variables to dnf config files (https://github.com/ansible/ansible/issues/72916).
+  - yum - Added ``config_environment`` parameter to module, to allow safely passing ``YUM[0-9]`` environment variables to yum config files (https://github.com/ansible/ansible/issues/72916).

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -228,6 +228,17 @@ options:
     type: bool
     default: "no"
     version_added: "2.11"
+  config_environment:
+    description:
+      - Dnf allows for replacing C($DNF0, ..., $DNF9) and C($DNF_VAR_*) with the
+         contents of an environment variable defined before C(dnf) is executed.
+      - These variables can be defined here and used, for example, as a way to
+        pass dnf repository credentials (username and password) safely to dnf.
+      - See U(https://dnf.readthedocs.io/en/latest/conf_ref.html#repo-variables)
+        for more details.
+    required: false
+    version_added: "2.11"
+    type: dict
 notes:
   - When used with a `loop:` each package will be processed individually, it is much more efficient to pass the list directly to the `name` option.
   - Group removal doesn't work if the group was installed with Ansible because
@@ -318,6 +329,17 @@ EXAMPLES = '''
   dnf:
     name: '@postgresql/client'
     state: present
+
+# Using a repository which, for example, defines:
+#   baseurl=https://$DNF1:$DNF2@$HOSTNAME/path/to/repo/
+- name: Install package with a private repo enabled
+  dnf:
+    name: sos
+    enablerepo: protected-repo
+    config_environment:
+      DNF1: "{{ dnf_user }}"
+      DNF2: "{{ dnf_password }}"
+      DNF_VAR_HOSTNAME: server.example.com
 '''
 
 import os

--- a/lib/ansible/modules/yum.py
+++ b/lib/ansible/modules/yum.py
@@ -236,6 +236,19 @@ options:
     version_added: "1.5"
     default: "yes"
     type: bool
+  config_environment:
+    description:
+      - Yum allows for replacing C($YUM0, ..., $YUM9) with the contents of an
+        environment variable defined before C(yum) is executed.
+      - These variables can be defined here and used, for example, as a way to
+        pass yum repository credentials (username and password) safely to
+        C(yum).
+      - See
+        U(https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-yum#sec-Using_Yum_Variables) or C(man 5 yum.conf)
+        for more details.
+    required: false
+    version_added: "2.11"
+    type: dict
 notes:
   - When used with a `loop:` each package will be processed individually,
     it is much more efficient to pass the list directly to the `name` option.
@@ -367,6 +380,16 @@ EXAMPLES = '''
       - nginx
     state: latest
     download_only: true
+
+# Using a repository which, for example, defines:
+#   baseurl=https://$YUM1:$YUM2@server/path/to/repo/
+- name: Install package with a private repo enabled
+  yum:
+    name: sos
+    enablerepo: protected-repo
+    config_environment:
+      YUM1: "{{ yum_user }}"
+      YUM2: "{{ yum_password }}"
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/yum.py
+++ b/lib/ansible/modules/yum.py
@@ -244,8 +244,8 @@ options:
         pass yum repository credentials (username and password) safely to
         C(yum).
       - See
-        U(https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-yum#sec-Using_Yum_Variables) or C(man 5 yum.conf)
-        for more details.
+        U(https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-yum#sec-Using_Yum_Variables)
+        or C(man 5 yum.conf) for more details.
     required: false
     version_added: "2.11"
     type: dict

--- a/test/integration/targets/dnf/tasks/config_environment.yml
+++ b/test/integration/targets/dnf/tasks/config_environment.yml
@@ -1,0 +1,68 @@
+- name: Test DNF[0-9] style variables
+  block:
+    - name: Add repository
+      yum_repository:
+        name: dnf1test
+        description: bar
+        baseurl: $DNF1
+        gpgcheck: no
+
+    - dnf:
+        name: toaster
+        state: present
+        config_environment:
+          NOT_DNF1: oops
+      ignore_errors: true
+      register: invalid_var
+
+    - assert:
+        that:
+          - invalid_var is failed
+          - "'only be used to set' in invalid_var.msg"
+
+    - dnf:
+        name: toaster
+        state: present
+        disablerepo: '*'
+        enablerepo: dnf1test
+        config_environment:
+          DNF1: "{{ updateinfo_repo }}"
+
+  always:
+    - name: Nix repository
+      yum_repository:
+        name: dnf1test
+        state: absent
+
+    - name: Nix package
+      dnf:
+        name: toaster
+        state: absent
+
+- name: Test DNF_VAR_ style variables
+  block:
+    - name: Add repository
+      yum_repository:
+        name: dnf1test
+        description: bar
+        baseurl: $MY_BASEURL
+        gpgcheck: no
+
+    - dnf:
+        name: toaster
+        state: present
+        disablerepo: '*'
+        enablerepo: dnf1test
+        config_environment:
+          DNF_VAR_MY_BASEURL: "{{ updateinfo_repo }}"
+
+  always:
+    - name: Nix repository
+      yum_repository:
+        name: dnf1test
+        state: absent
+
+    - name: Nix package
+      dnf:
+        name: toaster
+        state: absent

--- a/test/integration/targets/dnf/tasks/filters.yml
+++ b/test/integration/targets/dnf/tasks/filters.yml
@@ -1,9 +1,6 @@
 # We have a test repo set up with a valid updateinfo.xml which is referenced
 # from its repomd.xml.
 - block:
-    - set_fact:
-        updateinfo_repo: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/setup_rpm_repo/repo-with-updateinfo
-
     - name: Install the test repo
       yum_repository:
         name: test-repo-with-updateinfo

--- a/test/integration/targets/dnf/tasks/filters_check_mode.yml
+++ b/test/integration/targets/dnf/tasks/filters_check_mode.yml
@@ -1,9 +1,6 @@
 # We have a test repo set up with a valid updateinfo.xml which is referenced
 # from its repomd.xml.
 - block:
-    - set_fact:
-        updateinfo_repo: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/setup_rpm_repo/repo-with-updateinfo
-
     - name: Install the test repo
       yum_repository:
         name: test-repo-with-updateinfo

--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -23,6 +23,10 @@
   when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('23', '>=')) or
         (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
 
+- include_tasks: config_environment.yml
+  when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('23', '>=')) or
+        (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
+
 - include_tasks: filters_check_mode.yml
   when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('23', '>=')) or
         (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))

--- a/test/integration/targets/yum/tasks/config_environment.yml
+++ b/test/integration/targets/yum/tasks/config_environment.yml
@@ -1,0 +1,39 @@
+- block:
+    - name: Add repository
+      yum_repository:
+        name: yum1test
+        description: bar
+        baseurl: $YUM1
+        gpgcheck: no
+
+    - yum:
+        name: toaster
+        state: present
+        config_environment:
+          NOT_YUM1: oops
+      ignore_errors: true
+      register: invalid_var
+
+    - assert:
+        that:
+          - invalid_var is failed
+          - "'only be used to set' in invalid_var.msg"
+
+    - yum:
+        name: toaster
+        state: present
+        disablerepo: '*'
+        enablerepo: yum1test
+        config_environment:
+          YUM1: "{{ updateinfo_repo }}"
+
+  always:
+    - name: Nix repository
+      yum_repository:
+        name: yum1test
+        state: absent
+
+    - name: Nix package
+      yum:
+        name: toaster
+        state: absent

--- a/test/integration/targets/yum/tasks/main.yml
+++ b/test/integration/targets/yum/tasks/main.yml
@@ -10,7 +10,7 @@
       name:
       - sos
       state: absent
-    
+
   - import_tasks: yum.yml
   always:
     - name: remove installed packages
@@ -67,5 +67,10 @@
 
 
 - import_tasks: lock.yml
+  when:
+    - ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux']
+
+
+- import_tasks: config_environment.yml
   when:
     - ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux']

--- a/test/integration/targets/yum/tasks/main.yml
+++ b/test/integration/targets/yum/tasks/main.yml
@@ -74,3 +74,4 @@
 - import_tasks: config_environment.yml
   when:
     - ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux']
+    - ansible_distribution_major_version|int < 8

--- a/test/integration/targets/yum/vars/main.yml
+++ b/test/integration/targets/yum/vars/main.yml
@@ -1,6 +1,1 @@
-dnf_log_files:
-    - /var/log/dnf.log
-    - /var/log/dnf.rpm.log
-    - /var/log/dnf.librepo.log
-
 updateinfo_repo: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/setup_rpm_repo/repo-with-updateinfo


### PR DESCRIPTION
(This needs some discussion before merging)

##### SUMMARY

Change:

yum allows $YUM[0-9] env vars in config for (e.g.) masking credentials
and not having to store them on servers.

dnf allows similar functionality with $DNF[0-9] and $DNF_VAR_<foo>.

Using the existing `environment` keyword is unsafe because these get
passed on the commandline. This defeats the point of the built in yum
and dnf functionality for using environment variables.

This change adds a `config_environment` parameter to `yum` and `dnf` and
allows passing these (and only these) variables in to set them.

Test Plan:
- New tests

Tickets:
- Possibly fixes #72916

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME

yum, dnf