### PR TITLE
[stable-2.10] Fix YAML error message when error is at the end of the file (#73241)

### DIFF
--- a/changelogs/fragments/16456-correct-YAML-error-message-when-file-load-failed.yml
+++ b/changelogs/fragments/16456-correct-YAML-error-message-when-file-load-failed.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - display correct error information when an error exists in the last line of the file (https://github.com/ansible/ansible/issues/16456)

--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -89,7 +89,21 @@ class AnsibleError(Exception):
         with open(file_name, 'r') as f:
             lines = f.readlines()
 
+            # In case of a YAML loading error, PyYAML will report the very last line
+            # as the location of the error. Avoid an index error here in order to
+            # return a helpful message.
+            file_length = len(lines)
+            if line_number >= file_length:
+                line_number = file_length - 1
+
+            # If target_line contains only whitespace, move backwards until
+            # actual code is found. If there are several empty lines after target_line,
+            # the error lines would just be blank, which is not very helpful.
             target_line = lines[line_number]
+            while not target_line.strip():
+                line_number -= 1
+                target_line = lines[line_number]
+
             if line_number > 0:
                 prev_line = lines[line_number - 1]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #73241 for Ansible 2.10.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/errors/__init__.py`