### PR TITLE
ansible-test - change diff matching regexp so prefixes are optional

### DIFF
--- a/changelogs/fragments/ansible-test-diff-prefix-optional.yml
+++ b/changelogs/fragments/ansible-test-diff-prefix-optional.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    ansible-test - make the ``a/`` and ``b/`` prefixes an optional match
+    since these can be turned off with the ``diff.noprefix`` setting in ``git``

--- a/test/lib/ansible_test/_internal/diff.py
+++ b/test/lib/ansible_test/_internal/diff.py
@@ -180,7 +180,7 @@ class DiffParser:
         """Process a diff start line."""
         self.complete_file()
 
-        match = re.search(r'^diff --git "?a/(?P<old_path>.*)"? "?b/(?P<new_path>.*)"?$', self.line)
+        match = re.search(r'^diff --git "?(?:a/)?(?P<old_path>.*)"? "?(?:b/)?(?P<new_path>.*)"?$', self.line)
 
         if not match:
             raise Exception('Unexpected diff start line.')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `a/` and `b/` prefixes can be disabled in the `git diff` output by setting `diff.noprefix` to `true`. The output is still a valid diff, but `ansible-test` would raise an exception since without the prefixes, since it thought the diff line was invalid.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/lib/ansible_test/_internal/diff.py`