### PR TITLE
Improve messages when module/action loading fails after a redirect

### DIFF
--- a/changelogs/fragments/73603-redirect-names.yml
+++ b/changelogs/fragments/73603-redirect-names.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "core - improve error message when loading an action/module is redirected, but the result not found (https://github.com/ansible/ansible/pull/73603)."

--- a/changelogs/fragments/73603-redirect-names.yml
+++ b/changelogs/fragments/73603-redirect-names.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- "core - improve error message when loading an action/module is redirected, but the result not found (https://github.com/ansible/ansible/pull/73603)."
+- "core - improve error message when loading an action/module or lookup is redirected, but the result not found (https://github.com/ansible/ansible/pull/73603)."

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -733,9 +733,9 @@ class DocCLI(CLI, RoleMixin):
         if not result.resolved:
             if result.redirect_list and len(result.redirect_list) > 1:
                 # take the last one in the redirect list, we may have successfully jumped through N other redirects
-                target_module_name = result.redirect_list[-1]
+                target_redirection_list = ' -> '.join(result.redirect_list[1:])
                 raise PluginNotFound('%s %s was redirected to %s, which was not found in: %s' % (
-                    plugin_type, plugin, target_module_name, search_paths))
+                    plugin_type, plugin, target_redirection_list, search_paths))
             raise PluginNotFound('%s %s was not found in: %s' % (plugin_type, plugin, search_paths))
         plugin_name = result.plugin_resolved_name
         filename = result.plugin_resolved_path

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -732,7 +732,7 @@ class DocCLI(CLI, RoleMixin):
         result = loader.find_plugin_with_context(plugin, mod_type='.py', ignore_deprecated=True, check_aliases=True)
         if not result.resolved:
             if result.redirect_list and len(result.redirect_list) > 1:
-                # take the last one in the redirect list, we may have successfully jumped through N other redirects
+                # show all redirects that took place
                 target_redirection_list = ' -> '.join(result.redirect_list[1:])
                 raise PluginNotFound('%s %s was redirected to %s, which was not found in: %s' % (
                     plugin_type, plugin, target_redirection_list, search_paths))

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -732,8 +732,9 @@ class DocCLI(CLI, RoleMixin):
             if result.redirect_list and len(result.redirect_list) > 1:
                 # take the last one in the redirect list, we may have successfully jumped through N other redirects
                 target_module_name = result.redirect_list[-1]
-                raise PluginNotFound('%s was redirected to %s, which was not found in %s' % (plugin, target_module_name, search_paths))
-            raise PluginNotFound('%s was not found in %s' % (plugin, search_paths))
+                raise PluginNotFound('%s %s was redirected to %s, which was not found in %s' % (
+                    plugin_type, plugin, target_module_name, search_paths))
+            raise PluginNotFound('%s %s was not found in %s' % (plugin_type, plugin, search_paths))
         plugin_name = result.plugin_resolved_name
         filename = result.plugin_resolved_path
         collection_name = result.plugin_resolved_collection

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -69,7 +69,9 @@ def add_collection_plugins(plugin_list, plugin_type, coll_filter=None):
 
 
 class PluginNotFound(Exception):
-    pass
+    def __init__(self, message):
+        super(PluginNotFound, self).__init__(message)
+        self.message = message
 
 
 class RoleMixin(object):
@@ -558,7 +560,7 @@ class DocCLI(CLI, RoleMixin):
             try:
                 doc, plainexamples, returndocs, metadata = DocCLI._get_plugin_doc(plugin, plugin_type, loader, search_paths)
             except PluginNotFound as e:
-                display.warning("%s" % to_native(e))
+                display.warning(e.message)
                 continue
             except Exception as e:
                 display.vvv(traceback.format_exc())
@@ -732,9 +734,9 @@ class DocCLI(CLI, RoleMixin):
             if result.redirect_list and len(result.redirect_list) > 1:
                 # take the last one in the redirect list, we may have successfully jumped through N other redirects
                 target_module_name = result.redirect_list[-1]
-                raise PluginNotFound('%s %s was redirected to %s, which was not found in %s' % (
+                raise PluginNotFound('%s %s was redirected to %s, which was not found in: %s' % (
                     plugin_type, plugin, target_module_name, search_paths))
-            raise PluginNotFound('%s %s was not found in %s' % (plugin_type, plugin, search_paths))
+            raise PluginNotFound('%s %s was not found in: %s' % (plugin_type, plugin, search_paths))
         plugin_name = result.plugin_resolved_name
         filename = result.plugin_resolved_path
         collection_name = result.plugin_resolved_collection

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -310,12 +310,12 @@ class ModuleArgsParser:
                 context = action_loader.find_plugin_with_context(item, collection_list=self._collection_list)
                 if not context.resolved:
                     if context.redirect_list and len(context.redirect_list) > 1:
-                        bad_attempts.append((item, context.redirect_list[-1]))
+                        bad_attempts.append((item, context.redirect_list[1:]))
                     context = module_loader.find_plugin_with_context(item, collection_list=self._collection_list)
                     if context.resolved and context.redirect_list:
                         self.internal_redirect_list = context.redirect_list
                     if not context.resolved and context.redirect_list and len(context.redirect_list) > 1:
-                        bad_attempts.append((item, context.redirect_list[-1]))
+                        bad_attempts.append((item, context.redirect_list[1:]))
                 elif context.redirect_list:
                     self.internal_redirect_list = context.redirect_list
 
@@ -333,9 +333,11 @@ class ModuleArgsParser:
         if action is None:
             if non_task_ds:  # there was one non-task action, but we couldn't find it
                 if bad_attempts:
-                    bad_action, redirect = bad_attempts[0]
-                    raise AnsibleParserError("module/action '{0}' was redirected to '{1}', which could "
-                                             "not be loaded.".format(bad_action, redirect),
+                    bad_action, redirects = bad_attempts[0]
+                    raise AnsibleParserError("module/action '{0}' was redirected to {1}, which could "
+                                             "not be loaded.".format(
+                                                bad_action,
+                                                ' -> '.join(["'{0}'".format(redirect) for redirect in redirects])),
                                              obj=self._task_ds)
                 bad_action = list(non_task_ds.keys())[0]
                 raise AnsibleParserError("couldn't resolve module/action '{0}'. This often indicates a "

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -336,8 +336,8 @@ class ModuleArgsParser:
                     bad_action, redirects = bad_attempts[0]
                     raise AnsibleParserError("module/action '{0}' was redirected to {1}, which could "
                                              "not be loaded.".format(
-                                                bad_action,
-                                                ' -> '.join(["'{0}'".format(redirect) for redirect in redirects])),
+                                                 bad_action,
+                                                 ' -> '.join(["'{0}'".format(redirect) for redirect in redirects])),
                                              obj=self._task_ds)
                 bad_action = list(non_task_ds.keys())[0]
                 raise AnsibleParserError("couldn't resolve module/action '{0}'. This often indicates a "

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -978,7 +978,8 @@ class Templar:
         if instance is None:
             context = lookup_loader.find_plugin_with_context(name)
             if not context.resolved and context.redirect_list and len(context.redirect_list) > 1:
-                raise AnsibleError("lookup plugin '%s' was redirected to '%s', which could not be loaded" % (name, context.redirect_list[-1]))
+                redirections = ' -> '.join(["'%s'" % redirect for redirect in context.redirect_list[1:]])
+                raise AnsibleError("lookup plugin '%s' was redirected to %s, which could not be loaded" % (name, redirections))
             raise AnsibleError("lookup plugin (%s) not found" % name)
 
         wantlist = kwargs.pop('wantlist', False)

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -978,7 +978,7 @@ class Templar:
         if instance is None:
             context = lookup_loader.find_plugin_with_context(name)
             if not context.resolved and context.redirect_list and len(context.redirect_list) > 1:
-                raise AnsibleError("lookup plugin '%s' was redirected to '%s', which could not be loaded" % (name, context.redirect_list[0]))
+                raise AnsibleError("lookup plugin '%s' was redirected to '%s', which could not be loaded" % (name, context.redirect_list[-1]))
             raise AnsibleError("lookup plugin (%s) not found" % name)
 
         wantlist = kwargs.pop('wantlist', False)

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -976,6 +976,9 @@ class Templar:
         instance = lookup_loader.get(name, loader=self._loader, templar=self)
 
         if instance is None:
+            context = lookup_loader.find_plugin_with_context(name)
+            if not context.resolved and context.redirect_list and len(context.redirect_list) > 1:
+                raise AnsibleError("lookup plugin '%s' was redirected to '%s', which could not be loaded" % (name, context.redirect_list[0]))
             raise AnsibleError("lookup plugin (%s) not found" % name)
 
         wantlist = kwargs.pop('wantlist', False)

--- a/test/integration/targets/ansible-doc/test.yml
+++ b/test/integration/targets/ansible-doc/test.yml
@@ -60,7 +60,7 @@
       register: result
     - assert:
         that:
-          - '"[WARNING]: module test_does_not_exist not found in:" in result.stderr'
+          - '"[WARNING]: module test_does_not_exist was not found in:" in result.stderr'
 
     - name: documented module
       command: ansible-doc test_docs


### PR DESCRIPTION
##### SUMMARY
I've added a broken redirect `community.docker.docker_container` → `community.dockerx.docker_container` to investigate reports that the error messages are not helpful. The error message `ansible` produces is great. But `ansible-doc` and `ansible-playbook` are not helpful. This PR improves that a bit.

* ansible-doc now says
  ```
  [WARNING]: module docker_container was redirected to community.dockerx.docker_container, which was not found in XXX
  ```
  instead of
  ```
  [WARNING]: module docker_container not found in: XXX
  ```

* ansible-playbook now says
  ```
  ERROR! module/action 'docker_container' was redirected to 'community.dockerx.docker_container', which could not be loaded.
  ```
  instead of
  ```
  ERROR! couldn't resolve module/action 'docker_container'. This often indicates a misspelling, missing collection, or incorrect module path.
  ```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
core
