### PR TITLE
New AWS module mod_defaults - wafv2 modules

### DIFF
--- a/changelogs/fragments/wafv2-mod-defaults.yml
+++ b/changelogs/fragments/wafv2-mod-defaults.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - aws module_defaults - add wafv2_ip_set, wafv2_ip_set_info, wafv2_resources, wafv2_resources_info, wafv2_rule_group, wafv2_rule_group_info, wafv2_web_acl, wafv2_web_acl_info

--- a/lib/ansible/config/module_defaults.yml
+++ b/lib/ansible/config/module_defaults.yml
@@ -500,6 +500,22 @@ groupings:
   - aws
   sts_session_token:
   - aws
+  wafv2_ip_set:
+  - aws
+  wafv2_ip_set_info:
+  - aws
+  wafv2_resources:
+  - aws
+  wafv2_resources_info:
+  - aws
+  wafv2_rule_group:
+  - aws
+  wafv2_rule_group_info:
+  - aws
+  wafv2_web_acl:
+  - aws
+  wafv2_web_acl_info:
+  - aws
   gcp_compute_address:
   - gcp
   gcp_compute_address_facts:


### PR DESCRIPTION
##### SUMMARY
To support these new modules in CI, we need them to be in 2.9's mod_defaults:
https://github.com/ansible-collections-/community.aws#449
https://github.com/ansible-collections/community.aws#450

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
module_defaults
