### PR TITLE
fix: reset_connection and controlpath tokens

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1268,6 +1268,10 @@ class Connection(ConnectionBase):
         run_reset = False
         if controlpersist and len(cp_arg) > 0:
             cp_path = cp_arg[0].split(b"=", 1)[-1]
+            cp_replace = {
+                b'%h': self.host, b'%p': str(self.port), b'%r': self.user}
+            for key, val in cp_replace.items():
+                cp_path = cp_path.replace(key, to_bytes(val))
             if os.path.exists(cp_path):
                 run_reset = True
         elif controlpersist:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
reset now expands ssh tokens before checking path existence.
Successfully tested with molecule and meta: reset_connection.

Fixes  #68341
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/connection/ssh.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
