### PR TITLE
[bp-2.9] snmp_facts: Hide user sensitive information in console

### DIFF
--- a/changelogs/fragments/snmp_facts.yml
+++ b/changelogs/fragments/snmp_facts.yml
@@ -1,0 +1,2 @@
+security_fixes:
+- 'snmp_facts - **CVE-2021-20178** - hide user sensitive information such as ``privkey`` and ``authkey`` from logging into the console (https://github.com/ansible-collections/community.general/pull/1621).'

--- a/changelogs/fragments/snmp_facts.yml
+++ b/changelogs/fragments/snmp_facts.yml
@@ -1,2 +1,2 @@
 security_fixes:
-- 'snmp_facts - **CVE-2021-20178** - hide user sensitive information such as ``privkey`` and ``authkey`` from logging into the console (https://github.com/ansible-collections/community.general/pull/1621) (CVE-2021-20178).'
+- 'snmp_facts - hide user sensitive information such as ``privkey`` and ``authkey`` from logging into the console (https://github.com/ansible-collections/community.general/pull/1621) (CVE-2021-20178).'

--- a/changelogs/fragments/snmp_facts.yml
+++ b/changelogs/fragments/snmp_facts.yml
@@ -1,2 +1,2 @@
 security_fixes:
-- 'snmp_facts - **CVE-2021-20178** - hide user sensitive information such as ``privkey`` and ``authkey`` from logging into the console (https://github.com/ansible-collections/community.general/pull/1621).'
+- 'snmp_facts - **CVE-2021-20178** - hide user sensitive information such as ``privkey`` and ``authkey`` from logging into the console (https://github.com/ansible-collections/community.general/pull/1621) (CVE-2021-20178).'

--- a/lib/ansible/modules/net_tools/snmp_facts.py
+++ b/lib/ansible/modules/net_tools/snmp_facts.py
@@ -277,8 +277,8 @@ def main():
             level=dict(type='str', choices=['authNoPriv', 'authPriv']),
             integrity=dict(type='str', choices=['md5', 'sha']),
             privacy=dict(type='str', choices=['aes', 'des']),
-            authkey=dict(type='str'),
-            privkey=dict(type='str'),
+            authkey=dict(type='str', no_log=True),
+            privkey=dict(type='str', no_log=True),
         ),
         required_together=(
             ['username', 'level', 'integrity', 'authkey'],


### PR DESCRIPTION
##### SUMMARY

**SECURITY** - CVE-2021-20178

Hide user sensitive information like `privkey` and `authkey`
while logging in console.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/snmp_facts.yml
lib/ansible/modules/net_tools/snmp_facts.py
