### PR TITLE
unarchive: add support for .tar.zst (zstd compression)

### DIFF
--- a/changelogs/fragments/unarchive-support-zst.yml
+++ b/changelogs/fragments/unarchive-support-zst.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Add support in the unarchive module for .tar.zst (zstd compression)
+  - unarchive - Add support for .tar.zst (zstd compression) (https://github.com/ansible/ansible/pull/73265).

--- a/changelogs/fragments/unarchive-support-zst.yml
+++ b/changelogs/fragments/unarchive-support-zst.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add support in the unarchive module for .tar.zst (zstd compression)

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -4,6 +4,7 @@
 - import_tasks: test_tar_gz_creates.yml
 - import_tasks: test_tar_gz_owner_group.yml
 - import_tasks: test_tar_gz_keep_newer.yml
+- import_tasks: test_tar_zst.yml
 - import_tasks: test_zip.yml
 - import_tasks: test_exclude.yml
 - import_tasks: test_include.yml

--- a/test/integration/targets/unarchive/tasks/prepare_tests.yml
+++ b/test/integration/targets/unarchive/tasks/prepare_tests.yml
@@ -6,6 +6,13 @@
       - unzip
   when: ansible_pkg_mgr in ('yum', 'dnf', 'apt', 'pkgng')
 
+- name: Ensure zstd is present, if available
+  ignore_errors: true
+  package:
+    name:
+      - zstd
+  when: ansible_pkg_mgr in ('yum', 'dnf', 'apt', 'pkgng')
+
 - name: prep our file
   copy:
     src: foo.txt
@@ -17,6 +24,28 @@
 
 - name: prep a tar.gz file
   shell: tar czvf test-unarchive.tar.gz foo-unarchive.txt chdir={{remote_tmp_dir}}
+
+- name: see if we have the zstd executable
+  ignore_errors: true
+  shell: zstd --version
+  register: zstd_available
+
+- when: zstd_available.rc == 0
+  block:
+    - name: find gnu tar
+      shell: |
+        #!/bin/sh
+        which gtar 2>/dev/null
+        if test $? -ne 0; then
+            if test -z "`tar --version | grep bsdtar`"; then
+               which tar
+            fi
+        fi
+      register: gnu_tar
+
+    - name: prep a tar.zst file
+      shell: "{{ gnu_tar.stdout }} --use-compress-program=zstd -cvf test-unarchive.tar.zst foo-unarchive.txt chdir={{remote_tmp_dir}}"
+      when: gnu_tar.stdout != ""
 
 - name: prep a chmodded file for zip
   copy:

--- a/test/integration/targets/unarchive/tasks/test_tar_zst.yml
+++ b/test/integration/targets/unarchive/tasks/test_tar_zst.yml
@@ -1,0 +1,40 @@
+# Only do this whole file when the "zstd" executable is present
+- when:
+    - zstd_available.rc == 0
+    - gnu_tar.stdout != ""
+  block:
+    - name: create our tar.zst unarchive destination
+      file:
+        path: '{{remote_tmp_dir}}/test-unarchive-tar-zst'
+        state: directory
+
+    - name: unarchive a tar.zst file
+      unarchive:
+        src: '{{remote_tmp_dir}}/test-unarchive.tar.zst'
+        dest: '{{remote_tmp_dir}}/test-unarchive-tar-zst'
+        remote_src: yes
+      register: unarchive02
+
+    - name: verify that the file was marked as changed
+      assert:
+        that:
+          - "unarchive02.changed == true"
+          # Verify that no file list is generated
+          - "'files' not in unarchive02"
+
+    - name: verify that the file was unarchived
+      file:
+        path: '{{remote_tmp_dir}}/test-unarchive-tar-zst/foo-unarchive.txt'
+        state: file
+
+    - name: remove our tar.zst unarchive destination
+      file:
+        path: '{{remote_tmp_dir}}/test-unarchive-tar-zst'
+        state: absent
+
+    - name: test owner/group perms
+      include_tasks: test_owner_group.yml
+      vars:
+        ext: tar.zst
+        archive: test-unarchive.tar.zst
+        testfile: foo-unarchive.txt


### PR DESCRIPTION
##### SUMMARY
Add support for `.tar.zst` ([zstd compression](https://github.com/facebook/zstd)) to the `unarchive` module

The `zstd` package for compression/decompression is readily available in many OS distributions.  Its popularity is currently small, but is potentially growing due to its speed and compression ratios.  Adding native support to `unarchive` to create / expand `.tar.zst` files is both straightforward and forward-looking to if/when `.tar.zst` becomes more common.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
unarchive

##### ADDITIONAL INFORMATION
This PR simply allows `unarchive` to transparently handle `foo.tar.zst` files.

Although GNU Tar does not natively support Zstd compression, this PR uses GNU Tar's `-I` CLI option to pass in the `zstd` executable to use for compression / decompression.  Specifically: creating / expanding `.tar.zst` files requires that the `zstd` executable is available at the target.