### PR TITLE
Correctly set path and fullpath for template vars (#73924)

### DIFF
--- a/changelogs/fragments/template_temp_vars_fix.yml
+++ b/changelogs/fragments/template_temp_vars_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Correctly set template_path and template_fullpath for usage in template lookup and action plugins.

--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -20,6 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import re
+import traceback
 
 from ansible.errors.yaml_strings import (
     YAML_COMMON_DICT_ERROR,
@@ -320,7 +321,7 @@ class AnsibleActionFail(AnsibleAction):
     def __init__(self, message="", obj=None, show_content=True, suppress_extended_error=False, orig_exc=None, result=None):
         super(AnsibleActionFail, self).__init__(message=message, obj=obj, show_content=show_content,
                                                 suppress_extended_error=suppress_extended_error, orig_exc=orig_exc, result=result)
-        self.result.update({'failed': True, 'msg': message})
+        self.result.update({'failed': True, 'msg': message, 'exception': traceback.format_exc()})
 
 
 class _AnsibleActionDone(AnsibleAction):

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -129,7 +129,7 @@ class ActionModule(ActionBase):
 
                 # add ansible 'template' vars
                 temp_vars = task_vars.copy()
-                temp_vars.update(generate_ansible_template_vars(source, dest))
+                temp_vars.update(generate_ansible_template_vars(self._task.args.get('src', None), source, dest))
 
                 with self._templar.set_temporary_context(searchpath=searchpath, newline_sequence=newline_sequence,
                                                          block_start_string=block_start_string, block_end_string=block_end_string,

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -97,7 +97,7 @@ class LookupModule(LookupBase):
                 # plus anything passed to the lookup with the template_vars=
                 # argument.
                 vars = deepcopy(variables)
-                vars.update(generate_ansible_template_vars(lookupfile))
+                vars.update(generate_ansible_template_vars(term, lookupfile))
                 vars.update(lookup_template_vars)
 
                 # do the templating

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -99,8 +99,13 @@ JINJA2_END_TOKENS = frozenset(('variable_end', 'block_end', 'comment_end', 'raw_
 RANGE_TYPE = type(range(0))
 
 
-def generate_ansible_template_vars(path, dest_path=None):
-    b_path = to_bytes(path)
+def generate_ansible_template_vars(path, fullpath=None, dest_path=None):
+
+    if fullpath is None:
+        b_path = to_bytes(path)
+    else:
+        b_path = to_bytes(fullpath)
+
     try:
         template_uid = pwd.getpwuid(os.stat(b_path).st_uid).pw_name
     except (KeyError, TypeError):
@@ -111,10 +116,14 @@ def generate_ansible_template_vars(path, dest_path=None):
         'template_path': path,
         'template_mtime': datetime.datetime.fromtimestamp(os.path.getmtime(b_path)),
         'template_uid': to_text(template_uid),
-        'template_fullpath': os.path.abspath(path),
         'template_run_date': datetime.datetime.now(),
         'template_destpath': to_native(dest_path) if dest_path else None,
     }
+
+    if fullpath is None:
+        temp_vars['template_fullpath'] = os.path.abspath(path)
+    else:
+        temp_vars['template_fullpath'] = fullpath
 
     managed_default = C.DEFAULT_MANAGED_STR
     managed_str = managed_default.format(


### PR DESCRIPTION
* Correctly set path and fullpath for template vars

 don't expect path to always be full path
 also added exception/tb on action fail

(cherry picked from commit 22330dd322634548e0f4d88aa9c5c017b7c04851)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
template