### PR TITLE
Fix example with the backwards counting in the sequence lookup plugin.

### DIFF
--- a/lib/ansible/plugins/lookup/sequence.py
+++ b/lib/ansible/plugins/lookup/sequence.py
@@ -58,6 +58,7 @@ EXAMPLES = """
   with_sequence: count=4
 
 - name: the final countdown
+<<<<<<< HEAD
   debug: msg={{item}} seconds to detonation
   with_sequence: end=0 start=10
 
@@ -67,6 +68,11 @@ EXAMPLES = """
   with_sequence: start=1 end="{{ end_at }}"
   vars:
     - end_at: 10
+=======
+  debug: 
+    msg: "{{item}} seconds to detonation"
+  with_sequence: start=10 end=0 stride=-1
+>>>>>>> Fix example with backwards counting  
 """
 
 RETURN = """

--- a/lib/ansible/plugins/lookup/sequence.py
+++ b/lib/ansible/plugins/lookup/sequence.py
@@ -58,10 +58,9 @@ EXAMPLES = """
   with_sequence: count=4
 
 - name: the final countdown
-<<<<<<< HEAD
-<<<<<<< HEAD
-  debug: msg={{item}} seconds to detonation
-  with_sequence: end=0 start=10
+  debug:
+    msg: "{{item}} seconds to detonation"
+  with_sequence: start=10 end=0 stride=-1
 
 - name: Use of variable
   debug:
@@ -69,14 +68,6 @@ EXAMPLES = """
   with_sequence: start=1 end="{{ end_at }}"
   vars:
     - end_at: 10
-=======
-  debug:
-=======
-  debug:
->>>>>>> Remove trailing whitespace
-    msg: "{{item}} seconds to detonation"
-  with_sequence: start=10 end=0 stride=-1
->>>>>>> Fix example with backwards counting  
 """
 
 RETURN = """

--- a/lib/ansible/plugins/lookup/sequence.py
+++ b/lib/ansible/plugins/lookup/sequence.py
@@ -59,6 +59,7 @@ EXAMPLES = """
 
 - name: the final countdown
 <<<<<<< HEAD
+<<<<<<< HEAD
   debug: msg={{item}} seconds to detonation
   with_sequence: end=0 start=10
 
@@ -69,7 +70,10 @@ EXAMPLES = """
   vars:
     - end_at: 10
 =======
-  debug: 
+  debug:
+=======
+  debug:
+>>>>>>> Remove trailing whitespace
     msg: "{{item}} seconds to detonation"
   with_sequence: start=10 end=0 stride=-1
 >>>>>>> Fix example with backwards counting  


### PR DESCRIPTION
##### SUMMARY
Fix example with the backwards counting in the sequence lookup plugin. 

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
sequence_lookup plugin

##### ADDITIONAL INFORMATION

Before: 
```
TASK [the final countdown] ********************************************************************
Wednesday 30 December 2020  11:31:00 +0100 (0:00:00.027)       0:00:00.027 **** 
fatal: [localhost]: FAILED! => {"msg": "to count backwards make stride negative"}

```
After:
```
TASK [the final countdown] ********************************************************************
Wednesday 30 December 2020  11:31:13 +0100 (0:00:00.026)       0:00:00.026 **** 
ok: [localhost] => (item=10) => {
    "msg": "10 seconds to detonation"
}
ok: [localhost] => (item=9) => {
    "msg": "9 seconds to detonation"
}
ok: [localhost] => (item=8) => {
    "msg": "8 seconds to detonation"
}
...
```

