### PR TITLE
Add config option to disable role argspec dep warning

### DIFF
--- a/changelogs/fragments/73626-role-argspec-dep-warn-config.yml
+++ b/changelogs/fragments/73626-role-argspec-dep-warn-config.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Adds a config option and env variable to control if the role arg spec dependency warning is emitted.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -2072,6 +2072,17 @@ STRING_CONVERSION_ACTION:
     - section: defaults
       key: string_conversion_action
   type: string
+VALIDATE_ROLE_WITH_DEPS_WARNING:
+  name: Validation of role with dependencies warning
+  default: True
+  description: Toggle to control showing warnings related to validating arg spec of role with dependencies.
+  env:
+    - name: ANSIBLE_VALIDATE_ROLE_WITH_DEPS_WARNING
+  ini:
+    - section: defaults
+      key: validate_role_with_deps_warning
+  type: bool
+  version_added: "2.11"
 VERBOSE_TO_STDERR:
   version_added: '2.8'
   description:

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -290,7 +290,8 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
         '''
         if self._metadata.argument_specs:
             if C.config.get_config_value('VALIDATE_ROLE_WITH_DEPS_WARNING') and self._dependencies:
-                display.warning("Dependent roles will run before roles with argument specs even if validation fails.")
+                display.warning("Role dependencies will run before the dependent role even if argument validation fails "
+                                "for the dependent role. To disable this warning, set VALIDATE_ROLE_WITH_DEPS_WARNING to False.")
 
             # Determine the role entry point so we can retrieve the correct argument spec.
             # This comes from the `tasks_from` value to include_role or import_role.

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -21,6 +21,7 @@ __metaclass__ = type
 
 import os
 
+from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleParserError, AnsibleAssertionError
 from ansible.module_utils._text import to_text
 from ansible.module_utils.six import iteritems, binary_type, text_type
@@ -288,7 +289,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
         :returns: The (possibly modified) task list.
         '''
         if self._metadata.argument_specs:
-            if self._dependencies:
+            if C.VALIDATE_ROLE_WITH_DEPS_WARNING and self._dependencies:
                 display.warning("Dependent roles will run before roles with argument specs even if validation fails.")
 
             # Determine the role entry point so we can retrieve the correct argument spec.

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -289,7 +289,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
         :returns: The (possibly modified) task list.
         '''
         if self._metadata.argument_specs:
-            if C.VALIDATE_ROLE_WITH_DEPS_WARNING and self._dependencies:
+            if C.config.get_config_value('VALIDATE_ROLE_WITH_DEPS_WARNING') and self._dependencies:
                 display.warning("Dependent roles will run before roles with argument specs even if validation fails.")
 
             # Determine the role entry point so we can retrieve the correct argument spec.


### PR DESCRIPTION
##### SUMMARY

This will disable the warning emitted when a role argument spec is going to be validated for a role
that has dependencies.

Also modify the warning text.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
