### PR TITLE
[mongodb tests] Wait for ports in TIME_WAIT [2.9]

### DIFF
--- a/test/integration/targets/mongodb_replicaset/tasks/main.yml
+++ b/test/integration/targets/mongodb_replicaset/tasks/main.yml
@@ -78,16 +78,11 @@
 - name: Murder all mongod processes
   shell: pkill -{{ kill_signal }} mongod;
 
-- name: Getting pids for mongod
-  pids:
-      name: mongod
-  register: pids_of_mongod
-
-- name: Wait for all mongod processes to exit
+- name: Wait for ports to get out of TIME_WAIT
   wait_for:
-    path: "/proc/{{ item }}/status"
-    state: absent
-  with_items: "{{ pids_of_mongod.pids }}"
+    port: '{{ item }}'
+    state: drained
+  with_sequence: start=3001 end=3003
 
 - set_fact:
     current_replicaset: "{{ mongodb_replicaset1 }}"

--- a/test/integration/targets/mongodb_replicaset/tasks/mongod_teardown.yml
+++ b/test/integration/targets/mongodb_replicaset/tasks/mongod_teardown.yml
@@ -2,17 +2,11 @@
   command: pkill  -{{ kill_signal }} mongod
   ignore_errors: true
 
-- name: Getting pids for mongod
-  pids:
-      name: mongod
-  register: pids_of_mongod
-
-- name: Wait for all mongod processes to exit
+- name: Wait for ports to get out of TIME_WAIT
   wait_for:
-    path: "/proc/{{ item }}/status"
-    state: absent
-    delay: 1
-  with_items: "{{ pids_of_mongod }}"
+    port: '{{ item }}'
+    state: drained
+  with_sequence: start=3001 end=3003
 
 - name: Remove all mongod folders
   file:

--- a/test/integration/targets/mongodb_shard/tasks/main.yml
+++ b/test/integration/targets/mongodb_shard/tasks/main.yml
@@ -289,16 +289,11 @@
 - name: Murder all mongod processes
   shell: pkill -{{ kill_signal }} mongod || true;
 
-- name: Getting pids for mongod
-  pids:
-      name: mongod
-  register: pids_of_mongod
-
-- name: Wait for all mongod processes to exit
+- name: Wait for ports to get out of TIME_WAIT
   wait_for:
-    path: "/proc/{{ item }}/status"
-    state: absent
-  with_items: "{{ pids_of_mongod }}"
+    port: '{{ item }}'
+    state: drained
+  with_sequence: start=3001 end=3006
 
 - set_fact:
     current_replicaset: "{{ mongodb_replicaset1 }}"

--- a/test/integration/targets/mongodb_shard/tasks/mongod_teardown.yml
+++ b/test/integration/targets/mongodb_shard/tasks/mongod_teardown.yml
@@ -6,17 +6,11 @@
   command: pkill  -{{ kill_signal }} mongos
   ignore_errors: true
 
-- name: Getting pids for mongod
-  pids:
-      name: mongod
-  register: pids_of_mongod
-
-- name: Wait for all mongod processes to exit
+- name: Wait for ports to get out of TIME_WAIT
   wait_for:
-    path: "/proc/{{ item }}/status"
-    state: absent
-    delay: 1
-  with_items: "{{ pids_of_mongod }}"
+    port: '{{ item }}'
+    state: drained
+  with_sequence: start=3001 end=3006
 
 - name: Remove all mongod folders
   file:

--- a/test/integration/targets/setup_mongodb/tasks/main.yml
+++ b/test/integration/targets/setup_mongodb/tasks/main.yml
@@ -69,23 +69,10 @@
 # Need to handle various platforms here. Package name will not always be the same
 - name: Ensure mongod package is installed
   apt:
-    name: "{{ mongodb_packages.mongod }}"
-    state: present
-    force: yes
-  when:
-    - ansible_distribution == 'Ubuntu'
-
-- name: Ensure mongos package is installed
-  apt:
-    name: "{{ mongodb_packages.mongos }}"
-    state: present
-    force: yes
-  when:
-    - ansible_distribution == 'Ubuntu'
-
-- name: Ensure mongo client is installed
-  apt:
-    name: "{{ mongodb_packages.mongo }}"
+    name:
+      - "{{ mongodb_packages.mongod }}"
+      - "{{ mongodb_packages.mongos }}"
+      - "{{ mongodb_packages.mongo }}"
     state: present
     force: yes
   when:
@@ -128,21 +115,12 @@
   when:
     - ansible_distribution == "Fedora"
 
-- name: Ensure mongod package is installed
+- name: Ensure mongodb packages are installed
   yum:
-    name: "{{ mongodb_packages.mongod }}"
-    state: present
-  when: ansible_os_family == "RedHat"
-
-- name: Ensure mongos package is installed
-  yum:
-    name: "{{ mongodb_packages.mongos }}"
-    state: present
-  when: ansible_os_family == "RedHat"
-
-- name: Ensure mongo client is installed
-  yum:
-    name: "{{ mongodb_packages.mongo }}"
+    name:
+      - "{{ mongodb_packages.mongod }}"
+      - "{{ mongodb_packages.mongos }}"
+      - "{{ mongodb_packages.mongo }}"
     state: present
   when: ansible_os_family == "RedHat"
 # EOF Redhat


### PR DESCRIPTION

##### SUMMARY
Change:
- The latest mongodb we install causes processes to not die correctly
  (they end up as zombies), and this causes the ports they listen on to
  be held in TIME_WAIT. We need to wait for them to fall out of
  TIME_WAIT before we can continue and use them again.

Test Plan:
- CI
- Local playing in containers

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Test Pull Request

##### COMPONENT NAME

tests