### PR TITLE
[tests] Work around vixie-cron and PAM issue, el6

### DIFF
--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -1,3 +1,10 @@
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=726661
+- name: Work around vixie-cron/PAM issue on old distros
+  command: sed -i '/pam_loginuid/ s/^/#/' /etc/pam.d/crond
+  when:
+    - ansible_distribution in ('RedHat', 'CentOS')
+    - ansible_distribution_major_version is version('6', '==')
+
 - name: add cron task (check mode enabled, cron task not already created)
   cron:
     name: test cron task


### PR DESCRIPTION

##### SUMMARY
Change:
- This works around an issue that causes the cron test to fail sometimes
  on el6.

Test Plan:
- ansible-test integration cron --docker centos6

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Test Pull Request

##### COMPONENT NAME

tests