### PR TITLE
[stable-2.9]:Fix IOSXR integration test

### DIFF
--- a/changelogs/fragments/fix-iosxr-netconf-config-integration-testcase.yaml
+++ b/changelogs/fragments/fix-iosxr-netconf-config-integration-testcase.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - Fix iosxr netconf_config integration teastcase.
+    update assert statement with valid condition.
+

--- a/changelogs/fragments/fix-iosxr-netconf-config-integration-testcase.yaml
+++ b/changelogs/fragments/fix-iosxr-netconf-config-integration-testcase.yaml
@@ -1,4 +1,0 @@
----
-bugfixes:
-  - Fix iosxr netconf_config integration teastcase.
-    update assert statement with valid condition.

--- a/changelogs/fragments/fix-iosxr-netconf-config-integration-testcase.yaml
+++ b/changelogs/fragments/fix-iosxr-netconf-config-integration-testcase.yaml
@@ -2,4 +2,3 @@
 bugfixes:
   - Fix iosxr netconf_config integration teastcase.
     update assert statement with valid condition.
-

--- a/test/integration/targets/netconf_config/tests/iosxr/basic.yaml
+++ b/test/integration/targets/netconf_config/tests/iosxr/basic.yaml
@@ -29,6 +29,6 @@
 
 - assert:
     that:
-      - "'failed' not in result"
+      - "result.failed == false"
 
 - debug: msg="END netconf_config iosxr/basic.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix iosxr netconf_config testcase.
update valid assert condition.
Please refer netcommon collection PR(Backport changes):
https://github.com/ansible-collections/ansible.netcommon/pull/177

testcase in netcommon:
https://github.com/ansible-collections/ansible.netcommon/blob/main/tests/integration/targets/netconf_config/tests/iosxr/basic.yaml#L43
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
IOSXR, netconf_config
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
