### PR TITLE
ansible-pull: Run All Playbooks When Multiple Are Supplied

### DIFF
--- a/changelogs/fragments/72708_ansible_pull_multiple_playbooks.yml
+++ b/changelogs/fragments/72708_ansible_pull_multiple_playbooks.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-pull - Run all playbooks that when multiple are supplied via the command line (https://github.com/ansible/ansible/issues/72708)

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -311,19 +311,26 @@ class PullCLI(CLI):
     @staticmethod
     def select_playbook(path):
         playbook = None
+        errors = []
         if context.CLIARGS['args'] and context.CLIARGS['args'][0] is not None:
-            playbook = os.path.join(path, context.CLIARGS['args'][0])
-            rc = PullCLI.try_playbook(playbook)
-            if rc != 0:
-                display.warning("%s: %s" % (playbook, PullCLI.PLAYBOOK_ERRORS[rc]))
-                return None
+            playbooks = []
+            for book in context.CLIARGS['args']:
+                book_path = os.path.join(path, book)
+                rc = PullCLI.try_playbook(book_path)
+                if rc != 0:
+                    errors.append("%s: %s" % (book_path, PullCLI.PLAYBOOK_ERRORS[rc]))
+                    continue
+                playbooks.append(book_path)
+            if 0 < len(errors):
+                display.warning("\n".join(errors))
+            elif len(playbooks) == len(context.CLIARGS['args']):
+                playbook = " ".join(playbooks)
             return playbook
         else:
             fqdn = socket.getfqdn()
             hostpb = os.path.join(path, fqdn + '.yml')
             shorthostpb = os.path.join(path, fqdn.split('.')[0] + '.yml')
             localpb = os.path.join(path, PullCLI.DEFAULT_PLAYBOOK)
-            errors = []
             for pb in [hostpb, shorthostpb, localpb]:
                 rc = PullCLI.try_playbook(pb)
                 if rc == 0:

--- a/test/integration/targets/pull/pull-integration-test/multi_play_1.yml
+++ b/test/integration/targets/pull/pull-integration-test/multi_play_1.yml
@@ -1,0 +1,6 @@
+- name: test multiple playbooks for ansible-pull
+  hosts: all
+  gather_facts: False
+  tasks:
+    - name: debug output
+      debug: msg="test multi_play_1"

--- a/test/integration/targets/pull/pull-integration-test/multi_play_2.yml
+++ b/test/integration/targets/pull/pull-integration-test/multi_play_2.yml
@@ -1,0 +1,6 @@
+- name: test multiple playbooks for ansible-pull
+  hosts: all
+  gather_facts: False
+  tasks:
+    - name: debug output
+      debug: msg="test multi_play_2"

--- a/test/integration/targets/pull/runme.sh
+++ b/test/integration/targets/pull/runme.sh
@@ -49,6 +49,20 @@ function pass_tests {
 	fi
 }
 
+function pass_tests_multi {
+	# test for https://github.com/ansible/ansible/issues/72708
+	if ! grep 'test multi_play_1' "${temp_log}"; then
+		cat "${temp_log}"
+		echo "Did not run multiple playbooks"
+		exit 1
+	fi
+	if ! grep 'test multi_play_2' "${temp_log}"; then
+		cat "${temp_log}"
+		echo "Did not run multiple playbooks"
+		exit 1
+	fi
+}
+
 export ANSIBLE_INVENTORY
 export ANSIBLE_HOST_PATTERN_MISMATCH
 
@@ -67,3 +81,7 @@ JSON_EXTRA_ARGS='{"docker_registries_login": [{ "docker_password": "'"${PASSWORD
 ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${repo_dir}" -e "${JSON_EXTRA_ARGS}" "$@" --tags untagged,test_ev | tee "${temp_log}"
 
 pass_tests
+
+ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${repo_dir}" "$@" multi_play_1.yml multi_play_2.yml | tee "${temp_log}"
+
+pass_tests_multi


### PR DESCRIPTION
##### SUMMARY
Iterates over all supplied `playbooks` arguments, and constructs the runner arguments with the validated results. Small test sample (full local tests in attached text file).

```shell
(venv) ~/Dev/ansible_dev/ansible_test:$> ansible-pull --url https://github.com/ansible/test-playbooks.git --inventory 127.0.0.1, debug.yml check.yml
Starting Ansible Pull at 2021-01-09 19:42:35
/home/sommersoft/Dev/ansible_dev/ansible/venv/bin/ansible-pull --url https://github.com/ansible/test-playbooks.git --inventory 127.0.0.1, debug.yml check.yml

PLAY [all] *********************************************************************

TASK [debug] *******************************************************************
ok: [127.0.0.1] => {
    "msg": "hello"
}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


PLAY [all] *********************************************************************

TASK [Gathering Facts] *********************************************************
ok: [127.0.0.1]

TASK [Fail if not run with --check] ********************************************
fatal: [127.0.0.1]: FAILED! => {"changed": true, "cmd": "exit 1", "delta": "0:00:00.001742", "end": "2021-01-09 19:42:41.004331", "msg": "non-zero return code", "rc": 1, "start": "2021-01-09 19:42:41.002589", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=2    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0  
```

Fixes #72708

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/cli/pull.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
[pull_multiple_playbooks_tests_output.txt](https://github.com/ansible/ansible/files/5793020/pull_multiple_playbooks_tests_output.txt)
