### PR TITLE
Support venv in ansible-test virtualenv scripts

### DIFF
--- a/changelogs/fragments/ansible-test-venv-virtualenv-fallback.yml
+++ b/changelogs/fragments/ansible-test-venv-virtualenv-fallback.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ansible-test - virtualenv helper scripts now prefer ``venv`` on Python 3 over ``virtualenv``
+  - ansible-test - remote macOS instances no longer install ``virtualenv`` during provisioning

--- a/changelogs/fragments/ansible-test-venv-virtualenv-fallback.yml
+++ b/changelogs/fragments/ansible-test-venv-virtualenv-fallback.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - ansible-test - virtualenv helper scripts now prefer ``venv`` on Python 3 over ``virtualenv``
+  - ansible-test - virtualenv helper scripts now prefer ``venv`` on Python 3 over ``virtualenv`` if the ``ANSIBLE_TEST_PREFER_VENV`` environment variable is set
   - ansible-test - remote macOS instances no longer install ``virtualenv`` during provisioning

--- a/test/lib/ansible_test/_data/injector/virtualenv-isolated.sh
+++ b/test/lib/ansible_test/_data/injector/virtualenv-isolated.sh
@@ -2,7 +2,13 @@
 # Create and activate a fresh virtual environment with `source virtualenv-isolated.sh`.
 
 rm -rf "${OUTPUT_DIR}/venv"
-"${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m virtualenv --python "${ANSIBLE_TEST_PYTHON_INTERPRETER}" "${OUTPUT_DIR}/venv"
+
+# Try to use 'venv' if it is available, then fallback to 'virtualenv' since some systems provide 'venv' although it is non-functional.
+if [[ "${ANSIBLE_TEST_PYTHON_VERSION}" =~ ^2\. ]] || ! "${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m venv "${OUTPUT_DIR}/venv" > /dev/null 2>&1; then
+    rm -rf "${OUTPUT_DIR}/venv"
+    "${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m virtualenv --python "${ANSIBLE_TEST_PYTHON_INTERPRETER}" "${OUTPUT_DIR}/venv"
+fi
+
 set +ux
 source "${OUTPUT_DIR}/venv/bin/activate"
 set -ux

--- a/test/lib/ansible_test/_data/injector/virtualenv-isolated.sh
+++ b/test/lib/ansible_test/_data/injector/virtualenv-isolated.sh
@@ -4,7 +4,7 @@
 rm -rf "${OUTPUT_DIR}/venv"
 
 # Try to use 'venv' if it is available, then fallback to 'virtualenv' since some systems provide 'venv' although it is non-functional.
-if [[ "${ANSIBLE_TEST_PYTHON_VERSION}" =~ ^2\. ]] || ! "${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m venv "${OUTPUT_DIR}/venv" > /dev/null 2>&1; then
+if [ -z "${ANSIBLE_TEST_PREFER_VENV:-}" ] || [[ "${ANSIBLE_TEST_PYTHON_VERSION}" =~ ^2\. ]] || ! "${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m venv "${OUTPUT_DIR}/venv" > /dev/null 2>&1; then
     rm -rf "${OUTPUT_DIR}/venv"
     "${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m virtualenv --python "${ANSIBLE_TEST_PYTHON_INTERPRETER}" "${OUTPUT_DIR}/venv"
 fi

--- a/test/lib/ansible_test/_data/injector/virtualenv.sh
+++ b/test/lib/ansible_test/_data/injector/virtualenv.sh
@@ -2,7 +2,13 @@
 # Create and activate a fresh virtual environment with `source virtualenv.sh`.
 
 rm -rf "${OUTPUT_DIR}/venv"
-"${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m virtualenv --system-site-packages --python "${ANSIBLE_TEST_PYTHON_INTERPRETER}" "${OUTPUT_DIR}/venv"
+
+# Try to use 'venv' if it is available, then fallback to 'virtualenv' since some systems provide 'venv' although it is non-functional.
+if [[ "${ANSIBLE_TEST_PYTHON_VERSION}" =~ ^2\. ]] || ! "${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m venv --system-site-packages "${OUTPUT_DIR}/venv" > /dev/null 2>&1; then
+    rm -rf "${OUTPUT_DIR}/venv"
+    "${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m virtualenv --system-site-packages --python "${ANSIBLE_TEST_PYTHON_INTERPRETER}" "${OUTPUT_DIR}/venv"
+fi
+
 set +ux
 source "${OUTPUT_DIR}/venv/bin/activate"
 set -ux

--- a/test/lib/ansible_test/_data/injector/virtualenv.sh
+++ b/test/lib/ansible_test/_data/injector/virtualenv.sh
@@ -4,7 +4,7 @@
 rm -rf "${OUTPUT_DIR}/venv"
 
 # Try to use 'venv' if it is available, then fallback to 'virtualenv' since some systems provide 'venv' although it is non-functional.
-if [[ "${ANSIBLE_TEST_PYTHON_VERSION}" =~ ^2\. ]] || ! "${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m venv --system-site-packages "${OUTPUT_DIR}/venv" > /dev/null 2>&1; then
+if [ -z "${ANSIBLE_TEST_PREFER_VENV:-}" ] || [[ "${ANSIBLE_TEST_PYTHON_VERSION}" =~ ^2\. ]] || ! "${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m venv --system-site-packages "${OUTPUT_DIR}/venv" > /dev/null 2>&1; then
     rm -rf "${OUTPUT_DIR}/venv"
     "${ANSIBLE_TEST_PYTHON_INTERPRETER}" -m virtualenv --system-site-packages --python "${ANSIBLE_TEST_PYTHON_INTERPRETER}" "${OUTPUT_DIR}/venv"
 fi

--- a/test/lib/ansible_test/_data/setup/remote.sh
+++ b/test/lib/ansible_test/_data/setup/remote.sh
@@ -88,18 +88,10 @@ elif [ "${platform}" = "centos" ]; then
     done
 
     install_pip
-elif [ "${platform}" = "macos" ]; then
-    while true; do
-        pip3 install --disable-pip-version-check --quiet \
-            'virtualenv<20' \
-        && break
-        echo "Failed to install packages. Sleeping before trying again..."
-        sleep 10
-    done
 elif [ "${platform}" = "osx" ]; then
     while true; do
         pip install --disable-pip-version-check --quiet \
-            'virtualenv<20' \
+            'virtualenv==16.7.10' \
         && break
         echo "Failed to install packages. Sleeping before trying again..."
         sleep 10


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/73000

The new behavior is opt-in, using the `ANSIBLE_TEST_PREFER_VENV` environment variable.

This change provides better compatibility when testing across multiple Ansible versions.

The macOS provisioning change is backwards compatible, since the macOS 10.15 image already includes `virtualenv`.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
