### PR TITLE
Allow for searching handler subdir for included tasks

### DIFF
--- a/changelogs/fragments/73809-search-handler-subdir.yml
+++ b/changelogs/fragments/73809-search-handler-subdir.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - A handler defined within a role will now search handlers subdir for included tasks (issue https://github.com/ansible/ansible/issues/71222).

--- a/test/integration/targets/handlers/roles/test_role_handlers_include_tasks/handlers/A.yml
+++ b/test/integration/targets/handlers/roles/test_role_handlers_include_tasks/handlers/A.yml
@@ -1,0 +1,1 @@
+- debug: msg="handler with tasks from A.yml called"

--- a/test/integration/targets/handlers/roles/test_role_handlers_include_tasks/handlers/main.yml
+++ b/test/integration/targets/handlers/roles/test_role_handlers_include_tasks/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: role-based handler from handler subdir
+  include_tasks: A.yml
+
+- name: role-based handler from tasks subdir
+  include_tasks: B.yml

--- a/test/integration/targets/handlers/roles/test_role_handlers_include_tasks/tasks/B.yml
+++ b/test/integration/targets/handlers/roles/test_role_handlers_include_tasks/tasks/B.yml
@@ -1,0 +1,1 @@
+- debug: msg="handler with tasks from B.yml called"

--- a/test/integration/targets/handlers/runme.sh
+++ b/test/integration/targets/handlers/runme.sh
@@ -87,6 +87,9 @@ set -e
 # https://github.com/ansible/ansible/issues/47287
 [ "$(ansible-playbook test_handlers_including_task.yml -i ../../inventory -v "$@" | grep -E -o 'failed=[0-9]+')" = "failed=0" ]
 
+# https://github.com/ansible/ansible/issues/71222
+ansible-playbook test_role_handlers_including_tasks.yml -i ../../inventory -v "$@"
+
 # https://github.com/ansible/ansible/issues/27237
 set +e
 result="$(ansible-playbook test_handlers_template_run_once.yml -i inventory.handlers "$@" 2>&1)"

--- a/test/integration/targets/handlers/test_role_handlers_including_tasks.yml
+++ b/test/integration/targets/handlers/test_role_handlers_including_tasks.yml
@@ -1,0 +1,18 @@
+---
+- name: Verify a role handler can include other tasks from handlers and tasks subdirs
+  hosts: testhost
+  roles:
+    - test_role_handlers_include_tasks
+
+  tasks:
+    - name: notify a role-based handler (include tasks from handler subdir)
+      debug:
+        msg: notifying role handler
+      changed_when: yes
+      notify: role-based handler from handler subdir
+
+    - name: notify a role-based handler (include tasks from tasks subdir)
+      debug:
+        msg: notifying another role handler
+      changed_when: yes
+      notify: role-based handler from tasks subdir


### PR DESCRIPTION
##### SUMMARY

If a handler includes another file, allow for searching the `handlers` subdir for the include.

Note: The `tasks` subdir is automatically searched as well, so shouldn't break that scenario. Included test validates this.

This also removes an unneeded `if` clause.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #71222

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

include_tasks

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
