### PR TITLE
Correct pkg_mgr for Fedora-derived OSTree distros

### DIFF
--- a/changelogs/fragments/73084-rhel-for-edge-pkg_mgr-fact-fix.yml
+++ b/changelogs/fragments/73084-rhel-for-edge-pkg_mgr-fact-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible_pkg_mgr fact - now correctly returns ``atomic_container`` when run on "RHEL for Edge" images and Fedora/RHEL/CentOS Atomic Host (https://github.com/ansible/ansible/issues/73084).

--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -61,9 +61,10 @@ class PkgMgrFactCollector(BaseFactCollector):
     required_facts = set(['distribution'])
 
     def _check_rh_versions(self, pkg_mgr_name, collected_facts):
+        if os.path.exists('/run/ostree-booted'):
+            return "atomic_container"
+
         if collected_facts['ansible_distribution'] == 'Fedora':
-            if os.path.exists('/run/ostree-booted'):
-                return "atomic_container"
             try:
                 if int(collected_facts['ansible_distribution_major_version']) < 23:
                     for yum in [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'yum']:

--- a/test/units/module_utils/facts/test_ansible_collector.py
+++ b/test/units/module_utils/facts/test_ansible_collector.py
@@ -482,6 +482,26 @@ class TestPkgMgrFacts(TestCollectedFacts):
     }
 
 
+class TestPkgMgrOSTreeFacts(TestPkgMgrFacts):
+    @patch(
+        'ansible.module_utils.facts.system.pkg_mgr.os.path.exists',
+        side_effect=lambda x: x == '/run/ostree-booted')
+    def _recollect_facts(self, distribution, version, mock_exists):
+        self.collected_facts['ansible_distribution'] = distribution
+        self.collected_facts['ansible_distribution_major_version'] = \
+            str(version)
+        # Recollect facts
+        self.setUp()
+        self.assertIn('pkg_mgr', self.facts)
+        self.assertEqual(self.facts['pkg_mgr'], 'atomic_container')
+
+    def test_is_rhel_edge_ostree(self):
+        self._recollect_facts('RedHat', 8)
+
+    def test_is_fedora_ostree(self):
+        self._recollect_facts('Fedora', 33)
+
+
 class TestOpenBSDPkgMgrFacts(TestPkgMgrFacts):
     def test_is_openbsd_pkg(self):
         self.assertIn('pkg_mgr', self.facts)


### PR DESCRIPTION

##### SUMMARY

Change:
- Remove check that states that only Fedora can be an OSTree
  distribution.
- This allows us to correctly return "atomic_container" as the pkg_mgr
  fact for RHEL for Edge, Fedora/RHEL/CentOS Atomic Host, etc.

Test Plan:
- Created local RHEL for Edge image and tested against it.
- Tested against regular RHEL 8 and still got `dnf` as expected.
- Tested against RHEL 7 Atomic Host and got `atomic_container` now.
- New unit tests.

Tickets:
- Fixes #73084

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

pkg_mgr facts