### PR TITLE
Declare Framework::Ansible classifier for PyPI

### DIFF
--- a/changelogs/fragments/73955-trove.yml
+++ b/changelogs/fragments/73955-trove.yml
@@ -1,0 +1,6 @@
+minor_changes:
+  - |-
+    Ansible now has the Trove Classifier ``Framework :: Ansible`` on PyPI.
+    Python projects building on Ansible can use the same classifier. To
+    discover such packages visit https://pypi.org/search/?c=Framework+%3A%3A+Ansible.
+    (https://github.com/ansible/ansible/pull/73955)

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ license = GPLv3+
 classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Console
+    Framework :: Ansible
     Intended Audience :: Developers
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators


### PR DESCRIPTION
##### SUMMARY

https://github.com/pypa/trove-classifiers/pull/61 added Ansible as a
classifier for projects on PyPI. This allows Python projects, and their
distributions (e.g. ansible-lint) to declare they use, enhance, or
otherwise involve Ansible.

PyPI projects can be filtered by this classifier, <https://pypi.org/search/?c=Framework+%3A%3A+Ansible>,

Signed-off-by: Alex Willmer <alex@moreati.org.uk>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
