### PR TITLE
[stable-2.9] Normalize ConfigParser between Python2 and Python3 (#73715)

### DIFF
--- a/changelogs/fragments/73709-normalize-configparser.yml
+++ b/changelogs/fragments/73709-normalize-configparser.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- ConfigManager - Normalize ConfigParser between Python2 and Python3 to for handling comments
+  (https://github.com/ansible/ansible/issues/73709)

--- a/changelogs/fragments/73709-normalize-configparser.yml
+++ b/changelogs/fragments/73709-normalize-configparser.yml
@@ -1,3 +1,3 @@
 bugfixes:
-- ConfigManager - Normalize ConfigParser between Python2 and Python3 to for handling comments
+- ConfigManager - Normalize ConfigParser between Python2 and Python3 for handling comments
   (https://github.com/ansible/ansible/issues/73709)

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -316,7 +316,10 @@ class ConfigManager(object):
         ftype = get_config_type(cfile)
         if cfile is not None:
             if ftype == 'ini':
-                self._parsers[cfile] = configparser.ConfigParser()
+                kwargs = {}
+                if PY3:
+                    kwargs['inline_comment_prefixes'] = (';',)
+                self._parsers[cfile] = configparser.ConfigParser(**kwargs)
                 with open(to_bytes(cfile), 'rb') as f:
                     try:
                         cfg_text = to_text(f.read(), errors='surrogate_or_strict')

--- a/test/integration/targets/config/inline_comment_ansible.cfg
+++ b/test/integration/targets/config/inline_comment_ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+cowsay_enabled_stencils = ansibull  ; BOOM

--- a/test/integration/targets/config/inline_comment_ansible.cfg
+++ b/test/integration/targets/config/inline_comment_ansible.cfg
@@ -1,2 +1,2 @@
 [defaults]
-cowsay_enabled_stencils = ansibull  ; BOOM
+cow_whitelist = ansibull  ; BOOM

--- a/test/integration/targets/config/runme.sh
+++ b/test/integration/targets/config/runme.sh
@@ -9,7 +9,10 @@ ANSIBLE_TIMEOUT= ansible -m ping testhost -i ../../inventory "$@"
 # env var is wrong type, this should be a fatal error pointing at the setting
 ANSIBLE_TIMEOUT='lola' ansible -m ping testhost -i ../../inventory "$@" 2>&1|grep 'Invalid type for configuration option setting: DEFAULT_TIMEOUT'
 
-# https://github.com/ansible/ansible/issues/69577                                                         
-ANSIBLE_REMOTE_TMP="$HOME/.ansible/directory_with_no_space"  ansible -m ping testhost -i ../../inventory "$@" 
-                                                                                                          
+# https://github.com/ansible/ansible/issues/69577
+ANSIBLE_REMOTE_TMP="$HOME/.ansible/directory_with_no_space"  ansible -m ping testhost -i ../../inventory "$@"
+
 ANSIBLE_REMOTE_TMP="$HOME/.ansible/directory with space"  ansible -m ping testhost -i ../../inventory "$@"
+
+# https://github.com/ansible/ansible/pull/73715
+ANSIBLE_CONFIG=inline_comment_ansible.cfg ansible-config dump --only-changed | grep "'ansibull'"


### PR DESCRIPTION
* Normalize config parser between py2 and py3

* Add tests and changelog

* Use different config entry, since we supply certain env vars.
(cherry picked from commit 950ab74758a6014639236612594118b2b6f4751e)

Co-authored-by: Matt Martz <matt@sivel.net>