### PR TITLE
AnsibleModule - add methods for backwards compatibility

### DIFF
--- a/changelogs/fragments/add-methods-for-backwards-compatibility.yml
+++ b/changelogs/fragments/add-methods-for-backwards-compatibility.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - AnsibleModule - add back several private methods removed in #73703 to maintain backwards compatibility


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
With the move the the `ArgumentSpecValidator` class in `AnsibleModule`, many private methods were removed since that functionality moved to the validator class. However, this breaks existing plugins that are using the private methods.

While the methods are private and leaving dead code around is undesireable, leaving the private methods around does help ease the transition to the new interface.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/basic.py`