### PR TITLE
Fix flakes that occur when running tests without containerization.

### DIFF
--- a/test/units/cli/test_adhoc.py
+++ b/test/units/cli/test_adhoc.py
@@ -93,7 +93,9 @@ def test_run_no_extra_vars():
     assert exec_info.value.code == 2
 
 
-def test_ansible_version(capsys, mocker):
+def test_ansible_git_version(capsys, mocker):
+    mocker.patch("ansible.cli.arguments.option_helpers._git_repo_info",
+                 return_value="ansible 2.11.0.dev0 (devel 8a202cae3e) last updated 2021/01/11 10:24:38 (GMT +200)")
     adhoc_cli = AdHocCLI(args=['/bin/ansible', '--version'])
     with pytest.raises(SystemExit):
         adhoc_cli.run()
@@ -105,12 +107,37 @@ def test_ansible_version(capsys, mocker):
         version_lines = version[0].splitlines()
 
     assert len(version_lines) == 9, 'Incorrect number of lines in "ansible --version" output'
-    assert re.match('ansible [0-9.a-z]+$', version_lines[0]), 'Incorrect ansible version line in "ansible --version" output'
-    assert re.match('  config file = .*$', version_lines[1]), 'Incorrect config file line in "ansible --version" output'
-    assert re.match('  configured module search path = .*$', version_lines[2]), 'Incorrect module search path in "ansible --version" output'
-    assert re.match('  ansible python module location = .*$', version_lines[3]), 'Incorrect python module location in "ansible --version" output'
-    assert re.match('  ansible collection location = .*$', version_lines[4]), 'Incorrect collection location in "ansible --version" output'
-    assert re.match('  executable location = .*$', version_lines[5]), 'Incorrect executable locaction in "ansible --version" output'
-    assert re.match('  python version = .*$', version_lines[6]), 'Incorrect python version in "ansible --version" output'
-    assert re.match('  jinja version = .*$', version_lines[7]), 'Incorrect jinja version in "ansible --version" output'
-    assert re.match('  libyaml = .*$', version_lines[8]), 'Missing libyaml in "ansible --version" output'
+    assert re.match(r'ansible [0-9.a-z]+ .*$', version_lines[0]), 'Incorrect ansible version line in "ansible --version" output'
+    assert re.match(r'  config file = .*$', version_lines[1]), 'Incorrect config file line in "ansible --version" output'
+    assert re.match(r'  configured module search path = .*$', version_lines[2]), 'Incorrect module search path in "ansible --version" output'
+    assert re.match(r'  ansible python module location = .*$', version_lines[3]), 'Incorrect python module location in "ansible --version" output'
+    assert re.match(r'  ansible collection location = .*$', version_lines[4]), 'Incorrect collection location in "ansible --version" output'
+    assert re.match(r'  executable location = .*$', version_lines[5]), 'Incorrect executable locaction in "ansible --version" output'
+    assert re.match(r'  python version = .*$', version_lines[6]), 'Incorrect python version in "ansible --version" output'
+    assert re.match(r'  jinja version = .*$', version_lines[7]), 'Incorrect jinja version in "ansible --version" output'
+    assert re.match(r'  libyaml = .*$', version_lines[8]), 'Missing libyaml in "ansible --version" output'
+
+
+def test_ansible_plain_version(capsys, mocker):
+    mocker.patch("ansible.cli.arguments.option_helpers._git_repo_info", return_value="")
+
+    adhoc_cli = AdHocCLI(args=['/bin/ansible', '--version'])
+    with pytest.raises(SystemExit):
+        adhoc_cli.run()
+    version = capsys.readouterr()
+    try:
+        version_lines = version.out.splitlines()
+    except AttributeError:
+        # Python 2.6 does return a named tuple, so get the first item
+        version_lines = version[0].splitlines()
+
+    assert len(version_lines) == 9, 'Incorrect number of lines in "ansible --version" output'
+    assert re.match(r'ansible [0-9.a-z]+$', version_lines[0]), 'Incorrect ansible version line in "ansible --version" output'
+    assert re.match(r'  config file = .*$', version_lines[1]), 'Incorrect config file line in "ansible --version" output'
+    assert re.match(r'  configured module search path = .*$', version_lines[2]), 'Incorrect module search path in "ansible --version" output'
+    assert re.match(r'  ansible python module location = .*$', version_lines[3]), 'Incorrect python module location in "ansible --version" output'
+    assert re.match(r'  ansible collection location = .*$', version_lines[4]), 'Incorrect collection location in "ansible --version" output'
+    assert re.match(r'  executable location = .*$', version_lines[5]), 'Incorrect executable locaction in "ansible --version" output'
+    assert re.match(r'  python version = .*$', version_lines[6]), 'Incorrect python version in "ansible --version" output'
+    assert re.match(r'  jinja version = .*$', version_lines[7]), 'Incorrect jinja version in "ansible --version" output'
+    assert re.match(r'  libyaml = .*$', version_lines[8]), 'Missing libyaml in "ansible --version" output'

--- a/test/units/module_utils/urls/test_prepare_multipart.py
+++ b/test/units/module_utils/urls/test_prepare_multipart.py
@@ -58,6 +58,7 @@ def test_prepare_multipart():
         },
         'file5': {
             'filename': client_key,
+            'mime_type': 'application/pgp-keys',
         },
         'file6': {
             'filename': client_txt,


### PR DESCRIPTION
##### SUMMARY
test_adhoc fails when running tests from within a git checkout
since the `ansible --version` output contains git information
that the test does not expect. I duplicated the test into
test_adhoc_plain and test_adhoc_git, where mocks are used to mimic
the respective environment.

test_prepare_multipart fails on non debian environments since
debian installations map the file ending .key to the MIME type
application/pgp-keys, which is not IANA conformant. Hard coded
the type of the corresponding file to application/pgp-keys in
this test.


##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME
Tests `test_prepare_multipart` and `test_adhoc`

##### ADDITIONAL INFORMATION
-