### PR TITLE
Fix wrong backup directory var name in apt module

### DIFF
--- a/changelogs/fragments/73840_apt-policy-rc-d.yml
+++ b/changelogs/fragments/73840_apt-policy-rc-d.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    apt - fix policy_rc_d parameter throwing an exception when restoring
+    original file (https://github.com/ansible/ansible/issues/66211)

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -428,7 +428,7 @@ class PolicyRcD(object):
             try:
                 shutil.move(os.path.join(self.backup_dir, 'policy-rc.d'),
                             '/usr/sbin/policy-rc.d')
-                os.rmdir(self.tmpdir_name)
+                os.rmdir(self.backup_dir)
             except Exception:
                 self.m.fail_json(msg="Fail to move back %s to /usr/sbin/policy-rc.d"
                                      % os.path.join(self.backup_dir, 'policy-rc.d'))


### PR DESCRIPTION
##### SUMMARY
Fixes #66211

`apt` module has a `policy_rc_d` parameter that edits the contents of the `/usr/sbin/policy-rc.d` before package installation.

If this file already exists, a backup is created in a temporary location and restored after module execution. After restore, the temporary directory is meant to be deleted but an exception is raised and play is aborted due to a non-existing variable name being used.

This PR just changes that variable reference to the correct one.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
apt