### PR TITLE
Update `resource_prefix` syntax for ansible-test.

### DIFF
--- a/changelogs/fragments/ansible-test-resource-prefix.yml
+++ b/changelogs/fragments/ansible-test-resource-prefix.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - ansible-test - The generated ``resource_prefix`` variable now meets the host name syntax requirements specified in RFC 1123 and RFC 952.
+                   The value used for local tests now places the random number before the hostname component, rather than after.
+                   If the resulting value is too long, it will be truncated.

--- a/test/lib/ansible_test/_internal/ci/azp.py
+++ b/test/lib/ansible_test/_internal/ci/azp.py
@@ -73,8 +73,6 @@ class AzurePipelines(CIProvider):
         except KeyError as ex:
             raise MissingEnvironmentVariable(name=ex.args[0])
 
-        prefix = re.sub(r'[^a-zA-Z0-9]+', '-', prefix).lower()
-
         return prefix
 
     def get_base_branch(self):  # type: () -> str

--- a/test/lib/ansible_test/_internal/ci/local.py
+++ b/test/lib/ansible_test/_internal/ci/local.py
@@ -58,9 +58,10 @@ class Local(CIProvider):
 
     def generate_resource_prefix(self):  # type: () -> str
         """Return a resource prefix specific to this CI provider."""
-        node = re.sub(r'[^a-zA-Z0-9]+', '-', platform.node().split('.')[0]).lower()
-
-        prefix = 'ansible-test-%s-%d' % (node, random.randint(10000000, 99999999))
+        prefix = 'ansible-test-%d-%s' % (
+            random.randint(10000000, 99999999),
+            platform.node().split('.')[0],
+        )
 
         return prefix
 

--- a/test/lib/ansible_test/_internal/cloud/__init__.py
+++ b/test/lib/ansible_test/_internal/cloud/__init__.py
@@ -313,6 +313,7 @@ class CloudProvider(CloudBase):
     def setup(self):
         """Setup the cloud resource before delegation and register a cleanup callback."""
         self.resource_prefix = self.ci_provider.generate_resource_prefix()
+        self.resource_prefix = re.sub(r'[^a-zA-Z0-9]+', '-', self.resource_prefix)[:63].lower().rstrip('-')
 
         atexit.register(self.cleanup)
 


### PR DESCRIPTION
##### SUMMARY

The generated ``resource_prefix`` variable now meets the host name syntax requirements specified in RFC 1123 and RFC 952.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
