### PR TITLE
Fix debug factsetter (#74067)

### DIFF
--- a/changelogs/fragments/debug_dont_set_facts.yml
+++ b/changelogs/fragments/debug_dont_set_facts.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - debug action, prevent setting facts when displaying ansible_facts.

--- a/changelogs/fragments/debug_dont_set_facts.yml
+++ b/changelogs/fragments/debug_dont_set_facts.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - debug action, prevent setting facts when displaying ansible_facts.
+  - debug action - prevent setting facts when displaying ansible_facts (https://github.com/ansible/ansible/issues/74060).

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -713,7 +713,7 @@ class TaskExecutor:
                     failed_when_result = False
                 return failed_when_result
 
-            if 'ansible_facts' in result:
+            if 'ansible_facts' in result and self._task.action not in C._ACTION_DEBUG:
                 if self._task.action in C._ACTION_WITH_CLEAN_FACTS:
                     vars_copy.update(result['ansible_facts'])
                 else:
@@ -777,7 +777,7 @@ class TaskExecutor:
         if self._task.register:
             variables[self._task.register] = result = wrap_var(result)
 
-        if 'ansible_facts' in result:
+        if 'ansible_facts' in result and self._task.action not in C._ACTION_DEBUG:
             if self._task.action in C._ACTION_WITH_CLEAN_FACTS:
                 variables.update(result['ansible_facts'])
             else:

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -670,7 +670,7 @@ class StrategyBase:
                         self._add_group(original_host, result_item)
                         post_process_whens(result_item, original_task, handler_templar)
 
-                    if 'ansible_facts' in result_item:
+                    if 'ansible_facts' in result_item and original_task.action not in C._ACTION_DEBUG:
                         # if delegated fact and we are delegating facts, we need to change target host for them
                         if original_task.delegate_to is not None and original_task.delegate_facts:
                             host_list = self.get_delegated_hosts(result_item, original_task)

--- a/test/integration/targets/debug/nosetfacts.yml
+++ b/test/integration/targets/debug/nosetfacts.yml
@@ -1,0 +1,21 @@
+- name: check we dont set facts with debug ansible_facts https://github.com/ansible/ansible/issues/74060
+  hosts: localhost
+  gather_facts: false
+  tasks:
+  - name: create namespaced non fact
+    set_fact:
+        ansible_facts:
+            nonfact: 1
+
+  - name: ensure nonfact does not exist
+    assert:
+      that:
+        - nonfact is not defined
+
+  - name: debug ansible_facts to create issue
+    debug: var=ansible_facts
+
+  - name: ensure nonfact STILL does not exist
+    assert:
+      that:
+        - nonfact is not defined

--- a/test/integration/targets/debug/runme.sh
+++ b/test/integration/targets/debug/runme.sh
@@ -15,3 +15,6 @@ for i in 1 2 3; do
   grep "ok: \[localhost\] => (item=$i)" out
   grep "\"item\": $i" out
 done
+
+# ensure debug does not set top level vars when looking at ansible_facts
+ansible-playbook nosetfacts.yml "$@"


### PR DESCRIPTION
* prevent debug from setting namespaced facts as tlv
* also added tests

(cherry picked from commit f9f839fa08eee46ad7a86d6cbc7519541a50c7ef)


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
facts