### PR TITLE
Fix links to the collections org in doc & FR forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -96,7 +96,7 @@ body:
       appropriate project there instead.
 
 
-      [collections org]: ../../ansible-collections
+      [collections org]: /ansible-collections
     placeholder: docs/docsite/rst/dev_guide/debugging.rst
   validations:
     required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -138,7 +138,7 @@ body:
       appropriate project there instead.
 
 
-      [collections org]: ../../ansible-collections
+      [collections org]: /ansible-collections
     placeholder: dnf, apt, yum, pip, user etc.
   validations:
     required: true


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It's a follow-up hotfix for #74185 — 2/3 templates had broken links to @ansible-collections that I noticed post-merge. This patch fixes that.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Maintenance Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
.github/ISSUE_TEMPLATE/

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
N/A