### PR TITLE
add base 2.10 to version switcher

### DIFF
--- a/docs/docsite/sphinx_conf/core_conf.py
+++ b/docs/docsite/sphinx_conf/core_conf.py
@@ -168,7 +168,7 @@ html_context = {
     'current_version': version,
     'latest_version': '2.10',
     # list specifically out of order to make latest work
-    'available_versions': ('2.10','devel',),
+    'available_versions': ('2.10', 'devel',),
     'css_files': ('_static/ansible.css',  # overrides to the standard theme
                   ),
 }

--- a/docs/docsite/sphinx_conf/core_conf.py
+++ b/docs/docsite/sphinx_conf/core_conf.py
@@ -166,9 +166,9 @@ html_context = {
     'github_root_dir': 'devel/lib/ansible',
     'github_cli_version': 'devel/lib/ansible/cli/',
     'current_version': version,
-    'latest_version': 'devel',
+    'latest_version': '2.10',
     # list specifically out of order to make latest work
-    'available_versions': ('devel',),
+    'available_versions': ('2.10','devel',),
     'css_files': ('_static/ansible.css',  # overrides to the standard theme
                   ),
 }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Since ansible-base will continue to release, we need a way to publish it separate from the existing Ansible (aka package) 2.10 docs.  This adds 2.10 as a version for the Ansible Core docs.
This will need to be backported to stable-2.10
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs/docsite/sphinx_conf/core_conf.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
