### PR TITLE
missed extra end-div

### DIFF
--- a/docs/docsite/_themes/sphinx_rtd_theme/ansible_banner.html
+++ b/docs/docsite/_themes/sphinx_rtd_theme/ansible_banner.html
@@ -17,7 +17,6 @@
         document.write('<p>You are reading the latest community version of the Ansible documentation. Red Hat subscribers, select <b>2.9</b> in the version selection to the left for the most recent Red Hat release.</p>');
         document.write('</div>');
 
-        document.write('</div>');
       } else if (startsWith(current_url_path, "/ansible/2.9/")) {
         document.write('<div id="banner_id" class="admonition caution">');
         document.write('<p>You are reading the latest Red Hat released version of the Ansible documentation. Community users can use this, or select any version in version selection to the left, including <b>latest</b> for the most recent community version.</p>');


### PR DESCRIPTION
##### SUMMARY
Bugfix.

We missed a stray `</div>` line in #73125. And it made the formatting very wonky on the `latest` docs.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
