### PR TITLE
[2.8] docker_swarm: mark join_token as no_log

### DIFF
--- a/changelogs/fragments/community.docker-103-docker_swarm-no_log.yml
+++ b/changelogs/fragments/community.docker-103-docker_swarm-no_log.yml
@@ -1,0 +1,4 @@
+security_fixes:
+- "docker_swarm - the ``join_token`` option is now marked as ``no_log`` so it is no longer written into logs (https://github.com/ansible-collections/community.docker/pull/103)."
+breaking_changes:
+- "docker_swarm - if ``join_token`` is specified, a returned join token with the same value will be replaced by ``VALUE_SPECIFIED_IN_NO_LOG_PARAMETER``. Make sure that you do not blindly use the join tokens from the return value of this module when the module is invoked with ``join_token`` specified! This breaking change appears in a minor release since it is necessary to fix a security issue (https://github.com/ansible-collections/community.docker/pull/103)."

--- a/lib/ansible/modules/cloud/docker/docker_swarm.py
+++ b/lib/ansible/modules/cloud/docker/docker_swarm.py
@@ -92,6 +92,8 @@ options:
     description:
       - Swarm token used to join a swarm cluster.
       - Used with I(state=join).
+      - If this value is specified, the corresponding value in the return values will be censored by Ansible.
+        This is a side-effect of this value not being logged.
     type: str
   remote_addrs:
     description:
@@ -242,12 +244,20 @@ swarm_facts:
           type: complex
           contains:
               Worker:
-                  description: Token to create a new *worker* node
+                  description:
+                    - Token to join the cluster as a new *worker* node.
+                    - "B(Note:) if this value has been specified as I(join_token), the value here will not
+                       be the token, but C(VALUE_SPECIFIED_IN_NO_LOG_PARAMETER). If you pass I(join_token),
+                       make sure your playbook/role does not depend on this return value!"
                   returned: success
                   type: str
                   example: SWMTKN-1--xxxxx
               Manager:
-                  description: Token to create a new *manager* node
+                  description:
+                    - Token to join the cluster as a new *manager* node.
+                    - "B(Note:) if this value has been specified as I(join_token), the value here will not
+                       be the token, but C(VALUE_SPECIFIED_IN_NO_LOG_PARAMETER). If you pass I(join_token),
+                       make sure your playbook/role does not depend on this return value!"
                   returned: success
                   type: str
                   example: SWMTKN-1--xxxxx
@@ -608,7 +618,7 @@ def main():
         force=dict(type='bool', default=False),
         listen_addr=dict(type='str', default='0.0.0.0:2377'),
         remote_addrs=dict(type='list', elements='str'),
-        join_token=dict(type='str'),
+        join_token=dict(type='str', no_log=True),
         snapshot_interval=dict(type='int'),
         task_history_retention_limit=dict(type='int'),
         keep_old_snapshots=dict(type='int'),


### PR DESCRIPTION
##### SUMMARY
Backport of ansible-collections/community.docker#103 to stable-2.8.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
docker_swarm
