### PR TITLE
2.11: Use a file-like obj for stdout/stderr for deadlock workaround (#74156)

### DIFF
--- a/changelogs/fragments/fix-for-workerprocess-stdout-deadlock-fix.yml
+++ b/changelogs/fragments/fix-for-workerprocess-stdout-deadlock-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - "WorkerProcess - Python 3.5 fix for workaround for stdout deadlock in multiprocessing shutdown to avoid process hangs. (https://github.com/ansible/ansible/issues/74149)"

--- a/lib/ansible/executor/process/worker.py
+++ b/lib/ansible/executor/process/worker.py
@@ -145,8 +145,7 @@ class WorkerProcess(multiprocessing_context.Process):
             # TODO: Evaluate overhauling ``Display`` to not write directly to stdout
             # and evaluate migrating away from the ``fork`` multiprocessing start method.
             if sys.version_info[0] >= 3:
-                sys.stdout = os.devnull
-                sys.stderr = os.devnull
+                sys.stdout = sys.stderr = open(os.devnull, 'w')
 
     def _run(self):
         '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of https://github.com/ansible/ansible/pull/74156

(cherry picked from commit 96f94c0fef18cf25f772a2b241b9c4ce9ab9b74e)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/executor/process/worker.py`