### PR TITLE
Add STDERR exception for ClientScriptVaultSecret

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -498,9 +498,8 @@ class ClientScriptVaultSecret(ScriptVaultSecret):
 
     def _run(self, command):
         try:
-            p = subprocess.Popen(command,
-                                 stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE)
+            # STDERR not captured to make it easier for users to prompt for input in their scripts
+            p = subprocess.Popen(command, stdout=subprocess.PIPE)
         except OSError as e:
             msg_format = "Problem running vault password client script %s (%s)." \
                 " If this is not a script, remove the executable bit from the file."


### PR DESCRIPTION
##### SUMMARY
Seems like the function to not capture STDERR for vault scripts was applied to the wrong class, added it to ClientScriptVaultSecret but did not remove it from ScriptVaultSecret

Messages printed to STDERR by the script where actually not printed to the user.

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
Vault parser

