### PR TITLE
Fix "canonical" typo in win_host examples

### DIFF
--- a/lib/ansible/modules/windows/win_hosts.py
+++ b/lib/ansible/modules/windows/win_hosts.py
@@ -100,7 +100,7 @@ EXAMPLES = r'''
 - name: Remove 'bar' and 'zed' from the list of aliases for foo (192.168.1.100)
   win_hosts:
     state: present
-    canoncial_name: foo
+    canonical_name: foo
     ip_address: 192.168.1.100
     action: remove
     aliases:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix canonical typo in examples documentation for 2.9
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_hosts

