### PR TITLE
Introduce the concept of playbooks early on

### DIFF
--- a/docs/docsite/rst/user_guide/intro_getting_started.rst
+++ b/docs/docsite/rst/user_guide/intro_getting_started.rst
@@ -94,6 +94,56 @@ You should see output for each host in your inventory, similar to this:
     aserver.example.org | CHANGED | rc=0 >>
     hello
 
+Action: Run your first playbook
+-------------------------------
+
+Playbooks are used to pull together tasks into reusable units.
+
+Ansible does not store playbooks for you; they are simply yaml documents that you store and manage, passing them to Ansible to run as needed.
+
+In a directory of your choice you can create your first playbook by creating a file called mytask.yml (the extension is optional but may help ediors assist you with formatting). Enter:
+
+.. code-block:: yaml
+
+    ---
+    - name: My task
+      hosts: all
+      tasks:
+         - name: Leaving a mark
+           command: "touch /tmp/ansible_was_here"
+
+You would run this like so:
+
+.. code-block:: bash
+
+    $ ansible-playbook mytask.yaml
+
+and may see output like this:
+
+.. code-block:: ansible-output
+
+
+   PLAY [My task] **************************************************************************************************************************
+   
+   TASK [Gathering Facts] ******************************************************************************************************************
+   ok: [aserver.example.org]
+   ok: [aserver.example.org]
+   ok: [192.0.2.50]
+   fatal: [192.0.2.50]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: ssh: connect to host 192.0.2.50 port 22: No route to host", "unreachable": true}
+   
+   TASK [Leaving a mark] *******************************************************************************************************************
+   [WARNING]: Consider using the file module with state=touch rather than running 'touch'.  If you need to use command because file is
+   insufficient you can add 'warn: false' to this command task or set 'command_warnings=False' in ansible.cfg to get rid of this message.
+   changed: [aserver.example.org]
+   changed: [bserver.example.org]
+   
+   PLAY RECAP ******************************************************************************************************************************
+   aserver.example.org        : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+   bserver.example.org        : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+   192.0.2.50                 : ok=0    changed=0    unreachable=1    failed=0    skipped=0    rescued=0    ignored=0   
+
+Read on to learn more about controlling which nodes playbooks are executed on, more sophisticated tasks and the meaning of the output.
+
 Beyond the basics
 -----------------
 By default Ansible uses SFTP to transfer files. If the machine or device you want to manage does not support SFTP, you can switch to SCP mode in :ref:`intro_configuration`. The files are placed in a temporary directory and executed from there.

--- a/docs/docsite/rst/user_guide/intro_getting_started.rst
+++ b/docs/docsite/rst/user_guide/intro_getting_started.rst
@@ -99,9 +99,9 @@ Action: Run your first playbook
 
 Playbooks are used to pull together tasks into reusable units.
 
-Ansible does not store playbooks for you; they are simply yaml documents that you store and manage, passing them to Ansible to run as needed.
+Ansible does not store playbooks for you; they are simply YAML documents that you store and manage, passing them to Ansible to run as needed.
 
-In a directory of your choice you can create your first playbook by creating a file called mytask.yml (the extension is optional but may help ediors assist you with formatting). Enter:
+In a directory of your choice you can create your first playbook in a file called mytask.yml:
 
 .. code-block:: yaml
 
@@ -112,7 +112,7 @@ In a directory of your choice you can create your first playbook by creating a f
          - name: Leaving a mark
            command: "touch /tmp/ansible_was_here"
 
-You would run this like so:
+You can run this command as follows:
 
 .. code-block:: bash
 
@@ -142,7 +142,7 @@ and may see output like this:
    bserver.example.org        : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
    192.0.2.50                 : ok=0    changed=0    unreachable=1    failed=0    skipped=0    rescued=0    ignored=0   
 
-Read on to learn more about controlling which nodes playbooks are executed on, more sophisticated tasks and the meaning of the output.
+Read on to learn more about controlling which nodes your playbooks execute on, more sophisticated tasks, and the meaning of the output.
 
 Beyond the basics
 -----------------


### PR DESCRIPTION
##### SUMMARY
I began learning about ansible yesterday and was rather confused about playbooks.
There is no initial concept of what a simple playbook looks like, where to store it or how to run it - so the subsequent documentation has no foundation for the reader to build upon.

Given the section above encourages the user to run a live command I thought it appropriate to run a trivial playbook

This also teaches that ansible does not manage playbook storage for you (I spent quite some time wondering about that!) and how to execute them.

Finally, as a puppet user, it was getting pretty frustrating to not see "real stuff" happening and running the playbook was a nice "ah ha!" moment for me.

Now I have a baseline to hack on and try out things in the docs :)

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
