### PR TITLE
Loads collection playbooks in subdirs

### DIFF
--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -890,13 +890,18 @@ def _get_collection_playbook_path(playbook):
             pkg = None
 
         if pkg:
+            parts = []
             cpath = os.path.join(sys.modules[acr.n_python_collection_package_name].__file__.replace('__synthetic__', 'playbooks'))
-            path = os.path.join(cpath, to_native(acr.resource))
+            parts.append(cpath)
+            parts.extend(acr.subdirs.split(u'.'))
+            parts.append(to_native(acr.resource))
+            path = os.path.join(*parts)
             if os.path.exists(to_bytes(path)):
                 return acr.resource, path, acr.collection
             elif not acr.resource.endswith(PB_EXTENSIONS):
                 for ext in PB_EXTENSIONS:
-                    path = os.path.join(cpath, to_native(acr.resource + ext))
+                    parts[-1] = to_native(acr.resource + ext)
+                    path = os.path.join(*parts)
                     if os.path.exists(to_bytes(path)):
                         return acr.resource, path, acr.collection
     return None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #74283. Loads playbooks from collections when they are in subdirectories.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
collection playbooks