### PR TITLE
New AWS module mod_defaults - ec2_vpc_endpoint_service_info

### DIFF
--- a/changelogs/fragments/73670-module_defaults-ec2_vpc_endpoint_service_info.yml
+++ b/changelogs/fragments/73670-module_defaults-ec2_vpc_endpoint_service_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "module_defaults - add module ec2_vpc_endpoint_service_info from community.aws to aws module_defaults group (https://github.com/ansible/ansible/pull/73669)."

--- a/lib/ansible/config/module_defaults.yml
+++ b/lib/ansible/config/module_defaults.yml
@@ -268,6 +268,8 @@ groupings:
   - aws
   ec2_vpc_endpoint_facts:
   - aws
+  ec2_vpc_endpoint_service_info:
+  - aws
   ec2_vpc_endpoint_info:
   - aws
   ec2_vpc_igw:


### PR DESCRIPTION
##### SUMMARY

To support this new module in CI, we need it to be in 2.9's mod_defaults:
ansible-collections/community.aws#346

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

module_defaults

##### ADDITIONAL INFORMATION