### PR TITLE
[stable-2.10]ansible-test: yamllint, check the assigment

### DIFF
--- a/changelogs/fragments/ansible_test_yamllint_avoid_attribute_exception.yaml
+++ b/changelogs/fragments/ansible_test_yamllint_avoid_attribute_exception.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- yamllint - do not raise an ``AttributeError`` if a value is assigned to a module attribute at the top of the module.

--- a/test/lib/ansible_test/_data/sanity/yamllint/yamllinter.py
+++ b/test/lib/ansible_test/_data/sanity/yamllint/yamllinter.py
@@ -180,7 +180,7 @@ class YamlChecker:
         def check_assignment(statement, doc_types=None):
             """Check the given statement for a documentation assignment."""
             for target in statement.targets:
-                if isinstance(target, ast.Tuple):
+                if not isinstance(target, ast.Name):
                     continue
 
                 if doc_types and target.id not in doc_types:


### PR DESCRIPTION
##### SUMMARY

Ensure `yamllint`'s `check_assignment()` correctly ignore the attribute assignment. Those don't have any `.id` attribute and will
trigger an `AttributeError` exception.

See: https://github.com/ansible/ansible/pull/73322
(cherry picked from commit 0a8d5c098367a58eaff10fd5b3868f099c1e17a7)

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test
