### PR TITLE
Rebalance Windows test groups to avoid timeouts

### DIFF
--- a/test/integration/targets/win_group_membership/aliases
+++ b/test/integration/targets/win_group_membership/aliases
@@ -1,1 +1,1 @@
-shippable/windows/group6
+shippable/windows/group4

--- a/test/integration/targets/win_uri/aliases
+++ b/test/integration/targets/win_uri/aliases
@@ -1,3 +1,3 @@
-shippable/windows/group6
+shippable/windows/group3
 needs/httptester
 skip/windows/2008  # httptester requires SSH which doesn't work with 2008


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Moving things around to hopefully avoid issues with `win_uri` failing as it gets close to the test timeout.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/win_group_membership/aliases`
`test/integration/targets/win_uri/aliases`
