### PR TITLE
[stable-2.9] Switch to hashlib.sha256() for ansible-test (#72411)

### DIFF
--- a/changelogs/fragments/72411-fips-mode-ansible-test.yml
+++ b/changelogs/fragments/72411-fips-mode-ansible-test.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Switch to hashlib.sha256() for ansible-test to allow for FIPs mode.

--- a/test/lib/ansible_test/_internal/executor.py
+++ b/test/lib/ansible_test/_internal/executor.py
@@ -2004,7 +2004,7 @@ class EnvironmentDescription:
         if not os.path.exists(path):
             return None
 
-        file_hash = hashlib.md5()
+        file_hash = hashlib.sha256()
 
         with open(path, 'rb') as file_fd:
             file_hash.update(file_fd.read())


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/72411

(cherry picked from commit a95213d2f521bc281f2be102a1b7008bc6762a7c)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
