### PR TITLE
Replace usage of private attribute by dnf API

### DIFF
--- a/changelogs/fragments/dnf-security.yaml
+++ b/changelogs/fragments/dnf-security.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Replace usage of private dnf.Base() attribute by future dnf API

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -679,15 +679,13 @@ class DnfModule(YumDnf):
                 rc=1
             )
 
-        filters = []
+        filters = {}
         if self.bugfix:
-            key = {'advisory_type__eq': 'bugfix'}
-            filters.append(base.sack.query().upgrades().filter(**key))
+            filters.setdefault('types', []).append('bugfix')
         if self.security:
-            key = {'advisory_type__eq': 'security'}
-            filters.append(base.sack.query().upgrades().filter(**key))
+            filters.setdefault('types', []).append('security')
         if filters:
-            base._update_security_filters = filters
+            base.add_security_filters('eq', **filters)
 
         return base
 

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -679,13 +679,25 @@ class DnfModule(YumDnf):
                 rc=1
             )
 
-        filters = {}
-        if self.bugfix:
-            filters.setdefault('types', []).append('bugfix')
-        if self.security:
-            filters.setdefault('types', []).append('security')
-        if filters:
-            base.add_security_filters('eq', **filters)
+        add_security_filters = getattr(base, "add_security_filters", None)
+        if callable(add_security_filters):
+            filters = {}
+            if self.bugfix:
+                filters.setdefault('types', []).append('bugfix')
+            if self.security:
+                filters.setdefault('types', []).append('security')
+            if filters:
+                add_security_filters('eq', **filters)
+        else:
+            filters = []
+            if self.bugfix:
+                key = {'advisory_type__eq': 'bugfix'}
+                filters.append(base.sack.query().upgrades().filter(**key))
+            if self.security:
+                key = {'advisory_type__eq': 'security'}
+                filters.append(base.sack.query().upgrades().filter(**key))
+            if filters:
+                base._update_security_filters = filters
 
         return base
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
base._update_security_filters is a private attribute of DNF used
as performance optimization. Modification or even call from outside
of DNF is against all recommendation including PEP8.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
DNF

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Requires: https://github.com/rpm-software-management/dnf/pull/1715
Resolves: https://github.com/ansible/ansible/issues/73527
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
