### PR TITLE
Fixed/improved regular expresssion for collection names

### DIFF
--- a/changelogs/fragments/73577-regex-fix.yml
+++ b/changelogs/fragments/73577-regex-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Improved/fixed regular expressions in ``validate-modules/validate_modules/schema.py`` and ``utils/collection_loader/_collection_finder.py`` (https://github.com/ansible/ansible/pull/73577).

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -701,7 +701,7 @@ class AnsibleCollectionRef:
 
     # FIXME: tighten this up to match Python identifier reqs, etc
     VALID_SUBDIRS_RE = re.compile(to_text(r'^\w+(\.\w+)*$'))
-    VALID_FQCR_RE = re.compile(to_text(r'^\w+\.\w+\.\w+(\.\w+)*$'))  # can have 0-N included subdirs as well
+    VALID_FQCR_RE = re.compile(to_text(r'^\w+(\.\w+){2,}$'))  # can have 0-N included subdirs as well
 
     def __init__(self, collection_name, subdirs, resource, ref_type):
         """

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -45,7 +45,7 @@ def isodate(v, error_code=None):
     return v
 
 
-COLLECTION_NAME_RE = re.compile('^([^.]+.[^.]+)$')
+COLLECTION_NAME_RE = re.compile(r'^([^.]+(\.[^.]+)+)$')
 
 
 def collection_name(v, error_code=None):

--- a/test/units/utils/collection_loader/test_collection_loader.py
+++ b/test/units/utils/collection_loader/test_collection_loader.py
@@ -722,6 +722,7 @@ def test_fqcr_parsing_valid(ref, ref_type, expected_collection,
     ('fqcn', 'expected'),
     (
         ('ns1.coll2', True),
+        ('ns1#coll2', False),
         ('def.coll3', False),
         ('ns4.return', False),
         ('assert.this', False),
@@ -742,6 +743,7 @@ def test_fqcn_validation(fqcn, expected):
     [
         ('no_dots_at_all_action', 'action', ValueError, 'is not a valid collection reference'),
         ('no_nscoll.myaction', 'action', ValueError, 'is not a valid collection reference'),
+        ('no_nscoll%myaction', 'action', ValueError, 'is not a valid collection reference'),
         ('ns.coll.myaction', 'bogus', ValueError, 'invalid collection ref_type'),
     ])
 def test_fqcr_parsing_invalid(ref, ref_type, expected_error_type, expected_error_expression):


### PR DESCRIPTION
##### SUMMARY
The regexp to determine a collection name in `schema.py`:
```python
COLLECTION_NAME_RE = re.compile('^([^.]+.[^.]+)$')
```
has two bugs: a) it does not protect the dot between names, allowing things like `community#general` or `community%general` or even `communitygeneral` to be validated, when they shouldn't, and b) it fails to validate namespaces with _deeper_ directory structures.

While investigating this, simplified a regexp in `lib/ansible/utils/collection_loader/_collection_finder.py` as well

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/utils/collection_loader/_collection_finder.py
test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
