### PR TITLE
[setup_rpm_repo test] Ensure rpm-build is present (#73516) [2.8]

### DIFF
--- a/test/integration/targets/setup_rpm_repo/tasks/main.yml
+++ b/test/integration/targets/setup_rpm_repo/tasks/main.yml
@@ -12,6 +12,7 @@
     with_items:
       - python{{ ansible_python_version.split(".")[0] }}-rpmfluff
       - createrepo
+      - rpm-build
     when:
       - ansible_distribution in ['Fedora']
 
@@ -19,6 +20,7 @@
     package:
       name: "{{ item }}"
     with_items:
+      - rpm-build
       - python-rpmfluff
       - createrepo_c
       - createrepo  # used by el6 version of rpmfluff
@@ -30,6 +32,7 @@
     package:
       name: "{{ item }}"
     with_items:
+      - rpm-build
       - python3-rpmfluff
       - createrepo_c
       - createrepo  # used by el6 version of rpmfluff


### PR DESCRIPTION

##### SUMMARY
Change:
- Other targets might remove rpm-build as they clean up after
  themselves. Ensure that it's present in setup_rpm_repo because
  rpmfluff needs it.

Test Plan:
- Local experimentation with yum_repository and mysql_db (the latter of
  which depends on a handler which was removing rpm-build) on
  stable-2.9.

Signed-off-by: Rick Elrod <rick@elrod.me>
(cherry picked from commit aca5b0e43be4d7bd067abc6631978b1cdfa75d84)

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Test Pull Request

##### COMPONENT NAME

tests