### PR TITLE
apt_key - update key ID and URL used in test

### DIFF
--- a/test/integration/targets/apt_key/tasks/file.yml
+++ b/test/integration/targets/apt_key/tasks/file.yml
@@ -1,11 +1,11 @@
 - name: Get Fedora GPG Key
   get_url:
-    url: https://getfedora.org/static/fedora.gpg
+    url: https://ansible-ci-files.s3.us-east-1.amazonaws.com/test/integration/targets/apt_key/fedora.gpg
     dest: /tmp/fedora.gpg
 
 - name: Ensure clean slate
   apt_key:
-    id: 49FD77499570FF31
+    id: 1161AE6945719A39
     state: absent
 
 - name: Run apt_key with both file and keyserver
@@ -36,13 +36,13 @@
 
 - name: remove fedora.gpg
   apt_key:
-    id: 49FD77499570FF31
+    id: 1161AE6945719A39
     state: absent
   register: remove_fedora
 
 - name: add key from url
   apt_key:
-    url: https://getfedora.org/static/fedora.gpg
+    url: https://ansible-ci-files.s3.us-east-1.amazonaws.com/test/integration/targets/apt_key/fedora.gpg
   register: apt_key_url
 
 - name: verify key from url


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The GPG key at `getfedora.org/static/fedora.gpg` changed and caused the test to fail. Update to using the new key ID and save the GPG file in our S3 to prevent spontaneous changes/breakage.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/apt_key/`