### PR TITLE
[2.10] galaxy: Handle ignored directory names in role skeleton (#72035)

### DIFF
--- a/changelogs/fragments/71977-ansible-galaxy-role-init.yml
+++ b/changelogs/fragments/71977-ansible-galaxy-role-init.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-galaxy - fixed galaxy role init command (https://github.com/ansible/ansible/issues/71977)."

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -877,7 +877,9 @@ class GalaxyCLI(CLI):
             else:
                 in_templates_dir = rel_root_dir == 'templates'
 
-            dirs = [d for d in dirs if not any(r.match(d) for r in skeleton_ignore_re)]
+            # Filter out ignored directory names
+            # Use [:] to mutate the list os.walk uses
+            dirs[:] = [d for d in dirs if not any(r.match(d) for r in skeleton_ignore_re)]
 
             for f in files:
                 filename, ext = os.path.splitext(f)

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -317,6 +317,19 @@ pushd "${role_testdir}"
 popd # ${role_testdir}
 rm -rf "${role_testdir}"
 
+f_ansible_galaxy_status \
+    "Test if git hidden directories are skipped while using role skeleton (#71977)"
+
+role_testdir=$(mktemp -d)
+pushd "${role_testdir}"
+
+    ansible-galaxy role init sample-role-skeleton
+    git init ./sample-role-skeleton
+    ansible-galaxy role init --role-skeleton=sample-role-skeleton example
+
+popd # ${role_testdir}
+rm -rf "${role_testdir}"
+
 #################################
 # ansible-galaxy collection tests
 #################################


### PR DESCRIPTION
##### SUMMARY
* galaxy: restore left hand slicing in assignment

Fix 'ansible-galaxy role init --role-skeleton=role-skeleton' when the role skeleton
contains an ignored directory.

The issue was because the 'dirs' variable was changed to reference a different list,
but needs to be mutated instead to stop os.walk from traversing ignored directories.

Fixes: #71977

Co-authored-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit eb72c36a71c8bf786d575a31246f602ad69cc9c9)

##### ISSUE TYPE
- Bugfix Pull Request
