### PR TITLE
Fix up install/download with pre-release in cli

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -656,6 +656,7 @@ class GalaxyCLI(CLI):
                 Requirement.from_requirement_dict(
                     self._init_coll_req_dict(collection_req),
                     artifacts_manager,
+                    user_defined=True,
                 )
                 for collection_req in file_requirements.get('collections') or []
             ]
@@ -799,7 +800,7 @@ class GalaxyCLI(CLI):
         else:
             requirements = {
                 'collections': [
-                    Requirement.from_string(coll_input, artifacts_manager)
+                    Requirement.from_string(coll_input, artifacts_manager, user_defined=True)
                     for coll_input in collections
                 ],
                 'roles': [],

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -422,7 +422,7 @@ def install_collections(
     :param force_deps: Re-install a collection as well as its dependencies if they have already been installed.
     """
     existing_collections = {
-        Requirement(coll.fqcn, coll.ver, coll.src, coll.type)
+        Requirement(coll.fqcn, coll.ver, coll.src, coll.type, coll.user_defined)
         for coll in find_existing_collections(output_path, artifacts_manager)
     }
 
@@ -472,7 +472,7 @@ def install_collections(
         else existing_collections
     )
     preferred_collections = {
-        Candidate(coll.fqcn, coll.ver, coll.src, coll.type)
+        Candidate(coll.fqcn, coll.ver, coll.src, coll.type, coll.user_defined)
         for coll in preferred_requirements
     }
     with _display_progress("Process install dependency map"):
@@ -628,7 +628,7 @@ def verify_collections(
                     collection.fqcn,
                     collection.ver if collection.ver != '*'
                     else local_collection.ver,
-                    None, 'galaxy',
+                    None, 'galaxy', False,
                 )
 
                 # Download collection on a galaxy server for comparison

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -183,11 +183,11 @@ class _ComputedReqKindsMixin:
                 ' collection directory.',
             )
 
-        tmp_inst_req = cls(None, None, dir_path, 'dir')
+        tmp_inst_req = cls(None, None, dir_path, 'dir', False)
         req_name = art_mgr.get_direct_collection_fqcn(tmp_inst_req)
         req_version = art_mgr.get_direct_collection_version(tmp_inst_req)
 
-        return cls(req_name, req_version, dir_path, 'dir')
+        return cls(req_name, req_version, dir_path, 'dir', False)
 
     @classmethod
     def from_dir_path_implicit(  # type: ignore[misc]
@@ -204,10 +204,10 @@ class _ComputedReqKindsMixin:
         u_dir_path = to_text(dir_path, errors='surrogate_or_strict')
         path_list = u_dir_path.split(os.path.sep)
         req_name = '.'.join(path_list[-2:])
-        return cls(req_name, '*', dir_path, 'dir')  # type: ignore[call-arg]
+        return cls(req_name, '*', dir_path, 'dir', False)  # type: ignore[call-arg]
 
     @classmethod
-    def from_string(cls, collection_input, artifacts_manager):
+    def from_string(cls, collection_input, artifacts_manager, user_defined=False):
         req = {}
         if _is_concrete_artifact_pointer(collection_input):
             # Arg is a file path or URL to a collection
@@ -217,10 +217,10 @@ class _ComputedReqKindsMixin:
             if not req['version']:
                 del req['version']
 
-        return cls.from_requirement_dict(req, artifacts_manager)
+        return cls.from_requirement_dict(req, artifacts_manager, user_defined=user_defined)
 
     @classmethod
-    def from_requirement_dict(cls, collection_req, art_mgr):
+    def from_requirement_dict(cls, collection_req, art_mgr, user_defined=False):
         req_name = collection_req.get('name', None)
         req_version = collection_req.get('version', '*')
         req_type = collection_req.get('type')
@@ -320,7 +320,7 @@ class _ComputedReqKindsMixin:
                 format(not_url=req_source.api_server),
             )
 
-        tmp_inst_req = cls(req_name, req_version, req_source, req_type)
+        tmp_inst_req = cls(req_name, req_version, req_source, req_type, user_defined)
 
         if req_type not in {'galaxy', 'subdirs'} and req_name is None:
             req_name = art_mgr.get_direct_collection_fqcn(tmp_inst_req)  # TODO: fix the cache key in artifacts manager?
@@ -331,6 +331,7 @@ class _ComputedReqKindsMixin:
         return cls(
             req_name, req_version,
             req_source, req_type,
+            user_defined,
         )
 
     def __repr__(self):
@@ -423,13 +424,13 @@ class _ComputedReqKindsMixin:
 
 class Requirement(
         _ComputedReqKindsMixin,
-        namedtuple('Requirement', ('fqcn', 'ver', 'src', 'type')),
+        namedtuple('Requirement', ('fqcn', 'ver', 'src', 'type', 'user_defined')),
 ):
     """An abstract requirement request."""
 
 
 class Candidate(
         _ComputedReqKindsMixin,
-        namedtuple('Candidate', ('fqcn', 'ver', 'src', 'type'))
+        namedtuple('Candidate', ('fqcn', 'ver', 'src', 'type', 'user_defined'))
 ):
     """A concrete collection candidate with its version resolved."""

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -223,11 +223,11 @@ class CollectionDependencyProvider(AbstractProvider):
         allow_pre_release = self._with_pre_releases or \
             candidate.user_defined or \
             candidate.is_concrete_artifact or not (
-            requirement.ver == '*' or
-            requirement.ver.startswith('<') or
-            requirement.ver.startswith('>') or
-            requirement.ver.startswith('!=')
-        )
+                requirement.ver == '*' or
+                requirement.ver.startswith('<') or
+                requirement.ver.startswith('>') or
+                requirement.ver.startswith('!=')
+            )
         if is_pre_release(candidate.ver) and not allow_pre_release:
             return False
 

--- a/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
@@ -420,3 +420,38 @@
   file:
     path: '{{ galaxy_dir }}/ansible_collections'
     state: absent
+
+
+- name: download collections with pre-release dep - {{ test_name }}
+  command: ansible-galaxy collection download dep_with_beta.parent namespace1.name1:1.1.0-beta.1 -p '{{ galaxy_dir }}/scratch'
+
+- name: install collection with concrete pre-release dep - {{ test_name }}
+  command: ansible-galaxy collection install -r '{{ galaxy_dir }}/scratch/requirements.yml'
+  args:
+    chdir: '{{ galaxy_dir }}/scratch'
+  environment:
+    ANSIBLE_COLLECTIONS_PATHS: '{{ galaxy_dir }}/ansible_collections'
+  register: install_concrete_pre
+
+- name: get result of install collections with concrete pre-release dep - {{ test_name }}
+  slurp:
+    path: '{{ galaxy_dir }}/ansible_collections/{{ collection }}/MANIFEST.json'
+  register: install_concrete_pre_actual
+  loop_control:
+    loop_var: collection
+  loop:
+  - namespace1/name1
+  - dep_with_beta/parent
+
+- name: assert install collections with ansible-galaxy install - {{ test_name }}
+  assert:
+    that:
+    - '"Installing ''namespace1.name1:1.1.0-beta.1'' to" in install_concrete_pre.stdout'
+    - '"Installing ''dep_with_beta.parent:1.0.0'' to" in install_concrete_pre.stdout'
+    - (install_concrete_pre_actual.results[0].content | b64decode | from_json).collection_info.version == '1.1.0-beta.1'
+    - (install_concrete_pre_actual.results[1].content | b64decode | from_json).collection_info.version == '1.0.0'
+
+- name: remove collection dir after round of testing - {{ test_name }}
+  file:
+    path: '{{ galaxy_dir }}/ansible_collections'
+    state: absent

--- a/test/integration/targets/ansible-galaxy-collection/vars/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/vars/main.yml
@@ -123,3 +123,9 @@ collection_list:
   - namespace: cache
     name: cache
     version: 1.0.0
+
+  # Dep with beta version
+  - namespace: dep_with_beta
+    name: parent
+    dependencies:
+      namespace1.name1: '*'

--- a/test/units/cli/galaxy/test_display_collection.py
+++ b/test/units/cli/galaxy/test_display_collection.py
@@ -14,7 +14,7 @@ from ansible.galaxy.dependency_resolution.dataclasses import Requirement
 @pytest.fixture
 def collection_object():
     def _cobj(fqcn='sandwiches.ham'):
-        return Requirement(fqcn, '1.5.0', None, 'galaxy')
+        return Requirement(fqcn, '1.5.0', None, 'galaxy', False)
     return _cobj
 
 

--- a/test/units/cli/galaxy/test_execute_list_collection.py
+++ b/test/units/cli/galaxy/test_execute_list_collection.py
@@ -56,12 +56,14 @@ def mock_collection_objects(mocker):
             '1.5.0',
             None,
             'dir',
+            False,
         ),
         (
             'sandwiches.reuben',
             '2.5.0',
             None,
             'dir',
+            False,
         ),
     )
 
@@ -71,12 +73,14 @@ def mock_collection_objects(mocker):
             '1.0.0',
             None,
             'dir',
+            False,
         ),
         (
             'sandwiches.ham',
             '1.0.0',
             None,
             'dir',
+            False,
         ),
     )
 
@@ -96,12 +100,14 @@ def mock_from_path(mocker):
                     '1.5.0',
                     None,
                     'dir',
+                    False,
                 ),
                 (
                     'sandwiches.pbj',
                     '1.0.0',
                     None,
                     'dir',
+                    False,
                 ),
             ),
             'sandwiches.ham': (
@@ -110,6 +116,7 @@ def mock_from_path(mocker):
                     '1.0.0',
                     None,
                     'dir',
+                    False,
                 ),
             ),
         }

--- a/test/units/cli/galaxy/test_get_collection_widths.py
+++ b/test/units/cli/galaxy/test_get_collection_widths.py
@@ -13,11 +13,11 @@ from ansible.galaxy.dependency_resolution.dataclasses import Requirement
 
 @pytest.fixture
 def collection_objects():
-    collection_ham = Requirement('sandwiches.ham', '1.5.0', None, 'galaxy')
+    collection_ham = Requirement('sandwiches.ham', '1.5.0', None, 'galaxy', False)
 
-    collection_pbj = Requirement('sandwiches.pbj', '2.5', None, 'galaxy')
+    collection_pbj = Requirement('sandwiches.pbj', '2.5', None, 'galaxy', False)
 
-    collection_reuben = Requirement('sandwiches.reuben', '4', None, 'galaxy')
+    collection_reuben = Requirement('sandwiches.reuben', '4', None, 'galaxy', False)
 
     return [collection_ham, collection_pbj, collection_reuben]
 
@@ -27,7 +27,7 @@ def test_get_collection_widths(collection_objects):
 
 
 def test_get_collection_widths_single_collection(mocker):
-    mocked_collection = Requirement('sandwiches.club', '3.0.0', None, 'galaxy')
+    mocked_collection = Requirement('sandwiches.club', '3.0.0', None, 'galaxy', False)
     # Make this look like it is not iterable
     mocker.patch('ansible.cli.galaxy.is_iterable', return_value=False)
 

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -698,7 +698,7 @@ def test_dep_candidate_with_conflict(monkeypatch, tmp_path_factory, galaxy_serve
 
 def test_install_installed_collection(monkeypatch, tmp_path_factory, galaxy_server):
 
-    mock_installed_collections = MagicMock(return_value=[Candidate('namespace.collection', '1.2.3', None, 'dir')])
+    mock_installed_collections = MagicMock(return_value=[Candidate('namespace.collection', '1.2.3', None, 'dir', True)])
 
     monkeypatch.setattr(collection, 'find_existing_collections', mock_installed_collections)
 
@@ -736,7 +736,7 @@ def test_install_collection(collection_artifact, monkeypatch):
     collection_path = os.path.join(output_path, b'ansible_namespace', b'collection')
     os.makedirs(os.path.join(collection_path, b'delete_me'))  # Create a folder to verify the install cleans out the dir
 
-    candidate = Candidate('ansible_namespace.collection', '0.1.0', to_text(collection_tar), 'file')
+    candidate = Candidate('ansible_namespace.collection', '0.1.0', to_text(collection_tar), 'file', True)
     collection.install(candidate, to_text(output_path), concrete_artifact_cm)
 
     # Ensure the temp directory is empty, nothing is left behind
@@ -775,7 +775,7 @@ def test_install_collection_with_download(galaxy_server, collection_artifact, mo
     mock_download.return_value = collection_tar
     monkeypatch.setattr(concrete_artifact_cm, 'get_galaxy_artifact_path', mock_download)
 
-    req = Requirement('ansible_namespace.collection', '0.1.0', 'https://downloadme.com', 'galaxy')
+    req = Requirement('ansible_namespace.collection', '0.1.0', 'https://downloadme.com', 'galaxy', True)
     collection.install(req, to_text(collections_dir), concrete_artifact_cm)
 
     actual_files = os.listdir(collection_path)
@@ -803,7 +803,7 @@ def test_install_collections_from_tar(collection_artifact, monkeypatch):
 
     concrete_artifact_cm = collection.concrete_artifact_manager.ConcreteArtifactsManager(temp_path, validate_certs=False)
 
-    requirements = [Requirement('ansible_namespace.collection', '0.1.0', to_text(collection_tar), 'file')]
+    requirements = [Requirement('ansible_namespace.collection', '0.1.0', to_text(collection_tar), 'file', True)]
     collection.install_collections(requirements, to_text(temp_path), [], False, False, False, False, False, concrete_artifact_cm)
 
     assert os.path.isdir(collection_path)
@@ -839,7 +839,7 @@ def test_install_collections_existing_without_force(collection_artifact, monkeyp
 
     assert os.path.isdir(collection_path)
 
-    requirements = [Requirement('ansible_namespace.collection', '0.1.0', to_text(collection_tar), 'file')]
+    requirements = [Requirement('ansible_namespace.collection', '0.1.0', to_text(collection_tar), 'file', True)]
     collection.install_collections(requirements, to_text(temp_path), [], False, False, False, False, False, concrete_artifact_cm)
 
     assert os.path.isdir(collection_path)
@@ -871,7 +871,7 @@ def test_install_missing_metadata_warning(collection_artifact, monkeypatch):
             os.unlink(b_path)
 
     concrete_artifact_cm = collection.concrete_artifact_manager.ConcreteArtifactsManager(temp_path, validate_certs=False)
-    requirements = [Requirement('ansible_namespace.collection', '0.1.0', to_text(collection_tar), 'file')]
+    requirements = [Requirement('ansible_namespace.collection', '0.1.0', to_text(collection_tar), 'file', True)]
     collection.install_collections(requirements, to_text(temp_path), [], False, False, False, False, False, concrete_artifact_cm)
 
     display_msgs = [m[1][0] for m in mock_display.mock_calls if 'newline' not in m[2] and len(m[1]) == 1]
@@ -892,7 +892,7 @@ def test_install_collection_with_circular_dependency(collection_artifact, monkey
     monkeypatch.setattr(Display, 'display', mock_display)
 
     concrete_artifact_cm = collection.concrete_artifact_manager.ConcreteArtifactsManager(temp_path, validate_certs=False)
-    requirements = [Requirement('ansible_namespace.collection', '0.1.0', to_text(collection_tar), 'file')]
+    requirements = [Requirement('ansible_namespace.collection', '0.1.0', to_text(collection_tar), 'file', True)]
     collection.install_collections(requirements, to_text(temp_path), [], False, False, False, False, False, concrete_artifact_cm)
 
     assert os.path.isdir(collection_path)


### PR DESCRIPTION
##### SUMMARY
When installing/downloading a collection with a pre-release version and another that depends on that collection it will fail to satisfy the constraints unless `--pre` was specified. This is because the pre-release collection specified in the cli/requirements file is the only candidate for that collection available and will not match `namespace.name: '*'` (or other version range) that the 2nd collection may have.

What this PR does is 2 things

* Fixes the `install` scenario by making sure any concrete collection as a candidate will not outright reject pre-release versions
    * My reasoning is that a concrete collection will always be something specified by the user and thus they know what they want
* Fixes the `download` scenario by designating any candidate/requirement from the cli args or requirements file with a special property `user_defined`
    * Like the above it makes sure that user defined candidates will check pre-release versions without `--pre`

I think `install` is also fixed with just the 2nd change but I'm not sure if that's the route we want to go with. The simple [concrete check](https://github.com/jborean93/ansible/blob/f9919634a780ecc0a3e2dc58a28962846b84d2d3/lib/ansible/galaxy/dependency_resolution/providers.py#L225) is enough to fix `install` but `download` is another story and required that more intrusive change to get working.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy