### PR TITLE
[2.8] na_cdot_user: mark set_password as no_log

### DIFF
--- a/changelogs/fragments/community.general-2018-missing-no_log-again.yml
+++ b/changelogs/fragments/community.general-2018-missing-no_log-again.yml
@@ -1,0 +1,2 @@
+security_fixes:
+- "na_cdot_user - mark the ``set_password`` parameter as ``no_log`` to avoid leakage of secrets (https://github.com/ansible-collections/community.general/pull/2018)."

--- a/lib/ansible/modules/storage/netapp/_na_cdot_user.py
+++ b/lib/ansible/modules/storage/netapp/_na_cdot_user.py
@@ -132,7 +132,7 @@ class NetAppCDOTUser(object):
                                        choices=['community', 'password',
                                                 'publickey', 'domain',
                                                 'nsswitch', 'usm']),
-            set_password=dict(required=False, type='str', default=None),
+            set_password=dict(required=False, type='str', default=None, no_log=True),
             role_name=dict(required=False, type='str'),
 
             vserver=dict(required=True, type='str'),


### PR DESCRIPTION
##### SUMMARY
Partial backport of ansible-collections/community.general#2018. The other module has already been fixed in #73489.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
na_cdot_user
