### PR TITLE
docs(#73995): fix broken link in doc

### DIFF
--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -88,7 +88,7 @@ options:
             - On macOS systems, this value has to be cleartext. Beware of security issues.
             - To create a disabled account on Linux systems, set this to C('!') or C('*').
             - To create a disabled account on OpenBSD, set this to C('*************').
-            - See U(https://docs.ansible.com/ansible/2.10/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
+            - See R(how do I generate encrypted passwords for the user module,user_passwords)
               for details on various ways to generate these password values.
         type: str
     state:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -88,7 +88,7 @@ options:
             - On macOS systems, this value has to be cleartext. Beware of security issues.
             - To create a disabled account on Linux systems, set this to C('!') or C('*').
             - To create a disabled account on OpenBSD, set this to C('*************').
-            - See U(https://docs.ansible.com/ansible/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
+            - See U(https://docs.ansible.com/ansible/2.10/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
               for details on various ways to generate these password values.
         type: str
     state:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix broken link for creating a hashed password  (#73995)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
builtin/user_module
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
**before:**
![image](https://user-images.githubusercontent.com/52507296/112159047-05731100-8be9-11eb-8af2-c8d4fe38d5b4.png)
```
- See U(https://docs.ansible.com/ansible/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
```
**after:**
```
- See U(https://docs.ansible.com/ansible/2.10/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
```
![image](https://user-images.githubusercontent.com/52507296/112159278-44a16200-8be9-11eb-908c-f7dc98349312.png)
