### PR TITLE
Remove needless get_next_task_for_host calls

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -548,9 +548,7 @@ class StrategyBase:
                         # if we're using run_once, we have to fail every host here
                         for h in self._inventory.get_hosts(iterator._play.hosts):
                             if h.name not in self._tqm._unreachable_hosts:
-                                state, _ = iterator.get_next_task_for_host(h, peek=True)
                                 iterator.mark_host_failed(h)
-                                state, new_task = iterator.get_next_task_for_host(h, peek=True)
                     else:
                         iterator.mark_host_failed(original_host)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Called with `peek=True` and the return values are not used.

ci_complete
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Introduced in https://github.com/ansible/ansible/commit/c669a381d117ccd96d4d59ab9191a107d08dfdb4
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/strategy/__init__.py`