### PR TITLE
Solaris: Correct version check in svcadm_supports_sync API

### DIFF
--- a/changelogs/fragments/73860-solaris-correct-version-check-in-svcadm_supports_sync.yml
+++ b/changelogs/fragments/73860-solaris-correct-version-check-in-svcadm_supports_sync.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Solaris - correct version check in svcadm_supports_sync (https://github.com/ansible/ansible/pull/73860).

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -1356,7 +1356,7 @@ class SunOSService(Service):
         # Oracle Solaris >= 11.2
         for line in open('/etc/release', 'r').readlines():
             m = re.match(r'\s+Oracle Solaris (\d+\.\d+).*', line.rstrip())
-            if m and m.groups()[0] >= 11.2:
+            if m and LooseVersion(m.groups()[0]) >= LooseVersion('11.2'):
                 return True
 
     def get_service_status(self):

--- a/test/units/modules/test_service.py
+++ b/test/units/modules/test_service.py
@@ -1,0 +1,68 @@
+# Copyright: (c) 2021, Ansible Project
+# Copyright: (c) 2021, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+import platform
+
+import pytest
+from ansible.modules import service
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import PY2
+from units.modules.utils import set_module_args
+
+
+def mocker_sunos_service(mocker):
+    """
+    Configure common mocker object for SunOSService
+    """
+    platform_system = mocker.patch.object(platform, "system")
+    platform_system.return_value = "SunOS"
+
+    get_bin_path = mocker.patch.object(AnsibleModule, "get_bin_path")
+    get_bin_path.return_value = "/usr/bin/svcs"
+
+    # Read a mocked /etc/release file
+    mocked_etc_release_data = mocker.mock_open(
+        read_data=" Oracle Solaris 12.0")
+    builtin_open = "__builtin__.open" if PY2 else "builtins.open"
+    mocker.patch(builtin_open, mocked_etc_release_data)
+
+    service_status = mocker.patch.object(
+        service.Service, "modify_service_state")
+    service_status.return_value = (0, "", "")
+
+    get_sunos_svcs_status = mocker.patch.object(
+        service.SunOSService, "get_sunos_svcs_status")
+    get_sunos_svcs_status.return_value = "offline"
+    get_service_status = mocker.patch.object(
+        service.Service, "get_service_status")
+    get_service_status.return_value = ""
+
+
+@pytest.fixture
+def mocked_sunos_service(mocker):
+    mocker_sunos_service(mocker)
+
+
+def test_sunos_service_start(mocked_sunos_service, capfd):
+    """
+    test SunOS Service Start
+    """
+    set_module_args(
+        {
+            "name": "environment",
+            "state": "started",
+        }
+    )
+    with pytest.raises(SystemExit):
+        service.main()
+
+    out, dummy = capfd.readouterr()
+    results = json.loads(out)
+    assert not results.get("failed")
+    assert results["changed"]


### PR DESCRIPTION
##### SUMMARY
This is a bug and a fix, the service module fails in Solaris, the way the comparison of the version is implemented in lib/ansible/modules/service.py:

`    def svcadm_supports_sync(self):
        # Support for synchronous restart/refresh is only supported on
        # Oracle Solaris >= 11.2
        for line in open('/etc/release', 'r').readlines():
            m = re.match(r'\s+Oracle Solaris (\d+\.\d+).*', line.rstrip())
            if m and m.groups()[0] >= 11.2:
                return True
`

It compares the string "11.X" with the float 11.2 raising an exception.
I propose to convert it to a float and guard it for exception with:

`    def svcadm_supports_sync(self):
        # Support for synchronous restart/refresh is only supported on
        # Oracle Solaris >= 11.2
        for line in open('/etc/release', 'r').readlines():
            m = re.match(r'\s+Oracle Solaris (\d+\.\d+).*', line.rstrip())
            try:
                if m and float(m.groups()[0]) >= 11.2:
                    return True
            except:
                pass
`

This new code is tested ok in Solaris 11.4

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
service

##### ADDITIONAL INFORMATION
