### PR TITLE
remove deprecated ansible.module_utils._text from documentation

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -99,7 +99,7 @@ In the Python example the ``module_util`` in question is called ``qradar`` such 
 .. code-block:: python
 
     from ansible.module_utils.basic import AnsibleModule
-    from ansible.module_utils._text import to_text
+    from ansible.module_utils.common.text.converters import to_text
 
     from ansible.module_utils.six.moves.urllib.parse import urlencode, quote_plus
     from ansible.module_utils.six.moves.urllib.error import HTTPError

--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -29,7 +29,7 @@ You should return errors encountered during plugin execution by raising ``Ansibl
 
 .. code-block:: python
 
-    from ansible.module_utils._text import to_native
+    from ansible.module_utils.common.text.converters import to_native
 
     try:
         cause_an_exception()
@@ -45,7 +45,7 @@ You must convert any strings returned by your plugin into Python's unicode type.
 
 .. code-block:: python
 
-    from ansible.module_utils._text import to_text
+    from ansible.module_utils.common.text.converters import to_text
     result_string = to_text(result_string)
 
 Plugin configuration & documentation standards

--- a/docs/docsite/rst/dev_guide/developing_python_3.rst
+++ b/docs/docsite/rst/dev_guide/developing_python_3.rst
@@ -116,7 +116,7 @@ to yield text but instead do the conversion explicitly ourselves. For example:
 
 .. code-block:: python
 
-    from ansible.module_utils._text import to_text
+    from ansible.module_utils.common.text.converters import to_text
 
     with open('filename-with-utf8-data.txt', 'rb') as my_file:
         b_data = my_file.read()
@@ -136,7 +136,7 @@ Writing to files is the opposite process:
 
 .. code-block:: python
 
-    from ansible.module_utils._text import to_bytes
+    from ansible.module_utils.common.text.converters import to_bytes
 
     with open('filename.txt', 'wb') as my_file:
         my_file.write(to_bytes(some_text_string))
@@ -160,7 +160,7 @@ works on both versions:
 
     import os.path
 
-    from ansible.module_utils._text import to_bytes
+    from ansible.module_utils.common.text.converters import to_bytes
 
     filename = u'/var/tmp/くらとみ.txt'
     f = open(to_bytes(filename), 'wb')
@@ -246,9 +246,9 @@ In ``module_utils`` code:
 * Functions that return strings **must** document whether they return strings of the same type as they were given or native strings.
 
 Module-utils functions are therefore often very defensive in nature.
-They convert their string parameters into text (using ``ansible.module_utils._text.to_text``)
+They convert their string parameters into text (using ``ansible.module_utils.common.text.converters.to_text``)
 at the beginning of the function, do their work, and then convert
-the return values into the native string type (using ``ansible.module_utils._text.to_native``)
+the return values into the native string type (using ``ansible.module_utils.common.text.converters.to_native``)
 or back to the string type that their parameters received.
 
 Tips, tricks, and idioms for Python 2/Python 3 compatibility

--- a/docs/docsite/rst/dev_guide/migrating_roles.rst
+++ b/docs/docsite/rst/dev_guide/migrating_roles.rst
@@ -226,7 +226,7 @@ In the Python example the ``module_utils`` is ``helper`` and the :abbr:`FQCN (Fu
 .. code-block:: text
 
   from ansible.module_utils.basic import AnsibleModule
-  from ansible.module_utils._text import to_text
+  from ansible.module_utils.common.text.converters import to_text
   from ansible.module_utils.six.moves.urllib.parse import urlencode
   from ansible.module_utils.six.moves.urllib.error import HTTPError
   from ansible_collections.ansible_example.community.plugins.module_utils.helper import HelperRequest

--- a/docs/docsite/rst/dev_guide/testing/sanity/no-basestring.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/no-basestring.rst
@@ -7,5 +7,5 @@ from ``ansible.module_utils.six`` and then use ``isinstance(s, string_types)``
 or ``isinstance(s, (binary_type, text_type))`` instead.
 
 If this is part of code to convert a string to a particular type,
-``ansible.module_utils._text`` contains several functions that may be even
-better for you: ``to_text``, ``to_bytes``, and ``to_native``.
+``ansible.module_utils.common.text.converters`` contains several functions 
+that may be even better for you: ``to_text``, ``to_bytes``, and ``to_native``.

--- a/docs/docsite/rst/dev_guide/testing_units_modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_units_modules.rst
@@ -296,7 +296,7 @@ variable is set it will be treated as if the input came on ``STDIN`` to the modu
 
     import json
     from units.modules.utils import set_module_args
-    from ansible.module_utils._text import to_bytes
+    from ansible.module_utils.common.text.converters import to_bytes
 
     def test_already_registered(self):
         set_module_args({
@@ -388,7 +388,7 @@ mock for :meth:`Ansible.get_bin_path`::
     from units.compat import unittest
     from units.compat.mock import patch
     from ansible.module_utils import basic
-    from ansible.module_utils._text import to_bytes
+    from ansible.module_utils.common.text.converters import to_bytes
     from ansible.modules.namespace import my_module
 
 


### PR DESCRIPTION
##### SUMMARY
According to comment in ansible.module_utils._text it is deprecated and
should not be used. This is now reflected in the documentation.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ansible.module_utils._text

##### ADDITIONAL INFORMATION
Once this is accepted I'm not sure on how to continue. We should also change all usages in the Ansible code. I could do that, if it is wanted.
