### PR TITLE
Allow include_vars to operate on multiple files

### DIFF
--- a/changelogs/fragments/include_vars_multiple_files.yml
+++ b/changelogs/fragments/include_vars_multiple_files.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - include_vars - ``file`` option now also accepts a list of files.
+  - include_vars - add ``skip_if_missing`` option to ignore file not found errors.

--- a/lib/ansible/modules/include_vars.py
+++ b/lib/ansible/modules/include_vars.py
@@ -22,9 +22,11 @@ version_added: "1.4"
 options:
   file:
     description:
-      - The file name from which variables should be loaded.
-      - If the path is relative, it will look for the file in vars/ subdirectory of a role or relative to playbook.
-    type: path
+      - The file name(s) from which variables should be loaded.
+      - If a path is relative, it will look for the file in vars/ subdirectory of a role or relative to playbook.
+      - When including multiple files values are updated in given order.
+    elements: path
+    type: list
     version_added: "2.2"
   dir:
     description:
@@ -70,6 +72,12 @@ options:
     type: bool
     default: no
     version_added: "2.7"
+  skip_if_missing:
+    description:
+      - Ignore non-existent files instead of reporting an error.
+    type: bool
+    default: no
+    version_added: "2.11"
   free-form:
     description:
       - This module allows you to specify the 'file' option directly without any other options.
@@ -147,6 +155,14 @@ EXAMPLES = r'''
       - 'yaml'
       - 'yml'
       - 'json'
+
+- name: Include multiple files, if available. (2.11)
+  include_vars:
+    file:
+      - 'default.yml'
+      - 'overwrite.yml'
+      - 'missing.yml'
+    skip_if_missing: True
 '''
 
 RETURN = r'''

--- a/test/integration/targets/include_vars/tasks/main.yml
+++ b/test/integration/targets/include_vars/tasks/main.yml
@@ -162,3 +162,21 @@
     that:
       - "'my_custom_service' == service_name_fqcn"
       - "'my_custom_service' == service_name_tmpl_fqcn"
+
+- name: include multiple var files if available
+  include_vars:
+    file:
+      - "all/all.yml"
+      - "missing.yml"
+      - "environments/development/services/webapp.yml"
+      - "environments/development/all.yml"
+    name: multiple
+    skip_if_missing: True
+
+- name: verify that multiple files have been included
+  assert:
+    that:
+      - "multiple['unchanged'] == True"
+      - "multiple['testing'] == 789"
+      - "multiple['base_dir'] == 'environments/development'"
+      - "multiple['webapp_containers'] == 20"

--- a/test/integration/targets/include_vars/vars/all/all.yml
+++ b/test/integration/targets/include_vars/vars/all/all.yml
@@ -1,3 +1,4 @@
 ---
 testing: 123
 base_dir: all
+unchanged: true


### PR DESCRIPTION
##### SUMMARY
Allow the `include_vars` plugin to operate on multiple files at once using the `file` option. Compared to the existing `dir` option these files can be in arbitrary locations. Files are processed in user-defined order and a new option `skip_if_missing` allows ignoring errors on non-existent files.

Although it is possible to use this plugin together with `with_items` (or just multiple manual invocations), when also using the `name` option the previous contents of the named variable are dropped in later invocations. Here, the named variable will contain older contents that were not replaced by later files. Both use cases seem reasonable to me, so I did not change existing behavior.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
include_vars

##### ADDITIONAL INFORMATION
Consider the following variable files:
```
# vars/default.yml
default: 0
bar: 23

# vars/foo.yml
baz: 17
bar: 42
```

This will output `foo: { baz: 17, bar: 42 }`:
```
- include_vars:
    file: "{{ item }}"
    name: foo
  with_items:
    - default.yml
    - foo.yml

- debug:
    var: foo
```

However, this will output `foo: { default: 0, baz: 17, bar: 42 }`:
```
- include_vars:
    file:
      - default.yml
      - foo.yml
    name: foo

- debug:
    var: foo
```

This will output the same:
```
- include_vars:
    file:
      - default.yml
      - non-existing.yml
      - foo.yml
    skip_if_missing: True
    name: foo

- debug:
    var: foo
```

One could potentially use multiple named variables and then use the `combine` and `default` filters on every usage to achieve the same result, but this becomes tedious quickly. Furthermore, even if the files were all in the same place to be used with the `dir` option, this change allows the user to specify a loading order instead of an alphabetical one.