### PR TITLE
discourage hexdigits in password lookup

### DIFF
--- a/changelogs/fragments/passwd_lookup_hexdigits.yml
+++ b/changelogs/fragments/passwd_lookup_hexdigits.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Discourage the use of 'hexdigits' in password lookup, as it distorts expected entropy.

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -40,6 +40,8 @@ DOCUMENTATION = """
           - 'By default generated passwords contain a random mix of upper and lowercase ASCII letters, the numbers 0-9 and punctuation (". , : - _").'
           - "They can be either parts of Python's string module attributes (ascii_letters,digits, etc) or are used literally ( :, -)."
           - "Other valid values include 'ascii_lowercase', 'ascii_uppercase', 'digits', 'hexdigits', 'octdigits', 'printable', 'punctuation' and 'whitespace'."
+          - Be aware that Python's 'hexdigits' includes lower and upper case version of a-f, so it is not good choice as it doubles
+            the chances of those values for systems that won't distinguish case, distorting the expected entropy.
           - "To enter comma use two commas ',,' somewhere - preferably at the end. Quotes and double quotes are not supported."
         type: string
       length:
@@ -83,7 +85,7 @@ EXAMPLES = """
 - name: create a mysql user with a random password using many different char sets
   mysql_user:
     name: "{{ client }}"
-    password: "{{ lookup('password', '/tmp/passwordfile chars=ascii_letters,digits,hexdigits,punctuation') }}"
+    password: "{{ lookup('password', '/tmp/passwordfile chars=ascii_letters,digits,punctuation') }}"
     priv: "{{ client }}_{{ tier }}_{{ role }}.*:ALL"
 
 - name: create lowercase 8 character name for Kubernetes pod name

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -40,7 +40,7 @@ DOCUMENTATION = """
           - 'By default generated passwords contain a random mix of upper and lowercase ASCII letters, the numbers 0-9 and punctuation (". , : - _").'
           - "They can be either parts of Python's string module attributes (ascii_letters,digits, etc) or are used literally ( :, -)."
           - "Other valid values include 'ascii_lowercase', 'ascii_uppercase', 'digits', 'hexdigits', 'octdigits', 'printable', 'punctuation' and 'whitespace'."
-          - Be aware that Python's 'hexdigits' includes lower and upper case version of a-f, so it is not good choice as it doubles
+          - Be aware that Python's 'hexdigits' includes lower and upper case version of a-f, so it is not a good choice as it doubles
             the chances of those values for systems that won't distinguish case, distorting the expected entropy.
           - "To enter comma use two commas ',,' somewhere - preferably at the end. Quotes and double quotes are not supported."
         type: string


### PR DESCRIPTION
Since it doubles a-f with A-F it skews the expected entropy.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lookups/password