### PR TITLE
[stable-2.9] pause - do not continue with '\r' when timeout is set (#…

### DIFF
--- a/changelogs/fragments/73948-pause-no-enter-with-timeout.yml
+++ b/changelogs/fragments/73948-pause-no-enter-with-timeout.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pause - do not accept enter to continue when a timeout is set (https://github.com/ansible/ansible/issues/73948)

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -245,19 +245,20 @@ class ActionModule(ActionBase):
                         clear_line(stdout)
                         raise KeyboardInterrupt
 
-                    # read key presses and act accordingly
-                    if key_pressed in (b'\r', b'\n'):
-                        clear_line(stdout)
-                        break
-                    elif key_pressed in backspace:
-                        # delete a character if backspace is pressed
-                        result['user_input'] = result['user_input'][:-1]
-                        clear_line(stdout)
-                        if echo:
-                            stdout.write(result['user_input'])
-                        stdout.flush()
-                    else:
-                        result['user_input'] += key_pressed
+                    if not seconds:
+                        # read key presses and act accordingly
+                        if key_pressed in (b'\r', b'\n'):
+                            clear_line(stdout)
+                            break
+                        elif key_pressed in backspace:
+                            # delete a character if backspace is pressed
+                            result['user_input'] = result['user_input'][:-1]
+                            clear_line(stdout)
+                            if echo:
+                                stdout.write(result['user_input'])
+                            stdout.flush()
+                        else:
+                            result['user_input'] += key_pressed
 
                 except KeyboardInterrupt:
                     signal.alarm(0)

--- a/test/integration/targets/pause/test-pause.py
+++ b/test/integration/targets/pause/test-pause.py
@@ -271,3 +271,19 @@ pause_test.send('supersecretpancakes')
 pause_test.send('\r')
 pause_test.expect(pexpect.EOF)
 pause_test.close()
+
+
+# Test that enter presses may not continue the play when a timeout is set.
+
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=["pause-3.yml"] + args,
+    timeout=10,
+    env=os.environ
+)
+
+pause_test.logfile = log_buffer
+pause_test.expect(r"\(ctrl\+C then 'C' = continue early, ctrl\+C then 'A' = abort\)")
+pause_test.send('\r')
+pause_test.expect(pexpect.EOF)
+pause_test.close()


### PR DESCRIPTION
…74030)

Original function of pause was, to only allow user input
(finished with enter) when no timeout was set. This restores
the behaviour.
(cherry picked from commit 1527078a8f4fb80cb3f2c48c00b3e683086332eb)

Co-authored-by: Alexander Sowitzki <asowitzk@redhat.com>

Original PR: #74030

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
