### PR TITLE
Specify Python as a dependency for managed nodes

### DIFF
--- a/docs/docsite/rst/shared_snippets/basic_concepts.txt
+++ b/docs/docsite/rst/shared_snippets/basic_concepts.txt
@@ -6,12 +6,12 @@ Any machine with Ansible installed. You can run Ansible commands and playbooks b
 Managed nodes
 =============
 
-The network devices (and/or servers) you manage with Ansible. Managed nodes are also sometimes called "hosts". Ansible is not installed on managed nodes.
+The network devices (and/or servers) you manage with Ansible. Managed nodes are also sometimes called "hosts". Ansible is not required on managed nodes, but a valid installation of Python to run most Ansible modules is.
 
 Inventory
 =========
 
-A list of managed nodes. An inventory file is also sometimes called a "hostfile". Your inventory can specify information like IP address for each managed node. An inventory can also organize managed nodes, creating and nesting groups for easier scaling. To learn more about inventory, see :ref:`the Working with Inventory<intro_inventory>` section.
+A list of managed nodes. An inventory file is also sometimes called a "hostfile". Your inventory can specify information like hostname, IP address, and other connection information for each managed node. An inventory can also organize managed nodes, creating and nesting groups for easier scaling. To learn more about inventory, see :ref:`the Working with Inventory<intro_inventory>` section.
 
 Collections
 ===========


### PR DESCRIPTION
##### SUMMARY

Python is a dependency for most of Ansible's modules, and something that might be worthwhile to include as part of the [Ansbile Concepts](https://docs.ansible.com/ansible/latest/user_guide/basic_concepts.html) page.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

Seen in the [Ansbile Concepts](https://docs.ansible.com/ansible/latest/user_guide/basic_concepts.html) page referenced by the 
[User Guide](https://docs.ansible.com/ansible/latest/user_guide/index.html).

