### PR TITLE
Inhibit chmod

### DIFF
--- a/changelogs/fragments/51103-add-inhibit_copystat-to-copy-module.yml
+++ b/changelogs/fragments/51103-add-inhibit_copystat-to-copy-module.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Added the inhibit_copystat flag to copy to allow copy to succeed on platforms where stat values cannot be copied from src to dest. (https://github.com/ansible/ansible/pull/51103)

--- a/changelogs/fragments/51103-add-inhibit_copystat-to-copy-module.yml
+++ b/changelogs/fragments/51103-add-inhibit_copystat-to-copy-module.yml
@@ -1,2 +1,2 @@
-bugfixes:
+minor_changes:
   - Added the inhibit_copystat flag to copy to allow copy to succeed on platforms where stat values cannot be copied from src to dest. (https://github.com/ansible/ansible/pull/51103)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1633,7 +1633,7 @@ class AnsibleModule(object):
         current_attribs = current_attribs.get('attr_flags', '')
         self.set_attributes_if_different(dest, current_attribs, True)
 
-    def atomic_move(self, src, dest, unsafe_writes=False):
+    def atomic_move(self, src, dest, unsafe_writes=False, inhibit_copystat=False):
         '''atomically move src to dest, copying attributes from dest, returns true on success
         it uses os.rename to ensure this as it is an atomic operation, rest of the function is
         to work around limitations, corner cases and ensure selinux context is saved if possible'''
@@ -1746,7 +1746,7 @@ class AnsibleModule(object):
                     finally:
                         self.cleanup(b_tmp_dest_name)
 
-        if creating:
+        if creating and not inhibit_copystat:
             # make sure the file has the correct permissions
             # based on the current value of umask
             umask = os.umask(0)

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -124,7 +124,7 @@ options:
     - If this is not provided, or no, ansible will preserve historical behaviour of copying stats from src to dest.
     default: no
     type: bool
-    version_added: '2.11'
+    version_added: '2.12'
 extends_documentation_fragment:
 - decrypt
 - files

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -124,6 +124,7 @@ options:
     - If this is not provided, or no, ansible will preserve historical behaviour of copying stats from src to dest.
     default: no
     type: bool
+    version_added: '2.8'
 extends_documentation_fragment:
 - decrypt
 - files

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -124,7 +124,7 @@ options:
     - If this is not provided, or no, ansible will preserve historical behaviour of copying stats from src to dest.
     default: no
     type: bool
-    version_added: '2.8'
+    version_added: '2.11'
 extends_documentation_fragment:
 - decrypt
 - files

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -117,6 +117,13 @@ options:
     - If this is not provided, ansible will use the local calculated checksum of the src file.
     type: str
     version_added: '2.5'
+  inhibit_copystat:
+    description:
+    - Prevents copying stat values from src to dest.
+    - Used to allow copy to succeed on platforms where stat values are incompatible between src and dest.
+    - If this is not provided, or no, ansible will preserve historical behaviour of copying stats from src to dest.
+    default: no
+    type: bool
 extends_documentation_fragment:
 - decrypt
 - files
@@ -522,6 +529,7 @@ def main():
             local_follow=dict(type='bool'),
             checksum=dict(type='str'),
             follow=dict(type='bool', default=False),
+            inhibit_copystat=dict(type='bool', default=False),
         ),
         add_file_common_args=True,
         supports_check_mode=True,
@@ -549,6 +557,7 @@ def main():
     group = module.params['group']
     remote_src = module.params['remote_src']
     checksum = module.params['checksum']
+    inhibit_copystat = module.params['inhibit_copystat']
 
     if not os.path.exists(b_src):
         module.fail_json(msg="Source %s not found" % (src))
@@ -670,13 +679,14 @@ def main():
                     _, b_mysrc = tempfile.mkstemp(dir=os.path.dirname(b_dest))
 
                     shutil.copyfile(b_src, b_mysrc)
-                    try:
-                        shutil.copystat(b_src, b_mysrc)
-                    except OSError as err:
-                        if err.errno == errno.ENOSYS and mode == "preserve":
-                            module.warn("Unable to copy stats {0}".format(to_native(b_src)))
-                        else:
-                            raise
+                    if not inhibit_copystat:
+                        try:
+                            shutil.copystat(b_src, b_mysrc)
+                        except OSError as err:
+                            if err.errno == errno.ENOSYS and mode == "preserve":
+                                module.warn("Unable to copy stats {0}".format(to_native(b_src)))
+                            else:
+                                raise
 
                 # might be needed below
                 if PY3 and hasattr(os, 'listxattr'):

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -697,7 +697,7 @@ def main():
                         # assume unwanted ACLs by default
                         src_has_acls = True
 
-                module.atomic_move(b_mysrc, dest, unsafe_writes=module.params['unsafe_writes'])
+                module.atomic_move(b_mysrc, dest, unsafe_writes=module.params['unsafe_writes'], inhibit_copystat=inhibit_copystat)
 
                 if PY3 and hasattr(os, 'listxattr') and platform.system() == 'Linux' and not remote_src:
                     # atomic_move used above to copy src into dest might, in some cases,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added the inhibit_copystat flag to copy to allow copy to succeed on platforms where stat values cannot be copied from src to dest.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
copy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
When running playbooks on HPE NonStop platforms, the shutil.copystat operation does not succeed
when copying files between legacy (GUARDIAN) and current file systems (OSS/POSIX). The stat values are incompatible and does not work of the dest file is in the always-three-level GUARDIAN space
(e.g., /G/disk/dir/file). This option will allow the copy operation to succeed. The author considered adding
to the except clause, but felt that the decision to enable this behaviour in general is not desirable, and should by by deliberate choice of the user of the copy module on platforms where this situation applies.

This is originally work of @rsbeckerca, see #51103

<!--- Paste verbatim command output below, e.g. before and after your change -->
###### before
```
$ ansible-playbook testCopy.yml
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.

PLAY [cs5] ****************************************************************************************************************************

TASK [Gathering Facts] ***************************************************************************************************************
ok: [cs5]

TASK [copyTest : Copy file oss to oss] ************************************************************************************************
changed: [cs5]

TASK [copyTest : Copy file oss to guardian] ******************************************************************************************
fatal: [cs5]: FAILED! => {"changed": false, "msg": "failed to copy: /home/test/test0cat to /G/data01/anscpyt/test0cat", "traceback": "Traceback (most recent call last):\n  File \"/tmp/ansible_ansible.legacy.copy_payload_gxz2_3q3/ansible_ansible.legacy.copy_payload.zip/ansible/modules/copy.py\", line 685, in main\n  File \"/usr/lib/python3.6/shutil.py\", line 203, in copystat\n    lookup(\"chmod\")(dst, mode, follow_symlinks=follow)\nOSError: [Errno 4022] Invalid function argument: b'/G/data01/anscpyt/tmpstorzhk2'\n"}

PLAY RECAP **************************************************************************************************************************
cs5                        : ok=2    changed=1    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0 
```
###### after
```
$ ansible-playbook testCopy.yml
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.

PLAY [cs5] ****************************************************************************************************************************

TASK [Gathering Facts] ***************************************************************************************************************
ok: [cs5]

TASK [copyTest : Copy file oss to oss] ************************************************************************************************
changed: [cs5]

TASK [copyTest : Copy file oss to guardian] ******************************************************************************************
changed: [cs5]

TASK [copyTest : Copy file guardian to guardian] ************************************************************************************
changed: [cs5]

TASK [copyTest : Copy file guardian to oss] ******************************************************************************************
changed: [cs5]

TASK [copyTest : Remove file (delete file) oss 1/2] ************************************************************************************
changed: [cs5]

TASK [copyTest : Remove file (delete file) oss 2/2] ************************************************************************************
changed: [cs5]

TASK [copyTest : Remove file (delete file) guardian 1/2] ******************************************************************************
changed: [cs5]

TASK [copyTest : Remove file (delete file) guardian 2/2] ******************************************************************************
changed: [cs5]

PLAY RECAP **************************************************************************************************************************
cs5                        : ok=9    changed=8    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```