### PR TITLE
Backport/2.10/73079

### DIFF
--- a/changelogs/fragments/73079-update-documentation-around-apt-lock.yml
+++ b/changelogs/fragments/73079-update-documentation-around-apt-lock.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "Documentation change to the apt module to reference lock files (https://github.com/ansible/ansible/issues/73079)."

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -245,13 +245,9 @@ EXAMPLES = '''
   apt:
     autoremove: yes
 
-# A common issue, particularly during early boot or at specific clock times
-# is that apt will be locked by another process, perhaps trying to autoupdate
-# or just a race condition on a thread. This work-around (which can also be
-# applied to any of the above statements) ensures that if there is a lock file
-# engaged, which is trapped by the `msg` value, triggers a repeat until the
-# lock file is released.
-- name: Install packages only when the apt process isn't locked
+# Sometimes apt tasks fail because apt is locked by an autoupdate or by a race condition on a thread.
+# To check for a lock file before executing, and keep trying until the lock file is released:
+- name: Install packages only when the apt process is not locked
   apt:
     name: foo
     state: present

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -245,6 +245,21 @@ EXAMPLES = '''
   apt:
     autoremove: yes
 
+# A common issue, particularly during early boot or at specific clock times
+# is that apt will be locked by another process, perhaps trying to autoupdate
+# or just a race condition on a thread. This work-around (which can also be
+# applied to any of the above statements) ensures that if there is a lock file
+# engaged, which is trapped by the `msg` value, triggers a repeat until the
+# lock file is released.
+- name: Install packages only when the apt process isn't locked
+  apt:
+    name: foo
+    state: present
+  register: apt_action
+  retries: 100
+  until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)
+
+
 '''
 
 RETURN = '''


### PR DESCRIPTION
##### SUMMARY
Backport of documentation change from #73079 (This is a documentation change, noting the register/retries/until stanzas required to wait for the apt/dpkg lock file to be released.)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ansible.builtin.apt

##### ADDITIONAL INFORMATION
This change references the suggested workaround in #25414