### PR TITLE
fix typo in ansible vault decrypt if file content error

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -680,7 +680,7 @@ class VaultLib:
             raise AnsibleVaultError("A vault password must be specified to decrypt data")
 
         if not is_encrypted(b_vaulttext):
-            msg = "input is not vault encrypted data"
+            msg = "input is not vault encrypted data. "
             if filename:
                 msg += "%s is not a vault encrypted file" % to_native(filename)
             raise AnsibleError(msg)


### PR DESCRIPTION
##### SUMMARY
Fix typo in `ansible-vault decrypt` command if error detected in encrypted files

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- ansible-vault

##### ADDITIONAL INFORMATION
I use `ansible-vault encrypt_string "example_string" > vault_ret.txt`
Then when I use `ansible-vault decrypt vault_ret.txt` it shown like
```
ERROR! input is not vault encrypted data/home/laznp/vault_ret.txt is not a vault encrypted file for /home/laznp/vault_ret.txt
```

My `~/.ansible.cfg` only contain
```
[defaults]
vault_password_file=/home/laznp/.vault-password-file
```

Step to reproduce:
```
$ ansible-vault encrypt_string "example_string" > vault_ret.txt
$ ansible-vault decrypt vault_ret.txt
```

Expected output
```
ERROR! input is not vault encrypted data. /home/laznp/vault_ret.txt is not a vault encrypted file for /home/laznp/vault_ret.txt
```

Actual output
```
ERROR! input is not vault encrypted data/home/laznp/vault_ret.txt is not a vault encrypted file for /home/laznp/vault_ret.txt

```
##### ANSIBLE VERSION
- devel
- 2.10.5