### PR TITLE
Add Playbook and PlaybookInclude into parent chain

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -175,9 +175,6 @@ class PlayIterator:
         if fact_path:
             setup_task.args['fact_path'] = fact_path
         setup_task.set_loader(self._play._loader)
-        # short circuit fact gathering if the entire playbook is conditional
-        if self._play._included_conditional is not None:
-            setup_task.when = self._play._included_conditional[:]
         setup_block.block = [setup_task]
 
         setup_block = setup_block.filter_tagged_tasks(all_vars)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -341,8 +341,7 @@ class TaskExecutor:
                 ran_once = True
 
             try:
-                tmp_task = self._task.copy(exclude_parent=True, exclude_tasks=True)
-                tmp_task._parent = self._task._parent
+                tmp_task = self._task.copy(direct_parent=True, exclude_tasks=True)
                 tmp_play_context = self._play_context.copy()
             except AnsibleParserError as e:
                 results.append(dict(failed=True, msg=to_text(e)))

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -28,6 +28,7 @@ from ansible.playbook.play import Play
 from ansible.playbook.playbook_include import PlaybookInclude
 from ansible.plugins.loader import add_all_plugin_dirs
 from ansible.utils.display import Display
+from ansible.utils.vars import get_unique_id
 
 display = Display()
 
@@ -45,6 +46,7 @@ class Playbook:
         self._loader = loader
         self._file_name = None
         self._parent = parent
+        self._uuid = get_unique_id()
 
     def __repr__(self):
         return self.get_name()

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -310,7 +310,7 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
                 self._attributes[name] = getattr(self, name)
             self._squashed = True
 
-    def copy(self):
+    def copy(self, **kwargs):
         '''
         Create a copy of this object and return it.
         '''

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -60,7 +60,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
             self._parent = parent_block
 
         if self._parent is None:
-            self._parent = play
+            self._parent = role if role else play
 
         super(Block, self).__init__()
 

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -184,7 +184,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
             for task in task_list:
                 new_task = task.copy(exclude_parent=True)
                 if task._parent:
-                    new_task._parent = task._parent.copy(exclude_tasks=True)
+                    new_task._parent = task._parent.copy(exclude_tasks=True, direct_parent=True)
                     if task._parent == new_block:
                         # If task._parent is the same as new_block, just replace it
                         new_task._parent = new_block

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -212,11 +212,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
 
         new_me._parent = None
         if self._parent and not exclude_parent:
-            try:
-                new_me._parent = self._parent.copy(exclude_tasks=True)
-            except:
-                print((type(self._parent), self._parent))
-                raise
+            new_me._parent = self._parent.copy(exclude_tasks=True)
 
         if not exclude_tasks:
             new_me.block = _dupe_task_list(self.block or [], new_me)

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -59,6 +59,9 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
         elif parent_block:
             self._parent = parent_block
 
+        if self._parent is None:
+            self._parent = play
+
         super(Block, self).__init__()
 
     def __repr__(self):
@@ -169,7 +172,10 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
     def get_dep_chain(self):
         if self._dep_chain is None:
             if self._parent:
-                return self._parent.get_dep_chain()
+                try:
+                    return self._parent.get_dep_chain()
+                except AttributeError:
+                    return None
             else:
                 return None
         else:
@@ -206,7 +212,11 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
 
         new_me._parent = None
         if self._parent and not exclude_parent:
-            new_me._parent = self._parent.copy(exclude_tasks=True)
+            try:
+                new_me._parent = self._parent.copy(exclude_tasks=True)
+            except:
+                print((type(self._parent), self._parent))
+                raise
 
         if not exclude_tasks:
             new_me.block = _dupe_task_list(self.block or [], new_me)
@@ -389,10 +399,10 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
         return len(self.block) > 0 or len(self.rescue) > 0 or len(self.always) > 0
 
     def get_include_params(self):
-        if self._parent:
+        try:
             return self._parent.get_include_params()
-        else:
-            return dict()
+        except AttributeError:
+            return {}
 
     def all_parents_static(self):
         '''

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -69,11 +69,11 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
 
     def __eq__(self, other):
         '''object comparison based on _uuid'''
-        return self._uuid == other._uuid
+        return isinstance(other, Block) and self._uuid == other._uuid
 
     def __ne__(self, other):
         '''object comparison based on _uuid'''
-        return self._uuid != other._uuid
+        return isinstance(other, Block) and self._uuid != other._uuid
 
     def get_vars(self):
         '''

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -191,7 +191,8 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
                     else:
                         # task may not be a direct child of new_block, search for the correct place to insert new_block
                         cur_obj = new_task._parent
-                        while cur_obj._parent and cur_obj._parent != new_block:
+                        # Prevent the new block from becoming a parent higher than the Play
+                        while cur_obj._parent.__class__.__name__ != 'Play' and cur_obj._parent != new_block:
                             cur_obj = cur_obj._parent
 
                         cur_obj._parent = new_block

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -406,7 +406,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
         the chain check the statically_loaded value of the parent.
         '''
         from ansible.playbook.task_include import TaskInclude
-        if self._parent:
+        if self._parent and hasattr(self._parent, 'all_parents_static'):
             if isinstance(self._parent, TaskInclude) and not self._parent.statically_loaded:
                 return False
             return self._parent.all_parents_static()

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -81,11 +81,8 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
         of a role or task include which does, so return those if present.
         '''
 
-        all_vars = self.vars.copy()
-
-        if self._parent:
-            all_vars.update(self._parent.get_vars())
-
+        all_vars = self._parent.get_vars()
+        all_vars.update(self.vars.copy())
         return all_vars
 
     @staticmethod

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -178,7 +178,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
         else:
             return self._dep_chain[:]
 
-    def copy(self, exclude_parent=False, exclude_tasks=False):
+    def copy(self, exclude_parent=False, exclude_tasks=False, direct_parent=False):
         def _dupe_task_list(task_list, new_block):
             new_task_list = []
             for task in task_list:
@@ -208,7 +208,9 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
             new_me._dep_chain = self._dep_chain[:]
 
         new_me._parent = None
-        if self._parent and not exclude_parent:
+        if direct_parent:
+            new_me._parent = self._parent
+        elif not exclude_parent:
             new_me._parent = self._parent.copy(exclude_tasks=True)
 
         if not exclude_tasks:
@@ -379,8 +381,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
             return tmp_list
 
         def evaluate_block(block):
-            new_block = block.copy(exclude_parent=True, exclude_tasks=True)
-            new_block._parent = block._parent
+            new_block = block.copy(direct_parent=True, exclude_tasks=True)
             new_block.block = evaluate_and_append_task(block.block)
             new_block.rescue = evaluate_and_append_task(block.rescue)
             new_block.always = evaluate_and_append_task(block.always)

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -184,7 +184,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
             for task in task_list:
                 new_task = task.copy(exclude_parent=True)
                 if task._parent:
-                    new_task._parent = task._parent.copy(exclude_tasks=True)
+                    new_task._parent = task._parent.copy(exclude_tasks=True, direct_parent=True)
                     if task._parent == new_block:
                         # If task._parent is the same as new_block, just replace it
                         new_task._parent = new_block
@@ -211,7 +211,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
         new_me._parent = None
         if direct_parent:
             new_me._parent = self._parent
-        elif not exclude_parent:
+        elif exclude_parent is False:
             new_me._parent = self._parent.copy(exclude_tasks=True)
 
         if not exclude_tasks:

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -412,7 +412,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
         the chain check the statically_loaded value of the parent.
         '''
         from ansible.playbook.task_include import TaskInclude
-        if self._parent:
+        if self._parent and hasattr(self._parent, 'all_parents_static'):
             if isinstance(self._parent, TaskInclude) and not self._parent.statically_loaded:
                 return False
             return self._parent.all_parents_static()
@@ -421,7 +421,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
 
     def get_first_parent_include(self):
         from ansible.playbook.task_include import TaskInclude
-        if self._parent:
+        if self._parent and hasattr(self._parent, 'get_first_parent_include'):
             if isinstance(self._parent, TaskInclude):
                 return self._parent
             return self._parent.get_first_parent_include()

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -408,7 +408,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
         the chain check the statically_loaded value of the parent.
         '''
         from ansible.playbook.task_include import TaskInclude
-        if self._parent and hasattr(self._parent, 'all_parents_static'):
+        if self._parent:
             if isinstance(self._parent, TaskInclude) and not self._parent.statically_loaded:
                 return False
             return self._parent.all_parents_static()

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -184,7 +184,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
             for task in task_list:
                 new_task = task.copy(exclude_parent=True)
                 if task._parent:
-                    new_task._parent = task._parent.copy(exclude_tasks=True, direct_parent=True)
+                    new_task._parent = task._parent.copy(exclude_tasks=True)
                     if task._parent == new_block:
                         # If task._parent is the same as new_block, just replace it
                         new_task._parent = new_block

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -288,7 +288,8 @@ class Play(Base, Taggable, CollectionSearch, Conditional):
         return block_list
 
     def get_vars(self):
-        all_vars = self._parent.get_vars()
+        # With adhoc, self._parent may be None
+        all_vars = {} if not self._parent else self._parent.get_vars()
         all_vars.update(self.vars)
         return all_vars
 

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -35,6 +35,7 @@ from ansible.playbook.taggable import Taggable
 from ansible.vars.manager import preprocess_vars
 from ansible.utils.display import Display
 from ansible.utils.sentinel import Sentinel
+from ansible.utils.vars import combine_vars
 
 display = Display()
 
@@ -290,12 +291,12 @@ class Play(Base, Taggable, CollectionSearch, Conditional):
     def get_vars(self):
         # With adhoc, self._parent may be None
         all_vars = {} if not self._parent else self._parent.get_vars()
-        all_vars.update(self.vars)
-        all_vars.update(self.get_vars_files_vars())
+        all_vars = combine_vars(all_vars, self.vars)
+        all_vars = combine_vars(all_vars, self.get_vars_files_vars())
 
         if C.DEFAULT_PRIVATE_ROLE_VARS is False:
             for role in self.get_roles():
-                all_vars.update(role.get_vars())
+                all_vars = combine_vars(all_vars, role.get_vars())
         return all_vars
 
     def get_vars_files(self):

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -312,10 +312,10 @@ class Play(Base, Taggable, CollectionSearch, Conditional):
         try:
             for vars_file in vars_files:
                 try:
-                    data = self._loader.load_from_file(vars_file, unsafe=True)
+                    data = preprocess_vars(self._loader.load_from_file(vars_file, unsafe=True))
                     if data is not None:
-                        all_vars.update(data)
-                    break
+                        for item in data:
+                            all_vars.update(item)
                 except AnsibleFileNotFound:
                     raise AnsibleFileNotFound("vars file %s was not found" % vars_file)
                 except AnsibleParserError:

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -389,3 +389,6 @@ class Play(Base, Taggable, CollectionSearch, Conditional):
             pass
 
         return value
+
+    def all_parents_static(self):
+        return True

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -199,7 +199,7 @@ class Play(Base, Taggable, CollectionSearch, Conditional):
 
         roles = []
         for ri in role_includes:
-            roles.append(Role.load(ri, play=self))
+            roles.append(Role.load(ri, play=self, parent=self))
 
         self.roles[:0] = roles
 

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -293,8 +293,9 @@ class Play(Base, Taggable, CollectionSearch, Conditional):
         all_vars.update(self.vars)
         all_vars.update(self.get_vars_files_vars())
 
-        for role in self.get_roles():
-            all_vars.update(role.get_vars())
+        if C.DEFAULT_PRIVATE_ROLE_VARS is False:
+            for role in self.get_roles():
+                all_vars.update(role.get_vars())
         return all_vars
 
     def get_vars_files(self):

--- a/lib/ansible/playbook/playbook_include.py
+++ b/lib/ansible/playbook/playbook_include.py
@@ -35,6 +35,7 @@ from ansible.utils.collection_loader import AnsibleCollectionConfig
 from ansible.utils.collection_loader._collection_finder import _get_collection_name_from_path, _get_collection_playbook_path
 from ansible.template import Templar
 from ansible.utils.display import Display
+from ansible.utils.vars import get_unique_id
 
 display = Display()
 
@@ -48,6 +49,7 @@ class PlaybookInclude(Base, Conditional, Taggable):
         super(PlaybookInclude, self).__init__()
 
         self._parent = parent
+        self._uuid = get_unique_id()
 
     def __repr__(self):
         return self.get_name()

--- a/lib/ansible/playbook/playbook_include.py
+++ b/lib/ansible/playbook/playbook_include.py
@@ -35,7 +35,6 @@ from ansible.utils.collection_loader import AnsibleCollectionConfig
 from ansible.utils.collection_loader._collection_finder import _get_collection_name_from_path, _get_collection_playbook_path
 from ansible.template import Templar
 from ansible.utils.display import Display
-from ansible.utils.vars import get_unique_id
 
 display = Display()
 
@@ -49,7 +48,6 @@ class PlaybookInclude(Base, Conditional, Taggable):
         super(PlaybookInclude, self).__init__()
 
         self._parent = parent
-        self._uuid = get_unique_id()
 
     def __repr__(self):
         return self.get_name()

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -454,7 +454,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
             block_list.extend(dep_blocks)
 
         for task_block in self._task_blocks:
-            new_task_block = task_block.copy()
+            new_task_block = task_block.copy(direct_parent=True)
             new_task_block._dep_chain = new_dep_chain
             new_task_block._play = play
             block_list.append(new_task_block)
@@ -488,6 +488,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
         res['_default_vars'] = self._default_vars
         res['_had_task_run'] = self._had_task_run.copy()
         res['_completed'] = self._completed.copy()
+        res['_parent'] = self._parent
 
         if self._metadata:
             res['_metadata'] = self._metadata.serialize()
@@ -513,6 +514,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
         self._default_vars = data.get('_default_vars', dict())
         self._had_task_run = data.get('_had_task_run', dict())
         self._completed = data.get('_completed', dict())
+        self._parent = data.get('parent')
 
         if include_deps:
             deps = []
@@ -537,6 +539,10 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
             self._metadata = m
 
         super(Role, self).deserialize(data)
+
+    def copy(self, **kwargs):
+        new_me = super(Role, self).copy(**kwargs)
+        new_me._parent = self._parent
 
     def set_loader(self, loader):
         self._loader = loader

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -543,6 +543,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
     def copy(self, **kwargs):
         new_me = super(Role, self).copy(**kwargs)
         new_me._parent = self._parent
+        return new_me
 
     def set_loader(self, loader):
         self._loader = loader

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -97,12 +97,13 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
     _delegate_to = FieldAttribute(isa='string')
     _delegate_facts = FieldAttribute(isa='bool')
 
-    def __init__(self, play=None, from_files=None, from_include=False):
+    def __init__(self, play=None, from_files=None, from_include=False, parent=None):
         self._role_name = None
         self._role_path = None
         self._role_collection = None
         self._role_params = dict()
         self._loader = None
+        self._parent = parent
 
         self._metadata = None
         self._play = play
@@ -134,7 +135,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
         return self._role_name
 
     @staticmethod
-    def load(role_include, play, parent_role=None, from_files=None, from_include=False):
+    def load(role_include, play, parent_role=None, from_files=None, from_include=False, parent=None):
 
         if from_files is None:
             from_files = {}
@@ -168,7 +169,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
             #  for the in-flight in role cache as a sentinel that we're already trying to load
             #  that role?)
             # see https://github.com/ansible/ansible/issues/61527
-            r = Role(play=play, from_files=from_files, from_include=from_include)
+            r = Role(play=play, from_files=from_files, from_include=from_include, parent=parent)
             r._load_role_data(role_include, parent_role=parent_role)
 
             if role_include.get_name() not in play.ROLE_CACHE:
@@ -305,7 +306,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
         deps = []
         if self._metadata:
             for role_include in self._metadata.dependencies:
-                r = Role.load(role_include, play=self._play, parent_role=self)
+                r = Role.load(role_include, play=self._play, parent_role=self, parent=self._play)
                 deps.append(r)
 
         return deps

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -156,9 +156,9 @@ class IncludeRole(TaskInclude):
 
         return ir
 
-    def copy(self, exclude_parent=False, exclude_tasks=False):
+    def copy(self, exclude_parent=False, exclude_tasks=False, direct_parent=False):
 
-        new_me = super(IncludeRole, self).copy(exclude_parent=exclude_parent, exclude_tasks=exclude_tasks)
+        new_me = super(IncludeRole, self).copy(exclude_parent=exclude_parent, exclude_tasks=exclude_tasks, direct_parent=direct_parent)
         new_me.statically_loaded = self.statically_loaded
         new_me._from_files = self._from_files.copy()
         new_me._parent_role = self._parent_role

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -80,7 +80,7 @@ class IncludeRole(TaskInclude):
 
         # build role
         actual_role = Role.load(ri, myplay, parent_role=self._parent_role, from_files=self._from_files,
-                                from_include=True)
+                                from_include=True, parent=myplay)
         actual_role._metadata.allow_duplicates = self.allow_duplicates
 
         if self.statically_loaded or self.public:

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -398,14 +398,16 @@ class Task(Base, Conditional, Taggable, CollectionSearch):
             all_vars.update(self.vars)
         return all_vars
 
-    def copy(self, exclude_parent=False, exclude_tasks=False):
+    def copy(self, exclude_parent=False, exclude_tasks=False, direct_parent=False):
         new_me = super(Task, self).copy()
 
         # if the task has an associated list of candidate names, copy it to the new object too
         new_me._ansible_internal_redirect_list = self._ansible_internal_redirect_list[:]
 
         new_me._parent = None
-        if self._parent and not exclude_parent:
+        if direct_parent:
+            new_me._parent = self._parent
+        elif not exclude_parent:
             new_me._parent = self._parent.copy(exclude_tasks=exclude_tasks)
 
         new_me._role = None

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -149,6 +149,7 @@ class TaskInclude(Task):
                 role=self._role,
                 variable_manager=self._variable_manager,
                 loader=self._loader,
+                parent=self._parent
             )
         else:
             p_block = self

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -149,7 +149,6 @@ class TaskInclude(Task):
                 role=self._role,
                 variable_manager=self._variable_manager,
                 loader=self._loader,
-                parent=self._parent
             )
         else:
             p_block = self

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -106,8 +106,8 @@ class TaskInclude(Task):
 
         return ds
 
-    def copy(self, exclude_parent=False, exclude_tasks=False):
-        new_me = super(TaskInclude, self).copy(exclude_parent=exclude_parent, exclude_tasks=exclude_tasks)
+    def copy(self, exclude_parent=False, exclude_tasks=False, direct_parent=False):
+        new_me = super(TaskInclude, self).copy(exclude_parent=exclude_parent, exclude_tasks=exclude_tasks, direct_parent=direct_parent)
         new_me.statically_loaded = self.statically_loaded
         return new_me
 

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -516,8 +516,7 @@ class StrategyBase:
             original_host = get_original_host(task_result._host)
             queue_cache_entry = (original_host.name, task_result._task)
             found_task = self._queued_task_cache.get(queue_cache_entry)['task']
-            original_task = found_task.copy(exclude_parent=True, exclude_tasks=True)
-            original_task._parent = found_task._parent
+            original_task = found_task.copy(direct_parent=True, exclude_tasks=True)
             original_task.from_attrs(task_result._task_fields)
 
             task_result._host = original_host

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -323,70 +323,69 @@ class VariableManager:
         if play:
             all_vars = _combine_and_track(all_vars, play.get_vars(), "play vars")
 
-            vars_files = play.get_vars_files()
-            try:
-                for vars_file_item in vars_files:
-                    # create a set of temporary vars here, which incorporate the extra
-                    # and magic vars so we can properly template the vars_files entries
-                    temp_vars = combine_vars(all_vars, self._extra_vars)
-                    temp_vars = combine_vars(temp_vars, magic_variables)
-                    templar = Templar(loader=self._loader, variables=temp_vars)
+            # try:
+            #     for vars_file_item in vars_files:
+            #         # create a set of temporary vars here, which incorporate the extra
+            #         # and magic vars so we can properly template the vars_files entries
+            #         temp_vars = combine_vars(all_vars, self._extra_vars)
+            #         temp_vars = combine_vars(temp_vars, magic_variables)
+            #         templar = Templar(loader=self._loader, variables=temp_vars)
 
-                    # we assume each item in the list is itself a list, as we
-                    # support "conditional includes" for vars_files, which mimics
-                    # the with_first_found mechanism.
-                    vars_file_list = vars_file_item
-                    if not isinstance(vars_file_list, list):
-                        vars_file_list = [vars_file_list]
+            #         # we assume each item in the list is itself a list, as we
+            #         # support "conditional includes" for vars_files, which mimics
+            #         # the with_first_found mechanism.
+            #         vars_file_list = vars_file_item
+            #         if not isinstance(vars_file_list, list):
+            #             vars_file_list = [vars_file_list]
 
-                    # now we iterate through the (potential) files, and break out
-                    # as soon as we read one from the list. If none are found, we
-                    # raise an error, which is silently ignored at this point.
-                    try:
-                        for vars_file in vars_file_list:
-                            vars_file = templar.template(vars_file)
-                            if not (isinstance(vars_file, Sequence)):
-                                raise AnsibleError(
-                                    "Invalid vars_files entry found: %r\n"
-                                    "vars_files entries should be either a string type or "
-                                    "a list of string types after template expansion" % vars_file
-                                )
-                            try:
-                                data = preprocess_vars(self._loader.load_from_file(vars_file, unsafe=True))
-                                if data is not None:
-                                    for item in data:
-                                        all_vars = _combine_and_track(all_vars, item, "play vars_files from '%s'" % vars_file)
-                                break
-                            except AnsibleFileNotFound:
-                                # we continue on loader failures
-                                continue
-                            except AnsibleParserError:
-                                raise
-                        else:
-                            # if include_delegate_to is set to False, we ignore the missing
-                            # vars file here because we're working on a delegated host
-                            if include_delegate_to:
-                                raise AnsibleFileNotFound("vars file %s was not found" % vars_file_item)
-                    except (UndefinedError, AnsibleUndefinedVariable):
-                        if host is not None and self._fact_cache.get(host.name, dict()).get('module_setup') and task is not None:
-                            raise AnsibleUndefinedVariable("an undefined variable was found when attempting to template the vars_files item '%s'"
-                                                           % vars_file_item, obj=vars_file_item)
-                        else:
-                            # we do not have a full context here, and the missing variable could be because of that
-                            # so just show a warning and continue
-                            display.vvv("skipping vars_file '%s' due to an undefined variable" % vars_file_item)
-                            continue
+            #         # now we iterate through the (potential) files, and break out
+            #         # as soon as we read one from the list. If none are found, we
+            #         # raise an error, which is silently ignored at this point.
+            #         try:
+            #             for vars_file in vars_file_list:
+            #                 vars_file = templar.template(vars_file)
+            #                 if not (isinstance(vars_file, Sequence)):
+            #                     raise AnsibleError(
+            #                         "Invalid vars_files entry found: %r\n"
+            #                         "vars_files entries should be either a string type or "
+            #                         "a list of string types after template expansion" % vars_file
+            #                     )
+            #                 try:
+            #                     data = preprocess_vars(self._loader.load_from_file(vars_file, unsafe=True))
+            #                     if data is not None:
+            #                         for item in data:
+            #                             all_vars = _combine_and_track(all_vars, item, "play vars_files from '%s'" % vars_file)
+            #                     break
+            #                 except AnsibleFileNotFound:
+            #                     # we continue on loader failures
+            #                     continue
+            #                 except AnsibleParserError:
+            #                     raise
+            #             else:
+            #                 # if include_delegate_to is set to False, we ignore the missing
+            #                 # vars file here because we're working on a delegated host
+            #                 if include_delegate_to:
+            #                     raise AnsibleFileNotFound("vars file %s was not found" % vars_file_item)
+            #         except (UndefinedError, AnsibleUndefinedVariable):
+            #             if host is not None and self._fact_cache.get(host.name, dict()).get('module_setup') and task is not None:
+            #                 raise AnsibleUndefinedVariable("an undefined variable was found when attempting to template the vars_files item '%s'"
+            #                                                % vars_file_item, obj=vars_file_item)
+            #             else:
+            #                 # we do not have a full context here, and the missing variable could be because of that
+            #                 # so just show a warning and continue
+            #                 display.vvv("skipping vars_file '%s' due to an undefined variable" % vars_file_item)
+            #                 continue
 
-                    display.vvv("Read vars_file '%s'" % vars_file_item)
-            except TypeError:
-                raise AnsibleParserError("Error while reading vars files - please supply a list of file names. "
-                                         "Got '%s' of type %s" % (vars_files, type(vars_files)))
+            #         display.vvv("Read vars_file '%s'" % vars_file_item)
+            # except TypeError:
+            #     raise AnsibleParserError("Error while reading vars files - please supply a list of file names. "
+            #                              "Got '%s' of type %s" % (vars_files, type(vars_files)))
 
-            # By default, we now merge in all vars from all roles in the play,
-            # unless the user has disabled this via a config option
-            if not C.DEFAULT_PRIVATE_ROLE_VARS:
-                for role in play.get_roles():
-                    all_vars = _combine_and_track(all_vars, role.get_vars(include_params=False), "role '%s' vars" % role.name)
+            # # By default, we now merge in all vars from all roles in the play,
+            # # unless the user has disabled this via a config option
+            # if not C.DEFAULT_PRIVATE_ROLE_VARS:
+            #     for role in play.get_roles():
+            #         all_vars = _combine_and_track(all_vars, role.get_vars(include_params=False), "role '%s' vars" % role.name)
 
         # next, we merge in the vars from the role, which will specifically
         # follow the role dependency chain, and then we merge in the tasks

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -321,7 +321,10 @@ class VariableManager:
                 pass
 
         if play:
-            all_vars = _combine_and_track(all_vars, play.get_vars(), "play vars")
+            temp_vars = combine_vars(all_vars, self._extra_vars)
+            temp_vars = combine_vars(temp_vars, magic_variables)
+            templar = Templar(loader=self._loader, variables=temp_vars)
+            all_vars = _combine_and_track(all_vars, play.get_vars(templar), "play vars")
 
             # try:
             #     for vars_file_item in vars_files:

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/playbooks/roles/non_coll_role/tasks/main.yml
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/playbooks/roles/non_coll_role/tasks/main.yml
@@ -26,4 +26,4 @@
 
   - assert:
       that:
-        - test_role_output.msg == test_role_input
+        - non_coll_role_to_call_test_role_output.msg == test_role_input

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/playbooks/roles/non_coll_role_to_call/tasks/main.yml
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/playbooks/roles/non_coll_role_to_call/tasks/main.yml
@@ -1,7 +1,7 @@
 - debug:
     msg: '{{ test_role_input | default("(undefined)") }}'
-  register: test_role_output
+  register: non_coll_role_to_call_test_role_output
 
 - assert:
     that:
-    - test_role_input is not defined or test_role_input == test_role_output.msg
+    - non_coll_role_to_call_test_role_input is not defined or test_role_input == non_coll_role_to_call_test_role_output.msg

--- a/test/integration/targets/var_precedence/runme.sh
+++ b/test/integration/targets/var_precedence/runme.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-ansible-playbook test_var_precedence.yml -i inventory -v "$@" \
+ansible-playbook test_var_precedence_playbook.yml -i inventory -v "$@" \
     -e 'extra_var=extra_var' \
     -e 'extra_var_override=extra_var_override'
 

--- a/test/integration/targets/var_precedence/test_var_precedence_playbook.yml
+++ b/test/integration/targets/var_precedence/test_var_precedence_playbook.yml
@@ -38,7 +38,7 @@
 
 - hosts: inven_overridehosts
   vars_files:
-    - "test_var_precedence.yml"
+    - "vars/test_var_precedence.yml"
   roles:
     - role: test_var_precedence_inven_override
       foo: bar

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -158,7 +158,7 @@ class TestTaskExecutor(unittest.TestCase):
 
         mock_host = MagicMock()
 
-        def _copy(exclude_parent=False, exclude_tasks=False):
+        def _copy(exclude_parent=False, exclude_tasks=False, direct_parent=False):
             new_item = MagicMock()
             return new_item
 

--- a/test/units/playbook/test_helpers.py
+++ b/test/units/playbook/test_helpers.py
@@ -45,6 +45,7 @@ class MixinForMocks(object):
         self.mock_play = MagicMock(name='MockPlay')
         self.mock_play._attributes = []
         self.mock_play.collections = None
+        self.mock_play._get_parent_attribute.return_value = []
 
         self.mock_iterator = MagicMock(name='MockIterator')
         self.mock_iterator._play = self.mock_play

--- a/test/units/playbook/test_included_file.py
+++ b/test/units/playbook/test_included_file.py
@@ -237,6 +237,10 @@ def test_process_include_simulate_free_block_role_tasks(mock_iterator,
     hostname = "testhost1"
     hostname2 = "testhost2"
 
+    mock_play = MagicMock()
+    mock_play.copy.return_value = mock_play
+    mock_play._get_parent_attribute.return_value = []
+
     role1_ds = {
         'name': 'task1 include',
         'include_role': {
@@ -257,7 +261,7 @@ def test_process_include_simulate_free_block_role_tasks(mock_iterator,
             role2_ds
         ]
     }
-    parent_block = Block.load(parent_task_ds, loader=fake_loader)
+    parent_block = Block.load(parent_task_ds, loader=fake_loader, play=mock_play)
 
     parent_block._play = None
 

--- a/test/units/vars/test_variable_manager.py
+++ b/test/units/vars/test_variable_manager.py
@@ -95,14 +95,14 @@ class TestVariableManager(unittest.TestCase):
             """
         })
 
-        mock_play = MagicMock()
-        mock_play.get_vars.return_value = dict()
-        mock_play.get_roles.return_value = []
-        mock_play.get_vars_files.return_value = [__file__]
-
         mock_inventory = MagicMock()
         v = VariableManager(inventory=mock_inventory, loader=fake_loader)
-        self.assertEqual(v.get_vars(play=mock_play, use_cache=False).get("foo"), "bar")
+        play = Play.load(dict(
+            hosts=['all'],
+            vars_files=[__file__],
+        ), loader=fake_loader, variable_manager=v)
+
+        self.assertEqual(v.get_vars(play=play, use_cache=False).get("foo"), "bar")
 
     def test_variable_manager_task_vars(self):
         # FIXME: BCS make this work


### PR DESCRIPTION
##### SUMMARY
Add Playbook and PlaybookInclude into parent chain

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
Checklist

- [x] Ensure block reparenting works. Stop at `Play`?
- [x] ~Prefer and allow `vars/` for `vars_files`~
- [ ] Multiple static role parents, like a diamond of `import_role` in roles...
  * I'm not sure this is a concern, static roles are always children of the play, regardless of their structure 