### PR TITLE
ansible CLI allow other types than a string in module arguments 

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -67,7 +67,7 @@ class AdHocCLI(CLI):
         return options
 
     def _play_ds(self, pattern, async_val, poll):
-        if context.CLIARGS['module_args'].startswith([u'[', u'{']):
+        if context.CLIARGS['module_args'].startswith((u'[', u'{')):
             args = json.loads(context.CLIARGS['module_args'])
         else:
             check_raw = context.CLIARGS['module_name'] in C.MODULE_REQUIRE_ARGS


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Hello there,
when the user is trying to add module arguments with only using the CLI he can only pass string values.
With this patch, if the user would use only the JSON it would format the objects properly, otherways it will stay the same. 

Examples:
This stays the same
```cmd
ansible -m debug localhost -a 'msg={"msg":[{"test":123}]}'
```
```json
"msg": "{\"msg\":[{\"test\":123}]}"
```
This example always throw error before the change
```cmd
ansible -m debug localhost -a '{"msg":[{"test":123}]}'
```
```json
    "msg": [
        {
            "test": 123
        }
    ]
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible CLI 
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
