### PR TITLE
ansible-test/sanity: accept --docker-network

### DIFF
--- a/test/lib/ansible_test/_internal/cli.py
+++ b/test/lib/ansible_test/_internal/cli.py
@@ -1036,15 +1036,16 @@ def add_extra_docker_options(parser, integration=True):
                         choices=['never', 'always', 'success'],
                         default='always')
 
+    docker.add_argument('--docker-network',
+                        help='run using the specified docker network')
+
+
     if not integration:
         return
 
     docker.add_argument('--docker-privileged',
                         action='store_true',
                         help='run docker container in privileged mode')
-
-    docker.add_argument('--docker-network',
-                        help='run using the specified docker network')
 
     # noinspection PyTypeChecker
     docker.add_argument('--docker-memory',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The default network of podman is called `podman`. `ansible-test` uses
instead the following hardcoded value: `bridge`.

An optional argument exists to adjust the value but it's only available
for the integration tests.

This patch ensures we can pass a different network for all the
situations.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-test
