### PR TITLE
Fix command line parsing for ansible-vault encrypt_string --prompt

### DIFF
--- a/changelogs/fragments/73301-fix-encrypt-string-parsing.yml
+++ b/changelogs/fragments/73301-fix-encrypt-string-parsing.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix improper parsing for ansible-vault encrypt_string --prompt (https://github.com/ansible/ansible/issues/70200)

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -96,17 +96,20 @@ class VaultCLI(CLI):
         enc_str_parser = subparsers.add_parser('encrypt_string', help='Encrypt a string', parents=[common, output, vault_id])
         enc_str_parser.set_defaults(func=self.execute_encrypt_string)
         enc_str_parser.add_argument('args', help='String to encrypt', metavar='string_to_encrypt', nargs='*')
-        enc_str_parser.add_argument('-p', '--prompt', dest='encrypt_string_prompt',
-                                    action='store_true',
-                                    help="Prompt for the string to encrypt")
+
         enc_str_parser.add_argument('--show-input', dest='show_string_input', default=False, action='store_true',
                                     help='Do not hide input when prompted for the string to encrypt')
         enc_str_parser.add_argument('-n', '--name', dest='encrypt_string_names',
                                     action='append',
                                     help="Specify the variable name")
-        enc_str_parser.add_argument('--stdin-name', dest='encrypt_string_stdin_name',
-                                    default=None,
-                                    help="Specify the variable name for stdin")
+
+        enc_str_parser_exclusive = enc_str_parser.add_mutually_exclusive_group()
+        enc_str_parser_exclusive.add_argument('-p', '--prompt', dest='encrypt_string_prompt',
+                                              action='store_true',
+                                              help="Prompt for the string to encrypt")
+        enc_str_parser_exclusive.add_argument('--stdin-name', dest='encrypt_string_stdin_name',
+                                              default=None,
+                                              help="Specify the variable name for stdin")
 
         rekey_parser = subparsers.add_parser('rekey', help='Re-key a vault encrypted file', parents=[common, vault_id])
         rekey_parser.set_defaults(func=self.execute_rekey)
@@ -131,10 +134,9 @@ class VaultCLI(CLI):
             raise AnsibleOptionsError("At most one input file may be used with the --output option")
 
         if options.action == 'encrypt_string':
-            if '-' in options.args or (not options.args and not options.encrypt_string_prompt) or options.encrypt_string_stdin_name:
+            if '-' in options.args or options.encrypt_string_stdin_name:
                 self.encrypt_string_read_stdin = True
 
-            # TODO: prompting from stdin and reading from stdin seem mutually exclusive, but verify that.
             if options.encrypt_string_prompt and self.encrypt_string_read_stdin:
                 raise AnsibleOptionsError('The --prompt option is not supported if also reading input from stdin')
 

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -131,7 +131,7 @@ class VaultCLI(CLI):
             raise AnsibleOptionsError("At most one input file may be used with the --output option")
 
         if options.action == 'encrypt_string':
-            if '-' in options.args or not options.args or options.encrypt_string_stdin_name:
+            if '-' in options.args or (not options.args and not options.encrypt_string_prompt) or options.encrypt_string_stdin_name:
                 self.encrypt_string_read_stdin = True
 
             # TODO: prompting from stdin and reading from stdin seem mutually exclusive, but verify that.

--- a/test/units/cli/test_vault.py
+++ b/test/units/cli/test_vault.py
@@ -151,9 +151,12 @@ class TestVaultCli(unittest.TestCase):
                              'the_var_from_stdin',
                              '-',
                              '--prompt'])
-        self.assertRaisesRegexp(errors.AnsibleOptionsError,
-                                "The --prompt option is not supported if also reading input from stdin",
-                                cli.parse)
+        expected_error_msg = (
+            r'^The --prompt option is not supported if '
+            r'also reading input from stdin$'
+        )
+        with pytest.raises(errors.AnsibleOptionsError, match=expected_error_msg):
+            cli.parse()
 
     @patch('ansible.cli.vault.VaultCLI.setup_vault_secrets')
     @patch('ansible.cli.vault.VaultEditor')

--- a/test/units/cli/test_vault.py
+++ b/test/units/cli/test_vault.py
@@ -107,9 +107,8 @@ class TestVaultCli(unittest.TestCase):
         mock_setup_vault_secrets.return_value = [('default', TextVaultSecret('password'))]
         cli = VaultCLI(args=['ansible-vault',
                              'encrypt_string',
-                             '--prompt',
                              '--show-input',
-                             'some string to encrypt'])
+                             '--prompt',
         cli.parse()
         cli.run()
         args, kwargs = mock_display.call_args
@@ -141,6 +140,20 @@ class TestVaultCli(unittest.TestCase):
                              '-'])
         cli.parse()
         cli.run()
+    
+    @patch('ansible.cli.vault.VaultCLI.setup_vault_secrets')
+    @patch('ansible.cli.vault.VaultEditor')
+    def test_encrypt_string_stdin_prompt_error(self, mock_vault_editor, mock_setup_vault_secrets):
+        mock_setup_vault_secrets.return_value = [('default', TextVaultSecret('password'))]
+        cli = VaultCLI(args=['ansible-vault',
+                             'encrypt_string',
+                             '--stdin-name',
+                             'the_var_from_stdin',
+                             '-',
+                             '--prompt'])
+        self.assertRaisesRegexp(errors.AnsibleOptionsError,
+                            "The --prompt option is not supported if also reading input from stdin",
+                            cli.parse)
 
     @patch('ansible.cli.vault.VaultCLI.setup_vault_secrets')
     @patch('ansible.cli.vault.VaultEditor')

--- a/test/units/cli/test_vault.py
+++ b/test/units/cli/test_vault.py
@@ -108,7 +108,7 @@ class TestVaultCli(unittest.TestCase):
         cli = VaultCLI(args=['ansible-vault',
                              'encrypt_string',
                              '--show-input',
-                             '--prompt',
+                             '--prompt'])
         cli.parse()
         cli.run()
         args, kwargs = mock_display.call_args
@@ -140,7 +140,7 @@ class TestVaultCli(unittest.TestCase):
                              '-'])
         cli.parse()
         cli.run()
-    
+
     @patch('ansible.cli.vault.VaultCLI.setup_vault_secrets')
     @patch('ansible.cli.vault.VaultEditor')
     def test_encrypt_string_stdin_prompt_error(self, mock_vault_editor, mock_setup_vault_secrets):
@@ -152,8 +152,8 @@ class TestVaultCli(unittest.TestCase):
                              '-',
                              '--prompt'])
         self.assertRaisesRegexp(errors.AnsibleOptionsError,
-                            "The --prompt option is not supported if also reading input from stdin",
-                            cli.parse)
+                                "The --prompt option is not supported if also reading input from stdin",
+                                cli.parse)
 
     @patch('ansible.cli.vault.VaultCLI.setup_vault_secrets')
     @patch('ansible.cli.vault.VaultEditor')

--- a/test/units/cli/test_vault.py
+++ b/test/units/cli/test_vault.py
@@ -149,6 +149,17 @@ class TestVaultCli(unittest.TestCase):
                              'encrypt_string',
                              '--stdin-name',
                              'the_var_from_stdin',
+                             '--prompt'])
+
+        with pytest.raises(SystemExit):
+            cli.parse()
+
+    @patch('ansible.cli.vault.VaultCLI.setup_vault_secrets')
+    @patch('ansible.cli.vault.VaultEditor')
+    def test_encrypt_string_pseudostdin_prompt_error(self, mock_vault_editor, mock_setup_vault_secrets):
+        mock_setup_vault_secrets.return_value = [('default', TextVaultSecret('password'))]
+        cli = VaultCLI(args=['ansible-vault',
+                             'encrypt_string',
                              '-',
                              '--prompt'])
         expected_error_msg = (


### PR DESCRIPTION
##### SUMMARY
At the moment executing `ansible-vault encrypt_string --prompt` won't work, throwing an error if an additional string isn't passed as an argument. This would result in two encrypted strings and thus isn't the intended behaviour.

This change corrects the conditions needed to trigger a read from stdin while retaining the original check to ensure that `--prompt` and stdin can't be used simultaneously.

The existing unit test has been modified to not require an additional string, and a new one has been created to verify an error is thrown if both `--prompt` and stdin are used.

Fixes #70200

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-vault

##### ADDITIONAL INFORMATION
N/A