### PR TITLE
Avoid sphinx usage in changelog sanity test.

### DIFF
--- a/changelogs/fragments/ansible-test-changelog-lint-update.yml
+++ b/changelogs/fragments/ansible-test-changelog-lint-update.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - The ``changelog`` sanity test has been updated to ensure ``rstcheck`` does not load the ``sphinx`` module.

--- a/test/lib/ansible_test/_data/sanity/code-smell/changelog.py
+++ b/test/lib/ansible_test/_data/sanity/code-smell/changelog.py
@@ -42,7 +42,14 @@ def main():
         return
 
     cmd = [sys.executable, '-m', 'antsibull_changelog', 'lint'] + paths_to_check
-    subprocess.call(cmd)  # ignore the return code, rely on the output instead
+
+    # The sphinx module is a soft dependency for rstcheck, which is used by the changelog linter.
+    # If sphinx is found it will be loaded by rstcheck, which can affect the results of the test.
+    # To maintain consistency across environments, loading of sphinx is blocked, since any version (or no version) of sphinx may be present.
+    env = os.environ.copy()
+    env.update(PYTHONPATH='%s:%s' % (os.path.join(os.path.dirname(__file__), 'changelog'), env['PYTHONPATH']))
+
+    subprocess.call(cmd, env=env)  # ignore the return code, rely on the output instead
 
 
 if __name__ == '__main__':

--- a/test/lib/ansible_test/_data/sanity/code-smell/changelog/sphinx.py
+++ b/test/lib/ansible_test/_data/sanity/code-smell/changelog/sphinx.py
@@ -1,0 +1,5 @@
+"""Block the sphinx module from being loaded."""
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+raise ImportError('The sphinx module has been prevented from loading to maintain consistent test results.')


### PR DESCRIPTION
##### SUMMARY

Avoid sphinx usage in changelog sanity test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
