### PR TITLE
Add rolespec_validate to import/include_role

### DIFF
--- a/changelogs/fragments/73589-rolespec-validate.yml
+++ b/changelogs/fragments/73589-rolespec-validate.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Add new rolespec_validate option to the import/include_role modules do allow
+    disabling of the implicit role arg validation task on a per-role basis.

--- a/lib/ansible/modules/import_role.py
+++ b/lib/ansible/modules/import_role.py
@@ -51,6 +51,12 @@ options:
     type: str
     default: main
     version_added: '2.8'
+  rolespec_validate:
+    description:
+      - Perform role argument spec validation if an argument spec is defined.
+    type: bool
+    default: yes
+    version_added: '2.11'
 notes:
   - Handlers are made available to the whole play.
   - Since Ansible 2.7 variables defined in C(vars) and C(defaults) for the role are exposed to the play at playbook parsing time.

--- a/lib/ansible/modules/include_role.py
+++ b/lib/ansible/modules/include_role.py
@@ -67,6 +67,12 @@ options:
     type: str
     default: main
     version_added: '2.8'
+  rolespec_validate:
+    description:
+      - Perform role argument spec validation if an argument spec is defined.
+    type: bool
+    default: yes
+    version_added: '2.11'
 notes:
   - Handlers are made available to the whole play.
   - Before Ansible 2.4, as with C(include), this task could be static or dynamic, If static, it implied that it won't

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -53,7 +53,7 @@ class IncludeRole(TaskInclude):
     # private as this is a 'module options' vs a task property
     _allow_duplicates = FieldAttribute(isa='bool', default=True, private=True)
     _public = FieldAttribute(isa='bool', default=False, private=True)
-    _rolespec_validate = FieldAttribute(isa='bool', default=True, private=True)
+    _rolespec_validate = FieldAttribute(isa='bool', default=True)
 
     def __init__(self, block=None, role=None, task_include=None):
 

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -44,7 +44,7 @@ class IncludeRole(TaskInclude):
 
     BASE = ('name', 'role')  # directly assigned
     FROM_ARGS = ('tasks_from', 'vars_from', 'defaults_from', 'handlers_from')  # used to populate from dict in role
-    OTHER_ARGS = ('apply', 'public', 'allow_duplicates')  # assigned to matching property
+    OTHER_ARGS = ('apply', 'public', 'allow_duplicates', 'rolespec_validate')  # assigned to matching property
     VALID_ARGS = tuple(frozenset(BASE + FROM_ARGS + OTHER_ARGS))  # all valid args
 
     # =================================================================================
@@ -53,6 +53,7 @@ class IncludeRole(TaskInclude):
     # private as this is a 'module options' vs a task property
     _allow_duplicates = FieldAttribute(isa='bool', default=True, private=True)
     _public = FieldAttribute(isa='bool', default=False, private=True)
+    _rolespec_validate = FieldAttribute(isa='bool', default=True, private=True)
 
     def __init__(self, block=None, role=None, task_include=None):
 
@@ -80,7 +81,7 @@ class IncludeRole(TaskInclude):
 
         # build role
         actual_role = Role.load(ri, myplay, parent_role=self._parent_role, from_files=self._from_files,
-                                from_include=True)
+                                from_include=True, validate=self.rolespec_validate)
         actual_role._metadata.allow_duplicates = self.allow_duplicates
 
         if self.statically_loaded or self.public:

--- a/test/integration/targets/roles_arg_spec/test.yml
+++ b/test/integration/targets/roles_arg_spec/test.yml
@@ -247,3 +247,27 @@
                 - ansible_failed_result.validate_args_context.name == "role_with_no_tasks"
                 - ansible_failed_result.validate_args_context.type == "role"
                 - "ansible_failed_result.validate_args_context.path is search('roles_arg_spec/roles/role_with_no_tasks')"
+
+- name: "New play to reset vars: Test disabling role validation with rolespec_validate=False"
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - block:
+      - name: "Test import_role of role C (missing a_str), but validation turned off"
+        import_role:
+          name: c
+          rolespec_validate: False
+      - fail:
+          msg: "Should not get here"
+
+      rescue:
+        - debug:
+            var: ansible_failed_result
+        - name: "Validate import_role failure"
+          assert:
+            that:
+              # We expect the role to actually run, but will fail because an undefined variable was referenced
+              # and validation wasn't performed up front (thus not returning 'argument_errors').
+              - "'argument_errors' not in ansible_failed_result"
+              - "'The task includes an option with an undefined variable.' in ansible_failed_result.msg"
+

--- a/test/integration/targets/roles_arg_spec/test.yml
+++ b/test/integration/targets/roles_arg_spec/test.yml
@@ -270,4 +270,3 @@
               # and validation wasn't performed up front (thus not returning 'argument_errors').
               - "'argument_errors' not in ansible_failed_result"
               - "'The task includes an option with an undefined variable.' in ansible_failed_result.msg"
-


### PR DESCRIPTION
##### SUMMARY
Adds a new keyword to import_role and include_role to disable role argument validation.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

import_role
include_role

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
