### PR TITLE
Send callbacks directly from the TaskExecutor instead of TaskResults masquerading as callbacks

### DIFF
--- a/changelogs/fragments/73899-more-te-callbacks.yml
+++ b/changelogs/fragments/73899-more-te-callbacks.yml
@@ -1,0 +1,5 @@
+minor_changes:
+- Callbacks - Migrate more places in the ``TaskExecutor`` to sending callbacks directly
+  over the queue, instead of sending them as ``TaskResult`` and short circuiting in the
+  Strategy to send the callback. This enables closer to real time callbacks of retries
+  and loop results (https://github.com/ansible/ansible/issues/73899)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -16,7 +16,6 @@ import termios
 import traceback
 
 from ansible import constants as C
-from ansible import context
 from ansible.errors import AnsibleError, AnsibleParserError, AnsibleUndefinedVariable, AnsibleConnectionFailure, AnsibleActionFail, AnsibleActionSkip
 from ansible.executor.task_result import TaskResult
 from ansible.executor.module_common import get_action_args_with_defaults
@@ -394,7 +393,7 @@ class TaskExecutor:
             elif tr.is_skipped():
                 self._final_q.send_callback('v2_runner_item_on_skipped', tr)
             else:
-                if context.CLIARGS.get('diff', False) or getattr(self._task, 'diff', False):
+                if getattr(self._task, 'diff', False):
                     self._final_q.send_callback('v2_on_file_diff', tr)
                 self._final_q.send_callback('v2_runner_item_on_ok', tr)
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -384,8 +384,8 @@ class TaskExecutor:
                 })
 
             tr = TaskResult(
-                self._host,
-                self._task,
+                self._host.name,
+                self._task._uuid,
                 res,
                 task_fields=task_fields,
             )
@@ -689,8 +689,8 @@ class TaskExecutor:
                         self._final_q.send_callback(
                             'v2_runner_retry',
                             TaskResult(
-                                self._host,
-                                self._task,
+                                self._host.name,
+                                self._task._uuid,
                                 result,
                                 task_fields=self._task.dump_attrs()
                             )
@@ -803,8 +803,8 @@ class TaskExecutor:
                 self._final_q.send_callback(
                     'v2_runner_on_async_poll',
                     TaskResult(
-                        self._host,
-                        async_task,
+                        self._host.name,
+                        async_task._uuid,
                         async_result,
                         task_fields=self._task.dump_attrs(),
                     ),

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -389,17 +389,14 @@ class TaskExecutor:
                 res,
                 task_fields=task_fields,
             )
-            callbacks = []
             if tr.is_failed() or tr.is_unreachable():
-                callbacks.append('v2_runner_item_on_failed')
+                self._final_q.send_callback('v2_runner_item_on_failed', tr)
             elif tr.is_skipped():
-                callbacks.append('v2_runner_item_on_skipped')
+                self._final_q.send_callback('v2_runner_item_on_skipped', tr)
             else:
                 if context.CLIARGS.get('diff', False) or getattr(self._task, 'diff', False):
-                    callbacks.append('v2_on_file_diff')
-                callbacks.append('v2_runner_item_on_ok')
-            for callback in callbacks:
-                self._final_q.send_callback(callback, tr)
+                    self._final_q.send_callback('v2_on_file_diff', tr)
+                self._final_q.send_callback('v2_runner_item_on_ok', tr)
 
             results.append(res)
             del task_vars[loop_var]

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -800,7 +800,7 @@ class TaskExecutor:
                     'v2_runner_on_async_poll',
                     TaskResult(
                         self._host.name,
-                        async_task._uuid,
+                        async_task,  # We send the full task here, because the controller knows nothing about it, the TE created it
                         async_result,
                         task_fields=self._task.dump_attrs(),
                     ),

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -523,22 +523,6 @@ class StrategyBase:
             task_result._host = original_host
             task_result._task = original_task
 
-            # send callbacks for 'non final' results
-            if '_ansible_retry' in task_result._result:
-                self._tqm.send_callback('v2_runner_retry', task_result)
-                continue
-            elif '_ansible_item_result' in task_result._result:
-                if task_result.is_failed() or task_result.is_unreachable():
-                    self._tqm.send_callback('v2_runner_item_on_failed', task_result)
-                elif task_result.is_skipped():
-                    self._tqm.send_callback('v2_runner_item_on_skipped', task_result)
-                else:
-                    if 'diff' in task_result._result:
-                        if self._diff or getattr(original_task, 'diff', False):
-                            self._tqm.send_callback('v2_on_file_diff', task_result)
-                    self._tqm.send_callback('v2_runner_item_on_ok', task_result)
-                continue
-
             # all host status messages contain 2 entries: (msg, task_result)
             role_ran = False
             if task_result.is_failed():

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -46,6 +46,7 @@ from ansible.playbook.conditional import Conditional
 from ansible.playbook.handler import Handler
 from ansible.playbook.helpers import load_list_of_blocks
 from ansible.playbook.included_file import IncludedFile
+from ansible.playbook.task import Task
 from ansible.playbook.task_include import TaskInclude
 from ansible.plugins import loader as plugin_loader
 from ansible.template import Templar
@@ -459,14 +460,15 @@ class StrategyBase:
         """
 
         original_host = self._inventory.get_host(to_text(task_result._host))
-        queue_cache_entry = (original_host.name, task_result._task)
-        found_task = self._queued_task_cache.get(queue_cache_entry)['task']
-        original_task = found_task.copy(exclude_parent=True, exclude_tasks=True)
-        original_task._parent = found_task._parent
-        original_task.from_attrs(task_result._task_fields)
-
         task_result._host = original_host
-        task_result._task = original_task
+
+        if not isinstance(task_result._task, Task):
+            queue_cache_entry = (original_host.name, task_result._task)
+            found_task = self._queued_task_cache.get(queue_cache_entry)['task']
+            original_task = found_task.copy(exclude_parent=True, exclude_tasks=True)
+            original_task._parent = found_task._parent
+            original_task.from_attrs(task_result._task_fields)
+            task_result._task = original_task
 
         return task_result
 

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -455,13 +455,18 @@ class StrategyBase:
         """Normalize a TaskResult to reference actual Host and Task objects
         when only given the ``Host.name``, or the ``Task._uuid``
 
+        Only the ``Host.name`` and ``Task._uuid`` are commonly sent back from
+        the ``TaskExecutor`` or ``WorkerProcess`` due to performance concerns
+
         Mutates the original object
         """
 
         if isinstance(task_result._host, string_types):
+            # If the value is a string, it is ``Host.name``
             task_result._host = self._inventory.get_host(to_text(task_result._host))
 
         if isinstance(task_result._task, string_types):
+            # If the value is a string, it is ``Task._uuid``
             queue_cache_entry = (task_result._host.name, task_result._task)
             found_task = self._queued_task_cache.get(queue_cache_entry)['task']
             original_task = found_task.copy(exclude_parent=True, exclude_tasks=True)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -458,7 +458,7 @@ class StrategyBase:
         Mutates the original object
         """
 
-        original_host = self._get_original_host(task_result._host)
+        original_host = self._inventory.get_host(to_text(task_result._host))
         queue_cache_entry = (original_host.name, task_result._task)
         found_task = self._queued_task_cache.get(queue_cache_entry)['task']
         original_task = found_task.copy(exclude_parent=True, exclude_tasks=True)
@@ -469,14 +469,6 @@ class StrategyBase:
         task_result._task = original_task
 
         return task_result
-
-    def _get_original_host(self, host_name):
-        # FIXME: this should not need x2 _inventory
-        host_name = to_text(host_name)
-        if host_name in self._inventory.hosts:
-            return self._inventory.hosts[host_name]
-        else:
-            return self._inventory.get_host(host_name)
 
     @debug_closure
     def _process_pending_results(self, iterator, one_pass=False, max_passes=None, do_handlers=False):

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -46,7 +46,6 @@ from ansible.playbook.conditional import Conditional
 from ansible.playbook.handler import Handler
 from ansible.playbook.helpers import load_list_of_blocks
 from ansible.playbook.included_file import IncludedFile
-from ansible.playbook.task import Task
 from ansible.playbook.task_include import TaskInclude
 from ansible.plugins import loader as plugin_loader
 from ansible.template import Templar
@@ -459,11 +458,11 @@ class StrategyBase:
         Mutates the original object
         """
 
-        original_host = self._inventory.get_host(to_text(task_result._host))
-        task_result._host = original_host
+        if isinstance(task_result._host, string_types):
+            task_result._host = self._inventory.get_host(to_text(task_result._host))
 
-        if not isinstance(task_result._task, Task):
-            queue_cache_entry = (original_host.name, task_result._task)
+        if isinstance(task_result._task, string_types):
+            queue_cache_entry = (task_result._host.name, task_result._task)
             found_task = self._queued_task_cache.get(queue_cache_entry)['task']
             original_task = found_task.copy(exclude_parent=True, exclude_tasks=True)
             original_task._parent = found_task._parent

--- a/test/units/plugins/strategy/test_strategy.py
+++ b/test/units/plugins/strategy/test_strategy.py
@@ -20,7 +20,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.mock.loader import DictDataLoader
-from copy import deepcopy
 import uuid
 
 from units.compat import unittest
@@ -254,7 +253,7 @@ class TestStrategyBase(unittest.TestCase):
         mock_task._parent = None
         mock_task.ignore_errors = False
         mock_task.ignore_unreachable = False
-        mock_task._uuid = uuid.uuid4()
+        mock_task._uuid = str(uuid.uuid4())
         mock_task.loop = None
         mock_task.copy.return_value = mock_task
 
@@ -319,16 +318,17 @@ class TestStrategyBase(unittest.TestCase):
         strategy_base._blocked_hosts['test01'] = True
         strategy_base._pending_results = 1
 
-        mock_queued_task_cache = {
-            (mock_host.name, mock_task._uuid): {
-                'task': mock_task,
-                'host': mock_host,
-                'task_vars': {},
-                'play_context': {},
+        def mock_queued_task_cache():
+            return {
+                (mock_host.name, mock_task._uuid): {
+                    'task': mock_task,
+                    'host': mock_host,
+                    'task_vars': {},
+                    'play_context': {},
+                }
             }
-        }
 
-        strategy_base._queued_task_cache = deepcopy(mock_queued_task_cache)
+        strategy_base._queued_task_cache = mock_queued_task_cache()
         results = strategy_base._wait_on_pending_results(iterator=mock_iterator)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0], task_result)
@@ -340,7 +340,7 @@ class TestStrategyBase(unittest.TestCase):
         strategy_base._blocked_hosts['test01'] = True
         strategy_base._pending_results = 1
         mock_iterator.is_failed.return_value = True
-        strategy_base._queued_task_cache = deepcopy(mock_queued_task_cache)
+        strategy_base._queued_task_cache = mock_queued_task_cache()
         results = strategy_base._wait_on_pending_results(iterator=mock_iterator)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0], task_result)
@@ -354,7 +354,7 @@ class TestStrategyBase(unittest.TestCase):
         queue_items.append(task_result)
         strategy_base._blocked_hosts['test01'] = True
         strategy_base._pending_results = 1
-        strategy_base._queued_task_cache = deepcopy(mock_queued_task_cache)
+        strategy_base._queued_task_cache = mock_queued_task_cache()
         results = strategy_base._wait_on_pending_results(iterator=mock_iterator)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0], task_result)
@@ -367,7 +367,7 @@ class TestStrategyBase(unittest.TestCase):
         queue_items.append(task_result)
         strategy_base._blocked_hosts['test01'] = True
         strategy_base._pending_results = 1
-        strategy_base._queued_task_cache = deepcopy(mock_queued_task_cache)
+        strategy_base._queued_task_cache = mock_queued_task_cache()
         results = strategy_base._wait_on_pending_results(iterator=mock_iterator)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0], task_result)
@@ -377,7 +377,7 @@ class TestStrategyBase(unittest.TestCase):
         queue_items.append(TaskResult(host=mock_host.name, task=mock_task._uuid, return_data=dict(add_host=dict(host_name='newhost01', new_groups=['foo']))))
         strategy_base._blocked_hosts['test01'] = True
         strategy_base._pending_results = 1
-        strategy_base._queued_task_cache = deepcopy(mock_queued_task_cache)
+        strategy_base._queued_task_cache = mock_queued_task_cache()
         results = strategy_base._wait_on_pending_results(iterator=mock_iterator)
         self.assertEqual(len(results), 1)
         self.assertEqual(strategy_base._pending_results, 0)
@@ -386,7 +386,7 @@ class TestStrategyBase(unittest.TestCase):
         queue_items.append(TaskResult(host=mock_host.name, task=mock_task._uuid, return_data=dict(add_group=dict(group_name='foo'))))
         strategy_base._blocked_hosts['test01'] = True
         strategy_base._pending_results = 1
-        strategy_base._queued_task_cache = deepcopy(mock_queued_task_cache)
+        strategy_base._queued_task_cache = mock_queued_task_cache()
         results = strategy_base._wait_on_pending_results(iterator=mock_iterator)
         self.assertEqual(len(results), 1)
         self.assertEqual(strategy_base._pending_results, 0)
@@ -395,7 +395,7 @@ class TestStrategyBase(unittest.TestCase):
         queue_items.append(TaskResult(host=mock_host.name, task=mock_task._uuid, return_data=dict(changed=True, _ansible_notify=['test handler'])))
         strategy_base._blocked_hosts['test01'] = True
         strategy_base._pending_results = 1
-        strategy_base._queued_task_cache = deepcopy(mock_queued_task_cache)
+        strategy_base._queued_task_cache = mock_queued_task_cache()
         results = strategy_base._wait_on_pending_results(iterator=mock_iterator)
         self.assertEqual(len(results), 1)
         self.assertEqual(strategy_base._pending_results, 0)


### PR DESCRIPTION
##### SUMMARY
Send callbacks directly from the TaskExecutor instead of TaskResults masquerading as callbacks

Fixes #73899 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
```
lib/ansible/executor/task_executor.py
lib/ansible/plugins/strategy/__init__.py
```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
