### PR TITLE
lib/hostname: add current/permanent option

### DIFF
--- a/changelogs/fragments/74091-hostname-add-current-permanent.yml
+++ b/changelogs/fragments/74091-hostname-add-current-permanent.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible.builtin.hostname - add current/permanent option for more granularity in setting hostname

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -46,8 +46,9 @@ options:
         description:
             - Which hostname to set
         choices: ['current', 'permanent', 'all']
+        default: all
         type: str
-        version_added: '999'
+        version_added: '9.9'
 '''
 
 EXAMPLES = '''
@@ -1025,7 +1026,7 @@ def main():
 
     hostname = Hostname(module)
     name = module.params['name']
-    state = module.params['state'];
+    state = module.params['state']
 
     current_hostname = hostname.get_current_hostname()
     permanent_hostname = hostname.get_permanent_hostname()

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -48,7 +48,7 @@ options:
         choices: ['current', 'permanent', 'all']
         default: all
         type: str
-        version_added: '9.9'
+        version_added: '2.11'
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY
Sometimes you do not want to change the current hostname, but only the permanent hostname (e.g. during bootstrapping)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible.builtin.hostname

I didn't know what to put under changed_version, feel free to change it