### PR TITLE
[become] Fix Solaris regression caused by macOS tempdir perms fallback, and add Solaris fallback using its chmod syntax

### DIFF
--- a/changelogs/fragments/macos-solaris-regression.yml
+++ b/changelogs/fragments/macos-solaris-regression.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    become - fix a regression on Solaris where chmod can return 5 which we
+    interpret as auth failure and stop trying become tmpdir permission fallbacks

--- a/changelogs/fragments/solaris-setfacl-chmod-fallback.yml
+++ b/changelogs/fragments/solaris-setfacl-chmod-fallback.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - become - work around setfacl not existing on modern Solaris (and possibly failing on some filesystems even when it does exist)

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -470,7 +470,15 @@ class TestActionBase(unittest.TestCase):
         action_base._remote_chmod.side_effect = raise_if_plus_a
         assertSuccess()
 
-        # Step 3e: Common group
+        # Step 3e: chmod A+ on Solaris
+        # We threw AnsibleAuthenticationFailure above, try Solaris fallback.
+        # Based on our lambda above, it should be successful.
+        action_base._remote_chmod.assert_called_with(
+            remote_paths,
+            'A+user:remoteuser2:r:allow')
+        assertSuccess()
+
+        # Step 3f: Common group
         def rc_1_if_chmod_acl(definitely_not_underscore, mode):
             rc = 0
             if mode in CHMOD_ACL_FLAGS:


### PR DESCRIPTION
##### SUMMARY

See the individual commit messages for more detail.
Effectively, there's a regression currently where we try to run the macOS chmod syntax on Solaris and chmod exits with return code 5, which we take to mean "authentication failure" since sshpass returns 5 in that case. Work around this by catching AnsibleAuthenticationFailure for now. A future rewrite of this logic will eliminate the need for this.

Also add an actual fallback for solaris, because newer solaris no longer ships setfacl (and even on solaris that does, it could fail on some filesystems). This fixes #74282.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Test Pull Request

##### COMPONENT NAME

action