### PR TITLE
Clean up ansible-test cloud plugins.

### DIFF
--- a/changelogs/fragments/ansible-test-cloud-plugin-code-cleanup.yml
+++ b/changelogs/fragments/ansible-test-cloud-plugin-code-cleanup.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Clean up code in the cloud plugins.

--- a/test/lib/ansible_test/_internal/cloud/acme.py
+++ b/test/lib/ansible_test/_internal/cloud/acme.py
@@ -4,14 +4,18 @@ __metaclass__ = type
 
 import os
 
-from . import (
-    CloudProvider,
-    CloudEnvironment,
-    CloudEnvironmentConfig,
+from ..config import (
+    IntegrationConfig,
 )
 
 from ..containers import (
     run_support_container,
+)
+
+from . import (
+    CloudEnvironment,
+    CloudEnvironmentConfig,
+    CloudProvider,
 )
 
 
@@ -19,10 +23,7 @@ class ACMEProvider(CloudProvider):
     """ACME plugin. Sets up cloud resources for tests."""
     DOCKER_SIMULATOR_NAME = 'acme-simulator'
 
-    def __init__(self, args):
-        """
-        :type args: TestConfig
-        """
+    def __init__(self, args):  # type: (IntegrationConfig) -> None
         super(ACMEProvider, self).__init__(args)
 
         # The simulator must be pinned to a specific version to guarantee CI passes with the version used.
@@ -33,7 +34,7 @@ class ACMEProvider(CloudProvider):
 
         self.uses_docker = True
 
-    def setup(self):
+    def setup(self):  # type: () -> None
         """Setup the cloud resource before delegation and register a cleanup callback."""
         super(ACMEProvider, self).setup()
 
@@ -42,7 +43,7 @@ class ACMEProvider(CloudProvider):
         else:
             self._setup_dynamic()
 
-    def _setup_dynamic(self):
+    def _setup_dynamic(self):  # type: () -> None
         """Create a ACME test container using docker."""
         ports = [
             5000,  # control port for flask app in container
@@ -63,16 +64,14 @@ class ACMEProvider(CloudProvider):
 
         self._set_cloud_config('acme_host', self.DOCKER_SIMULATOR_NAME)
 
-    def _setup_static(self):
+    def _setup_static(self):  # type: () -> None
         raise NotImplementedError()
 
 
 class ACMEEnvironment(CloudEnvironment):
     """ACME environment plugin. Updates integration test environment after delegation."""
-    def get_environment_config(self):
-        """
-        :rtype: CloudEnvironmentConfig
-        """
+    def get_environment_config(self):  # type: () -> CloudEnvironmentConfig
+        """Return environment configuration for use in the test environment after delegation."""
         ansible_vars = dict(
             acme_host=self._get_cloud_config('acme_host'),
         )

--- a/test/lib/ansible_test/_internal/cloud/aws.py
+++ b/test/lib/ansible_test/_internal/cloud/aws.py
@@ -4,38 +4,42 @@ __metaclass__ = type
 
 import os
 
+from .. import types as t
+
 from ..util import (
     ApplicationError,
-    display,
     ConfigParser,
+    display,
 )
 
-from . import (
-    CloudProvider,
-    CloudEnvironment,
-    CloudEnvironmentConfig,
+from ..config import (
+    IntegrationConfig,
+)
+
+from ..target import (
+    IntegrationTarget,
 )
 
 from ..core_ci import (
     AnsibleCoreCI,
 )
 
+from . import (
+    CloudEnvironment,
+    CloudEnvironmentConfig,
+    CloudProvider,
+)
+
 
 class AwsCloudProvider(CloudProvider):
     """AWS cloud provider plugin. Sets up cloud resources before delegation."""
-    def __init__(self, args):
-        """
-        :type args: TestConfig
-        """
+    def __init__(self, args):  # type: (IntegrationConfig) -> None
         super(AwsCloudProvider, self).__init__(args)
 
         self.uses_config = True
 
-    def filter(self, targets, exclude):
-        """Filter out the cloud tests when the necessary config and resources are not available.
-        :type targets: tuple[TestTarget]
-        :type exclude: list[str]
-        """
+    def filter(self, targets, exclude):  # type: (t.Tuple[IntegrationTarget, ...], t.List[str]) -> None
+        """Filter out the cloud tests when the necessary config and resources are not available."""
         aci = self._create_ansible_core_ci()
 
         if aci.available:
@@ -43,7 +47,7 @@ class AwsCloudProvider(CloudProvider):
 
         super(AwsCloudProvider, self).filter(targets, exclude)
 
-    def setup(self):
+    def setup(self):  # type: () -> None
         """Setup the cloud resource before delegation and register a cleanup callback."""
         super(AwsCloudProvider, self).setup()
 
@@ -55,7 +59,7 @@ class AwsCloudProvider(CloudProvider):
         if not self._use_static_config():
             self._setup_dynamic()
 
-    def _setup_dynamic(self):
+    def _setup_dynamic(self):  # type: () -> None
         """Request AWS credentials through the Ansible Core CI service."""
         display.info('Provisioning %s cloud environment.' % self.platform, verbosity=1)
 
@@ -82,19 +86,15 @@ class AwsCloudProvider(CloudProvider):
 
         self._write_config(config)
 
-    def _create_ansible_core_ci(self):
-        """
-        :rtype: AnsibleCoreCI
-        """
+    def _create_ansible_core_ci(self):  # type: () -> AnsibleCoreCI
+        """Return an AWS instance of AnsibleCoreCI."""
         return AnsibleCoreCI(self.args, 'aws', 'aws', persist=False, stage=self.args.remote_stage, provider='aws', internal=True)
 
 
 class AwsCloudEnvironment(CloudEnvironment):
     """AWS cloud environment plugin. Updates integration test environment after delegation."""
-    def get_environment_config(self):
-        """
-        :rtype: CloudEnvironmentConfig
-        """
+    def get_environment_config(self):  # type: () -> CloudEnvironmentConfig
+        """Return environment configuration for use in the test environment after delegation."""
         parser = ConfigParser()
         parser.read(self.config_path)
 
@@ -119,11 +119,8 @@ class AwsCloudEnvironment(CloudEnvironment):
             callback_plugins=['aws_resource_actions'],
         )
 
-    def on_failure(self, target, tries):
-        """
-        :type target: TestTarget
-        :type tries: int
-        """
+    def on_failure(self, target, tries):  # type: (IntegrationTarget, int) -> None
+        """Callback to run when an integration target fails."""
         if not tries and self.managed:
             display.notice('If %s failed due to permissions, the IAM test policy may need to be updated. '
                            'https://docs.ansible.com/ansible/devel/dev_guide/platforms/aws_guidelines.html#aws-permissions-for-integration-tests.'

--- a/test/lib/ansible_test/_internal/cloud/cloudscale.py
+++ b/test/lib/ansible_test/_internal/cloud/cloudscale.py
@@ -7,30 +7,30 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import os
-
-from . import (
-    CloudProvider,
-    CloudEnvironment,
-    CloudEnvironmentConfig,
+from ..util import (
+    ConfigParser,
+    display,
 )
 
-from ..util import ConfigParser, display
+from ..config import (
+    IntegrationConfig,
+)
+
+from . import (
+    CloudEnvironment,
+    CloudEnvironmentConfig,
+    CloudProvider,
+)
 
 
 class CloudscaleCloudProvider(CloudProvider):
-    """Cloudscale cloud provider plugin. Sets up cloud resources before
-       delegation.
-    """
-    def __init__(self, args):
-        """
-        :type args: TestConfig
-        """
+    """Cloudscale cloud provider plugin. Sets up cloud resources before delegation."""
+    def __init__(self, args):  # type: (IntegrationConfig) -> None
         super(CloudscaleCloudProvider, self).__init__(args)
 
         self.uses_config = True
 
-    def setup(self):
+    def setup(self):  # type: () -> None
         """Setup the cloud resource before delegation and register a cleanup callback."""
         super(CloudscaleCloudProvider, self).setup()
 
@@ -38,13 +38,9 @@ class CloudscaleCloudProvider(CloudProvider):
 
 
 class CloudscaleCloudEnvironment(CloudEnvironment):
-    """Cloudscale cloud environment plugin. Updates integration test environment
-       after delegation.
-    """
-    def get_environment_config(self):
-        """
-        :rtype: CloudEnvironmentConfig
-        """
+    """Cloudscale cloud environment plugin. Updates integration test environment after delegation."""
+    def get_environment_config(self):  # type: () -> CloudEnvironmentConfig
+        """Return environment configuration for use in the test environment after delegation."""
         parser = ConfigParser()
         parser.read(self.config_path)
 

--- a/test/lib/ansible_test/_internal/cloud/cloudscale.py
+++ b/test/lib/ansible_test/_internal/cloud/cloudscale.py
@@ -34,12 +34,7 @@ class CloudscaleCloudProvider(CloudProvider):
         """Setup the cloud resource before delegation and register a cleanup callback."""
         super(CloudscaleCloudProvider, self).setup()
 
-        if os.path.isfile(self.config_static_path):
-            display.info('Using existing %s cloud config: %s'
-                         % (self.platform, self.config_static_path),
-                         verbosity=1)
-            self.config_path = self.config_static_path
-            self.managed = False
+        self._use_static_config()
 
 
 class CloudscaleCloudEnvironment(CloudEnvironment):

--- a/test/lib/ansible_test/_internal/cloud/cs.py
+++ b/test/lib/ansible_test/_internal/cloud/cs.py
@@ -5,16 +5,16 @@ __metaclass__ = type
 import json
 import os
 
-from . import (
-    CloudProvider,
-    CloudEnvironment,
-    CloudEnvironmentConfig,
-)
+from .. import types as t
 
 from ..util import (
     ApplicationError,
-    display,
     ConfigParser,
+    display,
+)
+
+from ..config import (
+    IntegrationConfig,
 )
 
 from ..http import (
@@ -30,15 +30,18 @@ from ..containers import (
     wait_for_file,
 )
 
+from . import (
+    CloudEnvironment,
+    CloudEnvironmentConfig,
+    CloudProvider,
+)
+
 
 class CsCloudProvider(CloudProvider):
     """CloudStack cloud provider plugin. Sets up cloud resources before delegation."""
     DOCKER_SIMULATOR_NAME = 'cloudstack-sim'
 
-    def __init__(self, args):
-        """
-        :type args: TestConfig
-        """
+    def __init__(self, args):  # type: (IntegrationConfig) -> None
         super(CsCloudProvider, self).__init__(args)
 
         self.image = os.environ.get('ANSIBLE_CLOUDSTACK_CONTAINER', 'quay.io/ansible/cloudstack-test-container:1.4.0')
@@ -48,7 +51,7 @@ class CsCloudProvider(CloudProvider):
         self.uses_docker = True
         self.uses_config = True
 
-    def setup(self):
+    def setup(self):  # type: () -> None
         """Setup the cloud resource before delegation and register a cleanup callback."""
         super(CsCloudProvider, self).setup()
 
@@ -57,7 +60,7 @@ class CsCloudProvider(CloudProvider):
         else:
             self._setup_dynamic()
 
-    def _setup_static(self):
+    def _setup_static(self):  # type: () -> None
         """Configure CloudStack tests for use with static configuration."""
         parser = ConfigParser()
         parser.read(self.config_static_path)
@@ -82,7 +85,7 @@ class CsCloudProvider(CloudProvider):
 
         display.info('Read cs host "%s" and port %d from config: %s' % (self.host, self.port, self.config_static_path), verbosity=1)
 
-    def _setup_dynamic(self):
+    def _setup_dynamic(self):  # type: () -> None
         """Create a CloudStack simulator using docker."""
         config = self._read_config_template()
 
@@ -129,11 +132,8 @@ class CsCloudProvider(CloudProvider):
 
         self._write_config(config)
 
-    def _get_credentials(self, container_name):
-        """Wait for the CloudStack simulator to return credentials.
-        :type container_name: str
-        :rtype: dict[str, str]
-        """
+    def _get_credentials(self, container_name):  # type: (str) -> t.Dict[str, t.Any]
+        """Wait for the CloudStack simulator to return credentials."""
         def check(value):
             # noinspection PyBroadException
             try:
@@ -150,10 +150,8 @@ class CsCloudProvider(CloudProvider):
 
 class CsCloudEnvironment(CloudEnvironment):
     """CloudStack cloud environment plugin. Updates integration test environment after delegation."""
-    def get_environment_config(self):
-        """
-        :rtype: CloudEnvironmentConfig
-        """
+    def get_environment_config(self):  # type: () -> CloudEnvironmentConfig
+        """Return environment configuration for use in the test environment after delegation."""
         parser = ConfigParser()
         parser.read(self.config_path)
 

--- a/test/lib/ansible_test/_internal/cloud/foreman.py
+++ b/test/lib/ansible_test/_internal/cloud/foreman.py
@@ -4,54 +4,49 @@ __metaclass__ = type
 
 import os
 
-from . import (
-    CloudProvider,
-    CloudEnvironment,
-    CloudEnvironmentConfig,
+from ..config import (
+    IntegrationConfig,
 )
 
 from ..containers import (
     run_support_container,
 )
 
+from . import (
+    CloudEnvironment,
+    CloudEnvironmentConfig,
+    CloudProvider,
+)
+
 
 class ForemanProvider(CloudProvider):
-    """Foreman plugin.
-
-    Sets up Foreman stub server for tests.
-    """
-
+    """Foreman plugin. Sets up Foreman stub server for tests."""
     DOCKER_SIMULATOR_NAME = 'foreman-stub'
 
+    # Default image to run Foreman stub from.
+    #
+    # The simulator must be pinned to a specific version
+    # to guarantee CI passes with the version used.
+    #
+    # It's source source itself resides at:
+    # https://github.com/ansible/foreman-test-container
     DOCKER_IMAGE = 'quay.io/ansible/foreman-test-container:1.4.0'
-    """Default image to run Foreman stub from.
 
-    The simulator must be pinned to a specific version
-    to guarantee CI passes with the version used.
-
-    It's source source itself resides at:
-    https://github.com/ansible/foreman-test-container
-    """
-
-    def __init__(self, args):
-        """Set up container references for provider.
-
-        :type args: TestConfig
-        """
+    def __init__(self, args):  # type: (IntegrationConfig) -> None
         super(ForemanProvider, self).__init__(args)
 
         self.__container_from_env = os.environ.get('ANSIBLE_FRMNSIM_CONTAINER')
-        """Overrides target container, might be used for development.
+        """
+        Overrides target container, might be used for development.
 
         Use ANSIBLE_FRMNSIM_CONTAINER=whatever_you_want if you want
         to use other image. Omit/empty otherwise.
         """
-
         self.image = self.__container_from_env or self.DOCKER_IMAGE
 
         self.uses_docker = True
 
-    def setup(self):
+    def setup(self):  # type: () -> None
         """Setup cloud resource before delegation and reg cleanup callback."""
         super(ForemanProvider, self).setup()
 
@@ -60,7 +55,7 @@ class ForemanProvider(CloudProvider):
         else:
             self._setup_dynamic()
 
-    def _setup_dynamic(self):
+    def _setup_dynamic(self):  # type: () -> None
         """Spawn a Foreman stub within docker container."""
         foreman_port = 8080
 
@@ -83,19 +78,14 @@ class ForemanProvider(CloudProvider):
         self._set_cloud_config('FOREMAN_HOST', self.DOCKER_SIMULATOR_NAME)
         self._set_cloud_config('FOREMAN_PORT', str(foreman_port))
 
-    def _setup_static(self):
+    def _setup_static(self):  # type: () -> None
         raise NotImplementedError()
 
 
 class ForemanEnvironment(CloudEnvironment):
-    """Foreman environment plugin.
-
-    Updates integration test environment after delegation.
-    """
-    def get_environment_config(self):
-        """
-        :rtype: CloudEnvironmentConfig
-        """
+    """Foreman environment plugin. Updates integration test environment after delegation."""
+    def get_environment_config(self):  # type: () -> CloudEnvironmentConfig
+        """Return environment configuration for use in the test environment after delegation."""
         env_vars = dict(
             FOREMAN_HOST=self._get_cloud_config('FOREMAN_HOST'),
             FOREMAN_PORT=self._get_cloud_config('FOREMAN_PORT'),

--- a/test/lib/ansible_test/_internal/cloud/galaxy.py
+++ b/test/lib/ansible_test/_internal/cloud/galaxy.py
@@ -5,10 +5,8 @@ __metaclass__ = type
 import os
 import tempfile
 
-from . import (
-    CloudProvider,
-    CloudEnvironment,
-    CloudEnvironmentConfig,
+from ..config import (
+    IntegrationConfig,
 )
 
 from ..docker_util import (
@@ -17,6 +15,12 @@ from ..docker_util import (
 
 from ..containers import (
     run_support_container,
+)
+
+from . import (
+    CloudEnvironment,
+    CloudEnvironmentConfig,
+    CloudProvider,
 )
 
 
@@ -70,17 +74,11 @@ foreground {
 
 
 class GalaxyProvider(CloudProvider):
-    """Galaxy plugin.
-
-    Sets up pulp (ansible-galaxy) servers for tests.
-
+    """
+    Galaxy plugin. Sets up pulp (ansible-galaxy) servers for tests.
     The pulp source itself resides at: https://github.com/pulp/pulp-oci-images
     """
-
-    def __init__(self, args):
-        """
-        :type args: TestConfig
-        """
+    def __init__(self, args):  # type: (IntegrationConfig) -> None
         super(GalaxyProvider, self).__init__(args)
 
         # Cannot use the latest container image as either galaxy_ng 4.2.0rc2 or pulp 0.5.0 has sporatic issues with
@@ -94,7 +92,7 @@ class GalaxyProvider(CloudProvider):
 
         self.uses_docker = True
 
-    def setup(self):
+    def setup(self):  # type: () -> None
         """Setup cloud resource before delegation and reg cleanup callback."""
         super(GalaxyProvider, self).setup()
 
@@ -145,14 +143,9 @@ class GalaxyProvider(CloudProvider):
 
 
 class GalaxyEnvironment(CloudEnvironment):
-    """Galaxy environment plugin.
-
-    Updates integration test environment after delegation.
-    """
-    def get_environment_config(self):
-        """
-        :rtype: CloudEnvironmentConfig
-        """
+    """Galaxy environment plugin. Updates integration test environment after delegation."""
+    def get_environment_config(self):  # type: () -> CloudEnvironmentConfig
+        """Return environment configuration for use in the test environment after delegation."""
         pulp_user = self._get_cloud_config('PULP_USER')
         pulp_password = self._get_cloud_config('PULP_PASSWORD')
         pulp_host = self._get_cloud_config('PULP_HOST')

--- a/test/lib/ansible_test/_internal/cloud/gcp.py
+++ b/test/lib/ansible_test/_internal/cloud/gcp.py
@@ -9,24 +9,25 @@ from ..util import (
     ConfigParser,
 )
 
+from ..config import (
+    IntegrationConfig,
+)
+
 from . import (
-    CloudProvider,
     CloudEnvironment,
     CloudEnvironmentConfig,
+    CloudProvider,
 )
 
 
 class GcpCloudProvider(CloudProvider):
     """GCP cloud provider plugin. Sets up cloud resources before delegation."""
-    def __init__(self, args):
-        """Set up container references for provider.
-        :type args: TestConfig
-        """
+    def __init__(self, args):  # type: (IntegrationConfig) -> None
         super(GcpCloudProvider, self).__init__(args)
 
         self.uses_config = True
 
-    def setup(self):
+    def setup(self):  # type: () -> None
         """Setup the cloud resource before delegation and register a cleanup callback."""
         super(GcpCloudProvider, self).setup()
 
@@ -38,10 +39,8 @@ class GcpCloudProvider(CloudProvider):
 
 class GcpCloudEnvironment(CloudEnvironment):
     """GCP cloud environment plugin. Updates integration test environment after delegation."""
-    def get_environment_config(self):
-        """
-        :rtype: CloudEnvironmentConfig
-        """
+    def get_environment_config(self):  # type: () -> CloudEnvironmentConfig
+        """Return environment configuration for use in the test environment after delegation."""
         parser = ConfigParser()
         parser.read(self.config_path)
 

--- a/test/lib/ansible_test/_internal/cloud/hcloud.py
+++ b/test/lib/ansible_test/_internal/cloud/hcloud.py
@@ -2,40 +2,41 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from .. import types as t
+
 from ..util import (
-    display,
     ConfigParser,
+    display,
 )
 
-from . import (
-    CloudProvider,
-    CloudEnvironment,
-    CloudEnvironmentConfig,
+from ..config import (
+    IntegrationConfig,
+)
+
+from ..target import (
+    IntegrationTarget,
 )
 
 from ..core_ci import (
     AnsibleCoreCI,
 )
 
+from . import (
+    CloudEnvironment,
+    CloudEnvironmentConfig,
+    CloudProvider,
+)
+
 
 class HcloudCloudProvider(CloudProvider):
-    """Hetzner Cloud provider plugin. Sets up cloud resources before
-       delegation.
-    """
-
-    def __init__(self, args):
-        """
-        :type args: TestConfig
-        """
+    """Hetzner Cloud provider plugin. Sets up cloud resources before delegation."""
+    def __init__(self, args):  # type: (IntegrationConfig) -> None
         super(HcloudCloudProvider, self).__init__(args)
 
         self.uses_config = True
 
-    def filter(self, targets, exclude):
-        """Filter out the cloud tests when the necessary config and resources are not available.
-        :type targets: tuple[TestTarget]
-        :type exclude: list[str]
-        """
+    def filter(self, targets, exclude):  # type: (t.Tuple[IntegrationTarget, ...], t.List[str]) -> None
+        """Filter out the cloud tests when the necessary config and resources are not available."""
         aci = self._create_ansible_core_ci()
 
         if aci.available:
@@ -43,14 +44,14 @@ class HcloudCloudProvider(CloudProvider):
 
         super(HcloudCloudProvider, self).filter(targets, exclude)
 
-    def setup(self):
+    def setup(self):  # type: () -> None
         """Setup the cloud resource before delegation and register a cleanup callback."""
         super(HcloudCloudProvider, self).setup()
 
         if not self._use_static_config():
             self._setup_dynamic()
 
-    def _setup_dynamic(self):
+    def _setup_dynamic(self):  # type: () -> None
         """Request Hetzner credentials through the Ansible Core CI service."""
         display.info('Provisioning %s cloud environment.' % self.platform, verbosity=1)
 
@@ -76,22 +77,15 @@ class HcloudCloudProvider(CloudProvider):
 
         self._write_config(config)
 
-    def _create_ansible_core_ci(self):
-        """
-        :rtype: AnsibleCoreCI
-        """
+    def _create_ansible_core_ci(self):  # type: () -> AnsibleCoreCI
+        """Return a Heztner instance of AnsibleCoreCI."""
         return AnsibleCoreCI(self.args, 'hetzner', 'hetzner', persist=False, stage=self.args.remote_stage, provider='hetzner', internal=True)
 
 
 class HcloudCloudEnvironment(CloudEnvironment):
-    """Hetzner Cloud cloud environment plugin. Updates integration test environment
-       after delegation.
-    """
-
-    def get_environment_config(self):
-        """
-        :rtype: CloudEnvironmentConfig
-        """
+    """Hetzner Cloud cloud environment plugin. Updates integration test environment after delegation."""
+    def get_environment_config(self):  # type: () -> CloudEnvironmentConfig
+        """Return environment configuration for use in the test environment after delegation."""
         parser = ConfigParser()
         parser.read(self.config_path)
 

--- a/test/lib/ansible_test/_internal/cloud/httptester.py
+++ b/test/lib/ansible_test/_internal/cloud/httptester.py
@@ -4,12 +4,6 @@ __metaclass__ = type
 
 import os
 
-from . import (
-    CloudProvider,
-    CloudEnvironment,
-    CloudEnvironmentConfig,
-)
-
 from ..util import (
     display,
     generate_password,
@@ -21,6 +15,12 @@ from ..config import (
 
 from ..containers import (
     run_support_container,
+)
+
+from . import (
+    CloudEnvironment,
+    CloudEnvironmentConfig,
+    CloudProvider,
 )
 
 KRB5_PASSWORD_ENV = 'KRB5_PASSWORD'
@@ -83,7 +83,7 @@ class HttptesterProvider(CloudProvider):
 class HttptesterEnvironment(CloudEnvironment):
     """HTTP Tester environment plugin. Updates integration test environment after delegation."""
     def get_environment_config(self):  # type: () -> CloudEnvironmentConfig
-        """Returns the cloud environment config."""
+        """Return environment configuration for use in the test environment after delegation."""
         return CloudEnvironmentConfig(
             env_vars=dict(
                 HTTPTESTER='1',  # backwards compatibility for tests intended to work with or without HTTP Tester

--- a/test/lib/ansible_test/_internal/cloud/nios.py
+++ b/test/lib/ansible_test/_internal/cloud/nios.py
@@ -4,43 +4,40 @@ __metaclass__ = type
 
 import os
 
-from . import (
-    CloudProvider,
-    CloudEnvironment,
-    CloudEnvironmentConfig,
+from ..config import (
+    IntegrationConfig,
 )
 
 from ..containers import (
     run_support_container,
 )
 
+from . import (
+    CloudEnvironment,
+    CloudEnvironmentConfig,
+    CloudProvider,
+)
+
 
 class NiosProvider(CloudProvider):
-    """Nios plugin.
-
-    Sets up NIOS mock server for tests.
-    """
-
+    """Nios plugin. Sets up NIOS mock server for tests."""
     DOCKER_SIMULATOR_NAME = 'nios-simulator'
 
+    # Default image to run the nios simulator.
+    #
+    # The simulator must be pinned to a specific version
+    # to guarantee CI passes with the version used.
+    #
+    # It's source source itself resides at:
+    # https://github.com/ansible/nios-test-container
     DOCKER_IMAGE = 'quay.io/ansible/nios-test-container:1.3.0'
-    """Default image to run the nios simulator.
 
-    The simulator must be pinned to a specific version
-    to guarantee CI passes with the version used.
-
-    It's source source itself resides at:
-    https://github.com/ansible/nios-test-container
-    """
-
-    def __init__(self, args):
-        """Set up container references for provider.
-        :type args: TestConfig
-        """
+    def __init__(self, args):  # type: (IntegrationConfig) -> None
         super(NiosProvider, self).__init__(args)
 
         self.__container_from_env = os.environ.get('ANSIBLE_NIOSSIM_CONTAINER')
-        """Overrides target container, might be used for development.
+        """
+        Overrides target container, might be used for development.
 
         Use ANSIBLE_NIOSSIM_CONTAINER=whatever_you_want if you want
         to use other image. Omit/empty otherwise.
@@ -50,7 +47,7 @@ class NiosProvider(CloudProvider):
 
         self.uses_docker = True
 
-    def setup(self):
+    def setup(self):  # type: () -> None
         """Setup cloud resource before delegation and reg cleanup callback."""
         super(NiosProvider, self).setup()
 
@@ -59,7 +56,7 @@ class NiosProvider(CloudProvider):
         else:
             self._setup_dynamic()
 
-    def _setup_dynamic(self):
+    def _setup_dynamic(self):  # type: () -> None
         """Spawn a NIOS simulator within docker container."""
         nios_port = 443
 
@@ -81,19 +78,14 @@ class NiosProvider(CloudProvider):
 
         self._set_cloud_config('NIOS_HOST', self.DOCKER_SIMULATOR_NAME)
 
-    def _setup_static(self):
+    def _setup_static(self):  # type: () -> None
         raise NotImplementedError()
 
 
 class NiosEnvironment(CloudEnvironment):
-    """NIOS environment plugin.
-
-    Updates integration test environment after delegation.
-    """
-    def get_environment_config(self):
-        """
-        :rtype: CloudEnvironmentConfig
-        """
+    """NIOS environment plugin. Updates integration test environment after delegation."""
+    def get_environment_config(self):  # type: () -> CloudEnvironmentConfig
+        """Return environment configuration for use in the test environment after delegation."""
         ansible_vars = dict(
             nios_provider=dict(
                 host=self._get_cloud_config('NIOS_HOST'),

--- a/test/lib/ansible_test/_internal/cloud/opennebula.py
+++ b/test/lib/ansible_test/_internal/cloud/opennebula.py
@@ -2,21 +2,21 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from . import (
-    CloudProvider,
-    CloudEnvironment,
-    CloudEnvironmentConfig,
+from ..util import (
+    ConfigParser,
+    display,
 )
 
-from ..util import (
-    display,
-    ConfigParser,
+from . import (
+    CloudEnvironment,
+    CloudEnvironmentConfig,
+    CloudProvider,
 )
 
 
 class OpenNebulaCloudProvider(CloudProvider):
     """Checks if a configuration file has been passed or fixtures are going to be used for testing"""
-    def setup(self):
+    def setup(self):  # type: () -> None
         """Setup the cloud resource before delegation and register a cleanup callback."""
         super(OpenNebulaCloudProvider, self).setup()
 
@@ -25,7 +25,7 @@ class OpenNebulaCloudProvider(CloudProvider):
 
         self.uses_config = True
 
-    def _setup_dynamic(self):
+    def _setup_dynamic(self):  # type: () -> None
         display.info('No config file provided, will run test from fixtures')
 
         config = self._read_config_template()
@@ -41,13 +41,9 @@ class OpenNebulaCloudProvider(CloudProvider):
 
 
 class OpenNebulaCloudEnvironment(CloudEnvironment):
-    """
-    Updates integration test environment after delegation. Will setup the config file as parameter.
-    """
-    def get_environment_config(self):
-        """
-        :rtype: CloudEnvironmentConfig
-        """
+    """Updates integration test environment after delegation. Will setup the config file as parameter."""
+    def get_environment_config(self):  # type: () -> CloudEnvironmentConfig
+        """Return environment configuration for use in the test environment after delegation."""
         parser = ConfigParser()
         parser.read(self.config_path)
 

--- a/test/lib/ansible_test/_internal/cloud/openshift.py
+++ b/test/lib/ansible_test/_internal/cloud/openshift.py
@@ -4,12 +4,6 @@ __metaclass__ = type
 
 import re
 
-from . import (
-    CloudProvider,
-    CloudEnvironment,
-    CloudEnvironmentConfig,
-)
-
 from ..io import (
     read_text_file,
 )
@@ -18,9 +12,19 @@ from ..util import (
     display,
 )
 
+from ..config import (
+    IntegrationConfig,
+)
+
 from ..containers import (
     run_support_container,
     wait_for_file,
+)
+
+from . import (
+    CloudEnvironment,
+    CloudEnvironmentConfig,
+    CloudProvider,
 )
 
 
@@ -28,10 +32,7 @@ class OpenShiftCloudProvider(CloudProvider):
     """OpenShift cloud provider plugin. Sets up cloud resources before delegation."""
     DOCKER_CONTAINER_NAME = 'openshift-origin'
 
-    def __init__(self, args):
-        """
-        :type args: TestConfig
-        """
+    def __init__(self, args):  # type: (IntegrationConfig) -> None
         super(OpenShiftCloudProvider, self).__init__(args, config_extension='.kubeconfig')
 
         # The image must be pinned to a specific version to guarantee CI passes with the version used.
@@ -40,7 +41,7 @@ class OpenShiftCloudProvider(CloudProvider):
         self.uses_docker = True
         self.uses_config = True
 
-    def setup(self):
+    def setup(self):  # type: () -> None
         """Setup the cloud resource before delegation and register a cleanup callback."""
         super(OpenShiftCloudProvider, self).setup()
 
@@ -49,7 +50,7 @@ class OpenShiftCloudProvider(CloudProvider):
         else:
             self._setup_dynamic()
 
-    def _setup_static(self):
+    def _setup_static(self):  # type: () -> None
         """Configure OpenShift tests for use with static configuration."""
         config = read_text_file(self.config_static_path)
 
@@ -58,7 +59,7 @@ class OpenShiftCloudProvider(CloudProvider):
         if not match:
             display.warning('Could not find OpenShift endpoint in kubeconfig.')
 
-    def _setup_dynamic(self):
+    def _setup_dynamic(self):  # type: () -> None
         """Create a OpenShift container using docker."""
         port = 8443
 
@@ -88,12 +89,8 @@ class OpenShiftCloudProvider(CloudProvider):
 
         self._write_config(config)
 
-    def _get_config(self, container_name, server):
-        """Get OpenShift config from container.
-        :type container_name: str
-        :type server: str
-        :rtype: dict[str, str]
-        """
+    def _get_config(self, container_name, server):  # type: (str, str) -> str
+        """Get OpenShift config from container."""
         stdout = wait_for_file(self.args, container_name, '/var/lib/origin/openshift.local.config/master/admin.kubeconfig', sleep=10, tries=30)
 
         config = stdout
@@ -105,10 +102,8 @@ class OpenShiftCloudProvider(CloudProvider):
 
 class OpenShiftCloudEnvironment(CloudEnvironment):
     """OpenShift cloud environment plugin. Updates integration test environment after delegation."""
-    def get_environment_config(self):
-        """
-        :rtype: CloudEnvironmentConfig
-        """
+    def get_environment_config(self):  # type: () -> CloudEnvironmentConfig
+        """Return environment configuration for use in the test environment after delegation."""
         env_vars = dict(
             K8S_AUTH_KUBECONFIG=self.config_path,
         )

--- a/test/lib/ansible_test/_internal/cloud/scaleway.py
+++ b/test/lib/ansible_test/_internal/cloud/scaleway.py
@@ -31,9 +31,7 @@ class ScalewayCloudProvider(CloudProvider):
         """Setup the cloud resource before delegation and register a cleanup callback."""
         super(ScalewayCloudProvider, self).setup()
 
-        if os.path.isfile(self.config_static_path):
-            self.config_path = self.config_static_path
-            self.managed = False
+        self._use_static_config()
 
 
 class ScalewayCloudEnvironment(CloudEnvironment):

--- a/test/lib/ansible_test/_internal/cloud/scaleway.py
+++ b/test/lib/ansible_test/_internal/cloud/scaleway.py
@@ -2,32 +2,30 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import os
-
-from . import (
-    CloudProvider,
-    CloudEnvironment,
-    CloudEnvironmentConfig,
-)
-
 from ..util import (
     ConfigParser,
     display,
 )
 
+from ..config import (
+    IntegrationConfig,
+)
+
+from . import (
+    CloudEnvironment,
+    CloudEnvironmentConfig,
+    CloudProvider,
+)
+
 
 class ScalewayCloudProvider(CloudProvider):
     """Checks if a configuration file has been passed or fixtures are going to be used for testing"""
-
-    def __init__(self, args):
-        """
-        :type args: TestConfig
-        """
+    def __init__(self, args):  # type: (IntegrationConfig) -> None
         super(ScalewayCloudProvider, self).__init__(args)
 
         self.uses_config = True
 
-    def setup(self):
+    def setup(self):  # type: () -> None
         """Setup the cloud resource before delegation and register a cleanup callback."""
         super(ScalewayCloudProvider, self).setup()
 
@@ -35,13 +33,9 @@ class ScalewayCloudProvider(CloudProvider):
 
 
 class ScalewayCloudEnvironment(CloudEnvironment):
-    """
-    Updates integration test environment after delegation. Will setup the config file as parameter.
-    """
-    def get_environment_config(self):
-        """
-        :rtype: CloudEnvironmentConfig
-        """
+    """Updates integration test environment after delegation. Will setup the config file as parameter."""
+    def get_environment_config(self):  # type: () -> CloudEnvironmentConfig
+        """Return environment configuration for use in the test environment after delegation."""
         parser = ConfigParser()
         parser.read(self.config_path)
 

--- a/test/lib/ansible_test/_internal/cloud/vcenter.py
+++ b/test/lib/ansible_test/_internal/cloud/vcenter.py
@@ -4,20 +4,24 @@ __metaclass__ = type
 
 import os
 
-from . import (
-    CloudProvider,
-    CloudEnvironment,
-    CloudEnvironmentConfig,
+from ..util import (
+    ApplicationError,
+    ConfigParser,
+    display,
 )
 
-from ..util import (
-    display,
-    ConfigParser,
-    ApplicationError,
+from ..config import (
+    IntegrationConfig,
 )
 
 from ..containers import (
     run_support_container,
+)
+
+from . import (
+    CloudEnvironment,
+    CloudEnvironmentConfig,
+    CloudProvider,
 )
 
 
@@ -25,10 +29,7 @@ class VcenterProvider(CloudProvider):
     """VMware vcenter/esx plugin. Sets up cloud resources for tests."""
     DOCKER_SIMULATOR_NAME = 'vcenter-simulator'
 
-    def __init__(self, args):
-        """
-        :type args: TestConfig
-        """
+    def __init__(self, args):  # type: (IntegrationConfig) -> None
         super(VcenterProvider, self).__init__(args)
 
         # The simulator must be pinned to a specific version to guarantee CI passes with the version used.
@@ -48,7 +49,7 @@ class VcenterProvider(CloudProvider):
             self.uses_docker = False
             self.uses_config = True
 
-    def setup(self):
+    def setup(self):  # type: () -> None
         """Setup the cloud resource before delegation and register a cleanup callback."""
         super(VcenterProvider, self).setup()
 
@@ -63,7 +64,7 @@ class VcenterProvider(CloudProvider):
         else:
             raise ApplicationError('Unknown vmware_test_platform: %s' % self.vmware_test_platform)
 
-    def _setup_dynamic_simulator(self):
+    def _setup_dynamic_simulator(self):  # type: () -> None
         """Create a vcenter simulator using docker."""
         ports = [
             443,
@@ -86,17 +87,15 @@ class VcenterProvider(CloudProvider):
 
         self._set_cloud_config('vcenter_hostname', self.DOCKER_SIMULATOR_NAME)
 
-    def _setup_static(self):
+    def _setup_static(self):  # type: () -> None
         if not os.path.exists(self.config_static_path):
             raise ApplicationError('Configuration file does not exist: %s' % self.config_static_path)
 
 
 class VcenterEnvironment(CloudEnvironment):
     """VMware vcenter/esx environment plugin. Updates integration test environment after delegation."""
-    def get_environment_config(self):
-        """
-        :rtype: CloudEnvironmentConfig
-        """
+    def get_environment_config(self):  # type: () -> CloudEnvironmentConfig
+        """Return environment configuration for use in the test environment after delegation."""
         try:
             # We may be in a container, so we cannot just reach VMWARE_TEST_PLATFORM,
             # We do a try/except instead

--- a/test/lib/ansible_test/_internal/cloud/vultr.py
+++ b/test/lib/ansible_test/_internal/cloud/vultr.py
@@ -2,31 +2,30 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import os
-
-from . import (
-    CloudProvider,
-    CloudEnvironment,
-    CloudEnvironmentConfig,
-)
-
 from ..util import (
     ConfigParser,
     display,
 )
 
+from ..config import (
+    IntegrationConfig,
+)
+
+from . import (
+    CloudEnvironment,
+    CloudEnvironmentConfig,
+    CloudProvider,
+)
+
 
 class VultrCloudProvider(CloudProvider):
     """Checks if a configuration file has been passed or fixtures are going to be used for testing"""
-    def __init__(self, args):
-        """
-        :type args: TestConfig
-        """
+    def __init__(self, args):  # type: (IntegrationConfig) -> None
         super(VultrCloudProvider, self).__init__(args)
 
         self.uses_config = True
 
-    def setup(self):
+    def setup(self):  # type: () -> None
         """Setup the cloud resource before delegation and register a cleanup callback."""
         super(VultrCloudProvider, self).setup()
 
@@ -34,13 +33,9 @@ class VultrCloudProvider(CloudProvider):
 
 
 class VultrCloudEnvironment(CloudEnvironment):
-    """
-    Updates integration test environment after delegation. Will setup the config file as parameter.
-    """
-    def get_environment_config(self):
-        """
-        :rtype: CloudEnvironmentConfig
-        """
+    """Updates integration test environment after delegation. Will setup the config file as parameter."""
+    def get_environment_config(self):  # type: () -> CloudEnvironmentConfig
+        """Return environment configuration for use in the test environment after delegation."""
         parser = ConfigParser()
         parser.read(self.config_path)
 

--- a/test/lib/ansible_test/_internal/cloud/vultr.py
+++ b/test/lib/ansible_test/_internal/cloud/vultr.py
@@ -30,9 +30,7 @@ class VultrCloudProvider(CloudProvider):
         """Setup the cloud resource before delegation and register a cleanup callback."""
         super(VultrCloudProvider, self).setup()
 
-        if os.path.isfile(self.config_static_path):
-            self.config_path = self.config_static_path
-            self.managed = False
+        self._use_static_config()
 
 
 class VultrCloudEnvironment(CloudEnvironment):


### PR DESCRIPTION
##### SUMMARY

Clean up ansible-test cloud plugins:

- Improve code reuse.
- Add missing type hints, fix existing ones and convert them to PEP 484 style.
- Add missing imports and clean up existing ones.
- Add missing docstrings and clean up existing ones.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
