### PR TITLE
uri - fix traceback on multipart-form int value

### DIFF
--- a/changelogs/fragments/uri-multipart-int-value.yml
+++ b/changelogs/fragments/uri-multipart-int-value.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- uri - Fix traceback and provide error message when trying to use non-string or mapping for ``form-multipart`` body - https://github.com/ansible/ansible/issues/74276

--- a/lib/ansible/module_utils/common/collections.py
+++ b/lib/ansible/module_utils/common/collections.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 
 from ansible.module_utils.six import binary_type, text_type
-from ansible.module_utils.common._collections_compat import Hashable, Mapping, Sequence
+from ansible.module_utils.common._collections_compat import Hashable, Mapping, MutableMapping, Sequence
 
 
 class ImmutableDict(Hashable, Mapping):

--- a/lib/ansible/plugins/action/uri.py
+++ b/lib/ansible/plugins/action/uri.py
@@ -11,7 +11,7 @@ import os
 
 from ansible.errors import AnsibleError, AnsibleAction, _AnsibleActionDone, AnsibleActionFail
 from ansible.module_utils._text import to_native
-from ansible.module_utils.common.collections import Mapping
+from ansible.module_utils.common.collections import Mapping, MutableMapping
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.six import text_type
 from ansible.plugins.action import ActionBase
@@ -61,7 +61,7 @@ class ActionModule(ActionBase):
                         'body must be mapping, cannot be type %s' % body.__class__.__name__
                     )
                 for field, value in body.items():
-                    if isinstance(value, text_type):
+                    if not isinstance(value, MutableMapping):
                         continue
                     content = value.get('content')
                     filename = value.get('filename')

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -474,6 +474,16 @@
       - multipart.json.form.text_form_field1 == 'value1'
       - multipart.json.form.text_form_field2 == 'value2'
 
+# https://github.com/ansible/ansible/issues/74276 - verifies we don't have a traceback
+- name: multipart/form-data with invalid value
+  uri:
+    url: https://{{ httpbin_host }}/post
+    method: POST
+    body_format: form-multipart
+    body:
+      integer_value: 1
+  register: multipart_invalid
+  failed_when: 'multipart_invalid.msg != "failed to parse body as form-multipart: value must be a string, or mapping, cannot be type int"'
 
 - name: Validate invalid method
   uri:


### PR DESCRIPTION
##### SUMMARY
Fixes a traceback when using a value other than a string or dict/mapping for `form-multipart` body.

Fixes https://github.com/ansible/ansible/issues/74276

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
uri