### PR TITLE
fix typo in _collection_finder.py

### DIFF
--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -86,7 +86,7 @@ class _AnsibleCollectionFinder:
         # expand any placeholders in configured paths
         for p in paths:
 
-            # ensure we alway shave ansible_collections
+            # ensure we always shave ansible_collections
             if os.path.basename(p) == 'ansible_collections':
                 p = os.path.dirname(p)
 

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -86,7 +86,7 @@ class _AnsibleCollectionFinder:
         # expand any placeholders in configured paths
         for p in paths:
 
-            # ensure we always shave ansible_collections
+            # ensure we always have ansible_collections
             if os.path.basename(p) == 'ansible_collections':
                 p = os.path.dirname(p)
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed minor typo.

`alway` -> `always`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
