### PR TITLE
Clarifying that lists can't be used for "name:" in the service module

### DIFF
--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -20,7 +20,8 @@ description:
 options:
     name:
         description:
-        - Name of the service.
+        - Name of the service. This parameter takes the name of exactly
+          one service to work with.
         type: str
         required: true
     state:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Just like with the systemd module, the service module doesn't take a list of names for services to be managed, one has to loop through them. Just clarifying this, since I ran into this, while assuming a list can be used, probably happens to others too.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
service

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
