### PR TITLE
find - set proper default based on use_regex (#73961)

### DIFF
--- a/changelogs/fragments/fix_find_default.yml
+++ b/changelogs/fragments/fix_find_default.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - find module, fix default pattern when use_regex is true.

--- a/changelogs/fragments/fix_find_default.yml
+++ b/changelogs/fragments/fix_find_default.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - find module, fix default pattern when use_regex is true.
+  - find - fix default pattern when use_regex is true (https://github.com/ansible/ansible/issues/50067).

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -45,7 +45,6 @@ options:
         type: list
         elements: str
         aliases: [ pattern ]
-        elements: str
     excludes:
         description:
             - One or more (shell or regex) patterns, which type is controlled by C(use_regex) option.
@@ -55,7 +54,6 @@ options:
         elements: str
         aliases: [ exclude ]
         version_added: "2.5"
-        elements: str
     contains:
         description:
             - A regular expression or pattern which should be matched against the file content.
@@ -67,7 +65,6 @@ options:
         required: true
         elements: str
         aliases: [ name, path ]
-        elements: str
     file_type:
         description:
             - Type of file to select.

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -29,7 +29,7 @@ options:
               first letter of any of those words (e.g., "1w").
         type: str
     patterns:
-        default: '*'
+        default: []
         description:
             - One or more (shell or regex) patterns, which type is controlled by C(use_regex) option.
             - The patterns restrict the list of files to be returned to those whose basenames match at
@@ -41,6 +41,7 @@ options:
             - This parameter expects a list, which can be either comma separated or YAML. If any of the
               patterns contain a comma, make sure to put them in a list to avoid splitting the patterns
               in undesirable ways.
+            - Defaults to '*' when C(use_regex=False), or '.*' when C(use_regex=True).
         type: list
         aliases: [ pattern ]
         elements: str
@@ -360,7 +361,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             paths=dict(type='list', required=True, aliases=['name', 'path'], elements='str'),
-            patterns=dict(type='list', default=['*'], aliases=['pattern'], elements='str'),
+            patterns=dict(type='list', default=[], aliases=['pattern'], elements='str'),
             excludes=dict(type='list', aliases=['exclude'], elements='str'),
             contains=dict(type='str'),
             file_type=dict(type='str', default="file", choices=['any', 'directory', 'file', 'link']),
@@ -378,6 +379,16 @@ def main():
     )
 
     params = module.params
+
+    # Set the default match pattern to either a match-all glob or
+    # regex depending on use_regex being set.  This makes sure if you
+    # set excludes: without a pattern pfilter gets something it can
+    # handle.
+    if not params['patterns']:
+        if params['use_regex']:
+            params['patterns'] = ['.*']
+        else:
+            params['patterns'] = ['*']
 
     filelist = []
 

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -43,6 +43,7 @@ options:
               in undesirable ways.
             - Defaults to '*' when C(use_regex=False), or '.*' when C(use_regex=True).
         type: list
+        elements: str
         aliases: [ pattern ]
         elements: str
     excludes:
@@ -51,6 +52,7 @@ options:
             - Items whose basenames match an C(excludes) pattern are culled from C(patterns) matches.
               Multiple patterns can be specified using a list.
         type: list
+        elements: str
         aliases: [ exclude ]
         version_added: "2.5"
         elements: str
@@ -63,6 +65,7 @@ options:
             - List of paths of directories to search. All paths must be fully qualified.
         type: list
         required: true
+        elements: str
         aliases: [ name, path ]
         elements: str
     file_type:

--- a/test/integration/targets/find/tasks/main.yml
+++ b/test/integration/targets/find/tasks/main.yml
@@ -139,3 +139,25 @@
           # dir contents are considered until the depth exceeds the requested depth
           # there are 6 files/directories in the requested depth and 4 that exceed it by 1
           - files_with_depth.examined == 10
+
+- name: exclude with regex
+  find:
+    paths: "{{ output_dir_test }}"
+    recurse: yes
+    use_regex: true
+    exclude: .*\.ogg
+  register: find_test3
+# Note that currently sane ways of doing this with map() or
+# selectattr() aren't available in centos6 era jinja2 ...
+- set_fact:
+    find_test3_list: >-
+      [ {% for f in find_test3.files %}
+      {{ f.path }}
+      {% if not loop.last %},{% endif %}
+      {% endfor %}
+      ]
+- debug: var=find_test3_list
+- name: assert we skipped the ogg file
+  assert:
+    that:
+      - '"{{ output_dir_test }}/e/f/g/h/8.ogg" not in find_test3_list'

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -107,6 +107,7 @@ lib/ansible/modules/file.py pylint:ansible-bad-function
 lib/ansible/modules/file.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/file.py validate-modules:undocumented-parameter
 lib/ansible/modules/find.py use-argspec-type-path # fix needed
+lib/ansible/modules/find.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/lineinfile.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/lineinfile.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/lineinfile.py validate-modules:nonexistent-parameter-documented

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -107,7 +107,6 @@ lib/ansible/modules/file.py pylint:ansible-bad-function
 lib/ansible/modules/file.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/file.py validate-modules:undocumented-parameter
 lib/ansible/modules/find.py use-argspec-type-path # fix needed
-lib/ansible/modules/find.py validate-modules:parameter-type-not-in-doc
 lib/ansible/modules/lineinfile.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/lineinfile.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/lineinfile.py validate-modules:nonexistent-parameter-documented


### PR DESCRIPTION
When using "use_regex: yes" and setting an excludes: without
specifying a pattern: the existing code passes the file-glob '*' to
the regex matcher.  This results in an internal invalid-regex
exception being thrown.

This maintains the old semantics of a default match-all for pattern:
but switches the default to '.*' when use_regex is specified.

The code made sense as-is before excludes: was added (2.5).  In that
case, it made no sense to set use_regex but *not* set a pattern.
However, with excludes: it now makes sense to only want to exclude a
given regex but not specify a specific matching pattern.

Closes: #50067

* moved change to new location
added changelog

* Update lib/ansible/modules/find.py

Co-authored-by: Ian Wienand <iwienand@redhat.com>
(cherry picked from commit 089d0a0508a470799d099d95fc371e66756a00b3)



##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
modules/find