### PR TITLE
[2.10] validate_modules: fails with .id attribute not found (#73322)

### DIFF
--- a/changelogs/fragments/validate-modules_found_try_except_import_fails_module_attribute.yaml
+++ b/changelogs/fragments/validate-modules_found_try_except_import_fails_module_attribute.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- validate-modules - do not raise an ``AttributeError`` if a value is assigned to a module attribute in a try/except block.

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -666,6 +666,8 @@ class ModuleValidator(Validator):
                         found_try_except_import = True
                     if isinstance(grandchild, ast.Assign):
                         for target in grandchild.targets:
+                            if not isinstance(target, ast.Name):
+                                continue
                             if target.id.lower().startswith('has_'):
                                 found_has = True
             if found_try_except_import and not found_has:


### PR DESCRIPTION
##### SUMMARY

* validate_modules: fails with .id attribute not found

This patch addresses a problem in the `found_try_except_import` test.

This module tries to identify lines like:

`HAS_FOO = True`

In this case, the target (`HAS_FOO`) is of type `ast.Name` and has a
`id` attribute which provide the name.

In my case, I've a line that set a module attribute`. In this case, the
target (`module.var`) has the type `ast.Attribute` and no `id`
attribute. The code trigger an `AttributeError` exception.

This patch ensures we compare a `ast.Name`.

* Update test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py

(cherry picked from commit 7cf80f50d16b7a7a2ba9f1318bdca5df53936369)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

ansible-test