### PR TITLE
pylint sanity test: stop ignoring 'used-before-assignment'

### DIFF
--- a/changelogs/fragments/73639-ansible-test-pylint-ignores.yml
+++ b/changelogs/fragments/73639-ansible-test-pylint-ignores.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "ansible-test pylint sanity test - stop ignoring ``used-before-assignment`` errors (https://github.com/ansible/ansible/pull/73639)."

--- a/changelogs/fragments/ansible-test-pylint-ignores.yml
+++ b/changelogs/fragments/ansible-test-pylint-ignores.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "ansible-test pylint sanity test - stop ignoring ``used-before-assignment`` errors."

--- a/changelogs/fragments/ansible-test-pylint-ignores.yml
+++ b/changelogs/fragments/ansible-test-pylint-ignores.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- "ansible-test pylint sanity test - stop ignoring ``used-before-assignment`` errors."

--- a/test/lib/ansible_test/_data/sanity/pylint/config/collection.cfg
+++ b/test/lib/ansible_test/_data/sanity/pylint/config/collection.cfg
@@ -111,7 +111,6 @@ disable=
     unused-argument,
     unused-import,
     unused-variable,
-    used-before-assignment,
     useless-object-inheritance,
     useless-return,
     useless-super-delegation,

--- a/test/lib/ansible_test/_data/sanity/pylint/config/default.cfg
+++ b/test/lib/ansible_test/_data/sanity/pylint/config/default.cfg
@@ -111,7 +111,6 @@ disable=
     unused-argument,
     unused-import,
     unused-variable,
-    used-before-assignment,
     useless-object-inheritance,
     useless-return,
     useless-super-delegation,


### PR DESCRIPTION
##### SUMMARY
The pylint sanity test currently ignores `used-before-assignment` errors, which are usually errors.

(Ignoring this caused a fatal bug in a module in community.general to go unnoticed until after the release.)

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
ansible-test
