### PR TITLE
add missing elements to list of shell/command opts

### DIFF
--- a/lib/ansible/module_utils/command.py
+++ b/lib/ansible/module_utils/command.py
@@ -1,0 +1,18 @@
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+def get_command_args():
+  return dict(
+      _raw_params=dict(),
+      _uses_shell=dict(type='bool', default=False),
+      argv=dict(type='list', elements='str'),
+      chdir=dict(type='path'),
+      executable=dict(),
+      creates=dict(type='path'),
+      removes=dict(type='path'),
+      # The default for this really comes from the action plugin
+      warn=dict(type='bool', default=False, removed_in_version='2.14', removed_from_collection='ansible.builtin'),
+      stdin=dict(required=False),
+      stdin_add_newline=dict(type='bool', default=True),
+      strip_empty_ends=dict(type='bool', default=True),
+      cmd=dict(),
+  )

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -6,6 +6,8 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from ansible.module_utils.command import get_command_args
+
 __metaclass__ = type
 
 
@@ -254,20 +256,7 @@ def main():
     # the command module is the one ansible module that does not take key=value args
     # hence don't copy this one if you are looking to build others!
     module = AnsibleModule(
-        argument_spec=dict(
-            _raw_params=dict(),
-            _uses_shell=dict(type='bool', default=False),
-            argv=dict(type='list', elements='str'),
-            chdir=dict(type='path'),
-            executable=dict(),
-            creates=dict(type='path'),
-            removes=dict(type='path'),
-            # The default for this really comes from the action plugin
-            warn=dict(type='bool', default=False, removed_in_version='2.14', removed_from_collection='ansible.builtin'),
-            stdin=dict(required=False),
-            stdin_add_newline=dict(type='bool', default=True),
-            strip_empty_ends=dict(type='bool', default=True),
-        ),
+        argument_spec=get_command_args(),
         supports_check_mode=True,
     )
     shell = module.params['_uses_shell']
@@ -371,7 +360,6 @@ def main():
         module.fail_json(msg='non-zero return code', **result)
 
     module.exit_json(**result)
-
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/parsing/splitter.py
+++ b/lib/ansible/parsing/splitter.py
@@ -25,7 +25,7 @@ import re
 from ansible.errors import AnsibleParserError
 from ansible.module_utils._text import to_text
 from ansible.parsing.quoting import unquote
-
+from ansible.module_utils.command import get_command_args
 
 # Decode escapes adapted from rspeer's answer here:
 # http://stackoverflow.com/questions/4020539/process-escape-sequences-in-a-string-in-python
@@ -87,9 +87,7 @@ def parse_kv(args, check_raw=False):
                 k = x[:pos]
                 v = x[pos + 1:]
 
-                # FIXME: make the retrieval of this list of shell/command
-                #        options a function, so the list is centralized
-                if check_raw and k not in ('creates', 'removes', 'chdir', 'executable', 'warn'):
+                if check_raw and k not in get_command_args().keys():
                     raw_params.append(orig_x)
                 else:
                     options[k.strip()] = unquote(v.strip())


### PR DESCRIPTION
##### SUMMARY
Fixes #73005 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/command.py
lib/ansible/modules/command.py
lib/ansible/parsing/splitter.py

##### ADDITIONAL INFORMATION
planning to add an integration test or two tomorrow :), just wanted to put up a quick PR in the meantime
