### PR TITLE
ansible-test: avoid exception if doc block is empty

### DIFF
--- a/changelogs/fragments/ansible_test_valide_modules_no_doc.yaml
+++ b/changelogs/fragments/ansible_test_valide_modules_no_doc.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- validate-modules - do not raise an exception if the ``DOCUMENTATION`` section exists but is empty. 

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -948,6 +948,8 @@ class ModuleValidator(Validator):
                 if doc:
                     add_collection_to_versions_and_dates(doc, self.collection_name, is_module=True)
                 else:
+                    documentation_exists = True
+
                     self.reporter.error(
                         path=self.object_path,
                         code='missing-documentation',

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -940,12 +940,12 @@ class ModuleValidator(Validator):
                     msg='No DOCUMENTATION provided'
                 )
             else:
-                documentation_exists = True
                 doc, errors, traces = parse_yaml(
                     doc_info['DOCUMENTATION']['value'],
                     doc_info['DOCUMENTATION']['lineno'],
                     self.name, 'DOCUMENTATION'
                 )
+                documentation_exists = bool(doc)
                 if doc:
                     add_collection_to_versions_and_dates(doc, self.collection_name, is_module=True)
                 for error in errors:
@@ -959,7 +959,7 @@ class ModuleValidator(Validator):
                         path=self.object_path,
                         tracebk=trace
                     )
-                if not errors and not traces:
+                if doc and not errors and not traces:
                     missing_fragment = False
                     with CaptureStd():
                         try:

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -948,8 +948,6 @@ class ModuleValidator(Validator):
                 if doc:
                     add_collection_to_versions_and_dates(doc, self.collection_name, is_module=True)
                 else:
-                    documentation_exists = True
-
                     self.reporter.error(
                         path=self.object_path,
                         code='missing-documentation',

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -948,6 +948,13 @@ class ModuleValidator(Validator):
                 documentation_exists = bool(doc)
                 if doc:
                     add_collection_to_versions_and_dates(doc, self.collection_name, is_module=True)
+                else:
+                    self.reporter.error(
+                        path=self.object_path,
+                        code='missing-documentation',
+                        msg='The DOCUMENTATION block is empty'
+                    )
+
                 for error in errors:
                     self.reporter.error(
                         path=self.object_path,

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -945,7 +945,6 @@ class ModuleValidator(Validator):
                     doc_info['DOCUMENTATION']['lineno'],
                     self.name, 'DOCUMENTATION'
                 )
-                documentation_exists = bool(doc)
                 if doc:
                     add_collection_to_versions_and_dates(doc, self.collection_name, is_module=True)
                 else:


### PR DESCRIPTION
##### SUMMARY
<!--- Explain the problem briefly below -->

Address the situation where the `DOCUMENTATION` key exists but is empty.

Without this patch, `validate-modules` raises am exception because `doc` is not a list, but `None`.

##### ISSUE TYPE
- Bug Report

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below, use your best guess if unsure -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
devel
```