### PR TITLE
add action_groups support to collections

### DIFF
--- a/changelogs/fragments/74039_enable_module_defaults_for_collections.yml
+++ b/changelogs/fragments/74039_enable_module_defaults_for_collections.yml
@@ -3,6 +3,7 @@ bugfixes:
 breaking_changes:
   - Action, module, and group names in module_defaults must be static values. Their values can still be templates.
   - Unresolvable groups, action plugins, and modules in module_defaults are an error.
+  - Fully qualified 'ansible.legacy' plugin names are not included implicitly in action_groups.
 minor_changes:
   - Collections can define action_groups in ``meta/runtime.yml``.
   - action_groups can include actions from other groups by using the special ``metadata`` dictionary field.

--- a/changelogs/fragments/74039_enable_module_defaults_for_collections.yml
+++ b/changelogs/fragments/74039_enable_module_defaults_for_collections.yml
@@ -2,6 +2,7 @@ bugfixes:
   - Fully qualified 'ansible.legacy' and 'ansible.builtin' plugin names work in conjunction with module_defaults.
 breaking_changes:
   - Action, module, and group names in module_defaults must be static values. Their values can still be templates.
+  - Unresolvable groups, action plugins, and modules in module_defaults are an error.
 minor_changes:
   - Collections can define action_groups in ``meta/runtime.yml``.
   - action_groups can include actions from other groups by using the special ``metadata`` dictionary field.

--- a/changelogs/fragments/74039_enable_module_defaults_for_collections.yml
+++ b/changelogs/fragments/74039_enable_module_defaults_for_collections.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - Fully qualified 'ansible.legacy' and 'ansible.builtin' plugin names work in conjunction with module_defaults.
+breaking_changes:
+  - Action, module, and group names in module_defaults must be static values. Their values can still be templates.
+minor_changes:
+  - Collections can define action_groups in ``meta/runtime.yml``.
+  - action_groups can include actions from other groups by using the special ``metadata`` dictionary field.

--- a/docs/docsite/rst/dev_guide/developing_collections_structure.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_structure.rst
@@ -246,6 +246,24 @@ A collection can store some additional metadata in a ``runtime.yml`` file in the
        ansible.module_utils.old_utility:
          redirect: ansible_collections.namespace_name.collection_name.plugins.module_utils.new_location
 
+- *action_groups*
+
+  A mapping of groups and the list of action plugin and module names they contain. They may also have a special 'metadata' dictionary in the list, which can be used to include actions from other groups.
+
+  .. code:: yaml
+
+     action_groups:
+       groupname:
+         # The special metadata dictionary. All action/module names should be strings.
+         - metadata:
+             extend_group:
+               - another.collection.groupname
+               - another_group
+         - my_action
+       another_group:
+         - my_module
+         - another.collection.another_module
+
 .. seealso::
 
    :ref:`distributing_collections`

--- a/docs/docsite/rst/user_guide/playbooks_module_defaults.rst
+++ b/docs/docsite/rst/user_guide/playbooks_module_defaults.rst
@@ -141,3 +141,25 @@ In a playbook, you can set module defaults for whole groups of modules, such as 
         ec2_ami_info:
           filters:
             name: 'RHEL*7.5*'
+
+In ansible-core 2.12, collections can define their own groups in the ``meta/runtime.yml`` file. ``module_defaults`` does not take the ``collections`` keyword into account, so the fully qualified group name must be used for new groups in ``module_defaults``.
+
+Here is an example ``runtime.yml`` file for a collection and a sample playbook using the group.
+
+.. code-block:: YAML
+
+   # collections/ansible_collections/ns/coll/meta/runtime.yml
+   action_groups:
+     groupname:
+       - module
+       - another.collection.module
+
+.. code-block:: YAML
+
+   - hosts: localhost
+     module_defaults:
+       group/ns.coll.groupname:
+         option_name: option_value
+     tasks:
+       - ns.coll.module:
+       - another.collection.module

--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -9689,8 +9689,10 @@ action_groups:
           - testns.testcoll.anothergroup
           - testns.boguscoll.testgroup
     - ping
-    - legacy_ping
+    - legacy_ping  # Includes ansible.builtin.legacy_ping, not ansible.legacy.legacy_ping
     - formerly_core_ping
+  testlegacy:
+    - ansible.legacy.legacy_ping
   aws:
     - metadata:
         extend_group:

--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -9689,6 +9689,7 @@ action_groups:
           - testns.testcoll.anothergroup
           - testns.boguscoll.testgroup
     - ping
+    - legacy_ping
     - formerly_core_ping
   aws:
     - metadata:

--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -9676,3 +9676,64 @@ import_redirection:
     redirect: ansible.module_utils
   ansible_collections.ansible.builtin.plugins:
     redirect: ansible.plugins
+action_groups:
+  testgroup:
+    # The list items under a group should always be action/module name strings except
+    # for a special 'metadata' dictionary.
+    # The only valid key currently for the metadata dictionary is 'extend_group', which is a
+    # list of other groups, the actions of which will be included in this group.
+    # (Note: it's still possible to also have a module/action named 'metadata' in the list)
+    - metadata:
+        extend_group:
+          - testns.testcoll.testgroup
+          - testns.testcoll.anothergroup
+          - testns.boguscoll.testgroup
+    - ping
+    - formerly_core_ping
+  aws:
+    - metadata:
+        extend_group:
+          - amazon.aws.aws
+          - community.aws.aws
+  acme:
+    - metadata:
+        extend_group:
+          - community.crypto.acme
+  azure:
+    - metadata:
+        extend_group:
+          - azure.azcollection.azure
+  cpm:
+    - metadata:
+        extend_group:
+          - wti.remote.cpm
+  docker:
+    - metadata:
+        extend_group:
+          - community.general.docker
+          - community.docker.docker
+  gcp:
+    - metadata:
+        extend_group:
+          - google.cloud.gcp
+  k8s:
+    - metadata:
+        extend_group:
+          - community.kubernetes.k8s
+          - community.general.k8s
+          - community.kubevirt.k8s
+          - community.okd.k8s
+          - kubernetes.core.k8s
+  os:
+    - metadata:
+        extend_group:
+          - openstack.cloud.os
+  ovirt:
+    - metadata:
+        extend_group:
+          - ovirt.ovirt.ovirt
+          - community.general.ovirt
+  vmware:
+    - metadata:
+        extend_group:
+          - community.vmware.vmware

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1968,6 +1968,7 @@ VALIDATE_ACTION_GROUP_METADATA:
     - A toggle to disable validating a collection's 'metadata' entry for a module_defaults action group.
       Metadata containing unexpected fields or value types will produce a warning when this is True.
   default: True
+  env: [{name: ANSIBLE_VALIDATE_ACTION_GROUP_METADATA}]
   ini:
     - section: defaults
       key: validate_action_group_metadata

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1962,6 +1962,16 @@ STRING_CONVERSION_ACTION:
     - section: defaults
       key: string_conversion_action
   type: string
+VALIDATE_ACTION_GROUP_METADATA:
+  version_added: '2.12'
+  description:
+    - A toggle to disable validating a collection's 'metadata' entry for a module_defaults action group.
+      Metadata containing unexpected fields or value types will produce a warning when this is True.
+  default: True
+  ini:
+    - section: defaults
+      key: validate_action_group_metadata
+  type: bool
 VERBOSE_TO_STDERR:
   version_added: '2.8'
   description:

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1370,23 +1370,12 @@ def modify_module(module_name, module_path, module_args, templar, task_vars=None
     return (b_module_data, module_style, shebang)
 
 
-def get_action_args_with_defaults(action, args, defaults, templar, redirected_names=None):
-    group_collection_map = {
-        'acme': ['community.crypto'],
-        'aws': ['amazon.aws', 'community.aws'],
-        'azure': ['azure.azcollection'],
-        'cpm': ['wti.remote'],
-        'docker': ['community.general', 'community.docker'],
-        'gcp': ['google.cloud'],
-        'k8s': ['community.kubernetes', 'community.general', 'community.kubevirt', 'community.okd', 'kubernetes.core'],
-        'os': ['openstack.cloud'],
-        'ovirt': ['ovirt.ovirt', 'community.general'],
-        'vmware': ['community.vmware'],
-        'testgroup': ['testns.testcoll', 'testns.othercoll', 'testns.boguscoll']
-    }
-
-    if not redirected_names:
-        redirected_names = [action]
+def get_action_args_with_defaults(action, args, defaults, templar, redirected_names=None, action_groups=None):
+    # FIXME: pass in the canonical name as the 'action' parameter and remove use of the 'redirected_names' list
+    if redirected_names:
+        resolved_action_name = redirected_names[-1]
+    else:
+        resolved_action_name = action
 
     tmp_args = {}
     module_defaults = {}
@@ -1396,36 +1385,26 @@ def get_action_args_with_defaults(action, args, defaults, templar, redirected_na
         for default in defaults:
             module_defaults.update(default)
 
-    # if I actually have defaults, template and merge
-    if module_defaults:
-        module_defaults = templar.template(module_defaults)
+    # module_defaults keys are static, but the values may be templated
+    module_defaults = templar.template(module_defaults)
 
-        # deal with configured group defaults first
-        for default in module_defaults:
-            if not default.startswith('group/'):
-                continue
-
+    for default in module_defaults:
+        if default.startswith('group/'):
             group_name = default.split('group/')[-1]
+            if action_groups is None:
+                # 3rd party called this without providing cached action_groups... add a warning, or just ignore?
+                continue
+            elif resolved_action_name in action_groups.get(group_name, []):
+                tmp_args.update((module_defaults.get('group/%s' % group_name) or {}).copy())
 
-            for collection_name in group_collection_map.get(group_name, []):
-                try:
-                    action_group = _get_collection_metadata(collection_name).get('action_groups', {})
-                except ValueError:
-                    # The collection may not be installed
-                    continue
-
-                if any(name for name in redirected_names if name in action_group):
-                    tmp_args.update((module_defaults.get('group/%s' % group_name) or {}).copy())
-
-        # handle specific action defaults
-        for redirected_action in redirected_names:
-            legacy = None
-            if redirected_action.startswith('ansible.legacy.') and action == redirected_action:
-                legacy = redirected_action.split('ansible.legacy.')[-1]
-            if legacy and legacy in module_defaults:
-                tmp_args.update(module_defaults[legacy].copy())
-            if redirected_action in module_defaults:
-                tmp_args.update(module_defaults[redirected_action].copy())
+    # handle specific action defaults
+    legacy = None
+    if resolved_action_name.startswith('ansible.legacy.') and action == resolved_action_name:
+        legacy = resolved_action_name.split('ansible.legacy.')[-1]
+    if legacy and legacy in module_defaults:
+        tmp_args.update(module_defaults[legacy].copy())
+    if resolved_action_name in module_defaults:
+        tmp_args.update(module_defaults[resolved_action_name].copy())
 
     # direct args override all
     tmp_args.update(args)

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1388,13 +1388,16 @@ def get_action_args_with_defaults(action, args, defaults, templar, redirected_na
     # module_defaults keys are static, but the values may be templated
     module_defaults = templar.template(module_defaults)
 
+    if action_groups is None:
+        # 3rd party called this without providing cached action_groups... add a warning, or just ignore?
+        group_names = []
+    else:
+        group_names = action_groups.get(resolved_action_name, [])
+
     for default in module_defaults:
         if default.startswith('group/'):
             group_name = default.split('group/')[-1]
-            if action_groups is None:
-                # 3rd party called this without providing cached action_groups... add a warning, or just ignore?
-                continue
-            elif resolved_action_name in action_groups.get(group_name, []):
+            if group_name in group_names:
                 tmp_args.update((module_defaults.get('group/%s' % group_name) or {}).copy())
 
     # handle specific action defaults

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -547,11 +547,10 @@ class TaskExecutor:
         # get handler
         self._handler = self._get_action_handler(connection=self._connection, templar=templar)
 
-        action_groups = self._task._parent._play._action_groups
-        # FIXME: discontinue use of the redirect list and only pass the canonical plugin name
         # Apply default params for action/module, if present
         self._task.args = get_action_args_with_defaults(
-            self._task.action, self._task.args, self._task.module_defaults, templar, self._task._ansible_internal_redirect_list, action_groups
+            self._task.resolved_action, self._task.args, self._task.module_defaults, templar,
+            action_groups=self._task._parent._play._action_groups
         )
 
         # And filter out any fields which were set to default(omit), and got the omit token value

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -547,9 +547,11 @@ class TaskExecutor:
         # get handler
         self._handler = self._get_action_handler(connection=self._connection, templar=templar)
 
+        action_groups = self._task._parent._play._action_groups
+        # FIXME: discontinue use of the redirect list and only pass the canonical plugin name
         # Apply default params for action/module, if present
         self._task.args = get_action_args_with_defaults(
-            self._task.action, self._task.args, self._task.module_defaults, templar, self._task._ansible_internal_redirect_list
+            self._task.action, self._task.args, self._task.module_defaults, templar, self._task._ansible_internal_redirect_list, action_groups
         )
 
         # And filter out any fields which were set to default(omit), and got the omit token value

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -122,7 +122,6 @@ class ModuleArgsParser:
         self._task_attrs = frozenset(self._task_attrs)
 
         self.resolved_action = None
-        self.internal_redirect_list = []
 
     def _split_module_string(self, module_string):
         '''
@@ -271,8 +270,6 @@ class ModuleArgsParser:
         delegate_to = self._task_ds.get('delegate_to', Sentinel)
         args = dict()
 
-        self.internal_redirect_list = []
-
         # This is the standard YAML form for command-type modules. We grab
         # the args and pass them in as additional arguments, which can/will
         # be overwritten via dict updates from the other arg sources below
@@ -308,19 +305,9 @@ class ModuleArgsParser:
             elif skip_action_validation:
                 is_action_candidate = True
             else:
-                # If the plugin is resolved and redirected smuggle the list of candidate names via the task attribute 'internal_redirect_list'
-                # TODO: remove self.internal_redirect_list (and Task._ansible_internal_redirect_list) once TE can use the resolved name for module_defaults
                 context = action_loader.find_plugin_with_context(item, collection_list=self._collection_list)
                 if not context.resolved:
                     context = module_loader.find_plugin_with_context(item, collection_list=self._collection_list)
-                if context.resolved and context.redirect_list:
-                    self.internal_redirect_list = context.redirect_list
-                    # FIXME: Hack to add the final fully qualified name to the task...
-                    # really just need the FQCN associated with the task, don't tack this onto the redir list
-                    if '.' not in context.plugin_resolved_name:
-                        fqcn = (context.plugin_resolved_collection or 'ansible.legacy') + '.' + context.plugin_resolved_name
-                        if fqcn not in context.redirect_list:
-                            self.internal_redirect_list.append(fqcn)
 
                 is_action_candidate = context.resolved and bool(context.redirect_list)
 

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -313,10 +313,14 @@ class ModuleArgsParser:
                 context = action_loader.find_plugin_with_context(item, collection_list=self._collection_list)
                 if not context.resolved:
                     context = module_loader.find_plugin_with_context(item, collection_list=self._collection_list)
-                    if context.resolved and context.redirect_list:
-                        self.internal_redirect_list = context.redirect_list
-                elif context.redirect_list:
+                if context.resolved and context.redirect_list:
                     self.internal_redirect_list = context.redirect_list
+                    # FIXME: Hack to add the final fully qualified name to the task...
+                    # really just need the FQCN associated with the task, don't tack this onto the redir list
+                    if '.' not in context.plugin_resolved_name:
+                        fqcn = context.plugin_resolved_collection + '.' + context.plugin_resolved_name
+                        if fqcn not in context.redirect_list:
+                            self.internal_redirect_list.append(fqcn)
 
                 is_action_candidate = context.resolved and bool(context.redirect_list)
 

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -318,7 +318,7 @@ class ModuleArgsParser:
                     # FIXME: Hack to add the final fully qualified name to the task...
                     # really just need the FQCN associated with the task, don't tack this onto the redir list
                     if '.' not in context.plugin_resolved_name:
-                        fqcn = context.plugin_resolved_collection + '.' + context.plugin_resolved_name
+                        fqcn = (context.plugin_resolved_collection or 'ansible.legacy') + '.' + context.plugin_resolved_name
                         if fqcn not in context.redirect_list:
                             self.internal_redirect_list.append(fqcn)
 

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -509,9 +509,8 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
         if not context.resolved:
             context = module_loader.find_plugin_with_context(action_name)
 
-        # TODO: use the canonical name on the context once it's available?
         if context.resolved:
-            return context.redirect_list[-1]
+            return context.resolved_fqcn
         if mandatory:
             raise AnsibleParserError("Could not resolve action %s in module_defaults" % action_name)
         display.vvvvv("Could not resolve action %s in module_defaults" % action_name)

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -315,6 +315,13 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
 
         validated_module_defaults = []
         for defaults_dict in value:
+            if not isinstance(defaults_dict, dict):
+                raise AnsibleParserError(
+                    "The field 'module_defaults' is supposed to be a dictionary or list of dictionaries, "
+                    "the keys of which must be static action, module, or group names. Only the values may contain "
+                    "templates. For example: {'ping': \"{{ ping_defaults }}\"}"
+                )
+
             validated_defaults_dict = {}
             for defaults_entry, defaults in defaults_dict.items():
                 # module_defaults do not use the 'collections' keyword, so actions and

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -24,7 +24,6 @@ from ansible.parsing.dataloader import DataLoader
 from ansible.playbook.attribute import Attribute, FieldAttribute
 from ansible.plugins.loader import module_loader, action_loader
 from ansible.utils.collection_loader._collection_finder import _get_collection_metadata, AnsibleCollectionRef
-from ansible.utils.collection_loader._collection_meta import _validate_action_group_metadata
 from ansible.utils.display import Display
 from ansible.utils.sentinel import Sentinel
 from ansible.utils.vars import combine_vars, isidentifier, get_unique_id
@@ -78,6 +77,45 @@ def _generic_s(prop_name, self, value):
 
 def _generic_d(prop_name, self):
     del self._attributes[prop_name]
+
+
+def _validate_action_group_metadata(action, found_group_metadata, fq_group_name):
+    valid_metadata = {
+        'extend_group': {
+            'types': (list, string_types,),
+            'errortype': 'list',
+        },
+    }
+
+    metadata_warnings = []
+
+    validate = C.VALIDATE_ACTION_GROUP_METADATA
+    metadata_only = isinstance(action, dict) and 'metadata' in action and len(action) == 1
+
+    if validate and not metadata_only:
+        found_keys = ', '.join(sorted(list(action)))
+        metadata_warnings.append("The only expected key is metadata, but got keys: {keys}".format(keys=found_keys))
+    elif validate:
+        if found_group_metadata:
+            metadata_warnings.append("The group contains multiple metadata entries.")
+        if not isinstance(action['metadata'], dict):
+            metadata_warnings.append("The metadata is not a dictionary. Got {metadata}".format(metadata=action['metadata']))
+        else:
+            unexpected_keys = set(action['metadata'].keys()) - set(valid_metadata.keys())
+            if unexpected_keys:
+                metadata_warnings.append("The metadata contains unexpected keys: {0}".format(', '.join(unexpected_keys)))
+            unexpected_types = []
+            for field, requirement in valid_metadata.items():
+                if field not in action['metadata']:
+                    continue
+                value = action['metadata'][field]
+                if not isinstance(value, requirement['types']):
+                    unexpected_types.append("%s is %s (expected type %s)" % (field, value, requirement['errortype']))
+            if unexpected_types:
+                metadata_warnings.append("The metadata contains unexpected key types: {0}".format(', '.join(unexpected_types)))
+    if metadata_warnings:
+        metadata_warnings.insert(0, "Invalid metadata was found for action_group {0} while loading module_defaults.".format(fq_group_name))
+        display.warning(" ".join(metadata_warnings))
 
 
 class BaseMeta(type):

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -331,7 +331,7 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
                 if defaults_entry.startswith('group/'):
                     group_name = defaults_entry.split('group/')[-1]
                     if len(group_name.split('.')) < 3:
-                        group_name = 'ansible.legacy.' + group_name
+                        group_name = 'ansible.builtin.' + group_name
 
                     # The resolved action_groups cache is associated saved on the current Play
                     if self.play is not None:
@@ -387,10 +387,7 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
             return fq_group_name, self.play._group_actions[fq_group_name]
 
         try:
-            if collection_name == 'ansible.legacy':
-                action_groups = _get_collection_metadata('ansible.builtin').get('action_groups', {})
-            else:
-                action_groups = _get_collection_metadata(collection_name).get('action_groups', {})
+            action_groups = _get_collection_metadata(collection_name).get('action_groups', {})
         except ValueError:
             if not mandatory:
                 display.vvvvv("Error loading module_defaults: could not resolve the module_defaults group %s" % fq_group_name)
@@ -474,9 +471,6 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
                 action_names.append(action)
             else:
                 action_names.append(collection_name + '.' + action)
-                if collection_name == 'ansible.legacy':
-                    # ansible.legacy is a superset of ansible.builtin
-                    action_names.append('ansible.builtin.' + action)
 
             for action_name in action_names:
                 resolved_action = self._resolve_action(action_name, mandatory=False)

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -62,14 +62,6 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
 
         super(Block, self).__init__()
 
-    def _get_action_group_cache(self):
-        if self._play:
-            return self._play._action_groups
-
-    def _get_group_action_cache(self):
-        if self._play:
-            return self._play._group_actions
-
     def __repr__(self):
         return "BLOCK(uuid=%s)(id=%s)(parent=%s)" % (self._uuid, id(self), self._parent)
 

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -66,6 +66,10 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
         if self._play:
             return self._play._action_groups
 
+    def _get_group_action_cache(self):
+        if self._play:
+            return self._play._group_actions
+
     def __repr__(self):
         return "BLOCK(uuid=%s)(id=%s)(parent=%s)" % (self._uuid, id(self), self._parent)
 

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -62,6 +62,10 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
 
         super(Block, self).__init__()
 
+    def _get_action_group_cache(self):
+        if self._play:
+            return self._play._action_groups
+
     def __repr__(self):
         return "BLOCK(uuid=%s)(id=%s)(parent=%s)" % (self._uuid, id(self), self._parent)
 

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -96,6 +96,7 @@ class Play(Base, Taggable, CollectionSearch):
         self.skip_tags = set(context.CLIARGS.get('skip_tags', []))
 
         self._action_groups = {}
+        self._group_actions = {}
 
     def __repr__(self):
         return self.get_name()
@@ -342,6 +343,7 @@ class Play(Base, Taggable, CollectionSearch):
         data['roles'] = roles
         data['included_path'] = self._included_path
         data['action_groups'] = self._action_groups
+        data['group_actions'] = self._group_actions
 
         return data
 
@@ -350,6 +352,7 @@ class Play(Base, Taggable, CollectionSearch):
 
         self._included_path = data.get('included_path', None)
         self._action_groups = data.get('action_groups', {})
+        self._group_actions = data.get('group_actions', {})
         if 'roles' in data:
             role_data = data.get('roles', [])
             roles = []
@@ -367,4 +370,5 @@ class Play(Base, Taggable, CollectionSearch):
         new_me._included_conditional = self._included_conditional
         new_me._included_path = self._included_path
         new_me._action_groups = self._action_groups
+        new_me._group_actions = self._group_actions
         return new_me

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -95,6 +95,8 @@ class Play(Base, Taggable, CollectionSearch):
         self.only_tags = set(context.CLIARGS.get('tags', [])) or frozenset(('all',))
         self.skip_tags = set(context.CLIARGS.get('skip_tags', []))
 
+        self._action_groups = {}
+
     def __repr__(self):
         return self.get_name()
 
@@ -339,6 +341,7 @@ class Play(Base, Taggable, CollectionSearch):
             roles.append(role.serialize())
         data['roles'] = roles
         data['included_path'] = self._included_path
+        data['action_groups'] = self._action_groups
 
         return data
 
@@ -346,6 +349,7 @@ class Play(Base, Taggable, CollectionSearch):
         super(Play, self).deserialize(data)
 
         self._included_path = data.get('included_path', None)
+        self._action_groups = data.get('action_groups', {})
         if 'roles' in data:
             role_data = data.get('roles', [])
             roles = []
@@ -362,4 +366,5 @@ class Play(Base, Taggable, CollectionSearch):
         new_me.ROLE_CACHE = self.ROLE_CACHE.copy()
         new_me._included_conditional = self._included_conditional
         new_me._included_path = self._included_path
+        new_me._action_groups = self._action_groups
         return new_me

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -107,12 +107,6 @@ class Task(Base, Conditional, Taggable, CollectionSearch):
 
         super(Task, self).__init__()
 
-    def _get_action_group_cache(self):
-        return self._parent._play._action_groups
-
-    def _get_group_action_cache(self):
-        return self._parent._play._group_actions
-
     def get_path(self):
         ''' return the absolute path of the task with its line number '''
 

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -110,6 +110,9 @@ class Task(Base, Conditional, Taggable, CollectionSearch):
     def _get_action_group_cache(self):
         return self._parent._play._action_groups
 
+    def _get_group_action_cache(self):
+        return self._parent._play._group_actions
+
     def get_path(self):
         ''' return the absolute path of the task with its line number '''
 

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -107,6 +107,9 @@ class Task(Base, Conditional, Taggable, CollectionSearch):
 
         super(Task, self).__init__()
 
+    def _get_action_group_cache(self):
+        return self._parent._play._action_groups
+
     def get_path(self):
         ''' return the absolute path of the task with its line number '''
 

--- a/lib/ansible/plugins/action/gather_facts.py
+++ b/lib/ansible/plugins/action/gather_facts.py
@@ -41,12 +41,13 @@ class ActionModule(ActionBase):
         mod_args = dict((k, v) for k, v in mod_args.items() if v is not None)
 
         # handle module defaults
-        redirect_list = self._shared_loader_obj.module_loader.find_plugin_with_context(
+        resolved_fact_module = self._shared_loader_obj.module_loader.find_plugin_with_context(
             fact_module, collection_list=self._task.collections
-        ).redirect_list
+        ).resolved_fqcn
 
         mod_args = get_action_args_with_defaults(
-            fact_module, mod_args, self._task.module_defaults, self._templar, redirect_list
+            resolved_fact_module, mod_args, self._task.module_defaults, self._templar,
+            action_groups=self._task._parent._play._action_groups
         )
 
         return mod_args

--- a/lib/ansible/plugins/action/package.py
+++ b/lib/ansible/plugins/action/package.py
@@ -73,7 +73,8 @@ class ActionModule(ActionBase):
                     # get defaults for specific module
                     context = self._shared_loader_obj.module_loader.find_plugin_with_context(module, collection_list=self._task.collections)
                     new_module_args = get_action_args_with_defaults(
-                        module, new_module_args, self._task.module_defaults, self._templar, context.redirect_list
+                        context.resolved_fqcn, new_module_args, self._task.module_defaults, self._templar,
+                        action_groups=self._task._parent._play._action_groups
                     )
 
                     if module in self.BUILTIN_PKG_MGR_MODULES:

--- a/lib/ansible/plugins/action/service.py
+++ b/lib/ansible/plugins/action/service.py
@@ -81,7 +81,8 @@ class ActionModule(ActionBase):
                 # get defaults for specific module
                 context = self._shared_loader_obj.module_loader.find_plugin_with_context(module, collection_list=self._task.collections)
                 new_module_args = get_action_args_with_defaults(
-                    module, new_module_args, self._task.module_defaults, self._templar, context.redirect_list
+                    context.resolved_fqcn, new_module_args, self._task.module_defaults, self._templar,
+                    action_groups=self._task._parent._play._action_groups
                 )
 
                 # collection prefix known internal modules to avoid collisions from collections search, while still allowing library/ overrides

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -582,15 +582,6 @@ class _AnsibleCollectionPkgLoader(_AnsibleCollectionPkgLoaderBase):
         #         if redirect.startswith('..'):
         #             redirect =  redirect[2:]
 
-        action_groups = meta_dict.pop('action_groups', {})
-        meta_dict['action_groups'] = {}
-        for group_name in action_groups:
-            for action_name in action_groups[group_name]:
-                if action_name in meta_dict['action_groups']:
-                    meta_dict['action_groups'][action_name].append(group_name)
-                else:
-                    meta_dict['action_groups'][action_name] = [group_name]
-
         return meta_dict
 
 

--- a/lib/ansible/utils/collection_loader/_collection_meta.py
+++ b/lib/ansible/utils/collection_loader/_collection_meta.py
@@ -17,13 +17,7 @@ try:
 except ImportError:
     from collections import Mapping  # pylint: disable=ansible-bad-import-from
 
-import ansible.constants as C
 from ansible.module_utils.common.yaml import yaml_load
-from ansible.utils.display import Display
-from ansible.module_utils.six import string_types
-
-
-display = Display()
 
 
 def _meta_yml_to_dict(yaml_string_data, content_id):
@@ -41,42 +35,3 @@ def _meta_yml_to_dict(yaml_string_data, content_id):
     if not isinstance(routing_dict, Mapping):
         raise ValueError('collection metadata must be an instance of Python Mapping')
     return routing_dict
-
-
-def _validate_action_group_metadata(action, found_group_metadata, fq_group_name):
-    valid_metadata = {
-        'extend_group': {
-            'types': (list, string_types,),
-            'errortype': 'list',
-        },
-    }
-
-    metadata_warnings = []
-
-    validate = C.VALIDATE_ACTION_GROUP_METADATA
-    metadata_only = isinstance(action, dict) and 'metadata' in action and len(action) == 1
-
-    if validate and not metadata_only:
-        found_keys = ', '.join(sorted(list(action)))
-        metadata_warnings.append("The only expected key is metadata, but got keys: {keys}".format(keys=found_keys))
-    elif validate:
-        if found_group_metadata:
-            metadata_warnings.append("The group contains multiple metadata entries.")
-        if not isinstance(action['metadata'], dict):
-            metadata_warnings.append("The metadata is not a dictionary. Got {metadata}".format(metadata=action['metadata']))
-        else:
-            unexpected_keys = set(action['metadata'].keys()) - set(valid_metadata.keys())
-            if unexpected_keys:
-                metadata_warnings.append("The metadata contains unexpected keys: {0}".format(', '.join(unexpected_keys)))
-            unexpected_types = []
-            for field, requirement in valid_metadata.items():
-                if field not in action['metadata']:
-                    continue
-                value = action['metadata'][field]
-                if not isinstance(value, requirement['types']):
-                    unexpected_types.append("%s is %s (expected type %s)" % (field, value, requirement['errortype']))
-            if unexpected_types:
-                metadata_warnings.append("The metadata contains unexpected key types: {0}".format(', '.join(unexpected_types)))
-    if metadata_warnings:
-        metadata_warnings.insert(0, "Invalid metadata was found for action_group {0} while loading module_defaults.".format(fq_group_name))
-        display.warning(" ".join(metadata_warnings))

--- a/lib/ansible/utils/collection_loader/_collection_meta.py
+++ b/lib/ansible/utils/collection_loader/_collection_meta.py
@@ -17,7 +17,13 @@ try:
 except ImportError:
     from collections import Mapping  # pylint: disable=ansible-bad-import-from
 
+import ansible.constants as C
 from ansible.module_utils.common.yaml import yaml_load
+from ansible.utils.display import Display
+from ansible.module_utils.six import string_types
+
+
+display = Display()
 
 
 def _meta_yml_to_dict(yaml_string_data, content_id):
@@ -35,3 +41,42 @@ def _meta_yml_to_dict(yaml_string_data, content_id):
     if not isinstance(routing_dict, Mapping):
         raise ValueError('collection metadata must be an instance of Python Mapping')
     return routing_dict
+
+
+def _validate_action_group_metadata(action, found_group_metadata, fq_group_name):
+    valid_metadata = {
+        'extend_group': {
+            'types': (list, string_types,),
+            'errortype': 'list',
+        },
+    }
+
+    metadata_warnings = []
+
+    validate = C.VALIDATE_ACTION_GROUP_METADATA
+    metadata_only = isinstance(action, dict) and 'metadata' in action and len(action) == 1
+
+    if validate and not metadata_only:
+        found_keys = ', '.join(sorted(list(action)))
+        metadata_warnings.append("The only expected key is metadata, but got keys: {keys}".format(keys=found_keys))
+    elif validate:
+        if found_group_metadata:
+            metadata_warnings.append("The group contains multiple metadata entries.")
+        if not isinstance(action['metadata'], dict):
+            metadata_warnings.append("The metadata is not a dictionary. Got {metadata}".format(metadata=action['metadata']))
+        else:
+            unexpected_keys = set(action['metadata'].keys()) - set(valid_metadata.keys())
+            if unexpected_keys:
+                metadata_warnings.append("The metadata contains unexpected keys: {0}".format(', '.join(unexpected_keys)))
+            unexpected_types = []
+            for field, requirement in valid_metadata.items():
+                if field not in action['metadata']:
+                    continue
+                value = action['metadata'][field]
+                if not isinstance(value, requirement['types']):
+                    unexpected_types.append("%s is %s (expected type %s)" % (field, value, requirement['errortype']))
+            if unexpected_types:
+                metadata_warnings.append("The metadata contains unexpected key types: {0}".format(', '.join(unexpected_types)))
+    if metadata_warnings:
+        metadata_warnings.insert(0, "Invalid metadata was found for action_group {0} while loading module_defaults.".format(fq_group_name))
+        display.warning(" ".join(metadata_warnings))

--- a/test/integration/targets/gathering_facts/collections/ansible_collections/cisco/ios/plugins/modules/ios_facts.py
+++ b/test/integration/targets/gathering_facts/collections/ansible_collections/cisco/ios/plugins/modules/ios_facts.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+
+DOCUMENTATION = """
+---
+module: ios_facts
+short_description: supporting network facts module
+description:
+  - supporting network facts module for gather_facts + module_defaults tests
+options:
+  gather_subset:
+    description:
+      - When supplied, this argument restricts the facts collected
+         to a given subset.
+      - Possible values for this argument include
+         C(all), C(hardware), C(config), and C(interfaces).
+      - Specify a list of values to include a larger subset.
+      - Use a value with an initial C(!) to collect all facts except that subset.
+    required: false
+    default: '!config'
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    """main entry point for module execution
+    """
+    argument_spec = dict(
+        gather_subset=dict(default='!config')
+    )
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+
+    module.exit_json(ansible_facts={'gather_subset': module.params['gather_subset'], '_ansible_facts_gathered': True})
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/gathering_facts/runme.sh
+++ b/test/integration/targets/gathering_facts/runme.sh
@@ -23,3 +23,5 @@ ansible-playbook verify_subset.yml "$@"
 # ensure we can set defaults for the action plugin and facts module
 ansible-playbook  test_module_defaults.yml "$@" --tags default_fact_module
 ANSIBLE_FACTS_MODULES='ansible.legacy.setup' ansible-playbook test_module_defaults.yml "$@" --tags custom_fact_module
+
+ansible-playbook test_module_defaults.yml "$@" --tags networking

--- a/test/integration/targets/gathering_facts/test_module_defaults.yml
+++ b/test/integration/targets/gathering_facts/test_module_defaults.yml
@@ -77,3 +77,54 @@
     - assert:
         that:
           - "gather_subset == ['min']"
+
+- hosts: localhost
+  gather_facts: no
+  tags:
+    - networking
+  tasks:
+    - name: test that task args aren't used for fqcn network facts
+      gather_facts:
+        gather_subset: min
+      vars:
+        ansible_network_os: 'cisco.ios.ios'
+      register: result
+
+    - assert:
+        that:
+          - "ansible_facts.gather_subset == '!config'"
+
+    - name: test that module_defaults are used for fqcn network facts
+      gather_facts:
+      vars:
+        ansible_network_os: 'cisco.ios.ios'
+      module_defaults:
+        'cisco.ios.ios_facts': {'gather_subset': 'min'}
+      register: result
+
+    - assert:
+        that:
+          - "ansible_facts.gather_subset == 'min'"
+
+    - name: test that task args aren't used for legacy network facts
+      gather_facts:
+        gather_subset: min
+      vars:
+        ansible_network_os: 'ios'
+      register: result
+
+    - assert:
+        that:
+          - "ansible_facts.gather_subset == '!config'"
+
+    - name: test that module_defaults are used for legacy network facts
+      gather_facts:
+      vars:
+        ansible_network_os: 'ios'
+      module_defaults:
+        'ios_facts': {'gather_subset': 'min'}
+      register: result
+
+    - assert:
+        that:
+          - "ansible_facts.gather_subset == 'min'"

--- a/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/meta/runtime.yml
+++ b/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/meta/runtime.yml
@@ -15,3 +15,24 @@ action_groups:
     - metadata:
         extend_group:
           - testgroup
+  empty_metadata:
+    - metadata: {}
+  bad_metadata_format:
+    - unexpected_key:
+        key: value
+      metadata:
+        extend_group: testgroup
+  multiple_metadata:
+    - metadata:
+        extend_group: testgroup
+    - metadata:
+        extend_group: othergroup
+  bad_metadata_options:
+    - metadata:
+        unexpected_key: testgroup
+  bad_metadata_type:
+    - metadata: [testgroup]
+  bad_metadata_option_type:
+    - metadata:
+        extend_group:
+          name: testgroup

--- a/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/meta/runtime.yml
+++ b/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/meta/runtime.yml
@@ -1,5 +1,8 @@
 action_groups:
   testgroup:
+    # Test metadata 'extend_group' feature does not get stuck in a recursive loop
+    - metadata:
+        extend_group: othergroup
     - ping
     - testns.testcoll.echo1
     - testns.testcoll.echo2
@@ -8,3 +11,7 @@ action_groups:
 # note we can define defaults in this group for actions/modules in another collection
     - testns.othercoll.other_echoaction
     - testns.othercoll.other_echo1
+  othergroup:
+    - metadata:
+        extend_group:
+          - testgroup

--- a/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/meta/runtime.yml
+++ b/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/meta/runtime.yml
@@ -1,5 +1,6 @@
 action_groups:
   testgroup:
+    - ping
     - testns.testcoll.echo1
     - testns.testcoll.echo2
 # note we can define defaults for an action

--- a/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/meta/runtime.yml
+++ b/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/meta/runtime.yml
@@ -3,6 +3,7 @@ action_groups:
     # Test metadata 'extend_group' feature does not get stuck in a recursive loop
     - metadata:
         extend_group: othergroup
+    - metadata
     - ping
     - testns.testcoll.echo1
     - testns.testcoll.echo2

--- a/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/modules/metadata.py
+++ b/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/modules/metadata.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: metadata
+version_added: 2.12
+short_description: Test module with a specific name
+description: Test module with a specific name
+options:
+  data:
+    description: Required option to test module_defaults work
+    required: True
+    type: str
+author:
+  - Ansible Core Team
+'''
+
+EXAMPLES = '''
+'''
+
+RETURN = '''
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            data=dict(type='str', required=True),
+        ),
+    )
+
+    module.exit_json()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/modules/ping.py
+++ b/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/modules/ping.py
@@ -1,0 +1,83 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2016, Toshio Kuratomi <tkuratomi@ansible.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: ping
+version_added: historical
+short_description: Try to connect to host, verify a usable python and return C(pong) on success
+description:
+  - A trivial test module, this module always returns C(pong) on successful
+    contact. It does not make sense in playbooks, but it is useful from
+    C(/usr/bin/ansible) to verify the ability to login and that a usable Python is configured.
+  - This is NOT ICMP ping, this is just a trivial test module that requires Python on the remote-node.
+  - For Windows targets, use the M(ansible.windows.win_ping) module instead.
+  - For Network targets, use the M(ansible.netcommon.net_ping) module instead.
+options:
+  data:
+    description:
+      - Data to return for the C(ping) return value.
+      - If this parameter is set to C(crash), the module will cause an exception.
+    type: str
+    default: pong
+seealso:
+  - module: ansible.netcommon.net_ping
+  - module: ansible.windows.win_ping
+author:
+  - Ansible Core Team
+  - Michael DeHaan
+notes:
+  - Supports C(check_mode).
+'''
+
+EXAMPLES = '''
+# Test we can logon to 'webservers' and execute python with json lib.
+# ansible webservers -m ping
+
+- name: Example from an Ansible Playbook
+  ansible.builtin.ping:
+
+- name: Induce an exception to see what happens
+  ansible.builtin.ping:
+    data: crash
+'''
+
+RETURN = '''
+ping:
+    description: Value provided with the data parameter.
+    returned: success
+    type: str
+    sample: pong
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            data=dict(type='str', default='pong'),
+        ),
+        supports_check_mode=True
+    )
+
+    if module.params['data'] == 'crash':
+        raise Exception("boom")
+
+    result = dict(
+        ping=module.params['data'],
+    )
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/module_defaults/library/legacy_ping.py
+++ b/test/integration/targets/module_defaults/library/legacy_ping.py
@@ -1,0 +1,83 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2016, Toshio Kuratomi <tkuratomi@ansible.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: ping
+version_added: historical
+short_description: Try to connect to host, verify a usable python and return C(pong) on success
+description:
+  - A trivial test module, this module always returns C(pong) on successful
+    contact. It does not make sense in playbooks, but it is useful from
+    C(/usr/bin/ansible) to verify the ability to login and that a usable Python is configured.
+  - This is NOT ICMP ping, this is just a trivial test module that requires Python on the remote-node.
+  - For Windows targets, use the M(ansible.windows.win_ping) module instead.
+  - For Network targets, use the M(ansible.netcommon.net_ping) module instead.
+options:
+  data:
+    description:
+      - Data to return for the C(ping) return value.
+      - If this parameter is set to C(crash), the module will cause an exception.
+    type: str
+    default: pong
+seealso:
+  - module: ansible.netcommon.net_ping
+  - module: ansible.windows.win_ping
+author:
+  - Ansible Core Team
+  - Michael DeHaan
+notes:
+  - Supports C(check_mode).
+'''
+
+EXAMPLES = '''
+# Test we can logon to 'webservers' and execute python with json lib.
+# ansible webservers -m ping
+
+- name: Example from an Ansible Playbook
+  ansible.builtin.ping:
+
+- name: Induce an exception to see what happens
+  ansible.builtin.ping:
+    data: crash
+'''
+
+RETURN = '''
+ping:
+    description: Value provided with the data parameter.
+    returned: success
+    type: str
+    sample: pong
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            data=dict(type='str', default='pong'),
+        ),
+        supports_check_mode=True
+    )
+
+    if module.params['data'] == 'crash':
+        raise Exception("boom")
+
+    result = dict(
+        ping=module.params['data'],
+    )
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/module_defaults/runme.sh
+++ b/test/integration/targets/module_defaults/runme.sh
@@ -3,3 +3,5 @@
 set -eux
 
 ansible-playbook test_defaults.yml "$@"
+
+ansible-playbook test_action_groups.yml "$@"

--- a/test/integration/targets/module_defaults/runme.sh
+++ b/test/integration/targets/module_defaults/runme.sh
@@ -5,3 +5,5 @@ set -eux
 ansible-playbook test_defaults.yml "$@"
 
 ansible-playbook test_action_groups.yml "$@"
+
+ansible-playbook test_action_group_metadata.yml "$@"

--- a/test/integration/targets/module_defaults/tasks/main.yml
+++ b/test/integration/targets/module_defaults/tasks/main.yml
@@ -39,7 +39,7 @@
       module_defaults:
         # Meaningless values to make sure that 'module_defaults' gets
         # evaluated for this block
-        foo:
+        ping:
           bar: baz
       block:
       - debug:

--- a/test/integration/targets/module_defaults/templates/test_metadata_warning.yml.j2
+++ b/test/integration/targets/module_defaults/templates/test_metadata_warning.yml.j2
@@ -1,0 +1,8 @@
+---
+- hosts: localhost
+  gather_facts: no
+  module_defaults:
+    group/{{ group_name }}:
+      data: value
+  tasks:
+    - ping:

--- a/test/integration/targets/module_defaults/test_action_group_metadata.yml
+++ b/test/integration/targets/module_defaults/test_action_group_metadata.yml
@@ -2,8 +2,8 @@
 - hosts: localhost
   gather_facts: no
   vars:
-    format: '\u001b\[0m'
-    color: '\u001b\[[0-9];[0-9]{2}m'
+    reset_color: '\x1b\[0m'
+    color: '\x1b\[[0-9];[0-9]{2}m'
   tasks:
 
     - template:
@@ -18,7 +18,7 @@
     - assert:
         that: metadata_warning not in warnings
       vars:
-        warnings: "{{ result.stderr | regex_replace(format) | regex_replace(color) | regex_replace('\\n', ' ') }}"
+        warnings: "{{ result.stderr | regex_replace(reset_color) | regex_replace(color) | regex_replace('\\n', ' ') }}"
         metadata_warning: "Invalid metadata was found"
 
     - template:
@@ -33,7 +33,7 @@
     - assert:
         that: metadata_warning in warnings
       vars:
-        warnings: "{{ result.stderr | regex_replace(format) | regex_replace(color) | regex_replace('\\n', ' ') }}"
+        warnings: "{{ result.stderr | regex_replace(reset_color) | regex_replace(color) | regex_replace('\\n', ' ') }}"
         metadata_warning: >-
                 Invalid metadata was found for action_group testns.testcoll.bad_metadata_format while loading module_defaults.
                 The only expected key is metadata, but got keys: metadata, unexpected_key
@@ -50,7 +50,7 @@
     - assert:
         that: metadata_warning in warnings
       vars:
-        warnings: "{{ result.stderr | regex_replace(format) | regex_replace(color) | regex_replace('\\n', ' ') }}"
+        warnings: "{{ result.stderr | regex_replace(reset_color) | regex_replace(color) | regex_replace('\\n', ' ') }}"
         metadata_warning: >-
                 Invalid metadata was found for action_group testns.testcoll.multiple_metadata while loading module_defaults.
                 The group contains multiple metadata entries.
@@ -67,7 +67,7 @@
     - assert:
         that: metadata_warning in warnings
       vars:
-        warnings: "{{ result.stderr | regex_replace(format) | regex_replace(color) | regex_replace('\\n', ' ') }}"
+        warnings: "{{ result.stderr | regex_replace(reset_color) | regex_replace(color) | regex_replace('\\n', ' ') }}"
         metadata_warning: >-
                 Invalid metadata was found for action_group testns.testcoll.bad_metadata_options while loading module_defaults.
                 The metadata contains unexpected keys: unexpected_key
@@ -84,7 +84,7 @@
     - assert:
         that: metadata_warning in warnings
       vars:
-        warnings: "{{ result.stderr | regex_replace(format) | regex_replace(color) | regex_replace('\\n', ' ') }}"
+        warnings: "{{ result.stderr | regex_replace(reset_color) | regex_replace(color) | regex_replace('\\n', ' ') }}"
         metadata_warning: >-
                 Invalid metadata was found for action_group testns.testcoll.bad_metadata_type while loading module_defaults.
                 The metadata is not a dictionary. Got ['testgroup']
@@ -101,7 +101,7 @@
     - assert:
         that: metadata_warning in warnings
       vars:
-        warnings: "{{ result.stderr | regex_replace(format) | regex_replace(color) | regex_replace('\\n', ' ') }}"
+        warnings: "{{ result.stderr | regex_replace(reset_color) | regex_replace(color) | regex_replace('\\n', ' ') }}"
         metadata_warning: >-
                 Invalid metadata was found for action_group testns.testcoll.bad_metadata_option_type while loading module_defaults.
                 The metadata contains unexpected key types: extend_group is {'name': 'testgroup'} (expected type list)
@@ -115,7 +115,7 @@
     - assert:
         that: metadata_warning not in warnings
       vars:
-        warnings: "{{ result.stderr | regex_replace(format) | regex_replace(color) | regex_replace('\\n', ' ') }}"
+        warnings: "{{ result.stderr | regex_replace(reset_color) | regex_replace(color) | regex_replace('\\n', ' ') }}"
         metadata_warning: "Invalid metadata was found for action_group"
 
     - file:

--- a/test/integration/targets/module_defaults/test_action_group_metadata.yml
+++ b/test/integration/targets/module_defaults/test_action_group_metadata.yml
@@ -1,0 +1,123 @@
+---
+- hosts: localhost
+  gather_facts: no
+  vars:
+    format: '\u001b\[0m'
+    color: '\u001b\[[0-9];[0-9]{2}m'
+  tasks:
+
+    - template:
+        src: test_metadata_warning.yml.j2
+        dest: test_metadata_warning.yml
+      vars:
+        group_name: testns.testcoll.empty_metadata
+
+    - command: ansible-playbook test_metadata_warning.yml
+      register: result
+
+    - assert:
+        that: metadata_warning not in warnings
+      vars:
+        warnings: "{{ result.stderr | regex_replace(format) | regex_replace(color) | regex_replace('\\n', ' ') }}"
+        metadata_warning: "Invalid metadata was found"
+
+    - template:
+        src: test_metadata_warning.yml.j2
+        dest: test_metadata_warning.yml
+      vars:
+        group_name: testns.testcoll.bad_metadata_format
+
+    - command: ansible-playbook test_metadata_warning.yml
+      register: result
+
+    - assert:
+        that: metadata_warning in warnings
+      vars:
+        warnings: "{{ result.stderr | regex_replace(format) | regex_replace(color) | regex_replace('\\n', ' ') }}"
+        metadata_warning: >-
+                Invalid metadata was found for action_group testns.testcoll.bad_metadata_format while loading module_defaults.
+                The only expected key is metadata, but got keys: metadata, unexpected_key
+
+    - template:
+        src: test_metadata_warning.yml.j2
+        dest: test_metadata_warning.yml
+      vars:
+        group_name: testns.testcoll.multiple_metadata
+
+    - command: ansible-playbook test_metadata_warning.yml
+      register: result
+
+    - assert:
+        that: metadata_warning in warnings
+      vars:
+        warnings: "{{ result.stderr | regex_replace(format) | regex_replace(color) | regex_replace('\\n', ' ') }}"
+        metadata_warning: >-
+                Invalid metadata was found for action_group testns.testcoll.multiple_metadata while loading module_defaults.
+                The group contains multiple metadata entries.
+
+    - template:
+        src: test_metadata_warning.yml.j2
+        dest: test_metadata_warning.yml
+      vars:
+        group_name: testns.testcoll.bad_metadata_options
+
+    - command: 'ansible-playbook test_metadata_warning.yml'
+      register: result
+
+    - assert:
+        that: metadata_warning in warnings
+      vars:
+        warnings: "{{ result.stderr | regex_replace(format) | regex_replace(color) | regex_replace('\\n', ' ') }}"
+        metadata_warning: >-
+                Invalid metadata was found for action_group testns.testcoll.bad_metadata_options while loading module_defaults.
+                The metadata contains unexpected keys: unexpected_key
+
+    - template:
+        src: test_metadata_warning.yml.j2
+        dest: test_metadata_warning.yml
+      vars:
+        group_name: testns.testcoll.bad_metadata_type
+
+    - command: ansible-playbook test_metadata_warning.yml
+      register: result
+
+    - assert:
+        that: metadata_warning in warnings
+      vars:
+        warnings: "{{ result.stderr | regex_replace(format) | regex_replace(color) | regex_replace('\\n', ' ') }}"
+        metadata_warning: >-
+                Invalid metadata was found for action_group testns.testcoll.bad_metadata_type while loading module_defaults.
+                The metadata is not a dictionary. Got ['testgroup']
+
+    - template:
+        src: test_metadata_warning.yml.j2
+        dest: test_metadata_warning.yml
+      vars:
+        group_name: testns.testcoll.bad_metadata_option_type
+
+    - command: ansible-playbook test_metadata_warning.yml
+      register: result
+
+    - assert:
+        that: metadata_warning in warnings
+      vars:
+        warnings: "{{ result.stderr | regex_replace(format) | regex_replace(color) | regex_replace('\\n', ' ') }}"
+        metadata_warning: >-
+                Invalid metadata was found for action_group testns.testcoll.bad_metadata_option_type while loading module_defaults.
+                The metadata contains unexpected key types: extend_group is {'name': 'testgroup'} (expected type list)
+
+    - name: test disabling action_group metadata validation
+      command: ansible-playbook test_metadata_warning.yml
+      environment:
+        ANSIBLE_VALIDATE_ACTION_GROUP_METADATA: False
+      register: result
+
+    - assert:
+        that: metadata_warning not in warnings
+      vars:
+        warnings: "{{ result.stderr | regex_replace(format) | regex_replace(color) | regex_replace('\\n', ' ') }}"
+        metadata_warning: "Invalid metadata was found for action_group"
+
+    - file:
+        path: test_metadata_warning.yml
+        state: absent

--- a/test/integration/targets/module_defaults/test_action_groups.yml
+++ b/test/integration/targets/module_defaults/test_action_groups.yml
@@ -2,12 +2,32 @@
 - hosts: localhost
   gather_facts: no
   tasks:
-    - name: test ansible.builtin short group name
+    - name: test ansible.legacy short group name
       module_defaults:
         group/testgroup:
           data: test
       block:
+        - legacy_ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
+        - ansible.legacy.legacy_ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
         - ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
+        - ansible.legacy.ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
+        - ansible.builtin.ping:
           register: result
         - assert:
             that: "result.ping == 'test'"
@@ -17,7 +37,42 @@
         - assert:
             that: "result.ping == 'test'"
 
+        - ansible.builtin.formerly_core_ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
+    - name: test ansible.legacy fully qualified name
+      module_defaults:
+        group/ansible.legacy.testgroup:
+          data: test
+      block:
+        - legacy_ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
+        - ansible.legacy.legacy_ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
+        - ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
+        - ansible.legacy.ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
         - ansible.builtin.ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
+        - formerly_core_ping:
           register: result
         - assert:
             that: "result.ping == 'test'"
@@ -32,17 +87,35 @@
         group/ansible.builtin.testgroup:
           data: test
       block:
+        # ansible.builtin does not contain ansible.legacy
+        - legacy_ping:
+          register: result
+        - assert:
+            that: "result.ping != 'test'"
+
+        # ansible.builtin does not contain ansible.legacy
+        - ansible.legacy.legacy_ping:
+          register: result
+        - assert:
+            that: "result.ping != 'test'"
+
         - ping:
           register: result
         - assert:
             that: "result.ping == 'test'"
 
-        - formerly_core_ping:
+        # Resolves to ansible.builtin.ping
+        - ansible.legacy.ping:
           register: result
         - assert:
             that: "result.ping == 'test'"
 
         - ansible.builtin.ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
+        - formerly_core_ping:
           register: result
         - assert:
             that: "result.ping == 'test'"
@@ -57,6 +130,12 @@
         group/testns.testcoll.testgroup:
           data: test
       block:
+        # Plugin resolving to a different collection does not get the default
+        - ping:
+          register: result
+        - assert:
+            that: "result.ping != 'test'"
+
         - formerly_core_ping:
           register: result
         - assert:

--- a/test/integration/targets/module_defaults/test_action_groups.yml
+++ b/test/integration/targets/module_defaults/test_action_groups.yml
@@ -10,19 +10,19 @@
         - legacy_ping:
           register: result
         - assert:
-            that: "result.ping == 'test'"
+            that: "result.ping == 'pong'"
 
         - ansible.legacy.legacy_ping:
           register: result
         - assert:
-            that: "result.ping == 'test'"
+            that: "result.ping == 'pong'"
 
         - ping:
           register: result
         - assert:
             that: "result.ping == 'test'"
 
-        - ansible.legacy.ping:
+        - ansible.legacy.ping:  # resolves to ansible.builtin.ping
           register: result
         - assert:
             that: "result.ping == 'test'"
@@ -42,9 +42,10 @@
         - assert:
             that: "result.ping == 'test'"
 
-    - name: test ansible.legacy fully qualified name
+    - name: test group that includes a legacy action
       module_defaults:
-        group/ansible.legacy.testgroup:
+        # As of 2.12, legacy actions must be included in the action group definition
+        group/testlegacy:
           data: test
       block:
         - legacy_ping:
@@ -53,31 +54,6 @@
             that: "result.ping == 'test'"
 
         - ansible.legacy.legacy_ping:
-          register: result
-        - assert:
-            that: "result.ping == 'test'"
-
-        - ping:
-          register: result
-        - assert:
-            that: "result.ping == 'test'"
-
-        - ansible.legacy.ping:
-          register: result
-        - assert:
-            that: "result.ping == 'test'"
-
-        - ansible.builtin.ping:
-          register: result
-        - assert:
-            that: "result.ping == 'test'"
-
-        - formerly_core_ping:
-          register: result
-        - assert:
-            that: "result.ping == 'test'"
-
-        - ansible.builtin.formerly_core_ping:
           register: result
         - assert:
             that: "result.ping == 'test'"

--- a/test/integration/targets/module_defaults/test_action_groups.yml
+++ b/test/integration/targets/module_defaults/test_action_groups.yml
@@ -126,3 +126,7 @@
           register: result
         - assert:
             that: "result.ping == 'test'"
+
+        - metadata:
+          collections:
+            - testns.testcoll

--- a/test/integration/targets/module_defaults/test_action_groups.yml
+++ b/test/integration/targets/module_defaults/test_action_groups.yml
@@ -1,0 +1,73 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: test ansible.builtin short group name
+      module_defaults:
+        group/testgroup:
+          data: test
+      block:
+        - ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
+        - formerly_core_ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
+        - ansible.builtin.ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
+        - ansible.builtin.formerly_core_ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
+    - name: test ansible.builtin fully qualified group name
+      module_defaults:
+        group/ansible.builtin.testgroup:
+          data: test
+      block:
+        - ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
+        - formerly_core_ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
+        - ansible.builtin.ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
+        - ansible.builtin.formerly_core_ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
+    - name: test collection group name
+      module_defaults:
+        group/testns.testcoll.testgroup:
+          data: test
+      block:
+        - formerly_core_ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
+        - ansible.builtin.formerly_core_ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"
+
+        - testns.testcoll.ping:
+          register: result
+        - assert:
+            that: "result.ping == 'test'"

--- a/test/lib/ansible_test/_data/legacy_collection_loader/_collection_finder.py
+++ b/test/lib/ansible_test/_data/legacy_collection_loader/_collection_finder.py
@@ -582,15 +582,6 @@ class _AnsibleCollectionPkgLoader(_AnsibleCollectionPkgLoaderBase):
         #         if redirect.startswith('..'):
         #             redirect =  redirect[2:]
 
-        action_groups = meta_dict.pop('action_groups', {})
-        meta_dict['action_groups'] = {}
-        for group_name in action_groups:
-            for action_name in action_groups[group_name]:
-                if action_name in meta_dict['action_groups']:
-                    meta_dict['action_groups'][action_name].append(group_name)
-                else:
-                    meta_dict['action_groups'][action_name] = [group_name]
-
         return meta_dict
 
 

--- a/test/units/plugins/action/test_gather_facts.py
+++ b/test/units/plugins/action/test_gather_facts.py
@@ -97,36 +97,3 @@ class TestNetworkFacts(unittest.TestCase):
             get_module_args.call_args.args,
             ('cisco.ios.ios_facts', {'ansible_network_os': 'cisco.ios.ios'},)
         )
-
-    def test_network_gather_facts(self):
-        self.task_vars = {'ansible_network_os': 'ios'}
-        self.task.action = 'gather_facts'
-        self.task.async_val = False
-        self.task.args = {'gather_subset': 'min'}
-        self.task.module_defaults = [{'ios_facts': {'gather_subset': 'min'}}]
-
-        plugin = GatherFactsAction(self.task, self.connection, self.play_context, loader=None, templar=self.templar, shared_loader_obj=plugin_loader)
-        plugin._execute_module = MagicMock()
-
-        res = plugin.run(task_vars=self.task_vars)
-        self.assertEqual(res['ansible_facts']['_ansible_facts_gathered'], True)
-
-        mod_args = plugin._get_module_args('ios_facts', task_vars=self.task_vars)
-        self.assertEqual(mod_args['gather_subset'], 'min')
-
-    @patch.object(module_common, '_get_collection_metadata', return_value={})
-    def test_network_gather_facts_fqcn(self, mock_collection_metadata):
-        self.fqcn_task_vars = {'ansible_network_os': 'cisco.ios.ios'}
-        self.task.action = 'gather_facts'
-        self.task.async_val = False
-        self.task.args = {'gather_subset': 'min'}
-        self.task.module_defaults = [{'cisco.ios.ios_facts': {'gather_subset': 'min'}}]
-
-        plugin = GatherFactsAction(self.task, self.connection, self.play_context, loader=None, templar=self.templar, shared_loader_obj=plugin_loader)
-        plugin._execute_module = MagicMock()
-
-        res = plugin.run(task_vars=self.fqcn_task_vars)
-        self.assertEqual(res['ansible_facts']['_ansible_facts_gathered'], True)
-
-        mod_args = plugin._get_module_args('cisco.ios.ios_facts', task_vars=self.fqcn_task_vars)
-        self.assertEqual(mod_args['gather_subset'], 'min')


### PR DESCRIPTION
##### SUMMARY

This intends to solve two things: 
* Allow collections to create their own action groups

```
# ns/coll/meta/runtime.yml
action_groups:
  groupname:
    # special dict 'metadata' entry for including actions from other groups
    - metadata:
        extend_group:
          - another.collection.groupname
          - anothergroup
    # action names in this group should be strings
    - myaction
    - another.collection.action
```

```
# playbook.yml
...
module_defaults:
  group/ns.coll.groupname:
    ...
tasks:
  - ns.coll.myaction:
```


* Ensure that however a module_default action is provided, it's resolved to the canonical name

```
module_defaults:
  ping:
    data: test
tasks:
  # It should not matter if the task calls the module differently than defined in module_defaults.
  # If they resolve to the same plugin, the defaults apply.
  - ansible.builtin.ping:
    register: result
    failed_when: "result.data != 'test'"
```

This is a WIP while I'm working on fixing a few things:

* ~add an action-to-groups mapping for efficiency~
* ~fix module_defaults + legacy plugin paths~
* ~update action plugins, probably after #73864 is addressed/merged~
* ~add a changelog, including a note about module_defaults no longer being fully templatable (due to resolving actions pre-fork)~
* ~add documentation~
* ~make the resolved action name accessible to the task (#74709)~

~I'm also reconsidering the code organization because I initially had a large portion of this in  `lib/ansible/playbook/task.py`, which felt easier to read, but was problematic during extending FA/squashing.~

##### ISSUE TYPE
- Feature Pull Request
