### PR TITLE
[stable-2.9] Constrain pexpect and ptyprocess (#73109)

### DIFF
--- a/test/integration/targets/expect/aliases
+++ b/test/integration/targets/expect/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group2
 destructive
+needs/target/setup_pexpect

--- a/test/integration/targets/expect/tasks/main.yml
+++ b/test/integration/targets/expect/tasks/main.yml
@@ -16,9 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 - name: Install test requirements
-  pip:
-    name: pexpect
-    state: present
+  import_role:
+    name: setup_pexpect
 
 - name: record the test_command file
   set_fact: test_command_file={{output_dir | expanduser}}/test_command.py

--- a/test/integration/targets/setup_pexpect/files/constraints.txt
+++ b/test/integration/targets/setup_pexpect/files/constraints.txt
@@ -1,0 +1,2 @@
+pexpect == 4.8.0
+ptyprocess < 0.7.0 ; python_version < '2.7'  # ptyprocess >= 0.7.0 not compatible with Python 2.6

--- a/test/integration/targets/setup_pexpect/meta/main.yml
+++ b/test/integration/targets/setup_pexpect/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_remote_tmp_dir

--- a/test/integration/targets/setup_pexpect/tasks/main.yml
+++ b/test/integration/targets/setup_pexpect/tasks/main.yml
@@ -1,4 +1,10 @@
+- name: Copy constraints file
+  copy:
+    src: constraints.txt
+    dest: "{{ remote_tmp_dir }}/pexpect-constraints.txt"
+
 - name: Install pexpect
   pip:
     name: pexpect
+    extra_args: '--constraint "{{ remote_tmp_dir }}/pexpect-constraints.txt"'
     state: present


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #73109 for Ansible 2.9.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/expect`
`test/integration/targets/setup_pexpect`
