### PR TITLE
Revert "Add duplicated set filter and documentation (#72729)"

### DIFF
--- a/changelogs/fragments/72729-add-filter-duplicated.yml
+++ b/changelogs/fragments/72729-add-filter-duplicated.yml
@@ -1,3 +1,0 @@
-minor_changes:
-  - add filter duplicated that will return duplicate items from a list.
-    (https://github.com/ansible/ansible/pull/72729/)

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -978,14 +978,6 @@ To get the symmetric difference of 2 lists (items exclusive to each list)::
     {{ list1 | symmetric_difference(list2) }}
     # => [10, 11, 99]
 
-To get the duplicate values from a list (the resulting list contains unique duplicates)::
-
-.. versionadded:: 2.11
-
-    # list1: [1, 2, 5, 1, 3, 4, 10, 'a', 'z', 'a']
-    {{ list1 | duplicated }}
-    # => [1, 'a']
-
 .. _math_stuff:
 
 Calculating numbers (math)

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -26,7 +26,6 @@ __metaclass__ = type
 import itertools
 import math
 
-from collections import Counter
 from jinja2.filters import environmentfilter
 
 from ansible.errors import AnsibleFilterError, AnsibleFilterTypeError
@@ -85,11 +84,6 @@ def unique(environment, a, case_sensitive=False, attribute=None):
                 c.append(x)
 
     return c
-
-
-@environmentfilter
-def duplicated(environment, a):
-    return [k for k, v in Counter(a).items() if v > 1]
 
 
 @environmentfilter
@@ -263,7 +257,6 @@ class FilterModule(object):
 
             # set theory
             'unique': unique,
-            'duplicated': duplicated,
             'intersect': intersect,
             'difference': difference,
             'symmetric_difference': symmetric_difference,

--- a/test/units/plugins/filter/test_mathstuff.py
+++ b/test/units/plugins/filter/test_mathstuff.py
@@ -180,11 +180,3 @@ class TestRekeyOnMember():
         list_original = ({'proto': 'eigrp', 'id': 1}, {'proto': 'ospf', 'id': 2}, {'proto': 'eigrp', 'id': 3})
         expected = {'eigrp': {'proto': 'eigrp', 'id': 3}, 'ospf': {'proto': 'ospf', 'id': 2}}
         assert ms.rekey_on_member(list_original, 'proto', duplicates='overwrite') == expected
-
-
-class TestDuplicated:
-    def test_empty(self):
-        assert ms.duplicated(env, []) == []
-
-    def test_numbers(self):
-        assert ms.duplicated(env, [1, 3, 5, 5]) == [5]


### PR DESCRIPTION
##### SUMMARY
This reverts commit 99a6627c60d8734d90f6982107eebb9de24ba54d.

That should fix CI for `devel` (and some collections).

CC @acozine @relrod

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/filter/mathstuff.py
