### PR TITLE
Update windows_winrm.rst

### DIFF
--- a/docs/docsite/rst/user_guide/windows_winrm.rst
+++ b/docs/docsite/rst/user_guide/windows_winrm.rst
@@ -281,6 +281,7 @@ The following example shows host vars configured for Kerberos authentication:
     ansible_user: username@MY.DOMAIN.COM
     ansible_password: Password
     ansible_connection: winrm
+    ansible_port: 5985
     ansible_winrm_transport: kerberos
 
 As of Ansible version 2.3, the Kerberos ticket will be created based on


### PR DESCRIPTION
##### SUMMARY
<!--- Your description here -->
The standard Port for ansible winrm is set to 5986/HTTPS. 
To be able to use Kerberos, you need to set ansible_port: 5985/HTTP otherwiese you get error message or timeout.
HTTPS is not needed for environments with Kerberos, since kerberos has server identification built in to the protocoll.
FYI: HTTP traffic will by default also be encrypted when using kerberos

https://docs.microsoft.com/en-us/powershell/scripting/learn/remoting/winrmsecurity?view=powershell-7.1


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
