### PR TITLE
add RHEL8 Python 3.8 testing

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -92,7 +92,7 @@ stages:
             - name: RHEL 7.9
               test: rhel/7.9
             - name: RHEL 8.3 py36
-              test: rhel/8.3
+              test: rhel/8.3@3.6
             - name: RHEL 8.3 py38
               test: rhel/8.3@3.8
             - name: FreeBSD 11.4
@@ -173,7 +173,7 @@ stages:
             - name: RHEL 7.9
               test: rhel/7.9
             - name: RHEL 8.3 py36
-              test: rhel/8.3
+              test: rhel/8.3@3.6
             - name: RHEL 8.3 py38
               test: rhel/8.3@3.8
             - name: FreeBSD 11.4

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -93,6 +93,8 @@ stages:
               test: rhel/7.9
             - name: RHEL 8.3
               test: rhel/8.3
+            - name: RHEL 8.3 Python 3.8
+              test: rhel/8.3@3.8
             - name: FreeBSD 11.4
               test: freebsd/11.4
             - name: FreeBSD 12.2
@@ -172,6 +174,8 @@ stages:
               test: rhel/7.9
             - name: RHEL 8.3
               test: rhel/8.3
+            - name: RHEL 8.3 Python 3.8
+              test: rhel/8.3@3.8
             - name: FreeBSD 11.4
               test: freebsd/11.4
             - name: FreeBSD 12.2

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -91,9 +91,9 @@ stages:
               test: macos/11.1
             - name: RHEL 7.9
               test: rhel/7.9
-            - name: RHEL 8.3
+            - name: RHEL 8.3 py36
               test: rhel/8.3
-            - name: RHEL 8.3 Python 3.8
+            - name: RHEL 8.3 py38
               test: rhel/8.3@3.8
             - name: FreeBSD 11.4
               test: freebsd/11.4
@@ -172,9 +172,9 @@ stages:
               test: osx/10.11
             - name: RHEL 7.9
               test: rhel/7.9
-            - name: RHEL 8.3
+            - name: RHEL 8.3 py36
               test: rhel/8.3
-            - name: RHEL 8.3 Python 3.8
+            - name: RHEL 8.3 py38
               test: rhel/8.3@3.8
             - name: FreeBSD 11.4
               test: freebsd/11.4

--- a/.azure-pipelines/templates/test.yml
+++ b/.azure-pipelines/templates/test.yml
@@ -9,7 +9,7 @@ parameters:
 
 jobs:
   - ${{ each job in parameters.jobs }}:
-    - job: test_${{ replace(replace(replace(job.test, '/', '_'), '.', '_'), '-', '_') }}
+    - job: test_${{ replace(replace(replace(replace(job.test, '/', '_'), '.', '_'), '-', '_'), '@', '_') }}
       displayName: ${{ job.name }}
       container: default
       workspace:

--- a/test/utils/shippable/remote.sh
+++ b/test/utils/shippable/remote.sh
@@ -7,6 +7,16 @@ IFS='/:' read -ra args <<< "$1"
 
 platform="${args[0]}"
 version="${args[1]}"
+pyver=default
+
+# check for explicit python version like 8.3@3.8
+declare -a splitversion
+IFS='@' read -ra splitversion <<< "$version"
+
+if [ "${#splitversion[@]}" -gt 1 ]; then
+    version="${splitversion[0]}"
+    pyver="${splitversion[1]}"
+fi
 
 if [ "${#args[@]}" -gt 2 ]; then
     target="shippable/posix/group${args[2]}/"
@@ -19,4 +29,4 @@ provider="${P:-default}"
 
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
-    --remote "${platform}/${version}" --remote-terminate always --remote-stage "${stage}" --remote-provider "${provider}"
+    --python "${pyver}" --remote "${platform}/${version}" --remote-terminate always --remote-stage "${stage}" --remote-provider "${provider}"


### PR DESCRIPTION
##### SUMMARY
short-term tweak to test RHEL8 on both 3.6/3.8 until split controller/remote is ready to do it more cleanly

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
remote.sh

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
