### PR TITLE
single_list example: Transform single_list before passing it into dict()

### DIFF
--- a/docs/docsite/rst/user_guide/complex_data_manipulation.rst
+++ b/docs/docsite/rst/user_guide/complex_data_manipulation.rst
@@ -198,7 +198,7 @@ These example produces ``{"a": "b", "c": "d"}``
 
   vars:
       single_list: [ 'a', 'b', 'c', 'd' ]
-      mydict: "{{ dict(single_list) | slice(2) | list }}"
+      mydict: "{{ dict(single_list | slice(2) | list) }}"
 
 
 .. code-block:: YAML+Jinja


### PR DESCRIPTION
##### SUMMARY
<!--- Your description here -->
single_list must be transformed to a list of pairs before feeding it into dict().

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The current example tries to form a dict first, then feeds that dict to the list transformation. That doesn't seem to be quite right.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
user_guide/complex_data_manipulation

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

