### PR TITLE
Implement workaround for stdout deadlock in multiprocessing shutdown

### DIFF
--- a/changelogs/fragments/workerprocess-stdout-deadlock.yml
+++ b/changelogs/fragments/workerprocess-stdout-deadlock.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- WorkerProcess - Implement workaround for stdout deadlock in multiprocessing shutdown
+  to avoid process hangs.

--- a/lib/ansible/executor/process/worker.py
+++ b/lib/ansible/executor/process/worker.py
@@ -140,11 +140,13 @@ class WorkerProcess(multiprocessing_context.Process):
             # shutdown. We have various ``Display`` calls that may fire from a fork
             # so we cannot do this early. Instead, this happens at the very end
             # to avoid that deadlock, by simply side stepping it. This should not be
-            # treated as a long term fix.
+            # treated as a long term fix. Additionally this behavior only presents itself
+            # on Python3. Python2 does not exhibit the deadlock behavior.
             # TODO: Evaluate overhauling ``Display`` to not write directly to stdout
             # and evaluate migrating away from the ``fork`` multiprocessing start method.
-            sys.stdout = os.devnull
-            sys.stderr = os.devnull
+            if sys.version_info[0] >= 3:
+                sys.stdout = os.devnull
+                sys.stderr = os.devnull
 
     def _run(self):
         '''

--- a/lib/ansible/executor/process/worker.py
+++ b/lib/ansible/executor/process/worker.py
@@ -134,6 +134,17 @@ class WorkerProcess(multiprocessing_context.Process):
             return self._run()
         except BaseException as e:
             self._hard_exit(e)
+        finally:
+            # This is a hack, pure and simple, to work around a potential deadlock
+            # in ``multiprocessing.Process`` when flushing stdout/stderr during process
+            # shutdown. We have various ``Display`` calls that may fire from a fork
+            # so we cannot do this early. Instead, this happens at the very end
+            # to avoid that deadlock, by simply side stepping it. This should not be
+            # treated as a long term fix.
+            # TODO: Evaluate overhauling ``Display`` to not write directly to stdout
+            # and evaluate migrating away from the ``fork`` multiprocessing start method.
+            sys.stdout = os.devnull
+            sys.stderr = os.devnull
 
     def _run(self):
         '''


### PR DESCRIPTION
##### SUMMARY
Implement workaround for stdout deadlock in multiprocessing shutdown

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/process/worker.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
