### PR TITLE
update user module faq link

### DIFF
--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -89,7 +89,7 @@ options:
             - On macOS systems, this value has to be cleartext. Beware of security issues.
             - To create a disabled account on Linux systems, set this to C('!') or C('*').
             - To create a disabled account on OpenBSD, set this to C('*************').
-            - See U(https://docs.ansible.com/ansible/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
+            - See U(https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
               for details on various ways to generate these password values.
         type: str
     state:


### PR DESCRIPTION
Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>

##### SUMMARY

https://docs.ansible.com/ansible/latest/collections/ansible/builtin/user_module.html links to https://docs.ansible.com/ansible/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module which return a 404.

Updated the link to https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module

Fixes #73385

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

ansible.builtin.user
