### PR TITLE
Mention that version_added should be collection version in collections

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -114,7 +114,8 @@ All fields in the ``DOCUMENTATION`` block are lower-case. All fields are require
 :version_added:
 
   * The version of Ansible when the module was added.
-  * This is a string, and not a float, for example, ``version_added: '2.1'``
+  * This is a string, and not a float, for example, ``version_added: '2.1'``.
+  * In collections, this must be the collection version the module was added to, not the Ansible version. For example, ``version_added: 1.0.0``.
 
 :author:
 
@@ -182,6 +183,7 @@ All fields in the ``DOCUMENTATION`` block are lower-case. All fields are require
 
     * Only needed if this option was extended after initial Ansible release, in other words, this is greater than the top level `version_added` field.
     * This is a string, and not a float, for example, ``version_added: '2.3'``.
+    * In collections, this must be the collection version the option was added to, not the Ansible version. For example, ``version_added: 1.0.0``.
 
   :suboptions:
 

--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -221,7 +221,7 @@ but with an extra option so you can see how configuration works in Ansible versi
     requirements:
         - enable in configuration
     short_description: Adds time to play stats
-    version_added: "2.0"
+    version_added: "2.0"  # for collections, use the collection version, not the Ansible version
     description:
         - This callback just adds total play duration to the play stats.
     options:
@@ -339,7 +339,7 @@ Here's a simple lookup plugin implementation --- this lookup returns the content
     DOCUMENTATION = """
       lookup: file
       author: Daniel Hokka Zakrisson <daniel@hozac.com>
-      version_added: "0.9"
+      version_added: "0.9"  # for collections, use the collection version, not the Ansible version
       short_description: read file contents
       description:
           - This lookup returns the contents from a file on the Ansible controller's file system.
@@ -468,7 +468,7 @@ Include the ``vars_plugin_staging`` documentation fragment to allow users to det
 
     DOCUMENTATION = '''
         vars: custom_hostvars
-        version_added: "2.10"
+        version_added: "2.10"  # for collections, use the collection version, not the Ansible version
         short_description: Load custom host vars
         description: Load custom host vars
         options:

--- a/docs/docsite/rst/network/dev_guide/developing_resource_modules_network.rst
+++ b/docs/docsite/rst/network/dev_guide/developing_resource_modules_network.rst
@@ -167,7 +167,7 @@ For example, the resource model builder includes the ``myos_interfaces.yml`` sam
             description:
             - The some_int.
             type: int
-            version_added: '1.1'
+            version_added: '1.1.0'
           some_dict:
             type: dict
             description:


### PR DESCRIPTION
##### SUMMARY
It currently says "The version of Ansible when the module was added." in some places.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
dev guide
