### PR TITLE
pause - account for curses.tigetstr() retuning None

### DIFF
--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -52,8 +52,8 @@ except ImportError:
     HAS_CURSES = False
 
 if HAS_CURSES:
-    MOVE_TO_BOL = curses.tigetstr('cr')
-    CLEAR_TO_EOL = curses.tigetstr('el')
+    MOVE_TO_BOL = curses.tigetstr('cr') or b'\r'
+    CLEAR_TO_EOL = curses.tigetstr('el') or b'\x1b[K'
 else:
     MOVE_TO_BOL = b'\r'
     CLEAR_TO_EOL = b'\x1b[K'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #73264.

Handle the situation where a system has `curses` but `curses.tigetstr()` returns `None` by setting a value.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bug Fix Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/action/pause.py`
