### PR TITLE
[2.10] find module - stop dir traversal when depth is exceeded

### DIFF
--- a/changelogs/fragments/73718-find-dir-depth-traversal.yml
+++ b/changelogs/fragments/73718-find-dir-depth-traversal.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - find module - Stop traversing directories past the requested depth. (https://github.com/ansible/ansible/issues/73627)

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -413,6 +413,8 @@ def main():
                         wpath = npath.rstrip(os.path.sep) + os.path.sep
                         depth = int(fsname.count(os.path.sep)) - int(wpath.count(os.path.sep)) + 1
                         if depth > params['depth']:
+                            # Empty the list used by os.walk to avoid traversing deeper unnecessarily
+                            del(dirs[:])
                             continue
                     if os.path.basename(fsname).startswith('.') and not params['hidden']:
                         continue

--- a/test/integration/targets/find/tasks/main.yml
+++ b/test/integration/targets/find/tasks/main.yml
@@ -67,6 +67,7 @@
           - 'find_test0.msg is defined'
           - 'find_test0.matched == 8'
           - 'find_test0.files | length == 8'
+          - 'find_test0.examined == 16'
 
 - name: find the xml and img files
   find:
@@ -95,3 +96,46 @@
           - 'find_test2.matched == 1'
           - 'find_test2.files[0].pw_name is defined'
           - 'find_test2.files[0].gr_name is defined'
+
+- name: test number of examined directories/files
+  block:
+    - name: Get all files/directories in the path
+      find:
+        paths: "{{ output_dir_test }}"
+        recurse: yes
+        file_type: any
+      register: total_contents
+
+    - assert:
+        that:
+          - total_contents.matched == 18
+          - total_contents.examined == 18
+
+    - name: Get files and directories with depth
+      find:
+        paths: "{{ output_dir_test }}"
+        recurse: yes
+        file_type: any
+        depth: 2
+      register: contents_with_depth
+
+    - assert:
+        that:
+          - contents_with_depth.matched == 8
+          # dir contents are considered until the depth exceeds the requested depth
+          # there are 8 files/directories in the requested depth and 4 that exceed it by 1
+          - contents_with_depth.examined == 12
+
+    - name: Find files with depth
+      find:
+        paths: "{{ output_dir_test }}"
+        depth: 2
+        recurse: yes
+      register: files_with_depth
+
+    - assert:
+        that:
+          - files_with_depth.matched == 4
+          # dir contents are considered until the depth exceeds the requested depth
+          # there are 8 files/directories in the requested depth and 4 that exceed it by 1
+          - files_with_depth.examined == 12

--- a/test/integration/targets/find/tasks/main.yml
+++ b/test/integration/targets/find/tasks/main.yml
@@ -108,8 +108,8 @@
 
     - assert:
         that:
-          - total_contents.matched == 18
-          - total_contents.examined == 18
+          - total_contents.matched == 16
+          - total_contents.examined == 16
 
     - name: Get files and directories with depth
       find:
@@ -121,10 +121,10 @@
 
     - assert:
         that:
-          - contents_with_depth.matched == 8
+          - contents_with_depth.matched == 6
           # dir contents are considered until the depth exceeds the requested depth
-          # there are 8 files/directories in the requested depth and 4 that exceed it by 1
-          - contents_with_depth.examined == 12
+          # there are 6 files/directories in the requested depth and 4 that exceed it by 1
+          - contents_with_depth.examined == 10
 
     - name: Find files with depth
       find:
@@ -135,7 +135,7 @@
 
     - assert:
         that:
-          - files_with_depth.matched == 4
+          - files_with_depth.matched == 2
           # dir contents are considered until the depth exceeds the requested depth
-          # there are 8 files/directories in the requested depth and 4 that exceed it by 1
-          - files_with_depth.examined == 12
+          # there are 6 files/directories in the requested depth and 4 that exceed it by 1
+          - files_with_depth.examined == 10


### PR DESCRIPTION
##### SUMMARY
Backport #73718

The second commit is a minor modification to the test for this change since the test suite created fewer files/dirs at this point.

##### ISSUE TYPE
- Bugfix Pull Request
