### PR TITLE
[2.9] docker_image: do not crash in load_image for docker-py < 2.5.0.

### DIFF
--- a/changelogs/fragments/community.docker-73-docker_image-fix-old-docker-py-version.yml
+++ b/changelogs/fragments/community.docker-73-docker_image-fix-old-docker-py-version.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "docker_image - fix crash on loading images with versions of Docker SDK for Python before 2.5.0 (https://github.com/ansible-collections/community.docker/issues/72, https://github.com/ansible-collections/community.docker/pull/73)."

--- a/test/integration/targets/docker_image/tasks/tests/options.yml
+++ b/test/integration/targets/docker_image/tasks/tests/options.yml
@@ -223,6 +223,14 @@
   register: load_image_3
   ignore_errors: true
 
+- name: load image (invalid image, old API version)
+  docker_image:
+    name: foo:bar
+    load_path: "{{ output_dir }}/image-invalid.tar"
+    source: load
+    api_version: "1.22"
+  register: load_image_4
+
 - assert:
     that:
     - load_image is changed
@@ -233,6 +241,8 @@
       "The archive did not contain image 'foo:bar'. Instead, found 'quay.io/ansible/docker-test-containers:hello-world'." == load_image_2.msg
     - load_image_3 is failed
     - '"Detected no loaded images. Archive potentially corrupt?" == load_image_3.msg'
+    - load_image_4 is changed
+    - "'The API version of your Docker daemon is < 1.23, which does not return the image loading result from the Docker daemon. Therefore, we cannot verify whether the expected image was loaded, whether multiple images where loaded, or whether the load actually succeeded. You should consider upgrading your Docker daemon.' in load_image_4.warnings"
 
 ####################################################################
 ## path ############################################################


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible-collections/community.docker/pull/73 to stable-2.9.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_image
