### PR TITLE
[service] Fix problem occur traceback in NetBSD

### DIFF
--- a/changelogs/fragments/73055-fix-service-module-problem-in-NetBSD.yml
+++ b/changelogs/fragments/73055-fix-service-module-problem-in-NetBSD.yml
@@ -1,2 +1,2 @@
-bugxies:
+bugfixes:
   - service - update ``enabled`` parameter's implementation for NetBSD (https://github.com/ansible/ansible/pull/73056)

--- a/changelogs/fragments/73055-fix-service-module-problem-in-NetBSD.yml
+++ b/changelogs/fragments/73055-fix-service-module-problem-in-NetBSD.yml
@@ -1,0 +1,2 @@
+bugxies:
+  - service - update ``enabled`` parameter's implementation for NetBSD (https://github.com/ansible/ansible/pull/73056)

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -418,7 +418,7 @@ class Service(object):
 
             # Write out the contents of the list into our temporary file.
             for rcline in new_rc_conf:
-                os.write(TMP_RCCONF, rcline.encode())
+                os.write(TMP_RCCONF, to_bytes(rcline, errors='surrogate_or_strict'))
 
             # Close temporary file.
             os.close(TMP_RCCONF)


### PR DESCRIPTION
Change:
- Replace `string.replace()` to `self.name.replace()` because
  `AttributeError: module 'string' has no attribute 'replace'`
- Use `rcline.encode()` instead of `rcline` in `os.write()`
  second parameter because
  `TypeError: a bytes-like object is required, not 'str'`

Tickets:
 - Fixes #73055

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
service