### PR TITLE
New AWS module mod_defaults - iam_saml_federation

### DIFF
--- a/changelogs/fragments/73669-module_defaults-iam_saml_federation.yml
+++ b/changelogs/fragments/73669-module_defaults-iam_saml_federation.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "module_defaults - add module iam_saml_federation from community.aws to aws module_defaults group (https://github.com/ansible/ansible/pull/73669)."

--- a/lib/ansible/config/module_defaults.yml
+++ b/lib/ansible/config/module_defaults.yml
@@ -416,6 +416,8 @@ groupings:
   - aws
   iam_role_info:
   - aws
+  iam_saml_federation:
+  - aws
   iam_server_certificate_facts:
   - aws
   iam_server_certificate_info:


### PR DESCRIPTION
##### SUMMARY

To support this new module in CI, we need it to be in 2.9's mod_defaults:
ansible-collections/community.aws#419

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

module_defaults

##### ADDITIONAL INFORMATION

(Original PR against devel instead of stable-2.9 by mistake)