### PR TITLE
Fix syntax errors detected by rstcheck.

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
@@ -637,7 +637,7 @@ This section will discuss the behavioral attributes for arguments:
 
   .. code-block:: python
 
-      'option': {
+      option = {
         'type': 'str',
         'removed_in_version': '2.0.0',
         'collection_name': 'testns.testcol',
@@ -651,7 +651,7 @@ This section will discuss the behavioral attributes for arguments:
 
   .. code-block:: python
 
-      'option': {
+      option = {
         'type': 'str',
         'removed_at_date': '2020-12-31',
         'collection_name': 'testns.testcol',
@@ -685,7 +685,7 @@ This section will discuss the behavioral attributes for arguments:
 
   .. code-block:: python
 
-      'option': {
+      option = {
         'type': 'str',
         'aliases': ['foo', 'bar'],
         'depecated_aliases': [


### PR DESCRIPTION
##### SUMMARY

Fix syntax errors detected by rstcheck.

The errors occur when using sphinx >= 2.0.0.

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
