### PR TITLE
Add CoC checkboxes to the issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -122,4 +122,16 @@ body:
       ```
   validations:
     required: true
+
+
+- type: checkboxes
+  attributes:
+    label: Code of Conduct
+    description: |
+      Read the [Ansible Code of Conduct][CoC] first.
+
+      [CoC]: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--bug_report.yml
+    options:
+    - label: I agree to follow the Ansible Code of Conduct
+      required: true
 ...

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -86,6 +86,19 @@ body:
   validations:
     required: true
 
+
+- type: checkboxes
+  attributes:
+    label: Code of Conduct
+    description: |
+      Read the [Ansible Code of Conduct][CoC] first.
+
+      [CoC]: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--documentation_report.yml
+    options:
+    - label: I agree to follow the Ansible Code of Conduct
+      required: true
+
+
 - type: markdown
   attributes:
     value: |
@@ -94,4 +107,9 @@ body:
       Describe how this improves the documentation, e.g. before/after situation or screenshots.
 
       **HINT:** You can paste https://gist.github.com links for larger files.
+    placeholder: >-
+      When the improvement is applied, it makes it more straightforward
+      to understand X.
+  validations:
+    required: true
 ...

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -59,4 +59,16 @@ body:
       ```
   validations:
     required: true
+
+
+- type: checkboxes
+  attributes:
+    label: Code of Conduct
+    description: |
+      Read the [Ansible Code of Conduct][CoC] first.
+
+      [CoC]: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--feature_request.yml
+    options:
+    - label: I agree to follow the Ansible Code of Conduct
+      required: true
 ...


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is a follow-up for #73751. It essentially adds an unskippable checkbox certifying that the issue submitter saw the CoC. I think this would be encouraging for the community to behave.

One of the opinions is that we don't need this (https://github.com/ansible/ansible/pull/73751#discussion_r585872658) but I wanted to ask a broader audience what you all think.

###### **[:point_right: ISSUE FORMS CHANGES FROM THIS PR ARE IN THE DEMO REPOSITORY :point_left:](/ansible/issue-forms-demo-for-ansible/issues/new/choose)**

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
.github/ISSUE_TEMPLATE/*

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
https://gh-community.github.io/issue-template-feedback/structured/