### PR TITLE
Cumulus: support for 4-value Cumulus release versions

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -362,7 +362,7 @@ class DistributionFiles:
             if version:
                 debian_facts['distribution_version'] = version.group(1)
                 for val, name in zip(version.group(1).split("."), ['major', 'minor', 'maintenance', 'special']):
-                    debian_facts['distribution_{}_version'.format(name)] = val
+                    debian_facts['distribution_%s_version' % name] = val
             release = re.search(r'VERSION="(.*)"', data)
             if release:
                 debian_facts['distribution_release'] = release.groups()[0]

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -360,10 +360,9 @@ class DistributionFiles:
             debian_facts['distribution'] = 'Cumulus Linux'
             version = re.search(r"VERSION_ID=(.*)", data)
             if version:
-                major, _minor, _dummy_ver = version.group(1).split(".")
                 debian_facts['distribution_version'] = version.group(1)
-                debian_facts['distribution_major_version'] = major
-
+                for val, name in zip(version.group(1).split("."), ['major', 'minor', 'maintenance', 'special']):
+                    debian_facts['distribution_{}_version'.format(name)] = val
             release = re.search(r'VERSION="(.*)"', data)
             if release:
                 debian_facts['distribution_release'] = release.groups()[0]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
For internal releases and special releases, Cumulus uses a X.Y.Z.x format in the version numbers.
Ex: 3.7.14.1 or 3.7.13~16.d223

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Use the reboot module on an internal or special Cumulus release.

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before change:
```
ansible -b mux01 -m reboot -i ./hosts_ssim
mux01 | FAILED! => {
    "msg": "Failed to get distribution information. Missing \"ansible_distribution\" in output."
}
```
After change:
```
ansible -b mux01 -m reboot -i ./hosts_ssim                                                                                                                         
mux01 | CHANGED => {
    "changed": true,
    "elapsed": 36,
    "rebooted": true
}
```
