### PR TITLE
Replace internal links with refs

### DIFF
--- a/lib/ansible/modules/set_fact.py
+++ b/lib/ansible/modules/set_fact.py
@@ -33,7 +33,7 @@ options:
       - This boolean converts the variable into an actual 'fact' which will also be added to the fact cache, if fact caching is enabled.
       - Normally this module creates 'host level variables' and has much higher precedence, this option changes the nature and precedence
         (by 7 steps) of the variable created.
-        U(https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable)
+        R(ansible_variable_precedence)
       - "This actually creates 2 copies of the variable, a normal 'set_fact' host variable with high precedence and
         a lower 'ansible_fact' one that is available for persistance via the facts cache plugin.
         This creates a possibly confusing interaction with C(meta: clear_facts) as it will remove the 'ansible_fact' but not the host variable."

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -89,7 +89,7 @@ options:
             - On macOS systems, this value has to be cleartext. Beware of security issues.
             - To create a disabled account on Linux systems, set this to C('!') or C('*').
             - To create a disabled account on OpenBSD, set this to C('*************').
-            - See U(https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
+            - See R(user_passwords)
               for details on various ways to generate these password values.
         type: str
     state:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Replace `docs.ansible.com` links with `R(RST_ANCHOR)` syntax

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible.builtin.user
ansible.builtin.set_fact

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
