### PR TITLE
Add flag to specify ansible version for the docs build.

### DIFF
--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -31,8 +31,9 @@ ifdef PLUGINS
 endif
 endif
 
+ANSIBLE_VERSION_ARGS=
 ifdef ANSIBLE_VERSION
-	PLUGIN_ARGS="$(PLUGIN_ARGS) --ansible-version=$(ANSIBLE_VERSION)"
+	ANSIBLE_VERSION_ARGS=--ansible-version=$(ANSIBLE_VERSION)
 endif
 
 DOC_PLUGINS ?= become cache callback cliconf connection httpapi inventory lookup netconf shell strategy vars
@@ -128,7 +129,7 @@ plugins:
 	if expr "$(VERSION)" : '.*[.]dev[0-9]\{1,\}$$' &> /dev/null; then \
 		$(PLUGIN_FORMATTER) base -o rst $(PLUGIN_ARGS);\
 	else \
-		$(PLUGIN_FORMATTER) full -o rst $(PLUGIN_ARGS);\
+		$(PLUGIN_FORMATTER) full -o rst $(ANSIBLE_VERSION_ARGS) $(PLUGIN_ARGS);\
 	fi
 
 # This only builds the plugin docs included with ansible-base

--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -31,6 +31,9 @@ ifdef PLUGINS
 endif
 endif
 
+ifdef ANSIBLE_VERSION
+	PLUGIN_ARGS="$(PLUGIN_ARGS) --ansible-version=$(ANSIBLE_VERSION)"
+endif
 
 DOC_PLUGINS ?= become cache callback cliconf connection httpapi inventory lookup netconf shell strategy vars
 


### PR DESCRIPTION
When building split docs, we'll need to be able to specify which
version of ansible we're building for.

CC: @samccann 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
