### PR TITLE
[stable-2.11] Update test containers in ansible-test. (#74166)

### DIFF
--- a/changelogs/fragments/ansible-test-default-containers-3.2.yml
+++ b/changelogs/fragments/ansible-test-default-containers-3.2.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - ansible-test - Update the Ansible Core and Ansible Collection default test containers to 3.2.0 and 3.2.2 respectively.

--- a/changelogs/fragments/ansible-test-distro-containers-2.0.2.yml
+++ b/changelogs/fragments/ansible-test-distro-containers-2.0.2.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - ansible-test - Update distribution test containers from version 2.0.1 to 2.0.2.

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,12 +1,12 @@
-default name=quay.io/ansible/default-test-container:3.1.0 python=3.6,2.6,2.7,3.5,3.7,3.8,3.9 seccomp=unconfined context=collection
-default name=quay.io/ansible/ansible-core-test-container:3.1.0 python=3.6,2.6,2.7,3.5,3.7,3.8,3.9 seccomp=unconfined context=ansible-core
-alpine3 name=quay.io/ansible/alpine3-test-container:2.0.1 python=3.8
-centos6 name=quay.io/ansible/centos6-test-container:2.0.1 python=2.6 seccomp=unconfined
-centos7 name=quay.io/ansible/centos7-test-container:2.0.1 python=2.7 seccomp=unconfined
-centos8 name=quay.io/ansible/centos8-test-container:2.0.1 python=3.6 seccomp=unconfined
-fedora32 name=quay.io/ansible/fedora32-test-container:2.0.1 python=3.8
-fedora33 name=quay.io/ansible/fedora33-test-container:2.0.1 python=3.9
-opensuse15py2 name=quay.io/ansible/opensuse15py2-test-container:2.0.1 python=2.7
-opensuse15 name=quay.io/ansible/opensuse15-test-container:2.0.1 python=3.6
-ubuntu1804 name=quay.io/ansible/ubuntu1804-test-container:2.0.1 python=3.6 seccomp=unconfined
-ubuntu2004 name=quay.io/ansible/ubuntu2004-test-container:2.0.1 python=3.8 seccomp=unconfined
+default name=quay.io/ansible/default-test-container:3.2.2 python=3.6,2.6,2.7,3.5,3.7,3.8,3.9 seccomp=unconfined context=collection
+default name=quay.io/ansible/ansible-core-test-container:3.2.0 python=3.6,2.6,2.7,3.5,3.7,3.8,3.9 seccomp=unconfined context=ansible-core
+alpine3 name=quay.io/ansible/alpine3-test-container:2.0.2 python=3.8
+centos6 name=quay.io/ansible/centos6-test-container:2.0.2 python=2.6 seccomp=unconfined
+centos7 name=quay.io/ansible/centos7-test-container:2.0.2 python=2.7 seccomp=unconfined
+centos8 name=quay.io/ansible/centos8-test-container:2.0.2 python=3.6 seccomp=unconfined
+fedora32 name=quay.io/ansible/fedora32-test-container:2.0.2 python=3.8
+fedora33 name=quay.io/ansible/fedora33-test-container:2.0.2 python=3.9
+opensuse15py2 name=quay.io/ansible/opensuse15py2-test-container:2.0.2 python=2.7
+opensuse15 name=quay.io/ansible/opensuse15-test-container:2.0.2 python=3.6
+ubuntu1804 name=quay.io/ansible/ubuntu1804-test-container:2.0.2 python=3.6 seccomp=unconfined
+ubuntu2004 name=quay.io/ansible/ubuntu2004-test-container:2.0.2 python=3.8 seccomp=unconfined


### PR DESCRIPTION
##### SUMMARY

* Update distro test containers to version 2.0.2.
* Update the default test containers.

Backport of https://github.com/ansible/ansible/pull/74166

(cherry picked from commit 459ea5a4a48b770f09be9b8f48f2593594f348f2)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
