### PR TITLE
add python3-packaging to Depends, to be in sync with requirements.txt

### DIFF
--- a/changelogs/fragments/73870-add-python3-packaging-to-Depends-to-be-in-sync-with-requirements-txt.yml
+++ b/changelogs/fragments/73870-add-python3-packaging-to-Depends-to-be-in-sync-with-requirements-txt.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - add python3-packaging to Depends, to be in sync with requirements.txt (https://github.com/ansible/ansible/issues/72117)

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/ansible/ansible/
 
 Package: ansible-core
 Architecture: all
-Depends: python3-jinja2, python3-yaml, python3-paramiko, python3-cryptography, sshpass, ${misc:Depends}, ${python:Depends}
+Depends: python3-jinja2, python3-yaml, python3-paramiko, python3-cryptography, python3-packaging, sshpass, ${misc:Depends}, ${python:Depends}
 Description: Ansible IT Automation
  Ansible is a radically simple model-driven configuration management,
  multi-node deployment, and remote task execution system. Ansible works


### PR DESCRIPTION
##### SUMMARY
add python3-packaging to Depends, to be in sync with requirements.txt

Fixes also the Debian deb like #72117
Fixes the error on Debian: "[WARNING]: packaging Python module unavailable; unable to validate collection Ansible version requirements"

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
packaging

+affects_2.10