### PR TITLE
Drop deprecated `issue_body` from issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 ---
 name: 🐛 Bug report
 description: Create a report to help us improve
-issue_body: false  # default: true, adds a classic WSYWIG textarea, if on
 
 body:
 - type: markdown

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -1,8 +1,6 @@
 ---
 name: 📝 Documentation Report
 description: Ask us about docs
-# NOTE: issue body is enabled to allow screenshots
-issue_body: true  # default: true, adds a classic WSYWIG textarea, if on
 
 body:
 - type: markdown
@@ -87,6 +85,20 @@ body:
     required: true
 
 
+- type: textarea
+  attributes:
+    label: Additional Information
+    description: |
+      Describe how this improves the documentation, e.g. before/after situation or screenshots.
+
+      **HINT:** You can paste https://gist.github.com links for larger files.
+    placeholder: >-
+      When the improvement is applied, it makes it more straightforward
+      to understand X.
+  validations:
+    required: true
+
+
 - type: checkboxes
   attributes:
     label: Code of Conduct
@@ -97,19 +109,4 @@ body:
     options:
     - label: I agree to follow the Ansible Code of Conduct
       required: true
-
-
-- type: markdown
-  attributes:
-    value: |
-      **Additional Information**
-
-      Describe how this improves the documentation, e.g. before/after situation or screenshots.
-
-      **HINT:** You can paste https://gist.github.com links for larger files.
-    placeholder: >-
-      When the improvement is applied, it makes it more straightforward
-      to understand X.
-  validations:
-    required: true
 ...

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,6 @@
 ---
 name: ✨ Feature request
 description: Suggest an idea for this project
-issue_body: false  # default: true, adds a classic WSYWIG textarea, if on
 
 body:
 - type: markdown


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change removes the deprecated attribute and also adds an explicit
textarea at the end of the docs report form to replace it.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
.github/ISSUE_TEMPLATE/

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
`issue_body` is going to be removed from the forms schema on Tuesday. This will probably break our forms so we need to merge the fix ASAP. Since `devel` is merge-protected now, I'm leaving this at the mercy of folks having higher privileges than me.