### PR TITLE
Let unarchive handle huge files

### DIFF
--- a/changelogs/fragments/73985-let-unarchive-handle-huge-files.yml
+++ b/changelogs/fragments/73985-let-unarchive-handle-huge-files.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - unarchive - allow extracting archives that contain files which size exceeds free system memory (https://github.com/ansible/ansible/issues/73985).


### PR DESCRIPTION
##### SUMMARY
Allow extracting archives that contain files which size exceeds free system memory.

Fixes #73985

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
unarchive

##### ADDITIONAL INFORMATION

