### PR TITLE
strategy: Replace results_main_thread with inline queue processing to avoid threading/forking issues

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1881,14 +1881,13 @@ TASK_TIMEOUT:
   - {key: task_timeout, section: defaults}
   type: integer
   version_added: '2.10'
-WORKER_SHUTDOWN_POLL_COUNT:
-  name: Worker Shutdown Poll Count
-  default: 0
+WORKER_SHUTDOWN_TIMEOUT:
+  name: Worker Shutdown Timeout
+  default: 60
   description:
-    - The maximum number of times to check Task Queue Manager worker processes to verify they have exited cleanly.
+    - Timeout in seconds to wait for worker processes to exit gracefully.
     - After this limit is reached any worker processes still running will be terminated.
-    - This is for internal use only.
-  env: [{name: ANSIBLE_WORKER_SHUTDOWN_POLL_COUNT}]
+  env: [{name: ANSIBLE_WORKER_SHUTDOWN_TIMEOUT}]
   type: integer
   version_added: '2.10'
 WORKER_SHUTDOWN_POLL_DELAY:

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -30,9 +30,6 @@ DOCUMENTATION = '''
     version_added: "2.0"
     author: Ansible Core Team
 '''
-
-import time
-
 from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.playbook.included_file import IncludedFile
@@ -275,9 +272,6 @@ class StrategyModule(StrategyBase):
                 for host in hosts_left:
                     iterator.add_tasks(host, all_blocks[host])
                 display.debug("done adding collected blocks to iterator")
-
-            # pause briefly so we don't spin lock
-            time.sleep(C.DEFAULT_INTERNAL_POLL_INTERVAL)
 
         # collect all the final results
         results = self._wait_on_pending_results(iterator)

--- a/test/lib/ansible_test/_internal/ansible_util.py
+++ b/test/lib/ansible_test/_internal/ansible_util.py
@@ -83,11 +83,6 @@ def ansible_environment(args, color=True, ansible_config=None):
         PYTHONPATH=get_ansible_python_path(args),
         PAGER='/bin/cat',
         PATH=path,
-        # give TQM worker processes time to report code coverage results
-        # without this the last task in a play may write no coverage file, an empty file, or an incomplete file
-        # enabled even when not using code coverage to surface warnings when worker processes do not exit cleanly
-        ANSIBLE_WORKER_SHUTDOWN_POLL_COUNT='100',
-        ANSIBLE_WORKER_SHUTDOWN_POLL_DELAY='0.1',
     )
 
     if isinstance(args, IntegrationConfig) and args.coverage:


### PR DESCRIPTION
##### SUMMARY

Proposal to replace results_main_thread with inline queue processing in StrategyBase.

From the commit description:
>
> We observed #59642 when using templates with custom jinja filters
> using socket.getaddrinfo().
>
> On the first call to socket.getaddrinfo() during templating, libnss libraries
> are loaded dynamically. This operation can deadlock when the result thread of
> the previous play holds the glibc internal dl_load_write_lock while the next
> worker process is forked. dl_load_write_lock is acquired during during stack
> unwinding upon thread termination. #59642 has a great analysis about this.
>
> One could argue socket.getaddrinfo() should not be called during templating,
> but that seems like a trap.
>
> This patch removes the results_main_thread and replaces it with direct
> queue.get calls in _process_pending_results.

I gather this is a rather intrusive change, but would like to hear if this is a
direction worth exploring. After running into #59642 and reading about
threading/fork mixing, I feel this may be something that would be good
to move away from - this is one idea.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

StrategyBase / results_main_thread


##### ADDITIONAL INFORMATION

The second commit introduces graceful waiting/joining of worker processes. After removing the sentinel going through the queue, the main process races with the workers exiting after receiving the last result. Sometimes it would call `terminate()` on a worker that was still holding the internal write lock of the `_final_q`. The next `send_task_result()` would of a new worker would then deadlock because calling `.terminate()` in these scenarios is dangerous [1].

Above deadlock was more easily reproduced when using a single core only via something like  `taskset -c 7 python ./bin/ansible-playbook ...`.

[1] https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process.terminate