### PR TITLE
correct how to install Docker SDK for Python

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_docker.rst
+++ b/docs/docsite/rst/scenario_guides/guide_docker.rst
@@ -21,7 +21,7 @@ You can install the Docker SDK for Python for Python 3.6 or later as follows:
 
     $ pip install docker
 
-For Python 2.7, you need to use a version between 2.0.0 and 4.4.4 since removed support for Python 2.7 on 5.0.0. You can install the specific version of the Docker SDK for Python as follows:
+For Python 2.7, you need to use a version between 2.0.0 and 4.4.4 since the Python package for Docker removed support for Python 2.7 on 5.0.0. You can install the specific version of the Docker SDK for Python as follows:
 
 .. code-block:: bash
 

--- a/docs/docsite/rst/scenario_guides/guide_docker.rst
+++ b/docs/docsite/rst/scenario_guides/guide_docker.rst
@@ -15,7 +15,7 @@ Most of the modules and plugins in community.docker require the `Docker SDK for 
 
 Note that plugins (inventory plugins and connection plugins) are always executed in the context of Ansible itself. If you use a plugin that requires the Docker SDK for Python, you need to install it on the machine running ``ansible`` or ``ansible-playbook`` and for the same Python interpreter used by Ansible. To see which Python is used, run ``ansible --version``.
 
-You can install the Docker SDK for Python for Python>=3.6 as follows:
+You can install the Docker SDK for Python for Python 3.6 or later as follows:
 
 .. code-block:: bash
 

--- a/docs/docsite/rst/scenario_guides/guide_docker.rst
+++ b/docs/docsite/rst/scenario_guides/guide_docker.rst
@@ -15,13 +15,19 @@ Most of the modules and plugins in community.docker require the `Docker SDK for 
 
 Note that plugins (inventory plugins and connection plugins) are always executed in the context of Ansible itself. If you use a plugin that requires the Docker SDK for Python, you need to install it on the machine running ``ansible`` or ``ansible-playbook`` and for the same Python interpreter used by Ansible. To see which Python is used, run ``ansible --version``.
 
-You can install the Docker SDK for Python for Python 2.7 or Python 3 as follows:
+You can install the Docker SDK for Python for Python>=3.6 as follows:
 
 .. code-block:: bash
 
     $ pip install docker
 
-For Python 2.6, you need a version before 2.0. For these versions, the SDK was called ``docker-py``, so you need to install it as follows:
+For Python 2.7, you need to use a version between 2.0.0 and 4.4.4 since removed support for Python 2.7 on 5.0.0. You can install the specific version of the Docker SDK for Python as follows:
+
+.. code-block:: bash
+
+    $ pip install 'docker==4.4.4'
+
+For Python 2.6, you need a version before 2.0.0. For these versions, the SDK was called ``docker-py``, so you need to install it as follows:
 
 .. code-block:: bash
 


### PR DESCRIPTION
##### SUMMARY
The latest version 5.0.0 do not support Python 2.7 anymore.

Documents and error message to guide docker/docker-py module with pip corresponding Python version.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docker

##### ADDITIONAL INFORMATION
When install  Docker SDK for Python 5.0.0 in system used Python 2.7, ansible failed to run related to docker module with following message.
```json
"msg": "Failed to import the required Python library (Docker SDK for Python: docker (Python >= 2.7) or docker-py (Python 2.6)) on cstgnmss0022.lip2's Python /usr/bin/python. Please read module documentation and install in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter, for example via `pip install docker` or `pip install docker-py` (Python 2.6). The error was: cannot import name credentials",
```
But it is not correct, the 5.0.0 do not support Python 2.7. We should install docker sdk version before 5.0.0 or install Python 3.6 in target system. so correct message following below:
```json
"msg": "Failed to import the required Python library (Docker SDK for Python: docker above 5.0.0 (Python >= 3.6) or docker before 5.0.0 (Python >= 2.7) or docker-py (Python 2.6)) on sstgnmss0003.lip2's Python /usr/bin/python. Please read module documentation and install in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter, for example via `pip install docker` (Python >= 3.6) or `pip install docker==4.4.4` (Python >= 2.7) or `pip install docker-py` (Python 2.6). The error was: cannot import name credentials"
```
