### PR TITLE
Mention that minor releases end once the next ansible release is made.

### DIFF
--- a/docs/docsite/rst/roadmap/COLLECTIONS_2_10.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_2_10.rst
@@ -39,8 +39,13 @@ Release Schedule
 
 Ansible-2.10.x patch releases will occur roughly every three weeks if changes to collections have been made or if it is deemed necessary to force an upgrade to a later ansible-base-2.10.x.  Ansible-2.10.x patch releases may contain new features but not backwards incompatibilities.  In practice, this means we will include new collection versions where either the patch or the minor version number has changed but not when the major number has changed (example: Ansible-2.10 ships with community-crypto-1.1.0; ansible-2.10.1 may ship with community-crypto-1.2.0 but would not ship with community-crypto-2.0.0).
 
-Breaking changes may be introduced in ansible-2.11.0 although we encourage collection owners to use deprecation periods that will show up in at least one Ansible release before being changed incompatibly.
 
-The rough schedule for Ansible-2.11 and beyond (such as how many months we'll aim for between versions) is still to be discussed and likely will be made after 2.10.0 has been released.
+.. note::
+
+    Minor releases will stop when :ref:`Ansible-3 <ansible_3_roadmap>` is released.  See the :ref:`Release and Maintenance Page <release_and_maintenance>` for more information.
+
+
+Breaking changes may be introduced in ansible-3.0 although we encourage collection owners to use deprecation periods that will show up in at least one Ansible release before being changed incompatibly.
+
 
 For more information, reach out on a mailing list or an IRC channel - see :ref:`communication` for more details.

--- a/docs/docsite/rst/roadmap/COLLECTIONS_3_0.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_3_0.rst
@@ -1,3 +1,5 @@
+.. _ansible_3_roadmap:
+
 ===================
 Ansible project 3.0
 ===================
@@ -42,7 +44,13 @@ Ansible minor releases
 Ansible 3.x.x minor releases will occur approximately every three weeks if changes to collections have been made or if it is deemed necessary to force an upgrade to a later ansible-base-2.10.x.  Ansible 3.x.x minor releases may contain new features but not backwards incompatibilities.  In practice, this means we will include new collection versions where either the patch or the minor version number has changed but not when the major number has changed. For example, if Ansible-3.0.0 ships with community-crypto-2.1.0; Ansible-3.1.0 may ship with community-crypto-2.2.0 but would not ship with community-crypto-3.0.0).
 
 
+.. note::
+
+    Minor releases will stop when :ref:`Ansible-4 <ansible_4_roadmap>` is released.  See the :ref:`Release and Maintenance Page <release_and_maintenance>` for more information.
+
+
 For more information, reach out on a mailing list or an IRC channel - see :ref:`communication` for more details.
+
 
 ansible-base release
 ====================

--- a/docs/docsite/rst/roadmap/COLLECTIONS_4.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_4.rst
@@ -1,3 +1,5 @@
+.. _ansible_4_roadmap:
+
 ===================
 Ansible project 4.0
 ===================
@@ -43,6 +45,11 @@ Ansible minor releases
 =======================
 
 Ansible 4.x minor releases will occur approximately every three weeks if changes to collections have been made or if it is deemed necessary to force an upgrade to a later ansible-core-2.11.x.  Ansible 4.x minor releases may contain new features but not backwards incompatibilities.  In practice, this means we will include new collection versions where either the patch or the minor version number has changed but not when the major number has changed. For example, if Ansible-4.0.0 ships with community-crypto-2.1.0; Ansible-4.1.0 may ship with community-crypto-2.2.0 but would not ship with community-crypto-3.0.0).
+
+
+.. note::
+
+    Minor releases will stop when Ansible-5 is released.  See the :ref:`Release and Maintenance Page <release_and_maintenance>` for more information.
 
 
 For more information, reach out on a mailing list or an IRC channel - see :ref:`communication` for more details.


### PR DESCRIPTION
##### SUMMARY

In ansible-2.9 and before, minor releases continued after several other releases happened.  Point out on the bugfix that this is not the case with ansible-3 and ansible-4.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
