### PR TITLE
ansible-doc - account for empty meta/main.yml

### DIFF
--- a/changelogs/fragments/ansible-doc-role-empty-meta-main.yml
+++ b/changelogs/fragments/ansible-doc-role-empty-meta-main.yml
@@ -1,4 +1,4 @@
 bugfixes:
   - >-
     ansible-doc - account for an empty ``meta/main.yml`` file when displaying
-    role information
+    role information (https://github.com/ansible/ansible/pull/73590)

--- a/changelogs/fragments/ansible-doc-role-empty-meta-main.yml
+++ b/changelogs/fragments/ansible-doc-role-empty-meta-main.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    ansible-doc - account for an empty ``meta/main.yml`` file when displaying
+    role information

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -91,6 +91,8 @@ class RoleMixin(object):
         try:
             with open(path, 'r') as f:
                 data = from_yaml(f.read(), file_name=path)
+                if data is None:
+                    data = {}
                 return data.get('argument_specs', {})
         except (IOError, OSError) as e:
             raise AnsibleParserError("An error occurred while trying to read the file '%s': %s" % (path, to_native(e)), orig_exc=e)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`from_yaml()` will return `None` when encountering an empty file due to an exception from `json.loads()`:
```
JSONDecodeError('Expecting value: line 1 column 1 (char 0)')
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/cli/doc.py`

##### ADDITIONAL INFORMATION

Existing tests covered this. I just had to add a role with an empty `meta/main.yml` to trigger the failure.
