### PR TITLE
Expand environment variables in proxy_command

### DIFF
--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -283,6 +283,7 @@ class Connection(ConnectionBase):
             for find, replace in replacers.items():
                 proxy_command = proxy_command.replace(find, str(replace))
             try:
+                proxy_command = os.path.expandvars(proxy_command)
                 sock_kwarg = {'sock': paramiko.ProxyCommand(proxy_command)}
                 display.vvv("CONFIGURE PROXY COMMAND FOR CONNECTION: %s" % proxy_command, host=self._play_context.remote_addr)
             except AttributeError:


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Related to https://github.com/ansible-collections/ansible.netcommon/issues/195.
- If the proxy_command has environment variables, those are not expanded before creating the ProxyCommand object and passing to the connect().
- This patch attempts to fix this.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
paramiko_ssh.py