### PR TITLE
Auto cleanup of async cache file

### DIFF
--- a/changelogs/fragments/73760-async-cleanup.yml
+++ b/changelogs/fragments/73760-async-cleanup.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Automatically remove async cache files for polled async tasks that have completed (issue https://github.com/ansible/ansible/issues/73206).

--- a/docs/docsite/rst/user_guide/playbooks_async.rst
+++ b/docs/docsite/rst/user_guide/playbooks_async.rst
@@ -62,6 +62,10 @@ To avoid timeouts on a task, specify its maximum runtime and how frequently you 
   task when run in check mode. See :ref:`check_mode_dry` on how to
   skip a task in check mode.
 
+.. note::
+   When an async task completes with polling enabled, the temporary async job cache
+   file (by default in ~/.ansible_async/) is automatically removed.
+
 Run tasks concurrently: poll = 0
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -86,6 +90,11 @@ To run a playbook task asynchronously::
 
 .. note::
    Using a higher value for ``--forks`` will result in kicking off asynchronous tasks even faster. This also increases the efficiency of polling.
+
+.. note::
+   When running with ``poll: 0``, Ansible will not automatically cleanup the async job cache file.
+   You will need to manually clean this up with the :ref:`async_status <async_status_module>` module
+   with ``mode: cleanup``.
 
 If you need a synchronization point with an async task, you can register it to obtain its job ID and use the :ref:`async_status <async_status_module>` module to observe it in a later task. For example::
 

--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -42,6 +42,25 @@
         - async_result.finished == 1
         - async_result is finished
 
+- name: assert temp async directory exists
+  stat:
+    path: "~/.ansible_async"
+  register: dir_st
+
+- assert:
+    that:
+      - dir_st.stat.isdir is defined and dir_st.stat.isdir
+
+- name: stat temp async status file
+  stat:
+    path: "~/.ansible_async/{{ async_result.ansible_job_id }}"
+  register: tmp_async_file_st
+
+- name: validate automatic cleanup of temp async status file on completed run
+  assert:
+    that:
+      - not tmp_async_file_st.stat.exists
+
 - name: test async without polling
   command: sleep 5
   async: 30


### PR DESCRIPTION
##### SUMMARY

Automatically remove the async cache file left behind in `~/.ansible_async` when an async task completes and its status has been polled.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #73206

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
async

