### PR TITLE
[stable-2.10] Vanquish rare container bootstrap failure (#73288)

### DIFF
--- a/changelogs/fragments/vanquish-rare-container-bootstrap-failure.yml
+++ b/changelogs/fragments/vanquish-rare-container-bootstrap-failure.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Avoid using ``/tmp`` to resolve occasional failures starting tests with the ``--docker`` option.

--- a/test/lib/ansible_test/_data/setup/docker.sh
+++ b/test/lib/ansible_test/_data/setup/docker.sh
@@ -6,9 +6,8 @@ set -eu
 rm -f /usr/sbin/policy-rc.d
 
 # Improve prompts on remote host for interactive use.
-# shellcheck disable=SC1117
-cat << EOF > ~/.bashrc
-alias ls='ls --color=auto'
-export PS1='\[\e]0;\u@\h: \w\a\]\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
-cd ~/ansible/
-EOF
+# `cat << EOF > ~/.bashrc` flakes sometimes since /tmp may not be ready yet in
+# the container. So don't do that
+echo "alias ls='ls --color=auto'" > ~/.bashrc
+echo "export PS1='\[\e]0;\u@\h: \w\a\]\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '" >> ~/.bashrc
+echo "cd ~/ansible/" >> ~/.bashrc


### PR DESCRIPTION
Origin: #73288

The init script for the test container writes additional lines to
the .bashrc of the user. This was done via a `cat` multiline
instruction, which is implemented internally by writing a
temporary file to TMPDIR (/tmp in this case) first. Docker fails
to provide /tmp just after creation, which results in a race
condition that rarely makes the init fail. Changed the `cat`
statement to multiple `echo`s.

Co-authored-by: Matt Clay <matt@mystile.com>
(cherry picked from commit fe792fdcd26ea41d38cef57ec18cef5ea45b7a7a)

Co-authored-by: Alexander Sowitzki <asowitzk@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
