### PR TITLE
move firewalld to ansible.posix (#70692)

### DIFF
--- a/changelogs/fragments/73689-move-firewalld-to-ansible-posix.yaml
+++ b/changelogs/fragments/73689-move-firewalld-to-ansible-posix.yaml
@@ -1,3 +1,3 @@
 bugfixes:
-- firewalld - redirect firewalld to ansible.posix.firewalld FQCN.
-  (https://github.com/ansible/ansible/issues/73689)
+- runtime routing - redirect ``firewalld`` to ``ansible.posix.firewalld`` FQCN
+  (https://github.com/ansible/ansible/issues/73689).

--- a/changelogs/fragments/73689-move-firewalld-to-ansible-posix.yaml
+++ b/changelogs/fragments/73689-move-firewalld-to-ansible-posix.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- firewalld - redirect firewalld to ansible.posix.firewalld FQCN.
+  (https://github.com/ansible/ansible/issues/73689)

--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -3101,7 +3101,7 @@ plugin_routing:
     filesystem:
       redirect: community.general.filesystem
     firewalld:
-      redirect: community.general.firewalld
+      redirect: ansible.posix.firewalld
     gconftool2:
       redirect: community.general.gconftool2
     interfaces_file:


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>
(cherry picked from commit b479adddce8fe46a2df5469f130cf7b6ad70fdc4)

##### SUMMARY

Module `firewalld` redirects to the wrong FQCN.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
firewalld

##### ADDITIONAL INFORMATION

```
$ cat firewalld.yml
- hosts: localhost
  tasks:
    - name: Call firewalld
      firewalld:
$ ansible-playbook firewalld.yml -vv
ansible-playbook 2.10.5
  config file = ansible.cfg
  configured module search path = ['.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /.tox/py3-ansible30/lib/python3.7/site-packages/ansible
  executable location = /.tox/py3-ansible30/bin/ansible-playbook
  python version = 3.7.3 (default, Jul 25 2020, 13:03:44) [GCC 8.3.0]
Using ansible.cfg as config file
redirecting (type: modules) ansible.builtin.firewalld to community.general.firewalld
ERROR! couldn't resolve module/action 'firewalld'. This often indicates a misspelling, missing collection, or incorrect module path.

The error appears to be in 'firewalld.yml': line 3, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  tasks:
    - name: Call firewalld
      ^ here

```
