### PR TITLE
Backport of Split Ansible docs from core docs (#73616)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ docs/man/man3/*
 docs/docsite/_build
 docs/docsite/*.html
 docs/docsite/htmlout
+docs/docsite/rst/conf.py
+docs/docsite/rst/index.rst
 docs/docsite/rst/cli/ansible-*.rst
 docs/docsite/rst/cli/ansible.rst
 docs/docsite/rst/dev_guide/collections_galaxy_meta.rst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,8 @@ include requirements.txt
 recursive-include docs *
 include docs/docsite/rst/collections/all_plugins.rst
 exclude docs/docsite/rst_warnings
+exclude docs/docsite/rst/conf.py
+exclude docs/docsite/rst/index.rst
 recursive-exclude docs/docsite/_build *
 recursive-exclude docs/docsite/_extensions *.pyc *.pyo
 include examples/hosts

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 # useful targets:
 #   make clean ---------------- clean up
 #   make webdocs -------------- produce ansible doc at docs/docsite/_build/html
+#   make coredocs ------------- produce core doc at docs/docsite/_build/html
 #   make sdist ---------------- produce a tarball
 #   make deb-src -------------- produce a DEB source
 #   make deb ------------------ produce a DEB
@@ -267,6 +268,10 @@ epub:
 .PHONY: webdocs
 webdocs:
 	(cd docs/docsite/; CPUS=$(CPUS) $(MAKE) docs)
+
+.PHONY: coredocs
+coredocs:
+	(cd docs/docsite/; CPUS=$(CPUS) $(MAKE) coredocs)
 
 .PHONY: linkcheckdocs
 linkcheckdocs:

--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -31,6 +31,10 @@ ifdef PLUGINS
 endif
 endif
 
+ANSIBLE_VERSION_ARGS=
+ifdef ANSIBLE_VERSION
+	ANSIBLE_VERSION_ARGS=--ansible-version=$(ANSIBLE_VERSION)
+endif
 
 DOC_PLUGINS ?= become cache callback cliconf connection httpapi inventory lookup netconf shell strategy vars
 
@@ -39,6 +43,11 @@ PYTHON=python
 VERSION := $(shell $(PYTHON) ../../packaging/release/versionhelper/version_helper.py --raw || echo error)
 ifeq ($(findstring error,$(VERSION)), error)
 $(error "version_helper failed")
+endif
+
+MAJOR_VERSION := $(shell $(PYTHON) ../../packaging/release/versionhelper/version_helper.py --majorversion || echo error)
+ifeq ($(findstring error,$(MAJOR_VERSION)), error)
+$(error "version_helper failed to determine major version")
 endif
 
 assertrst:
@@ -50,23 +59,47 @@ all: docs
 
 docs: htmldocs
 
+coredocs: core_htmldocs
+
 generate_rst: collections_meta config cli keywords plugins testing
-base_generate_rst: collections_meta config cli keywords base_plugins testing
+core_generate_rst: collections_meta config cli keywords base_plugins testing
 
-htmldocs: generate_rst
+# The following two symlinks are necessary to produce two different docsets
+# from the same set of rst files (Ansible the package docs, and core docs).
+# Symlink the relevant index into place for building Ansible docs
+ansible_structure: generate_rst
+	# We must have python and python-packaging for the version_helper
+	# script so use it for version comparison
+	if python -c "import sys, packaging.version as p; sys.exit(not p.Version('$(MAJOR_VERSION)') >  p.Version('2.10'))" ; then \
+		echo "Creating symlinks in generate_rst"; \
+		ln -sf ../rst/ansible_index.rst rst/index.rst; \
+		ln -sf ../sphinx_conf/ansible_conf.py rst/conf.py; \
+	else \
+		echo 'Creating symlinks for older ansible in generate_rst'; \
+		ln -sf ../rst/2.10_index.rst rst/index.rst; \
+		ln -sf ../sphinx_conf/2.10_conf.py rst/conf.py; \
+	fi
+
+# Symlink the relevant index into place for building core docs
+core_structure: core_generate_rst
+	@echo "Creating symlinks in core_generate_rst"
+	-ln -sf ../rst/core_index.rst rst/index.rst
+	-ln -sf ../sphinx_conf/core_conf.py rst/conf.py
+
+htmldocs: ansible_structure
 	CPUS=$(CPUS) $(MAKE) -f Makefile.sphinx html
 
-base_htmldocs: base_generate_rst
+core_htmldocs: core_structure
 	CPUS=$(CPUS) $(MAKE) -f Makefile.sphinx html
 
-singlehtmldocs: generate_rst
+singlehtmldocs: ansible_structure
 	CPUS=$(CPUS) $(MAKE) -f Makefile.sphinx singlehtml
 
-base_singlehtmldocs: base_generate_rst
+core_singlehtmldocs: core_structure
 	CPUS=$(CPUS) $(MAKE) -f Makefile.sphinx singlehtml
 
 linkcheckdocs: generate_rst
-		CPUS=$(CPUS) $(MAKE) -f Makefile.sphinx linkcheck
+	CPUS=$(CPUS) $(MAKE) -f Makefile.sphinx linkcheck
 
 webdocs: docs
 
@@ -99,6 +132,8 @@ clean:
 			rm -rf "rst/collections/$$filename"; \
 		fi \
 	done
+	@echo "Cleanning up generated ansible_structure"
+	find -type l -delete
 	@echo "Cleaning up legacy generated rst locations"
 	rm -rf rst/modules
 	rm -f rst/plugins/*/*.rst
@@ -122,11 +157,7 @@ config: ../templates/config.rst.j2
 # For now, if we're building on devel, just build base docs.  In the future we'll want to build docs that
 # are the latest versions on galaxy (using a different antsibull-docs subcommand)
 plugins:
-	if expr "$(VERSION)" : '.*[.]dev[0-9]\{1,\}$$' &> /dev/null; then \
-		$(PLUGIN_FORMATTER) base -o rst $(PLUGIN_ARGS);\
-	else \
-		$(PLUGIN_FORMATTER) full -o rst $(PLUGIN_ARGS);\
-	fi
+	$(PLUGIN_FORMATTER) full -o rst $(ANSIBLE_VERSION_ARGS) $(PLUGIN_ARGS);\
 
 # This only builds the plugin docs included with ansible-base
 base_plugins:

--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -35,10 +35,12 @@ PYTHON=python
 MAJOR_VERSION := $(shell $(PYTHON) ../../packaging/release/versionhelper/version_helper.py --majorversion || echo error)
 
 ANSIBLE_VERSION_ARGS=
+ifndef ANSIBLE_VERSION
+  # Only needed to make stable-2.10 docs build correctly.  Do not apply to devel and future branches
+  ANSIBLE_VERSION=$(MAJOR_VERSION)
+endif
 ifdef ANSIBLE_VERSION
 	ANSIBLE_VERSION_ARGS=--ansible-version=$(ANSIBLE_VERSION)
-else
-  ANSIBLE_VERSION=$(MAJOR_VERSION)
 endif
 
 DOC_PLUGINS ?= become cache callback cliconf connection httpapi inventory lookup netconf shell strategy vars

--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -31,21 +31,24 @@ ifdef PLUGINS
 endif
 endif
 
+PYTHON=python
+MAJOR_VERSION := $(shell $(PYTHON) ../../packaging/release/versionhelper/version_helper.py --majorversion || echo error)
+
 ANSIBLE_VERSION_ARGS=
 ifdef ANSIBLE_VERSION
 	ANSIBLE_VERSION_ARGS=--ansible-version=$(ANSIBLE_VERSION)
+else
+  ANSIBLE_VERSION=$(MAJOR_VERSION)
 endif
 
 DOC_PLUGINS ?= become cache callback cliconf connection httpapi inventory lookup netconf shell strategy vars
 
-PYTHON=python
 # fetch version from project release.py as single source-of-truth
 VERSION := $(shell $(PYTHON) ../../packaging/release/versionhelper/version_helper.py --raw || echo error)
 ifeq ($(findstring error,$(VERSION)), error)
 $(error "version_helper failed")
 endif
 
-MAJOR_VERSION := $(shell $(PYTHON) ../../packaging/release/versionhelper/version_helper.py --majorversion || echo error)
 ifeq ($(findstring error,$(MAJOR_VERSION)), error)
 $(error "version_helper failed to determine major version")
 endif
@@ -70,7 +73,7 @@ core_generate_rst: collections_meta config cli keywords base_plugins testing
 ansible_structure: generate_rst
 	# We must have python and python-packaging for the version_helper
 	# script so use it for version comparison
-	if python -c "import sys, packaging.version as p; sys.exit(not p.Version('$(MAJOR_VERSION)') >  p.Version('2.10'))" ; then \
+	if python -c "import sys, packaging.version as p; sys.exit(not p.Version('$(ANSIBLE_VERSION)') >  p.Version('2.10'))" ; then \
 		echo "Creating symlinks in generate_rst"; \
 		ln -sf ../rst/ansible_index.rst rst/index.rst; \
 		ln -sf ../sphinx_conf/ansible_conf.py rst/conf.py; \

--- a/docs/docsite/Makefile.sphinx
+++ b/docs/docsite/Makefile.sphinx
@@ -2,7 +2,8 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -j $(CPUS) -n -w rst_warnings
+SPHINXCONFDIR = rst
+SPHINXOPTS    = -j $(CPUS) -n -w rst_warnings -c "$(SPHINXCONFDIR)"
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = sdfsdf
 SOURCEDIR     = rst

--- a/docs/docsite/rst/2.10_index.rst
+++ b/docs/docsite/rst/2.10_index.rst
@@ -1,0 +1,106 @@
+.. _ansible_documentation:
+
+Ansible Documentation
+=====================
+
+About Ansible
+`````````````
+
+Ansible is an IT automation tool.  It can configure systems, deploy software, and orchestrate more advanced IT tasks such as continuous deployments or zero downtime rolling updates.
+
+Ansible's main goals are simplicity and ease-of-use. It also has a strong focus on security and reliability, featuring a minimum of moving parts, usage of OpenSSH for transport (with other transports and pull modes as alternatives), and a language that is designed around auditability by humans--even those not familiar with the program.
+
+We believe simplicity is relevant to all sizes of environments, so we design for busy users of all types: developers, sysadmins, release engineers, IT managers, and everyone in between. Ansible is appropriate for managing all environments, from small setups with a handful of instances to enterprise environments with many thousands of instances.
+
+You can learn more at `AnsibleFest <https://www.ansible.com/ansiblefest>`_, the annual event for all Ansible contributors, users, and customers hosted by Red Hat. AnsibleFest is the place to connect with others, learn new skills, and find a new friend to automate with.
+
+Ansible manages machines in an agent-less manner. There is never a question of how to upgrade remote daemons or the problem of not being able to manage systems because daemons are uninstalled.  Because OpenSSH is one of the most peer-reviewed open source components, security exposure is greatly reduced. Ansible is decentralized--it relies on your existing OS credentials to control access to remote machines. If needed, Ansible can easily connect with Kerberos, LDAP, and other centralized authentication management systems.
+
+This documentation covers the version of Ansible noted in the upper left corner of this page. We maintain multiple versions of Ansible and of the documentation, so please be sure you are using the version of the documentation that covers the version of Ansible you're using. For recent features, we note the version of Ansible where the feature was added.
+
+Ansible releases a new major release approximately twice a year. The core application evolves somewhat conservatively, valuing simplicity in language design and setup. Contributors develop and change modules and plugins, hosted in collections since version 2.10, much more quickly.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Installation, Upgrade & Configuration
+
+   installation_guide/index
+   porting_guides/porting_guides
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Using Ansible
+
+   user_guide/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contributing to Ansible
+
+   community/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Extending Ansible
+
+   dev_guide/index
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+   :caption: Common Ansible Scenarios
+
+   scenario_guides/cloud_guides
+   scenario_guides/network_guides
+   scenario_guides/virt_guides
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Network Automation
+
+   network/getting_started/index
+   network/user_guide/index
+   network/dev_guide/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Ansible Galaxy
+
+   galaxy/user_guide.rst
+   galaxy/dev_guide.rst
+
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Reference & Appendices
+
+   collections/index
+   collections/all_plugins
+   reference_appendices/playbooks_keywords
+   reference_appendices/common_return_values
+   reference_appendices/config
+   reference_appendices/general_precedence
+   reference_appendices/YAMLSyntax
+   reference_appendices/python_3_support
+   reference_appendices/interpreter_discovery
+   reference_appendices/release_and_maintenance
+   reference_appendices/test_strategies
+   dev_guide/testing/sanity/index
+   reference_appendices/faq
+   reference_appendices/glossary
+   reference_appendices/module_utils
+   reference_appendices/special_variables
+   reference_appendices/tower
+   reference_appendices/automationhub
+   reference_appendices/logging
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Release Notes
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Roadmaps
+
+   roadmap/index.rst

--- a/docs/docsite/rst/ansible_index.rst
+++ b/docs/docsite/rst/ansible_index.rst
@@ -1,0 +1,104 @@
+.. _ansible_documentation:
+..
+   This is the index file for Ansible the package. It gets symlinked to index.rst by the Makefile
+
+Ansible Documentation
+=====================
+
+About Ansible
+`````````````
+
+Ansible is an IT automation tool.  It can configure systems, deploy software, and orchestrate more advanced IT tasks such as continuous deployments or zero downtime rolling updates.
+
+Ansible's main goals are simplicity and ease-of-use. It also has a strong focus on security and reliability, featuring a minimum of moving parts, usage of OpenSSH for transport (with other transports and pull modes as alternatives), and a language that is designed around auditability by humans--even those not familiar with the program.
+
+We believe simplicity is relevant to all sizes of environments, so we design for busy users of all types: developers, sysadmins, release engineers, IT managers, and everyone in between. Ansible is appropriate for managing all environments, from small setups with a handful of instances to enterprise environments with many thousands of instances.
+
+You can learn more at `AnsibleFest <https://www.ansible.com/ansiblefest>`_, the annual event for all Ansible contributors, users, and customers hosted by Red Hat. AnsibleFest is the place to connect with others, learn new skills, and find a new friend to automate with.
+
+Ansible manages machines in an agent-less manner. There is never a question of how to upgrade remote daemons or the problem of not being able to manage systems because daemons are uninstalled.  Because OpenSSH is one of the most peer-reviewed open source components, security exposure is greatly reduced. Ansible is decentralized--it relies on your existing OS credentials to control access to remote machines. If needed, Ansible can easily connect with Kerberos, LDAP, and other centralized authentication management systems.
+
+This documentation covers the version of Ansible noted in the upper left corner of this page. We maintain multiple versions of Ansible and of the documentation, so please be sure you are using the version of the documentation that covers the version of Ansible you're using. For recent features, we note the version of Ansible where the feature was added.
+
+Ansible releases a new major release approximately twice a year. The core application evolves somewhat conservatively, valuing simplicity in language design and setup. Contributors develop and change modules and plugins, hosted in collections since version 2.10, much more quickly.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Installation, Upgrade & Configuration
+
+   installation_guide/index
+   porting_guides/porting_guides
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Using Ansible
+
+   user_guide/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contributing to Ansible
+
+   community/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Extending Ansible
+
+   dev_guide/index
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+   :caption: Common Ansible Scenarios
+
+   scenario_guides/cloud_guides
+   scenario_guides/network_guides
+   scenario_guides/virt_guides
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Network Automation
+
+   network/getting_started/index
+   network/user_guide/index
+   network/dev_guide/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Ansible Galaxy
+
+   galaxy/user_guide.rst
+   galaxy/dev_guide.rst
+
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Reference & Appendices
+
+   collections/index
+   collections/all_plugins
+   reference_appendices/playbooks_keywords
+   reference_appendices/common_return_values
+   reference_appendices/config
+   reference_appendices/general_precedence
+   reference_appendices/YAMLSyntax
+   reference_appendices/python_3_support
+   reference_appendices/interpreter_discovery
+   reference_appendices/release_and_maintenance
+   reference_appendices/test_strategies
+   dev_guide/testing/sanity/index
+   reference_appendices/faq
+   reference_appendices/glossary
+   reference_appendices/module_utils
+   reference_appendices/special_variables
+   reference_appendices/tower
+   reference_appendices/automationhub
+   reference_appendices/logging
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Roadmaps
+
+   roadmap/ansible_roadmap_index.rst

--- a/docs/docsite/rst/core_index.rst
+++ b/docs/docsite/rst/core_index.rst
@@ -1,10 +1,14 @@
-.. _ansible_documentation:
+.. _ansible_core_documentation:
 
-Ansible Documentation
-=====================
+..
+   This is the index file for ansible-core. It gets symlinked to index.rst by the Makefile
 
-About Ansible
-`````````````
+**************************
+Ansible Core Documentation
+**************************
+
+About ansible-core
+===================
 
 Ansible is an IT automation tool.  It can configure systems, deploy software, and orchestrate more advanced IT tasks such as continuous deployments or zero downtime rolling updates.
 
@@ -18,24 +22,27 @@ Ansible manages machines in an agent-less manner. There is never a question of h
 
 This documentation covers the version of Ansible noted in the upper left corner of this page. We maintain multiple versions of Ansible and of the documentation, so please be sure you are using the version of the documentation that covers the version of Ansible you're using. For recent features, we note the version of Ansible where the feature was added.
 
-Ansible releases a new major release of Ansible approximately three to four times per year. The core application evolves somewhat conservatively, valuing simplicity in language design and setup. Contributors develop and change modules and plugins, hosted in collections since version 2.10, much more quickly.
+
+``ansible-core`` releases a new major release approximately twice a year. The core application evolves somewhat conservatively, valuing simplicity in language design and setup. Contributors develop and change modules and plugins, hosted in collections since version 2.10, much more quickly.
+
+
 
 .. toctree::
    :maxdepth: 2
    :caption: Installation, Upgrade & Configuration
 
    installation_guide/index
-   porting_guides/porting_guides
+   porting_guides/core_porting_guides
 
 .. toctree::
    :maxdepth: 2
-   :caption: Using Ansible
+   :caption: Using Ansible Core
 
    user_guide/index
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contributing to Ansible
+   :caption: Contributing to Ansible Core
 
    community/index
 
@@ -44,30 +51,6 @@ Ansible releases a new major release of Ansible approximately three to four time
    :caption: Extending Ansible
 
    dev_guide/index
-
-.. toctree::
-   :glob:
-   :maxdepth: 1
-   :caption: Common Ansible Scenarios
-
-   scenario_guides/cloud_guides
-   scenario_guides/network_guides
-   scenario_guides/virt_guides
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Network Automation
-
-   network/getting_started/index
-   network/user_guide/index
-   network/dev_guide/index
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Ansible Galaxy
-
-   galaxy/user_guide.rst
-   galaxy/dev_guide.rst
 
 
 .. toctree::
@@ -94,13 +77,8 @@ Ansible releases a new major release of Ansible approximately three to four time
    reference_appendices/automationhub
    reference_appendices/logging
 
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Release Notes
-
 .. toctree::
    :maxdepth: 2
    :caption: Roadmaps
 
-   roadmap/index.rst
+   roadmap/ansible_base_roadmap_index.rst

--- a/docs/docsite/rst/porting_guides/core_porting_guides.rst
+++ b/docs/docsite/rst/porting_guides/core_porting_guides.rst
@@ -1,0 +1,16 @@
+.. _core_porting_guides:
+
+***************************
+Ansible Core Porting Guides
+***************************
+
+This section lists porting guides that can help you in updating playbooks, plugins and other parts of your Ansible infrastructure from one version of ``ansible-core`` to the next.
+
+Please note that this is not a complete list. If you believe any extra information would be useful in these pages, you can edit by clicking `Edit on GitHub` on the top right, or raising an issue.
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   porting_guide_core_2.11
+   porting_guide_base_2.10

--- a/docs/docsite/rst/porting_guides/core_porting_guides.rst
+++ b/docs/docsite/rst/porting_guides/core_porting_guides.rst
@@ -12,5 +12,4 @@ Please note that this is not a complete list. If you believe any extra informati
    :maxdepth: 1
    :glob:
 
-   porting_guide_core_2.11
    porting_guide_base_2.10

--- a/docs/docsite/rst/roadmap/ansible_base_roadmap_index.rst
+++ b/docs/docsite/rst/roadmap/ansible_base_roadmap_index.rst
@@ -1,15 +1,19 @@
-.. _ansible_base_roadmaps:
+.. _ansible_core_roadmaps:
 
-ansible-base Roadmap
+ansible-core Roadmaps
 =====================
 
-The ``ansible-base`` team develops a roadmap for each major and minor ``ansible-base`` release. The latest roadmap shows current work; older roadmaps provide a history of the project. We don't publish roadmaps for subminor versions. So 2.10 and 2.11 have roadmaps, but 2.10.1 does not.
+The ``ansible-core`` team develops a roadmap for each major and minor ``ansible-core`` release. The latest roadmap shows current work; older roadmaps provide a history of the project. We don't publish roadmaps for subminor versions. So 2.10 and 2.11 have roadmaps, but 2.10.1 does not.
+
+.. note::
+
+	Ansible renamed ``ansible-base`` to ``ansible-core``.
 
 We incorporate team and community feedback in each roadmap, and aim for further transparency and better inclusion of both community desires and submissions.
 
-Each roadmap offers a *best guess*, based on the ``ansible-base`` team's experience and on requests and feedback from the community, of what will be included in a given release. However, some items on the roadmap may be dropped due to time constraints, lack of community maintainers, and so on.
+Each roadmap offers a *best guess*, based on the ``ansible-core`` team's experience and on requests and feedback from the community, of what will be included in a given release. However, some items on the roadmap may be dropped due to time constraints, lack of community maintainers, and so on.
 
-Each roadmap is published both as an idea of what is upcoming in ``ansible-base``, and as a medium for seeking further feedback from the community.
+Each roadmap is published both as an idea of what is upcoming in ``ansible-core``, and as a medium for seeking further feedback from the community.
 
 You can submit feedback on the current roadmap in multiple ways:
 
@@ -22,6 +26,6 @@ See :ref:`Ansible communication channels <communication>` for details on how to 
 .. toctree::
    :maxdepth: 1
    :glob:
-   :caption: ansible-base Roadmaps
+   :caption: ansible-core Roadmaps
 
    ROADMAP_2_10

--- a/docs/docsite/sphinx_conf/2.10_conf.py
+++ b/docs/docsite/sphinx_conf/2.10_conf.py
@@ -13,6 +13,9 @@
 # All configuration values have a default value; values that are commented out
 # serve to show the default value.
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import sys
 import os
 

--- a/docs/docsite/sphinx_conf/2.10_conf.py
+++ b/docs/docsite/sphinx_conf/2.10_conf.py
@@ -1,0 +1,297 @@
+# -*- coding: utf-8 -*-
+#
+# documentation build configuration file, created by
+# sphinx-quickstart on Sat Sep 27 13:23:22 2008-2009.
+#
+# This file is execfile()d with the current directory set to its
+# containing dir.
+#
+# The contents of this file are pickled, so don't put values in the namespace
+# that aren't pickleable (module imports are okay, they're removed
+# automatically).
+#
+# All configuration values have a default value; values that are commented out
+# serve to show the default value.
+
+import sys
+import os
+
+# pip install sphinx_rtd_theme
+# import sphinx_rtd_theme
+# html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+# If your extensions are in another directory, add it here. If the directory
+# is relative to the documentation root, use os.path.abspath to make it
+# absolute, like shown here.
+# sys.path.append(os.path.abspath('some/directory'))
+#
+sys.path.insert(0, os.path.join('ansible', 'lib'))
+sys.path.append(os.path.abspath(os.path.join('..', '_extensions')))
+
+# We want sphinx to document the ansible modules contained in this repository,
+# not those that may happen to be installed in the version
+# of Python used to run sphinx.  When sphinx loads in order to document,
+# the repository version needs to be the one that is loaded:
+sys.path.insert(0, os.path.abspath(os.path.join('..', '..', '..', 'lib')))
+
+VERSION = '2.10'
+AUTHOR = 'Ansible, Inc'
+
+
+# General configuration
+# ---------------------
+
+# Add any Sphinx extension module names here, as strings.
+# They can be extensions
+# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+# TEST: 'sphinxcontrib.fulltoc'
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'pygments_lexer', 'notfound.extension']
+
+# Later on, add 'sphinx.ext.viewcode' to the list if you want to have
+# colorized code generated too for references.
+
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['.templates']
+
+# The suffix of source filenames.
+source_suffix = '.rst'
+
+# The master toctree document.
+master_doc = 'index'
+
+# General substitutions.
+project = 'Ansible'
+copyright = "2021 Red Hat, Inc."
+
+# The default replacements for |version| and |release|, also used in various
+# other places throughout the built documents.
+#
+# The short X.Y version.
+version = VERSION
+# The full version, including alpha/beta/rc tags.
+release = VERSION
+
+# There are two options for replacing |today|: either, you set today to some
+# non-false value, then it is used:
+# today = ''
+# Else, today_fmt is used as the format for a strftime call.
+today_fmt = '%B %d, %Y'
+
+# List of documents that shouldn't be included in the build.
+# unused_docs = []
+
+# List of directories, relative to source directories, that shouldn't be
+# searched for source files.
+# exclude_dirs = []
+
+# A list of glob-style patterns that should be excluded when looking
+# for source files.
+exclude_patterns = [
+    '2.10_index.rst',
+    'ansible_index.rst',
+    'core_index.rst',
+    'porting_guides/core_porting_guides',
+]
+
+# The reST default role (used for this markup: `text`) to use for all
+# documents.
+# default_role = None
+
+# If true, '()' will be appended to :func: etc. cross-reference text.
+# add_function_parentheses = True
+
+# If true, the current module name will be prepended to all description
+# unit titles (such as .. function::).
+# add_module_names = True
+
+# If true, sectionauthor and moduleauthor directives will be shown in the
+# output. They are ignored by default.
+# show_authors = False
+
+# The name of the Pygments (syntax highlighting) style to use.
+pygments_style = 'sphinx'
+
+highlight_language = 'YAML+Jinja'
+
+# Substitutions, variables, entities, & shortcuts for text which do not need to link to anything.
+# For titles which should be a link, use the intersphinx anchors set at the index, chapter, and section levels, such as  qi_start_:
+# |br| is useful for formatting fields inside of tables
+# |_| is a nonbreaking space; similarly useful inside of tables
+rst_epilog = """
+.. |br| raw:: html
+
+   <br>
+.. |_| unicode:: 0xA0
+    :trim:
+"""
+
+
+# Options for HTML output
+# -----------------------
+
+html_theme_path = ['../_themes']
+html_theme = 'sphinx_rtd_theme'
+html_short_title = 'Ansible Documentation'
+html_show_sphinx = False
+
+html_theme_options = {
+    'canonical_url': "https://docs.ansible.com/ansible/latest/",
+    'vcs_pageview_mode': 'edit'
+}
+
+html_context = {
+    'display_github': 'True',
+    'github_user': 'ansible',
+    'github_repo': 'ansible',
+    'github_version': 'devel/docs/docsite/rst/',
+    'github_module_version': 'devel/lib/ansible/modules/',
+    'github_root_dir': 'devel/lib/ansible',
+    'github_cli_version': 'devel/lib/ansible/cli/',
+    'current_version': version,
+    'latest_version': '2.10',
+    # list specifically out of order to make latest work
+    'available_versions': ('latest', '2.9', '2.9_ja', '2.8', 'devel'),
+    'css_files': ('_static/ansible.css',  # overrides to the standard theme
+                  ),
+}
+
+# The style sheet to use for HTML and HTML Help pages. A file of that name
+# must exist either in Sphinx' static/ path, or in one of the custom paths
+# given in html_static_path.
+# html_style = 'solar.css'
+
+# The name for this set of Sphinx documents.  If None, it defaults to
+# "<project> v<release> documentation".
+html_title = 'Ansible Documentation'
+
+# A shorter title for the navigation bar.  Default is the same as html_title.
+# html_short_title = None
+
+# The name of an image file (within the static path) to place at the top of
+# the sidebar.
+# html_logo =
+
+# The name of an image file (within the static path) to use as favicon of the
+# docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
+# pixels large.
+# html_favicon = 'favicon.ico'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['../_static']
+
+# If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
+# using the given strftime format.
+html_last_updated_fmt = '%b %d, %Y'
+
+# If true, SmartyPants will be used to convert quotes and dashes to
+# typographically correct entities.
+# html_use_smartypants = True
+
+# Custom sidebar templates, maps document names to template names.
+# html_sidebars = {}
+
+# Additional templates that should be rendered to pages, maps page names to
+# template names.
+# html_additional_pages = {}
+
+# If false, no module index is generated.
+# html_use_modindex = True
+
+# If false, no index is generated.
+# html_use_index = True
+
+# If true, the index is split into individual pages for each letter.
+# html_split_index = False
+
+# If true, the reST sources are included in the HTML build as _sources/<name>.
+html_copy_source = False
+
+# If true, an OpenSearch description file will be output, and all pages will
+# contain a <link> tag referring to it.  The value of this option must be the
+# base URL from which the finished HTML is served.
+# html_use_opensearch = 'https://docs.ansible.com/ansible/latest'
+
+# If nonempty, this is the file name suffix for HTML files (e.g. ".xhtml").
+# html_file_suffix = ''
+
+# Output file base name for HTML help builder.
+htmlhelp_basename = 'Poseidodoc'
+
+# Configuration for sphinx-notfound-pages
+# with no 'notfound_template' and no 'notfound_context' set,
+# the extension builds 404.rst into a location-agnostic 404 page
+#
+# default is `en` - using this for the sub-site:
+notfound_default_language = "ansible"
+# default is `latest`:
+# setting explicitly - docsite serves up /ansible/latest/404.html
+# so keep this set to `latest` even on the `devel` branch
+# then no maintenance is needed when we branch a new stable_x.x
+notfound_default_version = "latest"
+# makes default setting explicit:
+notfound_no_urls_prefix = False
+
+# Options for LaTeX output
+# ------------------------
+
+# The paper size ('letter' or 'a4').
+# latex_paper_size = 'letter'
+
+# The font size ('10pt', '11pt' or '12pt').
+# latex_font_size = '10pt'
+
+# Grouping the document tree into LaTeX files. List of tuples
+# (source start file, target name, title, author, document class
+# [howto/manual]).
+latex_documents = [
+    ('index', 'ansible.tex', 'Ansible 2.2 Documentation', AUTHOR, 'manual'),
+]
+
+# The name of an image file (relative to this directory) to place at the top of
+# the title page.
+# latex_logo = None
+
+# For "manual" documents, if this is true, then toplevel headings are parts,
+# not chapters.
+# latex_use_parts = False
+
+# Additional stuff for the LaTeX preamble.
+# latex_preamble = ''
+
+# Documents to append as an appendix to all manuals.
+# latex_appendices = []
+
+# If false, no module index is generated.
+# latex_use_modindex = True
+
+autoclass_content = 'both'
+
+# Note:  Our strategy for intersphinx mappings is to have the upstream build location as the
+# canonical source and then cached copies of the mapping stored locally in case someone is building
+# when disconnected from the internet.  We then have a script to update the cached copies.
+#
+# Because of that, each entry in this mapping should have this format:
+#   name: ('http://UPSTREAM_URL', (None, 'path/to/local/cache.inv'))
+#
+# The update script depends on this format so deviating from this (for instance, adding a third
+# location for the mappning to live) will confuse it.
+intersphinx_mapping = {'python': ('https://docs.python.org/2/', (None, '../python2.inv')),
+                       'python3': ('https://docs.python.org/3/', (None, '../python3.inv')),
+                       'jinja2': ('http://jinja.palletsprojects.com/', (None, '../jinja2.inv')),
+                       'ansible_2_10': ('https://docs.ansible.com/ansible/2.10/', (None, '../ansible_2_10.inv')),
+                       'ansible_2_9': ('https://docs.ansible.com/ansible/2.9/', (None, '../ansible_2_9.inv')),
+                       'ansible_2_8': ('https://docs.ansible.com/ansible/2.8/', (None, '../ansible_2_8.inv')),
+                       'ansible_2_7': ('https://docs.ansible.com/ansible/2.7/', (None, '../ansible_2_7.inv')),
+                       'ansible_2_6': ('https://docs.ansible.com/ansible/2.6/', (None, '../ansible_2_6.inv')),
+                       'ansible_2_5': ('https://docs.ansible.com/ansible/2.5/', (None, '../ansible_2_5.inv')),
+                       }
+
+# linckchecker settings
+linkcheck_ignore = [
+    r'http://irc\.freenode\.net',
+]
+linkcheck_workers = 25
+# linkcheck_anchors = False

--- a/docs/docsite/sphinx_conf/2.10_conf.py
+++ b/docs/docsite/sphinx_conf/2.10_conf.py
@@ -152,9 +152,9 @@ html_context = {
     'github_root_dir': 'devel/lib/ansible',
     'github_cli_version': 'devel/lib/ansible/cli/',
     'current_version': version,
-    'latest_version': '2.10',
+    'latest_version': '3',
     # list specifically out of order to make latest work
-    'available_versions': ('latest', '2.9', '2.9_ja', '2.8', 'devel'),
+    'available_versions': ('latest', '2.10', '2.9', '2.9_ja', '2.8', 'devel'),
     'css_files': ('_static/ansible.css',  # overrides to the standard theme
                   ),
 }

--- a/docs/docsite/sphinx_conf/ansible_conf.py
+++ b/docs/docsite/sphinx_conf/ansible_conf.py
@@ -1,0 +1,306 @@
+# -*- coding: utf-8 -*-
+#
+# documentation build configuration file, created by
+# sphinx-quickstart on Sat Sep 27 13:23:22 2008-2009.
+#
+# This file is execfile()d with the current directory set to its
+# containing dir.
+#
+# The contents of this file are pickled, so don't put values in the namespace
+# that aren't pickleable (module imports are okay, they're removed
+# automatically).
+#
+# All configuration values have a default value; values that are commented out
+# serve to show the default value.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import sys
+import os
+
+# pip install sphinx_rtd_theme
+# import sphinx_rtd_theme
+# html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+# If your extensions are in another directory, add it here. If the directory
+# is relative to the documentation root, use os.path.abspath to make it
+# absolute, like shown here.
+# sys.path.append(os.path.abspath('some/directory'))
+#
+sys.path.insert(0, os.path.join('ansible', 'lib'))
+sys.path.append(os.path.abspath(os.path.join('..', '_extensions')))
+
+# We want sphinx to document the ansible modules contained in this repository,
+# not those that may happen to be installed in the version
+# of Python used to run sphinx.  When sphinx loads in order to document,
+# the repository version needs to be the one that is loaded:
+sys.path.insert(0, os.path.abspath(os.path.join('..', '..', '..', 'lib')))
+
+VERSION = 'devel'
+AUTHOR = 'Ansible, Inc'
+
+
+# General configuration
+# ---------------------
+
+# Add any Sphinx extension module names here, as strings.
+# They can be extensions
+# coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
+# TEST: 'sphinxcontrib.fulltoc'
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'pygments_lexer', 'notfound.extension']
+
+# Later on, add 'sphinx.ext.viewcode' to the list if you want to have
+# colorized code generated too for references.
+
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['.templates']
+
+# The suffix of source filenames.
+source_suffix = '.rst'
+
+# The master toctree document.
+master_doc = 'index'
+
+# General substitutions.
+project = 'Ansible'
+copyright = "2021 Red Hat, Inc."
+
+# The default replacements for |version| and |release|, also used in various
+# other places throughout the built documents.
+#
+# The short X.Y version.
+version = VERSION
+# The full version, including alpha/beta/rc tags.
+release = VERSION
+
+# There are two options for replacing |today|: either, you set today to some
+# non-false value, then it is used:
+# today = ''
+# Else, today_fmt is used as the format for a strftime call.
+today_fmt = '%B %d, %Y'
+
+# List of documents that shouldn't be included in the build.
+# unused_docs = []
+
+# List of directories, relative to source directories, that shouldn't be
+# searched for source files.
+# exclude_dirs = []
+
+# A list of glob-style patterns that should be excluded when looking
+# for source files.
+exclude_patterns = [
+    '2.10_index.rst',
+    'ansible_index.rst',
+    'core_index.rst',
+    'porting_guides/core_porting_guides.rst',
+    'porting_guides/porting_guide_base_2.10.rst',
+    'porting_guides/porting_guide_core_2.11.rst',
+    'roadmap/index.rst',
+    'roadmap/ansible_base_roadmap_index.rst',
+    'roadmap/ROADMAP_2_10.rst',
+    'roadmap/ROADMAP_2_11.rst'
+]
+
+# The reST default role (used for this markup: `text`) to use for all
+# documents.
+# default_role = None
+
+# If true, '()' will be appended to :func: etc. cross-reference text.
+# add_function_parentheses = True
+
+# If true, the current module name will be prepended to all description
+# unit titles (such as .. function::).
+# add_module_names = True
+
+# If true, sectionauthor and moduleauthor directives will be shown in the
+# output. They are ignored by default.
+# show_authors = False
+
+# The name of the Pygments (syntax highlighting) style to use.
+pygments_style = 'sphinx'
+
+highlight_language = 'YAML+Jinja'
+
+# Substitutions, variables, entities, & shortcuts for text which do not need to link to anything.
+# For titles which should be a link, use the intersphinx anchors set at the index, chapter, and section levels, such as  qi_start_:
+# |br| is useful for formatting fields inside of tables
+# |_| is a nonbreaking space; similarly useful inside of tables
+rst_epilog = """
+.. |br| raw:: html
+
+   <br>
+.. |_| unicode:: 0xA0
+    :trim:
+"""
+
+
+# Options for HTML output
+# -----------------------
+
+html_theme_path = ['../_themes']
+html_theme = 'sphinx_rtd_theme'
+html_short_title = 'Ansible Documentation'
+html_show_sphinx = False
+
+html_theme_options = {
+    'canonical_url': "https://docs.ansible.com/ansible/latest/",
+    'vcs_pageview_mode': 'edit'
+}
+
+html_context = {
+    'display_github': 'True',
+    'github_user': 'ansible',
+    'github_repo': 'ansible',
+    'github_version': 'devel/docs/docsite/rst/',
+    'github_module_version': 'devel/lib/ansible/modules/',
+    'github_root_dir': 'devel/lib/ansible',
+    'github_cli_version': 'devel/lib/ansible/cli/',
+    'current_version': version,
+    'latest_version': '2.10',
+    # list specifically out of order to make latest work
+    'available_versions': ('latest', '2.9', '2.9_ja', '2.8', 'devel'),
+    'css_files': ('_static/ansible.css',  # overrides to the standard theme
+                  ),
+}
+
+# The style sheet to use for HTML and HTML Help pages. A file of that name
+# must exist either in Sphinx' static/ path, or in one of the custom paths
+# given in html_static_path.
+# html_style = 'solar.css'
+
+# The name for this set of Sphinx documents.  If None, it defaults to
+# "<project> v<release> documentation".
+html_title = 'Ansible Documentation'
+
+# A shorter title for the navigation bar.  Default is the same as html_title.
+# html_short_title = None
+
+# The name of an image file (within the static path) to place at the top of
+# the sidebar.
+# html_logo =
+
+# The name of an image file (within the static path) to use as favicon of the
+# docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
+# pixels large.
+# html_favicon = 'favicon.ico'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['../_static']
+
+# If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
+# using the given strftime format.
+html_last_updated_fmt = '%b %d, %Y'
+
+# If true, SmartyPants will be used to convert quotes and dashes to
+# typographically correct entities.
+# html_use_smartypants = True
+
+# Custom sidebar templates, maps document names to template names.
+# html_sidebars = {}
+
+# Additional templates that should be rendered to pages, maps page names to
+# template names.
+# html_additional_pages = {}
+
+# If false, no module index is generated.
+# html_use_modindex = True
+
+# If false, no index is generated.
+# html_use_index = True
+
+# If true, the index is split into individual pages for each letter.
+# html_split_index = False
+
+# If true, the reST sources are included in the HTML build as _sources/<name>.
+html_copy_source = False
+
+# If true, an OpenSearch description file will be output, and all pages will
+# contain a <link> tag referring to it.  The value of this option must be the
+# base URL from which the finished HTML is served.
+# html_use_opensearch = 'https://docs.ansible.com/ansible/latest'
+
+# If nonempty, this is the file name suffix for HTML files (e.g. ".xhtml").
+# html_file_suffix = ''
+
+# Output file base name for HTML help builder.
+htmlhelp_basename = 'Poseidodoc'
+
+# Configuration for sphinx-notfound-pages
+# with no 'notfound_template' and no 'notfound_context' set,
+# the extension builds 404.rst into a location-agnostic 404 page
+#
+# default is `en` - using this for the sub-site:
+notfound_default_language = "ansible"
+# default is `latest`:
+# setting explicitly - docsite serves up /ansible/latest/404.html
+# so keep this set to `latest` even on the `devel` branch
+# then no maintenance is needed when we branch a new stable_x.x
+notfound_default_version = "latest"
+# makes default setting explicit:
+notfound_no_urls_prefix = False
+
+# Options for LaTeX output
+# ------------------------
+
+# The paper size ('letter' or 'a4').
+# latex_paper_size = 'letter'
+
+# The font size ('10pt', '11pt' or '12pt').
+# latex_font_size = '10pt'
+
+# Grouping the document tree into LaTeX files. List of tuples
+# (source start file, target name, title, author, document class
+# [howto/manual]).
+latex_documents = [
+    ('index', 'ansible.tex', 'Ansible 2.2 Documentation', AUTHOR, 'manual'),
+]
+
+# The name of an image file (relative to this directory) to place at the top of
+# the title page.
+# latex_logo = None
+
+# For "manual" documents, if this is true, then toplevel headings are parts,
+# not chapters.
+# latex_use_parts = False
+
+# Additional stuff for the LaTeX preamble.
+# latex_preamble = ''
+
+# Documents to append as an appendix to all manuals.
+# latex_appendices = []
+
+# If false, no module index is generated.
+# latex_use_modindex = True
+
+autoclass_content = 'both'
+
+# Note:  Our strategy for intersphinx mappings is to have the upstream build location as the
+# canonical source and then cached copies of the mapping stored locally in case someone is building
+# when disconnected from the internet.  We then have a script to update the cached copies.
+#
+# Because of that, each entry in this mapping should have this format:
+#   name: ('http://UPSTREAM_URL', (None, 'path/to/local/cache.inv'))
+#
+# The update script depends on this format so deviating from this (for instance, adding a third
+# location for the mappning to live) will confuse it.
+intersphinx_mapping = {'python': ('https://docs.python.org/2/', (None, '../python2.inv')),
+                       'python3': ('https://docs.python.org/3/', (None, '../python3.inv')),
+                       'jinja2': ('http://jinja.palletsprojects.com/', (None, '../jinja2.inv')),
+                       'ansible_2_10': ('https://docs.ansible.com/ansible/2.10/', (None, '../ansible_2_10.inv')),
+                       'ansible_2_9': ('https://docs.ansible.com/ansible/2.9/', (None, '../ansible_2_9.inv')),
+                       'ansible_2_8': ('https://docs.ansible.com/ansible/2.8/', (None, '../ansible_2_8.inv')),
+                       'ansible_2_7': ('https://docs.ansible.com/ansible/2.7/', (None, '../ansible_2_7.inv')),
+                       'ansible_2_6': ('https://docs.ansible.com/ansible/2.6/', (None, '../ansible_2_6.inv')),
+                       'ansible_2_5': ('https://docs.ansible.com/ansible/2.5/', (None, '../ansible_2_5.inv')),
+                       }
+
+# linckchecker settings
+linkcheck_ignore = [
+    r'http://irc\.freenode\.net',
+]
+linkcheck_workers = 25
+# linkcheck_anchors = False

--- a/docs/docsite/sphinx_conf/ansible_conf.py
+++ b/docs/docsite/sphinx_conf/ansible_conf.py
@@ -37,7 +37,7 @@ sys.path.append(os.path.abspath(os.path.join('..', '_extensions')))
 # the repository version needs to be the one that is loaded:
 sys.path.insert(0, os.path.abspath(os.path.join('..', '..', '..', 'lib')))
 
-VERSION = 'devel'
+VERSION = '3'
 AUTHOR = 'Ansible, Inc'
 
 
@@ -158,9 +158,9 @@ html_context = {
     'github_root_dir': 'devel/lib/ansible',
     'github_cli_version': 'devel/lib/ansible/cli/',
     'current_version': version,
-    'latest_version': '2.10',
+    'latest_version': '3',
     # list specifically out of order to make latest work
-    'available_versions': ('latest', '2.9', '2.9_ja', '2.8', 'devel'),
+    'available_versions': ('latest', '2.10', '2.9', '2.9_ja', '2.8', 'devel'),
     'css_files': ('_static/ansible.css',  # overrides to the standard theme
                   ),
 }

--- a/docs/docsite/sphinx_conf/core_conf.py
+++ b/docs/docsite/sphinx_conf/core_conf.py
@@ -13,6 +13,9 @@
 # All configuration values have a default value; values that are commented out
 # serve to show the default value.
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import sys
 import os
 
@@ -34,7 +37,7 @@ sys.path.append(os.path.abspath(os.path.join('..', '_extensions')))
 # the repository version needs to be the one that is loaded:
 sys.path.insert(0, os.path.abspath(os.path.join('..', '..', '..', 'lib')))
 
-VERSION = '2.10'
+VERSION = 'devel'
 AUTHOR = 'Ansible, Inc'
 
 
@@ -62,7 +65,7 @@ master_doc = 'index'
 
 # General substitutions.
 project = 'Ansible'
-copyright = "2019 Red Hat, Inc."
+copyright = "2021 Red Hat, Inc."
 
 # The default replacements for |version| and |release|, also used in various
 # other places throughout the built documents.
@@ -87,8 +90,26 @@ today_fmt = '%B %d, %Y'
 
 # A list of glob-style patterns that should be excluded when looking
 # for source files.
-# OBSOLETE - removing this - dharmabumstead 2018-02-06
-# exclude_patterns = ['modules']
+exclude_patterns = [
+    '2.10_index.rst',
+    'ansible_index.rst',
+    'core_index.rst',
+    'galaxy',
+    'network',
+    'scenario_guides',
+    'porting_guides/porting_guides.rst',
+    'porting_guides/porting_guide_2*',
+    'porting_guides/porting_guide_3*',
+    'roadmap/index.rst',
+    'roadmap/ansible_roadmap_index.rst',
+    'roadmap/old_roadmap_index.rst',
+    'roadmap/ROADMAP_2_5.rst',
+    'roadmap/ROADMAP_2_6.rst',
+    'roadmap/ROADMAP_2_7.rst',
+    'roadmap/ROADMAP_2_8.rst',
+    'roadmap/ROADMAP_2_9.rst',
+    'roadmap/COLLECTIONS*'
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -128,7 +149,7 @@ rst_epilog = """
 
 html_theme_path = ['../_themes']
 html_theme = 'sphinx_rtd_theme'
-html_short_title = 'Ansible Documentation'
+html_short_title = 'Ansible Core Documentation'
 html_show_sphinx = False
 
 html_theme_options = {
@@ -147,7 +168,7 @@ html_context = {
     'current_version': version,
     'latest_version': '2.10',
     # list specifically out of order to make latest work
-    'available_versions': ('latest', '2.9', '2.9_ja', '2.8', 'devel'),
+    'available_versions': ('devel'),
     'css_files': ('_static/ansible.css',  # overrides to the standard theme
                   ),
 }
@@ -159,7 +180,7 @@ html_context = {
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = 'Ansible Documentation'
+html_title = 'Ansible Core Documentation'
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 # html_short_title = None

--- a/hacking/build_library/build_ansible/command_plugins/docs_build.py
+++ b/hacking/build_library/build_ansible/command_plugins/docs_build.py
@@ -19,6 +19,7 @@ from ansible.release import __version__ as ansible_base__version__
 # Pylint doesn't understand Python3 namespace modules.
 # pylint: disable=relative-beyond-top-level
 from ..commands import Command
+from ..errors import InvalidUserInput, MissingUserInput
 # pylint: enable=relative-beyond-top-level
 
 
@@ -27,6 +28,67 @@ __metaclass__ = type
 
 DEFAULT_TOP_DIR = pathlib.Path(__file__).parents[4]
 DEFAULT_OUTPUT_DIR = pathlib.Path(__file__).parents[4] / 'docs/docsite'
+
+
+class NoSuchFile(Exception):
+    """An expected file was not found."""
+
+
+#
+# Helpers
+#
+
+def find_latest_ansible_dir(build_data_working):
+    """Find the most recent ansible major version."""
+    # imports here so that they don't cause unnecessary deps for all of the plugins
+    from packaging.version import InvalidVersion, Version
+
+    ansible_directories = glob.glob(os.path.join(build_data_working, '[0-9.]*'))
+
+    # Find the latest ansible version directory
+    latest = None
+    latest_ver = Version('0')
+    for directory_name in (d for d in ansible_directories if os.path.isdir(d)):
+        try:
+            new_version = Version(os.path.basename(directory_name))
+        except InvalidVersion:
+            continue
+
+        if new_version > latest_ver:
+            latest_ver = new_version
+            latest = directory_name
+
+    if latest is None:
+        raise NoSuchFile('Could not find an ansible data directory in {0}'.format(build_data_working))
+
+    return latest
+
+
+def find_latest_deps_file(build_data_working, ansible_version):
+    """Find the most recent ansible deps file for the given ansible major version."""
+    # imports here so that they don't cause unnecessary deps for all of the plugins
+    from packaging.version import Version
+
+    data_dir = os.path.join(build_data_working, ansible_version)
+    deps_files = glob.glob(os.path.join(data_dir, '*.deps'))
+    if not deps_files:
+        raise Exception('No deps files exist for version {0}'.format(ansible_version))
+
+    # Find the latest version of the deps file for this major version
+    latest = None
+    latest_ver = Version('0')
+    for filename in deps_files:
+        with open(filename, 'r') as f:
+            deps_data = yaml.safe_load(f.read())
+        new_version = Version(deps_data['_ansible_version'])
+        if new_version > latest_ver:
+            latest_ver = new_version
+            latest = filename
+
+    if latest is None:
+        raise NoSuchFile('Could not find an ansible deps file in {0}'.format(data_dir))
+
+    return latest
 
 
 #
@@ -70,36 +132,23 @@ def generate_full_docs(args):
     # imports here so that they don't cause unnecessary deps for all of the plugins
     import sh
     from antsibull.cli import antsibull_docs
-    from packaging.version import Version
-
-    ansible_base_ver = Version(ansible_base__version__)
-    ansible_base_major_ver = '{0}.{1}'.format(ansible_base_ver.major, ansible_base_ver.minor)
 
     with TemporaryDirectory() as tmp_dir:
         sh.git(['clone', 'https://github.com/ansible-community/ansible-build-data'], _cwd=tmp_dir)
-        # This is wrong.  Once ansible and ansible-base major.minor versions get out of sync this
-        # will stop working.  We probably need to walk all subdirectories in reverse version order
-        # looking for the latest ansible version which uses something compatible with
-        # ansible_base_major_ver.
-        deps_files = glob.glob(os.path.join(tmp_dir, 'ansible-build-data',
-                                            ansible_base_major_ver, '*.deps'))
-        if not deps_files:
-            raise Exception('No deps files exist for version {0}'.format(ansible_base_major_ver))
+        # If we want to validate that the ansible version and ansible-base branch version match,
+        # this would be the place to do it.
 
-        # Find the latest version of the deps file for this version
-        latest = None
-        latest_ver = Version('0')
-        for filename in deps_files:
-            with open(filename, 'r') as f:
-                deps_data = yaml.safe_load(f.read())
-            new_version = Version(deps_data['_ansible_version'])
-            if new_version > latest_ver:
-                latest_ver = new_version
-                latest = filename
+        build_data_working = os.path.join(tmp_dir, 'ansible-build-data')
 
-        # Make a copy of the deps file so that we can set the ansible-base version to use
+        ansible_version = args.ansible_version
+        if ansible_version is None:
+            ansible_version = find_latest_ansible_dir(build_data_working)
+
+        latest_filename = find_latest_deps_file(build_data_working, ansible_version)
+
+        # Make a copy of the deps file so that we can set the ansible-base version we'll use
         modified_deps_file = os.path.join(tmp_dir, 'ansible.deps')
-        shutil.copyfile(latest, modified_deps_file)
+        shutil.copyfile(latest_filename, modified_deps_file)
 
         # Put our version of ansible-base into the deps file
         with open(modified_deps_file, 'r') as f:
@@ -136,6 +185,8 @@ class CollectionPluginDocs(Command):
                             ' documentation location that says the module is in a collection and'
                             ' point to generated plugin documentation under the collections/'
                             ' hierarchy.')
+        # I think we should make the actions a subparser but need to look in git history and see if
+        # we tried that and changed it for some reason.
         parser.add_argument('action', action='store', choices=('full', 'base', 'named'),
                             default='full', help=cls._ACTION_HELP)
         parser.add_argument("-o", "--output-dir", action="store", dest="output_dir",
@@ -149,10 +200,17 @@ class CollectionPluginDocs(Command):
                             dest="limit_to", default=None,
                             help="Limit building module documentation to comma-separated list of"
                             " plugins. Specify non-existing plugin name for no plugins.")
+        parser.add_argument('--ansible-version', action='store',
+                            dest='ansible_version', default=None,
+                            help='The version of the ansible package to make documentation for.'
+                            '  This only makes sense when used with full.')
 
     @staticmethod
     def main(args):
-        # normalize CLI args
+        # normalize and validate CLI args
+
+        if args.ansible_version and args.action != 'full':
+            raise InvalidUserInput('--ansible-version is only for use with "full".')
 
         if not args.output_dir:
             args.output_dir = os.path.abspath(str(DEFAULT_OUTPUT_DIR))

--- a/test/sanity/code-smell/docs-build.py
+++ b/test/sanity/code-smell/docs-build.py
@@ -30,7 +30,7 @@ def main():
         f.writelines(lines)
 
     try:
-        cmd = ['make', 'base_singlehtmldocs']
+        cmd = ['make', 'core_singlehtmldocs']
         sphinx = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=docs_dir)
         stdout, stderr = sphinx.communicate()
     finally:

--- a/test/sanity/code-smell/package-data.py
+++ b/test/sanity/code-smell/package-data.py
@@ -53,6 +53,9 @@ def assemble_files_to_ship(complete_file_list):
         'test/support/README.md',
         '.cherry_picker.toml',
         '.mailmap',
+        # Generated as part of a build step
+        'docs/docsite/rst/conf.py',
+        'docs/docsite/rst/index.rst',
         # Possibly should be included
         'examples/scripts/uptime.py',
         'examples/scripts/my_test.py',

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -4,8 +4,6 @@ docs/docsite/_extensions/pygments_lexer.py future-import-boilerplate
 docs/docsite/_extensions/pygments_lexer.py metaclass-boilerplate
 docs/docsite/_themes/sphinx_rtd_theme/__init__.py future-import-boilerplate
 docs/docsite/_themes/sphinx_rtd_theme/__init__.py metaclass-boilerplate
-docs/docsite/rst/conf.py future-import-boilerplate
-docs/docsite/rst/conf.py metaclass-boilerplate
 docs/docsite/rst/dev_guide/testing/sanity/no-smart-quotes.rst no-smart-quotes
 examples/play.yml shebang
 examples/scripts/my_test.py shebang # example module but not in a normal module location


### PR DESCRIPTION
* excludes scenario guides from core docs, splits porting guides and roadmaps, symlinks indices to create index.html pages, and adds .gitignore entries for conf.py and the toplevel index.rst files generated by the docs build

* creates separate build commands for the Ansible package docs and the ansible-core docs, for accuracy in building the package documentation from the correct underlying version of the core code

(cherry picked from commit ccbfdec334a7b0443f2daecf9f96ac5c5a33fd45)

##### SUMMARY
Allows the docs team to build package docs for Ansible 3.0.0 based on the stable-2.10 branch. The 3.0.0 documentation will reflect core features and functionality of ansible-base-2.10.

Backport of #73616.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com/ansible
docs.ansible.com/ansible-core
