### PR TITLE
Don't treat host_pinned as lockstep

### DIFF
--- a/changelogs/fragments/73364-default-callback-host-pinned-not-lockstep.yml
+++ b/changelogs/fragments/73364-default-callback-host-pinned-not-lockstep.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- default callback - Ensure that the ``host_pinned`` strategy is not treated as lockstep
+  (https://github.com/ansible/ansible/issues/73364)

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -188,8 +188,8 @@ class CallbackModule(CallbackBase):
 
         # Preserve task name, as all vars may not be available for templating
         # when we need it later
-        if self._play.strategy == 'free':
-            # Explicitly set to None for strategy 'free' to account for any cached
+        if self._play.strategy in ('free', 'host_pinned'):
+            # Explicitly set to None for strategy free/host_pinned to account for any cached
             # task title from a previous non-free play
             self._last_task_name = None
         else:

--- a/test/integration/targets/callback_default/callback_default.out.free.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.free.stdout
@@ -1,0 +1,29 @@
+
+PLAY [nonlockstep] *************************************************************
+
+TASK [command] *****************************************************************
+changed: [testhost10]
+changed: [testhost11]
+
+TASK [command] *****************************************************************
+changed: [testhost10]
+
+TASK [command] *****************************************************************
+changed: [testhost12]
+
+TASK [command] *****************************************************************
+changed: [testhost10]
+
+TASK [command] *****************************************************************
+changed: [testhost11]
+changed: [testhost12]
+
+TASK [command] *****************************************************************
+changed: [testhost11]
+changed: [testhost12]
+
+PLAY RECAP *********************************************************************
+testhost10                 : ok=3    changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+testhost11                 : ok=3    changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+testhost12                 : ok=3    changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+

--- a/test/integration/targets/callback_default/callback_default.out.host_pinned.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.host_pinned.stdout
@@ -1,0 +1,29 @@
+
+PLAY [nonlockstep] *************************************************************
+
+TASK [command] *****************************************************************
+changed: [testhost10]
+changed: [testhost11]
+
+TASK [command] *****************************************************************
+changed: [testhost10]
+
+TASK [command] *****************************************************************
+changed: [testhost12]
+
+TASK [command] *****************************************************************
+changed: [testhost10]
+
+TASK [command] *****************************************************************
+changed: [testhost11]
+changed: [testhost12]
+
+TASK [command] *****************************************************************
+changed: [testhost11]
+changed: [testhost12]
+
+PLAY RECAP *********************************************************************
+testhost10                 : ok=3    changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+testhost11                 : ok=3    changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+testhost12                 : ok=3    changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+

--- a/test/integration/targets/callback_default/inventory
+++ b/test/integration/targets/callback_default/inventory
@@ -3,3 +3,8 @@ testhost ansible_connection=local ansible_python_interpreter="{{ ansible_playboo
 
 [nonexistent]
 testhost5 ansible_host=169.254.199.200  # no connection is ever established with this host
+
+[nonlockstep]
+testhost10 i=1.0 ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"
+testhost11 i=2.0 ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"
+testhost12 i=3.0 ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/targets/callback_default/runme.sh
+++ b/test/integration/targets/callback_default/runme.sh
@@ -192,3 +192,7 @@ ansible-playbook -i host1,host2 no_implicit_meta_banners.yml > meta_test.out
 cat meta_test.out
 [ "$(grep -c 'TASK \[meta\]' meta_test.out)" -eq 0 ]
 rm -f meta_test.out
+
+# Ensure free/host_pinned non-lockstep strategies display correctly
+diff -u <(ANSIBLE_STRATEGY=free ansible-playbook -i inventory test_non_lockstep.yml 2>/dev/null) callback_default.out.free.stdout
+diff -u <(ANSIBLE_STRATEGY=host_pinned ansible-playbook -i inventory test_non_lockstep.yml 2>/dev/null) callback_default.out.host_pinned.stdout

--- a/test/integration/targets/callback_default/test_non_lockstep.yml
+++ b/test/integration/targets/callback_default/test_non_lockstep.yml
@@ -1,0 +1,7 @@
+---
+- hosts: nonlockstep
+  gather_facts: false
+  tasks:
+    - command: sleep {{ 2 * i }}
+    - command: sleep {{ 2 * i }}
+    - command: sleep {{ 2 * i }}


### PR DESCRIPTION
##### SUMMARY
Don't treat host_pinned as lockstep. Fixes #73364

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/callback/default.py

##### ADDITIONAL INFORMATION
A better fix will be implemented in future versions, see https://github.com/ansible/ansible/issues/73483 for more information
