### PR TITLE
Add refresh-token sub command for ansible-galaxy collection

### DIFF
--- a/hacking/build_library/build_ansible/command_plugins/generate_man.py
+++ b/hacking/build_library/build_ansible/command_plugins/generate_man.py
@@ -176,7 +176,7 @@ def opts_docs(cli_class_name, cli_module_name):
             # docs['actions'][action] = {}
             # docs['actions'][action]['name'] = action
             action_info['name'] = action
-            action_info['desc'] = trim_docstring(getattr(cli, 'execute_%s' % action).__doc__)
+            action_info['desc'] = trim_docstring(getattr(cli, 'execute_%s' % action.replace('-', '_')).__doc__)
 
             # docs['actions'][action]['desc'] = getattr(cli, 'execute_%s' % action).__doc__.strip()
             action_doc_list = opt_doc_list(parser)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -370,7 +370,7 @@ class GalaxyCLI(CLI):
     def add_refresh_token_options(self, parser, parents=None):
         galaxy_type = 'collection'
         refresh_parser = parser.add_parser('refresh-token', parents=parents,
-                                           help='Refresh the Automation Hub access token')
+                                           help='Refresh the Automation Hub access tokens for all servers')
         refresh_parser.set_defaults(func=self.execute_refresh_token)
 
     def add_install_options(self, parser, parents=None):

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -216,6 +216,7 @@ class GalaxyCLI(CLI):
         self.add_install_options(collection_parser, parents=[common, force, cache_options])
         self.add_list_options(collection_parser, parents=[common, collections_path])
         self.add_verify_options(collection_parser, parents=[common, collections_path])
+        self.add_refresh_token_options(collection_parser, parents=[common])
 
         # Add sub parser for the Galaxy role actions
         role = type_parser.add_parser('role', help='Manage an Ansible Galaxy role.')
@@ -365,6 +366,12 @@ class GalaxyCLI(CLI):
                                    help='Ignore errors during verification and continue with the next specified collection.')
         verify_parser.add_argument('-r', '--requirements-file', dest='requirements',
                                    help='A file containing a list of collections to be verified.')
+
+    def add_refresh_token_options(self, parser, parents=None):
+        galaxy_type = 'collection'
+        refresh_parser = parser.add_parser('refresh-token', parents=parents,
+                                           help='Refresh the Automation Hub access token')
+        refresh_parser.set_defaults(func=self.execute_refresh_token)
 
     def add_install_options(self, parser, parents=None):
         galaxy_type = 'collection' if parser.metavar == 'COLLECTION_ACTION' else 'role'
@@ -1094,6 +1101,11 @@ class GalaxyCLI(CLI):
         )
 
         return 0
+
+    def execute_refresh_token(self):
+        for server in self.api_servers:
+            if isinstance(server.token, KeycloakToken):
+                display.display('Refreshing access token for %s' % server)
 
     @with_collection_artifacts_manager
     def execute_install(self, artifacts_manager=None):


### PR DESCRIPTION
##### SUMMARY
Add refresh-token sub command for ansible-galaxy collection. See #73749

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/cli/galaxy.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
