### PR TITLE
Fix block example line emphasis

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_blocks.rst
+++ b/docs/docsite/rst/user_guide/playbooks_blocks.rst
@@ -58,7 +58,7 @@ Rescue blocks specify tasks to run when an earlier task in a block fails. This a
 
 .. _block_rescue:
 .. code-block:: YAML
- :emphasize-lines: 3,10
+ :emphasize-lines: 3,14
  :caption: Block error handling example
 
   tasks:
@@ -83,7 +83,7 @@ You can also add an ``always`` section to a block. Tasks in the ``always`` secti
 
 .. _block_always:
 .. code-block:: YAML
- :emphasize-lines: 2,9
+ :emphasize-lines: 2,13
  :caption: Block with always section
 
   - name: Always do X
@@ -106,7 +106,7 @@ You can also add an ``always`` section to a block. Tasks in the ``always`` secti
 Together, these elements offer complex error handling.
 
 .. code-block:: YAML
- :emphasize-lines: 2,9,16
+ :emphasize-lines: 2,13,24
  :caption: Block with all sections
 
  - name: Attempt and graceful roll back demo
@@ -144,7 +144,7 @@ If an error occurs in the block and the rescue task succeeds, Ansible reverts th
 You can use blocks with ``flush_handlers`` in a rescue task to ensure that all handlers run even if an error occurs:
 
 .. code-block:: YAML
- :emphasize-lines: 6,10
+ :emphasize-lines: 3,12
  :caption: Block run handlers in error handling
 
   tasks:


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In the commit to update code examples for blocks docs (https://github.com/ansible/ansible/commit/79dc6fa9481c9cf7ba8d781a40ff299918495100), the code examples were updated but not the line emphasis for the block reserved words. This updates the line emphasis indexes to be in alignment with the code example updates.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs/docsite/rst/user_guide/playbooks_blocks.rst

```
