### PR TITLE
added file_relative option for ansible_managed

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -140,7 +140,7 @@
 
 # Format of string {{ ansible_managed }} available within Jinja2
 # templates indicates to users editing templates files will be replaced.
-# replacing {file}, {host} and {uid} and strftime codes with proper values.
+# replacing {file}, {relative_file}, {host} and {uid} and strftime codes with proper values.
 #
 #ansible_managed = Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}
 

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -109,6 +109,7 @@ def generate_ansible_template_vars(path, dest_path=None):
     temp_vars = {
         'template_host': to_text(os.uname()[1]),
         'template_path': path,
+        'template_path_relative': re.sub(os.getcwd(), '', path),
         'template_mtime': datetime.datetime.fromtimestamp(os.path.getmtime(b_path)),
         'template_uid': to_text(template_uid),
         'template_fullpath': os.path.abspath(path),
@@ -121,6 +122,7 @@ def generate_ansible_template_vars(path, dest_path=None):
         host=temp_vars['template_host'],
         uid=temp_vars['template_uid'],
         file=temp_vars['template_path'],
+        file_relative=temp_vars['template_path_relative'],
     )
     temp_vars['ansible_managed'] = to_text(time.strftime(to_native(managed_str), time.localtime(os.path.getmtime(b_path))))
 


### PR DESCRIPTION
##### SUMMARY
added one more option - `file_relative` for `ansible_managed`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
template

##### ADDITIONAL INFORMATION
Useful for situations, where at least two people uses common playbooks/roles from different machines
If using `file` option, we catch difference in comments like:
```
-# Ansible managed: /home/my-collegue/git/repo/playbooks/roles/storage/templates/nginx/default.conf.j2
+# Ansible managed: /home/broken-ufa/projects/repo/playbooks/roles/storage/templates/nginx/default.conf.j2
```
but nothing important things changed in file.

With option `file_relative` ansible will put in comment relative path, which will be same