### PR TITLE
validate-modules: make sure that options that potentially contain secret data have no_log set

### DIFF
--- a/changelogs/fragments/73508-validate-modules-no_log.yml
+++ b/changelogs/fragments/73508-validate-modules-no_log.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "ansible-test validate-modules - option names that seem to indicate they contain secret information that should be marked ``no_log=True`` are now flagged in the validate-modules sanity test. False positives can be marked by explicitly setting ``no_log=False`` for these options in the argument spec. Please note that many false positives are expected; the assumption is that it is by far better to have false positives than false negatives (https://github.com/ansible/ansible/pull/73508)."

--- a/docs/docsite/rst/dev_guide/testing_validate-modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_validate-modules.rst
@@ -116,6 +116,7 @@ Codes
   multiple-utils-per-requires                                  Imports              Error                  ``Ansible.ModuleUtils`` requirements do not support multiple modules per statement
   multiple-csharp-utils-per-requires                           Imports              Error                  Ansible C# util requirements do not support multiple utils per statement
   no-default-for-required-parameter                            Documentation        Error                  Option is marked as required but specifies a default. Arguments with a default should not be marked as required
+  no-log-needed                                                Parameters           Error                  Option name suggests that the option contains a secret value, while ``no_log`` is not specified for this option in the argument spec. If this is a false positive, explicitly set ``no_log=False``
   nonexistent-parameter-documented                             Documentation        Error                  Argument is listed in DOCUMENTATION.options, but not accepted by the module
   option-incorrect-version-added                               Documentation        Error                  ``version_added`` for new option is incorrect
   option-invalid-version-added                                 Documentation        Error                  ``version_added`` for option is not a valid version number

--- a/lib/ansible/modules/apt_key.py
+++ b/lib/ansible/modules/apt_key.py
@@ -363,7 +363,7 @@ def main():
             url=dict(type='str'),
             data=dict(type='str'),
             file=dict(type='path'),
-            key=dict(type='str', removed_in_version='2.14', removed_from_collection='ansible.builtin'),
+            key=dict(type='str', removed_in_version='2.14', removed_from_collection='ansible.builtin', no_log=False),
             keyring=dict(type='path'),
             validate_certs=dict(type='bool', default=True),
             keyserver=dict(type='str'),

--- a/lib/ansible/modules/getent.py
+++ b/lib/ansible/modules/getent.py
@@ -99,7 +99,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             database=dict(type='str', required=True),
-            key=dict(type='str'),
+            key=dict(type='str', no_log=False),
             service=dict(type='str'),
             split=dict(type='str'),
             fail_key=dict(type='bool', default=True),

--- a/lib/ansible/modules/known_hosts.py
+++ b/lib/ansible/modules/known_hosts.py
@@ -335,7 +335,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             name=dict(required=True, type='str', aliases=['host']),
-            key=dict(required=False, type='str'),
+            key=dict(required=False, type='str', no_log=False),
             path=dict(default="~/.ssh/known_hosts", type='path'),
             hash_host=dict(required=False, type='bool', default=False),
             state=dict(default='present', choices=['absent', 'present']),

--- a/lib/ansible/modules/rpm_key.py
+++ b/lib/ansible/modules/rpm_key.py
@@ -233,7 +233,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             state=dict(type='str', default='present', choices=['absent', 'present']),
-            key=dict(type='str', required=True),
+            key=dict(type='str', required=True, no_log=False),
             fingerprint=dict(type='str'),
             validate_certs=dict(type='bool', default=True),
         ),

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -1483,13 +1483,10 @@ class ModuleValidator(Validator):
                         )
                         continue
 
-            # FIXME: This needs moving to somewhere that supports nested args, though should be good enough for now
-
-            # Could this a place where secrete are leaked?
-            # If it is type: path we know it's not a secret key as it's a file path
-            if (data.get('no_log') is None and
-                    NO_LOG_REGEX.match(arg) and
-                    data.get('type') != "path"):
+            # Could this a place where secrets are leaked?
+            # If it is type: path we know it's not a secret key as it's a file path.
+            # If it is type: bool it is more likely a flag indicating that something is secret, than an actual secret.
+            if (data.get('no_log') is None and NO_LOG_REGEX.match(arg) and data.get('type') not in ("path", "bool")):
                 msg = "Argument '%s' in argument_spec appears to be a secret, though doesn't have `no_log` set" % arg
                 if context:
                     msg += " found in %s" % " -> ".join(context)

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -100,10 +100,13 @@ def is_potential_secret_option(option_name):
     if not NO_LOG_REGEX.match(option_name):
         return False
     # If this is a count, type, algorithm, timeout, or name, it is probably not a secret
-    if option_name.endswith(('_count', '_type', '_alg', '_algorithm', '_timeout', '_name', '_comment', '_bits')):
+    if option_name.endswith((
+            '_count', '_type', '_alg', '_algorithm', '_timeout', '_name', '_comment',
+            '_bits', '_id', '_identifier',
+    )):
         return False
     # 'key' also matches 'publickey', which is generally not secret
-    if any(part in option_name for part in ('publickey', 'public_key')):
+    if any(part in option_name for part in ('publickey', 'public_key', 'key_usage')):
         return False
     return True
 


### PR DESCRIPTION
##### SUMMARY
@gundalow started working on this earlier, and after ansible-collections/community.general#1725 which found a lot of new cases, here's a new version. I've extended the regex and added some more rules which result in a lot more false-positives. Judging from community.general (see that PR above), this is a good idea though.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test validate-modules
