### PR TITLE
Remove warning about role validation with deps

### DIFF
--- a/changelogs/fragments/73653-rolespec-rm-warning.yml
+++ b/changelogs/fragments/73653-rolespec-rm-warning.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - We should not have a warning displayed about dependencies when a role is validated. Move it to role docs instead.
+  - Remove the warning displayed when validating the arg spec of a role with dependencies and add it to the documentation.

--- a/changelogs/fragments/73653-rolespec-rm-warning.yml
+++ b/changelogs/fragments/73653-rolespec-rm-warning.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - We should not have a warning displayed about dependencies when a role is validated. Move it to role docs instead.

--- a/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
@@ -264,6 +264,12 @@ specification defined in the role ``meta/main.yml`` file. When this argument spe
 a new task is inserted at the beginning of role execution that will validate the parameters supplied
 for the role against the specification. If the parameters fail validation, the role will fail execution.
 
+.. note::
+
+    When role argument validation is used on a role that has defined :ref:`dependencies <role_dependencies>`,
+    then validation on those dependencies will run before the dependent role, even if argument validation fails
+    for the dependent role.
+
 Specification Format
 --------------------
 

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -34,10 +34,8 @@ from ansible.playbook.role.metadata import RoleMetadata
 from ansible.playbook.taggable import Taggable
 from ansible.plugins.loader import add_all_plugin_dirs
 from ansible.utils.collection_loader import AnsibleCollectionConfig
-from ansible.utils.display import Display
 from ansible.utils.vars import combine_vars
 
-display = Display()
 
 __all__ = ['Role', 'hash_params']
 
@@ -288,9 +286,6 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
         :returns: The (possibly modified) task list.
         '''
         if self._metadata.argument_specs:
-            if self._dependencies:
-                display.warning("Dependent roles will run before roles with argument specs even if validation fails.")
-
             # Determine the role entry point so we can retrieve the correct argument spec.
             # This comes from the `tasks_from` value to include_role or import_role.
             entrypoint = self._from_files.get('tasks', 'main')


### PR DESCRIPTION
##### SUMMARY

We should not have a warning displayed about dependencies when a role is validated. Move it to role docs instead.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

roles

