### PR TITLE
Bypass fragile git ssh wrapper unless really needed

### DIFF
--- a/changelogs/fragments/git_fixes.yml
+++ b/changelogs/fragments/git_fixes.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - git module no longer uses wrapper script for ssh options.
+  - git module is more consistent and clearer about which ssh options are added to git calls.


### PR DESCRIPTION
  git module now uses env vars exclusively

  - updated docs to clarify usage
  - now env vars append instead of overwrite to allow existing custom setups to keep working
    fixes #38104
    fixes #64673
    fixes #64674
  - added note for hostkeychecking more securely
    fixes #69846



##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
modules/git.py