### PR TITLE
Add basic support for user subuid/subgid management.

### DIFF
--- a/changelogs/fragments/73741-subuid-management.yml
+++ b/changelogs/fragments/73741-subuid-management.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - >-
+    support ``subuid`` and ``subgid`` attributes for users on Linux
+    (https://github.com/ansible/ansible/issues/68199)

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -32,6 +32,7 @@
 - import_tasks: test_expires_new_account.yml
 - import_tasks: test_expires_new_account_epoch_negative.yml
 - import_tasks: test_expires_min_max.yml
+- import_tasks: test_subuid_subgid.yml
 - import_tasks: test_shadow_backup.yml
 - import_tasks: test_ssh_key_passphrase.yml
 - import_tasks: test_password_lock.yml

--- a/test/integration/targets/user/tasks/test_subuid_subgid.yml
+++ b/test/integration/targets/user/tasks/test_subuid_subgid.yml
@@ -1,6 +1,6 @@
 # https://github.com/ansible/ansible/issues/68199
 - name: Test setting subuid and subgid
-  when: ansible_facts.os_family in ['RedHat', 'Debian', 'Suse']
+  when: ansible_facts.os_family in ['RedHat', 'Debian', 'Suse'] and [ansible_facts.distribution, ansible_facts.distribution_major_version] != ['CentOS', '6']
   block:
     - name: create user
       user:

--- a/test/integration/targets/user/tasks/test_subuid_subgid.yml
+++ b/test/integration/targets/user/tasks/test_subuid_subgid.yml
@@ -1,0 +1,44 @@
+# https://github.com/ansible/ansible/issues/68199
+- name: Test setting subuid and subgid
+  when: ansible_facts.os_family in ['RedHat', 'Debian', 'Suse']
+  block:
+    - name: create user
+      user:
+        name: ansibulluser
+        state: present
+
+    - name: add subuid
+      user:
+        name: ansibulluser
+        subuid: present
+      register: subuid_1_0
+
+    - name: again add subuid
+      user:
+        name: ansibulluser
+        subuid: present
+      register: subuid_1_1
+
+    - name: validate result for subuid
+      assert:
+        that:
+          - subuid_1_0 is changed
+          - subuid_1_1 is not changed
+
+    - name: add subgid
+      user:
+        name: ansibulluser
+        subgid: present
+      register: subgid_2_0
+
+    - name: again add subgid
+      user:
+        name: ansibulluser
+        subgid: present
+      register: subgid_2_1
+
+    - name: validate result for subgid
+      assert:
+        that:
+          - subgid_2_0 is changed
+          - subgid_2_1 is not changed

--- a/test/integration/targets/user/tasks/test_subuid_subgid.yml
+++ b/test/integration/targets/user/tasks/test_subuid_subgid.yml
@@ -7,16 +7,16 @@
         name: ansibulluser
         state: present
 
-    - name: add subuid
+    - name: remove subuid
       user:
         name: ansibulluser
-        subuid: present
+        subuid: absent
       register: subuid_1_0
 
-    - name: again add subuid
+    - name: again remove subuid
       user:
         name: ansibulluser
-        subuid: present
+        subuid: absent
       register: subuid_1_1
 
     - name: validate result for subuid
@@ -24,6 +24,42 @@
         that:
           - subuid_1_0 is changed
           - subuid_1_1 is not changed
+
+    - name: add subuid
+      user:
+        name: ansibulluser
+        subuid: present
+      register: subuid_2_0
+
+    - name: again add subuid
+      user:
+        name: ansibulluser
+        subuid: present
+      register: subuid_2_1
+
+    - name: validate result for subuid
+      assert:
+        that:
+          - subuid_2_0 is changed
+          - subuid_2_1 is not changed
+
+    - name: remove subgid
+      user:
+        name: ansibulluser
+        subgid: absent
+      register: subgid_1_0
+
+    - name: again remove subgid
+      user:
+        name: ansibulluser
+        subgid: absent
+      register: subgid_1_1
+
+    - name: validate result for subgid
+      assert:
+        that:
+          - subgid_1_0 is changed
+          - subgid_1_1 is not changed
 
     - name: add subgid
       user:


### PR DESCRIPTION
##### SUMMARY

Fixes #68199 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
user

##### ADDITIONAL INFORMATION

This addition does not support arbitrary static assignments of subuid or subgid, but does support ensuring that a range is present for a user.

For example:

```
- name: set subid for gordon
  user: name=gordon subuid=present subgid=present
```
