### PR TITLE
pause - adjust warning when run in background

### DIFF
--- a/changelogs/fragments/pause-do-not-warn-background-with-seconds.yml
+++ b/changelogs/fragments/pause-do-not-warn-background-with-seconds.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pause - do not warn when running in the background if a timeout is provided (https://github.com/ansible/ansible/issues/73042)

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -231,7 +231,8 @@ class ActionModule(ActionBase):
 
             while True:
                 if not interactive:
-                    display.warning("Not waiting for response to prompt as stdin is not interactive")
+                    if seconds is None:
+                        display.warning("Not waiting for response to prompt as stdin is not interactive")
                     if seconds is not None:
                         # Give the signal handler enough time to timeout
                         time.sleep(seconds + 1)

--- a/test/integration/targets/pause/runme.sh
+++ b/test/integration/targets/pause/runme.sh
@@ -4,8 +4,8 @@ set -eux
 
 ANSIBLE_ROLES_PATH=../ ansible-playbook setup.yml
 
-# Test pause module when no tty and non-interactive. This is to prevent playbooks
-# from hanging in cron and Tower jobs.
+# Test pause module when no tty and non-interactive with no seconds parameter.
+# This is to prevent playbooks from hanging in cron and Tower jobs.
 /usr/bin/env bash << EOF
 ansible-playbook test-pause-no-tty.yml 2>&1 | \
     grep '\[WARNING\]: Not waiting for response to prompt as stdin is not interactive' && {
@@ -27,10 +27,14 @@ else
 fi
 
 # Test redirecting stdout
-# Issue #41717
-ansible-playbook pause-3.yml > /dev/null \
-    && echo "Successfully redirected stdout" \
-    || echo "Failure when attempting to redirect stdout"
+# https://github.com/ansible/ansible/issues/41717
+if ansible-playbook pause-3.yml > /dev/null ; then
+    echo "Successfully redirected stdout"
+else
+    echo "Failure when attempting to redirect stdout"
+    exit 1
+fi
+
 
 # Test pause with seconds and minutes specified
 ansible-playbook test-pause.yml "$@"

--- a/test/integration/targets/pause/runme.sh
+++ b/test/integration/targets/pause/runme.sh
@@ -17,6 +17,15 @@ ansible-playbook test-pause-no-tty.yml 2>&1 | \
     }
 EOF
 
+# Do not issue a warning when run in the background if a timeout is given
+# https://github.com/ansible/ansible/issues/73042
+if sleep 0 | ansible localhost -m pause -a 'seconds=1' 2>&1 | grep '\[WARNING\]: Not waiting for response'; then
+    echo "Incorrectly issued warning when run in the background"
+    exit 1
+else
+    echo "Succesfully ran in the background with no warning"
+fi
+
 # Test redirecting stdout
 # Issue #41717
 ansible-playbook pause-3.yml > /dev/null \


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When the pause module is run in the background and seconds parameter is provided, do not warn.

Fixes #73042
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/action/pause.py`