### PR TITLE
Let file module not change link to absolute when src not given(#65448)

### DIFF
--- a/changelogs/fragments/73700-let-file-module-not-change-link-to-absolute-on-touch.yml
+++ b/changelogs/fragments/73700-let-file-module-not-change-link-to-absolute-on-touch.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - file - prevent link src from being rewritten when src is not specified explicitly (https://github.com/ansible/ansible/issues/65448)

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -685,7 +685,7 @@ def ensure_symlink(path, src, follow, force, timestamps):
     if src is None:
         if follow:
             # use the current target of the link as the source
-            src = to_native(os.path.realpath(b_path), errors='strict')
+            src = to_native(os.readlink(b_path), errors='strict')
             b_src = to_bytes(src, errors='surrogate_or_strict')
 
     if not os.path.islink(b_path) and os.path.isdir(b_path):

--- a/test/integration/targets/file/tasks/link_rewrite.yml
+++ b/test/integration/targets/file/tasks/link_rewrite.yml
@@ -1,0 +1,47 @@
+- name: create temporary build directory
+  tempfile:
+    state: directory
+    suffix: ansible_test_leave_links_alone_during_touch
+  register: tempdir
+
+- name: create file
+  copy:
+    mode: 0600
+    content: "chicken"
+    dest: "{{ tempdir.path }}/somefile"
+
+- name: Create relative link
+  file:
+    src: somefile
+    dest: "{{ tempdir.path }}/somelink"
+    state: link
+
+- stat: 
+    path: "{{ tempdir.path }}/somelink"
+  register: link
+
+- stat: 
+    path: "{{ tempdir.path }}/somefile"
+  register: file
+
+- assert:
+    that:
+    - "file.stat.mode == '0600'"
+    - "link.stat.lnk_target == 'somefile'"
+
+- file:
+    path: "{{ tempdir.path }}/somelink"
+    mode: 0644
+    
+- stat: 
+    path: "{{ tempdir.path }}/somelink"
+  register: link
+
+- stat: 
+    path: "{{ tempdir.path }}/somefile"
+  register: file
+
+- assert:
+    that:
+    - "file.stat.mode == '0644'"
+    - "link.stat.lnk_target == 'somefile'"

--- a/test/integration/targets/file/tasks/state_link.yml
+++ b/test/integration/targets/file/tasks/state_link.yml
@@ -388,7 +388,6 @@
 - name: assert that the link target was unmodified
   assert:
     that:
-      - 'file10_result is changed'
       - 'file10_target_stat["stat"]["mode"] == "0644"'
 
 


### PR DESCRIPTION
##### SUMMARY
The file module changes existing sym links from relative to absolute
if the src is not stated in the tasks since it uses `os.path.realpath`
to fetch the link source and not `os.readlink`. Changed that.

Fixes #65448

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`file`
