### PR TITLE
Add rpm-build package for all OS versions in setup_rpm_repo test

### DIFF
--- a/test/integration/targets/setup_rpm_repo/vars/Fedora.yml
+++ b/test/integration/targets/setup_rpm_repo/vars/Fedora.yml
@@ -1,3 +1,4 @@
 rpm_repo_packages:
   - "{{ 'python' ~ rpm_repo_python_major_version ~ '-rpmfluff' }}"
   - createrepo
+  - rpm-build

--- a/test/integration/targets/setup_rpm_repo/vars/RedHat-6.yml
+++ b/test/integration/targets/setup_rpm_repo/vars/RedHat-6.yml
@@ -2,3 +2,4 @@ rpm_repo_packages:
   - python-rpmfluff
   - createrepo_c
   - createrepo
+  - rpm-build

--- a/test/integration/targets/setup_rpm_repo/vars/RedHat-7.yml
+++ b/test/integration/targets/setup_rpm_repo/vars/RedHat-7.yml
@@ -2,3 +2,4 @@ rpm_repo_packages:
   - python-rpmfluff
   - createrepo_c
   - createrepo
+  - rpm-build


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It was added for RHEL 8 but not the others. It exists in the images by default but the `setup_mysql_db` removes `bzip2` which has `rpm-build` as a dependency so `rpm-build` is removed after that test completes.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/setup_rpm_repo`