### PR TITLE
Amazon: Fix distribution facts for older release

### DIFF
--- a/changelogs/fragments/73946_amazon_linux.yml
+++ b/changelogs/fragments/73946_amazon_linux.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- setup - fix distribution facts for Older Amazon Linux with ``/etc/os-release`` (https://github.com/ansible/ansible/issues/73946).

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -226,9 +226,16 @@ class DistributionFiles:
         if path == '/etc/os-release':
             version = re.search(r"VERSION_ID=\"(.*)\"", data)
             if version:
-                amazon_facts['distribution_version'] = version.group(1)
-                amazon_facts['distribution_major_version'] = version.group(1).split('.')[0]
-                amazon_facts['distribution_minor_version'] = version.group(1).split('.')[1]
+                distribution_version = version.group(1)
+                amazon_facts['distribution_version'] = distribution_version
+                version_data = distribution_version.split(".")
+                if len(version_data) > 1:
+                    major, minor = version_data
+                else:
+                    major, minor = version_data[0], 'NA'
+
+                amazon_facts['distribution_major_version'] = major
+                amazon_facts['distribution_minor_version'] = minor
         else:
             version = [n for n in data.split() if n.isdigit()]
             version = version[0] if version else 'NA'

--- a/test/units/module_utils/facts/system/distribution/fixtures/amazon_linux_2.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/amazon_linux_2.json
@@ -1,14 +1,14 @@
 {
     "platform.dist": [
-        "",
-        "",
+        "amzn",
+        "2",
         ""
     ],
     "input": {
-        "/etc/system-release": "Amazon Linux release 2",
-        "/etc/os-release": ""
+        "/etc/os-release": "NAME=\"Amazon Linux\"\nVERSION=\"2\"\nID=\"amzn\"\nID_LIKE=\"centos rhel fedora\"\nVERSION_ID=\"2\"\nPRETTY_NAME=\"Amazon Linux 2\"\nANSI_COLOR=\"0;33\"\nCPE_NAME=\"cpe:2.3:o:amazon:amazon_linux:2\"\nHOME_URL=\"https://amazonlinux.com/\"\n",
+        "/etc/system-release": "Amazon Linux release 2 (Karoo)\n"
     },
-    "name": "Amazon Linux 2",
+    "name": "Amazon 2",
     "result": {
         "distribution_release": "NA",
         "distribution": "Amazon",
@@ -18,17 +18,22 @@
     },
     "distro": {
         "id": "amzn",
+        "name": "Amazon Linux",
         "version": "2",
         "codename": "",
+        "version_best": "2",
+        "lsb_release_info": {},
         "os_release_info": {
-            "name": "Amazon Linux AMI",
             "ansi_color": "0;33",
-            "id_like": "rhel fedora",
+            "id_like": "centos rhel fedora",
             "version_id": "2",
-            "pretty_name": "Amazon Linux release 2",
+            "pretty_name": "Amazon Linux 2",
+            "name": "Amazon Linux",
             "version": "2",
-            "home_url": "",
-            "id": "amzn"
+            "home_url": "https://amazonlinux.com/",
+            "id": "amzn",
+            "cpe_name": "cpe:2.3:o:amazon:amazon_linux:2"
         }
-    }
+    },
+    "platform.release": "4.14.181-142.260.amzn2.x86_64"
 }

--- a/test/units/module_utils/facts/system/distribution/fixtures/amazon_linux_release_2.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/amazon_linux_release_2.json
@@ -1,0 +1,34 @@
+{
+    "platform.dist": [
+        "",
+        "",
+        ""
+    ],
+    "input": {
+        "/etc/system-release": "Amazon Linux release 2",
+        "/etc/os-release": ""
+    },
+    "name": "Amazon Linux 2",
+    "result": {
+        "distribution_release": "NA",
+        "distribution": "Amazon",
+        "distribution_major_version": "2",
+        "os_family": "RedHat",
+        "distribution_version": "2"
+    },
+    "distro": {
+        "id": "amzn",
+        "version": "2",
+        "codename": "",
+        "os_release_info": {
+            "name": "Amazon Linux AMI",
+            "ansi_color": "0;33",
+            "id_like": "rhel fedora",
+            "version_id": "2",
+            "pretty_name": "Amazon Linux release 2",
+            "version": "2",
+            "home_url": "",
+            "id": "amzn"
+        }
+    }
+}


### PR DESCRIPTION
##### SUMMARY

Ansible can gather distribution facts for older Amazon Linux
with /etc/os-release data.

Fixes: #73946

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/73946_amazon_linux.yml
lib/ansible/module_utils/facts/system/distribution.py
test/units/module_utils/facts/system/distribution/fixtures/amazon_linux_2.json
test/units/module_utils/facts/system/distribution/fixtures/amazon_linux_release_2.json
