### PR TITLE
Add PyPI proxy container for tests on Python 2.6.

### DIFF
--- a/changelogs/fragments/ansible-test-pypi-test-container.yml
+++ b/changelogs/fragments/ansible-test-pypi-test-container.yml
@@ -1,0 +1,3 @@
+major_changes:
+  - ansible-test - Tests run with the ``centos6`` and ``default`` test containers now use a PyPI proxy container to access PyPI when Python 2.6 is used.
+                   This allows tests running under Python 2.6 to continue functioning even though PyPI is discontinuing support for non-SNI capable clients.

--- a/test/lib/ansible_test/_data/quiet_pip.py
+++ b/test/lib/ansible_test/_data/quiet_pip.py
@@ -13,6 +13,7 @@ LOGGING_MESSAGE_FILTER = re.compile("^("
                                     ".*Running pip install with root privileges is generally not a good idea.*|"  # custom Fedora patch [1]
                                     "DEPRECATION: Python 2.7 will reach the end of its life .*|"  # pip 19.2.3
                                     "Ignoring .*: markers .* don't match your environment|"
+                                    "Looking in indexes: .*|"  # pypi-test-container
                                     "Requirement already satisfied.*"
                                     ")$")
 

--- a/test/lib/ansible_test/_internal/cli.py
+++ b/test/lib/ansible_test/_internal/cli.py
@@ -39,6 +39,7 @@ from .executor import (
     Delegate,
     generate_pip_install,
     check_startup,
+    configure_pypi_proxy,
 )
 
 from .config import (
@@ -170,6 +171,7 @@ def main():
         display.info('MAXFD: %d' % MAXFD, verbosity=2)
 
         try:
+            configure_pypi_proxy(config)
             args.func(config)
             delegate_args = None
         except Delegate as ex:
@@ -235,6 +237,15 @@ def parse_args():
                         action='count',
                         default=0,
                         help='display more output')
+
+    common.add_argument('--pypi-proxy',
+                        action='store_true',
+                        help=argparse.SUPPRESS)  # internal use only
+
+    common.add_argument('--pypi-endpoint',
+                        metavar='URI',
+                        default=None,
+                        help=argparse.SUPPRESS)  # internal use only
 
     common.add_argument('--color',
                         metavar='COLOR',

--- a/test/lib/ansible_test/_internal/config.py
+++ b/test/lib/ansible_test/_internal/config.py
@@ -68,6 +68,9 @@ class EnvironmentConfig(CommonConfig):
         """
         super(EnvironmentConfig, self).__init__(args, command)
 
+        self.pypi_endpoint = args.pypi_endpoint  # type: str
+        self.pypi_proxy = args.pypi_proxy  # type: bool
+
         self.local = args.local is True
         self.venv = args.venv
         self.venv_system_site_packages = args.venv_system_site_packages

--- a/test/lib/ansible_test/_internal/delegation.py
+++ b/test/lib/ansible_test/_internal/delegation.py
@@ -19,6 +19,7 @@ from .executor import (
     HTTPTESTER_HOSTS,
     create_shell_command,
     run_httptester,
+    run_pypi_proxy,
     start_httptester,
     get_python_interpreter,
     get_python_version,
@@ -285,6 +286,11 @@ def delegate_docker(args, exclude, require, integration_targets):
     if isinstance(args, ShellConfig) or (isinstance(args, IntegrationConfig) and args.debug_strategy):
         cmd_options.append('-it')
 
+    pypi_proxy_id, pypi_proxy_endpoint = run_pypi_proxy(args)
+
+    if pypi_proxy_endpoint:
+        cmd += ['--pypi-endpoint', pypi_proxy_endpoint]
+
     with tempfile.NamedTemporaryFile(prefix='ansible-source-', suffix='.tgz') as local_source_fd:
         try:
             create_payload(args, local_source_fd.name)
@@ -405,6 +411,9 @@ def delegate_docker(args, exclude, require, integration_targets):
         finally:
             if httptester_id:
                 docker_rm(args, httptester_id)
+
+            if pypi_proxy_id:
+                docker_rm(args, pypi_proxy_id)
 
             if test_id:
                 if args.docker_terminate == 'always' or (args.docker_terminate == 'success' and success):

--- a/test/lib/ansible_test/_internal/docker_util.py
+++ b/test/lib/ansible_test/_internal/docker_util.py
@@ -112,7 +112,7 @@ def get_docker_container_ip(args, container_id):
     networks = network_settings.get('Networks')
 
     if networks:
-        network_name = get_docker_preferred_network_name(args)
+        network_name = get_docker_preferred_network_name(args) or 'bridge'
         ipaddress = networks[network_name]['IPAddress']
     else:
         # podman doesn't provide Networks, fall back to using IPAddress


### PR DESCRIPTION
##### SUMMARY

Add PyPI proxy container for tests on Python 2.6.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

Resolves https://github.com/ansible/ansible/issues/74120
Resolves https://github.com/ansible/ansible/issues/74014