### PR TITLE
Remove ini and env fields for config option CONNECTION_FACTS_MODULES

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1352,9 +1352,6 @@ CONNECTION_FACTS_MODULES:
     ironware: ansible.legacy.ironware_facts
     community.network.ironware: community.network.ironware_facts
   description: "Which modules to run during a play's fact gathering stage based on connection"
-  env: [{name: ANSIBLE_CONNECTION_FACTS_MODULES}]
-  ini:
-    - {key: connection_facts_modules, section: defaults}
   type: dict
 FACTS_MODULES:
   name: Gather Facts Modules


### PR DESCRIPTION
##### SUMMARY
It's type 'dict' and can only be set via ini or env var, so configuring it will never have the correct type. It looks like the only one we have like this, so I just removed the misleading fields. We could fix it by parsing the string with ast.literal_eval() but I guess no one uses this and fixing via YAML config files seems like less of a hack.

##### ISSUE TYPE
- Docs Pull Request
