### PR TITLE
fix: backport #66322 on 2.9

### DIFF
--- a/changelogs/fragments/66322-moved_line_causing_terraform_output_suppression.yml
+++ b/changelogs/fragments/66322-moved_line_causing_terraform_output_suppression.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - terraform - reset out and err before plan creation (https://github.com/ansible/ansible/issues/64369)

--- a/lib/ansible/modules/cloud/misc/terraform.py
+++ b/lib/ansible/modules/cloud/misc/terraform.py
@@ -347,6 +347,8 @@ def main():
     # we aren't sure if this plan will result in changes, so assume yes
     needs_application, changed = True, False
 
+    out, err = '', ''
+
     if state == 'absent':
         command.extend(variables_args)
     elif state == 'present' and plan_file:
@@ -359,7 +361,6 @@ def main():
                                                                      module.params.get('targets'), state, plan_file)
         command.append(plan_file)
 
-    out, err = '', ''
     if needs_application and not module.check_mode and not state == 'planned':
         rc, out, err = module.run_command(command, cwd=project_path)
         # checks out to decide if changes were made during execution


### PR DESCRIPTION

##### SUMMARY

Backport of #66322

<!--- Describe the change below, including rationale and design decisions -->

* remove the line that is suppressing the output being shown when running
terraform from ansible
* Address #56934 and #57044
* added changelog for bug fix for missing terraform output

Co-authored-by: Adam <adam.lemanski@gmail.com>

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
terraform

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
