### PR TITLE
Add new split filter

### DIFF
--- a/changelogs/fragments/split-filter.yml
+++ b/changelogs/fragments/split-filter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Filters - Add new ``split`` filter for splitting strings

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1612,6 +1612,10 @@ To concatenate a list into a string::
 
     {{ list | join(" ") }}
 
+To split a sting into a list::
+
+    {{ csv_string | split(",") }}
+
 To work with Base64 encoded strings::
 
     {{ encoded | b64decode }}

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1614,6 +1614,8 @@ To concatenate a list into a string::
 
 To split a sting into a list::
 
+.. versionadded:: 2.11
+
     {{ csv_string | split(",") }}
 
 To work with Base64 encoded strings::

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -41,7 +41,7 @@ from random import Random, SystemRandom, shuffle
 from jinja2.filters import environmentfilter, do_groupby as _do_groupby
 
 from ansible.errors import AnsibleError, AnsibleFilterError, AnsibleFilterTypeError
-from ansible.module_utils.six import iteritems, string_types, integer_types, reraise
+from ansible.module_utils.six import iteritems, string_types, integer_types, reraise, text_type
 from ansible.module_utils.six.moves import reduce, shlex_quote
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.common.collections import is_sequence
@@ -662,4 +662,5 @@ class FilterModule(object):
             'dict2items': dict_to_list_of_dict_key_value_elements,
             'items2dict': list_of_dict_key_value_elements_to_dict,
             'subelements': subelements,
+            'split': partial(unicode_wrap, text_type.split),
         }

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -608,3 +608,12 @@
       - thing|quote == "''"
   vars:
     thing: null
+
+- name: split filter
+  assert:
+    that:
+      - splitty|map('split', ',')|flatten|map('int') == [1, 2, 3, 4, 5, 6]
+  vars:
+    splitty:
+      - "1,2,3"
+      - "4,5,6"


### PR DESCRIPTION
##### SUMMARY
Add new `split` filter

This is typically not needed, but let's say you need to use it in a `map` you lose that functionality.  jinja2 upstream declined it, because the "data should be the correct type to begin with".  But we know this isn't always possible. See the tests for a simple example

This is a pretty minimal change.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/filter/core.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
