### PR TITLE
Fix comment in iptables unit test

### DIFF
--- a/changelogs/fragments/74061-iptables-unit_test-fix_comment.yaml
+++ b/changelogs/fragments/74061-iptables-unit_test-fix_comment.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - iptables - fix iptables unit test comment (https://github.com/ansible/ansible/pull/74061).

--- a/changelogs/fragments/74061-iptables-unit_test-fix_comment.yaml
+++ b/changelogs/fragments/74061-iptables-unit_test-fix_comment.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - iptables - fix iptables unit test comment (https://github.com/ansible/ansible/pull/74061).

--- a/test/units/modules/test_iptables.py
+++ b/test/units/modules/test_iptables.py
@@ -878,7 +878,7 @@ class TestIptables(ModuleTestCase):
         ])
 
     def test_comment_position_at_end(self):
-        """Test flush without parameters"""
+        """Test comment position to make sure it is at the end of command"""
         set_module_args({
             'chain': 'INPUT',
             'jump': 'ACCEPT',


### PR DESCRIPTION
##### SUMMARY
I've just noticed there has been a mistake in my previous PR for iptables unit test in https://github.com/ansible/ansible/commit/c1da427a5ec678f052fd2cd4885840c4d761946a

This little patch fixes the comment of unit test.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
iptables