### PR TITLE
Docs: Adds banner for core/package split

### DIFF
--- a/docs/docsite/_themes/sphinx_rtd_theme/ansible_banner.html
+++ b/docs/docsite/_themes/sphinx_rtd_theme/ansible_banner.html
@@ -12,7 +12,13 @@
     {% if (not READTHEDOCS) and (available_versions is defined) %}
       // Create a banner
       current_url_path = window.location.pathname;
-      if (startsWith(current_url_path, "/ansible/latest/") || startsWith(current_url_path, "/ansible/{{ latest_version }}/")) {
+
+      if (startsWith(current_url_path, "/ansible-core/")) {
+        document.write('<div id="banner_id" class="admonition caution">');
+        document.write('<p>You are reading documentation for Ansible Core, which must be installed from source. For documentation of the Ansible package, go to <a href="https://docs.ansible.com/ansible/latest">Docs survey</a>.</p>');
+        document.write('</div>');
+        
+      } else if (startsWith(current_url_path, "/ansible/latest/") || startsWith(current_url_path, "/ansible/{{ latest_version }}/")) {
         document.write('<div id="banner_id" class="admonition caution">');
         document.write('<p>You are reading the latest community version of the Ansible documentation. Red Hat subscribers, select <b>2.9</b> in the version selection to the left for the most recent Red Hat release.</p>');
         document.write('</div>');

--- a/docs/docsite/_themes/sphinx_rtd_theme/ansible_banner.html
+++ b/docs/docsite/_themes/sphinx_rtd_theme/ansible_banner.html
@@ -15,9 +15,9 @@
 
       if (startsWith(current_url_path, "/ansible-core/")) {
         document.write('<div id="banner_id" class="admonition caution">');
-        document.write('<p>You are reading documentation for Ansible Core, which must be installed from source. For documentation of the Ansible package, go to <a href="https://docs.ansible.com/ansible/latest">Docs survey</a>.</p>');
+        document.write('<p>You are reading documentation for Ansible Core, which contains no plugins except for those in ansible.builtin. For documentation of the Ansible package, go to <a href="https://docs.ansible.com/ansible/latest">the latest documentation</a>.</p>');
         document.write('</div>');
-        
+
       } else if (startsWith(current_url_path, "/ansible/latest/") || startsWith(current_url_path, "/ansible/{{ latest_version }}/")) {
         document.write('<div id="banner_id" class="admonition caution">');
         document.write('<p>You are reading the latest community version of the Ansible documentation. Red Hat subscribers, select <b>2.9</b> in the version selection to the left for the most recent Red Hat release.</p>');


### PR DESCRIPTION
##### SUMMARY
Adds a banner published only on the docs.ansible.com/ansible-core/ pages that gives readers a link to the main package docsite.

Closes #73197.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com/ansible-core
