### PR TITLE
clarify -e option in getting started guide

### DIFF
--- a/docs/docsite/rst/network/getting_started/first_playbook.rst
+++ b/docs/docsite/rst/network/getting_started/first_playbook.rst
@@ -64,7 +64,7 @@ The flags in this command set seven values:
   - the module (-m, the Ansible module to run, using the fully qualified collection name (FQCN))
   - an extra variable ( -e, in this case, setting the network OS value)
 
-NOTE: If you use ``ssh-agent`` with ssh keys, Ansible loads them automatically. You can omit ``-k`` flag.
+NOTE: If you use ``ssh-agent`` with ssh keys, Ansible loads them automatically. You can omit ``-k`` flag. You can also use ``-e "ansible_ssh_pass=ansible"`` to include the password in the command without prompting the user.
 
 .. note::
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add note on how to use '-e` for including a password in the command line without a prompt.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs/docsite/rst/network/getting_started/first_playbook.rst
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
