### PR TITLE
[backport/2.9] module_defaults: Add rds_snapshot

### DIFF
--- a/changelogs/fragments/74113-module_defaults-rds_snapshot.yml
+++ b/changelogs/fragments/74113-module_defaults-rds_snapshot.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- module_defaults - add module rds_snapshot to aws module_defaults group (https://github.com/ansible/ansible/pull/74113).

--- a/lib/ansible/config/module_defaults.yml
+++ b/lib/ansible/config/module_defaults.yml
@@ -452,6 +452,8 @@ groupings:
   - aws
   rds_param_group:
   - aws
+  rds_snapshot:
+  - aws
   rds_snapshot_facts:
   - aws
   rds_snapshot_info:


### PR DESCRIPTION
##### SUMMARY

Add rds_snapshot to AWS module_defaults group

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

rds_snapshot

##### ADDITIONAL INFORMATION

partial backport of:

https://github.com/ansible-collections/community.aws/pull/515