### PR TITLE
Docs: Update installation page for package split (#73790)

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -1,66 +1,60 @@
 .. _installation_guide:
 .. _intro_installation_guide:
 
+******************
 Installing Ansible
-===================
+******************
 
-This page describes how to install Ansible on different platforms.
-Ansible is an agentless automation tool that by default manages machines over the SSH protocol. Once installed, Ansible does
-not add a database, and there will be no daemons to start or keep running.  You only need to install it on one machine (which could easily be a laptop) and it can manage an entire fleet of remote machines from that central point.  When Ansible manages remote machines, it does not leave software installed or running on them, so there's no real question about how to upgrade Ansible when moving to a new version.
+Ansible is an agentless automation tool that you install on a control node. From the control node, Ansible manages machines and other devices remotely (by default, over the SSH protocol).
 
+To install Ansible for use at the command line, simply install the Ansible package on one machine (which could easily be a laptop). You do not need to install a database or run any daemons. Ansible can manage an entire fleet of remote machines from that one control node.
 
 .. contents::
   :local:
 
 Prerequisites
---------------
+=============
 
-You install Ansible on a control node, which then uses SSH (by default) to communicate with your managed nodes (those end devices you want to automate).
+Before you install Ansible, review the requirements for a control node. Before you use Ansible, review the requirements for managed nodes (those end devices you want to automate). Control nodes and managed nodes have different minimum requirements.
 
 .. _control_node_requirements:
 
 Control node requirements
-^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------
 
-Currently Ansible can be run from any machine with Python 2 (version 2.7) or Python 3 (versions 3.5 and higher) installed.
+For your control node (the machine that runs Ansible), you can use any machine with Python 2 (version 2.7) or Python 3 (versions 3.5 and higher) installed. ansible-core 2.11 and Ansible 4.0.0 will make Python 3.8 a soft dependency for the control node, but will function with the aforementioned requirements. ansible-core 2.12 and Ansible 5.0.0 will require Python 3.8 or newer to function on the control node. Starting with ansible-core 2.11, the project will only be packaged for Python 3.8 and newer.
 This includes Red Hat, Debian, CentOS, macOS, any of the BSDs, and so on.
 Windows is not supported for the control node, read more about this in `Matt Davis's blog post <http://blog.rolpdog.com/2020/03/why-no-ansible-controller-for-windows.html>`_.
 
-When choosing a control node, bear in mind that any management system benefits from being run near the machines being managed. If you are running Ansible in a cloud, consider running it from a machine inside that cloud. In most cases this will work better than on the open Internet.
+.. warning::
 
-.. note::
+    Please note that some plugins that run on the control node have additional requirements. These requirements should be listed in the plugin documentation.
 
-    macOS by default is configured for a small number of file handles, so if you want to use 15 or more forks you'll need to raise the ulimit with ``sudo launchctl limit maxfiles unlimited``. This command can also fix any "Too many open files" error.
-
+When choosing a control node, remember that any management system benefits from being run near the machines being managed. If you are using Ansible to manage machines in a cloud, consider using a machine inside that cloud as your control node. In most cases Ansible will perform better from a machine on the cloud than from a machine on the open Internet.
 
 .. warning::
 
-    Please note that some modules and plugins have additional requirements. For modules these need to be satisfied on the 'target' machine (the managed node) and should be listed in the module specific docs.
+    Ansible 2.11 will make Python 3.8 a soft dependency for the control node, but will function with the aforementioned requirements. Ansible 2.12 will require Python 3.8 or newer to function on the control node. Starting with Ansible 2.11, the project will only be packaged for Python 3.8 and newer.
+
 
 .. _managed_node_requirements:
 
 Managed node requirements
-^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------
 
-On the managed nodes, you need a way to communicate, which is normally SSH. By
-default this uses SFTP. If that's not available, you can switch to SCP in
-:ref:`ansible.cfg <ansible_configuration_settings>`.  You also need Python 2 (version 2.6 or later) or Python 3 (version 3.5 or
-later).
+Although you do not need a daemon on your managed nodes, you do need a way for Ansible to communicate with them. For most managed nodes, Ansible makes a connection over SSH and transfers modules using SFTP. If SSH works but SFTP is not available on some of your managed nodes, you can switch to SCP in :ref:`ansible.cfg <ansible_configuration_settings>`. For any machine or device that can run Python, you also need Python 2 (version 2.6 or later) or Python 3 (version 3.5 or later).
+
+.. warning::
+
+    Please note that some modules have additional requirements that need to be satisfied on the 'target' machine (the managed node). These requirements should be listed in the module documentation.
 
 .. note::
 
-   * If you have SELinux enabled on remote nodes, you will also want to install
-     libselinux-python on them before using any copy/file/template related functions in Ansible. You
-     can use the :ref:`yum module<yum_module>` or :ref:`dnf module<dnf_module>` in Ansible to install this package on remote systems
-     that do not have it.
+   * If you have SELinux enabled on remote nodes, you will also want to install libselinux-python on them before using any copy/file/template related functions in Ansible. You can use the :ref:`yum module<yum_module>` or :ref:`dnf module<dnf_module>` in Ansible to install this package on remote systems that do not have it.
 
    * By default, before the first Python module in a playbook runs on a host, Ansible attempts to discover a suitable Python interpreter on that host. You can override the discovery behavior by setting the :ref:`ansible_python_interpreter<ansible_python_interpreter>` inventory variable to a specific interpreter, and in other ways. See :ref:`interpreter_discovery` for details.
 
-   * Ansible's :ref:`raw module<raw_module>`, and the :ref:`script module<script_module>`, do not depend
-     on a client side install of Python to run.  Technically, you can use Ansible to install a compatible
-     version of Python using the :ref:`raw module<raw_module>`, which then allows you to use everything else.
-     For example, if you need to bootstrap Python 2 onto a RHEL-based system, you can install it
-     as follows:
+   * Ansible's :ref:`raw module<raw_module>`, and the :ref:`script module<script_module>`, do not depend on a client side install of Python to run.  Technically, you can use Ansible to install a compatible version of Python using the :ref:`raw module<raw_module>`, which then allows you to use everything else. For example, if you need to bootstrap Python 2 onto a RHEL-based system, you can install it as follows:
 
      .. code-block:: shell
 
@@ -68,27 +62,134 @@ later).
 
 .. _what_version:
 
-Selecting an Ansible version to install
----------------------------------------
+Selecting an Ansible artifact and version to install
+====================================================
 
-Which Ansible version to install is based on your particular needs. You can choose any of the following ways to install Ansible:
+Starting with version 2.10, Ansible distributes two artifacts: a community package called ``ansible`` and a minimalist language and runtime called ``ansible-core`` (called `ansible-base` in version 2.10). Choose the Ansible artifact and version that matches your particular needs.
+
+Installing the Ansible community package
+----------------------------------------
+
+The ``ansible`` package includes the Ansible language and runtime plus a range of community curated Collections. It recreates and expands on the functionality that was included in Ansible 2.9.
+
+You can choose any of the following ways to install the Ansible community package:
 
 * Install the latest release with your OS package manager (for Red Hat Enterprise Linux (TM), CentOS, Fedora, Debian, or Ubuntu).
 * Install with ``pip`` (the Python package manager).
-* Install ``ansible-base`` from source to access the development (``devel``) version to develop or test the latest features.
+
+Installing `ansible-core`
+-------------------------
+
+Ansible also distributes a minimalist object called ``ansible-core`` (or ``ansible-base`` in version 2.10). It contains the Ansible language, runtime, and a short list of core modules and other plugins. You can build functionality on top of ``ansible-core`` by installing collections from Galaxy, Automation Hub, or any other source.
+
+You can choose any of the following ways to install ``ansible-core``:
+
+* Install ``ansible-core`` (version 2.11 and greater) or ``ansible-base`` (version 2.10) with ``pip``.
+* Install ``ansible-core`` from source from the ansible/ansible GitHub repository to access the development (``devel``) version to develop or test the latest features.
 
 .. note::
 
-	You should only run ``ansible-base`` from ``devel`` if you are modifying ``ansible-base``, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
+	You should only run ``ansible-core`` from ``devel`` if you are modifying ``ansible-core``, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
 
+Ansible generally creates new releases twice a year. See :ref:`release_and_maintenance` for information on release timing and maintenance of older releases.
 
-Ansible creates new releases two to three times a year. Due to this short release cycle,
-minor bugs will generally be fixed in the next release rather than maintaining backports on the stable branch.
-Major bugs will still have maintenance releases when needed, though these are infrequent.
+.. _from_pip:
 
+Installing and upgrading Ansible with ``pip``
+=============================================
+
+Ansible can be installed on many systems with ``pip``, the Python package manager.
+
+Prerequisites: Installing ``pip``
+----------------------------------
+
+If ``pip`` is not already available on your system, run the following commands to install it::
+
+    $ curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+    $ python get-pip.py --user
+
+You may need to perform some additional configuration before you are able to run Ansible. See the Python documentation on `installing to the user site`_ for more information.
+
+.. _installing to the user site: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+Installing Ansible with ``pip``
+-------------------------------
+
+Once ``pip`` is installed, you can install Ansible [1]_::
+
+    $ python -m pip install --user ansible
+
+In order to use the ``paramiko`` connection plugin or modules that require ``paramiko``, install the required module [2]_::
+
+    $ python -m pip install --user paramiko
+
+If you wish to install Ansible globally, run the following commands::
+
+    $ sudo python get-pip.py
+    $ sudo python -m pip install ansible
+
+.. note::
+
+    Running ``pip`` with ``sudo`` will make global changes to the system. Since ``pip`` does not coordinate with system package managers, it could make changes to your system that leaves it in an inconsistent or non-functioning state. This is particularly true for macOS. Installing with ``--user`` is recommended unless you understand fully the implications of modifying global files on the system.
+
+.. note::
+
+    Older versions of ``pip`` default to http://pypi.python.org/simple, which no longer works.
+    Please make sure you have the latest version of ``pip`` before installing Ansible.
+    If you have an older version of ``pip`` installed, you can upgrade by following `pip's upgrade instructions <https://pip.pypa.io/en/stable/installing/#upgrading-pip>`_ .
+
+.. _from_pip_venv:
+
+Installing Ansible in a virtual environment with ``pip``
+--------------------------------------------------------
+
+.. note::
+
+	If you have Ansible 2.9 or older installed, you need to use ``pip uninstall ansible`` first to remove older versions of Ansible before re-installing it.
+
+Ansible can also be installed inside a new or existing ``virtualenv``::
+
+    $ python -m virtualenv ansible  # Create a virtualenv if one does not already exist
+    $ source ansible/bin/activate   # Activate the virtual environment
+    $ python -m pip install ansible
+
+.. _pip_upgrade:
+
+Upgrading Ansible with ``pip``
+------------------------------
+
+Upgrading from 2.9 or earlier to 2.10
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Starting in version 2.10, Ansible is made of two packages. When you upgrade from version 2.9 and older to version 2.10 or later, you need to uninstall the old Ansible version (2.9 or earlier) before upgrading. If you do not uninstall the older version of Ansible, you will see the following message, and no change will be performed:
+
+.. code-block:: console
+
+    Cannot install ansible-base with a pre-existing ansible==2.x installation.
+
+    Installing ansible-base with ansible-2.9 or older currently installed with
+    pip is known to cause problems. Please uninstall ansible and install the new
+    version:
+
+    pip uninstall ansible
+    pip install ansible-base
+
+    ...
+
+As explained by the message, to upgrade you must first remove the version of Ansible installed and then install it to the latest version.
+
+.. code-block:: console
+
+    $ pip uninstall ansible
+    $ pip install ansible
 
 .. _installing_the_control_node:
 .. _from_yum:
+
+Installing Ansible on specific operating systems
+================================================
+
+Follow these instructions to install the Ansible community package on a variety of operating systems.
 
 Installing Ansible on RHEL, CentOS, or Fedora
 ----------------------------------------------
@@ -150,8 +251,6 @@ Debian/Ubuntu packages can also be built from the source checkout, run:
 .. code-block:: bash
 
     $ make deb
-
-You may also wish to run from source to get the development branch, which is covered below.
 
 Installing Ansible on Debian
 ----------------------------
@@ -229,7 +328,11 @@ The instructions can be found in :ref:`from_pip`. If you are running macOS versi
 
 .. note::
 
-	If you have Ansible 2.9 or older installed, you need to use ``pip uninstall ansible`` first to remove older versions of Ansible before re-installing it.
+	To upgrade from Ansible 2.9 or older to Ansible 3 or later, you must ``pip uninstall ansible`` first to remove older versions of Ansible before re-installing it.
+
+.. note::
+
+   macOS by default is configured for a small number of file handles, so if you want to use 15 or more forks you'll need to raise the ulimit with ``sudo launchctl limit maxfiles unlimited``. This command can also fix any "Too many open files" errors.
 
 If you are installing on macOS Mavericks (10.9), you may encounter some noise from your compiler. A workaround is to do the following::
 
@@ -290,143 +393,70 @@ Update of the software will be managed by the swupd tool::
 
    $ sudo swupd update
 
-.. _from_pip:
-
-Installing Ansible with ``pip``
---------------------------------
-
-Ansible can be installed with ``pip``, the Python package manager. If ``pip`` isn't already available on your system of Python, run the following commands to install it::
-
-    $ curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-    $ python get-pip.py --user
-
-.. note::
-
-  	If you have Ansible 2.9 or older installed, you need to use ``pip uninstall ansible`` first to remove older versions of Ansible before re-installing it.
-
-Then install Ansible [1]_::
-
-    $ python -m pip install --user ansible
-
-In order to use the ``paramiko`` connection plugin or modules that require ``paramiko``, install the required module [2]_::
-
-    $ python -m pip install --user paramiko
-
-If you wish to install Ansible globally, run the following commands::
-
-    $ sudo python get-pip.py
-    $ sudo python -m pip install ansible
-
-.. note::
-
-    Running ``pip`` with ``sudo`` will make global changes to the system. Since ``pip`` does not coordinate with system package managers, it could make changes to your system that leaves it in an inconsistent or non-functioning state. This is particularly true for macOS. Installing with ``--user`` is recommended unless you understand fully the implications of modifying global files on the system.
-
-.. note::
-
-    Older versions of ``pip`` default to http://pypi.python.org/simple, which no longer works.
-    Please make sure you have the latest version of ``pip`` before installing Ansible.
-    If you have an older version of ``pip`` installed, you can upgrade by following `pip's upgrade instructions <https://pip.pypa.io/en/stable/installing/#upgrading-pip>`_ .
-
-Upgrading Ansible from version 2.9 and older to version 2.10 or later
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Starting in version 2.10, Ansible is made of two packages. You need to first uninstall the old Ansible version (2.9 or earlier) before upgrading.
-If you do not uninstall the older version of Ansible, you will see the following message, and no change will be performed:
-
-.. code-block:: console
-
-    Cannot install ansible-base with a pre-existing ansible==2.x installation.
-
-    Installing ansible-base with ansible-2.9 or older currently installed with
-    pip is known to cause problems. Please uninstall ansible and install the new
-    version:
-
-    pip uninstall ansible
-    pip install ansible-base
-
-    ...
-
-As explained by the message, to upgrade you must first remove the version of Ansible installed and then install it
-to the latest version.
-
-.. code-block:: console
-
-    $ pip uninstall ansible
-    $ pip install ansible
-
 .. _from_pip_devel:
+.. _getting_ansible:
 
-Installing the development version of ``ansible-base``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Installing and running the ``devel`` branch from source
+=======================================================
 
-In Ansible 2.10 and later, The `ansible/ansible repository <https://github.com/ansible/ansible>`_ contains the code for basic features and functions, such as copying module code to managed nodes. This code is also known as ``ansible-base``.
+In Ansible 2.10 and later, the `ansible/ansible repository <https://github.com/ansible/ansible>`_ contains the code for basic features and functions, such as copying module code to managed nodes. This code is also known as ``ansible-core``.
+
+New features are added to ``ansible-core`` on a branch called ``devel``. If you are testing new features, fixing bugs, or otherwise working with the development team on changes to the core code, you can install and run ``devel``.
 
 .. note::
 
-    You should only run ``ansible-base`` from ``devel`` if you are modifying ``ansible-base`` or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
+    You should only install and run the ``devel`` branch if you are modifying ``ansible-core`` or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
 
 .. note::
 
-    If you have Ansible 2.9 or older installed, you need to use ``pip uninstall ansible`` first to remove older versions of Ansible before re-installing it.
+   If you want to use Ansible Tower as the control node, do not install or run the ``devel`` branch of Ansible. Use an OS package manager (like ``apt`` or ``yum``) or ``pip`` to install a stable version.
 
+If you are running Ansible from source, you may also wish to follow the `Ansible GitHub project <https://github.com/ansible/ansible>`_. We track issues, document bugs, and share feature ideas in this and other related repositories.
 
-You can install the development version of ``ansible-base`` directly from GitHub with pip.
+For more information on getting involved in the Ansible project, see the :ref:`ansible_community_guide`. For more information on creating Ansible modules and Collections, see the :ref:`developer_guide`.
+
+Installing ``devel`` from GitHub with ``pip``
+---------------------------------------------
+
+You can install the ``devel`` branch of ``ansible-core`` directly from GitHub with ``pip``:
 
 .. code-block:: bash
 
     $ python -m pip install --user https://github.com/ansible/ansible/archive/devel.tar.gz
 
-Replace ``devel`` in the URL mentioned above, with any other branch or tag on GitHub to install older versions of Ansible (prior to ``ansible-base`` 2.10.) This installs all of Ansible.
+.. note::
+
+    If you have Ansible 2.9 or older installed, you need to use ``pip uninstall ansible`` first to remove older versions of Ansible before re-installing it. See :ref:`pip_upgrade` for more details.
+
+You can replace ``devel`` in the URL mentioned above, with any other branch or tag on GitHub to install older versions of Ansible (prior to ``ansible-base`` 2.10.), tagged alpha or beta versions, and release candidates. This installs all of Ansible.
 
 .. code-block:: bash
 
     $ python -m pip install --user https://github.com/ansible/ansible/archive/stable-2.9.tar.gz
 
-See :ref:`from_source` for instructions on how to run ``ansible-base`` directly from source, without the requirement of installation.
-
-.. _from_pip_venv:
-
-Virtual Environments
-^^^^^^^^^^^^^^^^^^^^
-
-.. note::
-
-	If you have Ansible 2.9 or older installed, you need to use ``pip uninstall ansible`` first to remove older versions of Ansible before re-installing it.
-
-Ansible can also be installed inside a new or existing ``virtualenv``::
-
-    $ python -m virtualenv ansible  # Create a virtualenv if one does not already exist
-    $ source ansible/bin/activate   # Activate the virtual environment
-    $ python -m pip install ansible
-
-.. _from_source:
-
-Running ``ansible-base`` from source (devel)
----------------------------------------------
-
-In Ansible 2.10 and later, The `ansible/ansible repository <https://github.com/ansible/ansible>`_ contains the code for basic features and functions, such as copying module code to managed nodes. This code is also known as ``ansible-base``.
-
-.. note::
-
-	You should only run ``ansible-base`` from ``devel`` if you are modifying ``ansible-base`` or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
-
-``ansible-base`` is easy to run from source. You do not need ``root`` permissions
-to use it and there is no software to actually install. No daemons
-or database setup are required.
-
-.. note::
-
-   If you want to use Ansible Tower as the control node, do not use a source installation of Ansible. Please use an OS package manager (like ``apt`` or ``yum``) or ``pip`` to install a stable version.
+See :ref:`from_source` for instructions on how to run ``ansible-core`` directly from source.
 
 
-To install from source, clone the ``ansible-base`` git repository:
+Installing ``devel`` from GitHub by cloning
+-------------------------------------------
+
+You can install the ``devel`` branch of ``ansible-core`` by cloning the GitHub repository:
 
 .. code-block:: bash
 
     $ git clone https://github.com/ansible/ansible.git
     $ cd ./ansible
 
-Once ``git`` has cloned the ``ansible-base`` repository, setup the Ansible environment:
+The default branch is ``devel``.
+
+.. _from_source:
+
+Running the ``devel`` branch from a clone
+-----------------------------------------
+
+``ansible-core`` is easy to run from source. You do not need ``root`` permissions to use it and there is no software to actually install. No daemons or database setup are required.
+
+Once you have installed the ``ansible-core`` repository by cloning, setup the Ansible environment:
 
 Using Bash:
 
@@ -442,7 +472,7 @@ If you want to suppress spurious warnings/errors, use::
 
     $ source ./hacking/env-setup -q
 
-If you don't have ``pip`` installed in your version of Python, install it::
+If you do not have ``pip`` installed in your version of Python, install it::
 
     $ curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
     $ python get-pip.py --user
@@ -453,7 +483,7 @@ Ansible also uses the following Python modules that need to be installed [1]_:
 
     $ python -m pip install --user -r ./requirements.txt
 
-To update ``ansible-base`` checkouts, use pull-with-rebase so any local changes are replayed.
+To update the ``devel`` branch of ``ansible-core`` on your local machine, use pull-with-rebase so any local changes are replayed.
 
 .. code-block:: bash
 
@@ -464,9 +494,7 @@ To update ``ansible-base`` checkouts, use pull-with-rebase so any local changes 
     $ git pull --rebase #same as above
     $ git submodule update --init --recursive
 
-Once running the env-setup script you'll be running from checkout and the default inventory file
-will be ``/etc/ansible/hosts``. You can optionally specify an inventory file (see :ref:`inventory`)
-other than ``/etc/ansible/hosts``:
+After you run the the env-setup script, you will be running from the source code. The default inventory file will be ``/etc/ansible/hosts``. You can optionally specify an inventory file (see :ref:`inventory`) other than ``/etc/ansible/hosts``:
 
 .. code-block:: bash
 
@@ -475,7 +503,10 @@ other than ``/etc/ansible/hosts``:
 
 You can read more about the inventory file at :ref:`inventory`.
 
-Now let's test things with a ping command:
+Confirming your installation
+============================
+
+Whatever method of installing Ansible you chose, you can test that it is installed correctly with a ping command:
 
 .. code-block:: bash
 
@@ -486,7 +517,7 @@ You can also use "sudo make install".
 .. _tagged_releases:
 
 Finding tarballs of tagged releases
------------------------------------
+===================================
 
 Packaging Ansible or wanting to build a local package yourself, but don't want to do a git checkout?  Tarballs of releases are available from ``pypi`` as https://pypi.python.org/packages/source/a/ansible/ansible-{{VERSION}}.tar.gz. You can make VERSION a variable in your package managing system that you update in one place whenever you package a new version. Alternately, you can download https://pypi.python.org/project/ansible  to get the latest stable release.
 
@@ -499,18 +530,17 @@ These releases are also tagged in the `git repository <https://github.com/ansibl
 
 .. _shell_completion:
 
-Ansible command shell completion
---------------------------------
+Adding Ansible command shell completion
+=======================================
 
-As of Ansible 2.9, shell completion of the Ansible command line utilities is available and provided through an optional dependency
-called ``argcomplete``. ``argcomplete`` supports bash, and has limited support for zsh and tcsh.
+As of Ansible 2.9, you can add shell completion of the Ansible command line utilities by installing an optional dependency called ``argcomplete``. ``argcomplete`` supports bash, and has limited support for zsh and tcsh.
 
 You can install ``python-argcomplete`` from EPEL on Red Hat Enterprise based distributions, and or from the standard OS repositories for many other distributions.
 
-For more information about installing and configuration see the `argcomplete documentation <https://argcomplete.readthedocs.io/en/latest/>`_.
+For more information about installation and configuration, see the `argcomplete documentation <https://argcomplete.readthedocs.io/en/latest/>`_.
 
 Installing ``argcomplete`` on RHEL, CentOS, or Fedora
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------------------------------------
 
 On Fedora:
 
@@ -527,7 +557,7 @@ On RHEL and CentOS:
 
 
 Installing ``argcomplete`` with ``apt``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------------------
 
 .. code-block:: bash
 
@@ -535,19 +565,19 @@ Installing ``argcomplete`` with ``apt``
 
 
 Installing ``argcomplete`` with ``pip``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------------------
 
 .. code-block:: bash
 
     $ python -m pip install argcomplete
 
 Configuring ``argcomplete``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------
 
 There are 2 ways to configure ``argcomplete`` to allow shell completion of the Ansible command line utilities: globally or per command.
 
-Globally
-"""""""""
+Global configuration
+^^^^^^^^^^^^^^^^^^^^
 
 Global completion requires bash 4.2.
 
@@ -557,8 +587,8 @@ Global completion requires bash 4.2.
 
 This will write a bash completion file to a global location. Use ``--dest`` to change the location.
 
-Per command
-"""""""""""
+Per command configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you do not have bash 4.2, you must register each script independently.
 
@@ -576,19 +606,10 @@ If you do not have bash 4.2, you must register each script independently.
 
 You should place the above commands into your shells profile file such as ``~/.profile`` or ``~/.bash_profile``.
 
-``argcomplete`` with zsh or tcsh
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Using ``argcomplete`` with zsh or tcsh
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 See the `argcomplete documentation <https://argcomplete.readthedocs.io/en/latest/>`_.
-
-.. _getting_ansible:
-
-``ansible-base`` on GitHub
----------------------------
-
-You may also wish to follow the `GitHub project <https://github.com/ansible/ansible>`_ if
-you have a GitHub account. This is also where we keep the issue tracker for sharing
-bugs and feature ideas.
 
 
 .. seealso::


### PR DESCRIPTION
##### SUMMARY
Backports updates to the installation page to reflect the split between the package and ansible-core.

Backport of #73790

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
