### PR TITLE
Let `pause` not accept enter to resume (#73948)

### DIFF
--- a/changelogs/fragments/73948-pause-no-enter-with-timeout.yml
+++ b/changelogs/fragments/73948-pause-no-enter-with-timeout.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pause - do not accept enter to continue when a timeout is set (https://github.com/ansible/ansible/issues/73948)

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -246,19 +246,20 @@ class ActionModule(ActionBase):
                         clear_line(stdout)
                         raise KeyboardInterrupt
 
-                    # read key presses and act accordingly
-                    if key_pressed in (b'\r', b'\n'):
-                        clear_line(stdout)
-                        break
-                    elif key_pressed in backspace:
-                        # delete a character if backspace is pressed
-                        result['user_input'] = result['user_input'][:-1]
-                        clear_line(stdout)
-                        if echo:
-                            stdout.write(result['user_input'])
-                        stdout.flush()
-                    else:
-                        result['user_input'] += key_pressed
+                    if not seconds:
+                        # read key presses and act accordingly
+                        if key_pressed in (b'\r', b'\n'):
+                            clear_line(stdout)
+                            break
+                        elif key_pressed in backspace:
+                            # delete a character if backspace is pressed
+                            result['user_input'] = result['user_input'][:-1]
+                            clear_line(stdout)
+                            if echo:
+                                stdout.write(result['user_input'])
+                            stdout.flush()
+                        else:
+                            result['user_input'] += key_pressed
 
                 except KeyboardInterrupt:
                     signal.alarm(0)

--- a/test/integration/targets/pause/test-pause.py
+++ b/test/integration/targets/pause/test-pause.py
@@ -274,3 +274,19 @@ pause_test.send('supersecretpancakes')
 pause_test.send('\r')
 pause_test.expect(pexpect.EOF)
 pause_test.close()
+
+
+# Test that enter presses may not continue the play when a timeout is set.
+
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=["pause-3.yml"] + args,
+    timeout=10,
+    env=os.environ
+)
+
+pause_test.logfile = log_buffer
+pause_test.expect(r"\(ctrl\+C then 'C' = continue early, ctrl\+C then 'A' = abort\)")
+pause_test.send('\r')
+pause_test.expect(pexpect.EOF)
+pause_test.close()


### PR DESCRIPTION
##### SUMMARY
Disallow continue on enter when pause has time set
    
Original function of pause was, to only allow user input
(finished with enter) when no timeout was set. This restores
the behaviour. Fixes #73948.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
