### PR TITLE
WIP Make v2_runner_retry fire on time

### DIFF
--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -202,7 +202,7 @@ class StrategyModule(StrategyBase):
                                     display.warning("Using any_errors_fatal with the free strategy is not supported, "
                                                     "as tasks are executed independently on each host")
                                 self._tqm.send_callback('v2_playbook_on_task_start', task, is_conditional=False)
-                                self._queue_task(host, task, task_vars, play_context)
+                                host_results += self._queue_task(host, task, task_vars, play_context, iterator)
                                 # each task is counted as a worker being busy
                                 workers_free -= 1
                                 del task_vars

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -312,7 +312,7 @@ class StrategyModule(StrategyBase):
                             display.debug("sending task start callback")
 
                         self._blocked_hosts[host.get_name()] = True
-                        self._queue_task(host, task, task_vars, play_context)
+                        results += self._queue_task(host, task, task_vars, play_context, iterator)
                         del task_vars
 
                     # if we're bypassing the host loop, break out now


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Horrid kludge for #73899. I'm not proposing this code should be merged,
it almost certainly shouldn't. I offer it as a POC that can be built
from.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible.plugins.callbacks.default

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Before, note the 4 second delay before the first `FAILED - RETRYING: Command (3 retries left).`

```console
± ansible-playbook -i inventory.yml playbook.yml | ts -s
00:00:00 
00:00:00 PLAY [locals] ******************************************************************
00:00:00 
00:00:00 TASK [Command] *****************************************************************
00:00:05 FAILED - RETRYING: Command (3 retries left).
00:00:05 FAILED - RETRYING: Command (3 retries left).
00:00:05 FAILED - RETRYING: Command (3 retries left).
00:00:05 FAILED - RETRYING: Command (3 retries left).
00:00:05 FAILED - RETRYING: Command (3 retries left).
00:00:05 FAILED - RETRYING: Command (2 retries left).
00:00:05 FAILED - RETRYING: Command (2 retries left).
00:00:05 FAILED - RETRYING: Command (2 retries left).
00:00:05 FAILED - RETRYING: Command (2 retries left).
00:00:05 FAILED - RETRYING: Command (2 retries left).
00:00:05 ok: [local1]
00:00:05 ok: [local4]
00:00:05 ok: [local3]
00:00:05 ok: [local2]
00:00:05 ok: [local5]
00:00:05 FAILED - RETRYING: Command (3 retries left).
00:00:05 FAILED - RETRYING: Command (3 retries left).
00:00:05 FAILED - RETRYING: Command (3 retries left).
00:00:08 FAILED - RETRYING: Command (2 retries left).
00:00:08 FAILED - RETRYING: Command (2 retries left).
00:00:08 FAILED - RETRYING: Command (2 retries left).
00:00:10 ok: [local6]
00:00:10 ok: [local7]
00:00:10 ok: [local8]
00:00:10 
00:00:10 PLAY RECAP *********************************************************************
00:00:10 local1                     : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
00:00:10 local2                     : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
00:00:10 local3                     : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
00:00:10 local4                     : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
00:00:10 local5                     : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
00:00:10 local6                     : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
00:00:10 local7                     : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
00:00:10 local8                     : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
00:00:10 

```

After, the 4 second delay in output is gone.
```console
± ansible-playbook -i inventory.yml playbook.yml | ts -s
00:00:01 
00:00:01 PLAY [locals] ******************************************************************
00:00:01 
00:00:01 TASK [Command] *****************************************************************
00:00:01 FAILED - RETRYING: Command (3 retries left).
00:00:01 FAILED - RETRYING: Command (3 retries left).
00:00:01 FAILED - RETRYING: Command (3 retries left).
00:00:02 FAILED - RETRYING: Command (3 retries left).
00:00:02 FAILED - RETRYING: Command (3 retries left).
00:00:04 FAILED - RETRYING: Command (2 retries left).
00:00:04 FAILED - RETRYING: Command (2 retries left).
00:00:04 FAILED - RETRYING: Command (2 retries left).
00:00:04 FAILED - RETRYING: Command (2 retries left).
00:00:04 FAILED - RETRYING: Command (2 retries left).
00:00:06 ok: [local3]
00:00:06 ok: [local4]
00:00:06 ok: [local5]
00:00:06 ok: [local1]
00:00:06 ok: [local2]
00:00:06 FAILED - RETRYING: Command (3 retries left).
00:00:06 FAILED - RETRYING: Command (3 retries left).
00:00:06 FAILED - RETRYING: Command (3 retries left).
00:00:08 FAILED - RETRYING: Command (2 retries left).
00:00:08 FAILED - RETRYING: Command (2 retries left).
00:00:08 FAILED - RETRYING: Command (2 retries left).
00:00:10 ok: [local6]
00:00:10 ok: [local8]
00:00:10 ok: [local7]
00:00:10 
00:00:10 PLAY RECAP *********************************************************************
00:00:10 local1                     : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
00:00:10 local2                     : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
00:00:10 local3                     : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
00:00:10 local4                     : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
00:00:10 local5                     : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
00:00:10 local6                     : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
00:00:10 local7                     : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
00:00:10 local8                     : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```