### PR TITLE
Allow restricting config values with list members

### DIFF
--- a/changelogs/fragments/allow_restricted_config_values.yml
+++ b/changelogs/fragments/allow_restricted_config_values.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - allow restricting config definition values with list members using 'choices' keyword.

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -552,7 +552,15 @@ class ConfigManager(object):
 
             # deal with restricted values
             if value is not None and 'choices' in defs[config] and defs[config]['choices'] is not None:
-                if value not in defs[config]['choices']:
+                invalid_choices_found = True
+                if defs[config].get('type') == 'list':
+                    # compare list of values to list of restricted choices
+                    invalid_choices_found = not all(choice in defs[config]['choices'] for choice in value)
+                else:
+                    # compare single value to list of restricted choices
+                    invalid_choices_found = value not in defs[config]['choices']
+
+                if invalid_choices_found:
                     raise AnsibleOptionsError('Invalid value "%s" for configuration option "%s", valid values are: %s' %
                                               (value, to_native(_get_entry(plugin_type, plugin_name, config)), defs[config]['choices']))
 


### PR DESCRIPTION
##### SUMMARY

Enable 'choices' keyword in config definitions for options with list type members (compare each value against allowed choices).

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

config/manager.py

##### ADDITIONAL INFORMATION

Fixes #74225
