### PR TITLE
Fix YAML error message when error is at the end of the file

### DIFF
--- a/changelogs/fragments/16456-correct-YAML-error-message-when-file-load-failed.yml
+++ b/changelogs/fragments/16456-correct-YAML-error-message-when-file-load-failed.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - display correct error information when an error exists in the last line of the file (https://github.com/ansible/ansible/issues/16456)

--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -100,7 +100,21 @@ class AnsibleError(Exception):
         with open(file_name, 'r') as f:
             lines = f.readlines()
 
+            # In case of a YAML loading error, PyYAML will report the very last line
+            # as the location of the error. Avoid an index error here in order to
+            # return a helpful message.
+            file_length = len(lines)
+            if line_number >= file_length:
+                line_number = file_length - 1
+
+            # If target_line contains only whitespace, move backwards until
+            # actual code is found. If there are several empty lines after target_line,
+            # the error lines would just be blank, which is not very helpful.
             target_line = lines[line_number]
+            while not target_line.strip():
+                line_number -= 1
+                target_line = lines[line_number]
+
             if line_number > 0:
                 prev_line = lines[line_number - 1]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If a YAML file fails to load due to a syntax error in a file, or there is an error in the last line of a file, PyYAML reports the last line number of the file as the index where the error occurred.

When reading the file lines, we use that index to the get the relevant line.  If the index value is out of range, the relevant line is lost for error reporting.

Subtract one from the index value to avoid the IndexError in this specific scenario. It is possible to still get an IndexError, which will be handled as it is currently.

Fixes #16456
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/errors/__init__.py`

##### ADDITIONAL INFORMATION

- [x] Update tests

The additional code that tries to avoid empty lines in the error message is not necessary for this fix. I can omit that if others see problems with it.
