### PR TITLE
[backport/2.9] Fix wrong backup directory var name in apt module (#73840)

### DIFF
--- a/changelogs/fragments/73840_apt-policy-rc-d.yml
+++ b/changelogs/fragments/73840_apt-policy-rc-d.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    apt - fix policy_rc_d parameter throwing an exception when restoring
+    original file (https://github.com/ansible/ansible/issues/66211)

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -381,7 +381,7 @@ class PolicyRcD(object):
             try:
                 shutil.move(os.path.join(self.backup_dir, 'policy-rc.d'),
                             '/usr/sbin/policy-rc.d')
-                os.rmdir(self.tmpdir_name)
+                os.rmdir(self.backup_dir)
             except Exception:
                 self.m.fail_json(msg="Fail to move back %s to /usr/sbin/policy-rc.d"
                                      % os.path.join(self.backup_dir, 'policy-rc.d'))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Backporting #73840 to `stable-2.9`

Fix exception caused in `apt` module when using `policy_rc_d` parameter.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

apt

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

@bcoca suggested backporting this.

Cherry-picking conflicted due to changed module path in `devel` branch. `lib/ansible/modules/apt.py` was `lib/ansible/modules/packaging/os/apt.py` in `stable-2.9`