### PR TITLE
bugfix: use to_text(stdout) in psrp.Connection.put_file method

### DIFF
--- a/changelogs/fragments/psrp-json-loads-bytes.yml
+++ b/changelogs/fragments/psrp-json-loads-bytes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - to_text(stdout) before json.loads in psrp.Connection.put_file in case stdout is bytes

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -472,7 +472,7 @@ class Connection(ConnectionBase):
         if rc != 0:
             raise AnsibleError(to_native(stderr))
 
-        put_output = json.loads(stdout)
+        put_output = json.loads(to_text(stdout))
         remote_sha1 = put_output.get("sha1")
 
         if not remote_sha1:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The `stdout` variable in `psrp.Connection.put_file` can be bytes, causing an unhandled exception when attempting to `json.loads`.  This PR uses Ansible's `to_text` helper to ensure the `json.loads` argument is a string.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

psrp connection plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
