### PR TITLE
WiP: Binary runner

### DIFF
--- a/lib/ansible/plugins/action/bincall.py
+++ b/lib/ansible/plugins/action/bincall.py
@@ -20,8 +20,14 @@ class BinaryModule(ActionBase):
        |
        +-- <name>-<osname>-<arch>
 
+    If a 'binary' module is actually a script (e.g. Perl script),
+    it does not need to be explicitly verified for the platform and architecture,
+    therefore can be also called generic way:
+
+        <name>-any-noarch
     """
     NAME = ""
+    BINARY = True
 
     def __init__(self, *args, **kwargs):
         ActionBase.__init__(self, *args, **kwargs)
@@ -31,14 +37,17 @@ class BinaryModule(ActionBase):
             raise Exception("Module name was not yet set")
 
         # Determine what is the target platform and choose the binary module accordingly
-        platform = self._low_level_execute_command("uname -sm")
-        if platform["rc"]:
-            raise Exception(platform["stderr"])
-        sysarch = platform["stdout"].lower().strip().split(" ")
-        if len(sysarch) == 2:
-            system, arch = sysarch
+        if self.BINARY:
+            platform = self._low_level_execute_command("uname -sm")
+            if platform["rc"]:
+                raise Exception(platform["stderr"])
+            sysarch = platform["stdout"].lower().strip().split(" ")
+            if len(sysarch) == 2:
+                system, arch = sysarch
+            else:
+                raise Exception("Unknown platform: {}".format(platform["stdout"]))
         else:
-            raise Exception("Unknown platform: {}".format(platform["stdout"]))
+            system, arch = "any", "noarch"
 
         self.module_name = "{}-{}-{}".format(self.NAME, system, arch)
 

--- a/lib/ansible/plugins/action/bincall.py
+++ b/lib/ansible/plugins/action/bincall.py
@@ -1,0 +1,62 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+
+from ansible.errors import AnsibleError
+from ansible.module_utils.json_utils import _filter_non_json_lines
+from ansible.plugins.action import ActionBase
+
+class BinaryModule(ActionBase):
+    """
+    Action plugin for calling binary modules.
+    Required layout:
+
+    +- action_plugins
+    |  |
+    |  +-- <name>.py
+    |
+    +- library
+       |
+       +-- <name>-<osname>-<arch>
+
+    """
+    NAME = ""
+
+    def __init__(self, *args, **kwargs):
+        ActionBase.__init__(self, *args, **kwargs)
+        self._supports_async = True
+
+        if not self.NAME:
+            raise Exception("Module name was not yet set")
+
+        # Determine what is the target platform and choose the binary module accordingly
+        platform = self._low_level_execute_command("uname -sm")
+        if platform["rc"]:
+            raise Exception(platform["stderr"])
+        sysarch = platform["stdout"].lower().strip().split(" ")
+        if len(sysarch) == 2:
+            system, arch = sysarch
+        else:
+            raise Exception("Unknown platform: {}".format(platform["stdout"]))
+
+        self.module_name = "{}-{}-{}".format(self.NAME, system, arch)
+
+    def run(self, tmp=None, task_vars=None):
+        """
+        Call a binary module according to the platform specifics.
+        """
+        if not task_vars:
+            task_vars = {}
+
+        result = ActionBase.run(self, tmp=tmp, task_vars=task_vars)
+        result.update(
+            self._execute_module(
+                module_name=self.module_name,
+                module_args=self._task.args,
+                task_vars=task_vars,
+                wrap_async=self._task.async_val
+            )
+        )
+
+        return result


### PR DESCRIPTION
##### SUMMARY
Extend Ansible to run binary modules, those are written in compiled languages like Go, Rust, C etc or scripting languages like Bash, Perl, Ruby and so on.

##### Problem
Collections are not aware of architecture and/or binary modules. This mechanism allows to fill this gap in Ansible by providing a wrapper, which would do the job calling modules, and only require to create a simple description in Python. This is how it normally works, assuming your module is called `my_module`:

1. Create `action_plugins` and `library` directories
2. Place your statically compiled module (or Perl/Ruby/Bash script) to `library` directory and call it according to the following convention:
   - Binary modules should be called `<name>-<os>-<arch>`. E.g.: `my_module-linux-x86_64`.
   - Non-binary (scripting) modules should be called `<name>-multi-noarch`. E.g.: `my_module-multi-noarch`.
   - If for some odd reasons there are both binary and scripting implementation of the same module, scripting module should be then called according to the binary convention.

3. Create `my_module.py` in the `action_plugins` directory and use the following Python code:

```python
from __future__ import absolute_import
from ansible.plugins.action.bincall import BinaryModule

class ActionModule(BinaryModule):
    NAME = "my_module"
```

In case your non-Ansible module is a script, configure `ActionModule` class accordingly:

```python
class ActionModule(BinaryModule):
    NAME = "my_module"
    BINARY = False
```

##### ISSUE TYPE
- Feature Pull Request

##### Alternatives and Proposals

@bcoca points (IRC):
- Do not have naming convention, but read executable header to determine which one is needed
- Binary modules are rare and not often shared, therefore this utility can be just shipped with the particular collection separately. If more binary collections needed, they either duplicate the code or depend on the collection that brings that wrapper code

Open questions to the point above:
- The proposed solution (credit for the ideas & PoC to @sivel ) is made to be generic for _any_ non-Ansible standalone module, so therefore the wrapping code does not need to be re-delivered/re-deployed every time in each collection like that. How do we avoid re-distributing the same functionality that will/might lead to more bugs and difficult maintenance?
- How do we eliminate unnecessary dependencies only to use that utility code for sake of only calling the binary module?
- Rare binary module occurrences is a very good point raised by @bcoca and raises the necessity to support binary modules at that level. However, unclear rules to binary modules might be one of the reasons why binary modules are not yet so popular. Would it be actually good to have something standard and make the architecture for binary modules is firm and equal as Ansible Python modules?
- If dropping naming convention and reading only headers from the pre-compiled binaries (as @bcoca suggested), how to make it efficient and precise? E.g. how to choose a proper module on a multitude of embedded devices that shares the same CPU architecture but are slightly different from each other and therefore need a slightly different modules for each? Also, before deploying a binary module to a target, Ansible would require a call to fetch the information about the target beforehand, e.g. an OS type and architecture. At the same call it also might fetch additional information, that is not possible to find out in just reading binary: a hardware type (and thus a different module might be necessary to select).
