### PR TITLE
fix documentation links for become warnings/permission error

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -659,8 +659,8 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                         'member. In this situation, '
                         'allow_world_readable_tmpfiles is a no-op. See this '
                         'URL for more details: '
-                        'https://docs.ansible.com/ansible/become.html'
-                        '#becoming-an-unprivileged-user')
+                        'https://docs.ansible.com/ansible/latest/user_guide/become.html'
+                        '#risks-of-becoming-an-unprivileged-user')
                 if execute:
                     group_mode = 'g+rwx'
                 else:
@@ -679,7 +679,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 'Using world-readable permissions for temporary files Ansible '
                 'needs to create when becoming an unprivileged user. This may '
                 'be insecure. For information on securing this, see '
-                'https://docs.ansible.com/ansible/user_guide/become.html'
+                'https://docs.ansible.com/ansible/latest/user_guide/become.html'
                 '#risks-of-becoming-an-unprivileged-user')
             res = self._remote_chmod(remote_paths, 'a+%s' % chmod_mode)
             if res['rc'] == 0:
@@ -694,8 +694,8 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             'Failed to set permissions on the temporary files Ansible needs '
             'to create when becoming an unprivileged user '
             '(rc: %s, err: %s}). For information on working around this, see '
-            'https://docs.ansible.com/ansible/become.html'
-            '#becoming-an-unprivileged-user' % (
+            'https://docs.ansible.com/ansible/latest/user_guide/become.html'
+            '#risks-of-becoming-an-unprivileged-user' % (
                 res['rc'],
                 to_native(res['stderr'])))
 


### PR DESCRIPTION
##### SUMMARY

I was running some task that resulted in a become permission issue.
In this case ansible spits out a warning or error (3 occurrences for this link in `lib/ansible/plugins/action/__init__.py`) to https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user like in https://github.com/ansible/ansible/blob/7ef3dc2b8b4428d20887777de3921c316feaf7be/lib/ansible/plugins/action/__init__.py#L697-L698.

That documentation link is dead now.
Also, 2 of these instances had a different anchor referenced which I couldn't find in an earlier version either, I'm assuming they should all be pointing to the same destination.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/__init__.py

##### ADDITIONAL INFORMATION
none