### PR TITLE
Disable JUnit callback on roles_arg_spec integration tests

### DIFF
--- a/test/integration/targets/roles_arg_spec/runme.sh
+++ b/test/integration/targets/roles_arg_spec/runme.sh
@@ -2,6 +2,18 @@
 
 set -eux
 
+# This effectively disables junit callback output by directing the output to
+# a directory ansible-test will not look at.
+#
+# Since the failures in these tests are on the role arg spec validation and the
+# name for those tasks is fixed (we cannot add "EXPECTED FAILURE" to the name),
+# disabling the junit callback output is the easiest way to prevent these from
+# showing up in test run output.
+#
+# Longer term, an option can be added to the junit callback allowing a custom
+# regexp to be supplied rather than the hard coded "EXPECTED FAILURE".
+export JUNIT_OUTPUT_DIR="${OUTPUT_DIR}"
+
 # Various simple role scenarios
 ansible-playbook test.yml -i ../../inventory "$@"
 

--- a/test/integration/targets/roles_arg_spec/test.yml
+++ b/test/integration/targets/roles_arg_spec/test.yml
@@ -71,7 +71,7 @@
 
   tasks:
       - block:
-        - name: "EXPECTED FAILURE: Invalid role usage"
+        - name: "Invalid role usage"
           include_role:
             name: b
           vars:
@@ -114,7 +114,7 @@
 
   tasks:
       - block:
-        - name: "EXPECTED FAILURE: Invalid role usage"
+        - name: "Invalid role usage"
           import_role:
             name: b
           vars:
@@ -172,7 +172,7 @@
 
   tasks:
       - block:
-        - name: "EXPECTED FAILURE: Test import_role of role C (missing a_str)"
+        - name: "Test import_role of role C (missing a_str)"
           import_role:
             name: c
           vars:
@@ -197,7 +197,7 @@
                 - ansible_failed_result.argument_spec_data == main_expected_returned_spec
 
       - block:
-        - name: "EXPECTED FAILURE: Test include_role of role C (missing a_int from `alternate` entry point)"
+        - name: "Test include_role of role C (missing a_int from `alternate` entry point)"
           include_role:
             name: c
           vars:
@@ -227,7 +227,7 @@
   gather_facts: false
   tasks:
       - block:
-        - name: "EXPECTED FAILURE: Test import_role of role role_with_no_tasks (missing a_str)"
+        - name: "Test import_role of role role_with_no_tasks (missing a_str)"
           import_role:
             name: role_with_no_tasks
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This prevents the role arg spec validation tasks from showing up as failure in the CI output even when the overall test passes.

The JUnit callback ignores tasks with "EXPECTED FAILURE" in the name. In the case of these tests, the task that is actually failing is not the `include_role` task and `import_role` has no task name in the callback output to inspect, but the dynamic task inserted for role arg spec validation that is failing. We have no mechanism to change the text in that task output.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/roles_arg_spec/test.yml`