### PR TITLE
Make `ansible-galaxy collection verify` error out on no `MANIFEST.json`

### DIFF
--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -108,7 +108,7 @@ from ansible.galaxy.dependency_resolution import (
     build_collection_dependency_resolver,
 )
 from ansible.galaxy.dependency_resolution.dataclasses import (
-    Candidate, Requirement, _is_installed_collection_dir
+    Candidate, Requirement, _is_installed_collection_dir,
 )
 from ansible.galaxy.dependency_resolution.errors import (
     CollectionDependencyResolutionImpossible,

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -628,8 +628,9 @@ def verify_collections(
                 else:
                     if not artifact:
                         raise AnsibleError(
-                            message="Collection %s does not have a MANIFEST.json. " % collection.fqcn +
-                            "A MANIFEST.json is expected if the collection has been built and installed via ansible-galaxy."
+                            message="Collection %s does not have a MANIFEST.json. "
+                            "A MANIFEST.json is expected if the collection has been built "
+                            "and installed via ansible-galaxy" % collection.fqcn
                         )
                     raise AnsibleError(message='Collection %s is not installed in any of the collection paths.' % collection.fqcn)
 

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -606,6 +606,7 @@ def verify_collections(
                 # NOTE: Verify local collection exists before
                 # NOTE: downloading its source artifact from
                 # NOTE: a galaxy server.
+                artifact = True
                 for search_path in search_paths:
                     b_search_path = to_bytes(
                         os.path.join(
@@ -616,12 +617,20 @@ def verify_collections(
                     )
                     if not os.path.isdir(b_search_path):
                         continue
+                    if not os.path.isfile(os.path.join(b_search_path, b'MANIFEST.json')):
+                        artifact = False
+                        continue
 
                     local_collection = Candidate.from_dir_path(
                         b_search_path, artifacts_manager,
                     )
                     break
                 else:
+                    if not artifact:
+                        raise AnsibleError(
+                            message="Collection %s does not have a MANIFEST.json. " % collection.fqcn +
+                            "A MANIFEST.json is expected if the collection has been built and installed via ansible-galaxy."
+                        )
                     raise AnsibleError(message='Collection %s is not installed in any of the collection paths.' % collection.fqcn)
 
                 remote_collection = Candidate(

--- a/test/integration/targets/ansible-galaxy-collection/tasks/verify.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/verify.yml
@@ -191,3 +191,33 @@
 - assert:
     that:
       - "'Collection ansible_test.verify contains modified content in the following files:\nansible_test.verify\n    MANIFEST.json' in verify.stdout"
+
+- name: remove the artifact metadata to test verifying a collection without it
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ manifest_path }}"
+    - "{{ file_manifest_path }}"
+
+- name: add some development metadata
+  copy:
+    content: |
+      namespace: 'ansible_test'
+      name: 'verify'
+      version: '2.0.0'
+      readme: 'README.md'
+      authors: ['Ansible']
+    dest: '{{ galaxy_dir }}/ansible_collections/ansible_test/verify/galaxy.yml'
+
+- name: test we only verify collections containing a MANIFEST.json with the version on the server
+  command: ansible-galaxy collection verify ansible_test.verify:2.0.0
+  register: verify
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
+  ignore_errors: yes
+
+- assert:
+    that:
+      - verify.failed
+      - "'Collection ansible_test.verify does not have a MANIFEST.json' in verify.stderr"


### PR DESCRIPTION
##### SUMMARY
`verify` expects a collection has a MANIFEST.json

##### ISSUE TYPE
- Bugfix Pull Request
