### PR TITLE
bugfix: use to_text(stdout) in psrp.Connection.put_file method (#73491) - 2.10

### DIFF
--- a/changelogs/fragments/psrp-json-loads-bytes.yml
+++ b/changelogs/fragments/psrp-json-loads-bytes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - to_text(stdout) before json.loads in psrp.Connection.put_file in case stdout is bytes

--- a/changelogs/fragments/psrp-json-loads-bytes.yml
+++ b/changelogs/fragments/psrp-json-loads-bytes.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - to_text(stdout) before json.loads in psrp.Connection.put_file in case stdout is bytes
+  - psrp connection plugin - ``to_text(stdout)`` before ``json.loads`` in psrp.Connection.put_file in case ``stdout`` is bytes.

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -470,7 +470,7 @@ class Connection(ConnectionBase):
         if rc != 0:
             raise AnsibleError(to_native(stderr))
 
-        put_output = json.loads(stdout)
+        put_output = json.loads(to_text(stdout))
         remote_sha1 = put_output.get("sha1")
 
         if not remote_sha1:


### PR DESCRIPTION
Co-authored-by: jakegatsby <jakegatsby@example.com>
(cherry picked from commit f271d02a9fa07299ea4fccbd7554a1bcec1782dc)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/73491

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
psrp