### PR TITLE
[stable-2.10] ansible-test - ensure trailing separator is added for connection unit test target (#74176)

### DIFF
--- a/changelogs/fragments/ansible-test-connection-units-init.yml
+++ b/changelogs/fragments/ansible-test-connection-units-init.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    ansible-test - ensure the correct unit test target is given when the
+    ``__init__.py`` file is modified inside the connection plugins directory

--- a/test/lib/ansible_test/_internal/classification.py
+++ b/test/lib/ansible_test/_internal/classification.py
@@ -527,7 +527,7 @@ class PathMapper:
                     'integration': self.integration_all_target,
                     'windows-integration': self.integration_all_target,
                     'network-integration': self.integration_all_target,
-                    'units': units_dir,
+                    'units': os.path.join(units_dir, ''),
                 }
 
             units_path = os.path.join(units_dir, 'test_%s.py' % name)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #74176 for Ansible 2.10.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/lib/ansible_test/_internal/classification.py`