### PR TITLE
dnf test - update libmodulemd when updating python3-dnf

### DIFF
--- a/test/integration/targets/dnf/tasks/logging.yml
+++ b/test/integration/targets/dnf/tasks/logging.yml
@@ -6,6 +6,7 @@
     name:
       - python3-dnf
       - python3-libdnf  # https://bugzilla.redhat.com/show_bug.cgi?id=1887502
+      - libmodulemd     # https://bugzilla.redhat.com/show_bug.cgi?id=1942236
     state: latest
   register: dnf_result
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The dependency version is set too low in the latest version of the package. Adding `lidmodulemd` to the update tasks ensures it is updated to an appropriate version.

https://bugzilla.redhat.com/show_bug.cgi?id=1942236
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/dnf`