### PR TITLE
Update documentation for "contains" parameter

### DIFF
--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -56,7 +56,7 @@ options:
     contains:
         description:
             - A regular expression or pattern which should be matched against the file content.
-            - Works only when C(file_type) is C(file).
+            - Works only when I(file_type) is C(file).
         type: str
     read_whole_file:
         description:

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -56,7 +56,7 @@ options:
     contains:
         description:
             - A regular expression or pattern which should be matched against the file content.
-            - Works only when C(file_type) is C(file). 
+            - Works only when C(file_type) is C(file).
         type: str
     read_whole_file:
         description:

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -56,6 +56,7 @@ options:
     contains:
         description:
             - A regular expression or pattern which should be matched against the file content.
+            - Works only when C(file_type) is C(file). 
         type: str
     read_whole_file:
         description:


### PR DESCRIPTION
##### SUMMARY
The documentation lacks a hint that the parameter _contents_ only works, if `file_type: file`. 
If you use `file_type: any` (for example to include also symlinks) I would expect "contents" does work as described in the documentation. 

This missing hint in the documention led to unexpected behavior. See example below.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
find

##### ADDITIONAL INFORMATION
Example of unexpected behavior

```
  - name: Check for existing OpCache config files.
    find:
      paths: "/etc/php/7.4/apache2/conf.d"
      contains: 'zend_extension(\s+)?=(\s+)?opcache\.so'
      file_type: 'file'
    register: test

...

TASK [debug] *****************************************************************************************************************************************************
ok: [localhost] => {
    "test.matched": "1"
}
``` 

```
  - name: Check for existing OpCache config files.
    find:
      paths: "/etc/php/7.4/apache2/conf.d"
      contains: 'zend_extension(\s+)?=(\s+)?opcache\.so'
      file_type: 'any'
    register: test

...

TASK [debug] *****************************************************************************************************************************************************
ok: [localhost] => {
    "test.matched": "24"
}
``` 

