### PR TITLE
[stable-2.9] Fix: nmcli bridge-slave fails with error

### DIFF
--- a/changelogs/fragments/74125-backport_nmcli_module-slave_bridge_error.yml
+++ b/changelogs/fragments/74125-backport_nmcli_module-slave_bridge_error.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- nmcli - fix the slaving of bridge interfaces (https://github.com/ansible/ansible/pull/74125).

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -1103,8 +1103,9 @@ class Nmcli(object):
         elif self.conn_name is not None:
             cmd.append(self.conn_name)
 
+        if self.master is not None:
+            cmd.extend(['master', self.master])
         options = {
-            'master': self.master,
             'bridge-port.path-cost': self.path_cost,
             'bridge-port.hairpin': self.bool_to_string(self.hairpin),
             'bridge-port.priority': self.slavepriority,
@@ -1119,8 +1120,9 @@ class Nmcli(object):
     def modify_connection_bridge_slave(self):
         # format for modifying bond-slave interface
         cmd = [self.nmcli_bin, 'con', 'mod', self.conn_name]
+        if self.master is not None:
+            cmd.extend(['master', self.master])
         options = {
-            'master': self.master,
             'bridge-port.path-cost': self.path_cost,
             'bridge-port.hairpin': self.bool_to_string(self.hairpin),
             'bridge-port.priority': self.slavepriority,


### PR DESCRIPTION
This commit fixes the error for adding bridge slaves:

This fix is related to #42460 and #54617

Authored-by: Denis Kadyshev 

##### SUMMARY
nmcli bridge-slave returns "Error: invalid or not allowed setting 'bridge-port'

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
nmcli module

##### ADDITIONAL INFORMATION
From #68065

Example tasks:

```
- name: Add bridge
  nmcli:
    type: bridge
    conn_name: br0
    ip4: "{{ ansible_default_ipv4.address }}/{{ ansible_default_ipv4.netmask | ipaddr('prefix') }}"
    gw4: "{{ ansible_default_ipv4.gateway }}"
    state: present

- name: Add bridge slave
  nmcli:
    type: bridge-slave
    conn_name: "{{ ansible_default_ipv4.interface }}"
    ifname: "{{ ansible_default_ipv4.interface }}"
    master: br0
    state: present
```

Fails with:
```
Error: invalid or not allowed setting 'bridge-port': 'bridge-port' not among [connection, tun, 802-3-ethernet (ethernet), ethtool, match, ipv4, ipv6, tc, proxy].
```
