### PR TITLE
argspec validation: fix apply_defaults

### DIFF
--- a/changelogs/fragments/74029-argspec-apply_defaults.yml
+++ b/changelogs/fragments/74029-argspec-apply_defaults.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "argument spec validation - fix behavior of ``apply_defaults=True`` when an empty dictionary is specified for such an option (https://github.com/ansible/ansible/pull/74029)."

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -702,8 +702,8 @@ def _validate_sub_spec(argument_spec, parameters, prefix='', options_context=Non
                 if sub_spec is not None:
                     if parameters.get(param) is None:
                         parameters[param] = {}
-                    else:
-                        continue
+                else:
+                    continue
             elif sub_spec is None or param not in parameters or parameters[param] is None:
                 continue
 

--- a/test/integration/targets/argspec/library/argspec.py
+++ b/test/integration/targets/argspec/library/argspec.py
@@ -126,6 +126,19 @@ def main():
             'int': {
                 'type': 'int',
             },
+            'apply_defaults': {
+                'type': 'dict',
+                'apply_defaults': True,
+                'options': {
+                    'foo': {
+                        'type': 'str',
+                    },
+                    'bar': {
+                        'type': 'str',
+                        'default': 'baz',
+                    },
+                },
+            },
         },
         required_if=(
             ('state', 'present', ('path', 'content'), True),

--- a/test/integration/targets/argspec/tasks/main.yml
+++ b/test/integration/targets/argspec/tasks/main.yml
@@ -342,6 +342,23 @@
   register: argspec_int_invalid
   ignore_errors: true
 
+- argspec:
+    required: value
+    required_one_of_one: value
+  register: argspec_apply_defaults_not_specified
+
+- argspec:
+    required: value
+    required_one_of_one: value
+    apply_defaults: ~
+  register: argspec_apply_defaults_none
+
+- argspec:
+    required: value
+    required_one_of_one: value
+    apply_defaults: {}
+  register: argspec_apply_defaults_empty
+
 - assert:
     that:
       - argspec_required_fail is failed
@@ -417,3 +434,7 @@
       - argspec_password_no_log.stdout|regex_findall('VALUE_SPECIFIED_IN_NO_LOG_PARAMETER')|length == 1
 
       - argspec_int_invalid is failed
+
+      - "argspec_apply_defaults_not_specified.apply_defaults == {'foo': none, 'bar': 'baz'}"
+      - "argspec_apply_defaults_none.apply_defaults == {'foo': none, 'bar': 'baz'}"
+      - "argspec_apply_defaults_empty.apply_defaults == {'foo': none, 'bar': 'baz'}"

--- a/test/integration/targets/argspec/tasks/main.yml
+++ b/test/integration/targets/argspec/tasks/main.yml
@@ -359,6 +359,13 @@
     apply_defaults: {}
   register: argspec_apply_defaults_empty
 
+- argspec:
+    required: value
+    required_one_of_one: value
+    apply_defaults:
+      foo: bar
+  register: argspec_apply_defaults_one
+
 - assert:
     that:
       - argspec_required_fail is failed
@@ -438,3 +445,4 @@
       - "argspec_apply_defaults_not_specified.apply_defaults == {'foo': none, 'bar': 'baz'}"
       - "argspec_apply_defaults_none.apply_defaults == {'foo': none, 'bar': 'baz'}"
       - "argspec_apply_defaults_empty.apply_defaults == {'foo': none, 'bar': 'baz'}"
+      - "argspec_apply_defaults_one.apply_defaults == {'foo': 'bar', 'bar': 'baz'}"


### PR DESCRIPTION
##### SUMMARY
If `foo: {}` is specified for a `apply_defaults=True` dict `foo` with suboptions, the defaults are not filled in.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/common/parameters.py
