### PR TITLE
More options for password passing

### DIFF
--- a/changelogs/fragments/password_file_options.yml
+++ b/changelogs/fragments/password_file_options.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Allow connection and become passwords to be set by file/executable script. Also document this was already the case for vault.

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -251,13 +251,13 @@ class CLI(with_metaclass(ABCMeta, object)):
         try:
             become_prompt = "%s password: " % become_prompt_method
             if op['ask_pass']:
-                sshpass = self._get_secret("SSH password: ")
+                sshpass = CLI._get_secret("SSH password: ")
                 become_prompt = "%s password[defaults to SSH password]: " % become_prompt_method
             elif op['connection_password_file']:
                 sshpass = CLI.get_password_from_file(op['connection_password_file'])
 
             if op['become_ask_pass']:
-                becomepass = self._get_secret(become_prompt)
+                becomepass = CLI._get_secret(become_prompt)
                 if op['ask_pass'] and becomepass == '':
                     becomepass = sshpass
             elif op['become_password_file']:

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -230,6 +230,14 @@ class CLI(with_metaclass(ABCMeta, object)):
         return vault_secrets
 
     @staticmethod
+    def _get_secret(prompt):
+
+        secret = getpass.getpass(prompt=prompt)
+        if secret:
+            secret = to_unsafe_text(secret)
+        return secret
+
+    @staticmethod
     def ask_passwords():
         ''' prompt for connection and become passwords if needed '''
 
@@ -243,13 +251,13 @@ class CLI(with_metaclass(ABCMeta, object)):
         try:
             become_prompt = "%s password: " % become_prompt_method
             if op['ask_pass']:
-                sshpass = getpass.getpass(prompt="SSH password: ")
+                sshpass = self._get_secret("SSH password: ")
                 become_prompt = "%s password[defaults to SSH password]: " % become_prompt_method
             elif op['connection_password_file']:
                 sshpass = CLI.get_password_from_file(op['connection_password_file'])
 
             if op['become_ask_pass']:
-                becomepass = getpass.getpass(prompt=become_prompt)
+                becomepass = self._get_secret(become_prompt)
                 if op['ask_pass'] and becomepass == '':
                     becomepass = sshpass
             elif op['become_password_file']:
@@ -257,13 +265,6 @@ class CLI(with_metaclass(ABCMeta, object)):
 
         except EOFError:
             pass
-
-        # we 'wrap' the passwords to prevent templating as
-        # they can contain special chars and trigger it incorrectly
-        if sshpass:
-            sshpass = to_unsafe_text(sshpass)
-        if becomepass:
-            becomepass = to_unsafe_text(becomepass)
 
         return (sshpass, becomepass)
 
@@ -540,4 +541,4 @@ class CLI(with_metaclass(ABCMeta, object)):
         if not secret:
             raise AnsibleError('Empty password was provided from file (%s)' % pwd_file)
 
-        return secret
+        return to_unsafe_text(secret)

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -516,7 +516,7 @@ class CLI(with_metaclass(ABCMeta, object)):
 
             stdout, stderr = p.communicate()
             if p.returncode != 0:
-                raise AnsibleError("The password script %s returned and error (rc=%s): %s" % (pwd_file, p.returncode, stderr))
+                raise AnsibleError("The password script %s returned an error (rc=%s): %s" % (pwd_file, p.returncode, stderr))
             secret = stdout
 
         else:

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -244,8 +244,6 @@ def add_connect_options(parser):
     """Add options for commands which need to connection to other hosts"""
     connect_group = parser.add_argument_group("Connection Options", "control as whom and how to connect to hosts")
 
-    connect_group.add_argument('-k', '--ask-pass', default=C.DEFAULT_ASK_PASS, dest='ask_pass', action='store_true',
-                               help='ask for connection password')
     connect_group.add_argument('--private-key', '--key-file', default=C.DEFAULT_PRIVATE_KEY_FILE, dest='private_key_file',
                                help='use this file to authenticate the connection', type=unfrack_path())
     connect_group.add_argument('-u', '--user', default=C.DEFAULT_REMOTE_USER, dest='remote_user',
@@ -266,6 +264,14 @@ def add_connect_options(parser):
                                help="specify extra arguments to pass to ssh only (e.g. -R)")
 
     parser.add_argument_group(connect_group)
+
+    connect_password_group = parser.add_mutually_exclusive_group()
+    connect_password_group.add_argument('-k', '--ask-pass', default=C.DEFAULT_ASK_PASS, dest='ask_pass', action='store_true',
+                                        help='ask for connection password')
+    connect_password_group.add_argument('--connection-password-file', '--conn-pass-file', default=None, dest='connection_password_file',
+                                        help="Connection password file", type=unfrack_path(), action='store')
+
+    parser.add_argument_group(connect_password_group)
 
 
 def add_fork_options(parser):
@@ -326,7 +332,9 @@ def add_runas_options(parser):
     runas_group.add_argument('--become-user', default=None, dest='become_user', type=str,
                              help='run operations as this user (default=%s)' % C.DEFAULT_BECOME_USER)
 
-    add_runas_prompt_options(parser, runas_group=runas_group)
+    parser.add_argument_group(runas_group)
+
+    add_runas_prompt_options(parser)
 
 
 def add_runas_prompt_options(parser, runas_group=None):
@@ -336,15 +344,18 @@ def add_runas_prompt_options(parser, runas_group=None):
     Note that add_runas_options() includes these options already.  Only one of the two functions
     should be used.
     """
-    if runas_group is None:
-        runas_group = parser.add_argument_group("Privilege Escalation Options",
-                                                "control how and which user you become as on target hosts")
+    if runas_group is not None:
+        parser.add_argument_group(runas_group)
 
-    runas_group.add_argument('-K', '--ask-become-pass', dest='become_ask_pass', action='store_true',
-                             default=C.DEFAULT_BECOME_ASK_PASS,
-                             help='ask for privilege escalation password')
+    runas_pass_group = parser.add_mutually_exclusive_group()
 
-    parser.add_argument_group(runas_group)
+    runas_pass_group.add_argument('-K', '--ask-become-pass', dest='become_ask_pass', action='store_true',
+                                  default=C.DEFAULT_BECOME_ASK_PASS,
+                                  help='ask for privilege escalation password')
+    runas_pass_group.add_argument('--become-password-file', '--become-pass-file', default=None, dest='become_password_file',
+                                  help="Become password file", type=unfrack_path(), action='store')
+
+    parser.add_argument_group(runas_pass_group)
 
 
 def add_runtask_options(parser):

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -268,7 +268,7 @@ def add_connect_options(parser):
     connect_password_group = parser.add_mutually_exclusive_group()
     connect_password_group.add_argument('-k', '--ask-pass', default=C.DEFAULT_ASK_PASS, dest='ask_pass', action='store_true',
                                         help='ask for connection password')
-    connect_password_group.add_argument('--connection-password-file', '--conn-pass-file', default=None, dest='connection_password_file',
+    connect_password_group.add_argument('--connection-password-file', '--conn-pass-file', default=C.CONNECTION_PASSWORD_FILE, dest='connection_password_file',
                                         help="Connection password file", type=unfrack_path(), action='store')
 
     parser.add_argument_group(connect_password_group)
@@ -352,7 +352,7 @@ def add_runas_prompt_options(parser, runas_group=None):
     runas_pass_group.add_argument('-K', '--ask-become-pass', dest='become_ask_pass', action='store_true',
                                   default=C.DEFAULT_BECOME_ASK_PASS,
                                   help='ask for privilege escalation password')
-    runas_pass_group.add_argument('--become-password-file', '--become-pass-file', default=None, dest='become_password_file',
+    runas_pass_group.add_argument('--become-password-file', '--become-pass-file', default=C.BECOME_PASSWORD_FILE, dest='become_password_file',
                                   help="Become password file", type=unfrack_path(), action='store')
 
     parser.add_argument_group(runas_pass_group)

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -135,6 +135,15 @@ BECOME_ALLOW_SAME_USER:
   - {key: become_allow_same_user, section: privilege_escalation}
   type: boolean
   yaml: {key: privilege_escalation.become_allow_same_user}
+BECOME_PASSWORD_FILE:
+  name: Become password file
+  default: ~
+  description: 'The password file to use for the become plugin. --become-password-file.'
+  env: [{name: ANSIBLE_CONNECTION_PASSWORD_FILE}]
+  ini:
+  - {key: become_password_file, section: defaults}
+  type: path
+  version_added: '2.11'
 AGNOSTIC_BECOME_PROMPT:
   name: Display an agnostic become prompt
   default: True
@@ -335,6 +344,15 @@ COLOR_WARN:
   env: [{name: ANSIBLE_COLOR_WARN}]
   ini:
   - {key: warn, section: colors}
+CONNECTION_PASSWORD_FILE:
+  name: Connection password file
+  default: ~
+  description: 'The password file to use for the connection plugin. --connection-password-file.'
+  env: [{name: ANSIBLE_CONNECTION_PASSWORD_FILE}]
+  ini:
+  - {key: connection_password_file, section: defaults}
+  type: path
+  version_added: '2.11'
 COVERAGE_REMOTE_OUTPUT:
   name: Sets the output directory and filename prefix to generate coverage run info.
   description:

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -129,7 +129,9 @@ ANY_ERRORS_FATAL:
 BECOME_ALLOW_SAME_USER:
   name: Allow becoming the same user
   default: False
-  description: This setting controls if become is skipped when remote user and become user are the same. I.E root sudo to root.
+  description:
+    - This setting controls if become is skipped when remote user and become user are the same. I.E root sudo to root.
+    - If executable, it will be run and the resulting stdout will be used as the password.
   env: [{name: ANSIBLE_BECOME_ALLOW_SAME_USER}]
   ini:
   - {key: become_allow_same_user, section: privilege_escalation}
@@ -138,8 +140,10 @@ BECOME_ALLOW_SAME_USER:
 BECOME_PASSWORD_FILE:
   name: Become password file
   default: ~
-  description: 'The password file to use for the become plugin. --become-password-file.'
-  env: [{name: ANSIBLE_CONNECTION_PASSWORD_FILE}]
+  description:
+    - 'The password file to use for the become plugin. --become-password-file.'
+    - If executable, it will be run and the resulting stdout will be used as the password.
+  env: [{name: ANSIBLE_BECOME_PASSWORD_FILE}]
   ini:
   - {key: become_password_file, section: defaults}
   type: path
@@ -1195,7 +1199,9 @@ DEFAULT_VAULT_IDENTITY_LIST:
 DEFAULT_VAULT_PASSWORD_FILE:
   name: Vault password file
   default: ~
-  description: 'The vault password file to use. Equivalent to --vault-password-file or --vault-id'
+  description:
+    - 'The vault password file to use. Equivalent to --vault-password-file or --vault-id'
+    - If executable, it will be run and the resulting stdout will be used as the password.
   env: [{name: ANSIBLE_VAULT_PASSWORD_FILE}]
   ini:
   - {key: vault_password_file, section: defaults}

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -147,7 +147,7 @@ BECOME_PASSWORD_FILE:
   ini:
   - {key: become_password_file, section: defaults}
   type: path
-  version_added: '2.11'
+  version_added: '2.12'
 AGNOSTIC_BECOME_PROMPT:
   name: Display an agnostic become prompt
   default: True
@@ -356,7 +356,7 @@ CONNECTION_PASSWORD_FILE:
   ini:
   - {key: connection_password_file, section: defaults}
   type: path
-  version_added: '2.11'
+  version_added: '2.12'
 COVERAGE_REMOTE_OUTPUT:
   name: Sets the output directory and filename prefix to generate coverage run info.
   description:


### PR DESCRIPTION
Add a 'file' option for password passing to ansible for connection and become plugins, including 'executable file' functions.

fixes #73026
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
CLI