### PR TITLE
ansible-galaxy role install: download from API response location

### DIFF
--- a/changelogs/fragments/73114-fix-ansible-role-download.yaml
+++ b/changelogs/fragments/73114-fix-ansible-role-download.yaml
@@ -1,2 +1,2 @@
-bugfixes:
+minor_changes:
   - galaxy - role install does not download artifact from API response `download_url` location (https://github.com/ansible/ansible/issues/73103).

--- a/changelogs/fragments/73114-fix-ansible-role-download.yaml
+++ b/changelogs/fragments/73114-fix-ansible-role-download.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - galaxy - support role artifact download from API response `download_url` location (https://github.com/ansible/ansible/issues/73103).
+  - galaxy - support role artifact download from API response ``download_url`` location (https://github.com/ansible/ansible/issues/73103).

--- a/changelogs/fragments/73114-fix-ansible-role-download.yaml
+++ b/changelogs/fragments/73114-fix-ansible-role-download.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - galaxy - role install does not download artifact from API response `download_url` location (https://github.com/ansible/ansible/issues/73103).

--- a/changelogs/fragments/73114-fix-ansible-role-download.yaml
+++ b/changelogs/fragments/73114-fix-ansible-role-download.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - galaxy - role install does not download artifact from API response `download_url` location (https://github.com/ansible/ansible/issues/73103).
+  - galaxy - support role install artifact download from API response `download_url` location (https://github.com/ansible/ansible/issues/73103).

--- a/changelogs/fragments/73114-fix-ansible-role-download.yaml
+++ b/changelogs/fragments/73114-fix-ansible-role-download.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - galaxy - support role install artifact download from API response `download_url` location (https://github.com/ansible/ansible/issues/73103).
+  - galaxy - support role artifact download from API response `download_url` location (https://github.com/ansible/ansible/issues/73103).

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -65,6 +65,7 @@ class GalaxyRole(object):
         self.name = name
         self.version = version
         self.src = src or name
+        self.download_url = None
         self.scm = scm
         self.paths = [os.path.join(x, self.name) for x in galaxy.roles_paths]
 
@@ -190,7 +191,9 @@ class GalaxyRole(object):
         if role_data:
 
             # first grab the file and save it to a temp location
-            if "github_user" in role_data and "github_repo" in role_data:
+            if self.download_url is not None:
+                archive_url = self.download_url
+            elif "github_user" in role_data and "github_repo" in role_data:
                 archive_url = 'https://github.com/%s/%s/archive/%s.tar.gz' % (role_data["github_user"], role_data["github_repo"], self.version)
             else:
                 archive_url = self.src
@@ -259,10 +262,12 @@ class GalaxyRole(object):
                                                                                                                                          self.name,
                                                                                                                                          role_versions))
 
-                # check if there's a source link for our role_version
+                # check if there's a source link/url for our role_version
                 for role_version in role_versions:
                     if role_version['name'] == self.version and 'source' in role_version:
                         self.src = role_version['source']
+                    if role_version['name'] == self.version and 'download_url' in role_version:
+                        self.download_url = role_version['download_url']
 
                 tmp_file = self.fetch(role_data)
 

--- a/test/units/galaxy/test_role_install.py
+++ b/test/units/galaxy/test_role_install.py
@@ -12,7 +12,6 @@ import pytest
 import tempfile
 
 from io import StringIO
-from units.compat.mock import MagicMock
 from ansible import context
 from ansible.cli.galaxy import GalaxyCLI
 from ansible.galaxy import api, role, Galaxy
@@ -52,10 +51,10 @@ def init_role_dir(tmp_path_factory):
     call_galaxy_cli(['init', '%s.%s' % (namespace, role), '-c', '--init-path', test_dir, '--role-skeleton', skeleton_path])
 
 
-def mock_NamedTemporaryFile(**args):
-    mock_ntf = MagicMock()
-    mock_ntf.write = MagicMock()
-    mock_ntf.close = MagicMock()
+def mock_NamedTemporaryFile(mocker, **args):
+    mock_ntf = mocker.MagicMock()
+    mock_ntf.write = mocker.MagicMock()
+    mock_ntf.close = mocker.MagicMock()
     mock_ntf.name = None
     return mock_ntf
 

--- a/test/units/galaxy/test_role_install.py
+++ b/test/units/galaxy/test_role_install.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import pytest
+import tempfile
+
+from io import StringIO
+from units.compat.mock import MagicMock
+
+from ansible import context
+from ansible.cli.galaxy import GalaxyCLI
+from ansible.galaxy import api, role, Galaxy
+from ansible.module_utils._text import to_text
+from ansible.utils import context_objects as co
+
+
+def call_galaxy_cli(args):
+    orig = co.GlobalCLIArgs._Singleton__instance
+    co.GlobalCLIArgs._Singleton__instance = None
+    try:
+        GalaxyCLI(args=['ansible-galaxy', 'role'] + args).run()
+    finally:
+        co.GlobalCLIArgs._Singleton__instance = orig
+
+
+@pytest.fixture(autouse='function')
+def reset_cli_args():
+    co.GlobalCLIArgs._Singleton__instance = None
+    yield
+    co.GlobalCLIArgs._Singleton__instance = None
+
+
+@pytest.fixture(autouse=True)
+def galaxy_server():
+    context.CLIARGS._store = {'ignore_certs': False}
+    galaxy_api = api.GalaxyAPI(None, 'test_server', 'https://galaxy.ansible.com')
+    return galaxy_api
+
+
+@pytest.fixture(autouse=True)
+def init_role_dir(tmp_path_factory):
+    test_dir = to_text(tmp_path_factory.mktemp('test-ÅÑŚÌβŁÈ Roles Input'))
+    namespace = 'ansible_namespace'
+    role = 'role'
+    skeleton_path = os.path.join(os.path.dirname(os.path.split(__file__)[0]), 'cli', 'test_data', 'role_skeleton')
+    call_galaxy_cli(['init', '%s.%s' % (namespace, role), '-c', '--init-path', test_dir, '--role-skeleton', skeleton_path])
+
+
+def mock_NamedTemporaryFile(**args):
+    mock_ntf = MagicMock()
+    mock_ntf.write = MagicMock()
+    mock_ntf.close = MagicMock()
+    mock_ntf.name = None
+    return mock_ntf
+
+
+@pytest.fixture(autouse=True)
+def init_test(monkeypatch):
+    monkeypatch.setattr(tempfile, 'NamedTemporaryFile', mock_NamedTemporaryFile)
+
+
+@pytest.fixture(autouse=True)
+def mock_role_download_api(monkeypatch):
+    mock_role_api = MagicMock()
+    mock_role_api.side_effect = [
+        StringIO(u''),
+    ]
+    monkeypatch.setattr(role, 'open_url', mock_role_api)
+    return mock_role_api
+
+
+def test_role_download_github(galaxy_server, mock_role_download_api, monkeypatch):
+    mock_api = MagicMock()
+    mock_api.side_effect = [
+        StringIO(u'{"available_versions":{"v1":"v1/"}}'),
+        StringIO(u'{"results":[{"id":"123","github_user":"test_owner","github_repo": "test_role"}]}'),
+        StringIO(u'{"results":[{"name": "0.0.1"},{"name": "0.0.2"}]}'),
+    ]
+    monkeypatch.setattr(api, 'open_url', mock_api)
+
+    role.GalaxyRole(Galaxy(), galaxy_server, 'test_owner.test_role', version="0.0.1").install()
+
+    assert mock_role_download_api.call_count == 1
+    assert mock_role_download_api.mock_calls[0][1][0] == 'https://github.com/test_owner/test_role/archive/0.0.1.tar.gz'
+
+
+def test_role_download_github_default_version(galaxy_server, mock_role_download_api, monkeypatch):
+    mock_api = MagicMock()
+    mock_api.side_effect = [
+        StringIO(u'{"available_versions":{"v1":"v1/"}}'),
+        StringIO(u'{"results":[{"id":"123","github_user":"test_owner","github_repo": "test_role"}]}'),
+        StringIO(u'{"results":[{"name": "0.0.1"},{"name": "0.0.2"}]}'),
+    ]
+    monkeypatch.setattr(api, 'open_url', mock_api)
+
+    role.GalaxyRole(Galaxy(), galaxy_server, 'test_owner.test_role').install()
+
+    assert mock_role_download_api.call_count == 1
+    assert mock_role_download_api.mock_calls[0][1][0] == 'https://github.com/test_owner/test_role/archive/0.0.2.tar.gz'
+
+
+def test_role_download_github_no_download_url_for_version(galaxy_server, mock_role_download_api, monkeypatch):
+    mock_api = MagicMock()
+    mock_api.side_effect = [
+        StringIO(u'{"available_versions":{"v1":"v1/"}}'),
+        StringIO(u'{"results":[{"id":"123","github_user":"test_owner","github_repo": "test_role"}]}'),
+        StringIO(u'{"results":[{"name": "0.0.1"},{"name": "0.0.2","download_url":"http://localhost:8080/test_owner/test_role/0.0.2.tar.gz"}]}'),
+    ]
+    monkeypatch.setattr(api, 'open_url', mock_api)
+
+    role.GalaxyRole(Galaxy(), galaxy_server, 'test_owner.test_role', version="0.0.1").install()
+
+    assert mock_role_download_api.call_count == 1
+    assert mock_role_download_api.mock_calls[0][1][0] == 'https://github.com/test_owner/test_role/archive/0.0.1.tar.gz'
+
+
+def test_role_download_url(galaxy_server, mock_role_download_api, monkeypatch):
+    mock_api = MagicMock()
+    mock_api.side_effect = [
+        StringIO(u'{"available_versions":{"v1":"v1/"}}'),
+        StringIO(u'{"results":[{"id":"123","github_user":"test_owner","github_repo": "test_role"}]}'),
+        StringIO(u'{"results":[{"name": "0.0.1","download_url":"http://localhost:8080/test_owner/test_role/0.0.1.tar.gz"},{"name": "0.0.2","download_url":"http://localhost:8080/test_owner/test_role/0.0.2.tar.gz"}]}'),
+    ]
+    monkeypatch.setattr(api, 'open_url', mock_api)
+
+    role.GalaxyRole(Galaxy(), galaxy_server, 'test_owner.test_role', version="0.0.1").install()
+
+    assert mock_role_download_api.call_count == 1
+    assert mock_role_download_api.mock_calls[0][1][0] == 'http://localhost:8080/test_owner/test_role/0.0.1.tar.gz'
+
+
+def test_role_download_url_default_version(galaxy_server, mock_role_download_api, monkeypatch):
+    mock_api = MagicMock()
+    mock_api.side_effect = [
+        StringIO(u'{"available_versions":{"v1":"v1/"}}'),
+        StringIO(u'{"results":[{"id":"123","github_user":"test_owner","github_repo": "test_role"}]}'),
+        StringIO(u'{"results":[{"name": "0.0.1","download_url":"http://localhost:8080/test_owner/test_role/0.0.1.tar.gz"},{"name": "0.0.2","download_url":"http://localhost:8080/test_owner/test_role/0.0.2.tar.gz"}]}'),
+    ]
+    monkeypatch.setattr(api, 'open_url', mock_api)
+
+    role.GalaxyRole(Galaxy(), galaxy_server, 'test_owner.test_role').install()
+
+    assert mock_role_download_api.call_count == 1
+    assert mock_role_download_api.mock_calls[0][1][0] == 'http://localhost:8080/test_owner/test_role/0.0.2.tar.gz'

--- a/test/units/galaxy/test_role_install.py
+++ b/test/units/galaxy/test_role_install.py
@@ -65,8 +65,8 @@ def init_test(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def mock_role_download_api(monkeypatch):
-    mock_role_api = MagicMock()
+def mock_role_download_api(mocker, monkeypatch):
+    mock_role_api = mocker.MagicMock()
     mock_role_api.side_effect = [
         StringIO(u''),
     ]
@@ -74,8 +74,8 @@ def mock_role_download_api(monkeypatch):
     return mock_role_api
 
 
-def test_role_download_github(galaxy_server, mock_role_download_api, monkeypatch):
-    mock_api = MagicMock()
+def test_role_download_github(mocker, galaxy_server, mock_role_download_api, monkeypatch):
+    mock_api = mocker.MagicMock()
     mock_api.side_effect = [
         StringIO(u'{"available_versions":{"v1":"v1/"}}'),
         StringIO(u'{"results":[{"id":"123","github_user":"test_owner","github_repo": "test_role"}]}'),
@@ -89,8 +89,8 @@ def test_role_download_github(galaxy_server, mock_role_download_api, monkeypatch
     assert mock_role_download_api.mock_calls[0][1][0] == 'https://github.com/test_owner/test_role/archive/0.0.1.tar.gz'
 
 
-def test_role_download_github_default_version(galaxy_server, mock_role_download_api, monkeypatch):
-    mock_api = MagicMock()
+def test_role_download_github_default_version(mocker, galaxy_server, mock_role_download_api, monkeypatch):
+    mock_api = mocker.MagicMock()
     mock_api.side_effect = [
         StringIO(u'{"available_versions":{"v1":"v1/"}}'),
         StringIO(u'{"results":[{"id":"123","github_user":"test_owner","github_repo": "test_role"}]}'),
@@ -104,8 +104,8 @@ def test_role_download_github_default_version(galaxy_server, mock_role_download_
     assert mock_role_download_api.mock_calls[0][1][0] == 'https://github.com/test_owner/test_role/archive/0.0.2.tar.gz'
 
 
-def test_role_download_github_no_download_url_for_version(galaxy_server, mock_role_download_api, monkeypatch):
-    mock_api = MagicMock()
+def test_role_download_github_no_download_url_for_version(mocker, galaxy_server, mock_role_download_api, monkeypatch):
+    mock_api = mocker.MagicMock()
     mock_api.side_effect = [
         StringIO(u'{"available_versions":{"v1":"v1/"}}'),
         StringIO(u'{"results":[{"id":"123","github_user":"test_owner","github_repo": "test_role"}]}'),
@@ -119,8 +119,8 @@ def test_role_download_github_no_download_url_for_version(galaxy_server, mock_ro
     assert mock_role_download_api.mock_calls[0][1][0] == 'https://github.com/test_owner/test_role/archive/0.0.1.tar.gz'
 
 
-def test_role_download_url(galaxy_server, mock_role_download_api, monkeypatch):
-    mock_api = MagicMock()
+def test_role_download_url(mocker, galaxy_server, mock_role_download_api, monkeypatch):
+    mock_api = mocker.MagicMock()
     mock_api.side_effect = [
         StringIO(u'{"available_versions":{"v1":"v1/"}}'),
         StringIO(u'{"results":[{"id":"123","github_user":"test_owner","github_repo": "test_role"}]}'),
@@ -135,8 +135,8 @@ def test_role_download_url(galaxy_server, mock_role_download_api, monkeypatch):
     assert mock_role_download_api.mock_calls[0][1][0] == 'http://localhost:8080/test_owner/test_role/0.0.1.tar.gz'
 
 
-def test_role_download_url_default_version(galaxy_server, mock_role_download_api, monkeypatch):
-    mock_api = MagicMock()
+def test_role_download_url_default_version(mocker, galaxy_server, mock_role_download_api, monkeypatch):
+    mock_api = mocker.MagicMock()
     mock_api.side_effect = [
         StringIO(u'{"available_versions":{"v1":"v1/"}}'),
         StringIO(u'{"results":[{"id":"123","github_user":"test_owner","github_repo": "test_role"}]}'),

--- a/test/units/galaxy/test_role_install.py
+++ b/test/units/galaxy/test_role_install.py
@@ -6,13 +6,13 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+
 import os
 import pytest
 import tempfile
 
 from io import StringIO
 from units.compat.mock import MagicMock
-
 from ansible import context
 from ansible.cli.galaxy import GalaxyCLI
 from ansible.galaxy import api, role, Galaxy

--- a/test/units/galaxy/test_role_install.py
+++ b/test/units/galaxy/test_role_install.py
@@ -125,7 +125,8 @@ def test_role_download_url(galaxy_server, mock_role_download_api, monkeypatch):
     mock_api.side_effect = [
         StringIO(u'{"available_versions":{"v1":"v1/"}}'),
         StringIO(u'{"results":[{"id":"123","github_user":"test_owner","github_repo": "test_role"}]}'),
-        StringIO(u'{"results":[{"name": "0.0.1","download_url":"http://localhost:8080/test_owner/test_role/0.0.1.tar.gz"},{"name": "0.0.2","download_url":"http://localhost:8080/test_owner/test_role/0.0.2.tar.gz"}]}'),
+        StringIO(u'{"results":[{"name": "0.0.1","download_url":"http://localhost:8080/test_owner/test_role/0.0.1.tar.gz"},'
+                 u'{"name": "0.0.2","download_url":"http://localhost:8080/test_owner/test_role/0.0.2.tar.gz"}]}'),
     ]
     monkeypatch.setattr(api, 'open_url', mock_api)
 
@@ -140,7 +141,8 @@ def test_role_download_url_default_version(galaxy_server, mock_role_download_api
     mock_api.side_effect = [
         StringIO(u'{"available_versions":{"v1":"v1/"}}'),
         StringIO(u'{"results":[{"id":"123","github_user":"test_owner","github_repo": "test_role"}]}'),
-        StringIO(u'{"results":[{"name": "0.0.1","download_url":"http://localhost:8080/test_owner/test_role/0.0.1.tar.gz"},{"name": "0.0.2","download_url":"http://localhost:8080/test_owner/test_role/0.0.2.tar.gz"}]}'),
+        StringIO(u'{"results":[{"name": "0.0.1","download_url":"http://localhost:8080/test_owner/test_role/0.0.1.tar.gz"},'
+                 u'{"name": "0.0.2","download_url":"http://localhost:8080/test_owner/test_role/0.0.2.tar.gz"}]}'),
     ]
     monkeypatch.setattr(api, 'open_url', mock_api)
 


### PR DESCRIPTION
##### SUMMARY
This PR fixes #73103 to have `ansible-galaxy` download and install a role from the location (URL) indicated in the API response. Current functionality (before this change) is ignores the `download_url` location specified in the API response and downloads the role directly from github.com.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy

##### ADDITIONAL INFORMATION
When providing the `--server API_SERVER` argument to `ansible-galaxy role install` and the API response includes a `download_url` for the desired version, the role should be downloaded and installed from that location.

See the test repo [l3ender/ansible-galaxy-api](https://github.com/l3ender/ansible-galaxy-api), which simulates a Galaxy API server when installing a role.

Before:
```bash
-> ansible-galaxy role install geerlingguy.docker -vvvv --server http://localhost:8000
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under
development. This is a rapidly changing source of code and can become unstable at any point.
ansible-galaxy 2.11.0.dev0 (devel 003a9e890d) last updated 2021/01/04 16:15:50 (GMT -500)
  config file = None
  configured module search path = ['/Users/ross/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/ross/repos/ansible/lib/ansible
  ansible collection location = /Users/ross/.ansible/collections:/usr/share/ansible/collections
  executable location = /Users/ross/repos/ansible/bin/ansible-galaxy
  python version = 3.9.1 (default, Dec 10 2020, 10:36:35) [Clang 12.0.0 (clang-1200.0.32.27)]
  jinja version = 2.11.2
  libyaml = False
No config file found; using defaults
Initial connection to galaxy_server: http://localhost:8000
Opened /Users/ross/.ansible/galaxy_token
Calling Galaxy at http://localhost:8000
Calling Galaxy at http://localhost:8000/api
Found API version 'v1, v2' with Galaxy server cmd_arg (http://localhost:8000/api)
Starting galaxy role install process
Processing role geerlingguy.docker
- downloading role 'docker', owned by geerlingguy
Calling Galaxy at http://localhost:8000/api/v1/roles/?owner__username=geerlingguy&name=docker
Calling Galaxy at http://localhost:8000/api/v1/roles/15836/versions/?page_size=50
- downloading role from https://github.com/geerlingguy/ansible-role-docker/archive/3.0.0.tar.gz
- extracting geerlingguy.docker to /Users/ross/.ansible/roles/geerlingguy.docker
- geerlingguy.docker (3.0.0) was installed successfully
```

After:
```bash
-> ansible-galaxy role install geerlingguy.docker -vvvv --server http://localhost:8000
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under
development. This is a rapidly changing source of code and can become unstable at any point.
ansible-galaxy 2.11.0.dev0 (role-download 5588d17431) last updated 2021/01/04 16:37:06 (GMT -500)
  config file = None
  configured module search path = ['/Users/ross/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/ross/repos/ansible/lib/ansible
  ansible collection location = /Users/ross/.ansible/collections:/usr/share/ansible/collections
  executable location = /Users/ross/repos/ansible/bin/ansible-galaxy
  python version = 3.9.1 (default, Dec 10 2020, 10:36:35) [Clang 12.0.0 (clang-1200.0.32.27)]
  jinja version = 2.11.2
  libyaml = False
No config file found; using defaults
Initial connection to galaxy_server: http://localhost:8000
Opened /Users/ross/.ansible/galaxy_token
Calling Galaxy at http://localhost:8000
Calling Galaxy at http://localhost:8000/api
Found API version 'v1, v2' with Galaxy server cmd_arg (http://localhost:8000/api)
Starting galaxy role install process
Processing role geerlingguy.docker
- downloading role 'docker', owned by geerlingguy
Calling Galaxy at http://localhost:8000/api/v1/roles/?owner__username=geerlingguy&name=docker
Calling Galaxy at http://localhost:8000/api/v1/roles/15836/versions/?page_size=50
- downloading role from http://localhost:8000/artifact/ansible-role-docker-3.0.0.tar.gz
- extracting geerlingguy.docker to /Users/ross/.ansible/roles/geerlingguy.docker
- geerlingguy.docker (3.0.0) was installed successfully
```

