### PR TITLE
ansible-test - Remove outdated --docker and --remote entries.

### DIFF
--- a/changelogs/fragments/ansible-test-platforms.yml
+++ b/changelogs/fragments/ansible-test-platforms.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - "ansible-test - Remove outdated ``--docker`` completion entries: fedora30, fedora31, ubuntu1604"
+  - "ansible-test - Remove outdated ``--remote`` completion entries: freebsd/11.1, freebsd/12.1, osx/10.11, macos/10.15, rhel/7.6, rhel/7.8, rhel/8.1, rhel/8.2"
+  - "ansible-test - Remove unused ``--remote`` completion entry: power/centos/7"

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -4,12 +4,9 @@ alpine3 name=quay.io/ansible/alpine3-test-container:2.0.1 python=3.8
 centos6 name=quay.io/ansible/centos6-test-container:2.0.1 python=2.6 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:2.0.1 python=2.7 seccomp=unconfined
 centos8 name=quay.io/ansible/centos8-test-container:2.0.1 python=3.6 seccomp=unconfined
-fedora30 name=quay.io/ansible/fedora30-test-container:2.0.1 python=3.7
-fedora31 name=quay.io/ansible/fedora31-test-container:2.0.1 python=3.7
 fedora32 name=quay.io/ansible/fedora32-test-container:2.0.1 python=3.8
 fedora33 name=quay.io/ansible/fedora33-test-container:2.0.1 python=3.9
 opensuse15py2 name=quay.io/ansible/opensuse15py2-test-container:2.0.1 python=2.7
 opensuse15 name=quay.io/ansible/opensuse15-test-container:2.0.1 python=3.6
-ubuntu1604 name=quay.io/ansible/ubuntu1604-test-container:2.0.1 python=2.7 seccomp=unconfined
 ubuntu1804 name=quay.io/ansible/ubuntu1804-test-container:2.0.1 python=3.6 seccomp=unconfined
 ubuntu2004 name=quay.io/ansible/ubuntu2004-test-container:2.0.1 python=3.8 seccomp=unconfined

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -1,15 +1,6 @@
-freebsd/11.1 python=2.7,3.6 python_dir=/usr/local/bin
 freebsd/11.4 python=2.7,3.7,3.8 python_dir=/usr/local/bin
-freebsd/12.1 python=3.6,2.7 python_dir=/usr/local/bin
 freebsd/12.2 python=3.7,2.7,3.8 python_dir=/usr/local/bin
-osx/10.11 python=2.7 python_dir=/usr/local/bin
-macos/10.15 python=3.8 python_dir=/usr/local/bin
 macos/11.1 python=3.9 python_dir=/usr/local/bin
-rhel/7.6 python=2.7
-rhel/7.8 python=2.7
 rhel/7.9 python=2.7
-rhel/8.1 python=3.6
-rhel/8.2 python=3.6,3.8
 rhel/8.3 python=3.6,3.8
 aix/7.2 python=2.7 httptester=disabled temp-unicode=disabled pip-check=disabled
-power/centos/7 python=2.7


### PR DESCRIPTION
##### SUMMARY

Remove outdated `--docker` and `--remote` entries from ansible-test.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
