### PR TITLE
[setup_rpm_repo test] Ensure rpm-build is present (#73516) [2.10]

### DIFF
--- a/test/integration/targets/setup_rpm_repo/vars/Fedora.yml
+++ b/test/integration/targets/setup_rpm_repo/vars/Fedora.yml
@@ -1,3 +1,4 @@
 rpm_repo_packages:
   - "{{ 'python' ~ rpm_repo_python_major_version ~ '-rpmfluff' }}"
   - createrepo
+  - rpm-build

--- a/test/integration/targets/setup_rpm_repo/vars/RedHat-6.yml
+++ b/test/integration/targets/setup_rpm_repo/vars/RedHat-6.yml
@@ -1,4 +1,5 @@
 rpm_repo_packages:
+  - rpm-build
   - python-rpmfluff
   - createrepo_c
   - createrepo

--- a/test/integration/targets/setup_rpm_repo/vars/RedHat-7.yml
+++ b/test/integration/targets/setup_rpm_repo/vars/RedHat-7.yml
@@ -1,4 +1,5 @@
 rpm_repo_packages:
+  - rpm-build
   - python-rpmfluff
   - createrepo_c
   - createrepo


### PR DESCRIPTION

##### SUMMARY

Change:
- Other targets might remove rpm-build as they clean up after
  themselves. Ensure that it's present in setup_rpm_repo because
  rpmfluff needs it.

Test Plan:
- Local experimentation with yum_repository and mysql_db (the latter of
  which depends on a handler which was removing rpm-build) on
  stable-2.9.

Signed-off-by: Rick Elrod <rick@elrod.me>
(cherry picked from commit aca5b0e43be4d7bd067abc6631978b1cdfa75d84)

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Test Pull Request

##### COMPONENT NAME

tests