### PR TITLE
Handle None values in cmd_quote

### DIFF
--- a/test/lib/ansible_test/_internal/util_common.py
+++ b/test/lib/ansible_test/_internal/util_common.py
@@ -58,7 +58,7 @@ class ShellScriptTemplate:
 
     def substitute(self, **kwargs):
         """Return a string templated with the given arguments."""
-        kvp = dict((k, cmd_quote(v)) for k, v in kwargs.items())
+        kvp = dict((k, cmd_quote(v or '')) for k, v in kwargs.items())
         pattern = re.compile(r'#{(?P<name>[^}]+)}')
         value = pattern.sub(lambda match: kvp[match.group('name')], self.template)
         return value


### PR DESCRIPTION
##### SUMMARY

* Handle None values for ``shlex.quote()`` API in Python 2

Fixes: #73674

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/lib/ansible_test/_internal/util_common.py
