### PR TITLE
Allow composite variable references within composite variables

### DIFF
--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -380,6 +380,7 @@ class Constructable(object):
                         raise AnsibleError("Could not set %s for host %s: %s" % (varname, host, to_native(e)))
                     continue
                 self.inventory.set_variable(host, varname, composite)
+                variables[varname] = composite
 
     def _add_host_to_composed_groups(self, groups, variables, host, strict=False):
         ''' helper to create complex groups for plugins based on jinja2 conditionals, hosts that meet the conditional are added to group'''


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently if you define a composite variable, you cannot reference that variable from another composite variable. This change allows that.

The use case is with the [constructed inventory plugin](https://docs.ansible.com/ansible/devel/collections/ansible/builtin/constructed_inventory.html). The following example will fail due to the `host_number` being undefined when evaluating `host_datacenter_id`.

```
plugin: constructed
compose:
  host_number: inventory_hostname_short | regex_replace('^[a-zA-Z]*', '') | int
  host_datacenter_id = ( host_number / 1000 ) | int
```

Now this implementation does make the variable composition dependent upon evaluation order, but as python preserves order of dictionary keys, there shouldn't be any issues as long as the user defines them in the correct order.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
constructed

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
