### PR TITLE
[ansible-test] cap cryptography dep on old pip

### DIFF
--- a/changelogs/fragments/ansible-test-cryptography-for-old-pip.yml
+++ b/changelogs/fragments/ansible-test-cryptography-for-old-pip.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - cap ``cryptography`` at ``< 3.4`` for old pip versions.

--- a/test/integration/targets/setup_paramiko/install-Alpine-3-python-3.yml
+++ b/test/integration/targets/setup_paramiko/install-Alpine-3-python-3.yml
@@ -1,6 +1,8 @@
 - name: Install Paramiko for Python 3 on Alpine
   pip: # no apk package manager in core, just use pip
-    name: paramiko
+    name:
+      - paramiko
+      - cryptography {{ cryptography_constraint }}
   environment:
     # Not sure why this fixes the test, but it does.
     SETUPTOOLS_USE_DISTUTILS: stdlib

--- a/test/integration/targets/setup_paramiko/install-Darwin-python-3.yml
+++ b/test/integration/targets/setup_paramiko/install-Darwin-python-3.yml
@@ -1,6 +1,8 @@
 - name: Install Paramiko for Python 3 on MacOS
   pip: # no homebrew package manager in core, just use pip
-    name: paramiko
+    name:
+      - paramiko
+      - cryptography {{ cryptography_constraint }}
   environment:
     # Not sure why this fixes the test, but it does.
     SETUPTOOLS_USE_DISTUTILS: stdlib

--- a/test/integration/targets/setup_paramiko/install-FreeBSD-11-python-3.yml
+++ b/test/integration/targets/setup_paramiko/install-FreeBSD-11-python-3.yml
@@ -6,4 +6,6 @@
     name: pip==18.1
 - name: Install Paramiko for Python 3 on FreeBSD 11
   pip: # no py36-paramiko package exists for FreeBSD 11
-    name: paramiko
+    name:
+      - paramiko
+      - cryptography {{ cryptography_constraint }}

--- a/test/integration/targets/setup_paramiko/install-RedHat-8-python-3.yml
+++ b/test/integration/targets/setup_paramiko/install-RedHat-8-python-3.yml
@@ -1,3 +1,5 @@
 - name: Install Paramiko for Python 3 on RHEL 8
   pip: # no python3-paramiko package exists for RHEL 8
-    name: paramiko
+    name:
+      - paramiko
+      - cryptography {{ cryptography_constraint }}

--- a/test/integration/targets/setup_paramiko/install.yml
+++ b/test/integration/targets/setup_paramiko/install.yml
@@ -3,17 +3,36 @@
     - name: Detect Paramiko
       detect_paramiko:
       register: detect_paramiko
+
     - name: Persist Result
       copy:
         content: "{{ detect_paramiko }}"
         dest: "{{ lookup('env', 'OUTPUT_DIR') }}/detect-paramiko.json"
-    - name: Install Paramiko
+
+    - block:
+        - name: Figure out pip version
+          command: "{{ ansible_python_interpreter }} -c 'import pip; print(pip.__version__)'"
+          register: pip_version
+          ignore_errors: true
+
+        - name: Figure out python-cryptography pip constraint
+          set_fact:
+            cryptography_constraint: "{{ '' if pip_version.stdout is version('19', '>=') else '>=2.5,<3.4' }}"
+          when: pip_version is successful
+
+        - debug:
+            msg:
+              - '{{ pip_version }}'
+              - '{{ cryptography_constraint }}'
+          when: pip_version is successful
+
+        - name: Install Paramiko
+          include_tasks: "{{ item }}"
+          with_first_found:
+            - "install-{{ ansible_distribution }}-{{ ansible_distribution_version }}-python-{{ ansible_python.version.major }}.yml"
+            - "install-{{ ansible_distribution }}-{{ ansible_distribution_major_version }}-python-{{ ansible_python.version.major }}.yml"
+            - "install-{{ ansible_os_family }}-{{ ansible_distribution_major_version }}-python-{{ ansible_python.version.major }}.yml"
+            - "install-{{ ansible_os_family }}-python-{{ ansible_python.version.major }}.yml"
+            - "install-python-{{ ansible_python.version.major }}.yml"
+            - "install-fail.yml"
       when: not detect_paramiko.found
-      include_tasks: "{{ item }}"
-      with_first_found:
-        - "install-{{ ansible_distribution }}-{{ ansible_distribution_version }}-python-{{ ansible_python.version.major }}.yml"
-        - "install-{{ ansible_distribution }}-{{ ansible_distribution_major_version }}-python-{{ ansible_python.version.major }}.yml"
-        - "install-{{ ansible_os_family }}-{{ ansible_distribution_major_version }}-python-{{ ansible_python.version.major }}.yml"
-        - "install-{{ ansible_os_family }}-python-{{ ansible_python.version.major }}.yml"
-        - "install-python-{{ ansible_python.version.major }}.yml"
-        - "install-fail.yml"


### PR DESCRIPTION

##### SUMMARY

Change:
- cryptography >= 3.4 requires rustc to build from source.
- It also drops support for manylinux1 wheels.
- pip < 19 cannot install manylinux2010 wheels.
- Constraint cryptography to <3.4 when pip is old.

Test Plan:
- ci_complete

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Test Pull Request

##### COMPONENT NAME

ansible-test