### PR TITLE
[stable-2.9] Update ansible-test pylint Python support. (#72972)

### DIFF
--- a/changelogs/fragments/ansible-test-pylint-python-3.8.yml
+++ b/changelogs/fragments/ansible-test-pylint-python-3.8.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - The ``pylint`` sanity test is now supported on Python 3.8.

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -42,10 +42,10 @@ setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require pyth
 cffi != 1.14.4 # Fails on systems with older gcc. Should be fixed in the next release. https://foss.heptapod.net/pypy/cffi/-/issues/480
 
 # freeze pylint and its requirements for consistent test results
-astroid == 2.2.5
+astroid == 2.3.3
 isort == 4.3.15
-lazy-object-proxy == 1.3.1
+lazy-object-proxy == 1.4.3
 mccabe == 0.6.1
 pylint == 2.3.1
-typed-ast == 1.4.0  # 1.4.0 is required to compile on Python 3.8
+typed-ast == 1.4.1
 wrapt == 1.11.1

--- a/test/lib/ansible_test/_data/sanity/pylint/plugins/blacklist.py
+++ b/test/lib/ansible_test/_data/sanity/pylint/plugins/blacklist.py
@@ -25,7 +25,7 @@ class BlacklistEntry:
         """
         self.alternative = alternative
         self.modules_only = modules_only
-        self.names = set(names) if names else None
+        self.names = set(names) if names else set()
         self.ignore_paths = ignore_paths
 
     def applies_to(self, path, name=None):


### PR DESCRIPTION
##### SUMMARY

Partial backport of https://github.com/ansible/ansible/pull/72972

* Update ansible-test pylint Python support.
* Python 3.8 is now officially supported.

(cherry picked from commit 37d09f24882c1f03be9900e610d53587cfa6bbd6)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
