### PR TITLE
Remove include from tests

### DIFF
--- a/docs/docsite/rst/network/dev_guide/developing_resource_modules_network.rst
+++ b/docs/docsite/rst/network/dev_guide/developing_resource_modules_network.rst
@@ -518,7 +518,7 @@ The following example walks through the integration tests for the ``vyos.vyos.vy
 .. code-block:: yaml
 
    ---
-   - include: cli.yaml
+   - import_tasks: cli.yaml
      tags:
        - cli
 
@@ -538,13 +538,20 @@ The following example walks through the integration tests for the ``vyos.vyos.vy
      set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
    - name: run test cases (connection=network_cli)
-     include: "{{ test_case_to_run }} ansible_connection=network_cli"
+     include_tasks:
+        file: "{{ test_case_to_run }}"
+     vars:
+        ansible_connection: network_cli
      with_items: "{{ test_items }}"
      loop_control:
        loop_var: test_case_to_run
 
    - name: run test case (connection=local)
-     include: "{{ test_case_to_run }} ansible_connection=local ansible_become=no"
+     include_tasks:
+        file: "{{ test_case_to_run }}"
+     vars:
+        ansible_connection: local
+        ansible_become: no
      with_first_found: "{{ test_items }}"
      loop_control:
        loop_var: test_case_to_run
@@ -558,11 +565,11 @@ The following example walks through the integration tests for the ``vyos.vyos.vy
    msg: START vyos_l3_interfaces merged integration tests on connection={{ ansible_connection
      }}
 
-  - include_tasks: _remove_config.yaml
+  - import_tasks: _remove_config.yaml
 
   - block:
 
-   - include_tasks: _populate.yaml
+   - import_tasks: _populate.yaml
 
    - name: Overrides all device configuration with provided configuration
      register: result
@@ -613,7 +620,7 @@ The following example walks through the integration tests for the ``vyos.vyos.vy
            \ == 0 }}"
   always:
 
-   - include_tasks: _remove_config.yaml
+   - import_tasks: _remove_config.yaml
 
 
 Detecting test resources at runtime

--- a/test/integration/targets/any_errors_fatal/on_includes.yml
+++ b/test/integration/targets/any_errors_fatal/on_includes.yml
@@ -4,4 +4,4 @@
   hosts: testhost,testhost2
   any_errors_fatal: True
   tasks:
-     - include_tasks: test_fatal.yml
+     - include_tasks: file=test_fatal.yml

--- a/test/integration/targets/any_errors_fatal/on_includes.yml
+++ b/test/integration/targets/any_errors_fatal/on_includes.yml
@@ -4,4 +4,4 @@
   hosts: testhost,testhost2
   any_errors_fatal: True
   tasks:
-     - include_tasks: file=test_fatal.yml
+     - import_tasks: test_fatal.yml

--- a/test/integration/targets/any_errors_fatal/on_includes.yml
+++ b/test/integration/targets/any_errors_fatal/on_includes.yml
@@ -4,4 +4,4 @@
   hosts: testhost,testhost2
   any_errors_fatal: True
   tasks:
-     - include: test_fatal.yml
+     - include_tasks: test_fatal.yml

--- a/test/integration/targets/become/tasks/main.yml
+++ b/test/integration/targets/become/tasks/main.yml
@@ -1,5 +1,5 @@
 - include_vars: default.yml
 
-- include: default.yml
-- include: sudo.yml
-- include: su.yml
+- import_tasks: default.yml
+- import_tasks: sudo.yml
+- import_tasks: su.yml

--- a/test/integration/targets/blocks/main.yml
+++ b/test/integration/targets/blocks/main.yml
@@ -96,8 +96,8 @@
   tasks:
   - block:
     - name: include fail.yml in tasks
-      include: fail.yml
-      args:
+      include_tasks: fail.yml
+      vars:
         msg: "failed from tasks"
     - name: tasks flag should not be set after failure
       set_fact:
@@ -106,8 +106,8 @@
     - set_fact:
         rescue_run_after_include_fail: true
     - name: include fail.yml in rescue
-      include: fail.yml
-      args:
+      include_tasks: fail.yml
+      vars:
         msg: "failed from rescue"
     - name: flag should not be set after failure in rescue
       set_fact:

--- a/test/integration/targets/blocks/main.yml
+++ b/test/integration/targets/blocks/main.yml
@@ -96,7 +96,7 @@
   tasks:
   - block:
     - name: include fail.yml in tasks
-      import_tasks: file=fail.yml
+      import_tasks: fail.yml
       vars:
         msg: "failed from tasks"
     - name: tasks flag should not be set after failure
@@ -106,7 +106,7 @@
     - set_fact:
         rescue_run_after_include_fail: true
     - name: include fail.yml in rescue
-      import_tasks: file=fail.yml
+      import_tasks: fail.yml
       vars:
         msg: "failed from rescue"
     - name: flag should not be set after failure in rescue

--- a/test/integration/targets/blocks/main.yml
+++ b/test/integration/targets/blocks/main.yml
@@ -96,7 +96,7 @@
   tasks:
   - block:
     - name: include fail.yml in tasks
-      include_tasks: fail.yml
+      include_tasks: file=fail.yml
       vars:
         msg: "failed from tasks"
     - name: tasks flag should not be set after failure
@@ -106,7 +106,7 @@
     - set_fact:
         rescue_run_after_include_fail: true
     - name: include fail.yml in rescue
-      include_tasks: fail.yml
+      include_tasks: file=fail.yml
       vars:
         msg: "failed from rescue"
     - name: flag should not be set after failure in rescue

--- a/test/integration/targets/blocks/main.yml
+++ b/test/integration/targets/blocks/main.yml
@@ -96,7 +96,7 @@
   tasks:
   - block:
     - name: include fail.yml in tasks
-      include_tasks: file=fail.yml
+      import_tasks: file=fail.yml
       vars:
         msg: "failed from tasks"
     - name: tasks flag should not be set after failure
@@ -106,7 +106,7 @@
     - set_fact:
         rescue_run_after_include_fail: true
     - name: include fail.yml in rescue
-      include_tasks: file=fail.yml
+      import_tasks: file=fail.yml
       vars:
         msg: "failed from rescue"
     - name: flag should not be set after failure in rescue

--- a/test/integration/targets/blocks/nested_fail.yml
+++ b/test/integration/targets/blocks/nested_fail.yml
@@ -1,3 +1,3 @@
-- include: fail.yml
-  args:
+- include_tasks: fail.yml
+  vars:
     msg: "nested {{msg}}"

--- a/test/integration/targets/blocks/nested_fail.yml
+++ b/test/integration/targets/blocks/nested_fail.yml
@@ -1,3 +1,3 @@
-- include_tasks: file=fail.yml
+- import_tasks: fail.yml
   vars:
     msg: "nested {{msg}}"

--- a/test/integration/targets/blocks/nested_fail.yml
+++ b/test/integration/targets/blocks/nested_fail.yml
@@ -1,3 +1,3 @@
-- include_tasks: fail.yml
+- include_tasks: file=fail.yml
   vars:
     msg: "nested {{msg}}"

--- a/test/integration/targets/blocks/nested_nested_fail.yml
+++ b/test/integration/targets/blocks/nested_nested_fail.yml
@@ -1,3 +1,3 @@
-- include_tasks: file=nested_fail.yml
+- import_tasks: nested_fail.yml
   vars:
     msg: "nested {{msg}}"

--- a/test/integration/targets/blocks/nested_nested_fail.yml
+++ b/test/integration/targets/blocks/nested_nested_fail.yml
@@ -1,3 +1,3 @@
-- include: nested_fail.yml
-  args:
+- include_tasks: nested_fail.yml
+  vars:
     msg: "nested {{msg}}"

--- a/test/integration/targets/blocks/nested_nested_fail.yml
+++ b/test/integration/targets/blocks/nested_nested_fail.yml
@@ -1,3 +1,3 @@
-- include_tasks: nested_fail.yml
+- include_tasks: file=nested_fail.yml
   vars:
     msg: "nested {{msg}}"

--- a/test/integration/targets/copy/tasks/tests.yml
+++ b/test/integration/targets/copy/tasks/tests.yml
@@ -1489,13 +1489,13 @@
 # src is a file, dest is a non-existent directory (2 levels of directories):
 # using remote_src
 # checks that dest is created
-- include: dest_in_non_existent_directories_remote_src.yml
+- include_tasks: file=dest_in_non_existent_directories_remote_src.yml
   with_items:
     - { src: 'foo.txt', dest: 'new_sub_dir1/sub_dir2/', check: 'new_sub_dir1/sub_dir2/foo.txt' }
 
 # src is a file, dest is file in a non-existent directory: checks that a failure occurs
 # using remote_src
-- include: src_file_dest_file_in_non_existent_dir_remote_src.yml
+- include_tasks: file=src_file_dest_file_in_non_existent_dir_remote_src.yml
   with_items:
     - 'new_sub_dir1/sub_dir2/foo.txt'
     - 'new_sub_dir1/foo.txt'
@@ -1504,7 +1504,7 @@
 
 # src is a file, dest is a non-existent directory (2 levels of directories):
 # checks that dest is created
-- include: dest_in_non_existent_directories.yml
+- include_tasks: file=dest_in_non_existent_directories.yml
   with_items:
     - { src: 'foo.txt', dest: 'new_sub_dir1/sub_dir2/', check: 'new_sub_dir1/sub_dir2/foo.txt' }
     - { src: 'subdir', dest: 'new_sub_dir1/sub_dir2/', check: 'new_sub_dir1/sub_dir2/subdir/bar.txt' }
@@ -1513,7 +1513,7 @@
     - { src: 'subdir/', dest: 'new_sub_dir1/sub_dir2', check: 'new_sub_dir1/sub_dir2/bar.txt' }
 
 # src is a file, dest is file in a non-existent directory: checks that a failure occurs
-- include: src_file_dest_file_in_non_existent_dir.yml
+- include_tasks: file=src_file_dest_file_in_non_existent_dir.yml
   with_items:
     - 'new_sub_dir1/sub_dir2/foo.txt'
     - 'new_sub_dir1/foo.txt'

--- a/test/integration/targets/dpkg_selections/tasks/main.yaml
+++ b/test/integration/targets/dpkg_selections/tasks/main.yaml
@@ -1,3 +1,3 @@
 ---
- - include: 'dpkg_selections.yaml'
+ - include_tasks: 'dpkg_selections.yaml'
    when: ansible_distribution in ('Ubuntu', 'Debian')

--- a/test/integration/targets/dpkg_selections/tasks/main.yaml
+++ b/test/integration/targets/dpkg_selections/tasks/main.yaml
@@ -1,3 +1,3 @@
 ---
- - include_tasks: 'dpkg_selections.yaml'
+ - include_tasks: file='dpkg_selections.yaml'
    when: ansible_distribution in ('Ubuntu', 'Debian')

--- a/test/integration/targets/file/tasks/directory_as_dest.yml
+++ b/test/integration/targets/file/tasks/directory_as_dest.yml
@@ -1,6 +1,6 @@
 # File module tests for overwriting directories
 - name: Initialize the test output dir
-  include: initialize.yml
+  import_tasks: initialize.yml
 
 # We need to make this more consistent:
 # https://github.com/ansible/proposals/issues/111

--- a/test/integration/targets/file/tasks/selinux_tests.yml
+++ b/test/integration/targets/file/tasks/selinux_tests.yml
@@ -17,7 +17,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 - name: Initialize the test output dir
-  include: initialize.yml
+  import_tasks: initialize.yml
 
 - name: touch a file for testing
   file: path={{output_dir}}/foo-se.txt state=touch

--- a/test/integration/targets/file/tasks/state_link.yml
+++ b/test/integration/targets/file/tasks/state_link.yml
@@ -1,7 +1,7 @@
 # file module tests for dealing with symlinks (state=link)
 
 - name: Initialize the test output dir
-  include: initialize.yml
+  import_tasks: initialize.yml
 
 #
 # Basic absolute symlink to a file

--- a/test/integration/targets/handlers/roles/test_handlers_include/handlers/main.yml
+++ b/test/integration/targets/handlers/roles/test_handlers_include/handlers/main.yml
@@ -1,1 +1,1 @@
-- include: handlers.yml
+- import_tasks: handlers.yml

--- a/test/integration/targets/handlers/test_handlers_include.yml
+++ b/test/integration/targets/handlers/test_handlers_include.yml
@@ -6,7 +6,7 @@
       notify: test handler
       tags: ['playbook_include_handlers']
   handlers:
-    - include: handlers.yml
+    - import_tasks: handlers.yml
 
 - name: verify that role can include handler
   hosts: testhost

--- a/test/integration/targets/incidental_ios_file/tasks/cli.yaml
+++ b/test/integration/targets/incidental_ios_file/tasks/cli.yaml
@@ -10,7 +10,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test cases (connection=ansible.netcommon.network_cli)
-  include: "{{ test_case_to_run }}"
+  include_tasks: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/incidental_ios_file/tasks/main.yaml
+++ b/test/integration/targets/incidental_ios_file/tasks/main.yaml
@@ -1,2 +1,2 @@
 ---
-- { include_tasks: cli.yaml, tags: ['cli'] }
+- { import_tasks: cli.yaml, tags: ['cli'] }

--- a/test/integration/targets/incidental_ios_file/tasks/main.yaml
+++ b/test/integration/targets/incidental_ios_file/tasks/main.yaml
@@ -1,2 +1,2 @@
 ---
-- { include: cli.yaml, tags: ['cli'] }
+- { include_tasks: cli.yaml, tags: ['cli'] }

--- a/test/integration/targets/incidental_setup_rabbitmq/tasks/main.yml
+++ b/test/integration/targets/incidental_setup_rabbitmq/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- include: ubuntu.yml
+- include_tasks: ubuntu.yml
   when:
     - ansible_distribution == 'Ubuntu'
     - ansible_distribution_release != 'focal'

--- a/test/integration/targets/incidental_vyos_config/tasks/cli.yaml
+++ b/test/integration/targets/incidental_vyos_config/tasks/cli.yaml
@@ -10,13 +10,13 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test case (connection=ansible.netcommon.network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=ansible.netcommon.network_cli"
+  include_tasks: "{{ test_case_to_run }} ansible_connection=ansible.netcommon.network_cli"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
 
 - name: run test case (connection=local)
-  include: "{{ test_case_to_run }} ansible_connection=local"
+  include_tasks: "{{ test_case_to_run }} ansible_connection=local"
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/incidental_vyos_config/tasks/cli.yaml
+++ b/test/integration/targets/incidental_vyos_config/tasks/cli.yaml
@@ -10,13 +10,17 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test case (connection=ansible.netcommon.network_cli)
-  include_tasks: "{{ test_case_to_run }} ansible_connection=ansible.netcommon.network_cli"
+  include_tasks: "file={{ test_case_to_run }}"
+  vars:
+      ansible_connection: ansible.netcommon.network_cli
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
 
 - name: run test case (connection=local)
-  include_tasks: "{{ test_case_to_run }} ansible_connection=local"
+  include_tasks: "file={{ test_case_to_run }}"
+  vars:
+      ansible_connection: local
   with_first_found: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/incidental_vyos_config/tasks/cli_config.yaml
+++ b/test/integration/targets/incidental_vyos_config/tasks/cli_config.yaml
@@ -10,7 +10,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test case (connection=ansible.netcommon.network_cli)
-  include: "{{ test_case_to_run }} ansible_connection=ansible.netcommon.network_cli"
+  include_tasks: "{{ test_case_to_run }} ansible_connection=ansible.netcommon.network_cli"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/incidental_vyos_config/tasks/cli_config.yaml
+++ b/test/integration/targets/incidental_vyos_config/tasks/cli_config.yaml
@@ -10,7 +10,9 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: run test case (connection=ansible.netcommon.network_cli)
-  include_tasks: "{{ test_case_to_run }} ansible_connection=ansible.netcommon.network_cli"
+  include_tasks: "file={{ test_case_to_run }}"
+  vars:
+      ansible_connection: ansible.netcommon.network_cli
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/incidental_vyos_config/tasks/main.yaml
+++ b/test/integration/targets/incidental_vyos_config/tasks/main.yaml
@@ -1,3 +1,9 @@
 ---
-- {include: cli.yaml, tags: ['cli']}
-- {include: cli_config.yaml, tags: ['cli_config']}
+- include_tasks: cli.yaml
+  apply:
+      tags:
+          - 'cli'
+- include_tasks: cli_config.yaml
+  apply:
+      tags:
+          - 'cli_config'

--- a/test/integration/targets/incidental_vyos_config/tasks/main.yaml
+++ b/test/integration/targets/incidental_vyos_config/tasks/main.yaml
@@ -1,9 +1,3 @@
 ---
-- include_tasks: cli.yaml
-  apply:
-      tags:
-          - 'cli'
-- include_tasks: cli_config.yaml
-  apply:
-      tags:
-          - 'cli_config'
+- {import_tasks: cli.yaml, tags: ['cli']}
+- {import_tasks: cli_config.yaml, tags: ['cli_config']}

--- a/test/integration/targets/incidental_vyos_lldp_interfaces/tasks/cli.yaml
+++ b/test/integration/targets/incidental_vyos_lldp_interfaces/tasks/cli.yaml
@@ -11,7 +11,7 @@
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
 - name: Run test case (connection=ansible.netcommon.network_cli)
-  include: "{{ test_case_to_run }}"
+  include_tasks: "{{ test_case_to_run }}"
   vars:
     ansible_connection: ansible.netcommon.network_cli
   with_items: "{{ test_items }}"

--- a/test/integration/targets/incidental_vyos_lldp_interfaces/tasks/main.yaml
+++ b/test/integration/targets/incidental_vyos_lldp_interfaces/tasks/main.yaml
@@ -1,2 +1,2 @@
 ---
-- {include: cli.yaml, tags: ['cli']}
+- {import_tasks: cli.yaml, tags: ['cli']}

--- a/test/integration/targets/incidental_win_data_deduplication/tasks/main.yml
+++ b/test/integration/targets/incidental_win_data_deduplication/tasks/main.yml
@@ -1,2 +1,2 @@
 ---
-- include: pre_test.yml
+- import_tasks: pre_test.yml

--- a/test/integration/targets/incidental_win_data_deduplication/tasks/pre_test.yml
+++ b/test/integration/targets/incidental_win_data_deduplication/tasks/pre_test.yml
@@ -34,7 +34,7 @@
 
 - name: Run tests
   block:
-    - include: tests.yml
+    - import_tasks: tests.yml
   always:
     - name: Detach disk
       win_command: diskpart.exe /s {{ remote_tmp_dir }}\partition_deletion_script.txt

--- a/test/integration/targets/include_import/undefined_var/playbook.yml
+++ b/test/integration/targets/include_import/undefined_var/playbook.yml
@@ -26,7 +26,7 @@
           - "_include_role_result is failed"
         msg: "'include_role' did not evaluate it's attached condition and failed"
 
-    - include_tasks: include_that_defines_var.yml
+    - include: include_that_defines_var.yml
       static: yes
       when:
         - "_undefined == 'yes'"

--- a/test/integration/targets/include_import/undefined_var/playbook.yml
+++ b/test/integration/targets/include_import/undefined_var/playbook.yml
@@ -26,7 +26,7 @@
           - "_include_role_result is failed"
         msg: "'include_role' did not evaluate it's attached condition and failed"
 
-    - include: include_that_defines_var.yml
+    - include_tasks: include_that_defines_var.yml
       static: yes
       when:
         - "_undefined == 'yes'"

--- a/test/integration/targets/include_when_parent_is_static/tasks.yml
+++ b/test/integration/targets/include_when_parent_is_static/tasks.yml
@@ -9,4 +9,4 @@
 
 # perform an include task which should be static if all of the task's parents are static, otherwise it should be dynamic
 # this file was loaded using import_tasks, which is static, so this include should also be static
-- include: syntax_error.yml
+- include_tasks: syntax_error.yml

--- a/test/integration/targets/include_when_parent_is_static/tasks.yml
+++ b/test/integration/targets/include_when_parent_is_static/tasks.yml
@@ -9,4 +9,4 @@
 
 # perform an include task which should be static if all of the task's parents are static, otherwise it should be dynamic
 # this file was loaded using import_tasks, which is static, so this include should also be static
-- include_tasks: syntax_error.yml
+- include: syntax_error.yml

--- a/test/integration/targets/rpm_key/tasks/main.yaml
+++ b/test/integration/targets/rpm_key/tasks/main.yaml
@@ -1,2 +1,2 @@
- - include: 'rpm_key.yaml'
+ - include_tasks: 'rpm_key.yaml'
    when: ansible_os_family == "RedHat"

--- a/test/integration/targets/task_ordering/tasks/main.yml
+++ b/test/integration/targets/task_ordering/tasks/main.yml
@@ -1,7 +1,7 @@
 - set_fact:
     temppath: "{{ remote_tmp_dir }}/output.txt"
 
-- include: taskorder-include.yml
+- include_tasks: taskorder-include.yml
   with_items:
   - 1
   - 2

--- a/test/integration/targets/template/tasks/main.yml
+++ b/test/integration/targets/template/tasks/main.yml
@@ -716,4 +716,4 @@
     that: "\"'y' is undefined\" in error.msg"
 
 # aliases file requires root for template tests so this should be safe
-- include: backup_test.yml
+- include_tasks: backup_test.yml

--- a/test/integration/targets/template/tasks/main.yml
+++ b/test/integration/targets/template/tasks/main.yml
@@ -716,4 +716,4 @@
     that: "\"'y' is undefined\" in error.msg"
 
 # aliases file requires root for template tests so this should be safe
-- include_tasks: backup_test.yml
+- import_tasks: backup_test.yml


### PR DESCRIPTION
##### SUMMARY

Now that `include:` is deprecated, remove it from tests that don't specifically test it.

Integration tests still using `include` (not sure if these should change):

- test/integration/targets/include_import/undefined_var/playbook.yml
- test/integration/targets/include_when_parent_is_dynamic/tasks.yml
- test/integration/targets/include_when_parent_is_static/tasks.yml
- test/integration/targets/includes/include_on_playbook_should_fail.yml
- test/integration/targets/includes/roles/test_includes/handlers/main.yml
- test/integration/targets/includes/roles/test_includes/tasks/branch_toplevel.yml
- test/integration/targets/includes/roles/test_includes/tasks/main.yml
- test/integration/targets/includes/roles/test_includes_free/tasks/main.yml
- test/integration/targets/includes/roles/test_includes_host_pinned/tasks/main.yml
- test/integration/targets/includes/test_includes2.yml
- test/integration/targets/includes/test_includes3.yml
- test/integration/targets/parsing/roles/test_bad_parsing/tasks/main.yml
- test/integration/targets/parsing/roles/test_good_parsing/tasks/main.yml
- test/integration/targets/parsing/roles/test_good_parsing/tasks/test_include_conditional.yml

##### ISSUE TYPE
- Docs Pull Request
- Test Pull Request

##### COMPONENT NAME
tests

