### PR TITLE
No longer warn about missing pip/python pair.

### DIFF
--- a/changelogs/fragments/ansible-test-python-pip-warnings.yml
+++ b/changelogs/fragments/ansible-test-python-pip-warnings.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - A warning is no longer emitted when a ``pip*`` or ``python*`` binary is found without a matching couterpart.

--- a/test/lib/ansible_test/_internal/executor.py
+++ b/test/lib/ansible_test/_internal/executor.py
@@ -2044,16 +2044,8 @@ class EnvironmentDescription:
         pip_path = pip_paths.get(version)
         python_path = python_paths.get(version)
 
-        if not python_path and not pip_path:
-            # neither python or pip is present for this version
-            return
-
-        if not python_path:
-            warnings.append('A %s interpreter was not found, yet a matching pip was found at "%s".' % (python_label, pip_path))
-            return
-
-        if not pip_path:
-            warnings.append('A %s interpreter was found at "%s", yet a matching pip was not found.' % (python_label, python_path))
+        if not python_path or not pip_path:
+            # skip checks when either python or pip are missing for this version
             return
 
         pip_shebang = pip_interpreters.get(version)


### PR DESCRIPTION
##### SUMMARY

This warning was intended to help improve test environment configuration.
However, it has ended up producing mostly non-actionable warning noise instead.

In most situations a missing pip or python should result in test failures.
Reporting a missing pip also implies that it should be used by tests, which is not the case.
Tests should be invoking pip as a python module with the appropriate python interpreter instead.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
