### PR TITLE
document json return property for uri module

### DIFF
--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -370,7 +370,7 @@ content:
 json:
   description: The response body content.
   returned: if the reported Content-type is "application/json"
-  type: complex
+  type: raw
   sample: "{}"
 cookies:
   description: The cookie values placed in cookie jar.

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -364,8 +364,13 @@ RETURN = r'''
 # The return information includes all the HTTP headers in lower-case.
 content:
   description: The response body content.
-  returned: status not in status_code or return_content is true
+  returned: status not in status_code or return_content is true and reported Content-type is not "application/json"
   type: str
+  sample: ""
+json:
+  description: The response body content.
+  returned: if the reported Content-type is "application/json"
+  type: complex
   sample: "{}"
 cookies:
   description: The cookie values placed in cookie jar.

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -371,7 +371,7 @@ json:
   description: The response body content.
   returned: if the reported Content-type is "application/json"
   type: raw
-  sample: "{}"
+  sample: ""
 cookies:
   description: The cookie values placed in cookie jar.
   returned: on success

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -71,7 +71,7 @@ options:
   return_content:
     description:
       - Whether or not to return the body of the response as a "content" key in
-        the dictionary result no matter it succeeded or failed.
+        the dictionary result no matter it succeeded or failed and independently of the reported Content-type.
       - Independently of this option, if the reported Content-type is "application/json", then the JSON is
         always loaded into a key called C(json) in the dictionary results.
     type: bool
@@ -364,7 +364,7 @@ RETURN = r'''
 # The return information includes all the HTTP headers in lower-case.
 content:
   description: The response body content.
-  returned: status not in status_code or return_content is true and reported Content-type is not "application/json"
+  returned: status not in status_code or return_content is true
   type: str
   sample: ""
 json:


### PR DESCRIPTION
The behavior of returning a property called json instead of content used to be only referred to in the description of the return_content parameter.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
