### PR TITLE
add porting guide info for optional module_utils

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.11.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.11.rst
@@ -39,6 +39,8 @@ Other:
 * The configuration system now validates the ``choices`` field, so any settings that currently violate it and are currently ignored will now cause an error.
   For example, `ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=0` will now cause an error (valid choices are 'ignore', 'warn' or 'error').
 * The ``ansible-galaxy`` command now uses ``resolvelib`` for resolving dependencies. In most cases this should not make a user-facing difference beyond being more performant, but we note it here for posterity and completeness.
+* Python ``module_utils`` imports may now be marked as optional during the module payload build by wrapping the ``import`` statement in a ``try`` or ``if`` block. This allows modules to use ``module_utils`` that may not be present in all versions of Ansible or a collection, and to perform arbitrary recovery or fallback actions during module runtime.
+
 
 Deprecated
 ==========


### PR DESCRIPTION
##### SUMMARY
add porting guide info for optional module_utils

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
porting guide

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
