### PR TITLE
New AWS module mod_defaults - rds_option_group (_info) modules

### DIFF
--- a/changelogs/fragments/rds-aws-mod-defaults.yml
+++ b/changelogs/fragments/rds-aws-mod-defaults.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - aws module_defaults - add rds_option_group, rds_option_group_info

--- a/lib/ansible/config/module_defaults.yml
+++ b/lib/ansible/config/module_defaults.yml
@@ -458,6 +458,10 @@ groupings:
   - aws
   rds_subnet_group:
   - aws
+  rds_option_group:
+  - aws
+  rds_option_group_info:
+  - aws
   redshift:
   - aws
   redshift_cross_region_snapshots:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To support these new modules in CI, we need them to be included in 2.9's module_defaults:
https://github.com/ansible-collections/community.aws/pull/517

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_defaults