### PR TITLE
[WIP] [might be horrible] Modulify async_wrapper + remove deprecations

### DIFF
--- a/changelogs/fragments/deprecate-ansible-async-dir-envvar.yml
+++ b/changelogs/fragments/deprecate-ansible-async-dir-envvar.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "async tasks - the use of the task-level ``ANSIBLE_ASYNC_DIR`` variable within ``environment:`` is no longer valid. Use the shell configuration variable ``async_dir`` instead."
+  - async_wrapper - internal restructuring, making use of ``AnsibleModule`` and deduplicating JSON code.

--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.12.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.12.rst
@@ -19,8 +19,18 @@ This document is part of a collection on porting. The complete list of porting g
 Playbook
 ========
 
-No notable changes
+* When calling tasks and setting ``async``, setting ``ANSIBLE_ASYNC_DIR`` under ``environment:`` is no longer valid. Instead, use the shell configuration variable ``async_dir``, for example by setting ``ansible_async_dir``:
 
+.. code-block:: yaml
+
+   tasks:
+     - dnf:
+         name: '*'
+         state: latest
+       async: 300
+       poll: 5
+       vars:
+         ansible_async_dir: /path/to/my/custom/dir
 
 Command Line
 ============

--- a/lib/ansible/module_utils/json_utils.py
+++ b/lib/ansible/module_utils/json_utils.py
@@ -29,9 +29,6 @@ __metaclass__ = type
 
 import json
 
-
-# NB: a copy of this function exists in ../../modules/core/async_wrapper.py. Ensure any
-# changes are propagated there.
 def _filter_non_json_lines(data, objects_only=False):
     '''
     Used to filter unrelated output around module JSON output, like messages from

--- a/lib/ansible/module_utils/json_utils.py
+++ b/lib/ansible/module_utils/json_utils.py
@@ -29,6 +29,7 @@ __metaclass__ = type
 
 import json
 
+
 def _filter_non_json_lines(data, objects_only=False):
     '''
     Used to filter unrelated output around module JSON output, like messages from

--- a/lib/ansible/modules/async_wrapper.py
+++ b/lib/ansible/modules/async_wrapper.py
@@ -113,6 +113,7 @@ def daemonize_self():
     os.dup2(dev_null.fileno(), sys.stdout.fileno())
     os.dup2(dev_null.fileno(), sys.stderr.fileno())
 
+
 def _get_interpreter(module_path):
     with open(module_path, 'rb') as module_fd:
         head = module_fd.read(1024)
@@ -215,7 +216,7 @@ def main():
             preserve_tmp=dict(type='bool', default=False),
             async_dir=dict(type='path', required=True),
         ),
-        supports_check_mode=False, # ??? The module does, the wrapper doesn't.
+        supports_check_mode=False,  # ??? The module does (maybe), the wrapper doesn't.
     )
 
     jid = "{0}.{1}".format(module.params['jid'], os.getpid())
@@ -332,6 +333,7 @@ def main():
         e = sys.exc_info()[1]
         notice("error: %s" % e)
         module.fail_json(msg="FATAL ERROR: {0}".format(to_text(e)))
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1035,7 +1035,10 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             self._transfer_data(remote_async_module_path, async_module_data)
             remote_files.append(remote_async_module_path)
 
-            cmd = remote_async_module_path
+            cmd = self._connection._shell.build_module_command(
+                environment_string,
+                shebang,
+                remote_async_module_path).strip()
         else:
             if self._is_pipelining_enabled(module_style):
                 in_data = module_data
@@ -1043,11 +1046,11 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             else:
                 cmd = remote_module_path
 
-        cmd = self._connection._shell.build_module_command(
-            environment_string,
-            shebang,
-            cmd,
-            arg_path=args_file_path).strip()
+            cmd = self._connection._shell.build_module_command(
+                environment_string,
+                shebang,
+                cmd,
+                arg_path=args_file_path).strip()
 
         # Fix permissions of the tmpdir path and tmpdir files. This should be called after all
         # files have been transferred.

--- a/lib/ansible/plugins/action/async_status.py
+++ b/lib/ansible/plugins/action/async_status.py
@@ -21,23 +21,7 @@ class ActionModule(ActionBase):
             raise AnsibleError("jid is required")
         jid = self._task.args["jid"]
         mode = self._task.args.get("mode", "status")
-
-        env_async_dir = [e for e in self._task.environment if
-                         "ANSIBLE_ASYNC_DIR" in e]
-        if len(env_async_dir) > 0:
-            # for backwards compatibility we need to get the dir from
-            # ANSIBLE_ASYNC_DIR that is defined in the environment. This is
-            # deprecated and will be removed in favour of shell options
-            async_dir = env_async_dir[0]['ANSIBLE_ASYNC_DIR']
-
-            msg = "Setting the async dir from the environment keyword " \
-                  "ANSIBLE_ASYNC_DIR is deprecated. Set the async_dir " \
-                  "shell option instead"
-            self._display.deprecated(msg, "2.12", collection_name='ansible.builtin')
-        else:
-            # inject the async directory based on the shell option into the
-            # module args
-            async_dir = self.get_shell_option('async_dir', default="~/.ansible_async")
+        async_dir = self.get_shell_option('async_dir', default="~/.ansible_async")
 
         module_args = dict(jid=jid, mode=mode, _async_dir=async_dir)
         status = self._execute_module(module_name='ansible.legacy.async_status', task_vars=task_vars,

--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -244,31 +244,6 @@
       path: '{{ custom_async_tmp }}'
       state: absent
 
-  - name: run async task with custom dir - deprecated format
-    command: sleep 1
-    register: async_custom_dir_dep
-    async: 5
-    poll: 1
-    environment:
-      ANSIBLE_ASYNC_DIR: '{{ custom_async_tmp }}'
-
-  - name: check if the async temp dir is created - deprecated format
-    stat:
-      path: '{{ custom_async_tmp }}'
-    register: async_custom_dir_dep_result
-
-  - name: assert run async task with custom dir - deprecated format
-    assert:
-      that:
-      - async_custom_dir_dep is successful
-      - async_custom_dir_dep is finished
-      - async_custom_dir_dep_result.stat.exists
-
-  - name: remove custom async dir after deprecation test
-    file:
-      path: '{{ custom_async_tmp }}'
-      state: absent
-
   - name: run fire and forget async task with custom dir
     command: echo moo
     register: async_fandf_custom_dir
@@ -290,13 +265,6 @@
     vars:
       ansible_async_dir: '{{ custom_async_tmp }}'
 
-  - name: get async status with custom dir - deprecated format
-    async_status:
-      jid: '{{ async_fandf_custom_dir.ansible_job_id }}'
-    register: async_fandf_custom_dir_dep_result
-    environment:
-      ANSIBLE_ASYNC_DIR: '{{ custom_async_tmp }}'
-
   - name: assert run fire and forget async task with custom dir
     assert:
       that:
@@ -304,7 +272,6 @@
       - async_fandf_custom_dir_fail is failed
       - async_fandf_custom_dir_fail.msg == "could not find job"
       - async_fandf_custom_dir_result is successful
-      - async_fandf_custom_dir_dep_result is successful
 
   always:
   - name: remove custom tmp dir after test

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -91,7 +91,6 @@ lib/ansible/modules/assemble.py validate-modules:nonexistent-parameter-documente
 lib/ansible/modules/async_status.py use-argspec-type-path
 lib/ansible/modules/async_status.py validate-modules!skip
 lib/ansible/modules/async_wrapper.py ansible-doc!skip  # not an actual module
-lib/ansible/modules/async_wrapper.py pylint:ansible-bad-function # ignore, required
 lib/ansible/modules/async_wrapper.py use-argspec-type-path
 lib/ansible/modules/blockinfile.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/blockinfile.py validate-modules:doc-default-does-not-match-spec
@@ -148,8 +147,6 @@ lib/ansible/playbook/conditional.py pylint:ansible-deprecated-version
 lib/ansible/playbook/helpers.py pylint:ansible-deprecated-version
 lib/ansible/playbook/helpers.py pylint:blacklisted-name
 lib/ansible/playbook/play_context.py pylint:ansible-deprecated-version
-lib/ansible/plugins/action/__init__.py pylint:ansible-deprecated-version
-lib/ansible/plugins/action/async_status.py pylint:ansible-deprecated-version
 lib/ansible/plugins/action/normal.py action-plugin-docs # default action plugin for modules without a dedicated action plugin
 lib/ansible/plugins/cache/__init__.py pylint:ansible-deprecated-version
 lib/ansible/plugins/cache/base.py ansible-doc!skip  # not a plugin, but a stub for backwards compatibility

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -225,16 +225,6 @@ class TestActionBase(unittest.TestCase):
         env_string = action_base._compute_environment_string()
         self.assertEqual(env_string, "FOO=bar")
 
-        # test environment with multiple items (order)
-        mock_task.environment = [dict(FOO='foo'), dict(BAR='baz'), dict(WHAT='hi'), None]
-        env_string = action_base._compute_environment_string()
-        self.assertEqual(env_string, "FOO=foo BAR=baz WHAT=hi")
-
-        # test environment with duplicate items
-        mock_task.environment = [dict(FOO='foo'), dict(BAR='baz'), dict(FOO='hi'), None]
-        env_string = action_base._compute_environment_string()
-        self.assertEqual(env_string, "FOO=hi BAR=baz")
-
         # test with a bad environment set
         mock_task.environment = dict(FOO='foo')
         mock_task.environment = ['hi there']

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -225,6 +225,16 @@ class TestActionBase(unittest.TestCase):
         env_string = action_base._compute_environment_string()
         self.assertEqual(env_string, "FOO=bar")
 
+        # test environment with multiple items (order)
+        mock_task.environment = [dict(FOO='foo'), dict(BAR='baz'), dict(WHAT='hi'), None]
+        env_string = action_base._compute_environment_string()
+        self.assertEqual(env_string, "FOO=foo BAR=baz WHAT=hi")
+
+        # test environment with duplicate items
+        mock_task.environment = [dict(FOO='foo'), dict(BAR='baz'), dict(FOO='hi'), None]
+        env_string = action_base._compute_environment_string()
+        self.assertEqual(env_string, "FOO=hi BAR=baz")
+
         # test with a bad environment set
         mock_task.environment = dict(FOO='foo')
         mock_task.environment = ['hi there']


### PR DESCRIPTION

##### SUMMARY

Change:
- Remove use of ANSIBLE_ASYNC_DIR from ActionBase and async_status.
- Use AnsibleModule in async_wrapper to take args including async_dir
  without hacky argv parsing and env vars.
- Remove duplicate _filter_non_json_lines() implementation.
- Drop py24 hack in async_wrapper.py.
- Drop use of ANSIBLE_ASYNC_DIR from async tests.
- Add porting guide and changelog docs.

Test Plan:
- ci_complete

Tickets:
- Fixes #74139
- Fixes #74138

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
async_wrapper