### PR TITLE
Docsite: clarify a changelog entry format

### DIFF
--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -195,7 +195,7 @@ When writing a changelog entry, follow the format:
 
   - scope - description starting with a lowercase letter and ending with a dot at the very end. Multiple sentences are allowed (https://github.com/reference/to/an/issue or, if there is no issue, reference to a pull request itself).
 
-The scope is usually a module or plugin name or group of modules or plugins, for example, ``lookup plugins``.
+The scope is usually a module or plugin name or group of modules or plugins, for example, ``lookup plugins``. While module names can (and should) be mentioned directly (``foo_module``), plugin names should always be followed by the type (``foo inventory plugin``).
 
 For changes that are not really scoped (for example, which affect a whole collection), follow the format:
 

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -198,6 +198,7 @@ When writing a changelog entry, follow the format:
 The scope is usually a module or plugin name or group of modules or plugins, for example, ``lookup plugins``.
 
 For changes that are not really scoped (for example, which affect a whole collection), follow the format:
+
 .. code-block:: yaml
 
   - Description starting with a lowercase letter and ending with a dot (https://github.com/reference/to/an/issue or, if there is no issue, reference to a pull request itself).

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -184,7 +184,18 @@ A single changelog fragment may contain multiple sections but most will only con
 
 Each changelog entry must contain a link to its issue between parentheses at the end. If there is no corresponding issue, the entry must contain a link to the PR itself.
 
-Most changelog entries will be ``bugfixes`` or ``minor_changes``. When writing a changelog entry that pertains to a particular module, start the entry with ``- [module name] -`` and the following sentence with a lowercase letter.
+Most changelog entries are ``bugfixes`` or ``minor_changes``.
+
+Changelog fragment entry format
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When writing a changelog entry, follow the format:
+
+.. code-block:: yaml
+
+  - scope - description starting with a lowercase letter and ending with a dot (https://github.com/reference/to/an/issue or, if there is no issue, reference to a pull request itself).
+
+The scope is usually a module or plugin name or group of modules or plugins, for example, ``lookup plugins``.
 
 Here are some examples:
 

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -189,7 +189,7 @@ Most changelog entries are ``bugfixes`` or ``minor_changes``.
 Changelog fragment entry format
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When writing a changelog entry, follow the format:
+When writing a changelog entry, use the following format:
 
 .. code-block:: yaml
 

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -193,7 +193,7 @@ When writing a changelog entry, use the following format:
 
 .. code-block:: yaml
 
-  - scope - description starting with a lowercase letter and ending with a dot at the very end. Multiple sentences are allowed (https://github.com/reference/to/an/issue or, if there is no issue, reference to a pull request itself).
+  - scope - description starting with a lowercase letter and ending with a period at the very end. Multiple sentences are allowed (https://github.com/reference/to/an/issue or, if there is no issue, reference to a pull request itself).
 
 The scope is usually a module or plugin name or group of modules or plugins, for example, ``lookup plugins``. While module names can (and should) be mentioned directly (``foo_module``), plugin names should always be followed by the type (``foo inventory plugin``).
 

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -197,7 +197,7 @@ When writing a changelog entry, use the following format:
 
 The scope is usually a module or plugin name or group of modules or plugins, for example, ``lookup plugins``. While module names can (and should) be mentioned directly (``foo_module``), plugin names should always be followed by the type (``foo inventory plugin``).
 
-For changes that are not really scoped (for example, which affect a whole collection), follow the format:
+For changes that are not really scoped (for example, which affect a whole collection), use the following format:
 
 .. code-block:: yaml
 

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -201,7 +201,7 @@ For changes that are not really scoped (for example, which affect a whole collec
 
 .. code-block:: yaml
 
-  - Description starting with a lowercase letter and ending with a dot (https://github.com/reference/to/an/issue or, if there is no issue, reference to a pull request itself).
+  - Description starting with an uppercase letter and ending with a dot (https://github.com/reference/to/an/issue or, if there is no issue, reference to a pull request itself).
 
 
 Here are some examples:

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -197,7 +197,7 @@ When writing a changelog entry, follow the format:
 
 The scope is usually a module or plugin name or group of modules or plugins, for example, ``lookup plugins``.
 
-For changes that are not really scoped (for example, which affect all modules), follow the format:
+For changes that are not really scoped (for example, which affect a whole collection), follow the format:
 .. code-block:: yaml
 
   - Description starting with a lowercase letter and ending with a dot (https://github.com/reference/to/an/issue or, if there is no issue, reference to a pull request itself).

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -201,7 +201,7 @@ For changes that are not really scoped (for example, which affect a whole collec
 
 .. code-block:: yaml
 
-  - Description starting with an uppercase letter and ending with a dot (https://github.com/reference/to/an/issue or, if there is no issue, reference to a pull request itself).
+  - Description starting with an uppercase letter and ending with a dot at the very end. Multiple sentences are allowed (https://github.com/reference/to/an/issue or, if there is no issue, reference to a pull request itself).
 
 
 Here are some examples:

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -197,6 +197,12 @@ When writing a changelog entry, follow the format:
 
 The scope is usually a module or plugin name or group of modules or plugins, for example, ``lookup plugins``.
 
+For changes that are not really scoped (for example, which affect all modules), follow the format:
+.. code-block:: yaml
+
+  - Description starting with a lowercase letter and ending with a dot (https://github.com/reference/to/an/issue or, if there is no issue, reference to a pull request itself).
+
+
 Here are some examples:
 
 .. code-block:: yaml

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -193,7 +193,7 @@ When writing a changelog entry, follow the format:
 
 .. code-block:: yaml
 
-  - scope - description starting with a lowercase letter and ending with a dot (https://github.com/reference/to/an/issue or, if there is no issue, reference to a pull request itself).
+  - scope - description starting with a lowercase letter and ending with a dot at the very end. Multiple sentences are allowed (https://github.com/reference/to/an/issue or, if there is no issue, reference to a pull request itself).
 
 The scope is usually a module or plugin name or group of modules or plugins, for example, ``lookup plugins``.
 


### PR DESCRIPTION
##### SUMMARY
Establish a certain changelog entry format:
```
- The change of the module.                               <- doesn't determine its scope, no reference to an issue / PR
- module - The description of the change                  <- starts with a capital letter
- module - the description of the change (https://...)    <- no dot at the end
- module - the description of the change (https://...).   <- this one fully corresponds to the examples
- The description of the change (https://...).            <- also correct, when it affects all modules, for example
- other variations
```

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`docs/docsite/rst/community/development_process.rst`