### PR TITLE
[stable-2.9] Do not pass file mode during recursive copy on symlink files  (#69011)

### DIFF
--- a/changelogs/fragments/68471-copy-with-preserve.yaml
+++ b/changelogs/fragments/68471-copy-with-preserve.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- Fixed a bug with the copy action plugin where mode=preserve was being passed on
+  symlink files and causing a traceback (https://github.com/ansible/ansible/issues/68471).

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -572,6 +572,11 @@ class ActionModule(ActionBase):
             if source_files['directories']:
                 new_module_args['follow'] = False
 
+            # file module cannot deal with 'preserve' mode and is meaningless
+            # for symlinks anyway, so just don't pass it.
+            if new_module_args.get('mode', None) == 'preserve':
+                new_module_args.pop('mode')
+
             module_return = self._execute_module(module_name='file', module_args=new_module_args, task_vars=task_vars)
             module_executed = True
 

--- a/test/integration/targets/copy/tasks/tests.yml
+++ b/test/integration/targets/copy/tasks/tests.yml
@@ -1338,6 +1338,26 @@
     that:
       - "dir_attrs.stat.mode == '0755'"
 
+# Test that recursive copy of a directory containing a symlink to another
+# directory, with mode=preserve and local_follow=no works.
+# See: https://github.com/ansible/ansible/issues/68471
+
+- name: Test recursive copy of dir with symlinks, mode=preserve, local_follow=False
+  copy:
+    src: '{{ role_path }}/files/subdir/'
+    dest: '{{ local_temp_dir }}/preserve_symlink/'
+    mode: preserve
+    local_follow: no
+
+- name: check that we actually used and still have a symlink
+  stat: path={{ local_temp_dir }}/preserve_symlink/subdir1/bar.txt
+  register: symlink_path
+
+- assert:
+    that:
+      - symlink_path.stat.exists
+      - symlink_path.stat.islnk
+
 #
 # I believe the below section is now covered in the recursive copying section.
 # Hold on for now as an original test case but delete once confirmed that


### PR DESCRIPTION
##### SUMMARY

This fixes issue #73861. Original PR was #69011

* Do not pass file mode during recursive copy on symlink files.

The 'file' module cannot deal with mode=preserve. Do not pass that
mode to the module when 'preserve' is used.

* Fix changelog fragment filename
(cherry picked from commit 1142faa2138589e359b6a1ef1d371326b6f21a49)

Co-authored-by: David Shrewsbury <Shrews@users.noreply.github.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION
