### PR TITLE
play - validate hosts entries

### DIFF
--- a/changelogs/fragments/65386-validate-hosts.yml
+++ b/changelogs/fragments/65386-validate-hosts.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - play - validate the ``hosts`` entry in a play (https://github.com/ansible/ansible/issues/65386)

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -23,6 +23,7 @@ from ansible import constants as C
 from ansible import context
 from ansible.errors import AnsibleParserError, AnsibleAssertionError
 from ansible.module_utils._text import to_native
+from ansible.module_utils.common.collections import is_sequence
 from ansible.module_utils.six import string_types
 from ansible.playbook.attribute import FieldAttribute
 from ansible.playbook.base import Base
@@ -99,17 +100,29 @@ class Play(Base, Taggable, CollectionSearch):
 
     def get_name(self):
         ''' return the name of the Play '''
-        return self.name
+        if self.name:
+            return self.name
+
+        if isinstance(self.hosts, list):
+            self.name = ','.join(self.hosts)
+        else:
+            self.name = self.hosts
+            return self.name
+
 
     @staticmethod
     def load(data, variable_manager=None, loader=None, vars=None):
-        if ('name' not in data or data['name'] is None) and 'hosts' in data:
-            if data['hosts'] is None or all(host is None for host in data['hosts']):
+        if 'hosts' in data:
+            if data['hosts'] is None:
                 raise AnsibleParserError("Hosts list cannot be empty - please check your playbook")
-            if isinstance(data['hosts'], list):
-                data['name'] = ','.join(data['hosts'])
-            else:
-                data['name'] = data['hosts']
+            elif any(host is None for host in data['hosts']):
+                raise AnsibleParserError("Hosts list cannot contain values of 'None' - please check your playbook")
+            if not is_sequence(data['hosts']):
+                raise AnsibleParserError("Hosts list must be a sequence.")
+            # if isinstance(data['hosts'], list):
+            #     data['name'] = ','.join(data['hosts'])
+            # else:
+            #     data['name'] = data['hosts']
         p = Play()
         if vars:
             p.vars = vars.copy()

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -100,7 +100,15 @@ class Play(Base, Taggable, CollectionSearch):
 
     def get_name(self):
         ''' return the name of the Play '''
-        return self.name
+        if self.name:
+            return self.name
+
+        if is_sequence(self.hosts):
+            self.name = ','.join(self.hosts)
+        else:
+            self.name = self.hosts
+
+        return ''
 
     @staticmethod
     def load(data, variable_manager=None, loader=None, vars=None):
@@ -121,13 +129,6 @@ class Play(Base, Taggable, CollectionSearch):
 
             elif not is_string(hosts):
                 raise AnsibleParserError("Hosts list must be a sequence or a string. Please check your playbook.")
-
-            # Set name if it wasn't provided
-            if not data.get('name'):
-                if is_string(hosts):
-                    data['name'] = hosts
-                elif is_sequence(hosts):
-                    data['name'] = ','.join(hosts)
 
         p = Play()
         if vars:

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -128,7 +128,7 @@ class Play(Base, Taggable, CollectionSearch):
                         raise AnsibleParserError("Hosts list contains an invalid host value: '{host!s}'".format(host=host))
 
             elif not is_string(hosts):
-                raise AnsibleParserError("Hosts list must be a sequence or a string. Please check your playbook.")
+                raise AnsibleParserError("Hosts list must be a sequence or string. Please check your playbook.")
 
         p = Play()
         if vars:

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -106,9 +106,9 @@ class Play(Base, Taggable, CollectionSearch):
         if is_sequence(self.hosts):
             self.name = ','.join(self.hosts)
         else:
-            self.name = self.hosts
+            self.name = self.hosts or ''
 
-        return ''
+        return self.name
 
     @staticmethod
     def load(data, variable_manager=None, loader=None, vars=None):

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -98,6 +98,24 @@ class Play(Base, Taggable, CollectionSearch):
     def __repr__(self):
         return self.get_name()
 
+    def _validate_hosts(self, attribute, name, value):
+        # Only validate 'hosts' if a value was passed in to original data set.
+        if 'hosts' in self._ds:
+            # Check for empty data
+            if value in ([], tuple(), set(), {}, ''):
+                raise AnsibleParserError("Hosts list cannot be empty. Please check your playbook")
+
+            if is_sequence(value):
+                # Make sure each item in the sequence is a string and not None
+                for host in value:
+                    if host is None:
+                        raise AnsibleParserError("Hosts list cannot contain values of 'None'. Please check your playbook")
+                    elif not is_string(host):
+                        raise AnsibleParserError("Hosts list contains an invalid host value: '{host!s}'".format(host=host))
+
+            elif not is_string(value):
+                raise AnsibleParserError("Hosts list must be a sequence or string. Please check your playbook.")
+
     def get_name(self):
         ''' return the name of the Play '''
         if self.name:
@@ -112,24 +130,6 @@ class Play(Base, Taggable, CollectionSearch):
 
     @staticmethod
     def load(data, variable_manager=None, loader=None, vars=None):
-        if 'hosts' in data:
-            hosts = data.get('hosts')
-
-            # Check for empty data
-            if hosts in ([], tuple(), set(), {}, ''):
-                raise AnsibleParserError("Hosts list cannot be empty. Please check your playbook")
-
-            if is_sequence(hosts):
-                # Make sure each item in the sequence is a string and not None
-                for host in hosts:
-                    if host is None:
-                        raise AnsibleParserError("Hosts list cannot contain values of 'None'. Please check your playbook")
-                    elif not is_string(host):
-                        raise AnsibleParserError("Hosts list contains an invalid host value: '{host!s}'".format(host=host))
-
-            elif not is_string(hosts):
-                raise AnsibleParserError("Hosts list must be a sequence or string. Please check your playbook.")
-
         p = Play()
         if vars:
             p.vars = vars.copy()

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -100,7 +100,6 @@ class Play(Base, Taggable, CollectionSearch):
         return self.get_name()
 
     def _validate_hosts(self, attribute, name, value):
-        # breakpoint()
         # Only validate 'hosts' if a value was passed in to original data set.
         if 'hosts' in self._ds:
             err_msg = "Hosts list contains an invalid host value: '{host!s}'"
@@ -177,8 +176,6 @@ class Play(Base, Taggable, CollectionSearch):
                 new_hosts = _flatten_list(new_hosts)
                 ds['hosts'] = new_hosts
 
-            # The "and ds['hosts']" test is for empty strings. If an empty string
-            # was set for hosts, leave it that way so it will later fail validation.
             if is_string(ds['hosts']):
                 ds['hosts'] = string_to_list(ds['hosts'], ',')
 

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -34,6 +34,7 @@ from ansible.playbook.role import Role
 from ansible.playbook.taggable import Taggable
 from ansible.vars.manager import preprocess_vars
 from ansible.utils.display import Display
+from ansible.utils.helpers import _flatten_list, string_to_list
 
 display = Display()
 
@@ -99,6 +100,7 @@ class Play(Base, Taggable, CollectionSearch):
         return self.get_name()
 
     def _validate_hosts(self, attribute, name, value):
+        # breakpoint()
         # Only validate 'hosts' if a value was passed in to original data set.
         if 'hosts' in self._ds:
             err_msg = "Hosts list contains an invalid host value: '{host!s}'"
@@ -106,17 +108,14 @@ class Play(Base, Taggable, CollectionSearch):
             if not value:
                 raise AnsibleParserError("Hosts list cannot be empty. Please check your playbook")
 
-            if is_string(value) and any(c in value for c in ('[', ']', '{', '}')):
-                raise AnsibleParserError(err_msg.format(host=value))
-
             if is_sequence(value):
-                # Make sure each item in the sequence is a valid string
+                # Make sure each item in the sequence is a string
                 for entry in value:
+                    if is_sequence(entry):
+                        continue
                     if entry is None:
                         raise AnsibleParserError("Hosts list cannot contain values of 'None'. Please check your playbook")
                     elif not is_string(entry):
-                        raise AnsibleParserError(err_msg.format(host=entry))
-                    elif is_string(entry) and any(c in entry for c in ('[', ']', '{', '}')):
                         raise AnsibleParserError(err_msg.format(host=entry))
 
             elif not is_string(value):
@@ -161,6 +160,27 @@ class Play(Base, Taggable, CollectionSearch):
 
             ds['remote_user'] = ds['user']
             del ds['user']
+
+        # Flatten hosts entry to a single list. Any list entries that consist of
+        # k,v pairs will be split into a list and flattened.
+        if ds.get('hosts'):
+            if is_sequence(ds['hosts']):
+                new_hosts = []
+                new_hosts = _flatten_list(ds['hosts'])
+
+                # Turn comma separated strings into a list
+                for id, entry in enumerate(new_hosts):
+                    if is_string(entry):
+                        new_hosts[id] = string_to_list(entry, ',')
+
+                # Flatten again since certain strings could now be lists
+                new_hosts = _flatten_list(new_hosts)
+                ds['hosts'] = new_hosts
+
+            # The "and ds['hosts']" test is for empty strings. If an empty string
+            # was set for hosts, leave it that way so it will later fail validation.
+            if is_string(ds['hosts']):
+                ds['hosts'] = string_to_list(ds['hosts'], ',')
 
         return super(Play, self).preprocess_data(ds)
 

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -106,9 +106,6 @@ class Play(Base, Taggable, CollectionSearch):
             if not value:
                 raise AnsibleParserError("Hosts list cannot be empty. Please check your playbook")
 
-            if is_string(value) and any(c in value for c in ('[', ']')):
-                raise AnsibleParserError(err_msg.format(host=value))
-
             if is_sequence(value):
                 # Make sure each item in the sequence is a valid string
                 for entry in value:
@@ -116,7 +113,7 @@ class Play(Base, Taggable, CollectionSearch):
                         raise AnsibleParserError("Hosts list cannot contain values of 'None'. Please check your playbook")
                     elif not is_string(entry):
                         raise AnsibleParserError(err_msg.format(host=entry))
-                    elif is_string(entry) and any(c in entry for c in ('[', ']')):
+                    elif not is_string(entry):
                         raise AnsibleParserError(err_msg.format(host=entry))
 
             elif not is_string(value):

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -23,8 +23,8 @@ from ansible import constants as C
 from ansible import context
 from ansible.errors import AnsibleParserError, AnsibleAssertionError
 from ansible.module_utils._text import to_native
-from ansible.module_utils.common.collections import is_sequence, is_string
-from ansible.module_utils.six import string_types
+from ansible.module_utils.common.collections import is_sequence
+from ansible.module_utils.six import binary_type, string_types, text_type
 from ansible.playbook.attribute import FieldAttribute
 from ansible.playbook.base import Base
 from ansible.playbook.block import Block
@@ -109,11 +109,10 @@ class Play(Base, Taggable, CollectionSearch):
                 for entry in value:
                     if entry is None:
                         raise AnsibleParserError("Hosts list cannot contain values of 'None'. Please check your playbook")
-                    elif not is_string(entry):
-                        raise AnsibleParserError(err_msg.format(host=entry))
+                    elif not isinstance(entry, (binary_type, text_type)):
                         raise AnsibleParserError("Hosts list contains an invalid host value: '{host!s}'".format(host=entry))
 
-            elif not is_string(value):
+            elif not isinstance(value, (binary_type, text_type)):
                 raise AnsibleParserError("Hosts list must be a sequence or string. Please check your playbook.")
 
     def get_name(self):

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -113,8 +113,6 @@ class Play(Base, Taggable, CollectionSearch):
                         raise AnsibleParserError("Hosts list cannot contain values of 'None'. Please check your playbook")
                     elif not is_string(entry):
                         raise AnsibleParserError(err_msg.format(host=entry))
-                    elif not is_string(entry):
-                        raise AnsibleParserError(err_msg.format(host=entry))
 
             elif not is_string(value):
                 raise AnsibleParserError("Hosts list must be a sequence or string. Please check your playbook.")

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -106,7 +106,7 @@ class Play(Base, Taggable, CollectionSearch):
             if not value:
                 raise AnsibleParserError("Hosts list cannot be empty. Please check your playbook")
 
-            if is_string(value) and any(c in value for c in ('[', ']', '{', '}')):
+            if is_string(value) and any(c in value for c in ('[', ']')):
                 raise AnsibleParserError(err_msg.format(host=value))
 
             if is_sequence(value):
@@ -116,7 +116,7 @@ class Play(Base, Taggable, CollectionSearch):
                         raise AnsibleParserError("Hosts list cannot contain values of 'None'. Please check your playbook")
                     elif not is_string(entry):
                         raise AnsibleParserError(err_msg.format(host=entry))
-                    elif is_string(entry) and any(c in entry for c in ('[', ']', '{', '}')):
+                    elif is_string(entry) and any(c in entry for c in ('[', ']')):
                         raise AnsibleParserError(err_msg.format(host=entry))
 
             elif not is_string(value):

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -101,8 +101,6 @@ class Play(Base, Taggable, CollectionSearch):
     def _validate_hosts(self, attribute, name, value):
         # Only validate 'hosts' if a value was passed in to original data set.
         if 'hosts' in self._ds:
-            err_msg = "Hosts list contains an invalid host value: '{host!s}'"
-
             if not value:
                 raise AnsibleParserError("Hosts list cannot be empty. Please check your playbook")
 
@@ -113,6 +111,7 @@ class Play(Base, Taggable, CollectionSearch):
                         raise AnsibleParserError("Hosts list cannot contain values of 'None'. Please check your playbook")
                     elif not is_string(entry):
                         raise AnsibleParserError(err_msg.format(host=entry))
+                        raise AnsibleParserError("Hosts list contains an invalid host value: '{host!s}'".format(host=entry))
 
             elif not is_string(value):
                 raise AnsibleParserError("Hosts list must be a sequence or string. Please check your playbook.")

--- a/lib/ansible/utils/helpers.py
+++ b/lib/ansible/utils/helpers.py
@@ -19,8 +19,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.errors import AnsibleRuntimeError
-from ansible.module_utils.common.collections import is_sequence
 from ansible.module_utils.six import string_types
 
 
@@ -51,35 +49,3 @@ def deduplicate_list(original_list):
     """
     seen = set()
     return [x for x in original_list if x not in seen and not seen.add(x)]
-
-
-def _flatten_list(data):
-    if not is_sequence(data):
-        raise TypeError('Cannot flatten a {type}'.format(type=type(data)))
-
-    if not data:
-        return data
-
-    if is_sequence(data[0]):
-        return _flatten_list(data[0] + data[1:])
-
-    try:
-        return data[:1] + _flatten_list(data[1:])
-    except RecursionError:
-        raise AnsibleRuntimeError('List contains too many nested lists')
-
-
-def string_to_list(string, split=None):
-    """Convert a string to a list splitting on ``split``.
-
-    Empty strings will be removed from the returned list.
-
-    If no splitting occurs, return a single item list containing ``string``.
-    """
-
-    if split in string:
-        # The filter() here removes empty strings from entries such as
-        # 'one,'.split(',') --> ['one', '']
-        return list(filter(None, string.split(split)))
-
-    return [string]

--- a/test/integration/targets/playbook/runme.sh
+++ b/test/integration/targets/playbook/runme.sh
@@ -35,7 +35,7 @@ echo "EXPECTED ERROR: Ensure we fail properly if a play has 0 hosts."
 set +e
 result="$(ansible-playbook -i ../../inventory empty_hosts.yml -v "$@" 2>&1)"
 set -e
-grep -q "ERROR! Hosts list cannot be empty - please check your playbook" <<< "$result"
+grep -q "ERROR! Hosts list cannot be empty. Please check your playbook" <<< "$result"
 
 # test that play errors if tasks is malformed
 echo "EXPECTED ERROR: Ensure we fail properly if tasks is malformed."

--- a/test/units/playbook/test_play.py
+++ b/test/units/playbook/test_play.py
@@ -27,6 +27,7 @@ from ansible.playbook.play import Play
 
 from units.mock.loader import DictDataLoader
 
+
 def test_empty_play():
     p = Play.load({})
 
@@ -36,10 +37,9 @@ def test_empty_play():
 def test_play_with_hosts_string():
     p = Play.load({'hosts': 'foo'})
 
-    assert str(p) == ''
-    assert p.get_name() == 'foo'
+    assert str(p) == 'foo'
 
-    # Test the caching
+    # Test the caching since self.name should be set by previous call.
     assert p.get_name() == 'foo'
 
 

--- a/test/units/playbook/test_play.py
+++ b/test/units/playbook/test_play.py
@@ -189,10 +189,8 @@ def test_play_empty_hosts(value):
 
 @pytest.mark.parametrize('value', ([None], (None,), ['one', None]))
 def test_play_none_hosts(value):
-    with pytest.raises(AnsibleParserError) as exc:
+    with pytest.raises(AnsibleParserError, match="Hosts list cannot contain values of 'None'"):
         Play.load({'hosts': value})
-
-    assert "Hosts list cannot contain values of 'None'" in exc.value.message
 
 
 @pytest.mark.parametrize(
@@ -203,10 +201,8 @@ def test_play_none_hosts(value):
     )
 )
 def test_play_invalid_hosts_sequence(value):
-    with pytest.raises(AnsibleParserError) as exc:
+    with pytest.raises(AnsibleParserError, match='Hosts list must be a sequence'):
         Play.load({'hosts': value})
-
-    assert 'Hosts list must be a sequence' in exc.value.message
 
 
 @pytest.mark.parametrize(
@@ -220,7 +216,5 @@ def test_play_invalid_hosts_sequence(value):
     )
 )
 def test_play_invalid_hosts_value(value):
-    with pytest.raises(AnsibleParserError) as exc:
+    with pytest.raises(AnsibleParserError, match='Hosts list contains an invalid host value'):
         Play.load({'hosts': value})
-
-    assert 'Hosts list contains an invalid host value' in exc.value.message

--- a/test/units/playbook/test_play.py
+++ b/test/units/playbook/test_play.py
@@ -168,3 +168,29 @@ def test_play_compile():
     # implicit meta flush_handler blocks inserted
     assert len(blocks) == 4
 
+
+@pytest.mark.parametrize(
+    'data, error',
+    (
+        ({'name': '', 'hosts': ''}, 'Hosts list cannot be empty'),
+        ({'hosts': ''}, 'Hosts list cannot be empty'),
+        ({'hosts': []}, 'Hosts list cannot be empty'),
+        ({'hosts': [None]}, 'Hosts list cannot be empty'),
+        ({'hosts': ['one', None, 'three']}, 'Hosts list cannot be empty'),
+        ({'hosts': [{'one': None}]}, 'Hosts list cannot be empty'),
+    ),
+    ids=[
+        'empty_name_hosts',
+        'no_name_empty_hosts_str',
+        'no_name_empt_hosts_list',
+        'no_name_hosts_list_all_none',
+        'no_name_hosts_list_some_none',
+        'no_name_host_dict_none',
+    ]
+)
+def test_play_with_invalid_hosts(data, error):
+    with pytest.raises(AnsibleParserError) as exc:
+        play = Play.load(data)
+        assert play.name == 'foo'
+
+    assert error in exc.value.message

--- a/test/units/playbook/test_play.py
+++ b/test/units/playbook/test_play.py
@@ -36,7 +36,11 @@ def test_empty_play():
 def test_play_with_hosts_string():
     p = Play.load({'hosts': 'foo'})
 
-    assert str(p) == 'foo'
+    assert str(p) == ''
+    assert p.get_name() == 'foo'
+
+    # Test the caching
+    assert p.get_name() == 'foo'
 
 
 def test_basic_play():

--- a/test/units/playbook/test_play.py
+++ b/test/units/playbook/test_play.py
@@ -172,12 +172,12 @@ def test_play_compile():
 @pytest.mark.parametrize(
     'data, error',
     (
-        ({'name': '', 'hosts': ''}, 'Hosts list cannot be empty'),
+        ({'name': '', 'hosts': ''}, 'Hosts list must be a sequence'),
         ({'hosts': ''}, 'Hosts list cannot be empty'),
         ({'hosts': []}, 'Hosts list cannot be empty'),
-        ({'hosts': [None]}, 'Hosts list cannot be empty'),
-        ({'hosts': ['one', None, 'three']}, 'Hosts list cannot be empty'),
-        ({'hosts': [{'one': None}]}, 'Hosts list cannot be empty'),
+        ({'hosts': [None]}, "Hosts list cannot contain values of 'None'"),
+        ({'hosts': ['one', None, 'three']}, "Hosts list cannot contain values of 'None'"),
+        ({'hosts': [{'one': None}]}, "Hosts list cannot contain values of 'None'"),
     ),
     ids=[
         'empty_name_hosts',
@@ -190,7 +190,6 @@ def test_play_compile():
 )
 def test_play_with_invalid_hosts(data, error):
     with pytest.raises(AnsibleParserError) as exc:
-        play = Play.load(data)
-        assert play.name == 'foo'
+        Play.load(data)
 
     assert error in exc.value.message

--- a/test/units/playbook/test_play.py
+++ b/test/units/playbook/test_play.py
@@ -226,10 +226,11 @@ def test_play_none_hosts(value):
     (
         {'one': None},
         {'one': 'two'},
+        None,
     )
 )
 def test_play_invalid_hosts_sequence(value):
-    with pytest.raises(AnsibleParserError, match='Hosts list must be a sequence'):
+    with pytest.raises(AnsibleParserError, match='Hosts list must be a sequence or string'):
         Play.load({'hosts': value})
 
 

--- a/test/units/playbook/test_play.py
+++ b/test/units/playbook/test_play.py
@@ -33,6 +33,12 @@ def test_empty_play():
     assert str(p) == ''
 
 
+def test_play_with_hosts_string():
+    p = Play.load({'hosts': 'foo'})
+
+    assert str(p) == 'foo'
+
+
 def test_basic_play():
     p = Play.load(dict(
         name="test play",
@@ -169,7 +175,7 @@ def test_play_compile():
     assert len(blocks) == 4
 
 
-@pytest.mark.parametrize('value', ('', set(), [], {}, None))
+@pytest.mark.parametrize('value', ([], tuple(), set(), {}, ''))
 def test_play_empty_hosts(value):
     with pytest.raises(AnsibleParserError) as exc:
         Play.load({'hosts': value})
@@ -177,7 +183,7 @@ def test_play_empty_hosts(value):
     assert 'Hosts list cannot be empty' in exc.value.message
 
 
-@pytest.mark.parametrize('value', ([None], (None,), set(('one', None)), ['one', None]))
+@pytest.mark.parametrize('value', ([None], (None,), ['one', None]))
 def test_play_none_hosts(value):
     with pytest.raises(AnsibleParserError) as exc:
         Play.load({'hosts': value})
@@ -199,8 +205,17 @@ def test_play_invalid_hosts_sequence(value):
     assert 'Hosts list must be a sequence' in exc.value.message
 
 
-@pytest.mark.parametrize('value', ([[1, 'two']]))
-def test_play_invalid_hosts(value):
+@pytest.mark.parametrize(
+    'value',
+    (
+        [[1, 'two']],
+        [{'one': None}],
+        [set((None, 'one'))],
+        ['one', 'two', {'three': None}],
+        ['one', 'two', {'three': 'four'}],
+    )
+)
+def test_play_invalid_hosts_value(value):
     with pytest.raises(AnsibleParserError) as exc:
         Play.load({'hosts': value})
 

--- a/test/units/playbook/test_play.py
+++ b/test/units/playbook/test_play.py
@@ -242,8 +242,6 @@ def test_play_invalid_hosts_sequence(value):
         [set((None, 'one'))],
         ['one', 'two', {'three': None}],
         ['one', 'two', {'three': 'four'}],
-        'one, [two, three]',
-        'one, two, three]',
     )
 )
 def test_play_invalid_hosts_value(value):

--- a/test/units/playbook/test_play.py
+++ b/test/units/playbook/test_play.py
@@ -207,12 +207,10 @@ def test_play_with_vars_files(value, expected):
     assert play.get_vars_files() == expected
 
 
-@pytest.mark.parametrize('value', ([], tuple(), set(), {}, ''))
+@pytest.mark.parametrize('value', ([], tuple(), set(), {}, '', None, False, 0))
 def test_play_empty_hosts(value):
-    with pytest.raises(AnsibleParserError) as exc:
+    with pytest.raises(AnsibleParserError, match='Hosts list cannot be empty'):
         Play.load({'hosts': value})
-
-    assert 'Hosts list cannot be empty' in exc.value.message
 
 
 @pytest.mark.parametrize('value', ([None], (None,), ['one', None]))
@@ -226,7 +224,6 @@ def test_play_none_hosts(value):
     (
         {'one': None},
         {'one': 'two'},
-        None,
         True,
         1,
         1.75,
@@ -245,6 +242,10 @@ def test_play_invalid_hosts_sequence(value):
         [set((None, 'one'))],
         ['one', 'two', {'three': None}],
         ['one', 'two', {'three': 'four'}],
+        'one, [two, three]',
+        'one, {two, three]',
+        'one, {two: three}',
+        '{one: two}',
     )
 )
 def test_play_invalid_hosts_value(value):

--- a/test/units/playbook/test_play.py
+++ b/test/units/playbook/test_play.py
@@ -227,6 +227,9 @@ def test_play_none_hosts(value):
         {'one': None},
         {'one': 'two'},
         None,
+        True,
+        1,
+        1.75,
     )
 )
 def test_play_invalid_hosts_sequence(value):

--- a/test/units/playbook/test_play.py
+++ b/test/units/playbook/test_play.py
@@ -22,6 +22,7 @@ __metaclass__ = type
 import pytest
 
 from ansible.errors import AnsibleAssertionError, AnsibleParserError
+from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
 from ansible.playbook.block import Block
 from ansible.playbook.play import Play
 from ansible.playbook.role import Role
@@ -227,6 +228,7 @@ def test_play_none_hosts(value):
         True,
         1,
         1.75,
+        AnsibleVaultEncryptedUnicode('secret'),
     )
 )
 def test_play_invalid_hosts_sequence(value):
@@ -242,6 +244,7 @@ def test_play_invalid_hosts_sequence(value):
         [set((None, 'one'))],
         ['one', 'two', {'three': None}],
         ['one', 'two', {'three': 'four'}],
+        [AnsibleVaultEncryptedUnicode('secret')],
     )
 )
 def test_play_invalid_hosts_value(value):

--- a/test/units/playbook/test_play.py
+++ b/test/units/playbook/test_play.py
@@ -207,6 +207,25 @@ def test_play_with_vars_files(value, expected):
     assert play.get_vars_files() == expected
 
 
+@pytest.mark.parametrize(
+    'value, expected',
+    (
+        ('host1', ['host1']),
+        ('host1,', ['host1']),
+        ('host1, host2', ['host1', ' host2']),
+        (['host1,host2'], ['host1', 'host2']),
+        (['host1,   host2'], ['host1', '   host2']),
+        (['host1', ['host2,host3,']], ['host1', 'host2', 'host3']),
+        (['host1', ['host2,host3,', ['host4', ['host5,host6']]]], ['host1', 'host2', 'host3', 'host4', 'host5', 'host6']),
+    )
+)
+def test_hosts_data(value, expected):
+    """Ensure host input is change to a valid host pattern"""
+
+    play = Play.load({'hosts': value})
+    assert play.hosts == expected
+
+
 @pytest.mark.parametrize('value', ([], tuple(), set(), {}, '', None, False, 0))
 def test_play_empty_hosts(value):
     with pytest.raises(AnsibleParserError, match='Hosts list cannot be empty'):
@@ -242,10 +261,6 @@ def test_play_invalid_hosts_sequence(value):
         [set((None, 'one'))],
         ['one', 'two', {'three': None}],
         ['one', 'two', {'three': 'four'}],
-        'one, [two, three]',
-        'one, {two, three]',
-        'one, {two: three}',
-        '{one: two}',
     )
 )
 def test_play_invalid_hosts_value(value):

--- a/test/units/playbook/test_play.py
+++ b/test/units/playbook/test_play.py
@@ -243,9 +243,7 @@ def test_play_invalid_hosts_sequence(value):
         ['one', 'two', {'three': None}],
         ['one', 'two', {'three': 'four'}],
         'one, [two, three]',
-        'one, {two, three]',
-        'one, {two: three}',
-        '{one: two}',
+        'one, two, three]',
     )
 )
 def test_play_invalid_hosts_value(value):
@@ -265,6 +263,12 @@ def test_play_no_name_hosts_sequence():
     play = Play.load({'hosts': ['host1', 'host2']})
 
     assert play.get_name() == 'host1,host2'
+
+
+def test_play_hosts_template_expression():
+    play = Play.load({'hosts': "{{ target_hosts }}"})
+
+    assert play.get_name() == '{{ target_hosts }}'
 
 
 @pytest.mark.parametrize(

--- a/test/units/playbook/test_play.py
+++ b/test/units/playbook/test_play.py
@@ -207,25 +207,6 @@ def test_play_with_vars_files(value, expected):
     assert play.get_vars_files() == expected
 
 
-@pytest.mark.parametrize(
-    'value, expected',
-    (
-        ('host1', ['host1']),
-        ('host1,', ['host1']),
-        ('host1, host2', ['host1', ' host2']),
-        (['host1,host2'], ['host1', 'host2']),
-        (['host1,   host2'], ['host1', '   host2']),
-        (['host1', ['host2,host3,']], ['host1', 'host2', 'host3']),
-        (['host1', ['host2,host3,', ['host4', ['host5,host6']]]], ['host1', 'host2', 'host3', 'host4', 'host5', 'host6']),
-    )
-)
-def test_hosts_data(value, expected):
-    """Ensure host input is change to a valid host pattern"""
-
-    play = Play.load({'hosts': value})
-    assert play.hosts == expected
-
-
 @pytest.mark.parametrize('value', ([], tuple(), set(), {}, '', None, False, 0))
 def test_play_empty_hosts(value):
     with pytest.raises(AnsibleParserError, match='Hosts list cannot be empty'):
@@ -261,6 +242,10 @@ def test_play_invalid_hosts_sequence(value):
         [set((None, 'one'))],
         ['one', 'two', {'three': None}],
         ['one', 'two', {'three': 'four'}],
+        'one, [two, three]',
+        'one, {two, three]',
+        'one, {two: three}',
+        '{one: two}',
     )
 )
 def test_play_invalid_hosts_value(value):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The `Play.load` method is defining `name` by joining values in `hosts` for the play. This should be done in `Play.get_name()`, allowing the `load` method to focus on loading data. Create a separate method for validating the values in `hosts`.

Fixes #65386
Closes #74054
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`ansible.playbook.play`

