### PR TITLE
Add environment support to adhoc

### DIFF
--- a/changelogs/fragments/73762-adhoc-environment.yml
+++ b/changelogs/fragments/73762-adhoc-environment.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- Ad Hoc - Add new ``--env`` flag to support ``key=value`` assignments to specify environment variables
+  for the task (https://github.com/ansible/ansible/pull/73762)

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -84,7 +84,7 @@ class AdHocCLI(CLI):
             if environment:
                 mytask['environment'] = environment
         elif environment:
-                mytask['action']['args']['apply'] = {'environment': environment}
+            mytask['action']['args']['apply'] = {'environment': environment}
 
         return dict(
             name="Ansible Ad-Hoc",

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -52,7 +52,7 @@ class AdHocCLI(CLI):
         self.parser.add_argument('-m', '--module-name', dest='module_name',
                                  help="module name to execute (default=%s)" % C.DEFAULT_MODULE_NAME,
                                  default=C.DEFAULT_MODULE_NAME)
-        self.parser.add_argument('--env', dest='environment', action='append',
+        self.parser.add_argument('--env', dest='environment', action='append', default=[],
                                  help='Environment vars to use in executing the module')
         self.parser.add_argument('args', metavar='pattern', help='host pattern')
 

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -52,6 +52,8 @@ class AdHocCLI(CLI):
         self.parser.add_argument('-m', '--module-name', dest='module_name',
                                  help="module name to execute (default=%s)" % C.DEFAULT_MODULE_NAME,
                                  default=C.DEFAULT_MODULE_NAME)
+        self.parser.add_argument('--env', dest='environment', action='append',
+                                 help='Environment vars to use in executing the module')
         self.parser.add_argument('args', metavar='pattern', help='host pattern')
 
     def post_process_args(self, options):
@@ -67,8 +69,12 @@ class AdHocCLI(CLI):
     def _play_ds(self, pattern, async_val, poll):
         check_raw = context.CLIARGS['module_name'] in C.MODULE_REQUIRE_ARGS
 
+        environment = {}
+        for env in context.CLIARGS['environment']:
+            environment.update(parse_kv(env))
+
         mytask = {'action': {'module': context.CLIARGS['module_name'], 'args': parse_kv(context.CLIARGS['module_args'], check_raw=check_raw)},
-                  'timeout': context.CLIARGS['task_timeout']}
+                  'timeout': context.CLIARGS['task_timeout'], 'environment': environment}
 
         # avoid adding to tasks that don't support it, unless set, then give user an error
         if context.CLIARGS['module_name'] not in C._ACTION_ALL_INCLUDE_ROLE_TASKS and any(frozenset((async_val, poll))):

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -74,12 +74,17 @@ class AdHocCLI(CLI):
             environment.update(parse_kv(env))
 
         mytask = {'action': {'module': context.CLIARGS['module_name'], 'args': parse_kv(context.CLIARGS['module_args'], check_raw=check_raw)},
-                  'timeout': context.CLIARGS['task_timeout'], 'environment': environment}
+                  'timeout': context.CLIARGS['task_timeout']}
 
         # avoid adding to tasks that don't support it, unless set, then give user an error
-        if context.CLIARGS['module_name'] not in C._ACTION_ALL_INCLUDE_ROLE_TASKS and any(frozenset((async_val, poll))):
-            mytask['async_val'] = async_val
-            mytask['poll'] = poll
+        if context.CLIARGS['module_name'] not in C._ACTION_ALL_INCLUDE_ROLE_TASKS:
+            if any(frozenset((async_val, poll))):
+                mytask['async_val'] = async_val
+                mytask['poll'] = poll
+            if environment:
+                mytask['environment'] = environment
+        elif environment:
+                mytask['action']['args']['apply'] = {'environment': environment}
 
         return dict(
             name="Ansible Ad-Hoc",


### PR DESCRIPTION
##### SUMMARY
Add environment support to adhoc

```
$ ansible localhost -a 'echo $FOOO' --env FOOO=BAR
localhost | CHANGED | rc=0 >>
BAR
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/cli/adhoc.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
