### PR TITLE
add self-signed https endpoint for ansible-test

### DIFF
--- a/changelogs/fragments/73463_self_signed_https_endpoint_for_ansible-test.yml
+++ b/changelogs/fragments/73463_self_signed_https_endpoint_for_ansible-test.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - add https endpoint for ansible-test

--- a/test/integration/targets/prepare_http_tests/defaults/main.yml
+++ b/test/integration/targets/prepare_http_tests/defaults/main.yml
@@ -1,4 +1,5 @@
 badssl_host: wrong.host.badssl.com
+self_signed_host: self-signed.ansible.http.tests
 httpbin_host: httpbin.org
 sni_host: ci-files.testing.ansible.com
 badssl_host_substring: wrong.host.badssl.com

--- a/test/integration/targets/prepare_http_tests/vars/httptester.yml
+++ b/test/integration/targets/prepare_http_tests/vars/httptester.yml
@@ -3,3 +3,4 @@ badssl_host: fail.ansible.http.tests
 httpbin_host: ansible.http.tests
 sni_host: sni1.ansible.http.tests
 badssl_host_substring: HTTP Client Testing Service
+self_signed_host: self-signed.ansible.http.tests

--- a/test/lib/ansible_test/_data/setup/windows-httptester.ps1
+++ b/test/lib/ansible_test/_data/setup/windows-httptester.ps1
@@ -5,7 +5,7 @@ on the Ansible host. This will setup the Windows host file and forward the
 local ports to use this connection. This will continue to run in the background
 until the script is deleted.
 
-Run this with SSH with the -R arguments to forward ports 8080 and 8443 to the
+Run this with SSH with the -R arguments to forward ports 8080, 8443 and 8444 to the
 httptester container.
 
 .PARAMETER Hosts
@@ -85,6 +85,7 @@ if ($changed) {
 $forwarded_ports = @{
     80 = 8080
     443 = 8443
+    444 = 8444
 }
 if ($os_version -ge [Version]"6.2") {
     Write-Verbose -Message "Using netsh to configure forwarded ports"

--- a/test/lib/ansible_test/_internal/executor.py
+++ b/test/lib/ansible_test/_internal/executor.py
@@ -821,7 +821,11 @@ def command_windows_integration(args):
                 # we are running in a Docker container that is linked to the httptester container, we just need to
                 # forward these requests to the linked hostname
                 first_host = HTTPTESTER_HOSTS[0]
-                ssh_options = ["-R", "8080:%s:80" % first_host, "-R", "8443:%s:443" % first_host, "8444:%s:444" % first_host]
+                ssh_options = [
+                    "-R", "8080:%s:80" % first_host,
+                    "-R", "8443:%s:443" % first_host,
+                    "-R", "8444:%s:444" % first_host
+                ]
             else:
                 # we are running directly and need to start the httptester container ourselves and forward the port
                 # from there manually set so HTTPTESTER env var is set during the run

--- a/test/lib/ansible_test/_internal/executor.py
+++ b/test/lib/ansible_test/_internal/executor.py
@@ -821,7 +821,7 @@ def command_windows_integration(args):
                 # we are running in a Docker container that is linked to the httptester container, we just need to
                 # forward these requests to the linked hostname
                 first_host = HTTPTESTER_HOSTS[0]
-                ssh_options = ["-R", "8080:%s:80" % first_host, "-R", "8443:%s:443" % first_host]
+                ssh_options = ["-R", "8080:%s:80" % first_host, "-R", "8443:%s:443" % first_host, "8444:%s:444" % first_host]
             else:
                 # we are running directly and need to start the httptester container ourselves and forward the port
                 # from there manually set so HTTPTESTER env var is set during the run
@@ -1312,6 +1312,10 @@ def start_httptester(args):
             container=443,
         ),
         dict(
+            remote=8444,
+            container=444,
+        ),
+        dict(
             remote=8749,
             container=749,
         ),
@@ -1403,6 +1407,7 @@ def inject_httptester(args):
 rdr pass inet proto tcp from any to any port 80 -> 127.0.0.1 port 8080
 rdr pass inet proto tcp from any to any port 88 -> 127.0.0.1 port 8088
 rdr pass inet proto tcp from any to any port 443 -> 127.0.0.1 port 8443
+rdr pass inet proto tcp from any to any port 444 -> 127.0.0.1 port 8444
 rdr pass inet proto tcp from any to any port 749 -> 127.0.0.1 port 8749
 '''
         cmd = ['pfctl', '-ef', '-']
@@ -1417,6 +1422,7 @@ rdr pass inet proto tcp from any to any port 749 -> 127.0.0.1 port 8749
             (80, 8080),
             (88, 8088),
             (443, 8443),
+            (444, 8444),
             (749, 8749),
         ]
 

--- a/test/lib/ansible_test/_internal/executor.py
+++ b/test/lib/ansible_test/_internal/executor.py
@@ -150,6 +150,7 @@ HTTPTESTER_HOSTS = (
     'ansible.http.tests',
     'sni1.ansible.http.tests',
     'fail.ansible.http.tests',
+    'self-signed.ansible.http.tests',
 )
 
 


### PR DESCRIPTION
##### SUMMARY

This prodives a https endpoint with a self-signed CA certificate. The main motivation is to provide infrastructure for integration tests for https://github.com/ansible/ansible/pull/71979.
 
##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

For more information and an example use case see https://github.com/ansible/ansible/pull/71979.