### PR TITLE
Fix issue with version 3 in docs version list

### DIFF
--- a/docs/docsite/_themes/sphinx_rtd_theme/ansible_versions.html
+++ b/docs/docsite/_themes/sphinx_rtd_theme/ansible_versions.html
@@ -13,10 +13,10 @@
             if ( "{{ slug }}" == "{{ current_version }}" ) {
               option.selected = true;
             }
-            if (current_url.search("{{ current_version }}") > -1) {
-              option.value = current_url.replace("{{ current_version }}","{{ slug }}");
+            if (current_url.search("/{{ current_version }}/") > -1) {
+              option.value = current_url.replace("/{{ current_version }}/","/{{ slug }}/");
             } else {
-              option.value = current_url.replace("latest","{{ slug }}");
+              option.value = current_url.replace("/latest/","/{{ slug }}/");
             }
             x.add(option);
           </script>


### PR DESCRIPTION
Previously would subsitute the "3" in "s3" instead of the version location in the URL

##### SUMMARY
Changes the javascript in the documentation to looking for "/<version>/" as opposed to plain "<version>" when substituting in the new version

Fixes #73841 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Ansible Documentation

##### ADDITIONAL INFORMATION
as noted in #73841 , the previous code for checking version was lacking, and this makes it a bit more robust, so the version list changer works for the "aws_s3" page

see current https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_s3_module.html and try changing versions. (while latest == 3)
