### PR TITLE
pause action: catch more potential errors when setting up curses

### DIFF
--- a/changelogs/fragments/pause-import.yml
+++ b/changelogs/fragments/pause-import.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "pause - catch additional error on setting up curses (https://github.com/ansible/ansible/pull/73588)."

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -40,12 +40,13 @@ display = Display()
 
 try:
     import curses
+    import io
 
     # Nest the try except since curses.error is not available if curses did not import
     try:
         curses.setupterm()
         HAS_CURSES = True
-    except (curses.error, TypeError):
+    except (curses.error, TypeError, io.UnsupportedOperation):
         HAS_CURSES = False
 except ImportError:
     HAS_CURSES = False


### PR DESCRIPTION
##### SUMMARY
In certain very constraint situations, `curses.setupterm()` can also raise an `io.UnsupportedOperation` exception: `ERROR: lib/ansible/plugins/action/pause.py:47:0: traceback: UnsupportedOperation: fileno` (seen in #72497).

This makes sure that that error is also handled the same as other errors.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pause
