### PR TITLE
[2.12] Factor out plugins.callback.CallbackBase.host_label()

### DIFF
--- a/changelogs/fragments/73814-host_label.yaml
+++ b/changelogs/fragments/73814-host_label.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - >-
+    `ansible.plugins.callback.CallbackBase.host_label()` has been factored out
+    as a static method (https://github.com/ansible/ansible/pull/73814).

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -99,6 +99,17 @@ class CallbackBase(AnsiblePlugin):
         # load from config
         self._plugin_options = C.config.get_plugin_options(get_plugin_class(self), self._load_name, keys=task_keys, variables=var_options, direct=direct)
 
+    @staticmethod
+    def host_label(result):
+        """Return label for the hostname (& delegated hostname) of a task
+        result.
+        """
+        hostname = result._host.get_name()
+        delegated_vars = result._result.get('_ansible_delegated_vars', None)
+        if delegated_vars:
+            return "%s -> %s" % (hostname, delegated_vars['ansible_host'])
+        return "%s" % (hostname,)
+
     def _run_is_verbose(self, result, verbosity=0):
         return ((self._display.verbosity > verbosity or result._result.get('_ansible_verbose_always', False) is True)
                 and result._result.get('_ansible_verbose_override', False) is False)

--- a/test/units/plugins/callback/test_callback.py
+++ b/test/units/plugins/callback/test_callback.py
@@ -27,6 +27,8 @@ import types
 from units.compat import unittest
 from units.compat.mock import MagicMock
 
+from ansible.executor.task_result import TaskResult
+from ansible.inventory.host import Host
 from ansible.plugins.callback import CallbackBase
 
 
@@ -46,6 +48,18 @@ class TestCallback(unittest.TestCase):
         display_mock.verbosity = 5
         cb = CallbackBase(display=display_mock)
         self.assertIs(cb._display, display_mock)
+
+    def test_host_label(self):
+        result = TaskResult(host=Host('host1'), task=None, return_data={})
+        self.assertEquals(CallbackBase.host_label(result), 'host1')
+
+    def test_host_label_delegated(self):
+        result = TaskResult(
+            host=Host('host1'),
+            task=None,
+            return_data={'_ansible_delegated_vars': {'ansible_host': 'host2'}},
+        )
+        self.assertEquals(CallbackBase.host_label(result), 'host1 -> host2')
 
     # TODO: import callback module so we can patch callback.cli/callback.C
 


### PR DESCRIPTION
##### SUMMARY

This simplifies rendering the hostname (or hostname+delegated host) in
the default callback module. A reduces code duplication.

I've chosen not move where in each handler the host_spec rendered, in
case subsequent operations has side effects. However I'm happy to change
that if considered safe.

I've chosen not to change the formatting operator used (%), to avoid
changes in rendering that might result.

_host_spec() could be made a static method, or a different name used
(e.g. host_label()).

Signed-off-by: Alex Willmer <alex@moreati.org.uk>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
plugins.callback.default

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
