### PR TITLE
WIP: Proposed semantic markup

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -247,12 +247,25 @@ content in a uniform way:
 
 .. note::
 
-  For links between modules and documentation within a collection, you can use either of the options above. Use ``U()`` or ``L()`` with full URLs (not relative links).
+  For links between modules and documentation within a collection, you can use any of the options above. For links outside of your collection, use ``R()`` if available. Otherwise, use ``U()`` or ``L()`` with full URLs (not relative links). For modules, use ``M()`` with the FQCN or ``ansible.builtin`` as shown in the example. If you are creating your own documentation site, you will need to use the `intersphinx extension <https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html>`_ to convert ``R()`` and ``M()`` to the correct links.
 
 .. note::
     - When a collection is not the right granularity, use ``C(..)``:
 
         - ``The C(win_*) modules (spread across several collections) allow you to manage various aspects of windows hosts.``
+
+Call out option names, option values, and environment variables in the module documentation using semantic markup. These macros display the content in a uniform way without creating links. With semantic markup, we can change the look of the output without changing the underlying code. The correct formats for semantic markup are:
+
+* ``O()`` for option names, whether mentioned alone or with values. For example: ``Required if O(state=present).``
+* ``V()`` for option values when mentioned alone. For example: ``Possible values include V(monospace) and V(pretty).``
+* ``E()`` for environment variables. For example: ``If not set the environment variable E(ACME_PASSWORD) will be used.``
+
+You can also use standard Python formatting to control the look of other terms in module documentation:
+
+* ``C()`` for monospace (code) font. For example: ``This module functions like the unix command C(foo).``
+* ``B()`` for bold font.
+* ``I()`` for italic font.
+* ``HORIZONTALLINE`` for a horizontal rule (the ``<hr>`` html tag) to separate long descriptions.
 
 .. note::
 

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -236,15 +236,6 @@ You can link from your module documentation to other module docs, other resource
 * ``L()`` for links with a heading. For example: ``See L(Ansible Automation Platform,https://www.ansible.com/products/automation-platform).`` As of Ansible 2.10, do not use ``L()`` for relative links between Ansible documentation and collection documentation.
 * ``U()`` for URLs. For example: ``See U(https://www.ansible.com/products/automation-platform) for an overview.``
 
-There are also some macros which do not create links but we use them to display certain types of
-content in a uniform way:
-
-* ``I()`` for option names. For example: ``Required if I(state=present).``  This is italicized in
-  the documentation.
-* ``C()`` for files, option values, and inline code. For example: ``If not set the environment variable C(ACME_PASSWORD) will be used.`` or ``Use C(var | foo.bar.my_filter) to transform C(var) into the required format.``  This displays with a mono-space font in the documentation.
-* ``B()`` currently has no standardized usage.  It is displayed in boldface in the documentation.
-* ``HORIZONTALLINE`` is used sparingly as a separator in long descriptions.  It becomes a horizontal rule (the ``<hr>`` html tag) in the documentation.
-
 .. note::
 
   For links between modules and documentation within a collection, you can use any of the options above. For links outside of your collection, use ``R()`` if available. Otherwise, use ``U()`` or ``L()`` with full URLs (not relative links). For modules, use ``M()`` with the FQCN or ``ansible.builtin`` as shown in the example. If you are creating your own documentation site, you will need to use the `intersphinx extension <https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html>`_ to convert ``R()`` and ``M()`` to the correct links.

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -228,8 +228,8 @@ All fields in the ``DOCUMENTATION`` block are lower-case. All fields are require
   * For example, whether ``check_mode`` is or is not supported.
 
 
-Linking and other format macros within module documentation
------------------------------------------------------------
+Linking within module documentation
+-----------------------------------
 
 You can link from your module documentation to other module docs, other resources on docs.ansible.com, and resources elsewhere on the internet with the help of some pre-defined macros. The correct formats for these macros are:
 
@@ -254,22 +254,28 @@ content in a uniform way:
 
         - ``The C(win_*) modules (spread across several collections) allow you to manage various aspects of windows hosts.``
 
-Call out option names, option values, and environment variables in the module documentation using semantic markup. These macros display the content in a uniform way without creating links. With semantic markup, we can change the look of the output without changing the underlying code. The correct formats for semantic markup are:
-
-* ``O()`` for option names, whether mentioned alone or with values. For example: ``Required if O(state=present).``
-* ``V()`` for option values when mentioned alone. For example: ``Possible values include V(monospace) and V(pretty).``
-* ``E()`` for environment variables. For example: ``If not set the environment variable E(ACME_PASSWORD) will be used.``
-
-You can also use standard Python formatting to control the look of other terms in module documentation:
-
-* ``C()`` for monospace (code) font. For example: ``This module functions like the unix command C(foo).``
-* ``B()`` for bold font.
-* ``I()`` for italic font.
-* ``HORIZONTALLINE`` for a horizontal rule (the ``<hr>`` html tag) to separate long descriptions.
-
 .. note::
 
    Because it stands out better, use ``seealso`` for general references over the use of notes or adding links to the description.
+
+Semantic markup within module documentation
+-------------------------------------------
+
+You can use semantic markup to highlight option names, option values, and environment variables. The publication process formats these terms in a uniform way, without creating links. With semantic markup, we can change the look of the output without changing the underlying code. The correct formats for semantic markup are:
+
+* ``O()`` for option names, whether mentioned alone or with values. For example: ``Required if O(state=present).`` and ``Use with O(force) to require secure access.``
+* ``V()`` for option values when mentioned alone. For example: ``Possible values include V(monospace) and V(pretty).``
+* ``E()`` for environment variables. For example: ``If not set the environment variable E(ACME_PASSWORD) will be used.``
+
+Format macros within module documentation
+-----------------------------------------
+
+You can also use standard Python formatting to control the look of other terms in module documentation. Use these macros sparingly. The available macros include:
+
+* ``C()`` for ``monospace`` (code) text. For example: ``This module functions like the unix command C(foo).``
+* ``B()`` for bold text.
+* ``I()`` for italic text.
+* ``HORIZONTALLINE`` for a horizontal rule (the ``<hr>`` html tag) to separate long descriptions.
 
 .. _module_docs_fragments:
 

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -261,11 +261,11 @@ content in a uniform way:
 Semantic markup within module documentation
 -------------------------------------------
 
-You can use semantic markup to highlight option names, option values, and environment variables. The publication process formats these terms in a uniform way, without creating links. With semantic markup, we can change the look of the output without changing the underlying code. The correct formats for semantic markup are:
+You can use semantic markup to highlight option names, option values, and environment variables. The publication process formats these terms in a uniform way. With semantic markup, we can change the look of the output without changing the underlying code. The correct formats for semantic markup are:
 
 * ``O()`` for option names, whether mentioned alone or with values. For example: ``Required if O(state=present).`` and ``Use with O(force) to require secure access.``
 * ``V()`` for option values when mentioned alone. For example: ``Possible values include V(monospace) and V(pretty).``
-* ``E()`` for environment variables. For example: ``If not set the environment variable E(ACME_PASSWORD) will be used.``
+* ``E()`` for environment variables. For example: ``If not set, the environment variable E(ACME_PASSWORD) will be used.``
 
 Format macros within module documentation
 -----------------------------------------


### PR DESCRIPTION
##### SUMMARY

In the Docs Working Group we've been discussing the best way to present options/values/envvars within module documentation. Currently our [documentation on documenting modules](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#linking-and-other-format-macros-within-module-documentation) tells developers to format option names and values directly with `I(.)` (rendered in _italics_) and `C(.0` (rendered in `code`). We started by debating the best way to display these terms, then started to consider switching to semantic markup. Semantic markup would mean using macros that refer to what the term is (for example, `O(.)` for options and `V(.)` for values) instead of how they are displayed.

Moving to semantic markup would mean changing all the current entries. Moving forward, however, it would allow us to control the display of those items by changing the publication process instead of the module code.

This WIP PR is a preliminary, incomplete proposal we can debate. If we go this route, we will need to change the docs build to handle these macros.

**Helpful links:**
Most recent discussion: https://github.com/ansible/community/issues/579#issuecomment-750470261
Previous discussion: https://github.com/ansible/community/issues/521#issuecomment-739263018
The comment that started it all: https://github.com/ansible/ansible/pull/72737#discussion_r533524766

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
