### PR TITLE
Prevent traceback when task depth exceeds python recursion depth

### DIFF
--- a/changelogs/fragments/73996-recursion-depth.yml
+++ b/changelogs/fragments/73996-recursion-depth.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- Task depth - Prevent exception when the task depth exceeds Pythons recursion depth
+  (https://github.com/ansible/ansible/issues/73996)

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -15,6 +15,7 @@ from jinja2.exceptions import UndefinedError
 
 from ansible import constants as C
 from ansible import context
+from ansible.errors import AnsibleError
 from ansible.module_utils.six import iteritems, string_types, with_metaclass
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.errors import AnsibleParserError, AnsibleUndefinedVariable, AnsibleAssertionError
@@ -315,7 +316,10 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
         Create a copy of this object and return it.
         '''
 
-        new_me = self.__class__()
+        try:
+            new_me = self.__class__()
+        except RuntimeError:
+            raise AnsibleError("Exceeded maximum object depth. This may have been caused by excesive role recurion.")
 
         for name in self._valid_attrs.keys():
             if name in self._alias_attrs:

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -319,7 +319,7 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
         try:
             new_me = self.__class__()
         except RuntimeError:
-            raise AnsibleError("Exceeded maximum object depth. This may have been caused by excesive role recurion.")
+            raise AnsibleError("Exceeded maximum object depth. This may have been caused by excessive role recursion.")
 
         for name in self._valid_attrs.keys():
             if name in self._alias_attrs:

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -318,7 +318,7 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
 
         try:
             new_me = self.__class__()
-        except RuntimeError:
+        except RuntimeError as e:
             raise AnsibleError("Exceeded maximum object depth. This may have been caused by excessive role recursion", orig_exc=e)
 
         for name in self._valid_attrs.keys():

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -319,7 +319,7 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
         try:
             new_me = self.__class__()
         except RuntimeError:
-            raise AnsibleError("Exceeded maximum object depth. This may have been caused by excessive role recursion.")
+            raise AnsibleError("Exceeded maximum object depth. This may have been caused by excessive role recursion", orig_exc=e)
 
         for name in self._valid_attrs.keys():
             if name in self._alias_attrs:


### PR DESCRIPTION
##### SUMMARY
Prevent traceback when task depth exceeds python recursion depth. Fixes #73996

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/base.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
