### PR TITLE
Remove __requires__ attribute for pkg_resources

### DIFF
--- a/changelogs/fragments/no-requires.yml
+++ b/changelogs/fragments/no-requires.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- CLI - Remove ``__requires__`` attribute for ``pkg_resources``

--- a/lib/ansible/cli/scripts/ansible_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_cli_stub.py
@@ -22,8 +22,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-__requires__ = ['ansible_core']
-
 
 import errno
 import os

--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -4,7 +4,6 @@
 from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
-__requires__ = ['ansible_core']
 
 
 import fcntl


### PR DESCRIPTION
##### SUMMARY
Remove `__requires__` attribute for `pkg_resources`.  We no longer depend on `pkg_resources`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/cli/scripts/

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
