### PR TITLE
[stable-2.10] Normalize ConfigParser between Python2 and Python3 (#73715)

### DIFF
--- a/changelogs/fragments/73709-normalize-configparser.yml
+++ b/changelogs/fragments/73709-normalize-configparser.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- ConfigManager - Normalize ConfigParser between Python2 and Python3 to for handling comments
+  (https://github.com/ansible/ansible/issues/73709)

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -325,7 +325,10 @@ class ConfigManager(object):
         ftype = get_config_type(cfile)
         if cfile is not None:
             if ftype == 'ini':
-                self._parsers[cfile] = configparser.ConfigParser()
+                kwargs = {}
+                if PY3:
+                    kwargs['inline_comment_prefixes'] = (';',)
+                self._parsers[cfile] = configparser.ConfigParser(**kwargs)
                 with open(to_bytes(cfile), 'rb') as f:
                     try:
                         cfg_text = to_text(f.read(), errors='surrogate_or_strict')

--- a/test/integration/targets/config/inline_comment_ansible.cfg
+++ b/test/integration/targets/config/inline_comment_ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+cowsay_enabled_stencils = ansibull  ; BOOM

--- a/test/integration/targets/config/inline_comment_ansible.cfg
+++ b/test/integration/targets/config/inline_comment_ansible.cfg
@@ -1,2 +1,2 @@
 [defaults]
-cowsay_enabled_stencils = ansibull  ; BOOM
+cow_whitelist = ansibull  ; BOOM

--- a/test/integration/targets/config/runme.sh
+++ b/test/integration/targets/config/runme.sh
@@ -15,3 +15,6 @@ ANSIBLE_REMOTE_TMP="$HOME/.ansible/directory_with_no_space"  ansible -m ping tes
 ANSIBLE_REMOTE_TMP="$HOME/.ansible/directory with space"  ansible -m ping testhost -i ../../inventory "$@"
 
 ANSIBLE_CONFIG=nonexistent.cfg ansible-config dump --only-changed -v | grep 'No config file found; using defaults'
+
+# https://github.com/ansible/ansible/pull/73715
+ANSIBLE_CONFIG=inline_comment_ansible.cfg ansible-config dump --only-changed | grep "'ansibull'"


### PR DESCRIPTION
* Normalize config parser between py2 and py3

* Add tests and changelog

* Use different config entry, since we supply certain env vars
(cherry picked from commit 950ab74)

Co-authored-by: Matt Martz <matt@sivel.net>