### PR TITLE
[ssh] Remove direct uses of ansible.constants

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -130,28 +130,6 @@ ANSIBLE_SSH_ARGS:
   ini:
   - {key: ssh_args, section: ssh_connection}
   yaml: {key: ssh_connection.ssh_args}
-ANSIBLE_SSH_CONTROL_PATH:
-  # TODO: move to ssh plugin
-  default: null
-  description:
-    - This is the location to save ssh's ControlPath sockets, it uses ssh's variable substitution.
-    - Since 2.3, if null, ansible will generate a unique hash. Use `%(directory)s` to indicate where to use the control dir path setting.
-    - Before 2.3 it defaulted to `control_path=%(directory)s/ansible-ssh-%%h-%%p-%%r`.
-    - Be aware that this setting is ignored if `-o ControlPath` is set in ssh args.
-  env: [{name: ANSIBLE_SSH_CONTROL_PATH}]
-  ini:
-  - {key: control_path, section: ssh_connection}
-  yaml: {key: ssh_connection.control_path}
-ANSIBLE_SSH_CONTROL_PATH_DIR:
-  # TODO: move to ssh plugin
-  default: ~/.ansible/cp
-  description:
-    - This sets the directory to use for ssh control path if the control path setting is null.
-    - Also, provides the `%(directory)s` variable for the control path setting.
-  env: [{name: ANSIBLE_SSH_CONTROL_PATH_DIR}]
-  ini:
-  - {key: control_path_dir, section: ssh_connection}
-  yaml: {key: ssh_connection.control_path_dir}
 ANSIBLE_SSH_EXECUTABLE:
   # TODO: move to ssh plugin, note that ssh_utils  refs this and needs to be updated if removed
   default: ssh
@@ -164,15 +142,6 @@ ANSIBLE_SSH_EXECUTABLE:
   - {key: ssh_executable, section: ssh_connection}
   yaml: {key: ssh_connection.ssh_executable}
   version_added: "2.2"
-ANSIBLE_SSH_RETRIES:
-  # TODO: move to ssh plugin
-  default: 0
-  description: Number of attempts to establish a connection before we give up and report the host as 'UNREACHABLE'
-  env: [{name: ANSIBLE_SSH_RETRIES}]
-  ini:
-  - {key: retries, section: ssh_connection}
-  type: integer
-  yaml: {key: ssh_connection.retries}
 ANY_ERRORS_FATAL:
   name: Make Task failures fatal
   default: False
@@ -1091,16 +1060,6 @@ DEFAULT_ROLES_PATH:
   - {key: roles_path, section: defaults}
   type: pathspec
   yaml: {key: defaults.roles_path}
-DEFAULT_SCP_IF_SSH:
-  # TODO: move to ssh plugin
-  default: smart
-  description:
-    - "Preferred method to use when transferring files over ssh."
-    - When set to smart, Ansible will try them until one succeeds or they all fail.
-    - If set to True, it will force 'scp', if False it will use 'sftp'.
-  env: [{name: ANSIBLE_SCP_IF_SSH}]
-  ini:
-  - {key: scp_if_ssh, section: ssh_connection}
 DEFAULT_SELINUX_SPECIAL_FS:
   name: Problematic file systems
   default: fuse, nfs, vboxsf, ramfs, 9p, vfat
@@ -1114,15 +1073,6 @@ DEFAULT_SELINUX_SPECIAL_FS:
   ini:
   - {key: special_context_filesystems, section: selinux}
   type: list
-DEFAULT_SFTP_BATCH_MODE:
-  # TODO: move to ssh plugin
-  default: True
-  description: 'TODO: write it'
-  env: [{name: ANSIBLE_SFTP_BATCH_MODE}]
-  ini:
-  - {key: sftp_batch_mode, section: ssh_connection}
-  type: boolean
-  yaml: {key: ssh_connection.sftp_batch_mode}
 DEFAULT_SSH_TRANSFER_METHOD:
   # TODO: move to ssh plugin
   default:
@@ -1546,14 +1496,6 @@ GALAXY_CACHE_DIR:
     key: cache_dir
   type: path
   version_added: '2.11'
-HOST_KEY_CHECKING:
-  name: Check host keys
-  default: True
-  description: 'Set this to "False" if you want to avoid host key checking by the underlying tools Ansible uses to connect to the host'
-  env: [{name: ANSIBLE_HOST_KEY_CHECKING}]
-  ini:
-  - {key: host_key_checking, section: defaults}
-  type: boolean
 HOST_PATTERN_MISMATCH:
   name: Control host pattern mismatch behaviour
   default: 'warning'


### PR DESCRIPTION
##### SUMMARY

Change:
- Remove direct uses of ansible.constants from ssh connection plugin.
  They are replaced by using the plugin's options.
- Remove the options from base config.
- Update plugin defaults of removed constants, to match what the
  constants defaulted to.
- Update unit tests to no longer make use of the constants.
- There is more work to be done here, but the remaining use of constants
  are routed through PlayContext and should be done in a separate
  changeset.

Test Plan:
- Used ssh plugin locally against a VM.
- Updated relevant unit tests to no longer patch constants.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ssh connection plugin