### PR TITLE
Openbsd bcrypt

### DIFF
--- a/changelogs/fragments/openbsd-bcrypt.yml
+++ b/changelogs/fragments/openbsd-bcrypt.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - encrypt - switch bcrypt to modern version 2b

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -68,7 +68,7 @@ class BaseHash(object):
     algo = namedtuple('algo', ['crypt_id', 'salt_size', 'implicit_rounds', 'salt_exact'])
     algorithms = {
         'md5_crypt': algo(crypt_id='1', salt_size=8, implicit_rounds=None, salt_exact=False),
-        'bcrypt': algo(crypt_id='2a', salt_size=22, implicit_rounds=None, salt_exact=True),
+        'bcrypt': algo(crypt_id='2b', salt_size=22, implicit_rounds=None, salt_exact=True),
         'sha256_crypt': algo(crypt_id='5', salt_size=16, implicit_rounds=5000, salt_exact=False),
         'sha512_crypt': algo(crypt_id='6', salt_size=16, implicit_rounds=5000, salt_exact=False),
     }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

@Akasurde  missed in https://github.com/ansible/ansible/pull/74056

updates bcrypt to version 2b, 2a has security issue. support in passlib by default for long time now https://passlib.readthedocs.io/en/stable/lib/passlib.hash.bcrypt.html

allowing maintainer edits if needed, changelog fragment added too, not sure if other files need changed but based on openbsd patch this looks like it

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
encrypt.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

old openbsd patch tested for some time in many ansible versions https://github.com/openbsd/ports/blob/master/sysutils/ansible/patches/patch-lib_ansible_utils_encrypt_py 

ref https://github.com/ansible/ansible/issues/70645
