### PR TITLE
[ansible-test] Bump CentOS 6 image (yum repos) (#73446) [2.10]

### DIFF
--- a/changelogs/fragments/ansible-test-centos6-vault-mirrors.yml
+++ b/changelogs/fragments/ansible-test-centos6-vault-mirrors.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - centos6 image now has multiple fallback yum repositories for CentOS Vault.

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,6 +1,6 @@
 default name=quay.io/ansible/default-test-container:2.9.0 python=3.6,2.6,2.7,3.5,3.7,3.8,3.9 seccomp=unconfined context=collection
 default name=quay.io/ansible/ansible-base-test-container:1.7.0 python=3.6,2.6,2.7,3.5,3.7,3.8,3.9 seccomp=unconfined context=ansible-base
-centos6 name=quay.io/ansible/centos6-test-container:1.26.0 python=2.6 seccomp=unconfined
+centos6 name=quay.io/ansible/centos6-test-container:1.30.0 python=2.6 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.17.0 python=2.7 seccomp=unconfined
 centos8 name=quay.io/ansible/centos8-test-container:1.21.0 python=3.6 seccomp=unconfined
 fedora30 name=quay.io/ansible/fedora30-test-container:1.17.0 python=3.7


### PR DESCRIPTION

##### SUMMARY
Change:
- Bump centos6 image version to one which includes multiple fallbacks
  for vault.centos.org content.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Test Pull Request

##### COMPONENT NAME

ansible-test