### PR TITLE
Update file.py

### DIFF
--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -105,6 +105,13 @@ options:
     type: str
     default: "%Y%m%d%H%M.%S"
     version_added: '2.7'
+  impose_suffix:
+    description:
+    - When used, a directory with suffix gets created if already exists.
+    - Default is False
+    type: bool
+    default: no
+    version_added: '2.11'
 seealso:
 - module: ansible.builtin.assemble
 - module: ansible.builtin.copy
@@ -603,7 +610,7 @@ def ensure_file_attributes(path, follow, timestamps):
     return {'path': path, 'changed': changed, 'diff': diff}
 
 
-def ensure_directory(path, follow, recurse, timestamps):
+def ensure_directory(path, follow, recurse, timestamps, impose_suffix):
     b_path = to_bytes(path, errors='surrogate_or_strict')
     prev_state = get_state(b_path)
     file_args = module.load_file_common_arguments(module.params)
@@ -654,6 +661,52 @@ def ensure_directory(path, follow, recurse, timestamps):
         except Exception as e:
             raise AnsibleModuleError(results={'msg': 'There was an issue creating %s as requested:'
                                                      ' %s' % (curpath, to_native(e)),
+                                              'path': path})
+        return {'path': path, 'changed': changed, 'diff': diff}
+
+    elif prev_state == 'directory' and impose_suffix:
+        curpath = ''
+        try:
+            # If the directory already exist and if we want to create a folder with a suffix appended if impose_suffix is set to True
+            # For example: if the Directory /Sample/Test dir already exist and if the path is /Sample/Test,
+            # then a directory /Sample/Test1 will be created. On subsequent run the number keeps increasing.                        
+            folder_exist = True
+            iteration = 0
+            original_path = path
+            while folder_exist:            
+                if os.path.exists(path):
+                    iteration = iteration + 1
+                    path = original_path + str(iteration)
+                    folder_exist = True
+                else:
+                    folder_exist = False
+            # Split the path so we can apply filesystem attributes recursively
+            # from the root (/) directory for absolute paths or the base path
+            # of a relative path.  We can then walk the appropriate directory
+            # path to apply attributes.
+            # Something like mkdir -p with mode applied to all of the newly created directories
+            for dirname in path.strip('/').split('/'):
+                curpath = '/'.join([curpath, dirname])
+                # Remove leading slash if we're creating a relative path
+                if not os.path.isabs(path):
+                    curpath = curpath.lstrip('/')
+                b_curpath = to_bytes(curpath, errors='surrogate_or_strict')
+                if not os.path.exists(b_curpath):
+                    try:
+                        os.mkdir(b_curpath)
+                        changed = True
+                    except OSError as ex:
+                        # Possibly something else created the dir since the os.path.exists
+                        # check above. As long as it's a dir, we don't need to error out.
+                        if not (ex.errno == errno.EEXIST and os.path.isdir(b_curpath)):
+                            raise
+                    tmp_file_args = file_args.copy()
+                    tmp_file_args['path'] = curpath
+                    changed = module.set_fs_attributes_if_different(tmp_file_args, changed, diff, expand=False)
+                    changed |= update_timestamp_for_file(file_args['path'], mtime, atime, diff)
+        except Exception as e:
+            raise AnsibleModuleError(results={'msg': 'There was an issue creating %s as requested:'
+                                                     ' %s' % (path, to_native(e)),
                                               'path': path})
         return {'path': path, 'changed': changed, 'diff': diff}
 
@@ -901,6 +954,7 @@ def main():
         argument_spec=dict(
             state=dict(type='str', choices=['absent', 'directory', 'file', 'hard', 'link', 'touch']),
             path=dict(type='path', required=True, aliases=['dest', 'name']),
+            impose_suffix=dict(type='bool', default=False),
             _original_basename=dict(type='str'),  # Internal use only, for recursive ops
             recurse=dict(type='bool', default=False),
             force=dict(type='bool', default=False),  # Note: Should not be in file_common_args in future
@@ -927,6 +981,7 @@ def main():
     follow = params['follow']
     path = params['path']
     src = params['src']
+    impose_suffix = params['impose_suffix']
 
     if module.check_mode and state != 'absent':
         file_args = module.load_file_common_arguments(module.params)
@@ -949,7 +1004,7 @@ def main():
     if state == 'file':
         result = ensure_file_attributes(path, follow, timestamps)
     elif state == 'directory':
-        result = ensure_directory(path, follow, recurse, timestamps)
+        result = ensure_directory(path, follow, recurse, timestamps, impose_suffix)
     elif state == 'link':
         result = ensure_symlink(path, src, follow, force, timestamps)
     elif state == 'hard':

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -214,6 +214,13 @@ EXAMPLES = r'''
     path: /etc/foo
     state: absent
 
+- name: create file with suffix if already exist
+  ansible.builtin.file:
+    path: /etc/some_existing_directory
+    state: directory
+    mode: 0755
+    impose_suffix: True
+
 '''
 RETURN = r'''
 dest:
@@ -669,11 +676,11 @@ def ensure_directory(path, follow, recurse, timestamps, impose_suffix):
         try:
             # If the directory already exist and if we want to create a folder with a suffix appended if impose_suffix is set to True
             # For example: if the Directory /Sample/Test dir already exist and if the path is /Sample/Test,
-            # then a directory /Sample/Test1 will be created. On subsequent run the number keeps increasing.                        
+            # then a directory /Sample/Test1 will be created. On subsequent run the number keeps increasing.
             folder_exist = True
             iteration = 0
             original_path = path
-            while folder_exist:            
+            while folder_exist:
                 if os.path.exists(path):
                     iteration = iteration + 1
                     path = original_path + str(iteration)


### PR DESCRIPTION
There are usecases when a folder should be created with a suffix appended in incremental order. If the directory already exist and if we want to create a folder with a suffix appended if impose_suffix is set to True
For example: if the Directory /Sample/Test dir already exist and if the path is /Sample/Test, then a directory /Sample/Test1 will be created. On subsequent run the number keeps increasing.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There are usecases when a folder should be created with a suffix appended in incremental order. If the directory already exist and if we want to create a folder with a suffix appended if impose_suffix is set to True
For example: if the Directory /Sample/Test dir already exist and if the path is /Sample/Test, then a directory /Sample/Test1 will be created. On subsequent run the number keeps increasing.

Ansible code :

name: create file
hosts: localhost
connection: localhost
tasks:
    file:
    path: rohit/test
    state: directory
    mode: 0755
    impose_suffix: True

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

file

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
There are usecases when a folder should be created with a suffix appended in incremental order automatically. If the directory already exist and if we want to create a folder with a suffix appended if impose_suffix is set to True
For example: if the Directory /Sample/Test dir already exist and if the path is /Sample/Test, then a directory /Sample/Test1 will be created.
On subsequent run the number keeps increasing, say /Sample/Test2