### PR TITLE
validate_modules: fails with .id attribute not found

### DIFF
--- a/changelogs/fragments/validate-modules_found_try_except_import_fails_module_attribute.yaml
+++ b/changelogs/fragments/validate-modules_found_try_except_import_fails_module_attribute.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- validate-modules - do not raise an ``AttributeError`` is a value is assigned to a module attribute in a try/except block.

--- a/changelogs/fragments/validate-modules_found_try_except_import_fails_module_attribute.yaml
+++ b/changelogs/fragments/validate-modules_found_try_except_import_fails_module_attribute.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-- validate-modules - do not raise an ``AttributeError`` is a value is assigned to a module attribute in a try/except block.
+- validate-modules - do not raise an ``AttributeError`` if a value is assigned to a module attribute in a try/except block.

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -666,6 +666,8 @@ class ModuleValidator(Validator):
                         found_try_except_import = True
                     if isinstance(grandchild, ast.Assign):
                         for target in grandchild.targets:
+                            if not hasattr(target, 'id'):
+                                continue
                             if target.id.lower().startswith('has_'):
                                 found_has = True
             if found_try_except_import and not found_has:

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -666,7 +666,7 @@ class ModuleValidator(Validator):
                         found_try_except_import = True
                     if isinstance(grandchild, ast.Assign):
                         for target in grandchild.targets:
-                            if not hasattr(target, 'id'):
+                            if not isinstance(target, ast.Name):
                                 continue
                             if target.id.lower().startswith('has_'):
                                 found_has = True


### PR DESCRIPTION
##### SUMMARY

This patch addresses a problem in the `found_try_except_import` test.

This module tries to identify lines like:

`HAS_FOO = True`

In this case, the target (`HAS_FOO`) is of type `ast.Name` and has a `id` attribute which provide the name.

In my case, I've a line that set a module attribute:

`foo.bar = True`

In this example, the target (`module.var`) has the type `ast.Attribute` and has no `id` attribute. The code triggers an `AttributeError` exception.

This patch ensures we compare an `ast.Name`.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

validate_modules