### PR TITLE
Fixes for ansible-console usability.

### DIFF
--- a/changelogs/fragments/73665-fixes-ansible-console.yml
+++ b/changelogs/fragments/73665-fixes-ansible-console.yml
@@ -1,0 +1,8 @@
+bugfixes:
+  - ansible-console - add more documentation, specifically on various commands[1] (https://github.com/ansible/ansible/issues/72195)
+  - ansible-console - Ctrl+C (on prompt) used to exit the shell, unlike most shells, it should just reset the current line
+    (ie. abort it and spawn a new prompt) (https://github.com/ansible/ansible/issues/68529)
+  - ansible-console - Ctrl+C (in a task) abort current task, and put you back on prompt (this behavior doesn't change) (ditto)
+  - ansible-console - Ctrl+D (on prompt) now exit the shell, this is the expected behavior in a shell (cf bash, sh, zsh, ipython, ...) (ditto)
+  - ansible-console - fixes few strings' typos
+  - ansible-console - remove useless and poorly formatted comment section (replaced with [1])


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Fixes #68529 : changed Ctrl+C and Ctrl+D , to something closer to a standard shell behavior. (ie. cancel/reset current line, end session instead of aborting current session)
- Fixes #68529 : added an exit message
- #72195 : add more documentation, describing the various commands
- Few typos
- Add more information on configuration transition: it should clearly state it's switching to/from Check mode even on quieter verbose modes for example

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-console

