### PR TITLE
Improve a documentation of the first_found lookup plugin

### DIFF
--- a/lib/ansible/plugins/lookup/first_found.py
+++ b/lib/ansible/plugins/lookup/first_found.py
@@ -77,7 +77,6 @@ EXAMPLES = """
         - foo
         - "{{ inventory_hostname }}"
         - bar
-        skip: yes
       paths:
         - /tmp/production
         - /tmp/staging

--- a/lib/ansible/plugins/lookup/first_found.py
+++ b/lib/ansible/plugins/lookup/first_found.py
@@ -41,9 +41,9 @@ EXAMPLES = """
     msg: "{{ lookup('first_found', findme, errors='ignore') }}"
   vars:
     findme:
-      - "/path/to/foo.txt"
-      - "bar.txt"  # will be looked in files/ dir relative to role and/or play
-      - "/path/to/biz.txt"
+      - /path/to/foo.txt
+      - bar.txt  # will be looked in files/ dir relative to role and/or play
+      - /path/to/biz.txt
 
 - name: include tasks only if files exist.
   include_tasks:
@@ -77,6 +77,7 @@ EXAMPLES = """
         - foo
         - "{{ inventory_hostname }}"
         - bar
+        skip: yes
       paths:
         - /tmp/production
         - /tmp/staging


### PR DESCRIPTION
##### SUMMARY
Made a notation more consistent across all examples




##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/lookup/first_found

##### ADDITIONAL INFORMATION

My initial intention was to add  an example of usage of the `skip` argument. But my first try - due to my misunderstand and limited knowledge - failed.

The correct usage of the `skip` parameter is not obvious - I've found - and tested the solution - at [Stack Overflow](https://stackoverflow.com/questions/39542085/how-to-use-skip-true-with-with-first-found).

But it will require adding - at least for my limited knowledge - something like

```
  tasks:
    - include_vars: "{{ item }}"
      with_first_found:
        - files: "{{ vars_files }}"
          skip: true
```
and I'm not sure if the example section of that file is the correct place.

Usage of `with_first_found` is described [in the documentation of Conditionals](https://docs.ansible.com/ansible/2.3/playbooks_conditionals.html#selecting-files-and-templates-based-on-variables).

