### PR TITLE
[2.9] mysql_user: Add missed privileges support

### DIFF
--- a/changelogs/fragments/87-mysql_user_update_valid_privs_frozen_set.yml
+++ b/changelogs/fragments/87-mysql_user_update_valid_privs_frozen_set.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- mysql_user - add ``SHOW_ROUTINE`` privilege support (https://github.com/ansible-collections/community.mysql/issues/86).
+- mysql_user - add missed privileges to support (https://github.com/ansible-collections/community.general/issues/617).
+- mysql_user - add ``INVOKE LAMBDA`` privilege support (https://github.com/ansible-collections/community.general/issues/283).

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -237,7 +237,19 @@ VALID_PRIVS = frozenset(('CREATE', 'DROP', 'GRANT', 'GRANT OPTION',
                          'GROUP_REPLICATION_ADMIN', 'PERSIST_RO_VARIABLES_ADMIN',
                          'REPLICATION_SLAVE_ADMIN', 'RESOURCE_GROUP_ADMIN', 'RESOURCE_GROUP_USER',
                          'ROLE_ADMIN', 'SESSION_VARIABLES_ADMIN', 'SET_USER_ID',
-                         'SYSTEM_VARIABLES_ADMIN', 'VERSION_TOKEN_ADMIN', 'XA_RECOVER_ADMIN'))
+                         'SYSTEM_VARIABLES_ADMIN', 'VERSION_TOKEN_ADMIN', 'XA_RECOVER_ADMIN',
+                         'INVOKE LAMBDA',
+                         'ALTER ROUTINE',
+                         'BINLOG ADMIN',
+                         'BINLOG MONITOR',
+                         'BINLOG REPLAY',
+                         'CONNECTION ADMIN',
+                         'READ_ONLY ADMIN',
+                         'REPLICATION MASTER ADMIN',
+                         'REPLICATION SLAVE',
+                         'REPLICATION SLAVE ADMIN',
+                         'SET USER',
+                         'SHOW_ROUTINE',))
 
 
 class InvalidPrivsError(Exception):


### PR DESCRIPTION
##### SUMMARY
Backports of
https://github.com/ansible-collections/community.mysql/pull/87
https://github.com/ansible-collections/community.general/pull/618
https://github.com/ansible-collections/community.general/pull/285


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
mysql_user