### PR TITLE
nonzero exit code on `ansible-galaxy collection verify` failures

### DIFF
--- a/changelogs/fragments/galaxy_verify_exitcode.yml
+++ b/changelogs/fragments/galaxy_verify_exitcode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ansible-galaxy CLI - ``collection verify`` command now exits with a non-zero exit code on verification failure

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -549,7 +549,7 @@ class GalaxyCLI(CLI):
                 **galaxy_options
             ))
 
-        context.CLIARGS['func']()
+        return context.CLIARGS['func']()
 
     @property
     def api(self):
@@ -1091,12 +1091,15 @@ class GalaxyCLI(CLI):
 
         resolved_paths = [validate_collection_path(GalaxyCLI._resolve_path(path)) for path in search_paths]
 
-        verify_collections(
+        results = verify_collections(
             requirements, resolved_paths,
             self.api_servers, ignore_errors,
             local_verify_only=local_verify_only,
             artifacts_manager=artifacts_manager,
         )
+
+        if any(result for result in results if not result.success):
+            return 1
 
         return 0
 

--- a/test/integration/targets/ansible-galaxy-collection/tasks/verify.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/verify.yml
@@ -16,11 +16,11 @@
 - name: test verifying a tarfile
   command: ansible-galaxy collection verify {{ galaxy_dir }}/ansible_test-verify-1.0.0.tar.gz
   register: verify
-  ignore_errors: yes
+  failed_when: verify.rc == 0
 
 - assert:
     that:
-      - verify.failed
+      - verify.rc != 0
       - >-
         "ERROR! 'file' type is not supported. The format namespace.name is expected." in verify.stderr
 
@@ -48,11 +48,11 @@
 - name: verify a collection that doesn't appear to be installed
   command: ansible-galaxy collection verify ansible_test.verify:1.0.0
   register: verify
-  ignore_errors: true
+  failed_when: verify.rc == 0
 
 - assert:
     that:
-      - verify.failed
+      - verify.rc != 0
       - "'Collection ansible_test.verify is not installed in any of the collection paths.' in verify.stderr"
 
 - name: create a modules directory
@@ -86,9 +86,11 @@
   environment:
     ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
   register: verify
+  failed_when: verify.rc == 0
 
 - assert:
     that:
+      - verify.rc != 0
       - '"ansible_test.verify has the version ''1.0.0'' but is being compared to ''2.0.0''" in verify.stdout'
 
 - name: install the new version from the server
@@ -147,9 +149,11 @@
   register: verify
   environment:
     ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
+  failed_when: verify.rc == 0
 
 - assert:
     that:
+      - verify.rc != 0
       - "'Collection ansible_test.verify contains modified content in the following files:\n    plugins/modules/test_module.py' in verify.stdout"
 
 - name: modify the FILES.json to match the new checksum
@@ -165,9 +169,11 @@
   register: verify
   environment:
     ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
+  failed_when: verify.rc == 0
 
 - assert:
     that:
+      - verify.rc != 0
       - "'Collection ansible_test.verify contains modified content in the following files:\n    FILES.json' in verify.stdout"
 
 - name: get the checksum of the FILES.json
@@ -187,9 +193,11 @@
   register: verify
   environment:
     ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
+  failed_when: verify.rc == 0
 
 - assert:
     that:
+      - verify.rc != 0
       - "'Collection ansible_test.verify contains modified content in the following files:\n    MANIFEST.json' in verify.stdout"
 
 - name: remove the artifact metadata to test verifying a collection without it
@@ -215,11 +223,11 @@
   register: verify
   environment:
     ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
-  ignore_errors: yes
+  failed_when: verify.rc == 0
 
 - assert:
     that:
-      - verify.failed
+      - verify.rc != 0
       - "'Collection ansible_test.verify does not have a MANIFEST.json' in verify.stderr"
 
 - name: update the collection version to something not present on the server
@@ -260,9 +268,10 @@
   register: verify
   environment:
     ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
-  ignore_errors: yes
+  failed_when: verify.rc == 0
 
 - assert:
     that:
+      - verify.rc != 0
       - "'Collection ansible_test.verify contains modified content in the following files:' in verify.stdout"
       - "'plugins/modules/test_module.py' in verify.stdout"


### PR DESCRIPTION
##### SUMMARY

`ansible-galaxy collection verify` will now exit with a non-zero error code on verification failures.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
ansible-galaxy CLI

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
