### PR TITLE
Move win_uri to a group that does not have another test using port 80

### DIFF
--- a/test/integration/targets/win_uri/aliases
+++ b/test/integration/targets/win_uri/aliases
@@ -1,3 +1,3 @@
-shippable/windows/group3
+shippable/windows/group7
 needs/httptester
 skip/windows/2008  # httptester requires SSH which doesn't work with 2008


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
~Another test in group3 reboots the test instance, killing the ssh connections needed for access to the httptest container.~

The `win_iis_webapppool` test is using port 80 and this conflicts with the port `httptest` wants to use.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/win_uri`
