### PR TITLE
Do not pretend expression is filename in compile() Python built-in call

### DIFF
--- a/changelogs/fragments/fix_expression_as_filename_in_compile.yaml
+++ b/changelogs/fragments/fix_expression_as_filename_in_compile.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - Pass expression in angle-bracket notation as filename argument to a
+    ``compile()`` built-in function, so that Python debuggers do not try to
+    parse it as filename.

--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -140,7 +140,7 @@ def safe_eval(expr, locals=None, include_exceptions=False):
     try:
         parsed_tree = ast.parse(expr, mode='eval')
         cnv.visit(parsed_tree)
-        compiled = compile(parsed_tree, to_native(expr), 'eval')
+        compiled = compile(parsed_tree, '<expr %s>' % to_native(expr), 'eval')
         # Note: passing our own globals and locals here constrains what
         # callables (and other identifiers) are recognized.  this is in
         # addition to the filtering of builtins done in CleansingNodeVisitor


### PR DESCRIPTION
##### SUMMARY

When calling `compile()`, the `filename` argument should be either a real file name or an angle-bracketed string. According to Python docs, most commonly used string is `'<string>'`. Keep the current behaviour (encapsulate the actual expression), but enclose it into angle brackets.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Ansible package `ansible.template.safe_eval`

##### ADDITIONAL INFORMATION

The expression instead of file name problem was discovered while debugging execution of ansible-playbook with VisualStudio Code. The expression used in `filename` argument of `compile()` caused VisualStudio Code Python integration to throw exceptions when trying to handle the filename as a real file.
