### PR TITLE
Backports list of available versions to 2.9 for Ansible 3 (#74265)

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -147,7 +147,7 @@ html_context = {
     'current_version': version,
     'latest_version': '2.10',
     # list specifically out of order to make latest work
-    'available_versions': ('latest', '2.9', '2.9_ja', '2.8', 'devel'),
+    'available_versions': ('latest', '2.9', 'devel'),
     'css_files': ('_static/ansible.css',  # overrides to the standard theme
                   ),
 }

--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -145,7 +145,7 @@ html_context = {
     'github_root_dir': 'devel/lib/ansible',
     'github_cli_version': 'devel/lib/ansible/cli/',
     'current_version': version,
-    'latest_version': '2.10',
+    'latest_version': '3',
     # list specifically out of order to make latest work
     'available_versions': ('latest', '2.9', 'devel'),
     'css_files': ('_static/ansible.css',  # overrides to the standard theme


### PR DESCRIPTION
* updates list of available versions for Ansible 3
Co-authored-by: Alicia Cozine <acozine@users.noreply.github.com>

(cherry picked from commit 126e9244c2bbe12234d0cbd98c0802444ab103f5)

##### SUMMARY
The sphinx config in stable-2.9 is not split, but functionally this is a backport of the commit listed here.  Removes Ansible 2.8 from the version-switcher.

The package (docs.ansible.com/ansible/) version-switcher will offer three versions:

- latest/Ansible 3 (built on ansible-base 2.10)
- 2.9
- devel

Documentation for 2.8 is still available if users replace `latest` or `2.9` in the URLs with `2.8`.  Version 2.8 is fully EOL with the release of ansible-core 2.11. The Japanese documentation is accessible through the landing pages, see https://docs.ansible.com/core-translated-ja.html. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com/ansible/
