### PR TITLE
[stable-2.10] Handle get-pip.py breaking change on Python 2.7.

### DIFF
--- a/changelogs/fragments/ansible-test-pip-bootstrap.yml
+++ b/changelogs/fragments/ansible-test-pip-bootstrap.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - The ``--remote`` option has been updated for Python 2.7 to work around breaking changes in the newly released ``get-pip.py`` bootstrapper.

--- a/test/lib/ansible_test/_data/setup/remote.sh
+++ b/test/lib/ansible_test/_data/setup/remote.sh
@@ -10,7 +10,15 @@ cd ~/
 
 install_pip () {
     if ! "${python_interpreter}" -m pip.__main__ --version --disable-pip-version-check 2>/dev/null; then
-        curl --silent --show-error https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
+        case "${python_version}" in
+            "2.7")
+                pip_bootstrap_url="https://bootstrap.pypa.io/${python_version}/get-pip.py"
+                ;;
+            *)
+                pip_bootstrap_url="https://bootstrap.pypa.io/get-pip.py"
+                ;;
+        esac
+        curl --silent --show-error "${pip_bootstrap_url}" -o /tmp/get-pip.py
         "${python_interpreter}" /tmp/get-pip.py --disable-pip-version-check --quiet
         rm /tmp/get-pip.py
     fi


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/73340

(cherry picked from commit 484e4af4d0b0f8ba88f73c20f592bb107eb9396a)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
