### PR TITLE
[stable-2.10] Ensure task from the worker is finalized/squashed (#73881)

### DIFF
--- a/changelogs/fragments/57399-finalize-task-in-strategy.yml
+++ b/changelogs/fragments/57399-finalize-task-in-strategy.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- Strategy - When building the task in the Strategy from the Worker,
+  ensure it is properly marked as finalized and squashed. Addresses an
+  issue with ``ansible_failed_task``.
+  (https://github.com/ansible/ansible/issues/57399)

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -545,6 +545,13 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
                 else:
                     setattr(self, attr, value)
 
+        # from_attrs is only used to create a finalized task
+        # from attrs from the Worker/TaskExecutor
+        # Those attrs are finalized and squashed in the TE
+        # and controller side use needs to reflect that
+        self._finalized = True
+        self._squashed = True
+
     def serialize(self):
         '''
         Serializes the object derived from the base object into

--- a/test/integration/targets/blocks/finalized_task.yml
+++ b/test/integration/targets/blocks/finalized_task.yml
@@ -1,0 +1,17 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - block:
+        - include_role:
+            name: '{{ item }}'
+          loop:
+            - fail
+      rescue:
+        - debug:
+            msg: "{{ ansible_failed_task.name }}"
+
+        - assert:
+            that:
+              - ansible_failed_task.name == "Fail"
+              - ansible_failed_task.action == "fail"
+              - ansible_failed_task.parent is not defined

--- a/test/integration/targets/blocks/roles/fail/tasks/main.yml
+++ b/test/integration/targets/blocks/roles/fail/tasks/main.yml
@@ -1,0 +1,3 @@
+- name: Fail
+  fail:
+    msg: fail


### PR DESCRIPTION
* Ensure task from the worker is finalized/squashed. Fixes #57399. Fixes #49942
(cherry picked from commit 832631b)


Co-authored-by: Matt Martz <matt@sivel.net>