### PR TITLE
[command] add chroot support

### DIFF
--- a/changelogs/fragments/73568-command-chroot.yml
+++ b/changelogs/fragments/73568-command-chroot.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - command - commands can now be executed inside the specified chroot

--- a/test/integration/targets/command_shell/tasks/main.yml
+++ b/test/integration/targets/command_shell/tasks/main.yml
@@ -215,6 +215,49 @@
     that:
       - "command_result6.stdout == '9cd0697c6a9ff6689f0afb9136fa62e0b3fee903'"
 
+# chroot
+
+- name: execute the test.sh script when chrooted via command
+  command: test_command_shell/test.sh
+  args:
+    chroot: "{{ output_dir }}"
+  register: command_result7
+
+- name: assert that the script executed correctly with chroot
+  assert:
+    that:
+      - command_result7.rc == 0
+      - command_result7.stderr == ''
+      - command_result7.stdout == 'win'
+
+- name: verify that afile.txt is absent in chroot directory
+  file:
+    path: "{{ output_dir_test }}/afile.txt"
+    state: absent
+
+- name: create afile.txt with create_afile.sh via command in chroot
+  command: test_command_shell/create_afile.sh test_command_shell/afile.txt
+  args:
+    chroot: "{{ output_dir }}"
+    creates: "{{ output_dir_test }}/afile.txt"
+
+- name: verify that afile.txt is present
+  file:
+    path: "{{ output_dir_test }}/afile.txt"
+    state: file
+
+- name: re-run previous command in chroot, using creates with globbing
+  command: test_command_shell/create_afile.sh test_command_shell/afile.txt
+  args:
+    chroot: "{{ output_dir }}"
+    creates: "{{ output_dir_test }}/afile.*"
+  register: command_result8
+
+- name: assert that creates with globbing is working in chroot
+  assert:
+    that:
+      - command_result8 is not changed
+
 ##
 ## shell
 ##


### PR DESCRIPTION
##### SUMMARY

This adds support for executing commands in a chrooted environment using the `ansible.builtin.command` module.
Note that this will neither create, nor "prepare" the chroot directory.

Additional `chroot` and `chroot_cmd` module parameters are introduced:
- `chroot` : path to the chroot directory (e.g. `/mnt/chroot`)
- `chroot_cmd` : path to the command to execute to perform the chroot (defaults to  `chroot`)

This is purposely limited to the `command` module (not the `shell` module), see below.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

`ansible.builtin.command`

##### ADDITIONAL INFORMATION

With this modification the following are equivalent:
```
- name: use the new chroot parameters
  command:
    cmd: "{{ my_cmd }}"
    chroot: "{{ my_chroot_dir }}"
    chroot_cmd: "{{ my_chroot_cmd }}"

- name: equivalent without the new parameters:
  command:
    cmd: >-
      {% if my_chroot_dir is defined and my_chroot_cmd is defined %}
      {{ my_chroot_cmd }} {{my_chroot_dir }}
      {% endif %}
      {{ my_cmd }}
```

Working on a chrooted installation playbook designed to be reusable on already installed hosts, I found myself repeating this pattern too much and thought the `ansible.builtin.command` could benefit from this.

Besides making the tasks easier to read, it adds sanity checks on:
- the existence of the `chroot_cmd`
- the existence of the `chroot` path
- the ability to actually chroot to the `chroot`path

###### Limitations

Changes are limited to the `command` module mainly because output redirection to files in the `shell` module can create confusion. They were nevertheless internally tested with the  `shell` module.

For example having a `shell` command writing inside the chrooted environment, it would be necessary to repeat the chroot path in the command itself:

```
- name: using shell would require to repeat chroot path in the command
  shell:
    cmd: "{{ my_command_with_output }} > {{ my_chroot }}/path/inside/chroot/output.txt"
    chroot: "{{ my_chroot }}"
```

###### Testing

The `command_shell` test role now tests use of those parameters.
Obviously, this only works if `{{ output_dir }}` is ready for a chrooted environment (have at least `/bin/bash`, the linked libraries, and `/usr/bin/env` as it is called in the shebang of `test.sh`).
One simple option for testing could be to use '/' as `{{ output_dir }}`, resulting in an idempotent chroot.