### PR TITLE
[2.10] Pass the top level dictionaries to combine_vars (#72979)

### DIFF
--- a/changelogs/fragments/72979-fix-inventory-merge-hash-replace.yaml
+++ b/changelogs/fragments/72979-fix-inventory-merge-hash-replace.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - inventory - pass the vars dictionary to combine_vars instead of an individual key's value (https://github.com/ansible/ansible/issues/72975).

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -248,7 +248,7 @@ class Group:
             self.set_priority(int(value))
         else:
             if key in self.vars and isinstance(self.vars[key], MutableMapping) and isinstance(value, Mapping):
-                self.vars[key] = combine_vars(self.vars[key], value)
+                self.vars = combine_vars(self.vars, {key: value})
             else:
                 self.vars[key] = value
 

--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -143,7 +143,7 @@ class Host:
 
     def set_variable(self, key, value):
         if key in self.vars and isinstance(self.vars[key], MutableMapping) and isinstance(value, Mapping):
-            self.vars[key] = combine_vars(self.vars[key], value)
+            self.vars = combine_vars(self.vars, {key: value})
         else:
             self.vars[key] = value
 

--- a/test/integration/targets/hash/runme.sh
+++ b/test/integration/targets/hash/runme.sh
@@ -6,3 +6,6 @@ JSON_ARG='{"test_hash":{"extra_args":"this is an extra arg"}}'
 
 ANSIBLE_HASH_BEHAVIOUR=replace ansible-playbook test_hash.yml -i ../../inventory -v "$@" -e "${JSON_ARG}"
 ANSIBLE_HASH_BEHAVIOUR=merge   ansible-playbook test_hash.yml -i ../../inventory -v "$@" -e "${JSON_ARG}"
+
+ANSIBLE_HASH_BEHAVIOUR=replace ansible-playbook test_inventory_hash.yml -i test_inv1.yml -i test_inv2.yml -v "$@"
+ANSIBLE_HASH_BEHAVIOUR=merge ansible-playbook test_inventory_hash.yml -i test_inv1.yml -i test_inv2.yml -v "$@"

--- a/test/integration/targets/hash/test_inv1.yml
+++ b/test/integration/targets/hash/test_inv1.yml
@@ -1,0 +1,10 @@
+all:
+  hosts:
+    host1:
+      test_inventory_host_hash:
+        host_var1: "inventory 1"
+        host_var2: "inventory 1"
+  vars:
+    test_inventory_group_hash:
+      group_var1: "inventory 1"
+      group_var2: "inventory 1"

--- a/test/integration/targets/hash/test_inv2.yml
+++ b/test/integration/targets/hash/test_inv2.yml
@@ -1,0 +1,8 @@
+all:
+  hosts:
+    host1:
+      test_inventory_host_hash:
+        host_var1: "inventory 2"
+  vars:
+    test_inventory_group_hash:
+      group_var1: "inventory 2"

--- a/test/integration/targets/hash/test_inventory_hash.yml
+++ b/test/integration/targets/hash/test_inventory_hash.yml
@@ -1,0 +1,41 @@
+---
+- hosts: localhost
+  gather_facts: no
+  vars:
+    host_hash_merged: {'host_var1': 'inventory 2', 'host_var2': 'inventory 1'}
+    host_hash_replaced: {'host_var1': 'inventory 2'}
+    group_hash_merged: {'group_var1': 'inventory 2', 'group_var2': 'inventory 1'}
+    group_hash_replaced: {'group_var1': 'inventory 2'}
+  tasks:
+
+    - name: debug hash behaviour result
+      debug:
+        var: "{{ lookup('env', 'ANSIBLE_HASH_BEHAVIOUR') }}"
+        verbosity: 2
+
+    - name: assert hash behaviour is merge or replace
+      assert:
+        that:
+          - lookup('env', 'ANSIBLE_HASH_BEHAVIOUR') in ('merge', 'replace')
+
+    - name: debug test_inventory_host_hash
+      debug:
+        var: hostvars['host1']['test_inventory_host_hash']
+        verbosity: 2
+
+    - name: debug test_inventory_group_hash
+      debug:
+        var: test_inventory_group_hash
+        verbosity: 2
+
+    - assert:
+        that:
+          - hostvars['host1']['test_inventory_host_hash'] == host_hash_replaced
+          - test_inventory_group_hash == group_hash_replaced
+      when: "lookup('env', 'ANSIBLE_HASH_BEHAVIOUR') == 'replace'"
+
+    - assert:
+        that:
+          - hostvars['host1']['test_inventory_host_hash'] == host_hash_merged
+          - test_inventory_group_hash == group_hash_merged
+      when: "lookup('env', 'ANSIBLE_HASH_BEHAVIOUR') == 'merge'"


### PR DESCRIPTION
##### SUMMARY
Backport #72979

* Pass the top level dictionaries to combine_vars

combine_vars uses dict.update() to replace keys

(cherry picked from commit 5e03e322de5b43b69c8aad5c0cb92e82ce0f3d17)

##### ISSUE TYPE
- Bugfix Pull Request
