### PR TITLE
Add support for sudo su -

### DIFF
--- a/lib/ansible/plugins/become/sudosu.py
+++ b/lib/ansible/plugins/become/sudosu.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright: (c) 2018, Ansible Project
+# Copyright: (c) 2021, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
@@ -10,7 +10,7 @@ DOCUMENTATION = """
     description:
         - This become plugins allows your remote/login user to execute commands as another user via the sudo and su utility combined.
     author: ansible (@core)
-    version_added: "2.11"
+    version_added: "2.12"
     options:
         become_user:
             description: User you 'become' to execute the task

--- a/lib/ansible/plugins/become/sudosu.py
+++ b/lib/ansible/plugins/become/sudosu.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2018, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    become: sudosu
+    short_description: Run tashks using sudo su -
+    description:
+        - This become plugins allows your remote/login user to execute commands as another user via the sudo and su utility combined.
+    author: ansible (@core)
+    version_added: "2.11"
+    options:
+        become_user:
+            description: User you 'become' to execute the task
+            default: root
+            ini:
+              - section: privilege_escalation
+                key: become_user
+              - section: sudo_become_plugin
+                key: user
+            vars:
+              - name: ansible_become_user
+              - name: ansible_sudo_user
+            env:
+              - name: ANSIBLE_BECOME_USER
+              - name: ANSIBLE_SUDO_USER
+        become_flags:
+            description: Options to pass to sudo
+            default: -H -S -n
+            ini:
+              - section: privilege_escalation
+                key: become_flags
+              - section: sudo_become_plugin
+                key: flags
+            vars:
+              - name: ansible_become_flags
+              - name: ansible_sudo_flags
+            env:
+              - name: ANSIBLE_BECOME_FLAGS
+              - name: ANSIBLE_SUDO_FLAGS
+        become_pass:
+            description: Password to pass to sudo
+            required: False
+            vars:
+              - name: ansible_become_password
+              - name: ansible_become_pass
+              - name: ansible_sudo_pass
+            env:
+              - name: ANSIBLE_BECOME_PASS
+              - name: ANSIBLE_SUDO_PASS
+            ini:
+              - section: sudo_become_plugin
+                key: password
+"""
+
+
+from ansible.plugins.become import BecomeBase
+
+
+class BecomeModule(BecomeBase):
+
+    name = 'sudo'
+
+    # messages for detecting prompted password issues
+    fail = ('Sorry, try again.',)
+    missing = ('Sorry, a password is required to run sudo', 'sudo: a password is required')
+
+    def build_become_command(self, cmd, shell):
+        super(BecomeModule, self).build_become_command(cmd, shell)
+
+        if not cmd:
+            return cmd
+
+        becomecmd = self.name
+
+        flags = self.get_option('become_flags') or ''
+        prompt = ''
+        if self.get_option('become_pass'):
+            self.prompt = '[sudo via ansible, key=%s] password:' % self._id
+            if flags:  # this could be simplified, but kept as is for now for backwards string matching
+                flags = flags.replace('-n', '')
+            prompt = '-p "%s"' % (self.prompt)
+
+        user = self.get_option('become_user') or ''
+        if user:
+            user = '%s' % (user)
+
+        return ' '.join([becomecmd, flags, prompt, 'su -l', user, self._build_success_command(cmd, shell)])


### PR DESCRIPTION
##### SUMMARY
Allow users to run Ansible tasks through `sudo su -`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
sudosu

##### ADDITIONAL INFORMATION
So I have been needing this at various customers for bootstrapping Ansible mostly.

Often you have an existing setup where there is a user that has root-access enabled through sudo, but only to run `su` to log using the user's password.
In these specific cases the root password is unique to the system and therefore not an easy way to automate bootstrapping.

Having a `sudo su -` become option with password prompt is not possible with the existing become methods (neither sudo nor su can be used) by abusing `become_exe` or `become_flags`.