### PR TITLE
Fix pb subs collapse

### DIFF
--- a/changelogs/fragments/coll_pb_subdir_fixes.yml
+++ b/changelogs/fragments/coll_pb_subdir_fixes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - playbook loaded from collection subdir now does not ignore subdirs.

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -890,13 +890,17 @@ def _get_collection_playbook_path(playbook):
             pkg = None
 
         if pkg:
+            subdirs = []
+            if acr.subdirs:
+                subdirs = acr.subdirs.split(u'.')
+
             cpath = os.path.join(sys.modules[acr.n_python_collection_package_name].__file__.replace('__synthetic__', 'playbooks'))
-            path = os.path.join(cpath, to_native(acr.resource))
+            path = os.path.join(cpath, *subdirs, to_native(acr.resource))
             if os.path.exists(to_bytes(path)):
                 return acr.resource, path, acr.collection
             elif not acr.resource.endswith(PB_EXTENSIONS):
                 for ext in PB_EXTENSIONS:
-                    path = os.path.join(cpath, to_native(acr.resource + ext))
+                    path = os.path.join(cpath, *subdirs, to_native(acr.resource + ext))
                     if os.path.exists(to_bytes(path)):
                         return acr.resource, path, acr.collection
     return None

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -893,7 +893,7 @@ def _get_collection_playbook_path(playbook):
             cpath = os.path.join(sys.modules[acr.n_python_collection_package_name].__file__.replace('__synthetic__', 'playbooks'))
 
             if acr.subdirs:
-                paths = acr.subdirs.split(u'.')
+                paths = [to_native(x) for x in acr.subdirs.split(u'.')]
                 paths.insert(0, cpath)
                 cpath = os.path.join(*paths)
 

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -890,17 +890,19 @@ def _get_collection_playbook_path(playbook):
             pkg = None
 
         if pkg:
-            subdirs = []
-            if acr.subdirs:
-                subdirs = acr.subdirs.split(u'.')
-
             cpath = os.path.join(sys.modules[acr.n_python_collection_package_name].__file__.replace('__synthetic__', 'playbooks'))
-            path = os.path.join(cpath, *subdirs, to_native(acr.resource))
+
+            if acr.subdirs:
+                paths = acr.subdirs.split(u'.')
+                paths.insert(0, cpath)
+                cpath = os.path.join(*paths)
+
+            path = os.path.join(cpath, to_native(acr.resource))
             if os.path.exists(to_bytes(path)):
                 return acr.resource, path, acr.collection
             elif not acr.resource.endswith(PB_EXTENSIONS):
                 for ext in PB_EXTENSIONS:
-                    path = os.path.join(cpath, *subdirs, to_native(acr.resource + ext))
+                    path = os.path.join(cpath, to_native(acr.resource + ext))
                     if os.path.exists(to_bytes(path)):
                         return acr.resource, path, acr.collection
     return None

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/playbooks/play.yml
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/playbooks/play.yml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - set_fact: play='tldr'

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/playbooks/type/play.yml
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/playbooks/type/play.yml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - set_fact: play_type='in type subdir'

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/playbooks/type/subtype/play.yml
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/playbooks/type/subtype/play.yml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - set_fact: play_type_subtype='in subtype subdir'

--- a/test/integration/targets/collections/import_collection_pb.yml
+++ b/test/integration/targets/collections/import_collection_pb.yml
@@ -1,2 +1,17 @@
 - import_playbook: testns.testcoll.default_collection_playbook.yml
 - import_playbook: testns.testcoll.default_collection_playbook
+
+# test subdirs
+- import_playbook: "testns.testcoll.play"
+- import_playbook: "testns.testcoll.type.play"
+- import_playbook: "testns.testcoll.type.subtype.play"
+
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: check values from imports
+      assert:
+        that:
+          - play is defined
+          - play_type is defined
+          - play_type_subtype is defined

--- a/test/lib/ansible_test/_data/legacy_collection_loader/_collection_finder.py
+++ b/test/lib/ansible_test/_data/legacy_collection_loader/_collection_finder.py
@@ -891,6 +891,12 @@ def _get_collection_playbook_path(playbook):
 
         if pkg:
             cpath = os.path.join(sys.modules[acr.n_python_collection_package_name].__file__.replace('__synthetic__', 'playbooks'))
+
+            if acr.subdirs:
+                paths = [to_native(x) for x in acr.subdirs.split(u'.')]
+                paths.insert(0, cpath)
+                cpath = os.path.join(*paths)
+
             path = os.path.join(cpath, to_native(acr.resource))
             if os.path.exists(to_bytes(path)):
                 return acr.resource, path, acr.collection


### PR DESCRIPTION

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
collections
##### ADDITIONAL INFORMATION
Or if we want to 'cleanly' disable:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
diff --git a/lib/ansible/utils/collection_loader/_collection_finder.py b/lib/ansible/utils/collection_loader/_collection_finder.py
index 9bc6cd544c..a7e8eb9a5a 100644
--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -888,19 +888,17 @@ def _get_collection_playbook_path(playbook):
         except (IOError, ModuleNotFoundError) as e:
             # leaving e as debug target, even though not used in normal code
             pkg = None
+        if acr.subdirs:
+            raise AnsibleError("Playbooks in collections are not allowed to live in subdirectories.")

         if pkg:
```
