### PR TITLE
Add epoch_int in date_time facts

### DIFF
--- a/changelogs/fragments/73822-date_time_facts_add_epoch_int.yaml
+++ b/changelogs/fragments/73822-date_time_facts_add_epoch_int.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - setup - add ``epoch_int`` option to date_time facts (https://github.com/ansible/ansible/pull/73822).

--- a/lib/ansible/module_utils/facts/system/date_time.py
+++ b/lib/ansible/module_utils/facts/system/date_time.py
@@ -49,6 +49,9 @@ class DateTimeFactCollector(BaseFactCollector):
         date_time_facts['epoch'] = now.strftime('%s')
         if date_time_facts['epoch'] == '' or date_time_facts['epoch'][0] == '%':
             date_time_facts['epoch'] = str(int(epoch_ts))
+        date_time_facts['epoch_int'] = str(int(now.strftime('%s')))
+        if date_time_facts['epoch_int'] == '' or date_time_facts['epoch_int'][0] == '%':
+            date_time_facts['epoch_int'] = str(int(epoch_ts))
         date_time_facts['date'] = now.strftime('%Y-%m-%d')
         date_time_facts['time'] = now.strftime('%H:%M:%S')
         date_time_facts['iso8601_micro'] = utcnow.strftime("%Y-%m-%dT%H:%M:%S.%fZ")

--- a/lib/ansible/module_utils/facts/system/date_time.py
+++ b/lib/ansible/module_utils/facts/system/date_time.py
@@ -47,8 +47,10 @@ class DateTimeFactCollector(BaseFactCollector):
         date_time_facts['minute'] = now.strftime('%M')
         date_time_facts['second'] = now.strftime('%S')
         date_time_facts['epoch'] = now.strftime('%s')
+        # epoch returns float or string in some non-linux environments
         if date_time_facts['epoch'] == '' or date_time_facts['epoch'][0] == '%':
             date_time_facts['epoch'] = str(int(epoch_ts))
+        # epoch_int always returns integer format of epoch
         date_time_facts['epoch_int'] = str(int(now.strftime('%s')))
         if date_time_facts['epoch_int'] == '' or date_time_facts['epoch_int'][0] == '%':
             date_time_facts['epoch_int'] = str(int(epoch_ts))

--- a/test/units/module_utils/facts/test_date_time.py
+++ b/test/units/module_utils/facts/test_date_time.py
@@ -79,6 +79,8 @@ def test_date_time_epoch(fake_date_facts):
 
     assert fake_date_facts['date_time']['epoch'].isdigit()
     assert len(fake_date_facts['date_time']['epoch']) == 10  # This length will not change any time soon
+    assert fake_date_facts['date_time']['epoch_int'].isdigit()
+    assert len(fake_date_facts['date_time']['epoch_int']) == 10  # This length will not change any time soon
 
 
 @pytest.mark.parametrize('fact_name', ('tz', 'tz_dst'))


### PR DESCRIPTION
##### SUMMARY
Add `epoch_int` to setup facts which always returns epoch as an integer.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/facts/system/date_time.py

##### ADDITIONAL INFORMATION
Previously opened in https://github.com/ansible/ansible/pull/72503.