### PR TITLE
Use `sh` for ansible-test raw remote shell.

### DIFF
--- a/changelogs/fragments/ansible-test-remote-shell-raw.yml
+++ b/changelogs/fragments/ansible-test-remote-shell-raw.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - The ``--raw`` option for ``ansible-test shell --remote`` now uses ``sh`` for the shell instead of ``bash``, which may not be present.

--- a/test/lib/ansible_test/_internal/delegation.py
+++ b/test/lib/ansible_test/_internal/delegation.py
@@ -448,7 +448,7 @@ def delegate_remote(args, exclude, require, integration_targets):
             manage = ManagePosixCI(core_ci)
             manage.setup(python_version)
 
-            cmd = create_shell_command(['bash'])
+            cmd = create_shell_command(['sh'])
         else:
             manage = ManagePosixCI(core_ci)
             pwd = manage.setup(python_version)


### PR DESCRIPTION
##### SUMMARY

Use `sh` for ansible-test raw remote shell.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
