### PR TITLE
Make sure collection name is included in plugin deprecations from collections

### DIFF
--- a/changelogs/fragments/73239-dont-forget-later-deprecations.yml
+++ b/changelogs/fragments/73239-dont-forget-later-deprecations.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "Plugin configuration loader now makes sure that the collection name is added for plugin deprecations (https://github.com/ansible/ansible/pull/73239)."

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -26,7 +26,7 @@ from ansible.plugins import get_plugin_class, MODULE_CACHE, PATH_CACHE, PLUGIN_P
 from ansible.utils.collection_loader import AnsibleCollectionConfig, AnsibleCollectionRef
 from ansible.utils.collection_loader._collection_finder import _AnsibleCollectionFinder, _get_collection_metadata
 from ansible.utils.display import Display
-from ansible.utils.plugin_docs import add_fragments
+from ansible.utils.plugin_docs import add_collection_to_versions_and_dates, add_fragments
 from ansible import __version__ as ansible_version
 
 # TODO: take the packaging dep, or vendor SpecifierSet?
@@ -387,7 +387,7 @@ class PluginLoader:
         paths_with_context = self._get_paths_with_context(subdirs=subdirs)
         return [path_with_context.path for path_with_context in paths_with_context]
 
-    def _load_config_defs(self, name, module, path):
+    def _load_config_defs(self, name, module, path, collection_name=None):
         ''' Reads plugin docs to find configuration setting definitions, to push to config manager for later use '''
 
         # plugins w/o class name don't support config
@@ -398,6 +398,8 @@ class PluginLoader:
             if type_name in C.CONFIGURABLE_PLUGINS:
                 dstring = AnsibleLoader(getattr(module, 'DOCUMENTATION', ''), file_name=path).get_single_data()
                 if dstring:
+                    if collection_name:
+                        add_collection_to_versions_and_dates(dstring, collection_name, is_module=(type_name == 'module'))
                     add_fragments(dstring, path, fragment_loader=fragment_loader, is_module=(type_name == 'module'))
 
                 if dstring and 'options' in dstring and isinstance(dstring['options'], dict):
@@ -828,7 +830,8 @@ class PluginLoader:
 
         if path not in self._module_cache:
             self._module_cache[path] = self._load_module_source(name, path)
-            self._load_config_defs(name, self._module_cache[path], path)
+            self._load_config_defs(
+                name, self._module_cache[path], path, collection_name=plugin_load_context.plugin_resolved_collection)
             found_in_cache = False
 
         obj = getattr(self._module_cache[path], self.class_name)

--- a/test/units/plugins/test_plugins.py
+++ b/test/units/plugins/test_plugins.py
@@ -105,8 +105,8 @@ class TestErrors(unittest.TestCase):
         self.assertEqual(one, two)
 
     @patch('ansible.plugins.loader.glob')
-    @patch.object(PluginLoader, '_get_paths')
-    def test_all_no_duplicate_names(self, gp_mock, glob_mock):
+    @patch.object(PluginLoader, '_get_paths_with_context')
+    def test_all_no_duplicate_names(self, gpwc_mock, glob_mock):
         '''
         This test goes along with ``test__load_module_source_no_duplicate_names``
         and ensures that we ignore duplicate imports on multiple paths
@@ -114,9 +114,9 @@ class TestErrors(unittest.TestCase):
 
         fixture_path = os.path.join(os.path.dirname(__file__), 'loader_fixtures')
 
-        gp_mock.return_value = [
-            fixture_path,
-            '/path/to'
+        gpwc_mock.return_value = [
+            PluginPathContext(fixture_path, True),
+            PluginPathContext('/path/to', True),
         ]
 
         glob_mock.glob.side_effect = [


### PR DESCRIPTION
##### SUMMARY
Make sure collection name is included in plugin deprecations from collections.

(One part of #73058.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/loader.py
