### PR TITLE
[2.10] Add Ubuntu 20.04 to CI and ansible-test (#69161)

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -128,6 +128,8 @@ stages:
               test: ubuntu1604
             - name: Ubuntu 18.04
               test: ubuntu1804
+            - name: Ubuntu 20.04
+              test: ubuntu2004
           groups:
             - 1
             - 2
@@ -198,6 +200,8 @@ stages:
               test: ubuntu1604
             - name: Ubuntu 18.04
               test: ubuntu1804
+            - name: Ubuntu 20.04
+              test: ubuntu2004
   - stage: Incidental_Windows
     displayName: Incidental Windows
     dependsOn: []

--- a/changelogs/fragments/ansible-test-ubuntu2004.yml
+++ b/changelogs/fragments/ansible-test-ubuntu2004.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Added Ubuntu 20.04 LTS image to the default completion list

--- a/test/integration/targets/apt/tasks/apt-builddep.yml
+++ b/test/integration/targets/apt/tasks/apt-builddep.yml
@@ -29,9 +29,9 @@
   when: dpkg_result is successful
   tags: ['test_apt_builddep']
 
-# install build-dep for netcat
-- name: install netcat build-dep with apt
-  apt: pkg=netcat state=build-dep
+# install build-dep for rolldice
+- name: install rolldice build-dep with apt
+  apt: pkg=rolldice state=build-dep
   register: apt_result
   tags: ['test_apt_builddep']
 

--- a/test/integration/targets/apt/tasks/apt-multiarch.yml
+++ b/test/integration/targets/apt/tasks/apt-multiarch.yml
@@ -1,24 +1,37 @@
 # verify that apt is handling multi-arch systems properly
+
+- name: load version specific vars
+  include_vars: '{{ item }}'
+  with_first_found:
+  - files:
+    - '{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml'
+    - 'default.yml'
+    paths: '../vars'
+
 - name: add architecture {{ apt_foreign_arch }}
   command: dpkg --add-architecture {{ apt_foreign_arch }}
 
-- name: install hello:{{ apt_foreign_arch }} with apt
-  apt: pkg=hello:{{ apt_foreign_arch }} state=present update_cache=yes
+- name: install {{ multiarch_test_pkg }}:{{ apt_foreign_arch }} with apt
+  apt: pkg={{ multiarch_test_pkg }}:{{ apt_foreign_arch }} state=present update_cache=yes
   register: apt_result
   until: apt_result is success
 
-- name: uninstall hello:{{ apt_foreign_arch }} with apt
-  apt: pkg=hello:{{ apt_foreign_arch }} state=absent purge=yes
+- name: check {{ multiarch_test_pkg }} version
+  shell: dpkg -s {{ multiarch_test_pkg }} | grep Version | awk '{print $2}'
+  register: pkg_version
+
+- name: uninstall {{ multiarch_test_pkg }}:{{ apt_foreign_arch }} with apt
+  apt: pkg={{ multiarch_test_pkg }}:{{ apt_foreign_arch }} state=absent purge=yes
 
 - name: install deb file
-  apt: deb="/var/cache/apt/archives/hello_{{ hello_version.stdout }}_{{ apt_foreign_arch }}.deb"
+  apt: deb="/var/cache/apt/archives/{{ multiarch_test_pkg }}_{{ pkg_version.stdout }}_{{ apt_foreign_arch }}.deb"
   register: apt_multi_initial
 
 - name: install deb file again
-  apt: deb="/var/cache/apt/archives/hello_{{ hello_version.stdout }}_{{ apt_foreign_arch }}.deb"
+  apt: deb="/var/cache/apt/archives/{{ multiarch_test_pkg }}_{{ pkg_version.stdout }}_{{ apt_foreign_arch }}.deb"
   register: apt_multi_secondary
 
-- name: verify installation of hello:{{ apt_foreign_arch }}
+- name: verify installation of {{ multiarch_test_pkg }}:{{ apt_foreign_arch }}
   assert:
     that:
         - "apt_multi_initial.changed"

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -271,6 +271,9 @@
 - name: autoclean during install
   apt: pkg=hello state=present autoclean=yes
 
+- name: undo previous install
+  apt: pkg=hello state=absent
+
 # https://github.com/ansible/ansible/issues/23155
 - name: create a repo file
   copy:

--- a/test/integration/targets/apt/vars/Ubuntu-20.yml
+++ b/test/integration/targets/apt/vars/Ubuntu-20.yml
@@ -1,0 +1,1 @@
+multiarch_test_pkg: libunistring2

--- a/test/integration/targets/apt/vars/default.yml
+++ b/test/integration/targets/apt/vars/default.yml
@@ -1,0 +1,1 @@
+multiarch_test_pkg: hello

--- a/test/integration/targets/incidental_lookup_rabbitmq/tasks/main.yml
+++ b/test/integration/targets/incidental_lookup_rabbitmq/tasks/main.yml
@@ -2,4 +2,4 @@
 - include: ubuntu.yml
   when: 
     - ansible_distribution == 'Ubuntu'
-    - ansible_distribution_release != 'trusty'
+    - ansible_distribution_release not in ('trusty', 'focal')

--- a/test/integration/targets/incidental_setup_mongodb/tasks/main.yml
+++ b/test/integration/targets/incidental_setup_mongodb/tasks/main.yml
@@ -20,8 +20,10 @@
 # https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/
 # Support for Ubuntu 14.04 has been removed from MongoDB 4.0.10+, 3.6.13+, and 3.4.21+.
 # CentOS6 has python version issues
+# Ubuntu 20.04 does not yet have the required packages
 - meta: end_play
   when: (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '14.04')
+    or (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '20.04')
     or (ansible_os_family == "RedHat" and ansible_distribution_major_version == '6')
     or ansible_os_family == "Suse"
     or ansible_distribution == 'Fedora'

--- a/test/integration/targets/incidental_setup_postgresql_db/vars/Ubuntu-20-py3.yml
+++ b/test/integration/targets/incidental_setup_postgresql_db/vars/Ubuntu-20-py3.yml
@@ -1,0 +1,8 @@
+postgresql_packages:
+  - "postgresql"
+  - "postgresql-common"
+  - "python3-psycopg2"
+
+pg_hba_location: "/etc/postgresql/12/main/pg_hba.conf"
+pg_dir: "/var/lib/postgresql/12/main"
+pg_ver: 12

--- a/test/integration/targets/incidental_setup_rabbitmq/tasks/main.yml
+++ b/test/integration/targets/incidental_setup_rabbitmq/tasks/main.yml
@@ -1,3 +1,5 @@
 ---
 - include: ubuntu.yml
-  when: ansible_distribution == 'Ubuntu'
+  when:
+    - ansible_distribution == 'Ubuntu'
+    - ansible_distribution_release != 'focal'

--- a/test/integration/targets/subversion/vars/Ubuntu-20.yml
+++ b/test/integration/targets/subversion/vars/Ubuntu-20.yml
@@ -1,0 +1,6 @@
+---
+subversion_packages:
+- subversion
+- libapache2-mod-svn
+apache_user: www-data
+apache_group: www-data

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -10,3 +10,4 @@ opensuse15py2 name=quay.io/ansible/opensuse15py2-test-container:1.21.0 python=2.
 opensuse15 name=quay.io/ansible/opensuse15-test-container:1.21.0 python=3.6
 ubuntu1604 name=quay.io/ansible/ubuntu1604-test-container:1.21.0 python=2.7 seccomp=unconfined
 ubuntu1804 name=quay.io/ansible/ubuntu1804-test-container:1.21.0 python=3.6 seccomp=unconfined
+ubuntu2004 name=quay.io/ansible/ubuntu2004-test-container:1.21.0 python=3.8 seccomp=unconfined


### PR DESCRIPTION

##### SUMMARY

Change:
- Add Ubuntu 20.04 to CI now that venv is default instead of virtualenv in ansible-test.

Test Plan:
- CI

Tickets:
- Fixes #69203

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME

ansible-test