### PR TITLE
Allow `test_prepare_multipart` to succeed on non Debian distros

### DIFF
--- a/test/units/module_utils/urls/fixtures/multipart.txt
+++ b/test/units/module_utils/urls/fixtures/multipart.txt
@@ -100,7 +100,7 @@ YTVjY0o0emZPdwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
 
 --===============3996062709511591449==
 Content-Transfer-Encoding: base64
-Content-Type: application/pgp-keys
+Content-Type: application/octet-stream
 Content-Disposition: form-data; name="file5"; filename="client.key"
 
 LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JSUV2UUlCQURBTkJna3Foa2lHOXcwQkFRRUZB

--- a/test/units/module_utils/urls/test_prepare_multipart.py
+++ b/test/units/module_utils/urls/test_prepare_multipart.py
@@ -58,6 +58,7 @@ def test_prepare_multipart():
         },
         'file5': {
             'filename': client_key,
+            'mime_type': 'application/octet-stream'
         },
         'file6': {
             'filename': client_txt,


### PR DESCRIPTION
##### SUMMARY
`test_prepare_multipart` fails in non Debian environments since
Debian installations map the file ending `.key` to the MIME type
`application/pgp-keys`, which is not IANA conformant. This commit
explicitly sets the corresponding file type to
`application/octet-stream` and adjusts the expected serialized
result.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`test_prepare_multipart`

##### ADDITIONAL INFORMATION
None