### PR TITLE
Mention renaming ansible-base to -core @ roadmap

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_11.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_11.rst
@@ -37,6 +37,7 @@ Release Manager
 Planned work
 ============
 
+- Rename ``ansible-base`` to ``ansible-core``.
 - Improve UX of ``ansible-galaxy collection`` CLI, specifically as it relates to install and upgrade.
 - Add new Role Argument Spec feature that will allow a role to define an argument spec to be used in
   validating variables used by the role.

--- a/docs/docsite/rst/roadmap/ROADMAP_2_11.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_11.rst
@@ -1,7 +1,7 @@
 .. _base_roadmap_2_11:
 
 =================
-Ansible-base 2.11
+Ansible-core 2.11
 =================
 
 .. contents::
@@ -13,7 +13,7 @@ Release Schedule
 Expected
 ========
 
-PRs must be raised well in advance of the dates below to have a chance of being included in this ansible-base release.
+PRs must be raised well in advance of the dates below to have a chance of being included in this ansible-core release.
 
 .. note:: There is no Alpha phase in 2.11.
 .. note:: Dates subject to change.
@@ -42,7 +42,7 @@ Planned work
 - Add new Role Argument Spec feature that will allow a role to define an argument spec to be used in
   validating variables used by the role.
 - Bump the minimum Python version requirement for the controller to Python 3.8. There will be no breaking changes
-  to this release, however ``ansible-base`` will only be packaged for Python 3.8+. ``ansible-base==2.12`` will include
+  to this release, however ``ansible-core`` will only be packaged for Python 3.8+. ``ansible-core==2.12`` will include
   breaking changes requiring at least Python 3.8.
 - Introduce split-controller testing in ``ansible-test`` to separate dependencies for the controller from
   dependencies on the target.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The roadmap is still referring to ansible/ansible as ansible-base so I've changed that and added a mention of the planned rename to the plan.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs/docsite/rst/roadmap/ROADMAP_2_11.rst

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A