### PR TITLE
Integrate mypy sanity check into `ansible-test`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -47,3 +47,4 @@ recursive-include hacking/build_library *.py
 include hacking/build-ansible.py
 include hacking/test-module.py
 include bin/*
+include test/sanity/code-smell/mypy.ini

--- a/changelogs/fragments/73319-mypy.yaml
+++ b/changelogs/fragments/73319-mypy.yaml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+- >-
+  Added support for ``mypy`` static type checker
+  (https://mypy.rtfd.io).
+...

--- a/docs/docsite/rst/dev_guide/testing/sanity/mypy.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/mypy.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+mypy
+====
+
+A type checker running against Pyhton 3.9, 3.6 and 2.7. At
+the moment it only runs agains a few subpackages and not the
+whole project.
+See https://mypy.rtfd.io for more details on how type
+annotations in Python work.

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -174,6 +174,7 @@ def verify_local_collection(
         # since we're not downloading this, just seed it with the value from disk
         manifest_hash = get_hash_from_validation_source(MANIFEST_FILENAME)
     else:
+        assert remote_collection is not None  # mypy thing
         # fetch remote
         b_temp_tar_path = (  # NOTE: AnsibleError is raised on URLError
             artifacts_manager.get_artifact_path
@@ -1346,7 +1347,7 @@ def _resolve_depenency_map(
                 'requirements:',
             ),
             conflict_causes,
-        )
+        )  # type: Union[Iterable[str], List[str]]
         raise raise_from(  # NOTE: Leading "raise" is a hack for mypy bug #9717
             AnsibleError('\n'.join(error_msg_lines)),
             dep_exc,

--- a/lib/ansible/galaxy/collection/galaxy_api_proxy.py
+++ b/lib/ansible/galaxy/collection/galaxy_api_proxy.py
@@ -14,7 +14,7 @@ except ImportError:
     TYPE_CHECKING = False
 
 if TYPE_CHECKING:
-    from typing import Dict, Iterable, Tuple
+    from typing import Dict, Iterable, Iterator, Tuple
     from ansible.galaxy.api import CollectionVersionMetadata
     from ansible.galaxy.collection.concrete_artifact_manager import (
         ConcreteArtifactsManager,
@@ -41,7 +41,7 @@ class MultiGalaxyAPIProxy:
         self._concrete_art_mgr = concrete_artifacts_manager
 
     def _get_collection_versions(self, requirement):
-        # type: (Requirement, Iterator[GalaxyAPI]) -> Iterator[Tuple[GalaxyAPI, str]]
+        # type: (Requirement) -> Iterator[Tuple[GalaxyAPI, str]]
         """Helper for get_collection_versions.
 
         Yield api, version pairs for all APIs,

--- a/test/sanity/code-smell/mypy.ini
+++ b/test/sanity/code-smell/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+follow_imports = skip
+
+[mypy-ansible.module_utils.six.*]
+ignore_missing_imports = True
+
+[mypy-resolvelib.*]
+ignore_missing_imports = True

--- a/test/sanity/code-smell/mypy.json
+++ b/test/sanity/code-smell/mypy.json
@@ -1,0 +1,4 @@
+{
+    "no_targets": true,
+    "output": "path-line-column-message"
+}

--- a/test/sanity/code-smell/mypy.py
+++ b/test/sanity/code-smell/mypy.py
@@ -31,7 +31,9 @@ def run_mypy() -> int:
     )
 
     try:
-        mypy_out = subprocess.check_output(mypy_cmd, text=True)  # noqa: S603
+        mypy_out = subprocess.check_output(  # noqa: S603
+            mypy_cmd, universal_newlines=True,
+        )
     except subprocess.CalledProcessError as proc_err:
         mypy_out = proc_err.output
         return_code = proc_err.returncode

--- a/test/sanity/code-smell/mypy.py
+++ b/test/sanity/code-smell/mypy.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# Copyright: (c) 2020-2021, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""Making sure the type annotations are correct across packages."""
+
+import pathlib
+import subprocess
+import sys
+
+
+THIS_PKG_DIR = pathlib.Path(__file__).parent
+
+
+def run_mypy(python_version: str = None) -> int:
+    """Execute mypy against a given Python version.
+
+    This function proxies mypy's return code and filters out
+    the output so that `ansible-test` wouldn't get confused.
+    """
+    mypy_cmd = (
+        sys.executable, '-m', 'mypy',
+        '--config-file', str(THIS_PKG_DIR / 'mypy.ini'),
+        '--install-types',
+        '--show-error-codes',
+        *(
+            () if python_version is None
+            else ('--python-version', python_version)
+        ),
+        # 'hacking/shippable/incidental.py',
+        'lib/ansible/galaxy/collection/',
+        'lib/ansible/galaxy/dependency_resolution',
+        # 'test/lib/ansible_test/_internal',
+        # 'test/utils/shippable/check_matrix.py',
+    )
+    if python_version and python_version[0] > '2':
+        mypy_cmd += 'test/sanity/code-smell/mypy.py',  # self-test
+
+    try:
+        mypy_out = subprocess.check_output(mypy_cmd, universal_newlines=True)
+    except subprocess.CalledProcessError as proc_err:
+        mypy_out = proc_err.output
+        return_code = proc_err.returncode
+    else:
+        return_code = 0
+
+    if not return_code:
+        # NOTE: Interrupt because `ansible-test sanity` runner treats any
+        # NOTE: output as a linting failure.
+        return return_code
+
+    print(
+        f'{__file__!s}:Results of type checking with mypy against '
+        f'{python_version or "unspecified"!s} Python '
+        f'(return code {return_code!s})',
+        file=sys.stderr,
+    )
+    for line in mypy_out.splitlines():
+        if line.startswith((u'Success: no issues found in ', u'Found ')):
+            out_stream = sys.stderr
+        else:
+            out_stream = sys.stdout
+
+        print(line, file=out_stream)
+
+    return return_code
+
+
+def main() -> int:
+    """Validate type annotations with mypy against Python 2 and 3."""
+    target_pythons = '3.9', '3.6', '2.7'
+    return_code = sum(run_mypy(py_ver) for py_ver in target_pythons)
+    return return_code
+
+
+if __name__ == '__main__':
+    main()

--- a/test/sanity/code-smell/mypy.requirements.txt
+++ b/test/sanity/code-smell/mypy.requirements.txt
@@ -1,0 +1,4 @@
+mypy
+types-PyYAML
+typing
+typing-extensions == 3.10.0.2

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -175,6 +175,7 @@ test/support/integration/plugins/modules/ec2_group.py pylint:use-a-generator
 test/support/integration/plugins/modules/timezone.py pylint:disallowed-name
 test/support/integration/plugins/module_utils/aws/core.py pylint:property-with-parameters
 test/support/integration/plugins/module_utils/cloud.py future-import-boilerplate
+lib/ansible/galaxy/collection/__init__.py no-assert  # Needed for MyPy to infer types properly
 test/support/integration/plugins/module_utils/cloud.py metaclass-boilerplate
 test/support/integration/plugins/module_utils/cloud.py pylint:isinstance-second-argument-not-valid-type
 test/support/integration/plugins/module_utils/compat/ipaddress.py future-import-boilerplate

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -174,11 +174,6 @@ test/support/integration/plugins/inventory/aws_ec2.py pylint:use-a-generator
 test/support/integration/plugins/modules/ec2_group.py pylint:use-a-generator
 test/support/integration/plugins/modules/timezone.py pylint:disallowed-name
 test/support/integration/plugins/module_utils/aws/core.py pylint:property-with-parameters
-test/sanity/code-smell/mypy.py compile-2.6!skip  # it's invoked under py3.6
-test/sanity/code-smell/mypy.py compile-2.7!skip  # it's invoked under py3.6
-test/sanity/code-smell/mypy.py compile-3.5!skip  # it's invoked under py3.6
-test/sanity/code-smell/mypy.py future-import-boilerplate!skip  # it's invoked under py3.6
-test/sanity/code-smell/mypy.py metaclass-boilerplate!skip  # it's invoked under py3.6
 test/support/integration/plugins/module_utils/cloud.py future-import-boilerplate
 test/support/integration/plugins/module_utils/cloud.py metaclass-boilerplate
 test/support/integration/plugins/module_utils/cloud.py pylint:isinstance-second-argument-not-valid-type

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -174,6 +174,11 @@ test/support/integration/plugins/inventory/aws_ec2.py pylint:use-a-generator
 test/support/integration/plugins/modules/ec2_group.py pylint:use-a-generator
 test/support/integration/plugins/modules/timezone.py pylint:disallowed-name
 test/support/integration/plugins/module_utils/aws/core.py pylint:property-with-parameters
+test/sanity/code-smell/mypy.py compile-2.6!skip  # it's invoked under py3.6
+test/sanity/code-smell/mypy.py compile-2.7!skip  # it's invoked under py3.6
+test/sanity/code-smell/mypy.py compile-3.5!skip  # it's invoked under py3.6
+test/sanity/code-smell/mypy.py future-import-boilerplate!skip  # it's invoked under py3.6
+test/sanity/code-smell/mypy.py metaclass-boilerplate!skip  # it's invoked under py3.6
 test/support/integration/plugins/module_utils/cloud.py future-import-boilerplate
 test/support/integration/plugins/module_utils/cloud.py metaclass-boilerplate
 test/support/integration/plugins/module_utils/cloud.py pylint:isinstance-second-argument-not-valid-type


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change adds a sanity check with several hardcoded paths originally pointing to changes in https://github.com/ansible/ansible/pull/72591 as it was used to lint those changes.

Right now it is simplistic and doesn't support pointing to separate modules/packages.

~It currently produces failures when run against `devel` but it's green with changes from https://github.com/ansible/ansible/pull/72591.~ Not anymore: I ported the relevant type ignores from that PR.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test/sanity/code-smell/mypy.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This is requested @ https://github.com/ansible/ansible/pull/72591#pullrequestreview-573598712