### PR TITLE
no_log mask suboption fallback values and defaults CVE-2021-20228

### DIFF
--- a/changelogs/fragments/no_log-fallback.yml
+++ b/changelogs/fragments/no_log-fallback.yml
@@ -1,0 +1,2 @@
+security_fixes:
+  - '**security issue** - Mask default and fallback values for ``no_log`` module options (CVE-2021-20228)'

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1934,9 +1934,7 @@ class AnsibleModule(object):
 
             # This prevents setting defaults on required items on the 1st run,
             # otherwise will set things without a default to None on the 2nd.
-            extra_check = lambda: default is not None if pre is True else lambda: True
-
-            if extra_check() and k not in param:
+            if k not in param and (default is not None or not pre):
                 # Make sure any default value for no_log fields are masked.
                 if v.get('no_log', False) and default:
                     self.no_log_values.add(default)

--- a/test/integration/targets/module_utils/callback/pure_json.py
+++ b/test/integration/targets/module_utils/callback/pure_json.py
@@ -1,0 +1,31 @@
+# (c) 2021 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    name: pure_json
+    type: stdout
+    short_description: only outputs the module results as json
+'''
+
+import json
+
+from ansible.plugins.callback import CallbackBase
+
+
+class CallbackModule(CallbackBase):
+
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'stdout'
+    CALLBACK_NAME = 'pure_json'
+
+    def v2_runner_on_failed(self, result, ignore_errors=False):
+        self._display.display(json.dumps(result._result))
+
+    def v2_runner_on_ok(self, result):
+        self._display.display(json.dumps(result._result))
+
+    def v2_runner_on_skipped(self, result):
+        self._display.display(json.dumps(result._result))

--- a/test/integration/targets/module_utils/library/test_no_log.py
+++ b/test/integration/targets/module_utils/library/test_no_log.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python
+# (c) 2021 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+from ansible.module_utils.basic import AnsibleModule, env_fallback
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            explicit_pass=dict(type='str', no_log=True),
+            fallback_pass=dict(type='str', no_log=True, fallback=(env_fallback, ['SECRET_ENV'])),
+            default_pass=dict(type='str', no_log=True, default='zyx'),
+            normal=dict(type='str', default='plaintext'),
+            suboption=dict(
+                type='dict',
+                options=dict(
+                    explicit_sub_pass=dict(type='str', no_log=True),
+                    fallback_sub_pass=dict(type='str', no_log=True, fallback=(env_fallback, ['SECRET_SUB_ENV'])),
+                    default_sub_pass=dict(type='str', no_log=True, default='xvu'),
+                    normal=dict(type='str', default='plaintext'),
+                ),
+            ),
+        ),
+    )
+
+    module.exit_json(changed=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/module_utils/module_utils_test_no_log.yml
+++ b/test/integration/targets/module_utils/module_utils_test_no_log.yml
@@ -1,0 +1,9 @@
+# This is called by module_utils_vvvvv.yml with a custom callback
+- hosts: testhost
+  gather_facts: no
+  tasks:
+    - name: Check no_log invocation results
+      test_no_log:
+        explicit_pass: abc
+        suboption:
+          explicit_sub_pass: def

--- a/test/integration/targets/module_utils/module_utils_vvvvv.yml
+++ b/test/integration/targets/module_utils/module_utils_vvvvv.yml
@@ -3,3 +3,28 @@
   tasks:
   - name: Use a specially crafted module to see if things were imported correctly
     test:
+
+  # Invocation usually is output with 3vs or more, our callback plugin displays it anyway
+  - name: Check no_log invocation results
+    command: ansible-playbook -i {{ inventory_file }} module_utils_test_no_log.yml
+    environment:
+      ANSIBLE_CALLBACK_PLUGINS: callback
+      ANSIBLE_STDOUT_CALLBACK: pure_json
+      SECRET_ENV: ghi
+      SECRET_SUB_ENV: jkl
+    register: no_log_invocation
+
+  - set_fact:
+      no_log_invocation: '{{ no_log_invocation.stdout | trim | from_json }}'
+
+  - name: check no log values from fallback or default are masked
+    assert:
+      that:
+      - no_log_invocation.invocation.module_args.default_pass == 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER'
+      - no_log_invocation.invocation.module_args.explicit_pass == 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER'
+      - no_log_invocation.invocation.module_args.fallback_pass == 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER'
+      - no_log_invocation.invocation.module_args.normal == 'plaintext'
+      - no_log_invocation.invocation.module_args.suboption.default_sub_pass == 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER'
+      - no_log_invocation.invocation.module_args.suboption.explicit_sub_pass == 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER'
+      - no_log_invocation.invocation.module_args.suboption.fallback_sub_pass == 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER'
+      - no_log_invocation.invocation.module_args.suboption.normal == 'plaintext'


### PR DESCRIPTION
##### SUMMARY
Make sure default and fallback values for `no_log` fields are masked in the module output.

CVE-2021-20228

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
basic.py