### PR TITLE
Update lookup.rst

### DIFF
--- a/docs/docsite/rst/plugins/lookup.rst
+++ b/docs/docsite/rst/plugins/lookup.rst
@@ -13,7 +13,7 @@ Lookup plugins are an Ansible-specific extension to the Jinja2 templating langua
    - Lookups are executed with a working directory relative to the role or play,
      as opposed to local tasks, which are executed relative the executed script.
    - Pass ``wantlist=True`` to lookups to use in Jinja2 template "for" loops.
-   - By default, lookups are marked as unsafe for security reasons. If you trust the outside source your lookup accesses, pass ``allow_unsafe=True`` to allow Jinja2 templates to evaluate lookup values.
+   - By default, lookup return values are marked as unsafe for security reasons. If you trust the outside source your lookup accesses, pass ``allow_unsafe=True`` to allow Jinja2 templates to evaluate lookup values.
 
 .. warning::
    - Some lookups pass arguments to a shell. When using variables from a remote/untrusted source, use the `|quote` filter to ensure safe usage.

--- a/docs/docsite/rst/plugins/lookup.rst
+++ b/docs/docsite/rst/plugins/lookup.rst
@@ -13,7 +13,7 @@ Lookup plugins are an Ansible-specific extension to the Jinja2 templating langua
    - Lookups are executed with a working directory relative to the role or play,
      as opposed to local tasks, which are executed relative the executed script.
    - Pass ``wantlist=True`` to lookups to use in Jinja2 template "for" loops.
-   - By default, lookups are marked as unsafe. Pass ``allow_unsafe=True`` to lookups if you plan to evaluate the variable using the Jinja2 templating language.
+   - By default, lookups are marked as unsafe for security reasons. If you trust the outside source your lookup accesses, pass ``allow_unsafe=True`` to allow Jinja2 templates to evaluate lookup values.
 
 .. warning::
    - Some lookups pass arguments to a shell. When using variables from a remote/untrusted source, use the `|quote` filter to ensure safe usage.

--- a/docs/docsite/rst/plugins/lookup.rst
+++ b/docs/docsite/rst/plugins/lookup.rst
@@ -13,6 +13,7 @@ Lookup plugins are an Ansible-specific extension to the Jinja2 templating langua
    - Lookups are executed with a working directory relative to the role or play,
      as opposed to local tasks, which are executed relative the executed script.
    - Pass ``wantlist=True`` to lookups to use in Jinja2 template "for" loops.
+   - By default, lookups are marked as unsafe. Pass ``allow_unsafe=True`` to lookups if you plan to evaluate the variable using the Jinja2 templating language.
 
 .. warning::
    - Some lookups pass arguments to a shell. When using variables from a remote/untrusted source, use the `|quote` filter to ensure safe usage.


### PR DESCRIPTION
##### SUMMARY
Adding a note that lookups by default are considered unsafe which is different from arrays/lists/dicts written in a playbook which by default are considered safe by the jinja2 templating engine.


##### ISSUE TYPE
- Docs Pull Request

##### SUMMARY
For anyone who plans to retrieve variables that will later be used and evaluated by the jinja2 evaluating engine, it is important to note that it wouldn't be possible unless they pass `allow_unsafe=True` as an option in the lookup. Finding this information is not the easiest unless you know what to search for online. Link to where that information can be found [here](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-allow-unsafe-lookups).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Lookup Plugin

