### PR TITLE
Bump antsibull-changelog version for changelog sanity test

### DIFF
--- a/changelogs/fragments/73428-changelog-linting-bump-version.yml
+++ b/changelogs/fragments/73428-changelog-linting-bump-version.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-test sanity changelog test - bump dependency on antsibull-changelog to 0.9.0 so that `fragments that add new plugins or objects <https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#adding-new-roles-playbooks-test-and-filter-plugins>`_ will not fail validation (https://github.com/ansible/ansible/pull/73428)."

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -49,7 +49,7 @@ setuptools < 45 ; python_version == '2.7' # setuptools 45 and later require pyth
 gssapi < 1.6.0 ; python_version <= '2.7' # gssapi 1.6.0 and later require python 3 or later
 
 # freeze antsibull-changelog for consistent test results
-antsibull-changelog == 0.7.0
+antsibull-changelog == 0.9.0
 
 # Make sure we have a new enough antsibull for the CLI args we use
 antsibull >= 0.21.0


### PR DESCRIPTION
##### SUMMARY
Bumps the antsibull-changelog version for the changelog sanity test to 0.9.0. This is necessary to support new changelog fragment types which allow to mention new filter and test plugins in the changelog (similar to other new plugins), and which allow to mention new roles and playbooks ([feature documentation](https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#adding-new-roles-playbooks-test-and-filter-plugins)).

Also note that antsibull-changelog 0.9.0 has a breaking change, which neither affects fragment validation (for which it is used in ansible-test sanity) or the ansible-core/-base changelog. So this should be a safe change.

(It would be great if it could also be backported to `stable-2.10` so that its changelog validation doesn't fail on such fragments as well.)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test sanity changelog test
