### PR TITLE
Temporarily disable strategy units

### DIFF
--- a/test/units/plugins/strategy/test_strategy.py
+++ b/test/units/plugins/strategy/test_strategy.py
@@ -32,6 +32,10 @@ from ansible.module_utils.six.moves import queue as Queue
 from ansible.playbook.handler import Handler
 from ansible.plugins.strategy import StrategyBase
 
+import pytest
+
+pytestmark = pytest.mark.skipif(True, reason="Temporarily disabled due to fragile tests that need rewritten")
+
 
 class TestStrategyBase(unittest.TestCase):
 


### PR DESCRIPTION
##### SUMMARY
We are seeing some transient failures in units, usually on python 3.5 where the tests seem to finish, but something isn't setup properly in the test, and some code in Ansible is still spinning waiting on a condition. The tests hang and are eventually killed.

This PR temporarily disables them until we can evaluate whether they are even needed, or until we can rewrite them, to isolate testing to the methods we are concerned with.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/units/plugins/strategy/test_strategy.py

##### ADDITIONAL INFORMATION
```
_________ TestStrategyBase.test_strategy_base_process_pending_results __________
17:13 [gw0] linux -- Python 3.5.10 /usr/bin/python3.5
17:13 :-1: running the test CRASHED with signal 9
```