### PR TITLE
[bp-2.9] bitbucket_pipeline_variable: Hide secured values in console log

### DIFF
--- a/changelogs/fragments/cve_bitbucket_pipeline_variable.yml
+++ b/changelogs/fragments/cve_bitbucket_pipeline_variable.yml
@@ -1,2 +1,2 @@
 security_fixes:
-- 'bitbucket_pipeline_variable - **CVE-2021-20180** - hide user sensitive information which are marked as ``secured`` from logging into the console (https://github.com/ansible-collections/community.general/pull/1635).'
+- 'bitbucket_pipeline_variable - hide user sensitive information which are marked as ``secured`` from logging into the console (https://github.com/ansible-collections/community.general/pull/1635) (CVE-2021-20180).'

--- a/changelogs/fragments/cve_bitbucket_pipeline_variable.yml
+++ b/changelogs/fragments/cve_bitbucket_pipeline_variable.yml
@@ -1,0 +1,2 @@
+security_fixes:
+- 'bitbucket_pipeline_variable - **CVE-2021-20180** - hide user sensitive information which are marked as ``secured`` from logging into the console (https://github.com/ansible-collections/community.general/pull/1635).'


### PR DESCRIPTION
##### SUMMARY

**SECURITY** - CVE-2021-20180

Hide user sensitive information which is marked as ``secured``
while logging in console.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/cve_bitbucket_pipeline_variable.yml
lib/ansible/modules/source_control/bitbucket/bitbucket_pipeline_variable.py
