### PR TITLE
[backport][stable-2.10] Fix `versionadded` syntax @ galaxy user guide

### DIFF
--- a/docs/docsite/rst/galaxy/user_guide.rst
+++ b/docs/docsite/rst/galaxy/user_guide.rst
@@ -385,7 +385,7 @@ There are two ways to define the dependencies of a role:
 Using ``meta/requirements.yml``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-`.. versionadded:: 2.10`
+.. versionadded:: 2.10
 
 You can create the file ``meta/requirements.yml`` and define dependencies in the same format used for :file:`requirements.yml` described in the `Installing multiple roles from a file`_ section.
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It's a backport of #73346

(cherry picked from commit 6abeabaff1356d0f4b88e87b5dd1eb86f81993ed)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs/docsite/rst/galaxy/user_guide.rst

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A