### PR TITLE
doc: fix ansible_play_hosts description about failure

### DIFF
--- a/docs/docsite/rst/reference_appendices/special_variables.rst
+++ b/docs/docsite/rst/reference_appendices/special_variables.rst
@@ -51,7 +51,7 @@ ansible_play_batch
     List of active hosts in the current play run limited by the serial, aka 'batch'. Failed/Unreachable hosts are not considered 'active'.
 
 ansible_play_hosts
-    List of hosts in the current play run, not limited by the serial. Failed/Unreachable hosts are included in this list.
+    List of hosts in the current play run, not limited by the serial. Failed/Unreachable hosts are excluded from this list.
 
 ansible_play_hosts_all
     List of all the hosts that were targeted by the play


### PR DESCRIPTION
##### SUMMARY

The variable ansible_play_hosts actually does _not_ includes failed or unreachable hosts, contrary to what the document says.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

docs

##### ADDITIONAL INFORMATION

The current document says `ansible_play_hosts` _includes_ failed or unreachable hosts, but this is not true as we can see below.

**Ansible version**: `2.10.3`

<details>
<summary>(output)</summary>

```
$ ansible --version
ansible 2.10.3
  config file = None
  configured module search path = ['/Users/koki/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.8/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.8.5 (default, Jul 21 2020, 10:48:26) [Clang 11.0.3 (clang-1103.0.32.62)]
```

</details>

**inventory**: we have 3 hosts `foo{1..3}` and simulate failure on `foo2`

<details>
<summary>(file: hosts)</summary>

```ini
[foo]
foo1 fail=False
foo2 fail=True
foo3 fail=False
```

</details>

**playbook**: we run with `serial: 2`, and print `ansible_play_*` variables before/after failure

<details>
<summary>(file: playbook.yml)</summary>

```yaml
- hosts: all
  gather_facts: no
  serial: 2
  tasks:
    - name: Print ansible_play_batch (before failure)
      debug:
        var: ansible_play_batch

    - name: Print ansible_play_hosts (before failure)
      debug:
        var: ansible_play_hosts

    - name: Print ansible_play_hosts_all (before failure)
      debug:
        var: ansible_play_hosts_all

    - name: Simulate failure
      fail:
        msg: "fail!"
      when: fail

    - name: Print ansible_play_batch (after failure)
      debug:
        var: ansible_play_batch

    - name: Print ansible_play_hosts (after failure)
      debug:
        var: ansible_play_hosts

    - name: Print ansible_play_hosts_all (after failure)
      debug:
        var: ansible_play_hosts_all
```

</details>

**Result**: The failed host (`foo2`) is _excluded_ from `ansible_play_hosts`, as seen in `Print ansible_play_hosts (after failure)` task result

<details>
<summary>(output)</summary>

```shell
$ ansible-playbook -i hosts -b playbook.yml

PLAY [all] *************************************************************************************************************************************************************************************************

TASK [Print ansible_play_batch (before failure)] ***********************************************************************************************************************************************************
ok: [foo1] => {
    "ansible_play_batch": [
        "foo1",
        "foo2"
    ]
}
ok: [foo2] => {
    "ansible_play_batch": [
        "foo1",
        "foo2"
    ]
}

TASK [Print ansible_play_hosts (before failure)] ***********************************************************************************************************************************************************
ok: [foo1] => {
    "ansible_play_hosts": [
        "foo1",
        "foo2",
        "foo3"
    ]
}
ok: [foo2] => {
    "ansible_play_hosts": [
        "foo1",
        "foo2",
        "foo3"
    ]
}

TASK [Print ansible_play_hosts_all (before failure)] *******************************************************************************************************************************************************
ok: [foo1] => {
    "ansible_play_hosts_all": [
        "foo1",
        "foo2",
        "foo3"
    ]
}
ok: [foo2] => {
    "ansible_play_hosts_all": [
        "foo1",
        "foo2",
        "foo3"
    ]
}

TASK [Simulate failure] ************************************************************************************************************************************************************************************
skipping: [foo1]
fatal: [foo2]: FAILED! => {"changed": false, "msg": "fail!"}

TASK [Print ansible_play_batch (after failure)] ************************************************************************************************************************************************************
ok: [foo1] => {
    "ansible_play_batch": [
        "foo1"
    ]
}

TASK [Print ansible_play_hosts (after failure)] ************************************************************************************************************************************************************
ok: [foo1] => {
    "ansible_play_hosts": [
        "foo1",
        "foo3"
    ]
}

TASK [Print ansible_play_hosts_all (after failure)] ********************************************************************************************************************************************************
ok: [foo1] => {
    "ansible_play_hosts_all": [
        "foo1",
        "foo2",
        "foo3"
    ]
}

PLAY [all] *************************************************************************************************************************************************************************************************

TASK [Print ansible_play_batch (before failure)] ***********************************************************************************************************************************************************
ok: [foo3] => {
    "ansible_play_batch": [
        "foo3"
    ]
}

TASK [Print ansible_play_hosts (before failure)] ***********************************************************************************************************************************************************
ok: [foo3] => {
    "ansible_play_hosts": [
        "foo1",
        "foo3"
    ]
}

TASK [Print ansible_play_hosts_all (before failure)] *******************************************************************************************************************************************************
ok: [foo3] => {
    "ansible_play_hosts_all": [
        "foo1",
        "foo2",
        "foo3"
    ]
}

TASK [Simulate failure] ************************************************************************************************************************************************************************************
skipping: [foo3]

TASK [Print ansible_play_batch (after failure)] ************************************************************************************************************************************************************
ok: [foo3] => {
    "ansible_play_batch": [
        "foo3"
    ]
}

TASK [Print ansible_play_hosts (after failure)] ************************************************************************************************************************************************************
ok: [foo3] => {
    "ansible_play_hosts": [
        "foo1",
        "foo3"
    ]
}

TASK [Print ansible_play_hosts_all (after failure)] ********************************************************************************************************************************************************
ok: [foo3] => {
    "ansible_play_hosts_all": [
        "foo1",
        "foo2",
        "foo3"
    ]
}

PLAY RECAP *************************************************************************************************************************************************************************************************
foo1                       : ok=6    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
foo2                       : ok=3    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
foo3                       : ok=6    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
```

</details>

To summarize,

|  | excludes failed/unreachable hosts | excludes hosts not targeted by the current play |
|-|-|-|
| `ansible_play_batch` | yes | yes |
| `ansible_play_hosts` | yes | no |
| `ansible_play_hosts_all` | no | no |