### PR TITLE
Shadow input for encrypt_string by default unless asked (fixes #71618)

### DIFF
--- a/changelogs/fragments/73263-shadow-encrypt-string.yml
+++ b/changelogs/fragments/73263-shadow-encrypt-string.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "Shadow prompt input to ansible-vault encrypt-string unless the ``--show-input`` flag is set"

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -309,7 +309,6 @@ class VaultCLI(CLI):
                 msg = "String to encrypt:"
 
             prompt_response = display.prompt(msg, private=hide_input)
-            prompt_response = display.prompt(msg)
 
             if prompt_response == '':
                 raise AnsibleOptionsError('The plaintext provided from the prompt was empty, not encrypting')

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -303,7 +303,7 @@ class VaultCLI(CLI):
             # TODO: could prompt for which vault_id to use for each plaintext string
             #       currently, it will just be the default
             hide_input = not context.CLIARGS['show_string_input']
-            if hide_input: 
+            if hide_input:
                 msg = "String to encrypt (hidden): "
             else:
                 msg = "String to encrypt:"

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -99,6 +99,8 @@ class VaultCLI(CLI):
         enc_str_parser.add_argument('-p', '--prompt', dest='encrypt_string_prompt',
                                     action='store_true',
                                     help="Prompt for the string to encrypt")
+        enc_str_parser.add_argument('--show-input', dest='show_string_input', default=False, action='store_true',
+                                    help='Do not hide input when prompted for the string to encrypt')
         enc_str_parser.add_argument('-n', '--name', dest='encrypt_string_names',
                                     action='append',
                                     help="Specify the variable name")
@@ -300,7 +302,13 @@ class VaultCLI(CLI):
 
             # TODO: could prompt for which vault_id to use for each plaintext string
             #       currently, it will just be the default
-            # could use private=True for shadowed input if useful
+            hide_input = not context.CLIARGS['show_string_input']
+            if hide_input: 
+                msg = "String to encrypt (hidden): "
+            else:
+                msg = "String to encrypt:"
+
+            prompt_response = display.prompt(msg, private=hide_input)
             prompt_response = display.prompt(msg)
 
             if prompt_response == '':

--- a/test/units/cli/test_vault.py
+++ b/test/units/cli/test_vault.py
@@ -112,7 +112,8 @@ class TestVaultCli(unittest.TestCase):
                              'some string to encrypt'])
         cli.parse()
         cli.run()
-        assert mock_display.call_args.kwargs["private"] is False
+        args, kwargs = mock_display.call_args
+        assert kwargs["private"] is False
 
     @patch('ansible.cli.vault.VaultCLI.setup_vault_secrets')
     @patch('ansible.cli.vault.VaultEditor')
@@ -125,7 +126,8 @@ class TestVaultCli(unittest.TestCase):
                              'some string to encrypt'])
         cli.parse()
         cli.run()
-        assert mock_display.call_args.kwargs["private"]
+        args, kwargs = mock_display.call_args
+        assert kwargs["private"]
 
     @patch('ansible.cli.vault.VaultCLI.setup_vault_secrets')
     @patch('ansible.cli.vault.VaultEditor')

--- a/test/units/cli/test_vault.py
+++ b/test/units/cli/test_vault.py
@@ -108,9 +108,24 @@ class TestVaultCli(unittest.TestCase):
         cli = VaultCLI(args=['ansible-vault',
                              'encrypt_string',
                              '--prompt',
+                             '--show-input',
                              'some string to encrypt'])
         cli.parse()
         cli.run()
+        assert mock_display.call_args.kwargs["private"] is False
+
+    @patch('ansible.cli.vault.VaultCLI.setup_vault_secrets')
+    @patch('ansible.cli.vault.VaultEditor')
+    @patch('ansible.cli.vault.display.prompt', return_value='a_prompt')
+    def test_shadowed_encrypt_string_prompt(self, mock_display, mock_vault_editor, mock_setup_vault_secrets):
+        mock_setup_vault_secrets.return_value = [('default', TextVaultSecret('password'))]
+        cli = VaultCLI(args=['ansible-vault',
+                             'encrypt_string',
+                             '--prompt',
+                             'some string to encrypt'])
+        cli.parse()
+        cli.run()
+        assert mock_display.call_args.kwargs["private"]
 
     @patch('ansible.cli.vault.VaultCLI.setup_vault_secrets')
     @patch('ansible.cli.vault.VaultEditor')


### PR DESCRIPTION
##### SUMMARY
When ansible-vault prompts for the string to encrypt, it's almost certain that it is sensitive somehow. This change hides the user input as they type unless the flag `--show-input` is passed as well.

Fixes #71618

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-vault

##### ADDITIONAL INFORMATION
This can be tested by checking the functionality of the following two commands:
- `ansible-vault encrypt_string --prompt "string_name"` should hide the user's input when prompted for the secret
- `ansible-vault encrypt_string --prompt "string_name" --show-input` should _not_ hide the user's input 

Note that due to issue #70200 it is necessary to add an extra string to encrypt in order to test the prompt functionality.

This is my first PR to Ansible so there's a good chance I've made a mistake or missed an element of procedure, so I'd be delighted to take any extra guidance on board. :)