### PR TITLE
ansible-test: add Zuul CI provider

### DIFF
--- a/changelogs/fragments/ansible_test_zuul_ci_provider.yaml
+++ b/changelogs/fragments/ansible_test_zuul_ci_provider.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- ansible-test - New CI provider driver for Zuul-CI. 

--- a/test/lib/ansible_test/_internal/ci/zuul.py
+++ b/test/lib/ansible_test/_internal/ci/zuul.py
@@ -1,0 +1,47 @@
+"""Support code for working without a supported CI provider."""
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import getpass
+import hashlib
+import random
+import platform
+
+
+from . import (
+    CIProvider,
+)
+
+from .local import Local
+
+
+CODE = "zuul"
+
+
+class Zuul(Local):
+    """CI provider implementation for Zuul-CI."""
+    priority = CIProvider.priority
+
+    @staticmethod
+    def is_supported():  # type: () -> bool
+        """Return True if this provider is supported in the current running environment."""
+        return getpass.getuser() == "zuul"
+
+    @property
+    def code(self):  # type: () -> str
+        """Return a unique code representing this provider."""
+        return CODE
+
+    @property
+    def name(self):  # type: () -> str
+        """Return descriptive name for this provider."""
+        return "Zuul"
+
+    def generate_resource_prefix(self):  # type: () -> str
+        """Return a resource prefix specific to this CI provider."""
+        node = hashlib.md5(platform.node().encode()).hexdigest()
+
+        prefix = "ansible-test-%s-%d" % (node, random.randint(10000000, 99999999))
+
+        return prefix

--- a/test/units/ansible_test/ci/test_zuul.py
+++ b/test/units/ansible_test/ci/test_zuul.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from .util import common_auth_test
+
+
+def test_zuul():
+    # noinspection PyProtectedMember
+    from ansible_test._internal.ci.zuul import (
+        Zuul,
+    )
+
+    zuul_driver = Zuul()
+    # some AWS services won't accept a longer prefix.
+    assert len(zuul_driver.generate_resource_prefix()) < 64


### PR DESCRIPTION
##### SUMMARY

Add a Zuul CI provider driver based on the Local one. The difference
is that we build the prefix with a md5 checksum to keep the final string
length under control.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ansible-test

