### PR TITLE
Docs: Fix k8s_config_resource_name YAML example

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1712,7 +1712,8 @@ This can then be used to reference hashes in Pod specifications::
 
     my_secret:
       kind: Secret
-      name: my_secret_name
+      metadata:
+        name: my_secret_name
 
     deployment_resource:
       kind: Deployment


### PR DESCRIPTION
##### SUMMARY

The `name` key should be beneath `metadata`:

https://github.com/ansible-collections/community.kubernetes/blob/1.2.1/plugins/filter/k8s.py#L22

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

+label: docsite_pr