### PR TITLE
Handle netconf plugin ncclient import error when running in FIPS mode

### DIFF
--- a/changelogs/fragments/fips-ncclient-import-error.yaml
+++ b/changelogs/fragments/fips-ncclient-import-error.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ncclient - catch and handle exception to prevent stack trace when running in FIPS mode

--- a/changelogs/fragments/fips-ncclient-import-error.yaml
+++ b/changelogs/fragments/fips-ncclient-import-error.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ncclient - catch and handle exception to prevent stack trace when running in FIPS mode
+  - netconf - catch and handle exception to prevent stack trace when running in FIPS mode

--- a/lib/ansible/plugins/netconf/__init__.py
+++ b/lib/ansible/plugins/netconf/__init__.py
@@ -32,7 +32,10 @@ try:
     from ncclient.xml_ import to_xml, to_ele, NCElement
     HAS_NCCLIENT = True
     NCCLIENT_IMP_ERR = None
-except (ImportError, AttributeError) as err:  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
+# paramiko and gssapi are incompatible and raise AttributeError not ImportError
+# When running in FIPS mode, cryptography raises InternalError
+# https://bugzilla.redhat.com/show_bug.cgi?id=1778939
+except Exception as err:
     HAS_NCCLIENT = False
     NCCLIENT_IMP_ERR = err
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
*  While running in FIPS mode importing ncclient result in
   InternalError raised by cryptography
*  Refer https://github.com/ansible/ansible/pull/65477
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`plugins/netconf/__init__.py`
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
