### PR TITLE
[stable-2.8] Use a versioned pip bootstrapper in ansible-test.

### DIFF
--- a/changelogs/fragments/ansible-test-pip-bootstrap-s3.yml
+++ b/changelogs/fragments/ansible-test-pip-bootstrap-s3.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - The ``--remote`` option has been updated to use a versioned ``get-pip.py`` bootstrapper to avoid issues with future releases.

--- a/test/runner/setup/remote.sh
+++ b/test/runner/setup/remote.sh
@@ -11,11 +11,8 @@ cd ~/
 install_pip () {
     if ! "${python_interpreter}" -m pip.__main__ --version --disable-pip-version-check 2>/dev/null; then
         case "${python_version}" in
-            "2.7")
-                pip_bootstrap_url="https://bootstrap.pypa.io/${python_version}/get-pip.py"
-                ;;
             *)
-                pip_bootstrap_url="https://bootstrap.pypa.io/get-pip.py"
+                pip_bootstrap_url="https://ansible-ci-files.s3.amazonaws.com/ansible-test/get-pip-20.3.4.py"
                 ;;
         esac
         curl --silent --show-error "${pip_bootstrap_url}" -o /tmp/get-pip.py


### PR DESCRIPTION
##### SUMMARY

Use a versioned pip bootstrapper in ansible-test.

Backport of https://github.com/ansible/ansible/pull/73358

(cherry picked from commit fc590aeb2104c2c4e6a3aacba53852da1d7a26d9)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
