### PR TITLE
updates list of available versions for Ansible 3

### DIFF
--- a/docs/docsite/sphinx_conf/ansible_conf.py
+++ b/docs/docsite/sphinx_conf/ansible_conf.py
@@ -158,7 +158,7 @@ html_context = {
     'github_root_dir': 'devel/lib/ansible',
     'github_cli_version': 'devel/lib/ansible/cli/',
     'current_version': version,
-    'latest_version': '2.10',
+    'latest_version': '3',
     # list specifically out of order to make latest work
     'available_versions': ('latest', '2.9', 'devel'),
     'css_files': ('_static/ansible.css',  # overrides to the standard theme

--- a/docs/docsite/sphinx_conf/ansible_conf.py
+++ b/docs/docsite/sphinx_conf/ansible_conf.py
@@ -160,7 +160,7 @@ html_context = {
     'current_version': version,
     'latest_version': '2.10',
     # list specifically out of order to make latest work
-    'available_versions': ('latest', '2.9', '2.9_ja', '2.8', 'devel'),
+    'available_versions': ('latest', '2.9', 'devel'),
     'css_files': ('_static/ansible.css',  # overrides to the standard theme
                   ),
 }


### PR DESCRIPTION
##### SUMMARY
Update the docs version-switcher to reflect the currently maintained versions of the Ansible package.

Current `latest` community distro is version 3.
Current maintained versions are: 3 and 2.9.
See https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html for details on release cadences and maintenance schedules.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com/ansible/

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
