### PR TITLE
Fix `test_adhoc` flake when running from within a git checkout.

### DIFF
--- a/test/units/cli/test_adhoc.py
+++ b/test/units/cli/test_adhoc.py
@@ -105,7 +105,7 @@ def test_ansible_version(capsys, mocker):
         version_lines = version[0].splitlines()
 
     assert len(version_lines) == 9, 'Incorrect number of lines in "ansible --version" output'
-    assert re.match('ansible [0-9.a-z]+$', version_lines[0]), 'Incorrect ansible version line in "ansible --version" output'
+    assert re.match('ansible [0-9.a-z]+(?: .*)?$', version_lines[0]), 'Incorrect ansible version line in "ansible --version" output'
     assert re.match('  config file = .*$', version_lines[1]), 'Incorrect config file line in "ansible --version" output'
     assert re.match('  configured module search path = .*$', version_lines[2]), 'Incorrect module search path in "ansible --version" output'
     assert re.match('  ansible python module location = .*$', version_lines[3]), 'Incorrect python module location in "ansible --version" output'


### PR DESCRIPTION
##### SUMMARY
The test currently only expects the literal `ansible` followed
by a semver in the first output line of `ansible --version`.
When running from within a git checkout, additional information
like the currently checkout branch are attached, which lets
the test fail. This commit allows arbitrary information to
follow the semver.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`test_adhoc`

##### ADDITIONAL INFORMATION
None