### PR TITLE
[controller ansiballz] escape directory regex

### DIFF
--- a/changelogs/fragments/ansiballz-re-escape-site-packages.yml
+++ b/changelogs/fragments/ansiballz-re-escape-site-packages.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    ansiballz - avoid treating path to site_packages as regex; escape it.
+    This prevents a crash when ansible is installed to, or running from, an oddly named directory like ``ansi[ble``

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -417,7 +417,7 @@ else:
 # Do this instead of getting site-packages from distutils.sysconfig so we work when we
 # haven't been installed
 site_packages = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-CORE_LIBRARY_PATH_RE = re.compile(r'%s/(?P<path>ansible/modules/.*)\.(py|ps1)$' % site_packages)
+CORE_LIBRARY_PATH_RE = re.compile(r'%s/(?P<path>ansible/modules/.*)\.(py|ps1)$' % re.escape(site_packages))
 COLLECTION_PATH_RE = re.compile(r'/(?P<path>ansible_collections/[^/]+/[^/]+/plugins/modules/.*)\.(py|ps1)$')
 
 # Detect new-style Python modules by looking for required imports:

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1173,7 +1173,8 @@ class ActionBase(with_metaclass(ABCMeta, object)):
 
             # try to figure out if we are missing interpreter
             if self._used_interpreter is not None:
-                match = re.compile('%s: (?:No such file or directory|not found)' % self._used_interpreter.lstrip('!#'))
+                interpreter = re.escape(self._used_interpreter.lstrip('!#'))
+                match = re.compile('%s: (?:No such file or directory|not found)' % interpreter)
                 if match.search(data['module_stderr']) or match.search(data['module_stdout']):
                     data['msg'] = "The module failed to execute correctly, you probably need to set the interpreter."
 

--- a/lib/ansible/vars/clean.py
+++ b/lib/ansible/vars/clean.py
@@ -133,7 +133,7 @@ def clean_facts(facts):
     # next we remove any connection plugin specific vars
     for conn_path in connection_loader.all(path_only=True):
         conn_name = os.path.splitext(os.path.basename(conn_path))[0]
-        re_key = re.compile('^ansible_%s_' % conn_name)
+        re_key = re.compile('^ansible_%s_' % re.escape(conn_name))
         for fact_key in fact_keys:
             # most lightweight VM or container tech creates devices with this pattern, this avoids filtering them out
             if (re_key.match(fact_key) and not fact_key.endswith(('_bridge', '_gwbridge'))) or fact_key.startswith('ansible_become_'):

--- a/test/integration/targets/ansible/module_common_regex_regression.sh
+++ b/test/integration/targets/ansible/module_common_regex_regression.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# #74270 -- ensure we escape directory names before passing to re.compile()
+# particularly in module_common.
+
+set -eux
+
+ansible_lib=$(python -c 'import os, ansible; print(os.path.dirname(ansible.__file__))')
+bad_dir="${OUTPUT_DIR}/ansi[ble"
+
+mkdir "${bad_dir}"
+cp -a "${ansible_lib}" "${bad_dir}"
+
+PYTHONPATH="${bad_dir}" ansible -m ping localhost -i ../../inventory "$@"
+rm -rf "${bad_dir}"

--- a/test/integration/targets/ansible/module_common_regex_regression.sh
+++ b/test/integration/targets/ansible/module_common_regex_regression.sh
@@ -5,11 +5,11 @@
 
 set -eux
 
-ansible_lib=$(python -c 'import os, ansible; print(os.path.dirname(ansible.__file__))')
+lib_path=$(python -c 'import os, ansible; print(os.path.dirname(os.path.dirname(ansible.__file__)))')
 bad_dir="${OUTPUT_DIR}/ansi[ble"
 
 mkdir "${bad_dir}"
-cp -a "${ansible_lib}" "${bad_dir}"
+cp -a "${lib_path}" "${bad_dir}"
 
-PYTHONPATH="${bad_dir}" ansible -m ping localhost -i ../../inventory "$@"
+PYTHONPATH="${bad_dir}/lib" ansible -m ping localhost -i ../../inventory "$@"
 rm -rf "${bad_dir}"

--- a/test/integration/targets/ansible/runme.sh
+++ b/test/integration/targets/ansible/runme.sh
@@ -80,3 +80,7 @@ if ansible-playbook -i ../../inventory --extra-vars ./vars.yml playbook.yml; the
 fi
 
 ansible-playbook -i ../../inventory --extra-vars @./vars.yml playbook.yml
+
+# #74270 -- ensure we escape directory names before passing to re.compile()
+# particularly in module_common.
+bash module_common_regex_regression.sh


### PR DESCRIPTION
##### SUMMARY

Change:
- We were passing a directory name directly to re.compile().
  If the directory isn't valid regex (or is) this can have odd side
  effects, such as crashing.

Test Plan:
- None yet, how do I test this?

Signed-off-by: Rick Elrod <rick@elrod.me>

Without this:

```
ERROR! Unexpected Exception, this is probably a bug: unterminated character set at position 31
the full traceback was:

Traceback (most recent call last):
  File "/Users/rick/dev/ansible/ansible[devel/bin/ansible", line 123, in <module>
    exit_code = cli.run()
  File "/Users/rick/dev/ansible/ansible[devel/lib/ansible/cli/adhoc.py", line 166, in run
    result = self._tqm.run(play)
  File "/Users/rick/dev/ansible/ansible[devel/lib/ansible/executor/task_queue_manager.py", line 261, in run
    strategy = strategy_loader.get(new_play.strategy, self)
  File "/Users/rick/dev/ansible/ansible[devel/lib/ansible/plugins/loader.py", line 547, in get
    name, path = self.find_plugin_with_name(name, collection_list=collection_list)
  File "/Users/rick/dev/ansible/ansible[devel/lib/ansible/plugins/loader.py", line 414, in find_plugin_with_name
    return name, self._find_plugin_legacy(name, ignore_deprecated, check_aliases, suffix)
  File "/Users/rick/dev/ansible/ansible[devel/lib/ansible/plugins/loader.py", line 439, in _find_plugin_legacy
    for path in (p for p in self._get_paths() if p not in self._searched_paths and os.path.isdir(p)):
  File "/Users/rick/dev/ansible/ansible[devel/lib/ansible/plugins/loader.py", line 255, in _get_paths
    ret.extend(self._get_package_paths(subdirs=subdirs))
  File "/Users/rick/dev/ansible/ansible[devel/lib/ansible/plugins/loader.py", line 220, in _get_package_paths
    m = __import__(self.package)
  File "/Users/rick/dev/ansible/ansible[devel/lib/ansible/plugins/strategy/__init__.py", line 38, in <module>
    from ansible.executor.process.worker import WorkerProcess
  File "/Users/rick/dev/ansible/ansible[devel/lib/ansible/executor/process/worker.py", line 39, in <module>
    from ansible.executor.task_executor import TaskExecutor
  File "/Users/rick/dev/ansible/ansible[devel/lib/ansible/executor/task_executor.py", line 20, in <module>
    from ansible.executor.module_common import get_action_args_with_defaults
  File "/Users/rick/dev/ansible/ansible[devel/lib/ansible/executor/module_common.py", line 417, in <module>
    CORE_LIBRARY_PATH_RE = re.compile(r'%s/(?P<path>ansible/modules/.*)\.py$' % site_packages)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/re.py", line 250, in compile
    return _compile(pattern, flags)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/re.py", line 302, in _compile
    p = sre_compile.compile(pattern, flags)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/sre_compile.py", line 764, in compile
    p = sre_parse.parse(p, flags)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/sre_parse.py", line 948, in parse
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/sre_parse.py", line 443, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/sre_parse.py", line 549, in _parse
    raise source.error("unterminated character set",
re.error: unterminated character set at position 31
```

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansiballz but controller side