### PR TITLE
add --offline option to galaxy collection verify

### DIFF
--- a/changelogs/fragments/galaxy_verify_local.yml
+++ b/changelogs/fragments/galaxy_verify_local.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ansible-galaxy CLI - ``collection verify`` command now supports a ``--offline`` option for local-only verification

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -363,6 +363,9 @@ class GalaxyCLI(CLI):
                                    'path/url to a tar.gz collection artifact. This is mutually exclusive with --requirements-file.')
         verify_parser.add_argument('-i', '--ignore-errors', dest='ignore_errors', action='store_true', default=False,
                                    help='Ignore errors during verification and continue with the next specified collection.')
+        verify_parser.add_argument('--offline', dest='offline', action='store_true', default=False,
+                                   help='Validate collection integrity locally without contacting server for '
+                                        'canonical manifest hash.')
         verify_parser.add_argument('-r', '--requirements-file', dest='requirements',
                                    help='A file containing a list of collections to be verified.')
 
@@ -1078,6 +1081,7 @@ class GalaxyCLI(CLI):
         collections = context.CLIARGS['args']
         search_paths = context.CLIARGS['collections_path']
         ignore_errors = context.CLIARGS['ignore_errors']
+        local_verify_only = context.CLIARGS['offline']
         requirements_file = context.CLIARGS['requirements']
 
         requirements = self._require_one_of_collections_requirements(
@@ -1090,6 +1094,7 @@ class GalaxyCLI(CLI):
         verify_collections(
             requirements, resolved_paths,
             self.api_servers, ignore_errors,
+            local_verify_only=local_verify_only,
             artifacts_manager=artifacts_manager,
         )
 

--- a/test/integration/targets/ansible-galaxy-collection/tasks/verify.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/verify.yml
@@ -150,7 +150,7 @@
 
 - assert:
     that:
-      - "'Collection ansible_test.verify contains modified content in the following files:\nansible_test.verify\n    plugins/modules/test_module.py' in verify.stdout"
+      - "'Collection ansible_test.verify contains modified content in the following files:\n    plugins/modules/test_module.py' in verify.stdout"
 
 - name: modify the FILES.json to match the new checksum
   lineinfile:
@@ -168,7 +168,7 @@
 
 - assert:
     that:
-      - "'Collection ansible_test.verify contains modified content in the following files:\nansible_test.verify\n    FILES.json' in verify.stdout"
+      - "'Collection ansible_test.verify contains modified content in the following files:\n    FILES.json' in verify.stdout"
 
 - name: get the checksum of the FILES.json
   stat:
@@ -190,7 +190,7 @@
 
 - assert:
     that:
-      - "'Collection ansible_test.verify contains modified content in the following files:\nansible_test.verify\n    MANIFEST.json' in verify.stdout"
+      - "'Collection ansible_test.verify contains modified content in the following files:\n    MANIFEST.json' in verify.stdout"
 
 - name: remove the artifact metadata to test verifying a collection without it
   file:
@@ -221,3 +221,48 @@
     that:
       - verify.failed
       - "'Collection ansible_test.verify does not have a MANIFEST.json' in verify.stderr"
+
+- name: update the collection version to something not present on the server
+  lineinfile:
+    regexp: "version: .*"
+    line: "version: '3.0.0'"
+    path: '{{ galaxy_dir }}/scratch/ansible_test/verify/galaxy.yml'
+
+- name: build the new version
+  command: ansible-galaxy collection build scratch/ansible_test/verify
+  args:
+    chdir: '{{ galaxy_dir }}'
+
+- name: force-install from local artifact
+  command: ansible-galaxy collection install '{{ galaxy_dir }}/ansible_test-verify-3.0.0.tar.gz' --force
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
+
+- name: verify locally only, no download or server manifest hash check
+  command: ansible-galaxy collection verify --offline ansible_test.verify
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
+  register: verify
+
+- assert:
+    that:
+    - >-
+      "Verifying 'ansible_test.verify:3.0.0'." in verify.stdout
+    - '"MANIFEST.json hash: " in verify.stdout'
+    - >-
+      "Successfully verified that checksums for 'ansible_test.verify:3.0.0' are internally consistent with its manifest." in verify.stdout
+
+- name: append a newline to a module to modify the checksum
+  shell: "echo '' >> {{ module_path }}"
+
+- name: verify modified collection locally-only (should fail)
+  command: ansible-galaxy collection verify --offline ansible_test.verify
+  register: verify
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
+  ignore_errors: yes
+
+- assert:
+    that:
+      - "'Collection ansible_test.verify contains modified content in the following files:' in verify.stdout"
+      - "'plugins/modules/test_module.py' in verify.stdout"

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -243,7 +243,7 @@ def test_build_artifact_from_path_no_version(collection_artifact, monkeypatch):
     concrete_artifact_cm = collection.concrete_artifact_manager.ConcreteArtifactsManager(tmp_path, validate_certs=False)
 
     expected = (
-        '^Collection metadata file at `.*` is expected to have a valid SemVer '
+        '^Collection metadata file `.*` at `.*` is expected to have a valid SemVer '
         'version value but got {empty_unicode_string!r}$'.
         format(empty_unicode_string=u'')
     )


### PR DESCRIPTION
##### SUMMARY
* new `--offline` option to `ansible-galaxy collection verify` allows in-place verify for installed collections with manifests
* manifest hash, collection name, version, and path are now always displayed
* test updates

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-galaxy CLI

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
