### PR TITLE
2.11: Prevent ansible_failed_task from further templating (#74290)

### DIFF
--- a/changelogs/fragments/74036-unsafe-ansible_failed_task.yml
+++ b/changelogs/fragments/74036-unsafe-ansible_failed_task.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Prevent ``ansible_failed_task`` from further templating (https://github.com/ansible/ansible/issues/74036)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -50,6 +50,7 @@ from ansible.playbook.task_include import TaskInclude
 from ansible.plugins import loader as plugin_loader
 from ansible.template import Templar
 from ansible.utils.display import Display
+from ansible.utils.unsafe_proxy import wrap_var
 from ansible.utils.vars import combine_vars
 from ansible.vars.clean import strip_internal_keys, module_response_deepcopy
 
@@ -572,7 +573,7 @@ class StrategyBase:
                         self._variable_manager.set_nonpersistent_facts(
                             original_host.name,
                             dict(
-                                ansible_failed_task=original_task.serialize(),
+                                ansible_failed_task=wrap_var(original_task.serialize()),
                                 ansible_failed_result=task_result._result,
                             ),
                         )

--- a/test/integration/targets/blocks/runme.sh
+++ b/test/integration/targets/blocks/runme.sh
@@ -103,3 +103,5 @@ rm -f role_complete_test.out
 
 # test notify inheritance
 ansible-playbook inherit_notify.yml "$@"
+
+ansible-playbook unsafe_failed_task.yml "$@"

--- a/test/integration/targets/blocks/unsafe_failed_task.yml
+++ b/test/integration/targets/blocks/unsafe_failed_task.yml
@@ -1,0 +1,17 @@
+- hosts: localhost
+  gather_facts: false
+  vars:
+    - data: {}
+  tasks:
+    - block:
+        - name: template error
+          debug:
+            msg: "{{ data.value }}"
+      rescue:
+        - debug:
+            msg: "{{ ansible_failed_task.action }}"
+
+        - assert:
+            that:
+              - ansible_failed_task.name == "template error"
+              - ansible_failed_task.action == "debug"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of https://github.com/ansible/ansible/pull/74290

(cherry picked from commit 664531d7d6253d5bdb182727501c08e3b5aea0c1)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/strategy/__init__.py`