### PR TITLE
[ansible-test] Fix coverage in virtualenv-isolated

### DIFF
--- a/changelogs/fragments/ansible-test-virtualenv-isolated-coverage.yml
+++ b/changelogs/fragments/ansible-test-virtualenv-isolated-coverage.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - virtualenv-isolated.sh injected script no longer references an invalid constraints file path.

--- a/test/lib/ansible_test/_data/injector/virtualenv-isolated.sh
+++ b/test/lib/ansible_test/_data/injector/virtualenv-isolated.sh
@@ -14,5 +14,5 @@ source "${OUTPUT_DIR}/venv/bin/activate"
 set -ux
 
 if [[ "${ANSIBLE_TEST_COVERAGE}" ]]; then
-    pip install coverage -c ../../../runner/requirements/constraints.txt --disable-pip-version-check
+    pip install coverage -c $OUTPUT_DIR/../../../lib/ansible_test/_data/requirements/constraints.txt --disable-pip-version-check
 fi

--- a/test/lib/ansible_test/_data/injector/virtualenv-isolated.sh
+++ b/test/lib/ansible_test/_data/injector/virtualenv-isolated.sh
@@ -14,5 +14,5 @@ source "${OUTPUT_DIR}/venv/bin/activate"
 set -ux
 
 if [[ "${ANSIBLE_TEST_COVERAGE}" ]]; then
-    pip install coverage -c $OUTPUT_DIR/../../../lib/ansible_test/_data/requirements/constraints.txt --disable-pip-version-check
+    pip install coverage -c "${_ANSIBLE_COVERAGE_CONSTRAINTS}" --disable-pip-version-check
 fi

--- a/test/lib/ansible_test/_internal/executor.py
+++ b/test/lib/ansible_test/_internal/executor.py
@@ -1601,6 +1601,7 @@ def integration_environment(args, target, test_dir, inventory_path, ansible_conf
         ANSIBLE_TEST_COVERAGE='check' if args.coverage_check else ('yes' if args.coverage else ''),
         OUTPUT_DIR=test_dir,
         INVENTORY_PATH=os.path.abspath(inventory_path),
+        _ANSIBLE_COVERAGE_CONSTRAINTS=os.path.join(ANSIBLE_TEST_DATA_ROOT, 'requirements', 'constraints.txt'),
     )
 
     if args.debug_strategy:


### PR DESCRIPTION
##### SUMMARY

Change:
- When run with `--coverage`, virtualenv-isolated.sh was referencing
  an old ansible-test path for its constraints file. This made it
  error out when being used with a target and `--coverage`.
- Update it to use the current global ansible-test constraints.txt.

Test Plan:
- Local testing with a new integration target in another branch.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Test Pull Request

##### COMPONENT NAME

ansible-test