### PR TITLE
[2.9 Backport] Partial backport of community.aws/471 - no_log=True for aws_secret

### DIFF
--- a/changelogs/fragments/471-no_log.yml
+++ b/changelogs/fragments/471-no_log.yml
@@ -1,0 +1,2 @@
+security_fixes:
+- aws_secret - flag the ``secret`` parameter as containing sensitive data which shouldn't be logged (https://github.com/ansible-collections/community.aws/pull/471).

--- a/lib/ansible/modules/cloud/amazon/aws_secret.py
+++ b/lib/ansible/modules/cloud/amazon/aws_secret.py
@@ -327,7 +327,7 @@ def main():
             'description': dict(default=""),
             'kms_key_id': dict(),
             'secret_type': dict(choices=['binary', 'string'], default="string"),
-            'secret': dict(default=""),
+            'secret': dict(default="", no_log=True),
             'tags': dict(type='dict', default={}),
             'rotation_lambda': dict(),
             'rotation_interval': dict(type='int', default=30),


### PR DESCRIPTION
##### SUMMARY

aws_secret's ``secret`` parameter contains potentialy sensitive data which shouldn't be logged

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

aws_secret

##### ADDITIONAL INFORMATION

https://github.com/ansible-collections/community.aws/pull/471