### PR TITLE
ansible-test - No virtualenv install on Python 3

### DIFF
--- a/changelogs/fragments/ansible-test-virtualenv-install.yml
+++ b/changelogs/fragments/ansible-test-virtualenv-install.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ansible-test - The ``--remote`` option no longer pre-installs the ``virtualenv`` module on Python 3.x instances. The Python built-in ``venv`` module should be used instead.
+  - ansible-test - Pin the ``virtualenv`` version used for ``--remote`` pip installs to the latest version supported by Python 2.x, which is version 16.7.10.

--- a/test/integration/targets/pip/tasks/main.yml
+++ b/test/integration/targets/pip/tasks/main.yml
@@ -1,20 +1,30 @@
 # Current pip unconditionally uses md5.
 # We can re-enable if pip switches to a different hash or allows us to not check md5.
 
-- name: find virtualenv command
-  command: "which virtualenv virtualenv-{{ ansible_python.version.major }}.{{ ansible_python.version.minor }}"
-  register: command
-  ignore_errors: true
+- name: Python 2
+  when: ansible_python.version.major == 2
+  block:
+    - name: find virtualenv command
+      command: "which virtualenv virtualenv-{{ ansible_python.version.major }}.{{ ansible_python.version.minor }}"
+      register: command
+      ignore_errors: true
 
-- name: is virtualenv available to python -m
-  command: '{{ ansible_python_interpreter }} -m virtualenv'
-  register: python_m
-  when: not command.stdout_lines
-  failed_when: python_m.rc != 2
+    - name: is virtualenv available to python -m
+      command: '{{ ansible_python_interpreter }} -m virtualenv'
+      register: python_m
+      when: not command.stdout_lines
+      failed_when: python_m.rc != 2
 
-- name: remember selected virtualenv command
-  set_fact:
-    virtualenv: "{{ command.stdout_lines[0] if command is successful else ansible_python_interpreter ~ ' -m virtualenv' }}"
+    - name: remember selected virtualenv command
+      set_fact:
+        virtualenv: "{{ command.stdout_lines[0] if command is successful else ansible_python_interpreter ~ ' -m virtualenv' }}"
+
+- name: Python 3+
+  when: ansible_python.version.major > 2
+  block:
+    - name: remember selected virtualenv command
+      set_fact:
+        virtualenv: "{{ ansible_python_interpreter ~ ' -m venv' }}"
 
 - block:
     - name: install git, needed for repo installs

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -521,7 +521,7 @@
 ### test virtualenv_command begin ###
 
 - name: Test virtualenv command with arguments
-  when: "ansible_system == 'Linux'"
+  when: ansible_python.version.major == 2
   block:
     - name: make sure the virtualenv does not exist
       file:
@@ -533,7 +533,7 @@
       pip:
         name: "{{ pip_test_package }}"
         virtualenv: "{{ output_dir }}/pipenv"
-        virtualenv_command: "virtualenv --verbose"
+        virtualenv_command: "{{ command.stdout_lines[0] | basename }} --verbose"
         state: present
       register: version13
 

--- a/test/lib/ansible_test/_data/setup/remote.sh
+++ b/test/lib/ansible_test/_data/setup/remote.sh
@@ -19,6 +19,14 @@ install_pip () {
 if [ "${platform}" = "freebsd" ]; then
     py_version="$(echo "${python_version}" | tr -d '.')"
 
+    if [ "${py_version}" = "27" ]; then
+        # on Python 2.7 our only option is to use virtualenv
+        virtualenv_pkg="py27-virtualenv"
+    else
+        # on Python 3.x we'll use the built-in venv instead
+        virtualenv_pkg=""
+    fi
+
     while true; do
         env ASSUME_ALWAYS_YES=YES pkg bootstrap && \
         pkg install -q -y \
@@ -27,8 +35,8 @@ if [ "${platform}" = "freebsd" ]; then
             gtar \
             "python${py_version}" \
             "py${py_version}-Jinja2" \
-            "py${py_version}-virtualenv" \
             "py${py_version}-cryptography" \
+            ${virtualenv_pkg} \
             sudo \
         && break
         echo "Failed to install packages. Sleeping before trying again..."
@@ -49,7 +57,6 @@ elif [ "${platform}" = "rhel" ]; then
                 gcc \
                 python3-devel \
                 python3-jinja2 \
-                python3-virtualenv \
                 python3-cryptography \
                 iptables \
             && break
@@ -109,7 +116,8 @@ elif [ "${platform}" = "aix" ]; then
             python-jinja2 \
             python-cryptography \
             python-pip && \
-        pip install --disable-pip-version-check --quiet virtualenv \
+        pip install --disable-pip-version-check --quiet \
+            'virtualenv==16.7.10' \
         && break
         echo "Failed to install packages. Sleeping before trying again..."
         sleep 10


### PR DESCRIPTION
##### SUMMARY

Tests should use the Python built-in ``venv`` module on Python 3 instead of the standalone ``virtualenv`` module.

On Python 2 the ``virtualenv`` module continues to be the only option.
The version installed is either the OS packaged version or the last release to support Python 2, which is version 16.7.10.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
