### PR TITLE
[ansible-test] Bump CentOS 6 image (yum repos) (#73446) [2.8]

### DIFF
--- a/changelogs/fragments/ansible-test-centos6-vault-mirrors.yml
+++ b/changelogs/fragments/ansible-test-centos6-vault-mirrors.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - centos6 image now has multiple fallback yum repositories for CentOS Vault.

--- a/test/runner/completion/docker.txt
+++ b/test/runner/completion/docker.txt
@@ -1,5 +1,5 @@
 default name=quay.io/ansible/default-test-container:1.9.1 python=3.6,2.6,2.7,3.5,3.7,3.8 seccomp=unconfined
-centos6 name=quay.io/ansible/centos6-test-container:1.26.0 python=2.6 seccomp=unconfined
+centos6 name=quay.io/ansible/centos6-test-container:1.30.0 python=2.6 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:1.8.0 python=2.7 seccomp=unconfined
 fedora29 name=quay.io/ansible/fedora29-test-container:1.9.4 python=3.7
 fedora30 name=quay.io/ansible/fedora30-test-container:1.9.2 python=3.7


### PR DESCRIPTION

##### SUMMARY

Change:
- Bump centos6 image version to one which includes multiple fallbacks
  for vault.centos.org content.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Test Pull Request

##### COMPONENT NAME

ansible-test