### PR TITLE
[2.10] Bump antsibull-changelog version for changelog sanity test

### DIFF
--- a/changelogs/fragments/73428-changelog-linting-bump-version.yml
+++ b/changelogs/fragments/73428-changelog-linting-bump-version.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-test sanity changelog test - bump dependency on antsibull-changelog to 0.9.0 so that `fragments that add new plugins or objects <https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#adding-new-roles-playbooks-test-and-filter-plugins>`_ will not fail validation (https://github.com/ansible/ansible/pull/73428)."

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -46,7 +46,7 @@ setuptools < 37 ; python_version == '2.6' # setuptools 37 and later require pyth
 setuptools < 45 ; python_version == '2.7' # setuptools 45 and later require python 3.5 or later
 
 # freeze antsibull-changelog for consistent test results
-antsibull-changelog == 0.7.0
+antsibull-changelog == 0.9.0
 
 # Make sure we have a new enough antsibull for the CLI args we use
 antsibull >= 0.21.0


### PR DESCRIPTION
##### SUMMARY
Backport of #73428 to stable-2.10.

The new version of antsibull-changelog allows to add changelog fragments which document new test and filter plugins, and new roles and plugins in collections. Older versions of antsibull-changelog will fail changelog fragment validation for such fragments.

As documented in #73428, while antsibull-changelog 0.9.0 has a breaking change, this does not affect changelog validation or the ansible-base changelog, so this is a safe change.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test sanity changelog test
