### PR TITLE
Support large folder size comparisons for win_find (#58466)

### DIFF
--- a/changelogs/fragments/58466-FIX_win_find-Bug-Get-FileStat_fails_on_large_files.yml
+++ b/changelogs/fragments/58466-FIX_win_find-Bug-Get-FileStat_fails_on_large_files.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "win_find - Get-FileStat used [int] instead of [int64] for file size calculations"

--- a/lib/ansible/modules/windows/win_find.ps1
+++ b/lib/ansible/modules/windows/win_find.ps1
@@ -177,7 +177,7 @@ Function Assert-Size($info) {
         $size_pattern = '^(-?\d+)(b|k|m|g|t)?$'
         $match = $size -match $size_pattern
         if ($match) {
-            [int]$specified_size = $matches[1]
+            [int64]$specified_size = $matches[1]
             if ($null -eq $matches[2]) {
                 $chosen_byte = 'b'
             } else {


### PR DESCRIPTION
(cherry picked from commit 8def67939dbd5dbba84fe160f3ad187c76ebe63a)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/58466

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_find