### PR TITLE
ansible-pull: Use Absolute Path For Destination Checkout 

### DIFF
--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -125,7 +125,7 @@ class PullCLI(CLI):
             hostname = socket.getfqdn()
             # use a hostname dependent directory, in case of $HOME on nfs
             options.dest = os.path.join('~/.ansible/pull', hostname)
-        options.dest = os.path.expandvars(os.path.expanduser(options.dest))
+        options.dest = os.path.abspath(os.path.expandvars(os.path.expanduser(options.dest)))
 
         if os.path.exists(options.dest) and not os.path.isdir(options.dest):
             raise AnsibleOptionsError("%s is not a valid or accessible directory." % options.dest)


### PR DESCRIPTION
##### SUMMARY
When parsing the args, use the absolute path for `-d`/`--destination`. This avoids unwanted behavior resulting from relative paths, especially when `--purge` is invoked and the current directory is changed to root (`/`).

Fixes #73100

Comparing the referenced issue's `strace` to this change:
```shell
mkdir ansible_test && cd ansible_test
strace ansible-pull --check --url https://somerepo.git --directory . --purge
```
```shell
...
read(4, "PLAY RECAP", 10)               = 10
select(7, [4 6], [], [4 6], {tv_sec=1, tv_usec=0}) = 2 (in [4 6], left {tv_sec=0, tv_usec=961214})
--- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=10404, si_uid=1000, si_status=0, si_utime=199, si_stime=1} ---
read(4, "", 10)                         = 0
read(6, "", 10)                         = 0
wait4(10404, [{WIFEXITED(s) && WEXITSTATUS(s) == 0}], WNOHANG, NULL) = 10404
close(6)                                = 0
close(4)                                = 0

### chdir to root ###
chdir("/")                              = 0

### now points to absolute path, vice '/.' ###
lstat("/home/sommersoft/Dev/ansible_dev/ansible_test", {st_mode=S_IFDIR|0775, st_size=4096, ...}) = 0

openat(AT_FDCWD, "/home/sommersoft/Dev/ansible_dev/ansible_test", O_RDONLY|O_CLOEXEC) = 4
fstat(4, {st_mode=S_IFDIR|0775, st_size=4096, ...}) = 0
fcntl(4, F_DUPFD_CLOEXEC, 0)            = 5
fstat(5, {st_mode=S_IFDIR|0775, st_size=4096, ...}) = 0
fcntl(5, F_GETFL)                       = 0x8000 (flags O_RDONLY|O_LARGEFILE)
fcntl(5, F_SETFD, FD_CLOEXEC)           = 0
getdents(5, /* 7 entries */, 32768)     = 208
getdents(5, /* 0 entries */, 32768)     = 0
...
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/cli/pull.py

##### ADDITIONAL INFORMATION
```

```
