### PR TITLE
INTERPRETER_PYTHON_DISTRO_MAP: Treat oracle same as rhel/centos

### DIFF
--- a/changelogs/fragments/73498-INTERPRETER_PYTHON_DISTRO_MAP-Treat-oracle-same-as-rhel-centos.yml
+++ b/changelogs/fragments/73498-INTERPRETER_PYTHON_DISTRO_MAP-Treat-oracle-same-as-rhel-centos.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- INTERPRETER_PYTHON_DISTRO_MAP - prefer `/usr/libexec/platform-python` on `oraclelinux 8` when other pythons are present.
+- INTERPRETER_PYTHON_DISTRO_MAP - prefer ``/usr/libexec/platform-python`` on ``oraclelinux 8`` when other pythons are present.

--- a/changelogs/fragments/73498-INTERPRETER_PYTHON_DISTRO_MAP-Treat-oracle-same-as-rhel-centos.yml
+++ b/changelogs/fragments/73498-INTERPRETER_PYTHON_DISTRO_MAP-Treat-oracle-same-as-rhel-centos.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- INTERPRETER_PYTHON_DISTRO_MAP - prefer `/usr/libexec/platform-python` on `oraclelinux 8` when other pythons are present.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1592,8 +1592,7 @@ INTERPRETER_PYTHON_DISTRO_MAP:
       '10': /usr/bin/python3
     fedora:
       '23': /usr/bin/python3
-    oracle: &rhelish
-      '8': /usr/libexec/platform-python
+    oracle: *rhelish
     redhat: *rhelish
     rhel: *rhelish
     ubuntu:

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1592,6 +1592,8 @@ INTERPRETER_PYTHON_DISTRO_MAP:
       '10': /usr/bin/python3
     fedora:
       '23': /usr/bin/python3
+    oracle: &rhelish
+      '8': /usr/libexec/platform-python
     redhat: *rhelish
     rhel: *rhelish
     ubuntu:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change treats OracleLinux 8 same as CentOS 8 and RHEL:  without this change, any pythons discovered including the available python2.7 take precedence.  Since platform-python is the home of dnf we need this to manage OracleLinux 8.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
interpreter config map

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
To replicate the bug, install python2 on OL8 and watch dnf modules fail in all cases.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
