### PR TITLE
Clarify tags on tasks are applied with OR and not AND

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tags.rst
@@ -331,7 +331,7 @@ Once you have added tags to your tasks, includes, blocks, plays, roles, and impo
 :ref:`ansible-playbook` offers five tag-related command-line options:
 
 * ``--tags all`` - run all tasks, ignore tags (default behavior)
-* ``--tags [tag1, tag2]`` - run only tasks with the tags ``tag1`` and ``tag2``
+* ``--tags [tag1, tag2]`` - run only tasks with either the tag ``tag1`` or the tag ``tag2``
 * ``--skip-tags [tag3, tag4]`` - run all tasks except those with the tags ``tag3`` and ``tag4``
 * ``--tags tagged`` - run only tasks with at least one tag
 * ``--tags untagged`` - run only tasks with no tags

--- a/docs/docsite/rst/user_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tags.rst
@@ -332,7 +332,7 @@ Once you have added tags to your tasks, includes, blocks, plays, roles, and impo
 
 * ``--tags all`` - run all tasks, ignore tags (default behavior)
 * ``--tags [tag1, tag2]`` - run only tasks with either the tag ``tag1`` or the tag ``tag2``
-* ``--skip-tags [tag3, tag4]`` - run all tasks except those with the tags ``tag3`` and ``tag4``
+* ``--skip-tags [tag3, tag4]`` - run all tasks except those with either the tag ``tag3`` or the tag ``tag4``
 * ``--tags tagged`` - run only tasks with at least one tag
 * ``--tags untagged`` - run only tasks with no tags
 


### PR DESCRIPTION
##### SUMMARY
when multiple tags are passed, clarify tasks are executed when they match at least one tag

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
tags