### PR TITLE
update rstcheck and sphinx versions in contraints

### DIFF
--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -9,6 +9,7 @@ urllib3 < 1.24 ; python_version < '2.7' # urllib3 1.24 and later require python 
 pywinrm >= 0.3.0 # message encryption support
 sphinx < 1.6 ; python_version < '2.7' # sphinx 1.6 and later require python 2.7 or later
 sphinx <= 2.1.2 ; python_version >= '2.7' # docs team hasn't  tested beyond 2.1.2 yet
+rstcheck >=3.3.1  # required for sphinx version >= 1.8
 pygments >= 2.4.0 # Pygments 2.4.0 includes bugfixes for YAML and YAML+Jinja lexers
 wheel < 0.30.0 ; python_version < '2.7' # wheel 0.30.0 and later require python 2.7 or later
 yamllint != 1.8.0, < 1.14.0 ; python_version < '2.7' # yamllint 1.8.0 and 1.14.0+ require python 2.7+

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -8,7 +8,7 @@ jinja2 < 2.11 ; python_version < '2.7' # jinja2 2.11 and later require python 2.
 urllib3 < 1.24 ; python_version < '2.7' # urllib3 1.24 and later require python 2.7 or later
 pywinrm >= 0.3.0 # message encryption support
 sphinx < 1.6 ; python_version < '2.7' # sphinx 1.6 and later require python 2.7 or later
-sphinx < 1.8 ; python_version >= '2.7' # sphinx 1.8 and later are currently incompatible with rstcheck 3.3
+sphinx <= 2.1.2 ; python_version >= '2.7' # docs team hasn't  tested beyond 2.1.2 yet
 pygments >= 2.4.0 # Pygments 2.4.0 includes bugfixes for YAML and YAML+Jinja lexers
 wheel < 0.30.0 ; python_version < '2.7' # wheel 0.30.0 and later require python 2.7 or later
 yamllint != 1.8.0, < 1.14.0 ; python_version < '2.7' # yamllint 1.8.0 and 1.14.0+ require python 2.7+

--- a/test/lib/ansible_test/_data/requirements/sanity.rstcheck.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.rstcheck.txt
@@ -1,1 +1,1 @@
-rstcheck
+rstcheck >=3.3.1  # required for sphinx version > 1.8

--- a/test/lib/ansible_test/_data/requirements/sanity.rstcheck.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.rstcheck.txt
@@ -1,1 +1,1 @@
-rstcheck >=3.3.1  # required for sphinx version > 1.8
+rstcheck


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
rstcheck version 3.3.1 now works with sphinx versions > 1.8.  Update sphinx to 2.1.2 (latest that the docs team has tested) and set constraint that rstcheck has to be >= 3.3.1
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs.ansible.com
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
