### PR TITLE
template - always mark string filters as Jinja text for more accurate handling

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -848,10 +848,14 @@ class Templar:
 
             if not self.jinja2_native:
                 unsafe = hasattr(result, '__UNSAFE__')
-                if convert_data and not self._no_type_regex.match(variable):
-                    # if this looks like a dictionary or list, convert it to such using the safe_eval method
-                    if (result.startswith("{") and not result.startswith(self.environment.variable_start_string)) or \
-                            result.startswith("[") or result in ("True", "False"):
+                if convert_data:
+                    # If this looks like a dictionary or list, convert it to such using safe_eval()
+                    if (result.startswith("{") and not result.startswith(self.environment.variable_start_string)) \
+                            or result.startswith("[") \
+                            or result in ("True", "False"):
+
+                        # TODO: Another function similar to ansible_native_concat() is needed to preserve the type wrapping.
+                        #       It gets removed by jinja2.utils.concat in do_template() above.
                         eval_results = safe_eval(result, include_exceptions=True)
                         if eval_results[1] is None:
                             result = eval_results[0]

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -82,19 +82,17 @@ JINJA2_OVERRIDE = '#jinja2:'
 
 from jinja2 import __version__ as j2_version
 from jinja2 import Environment
-from jinja2.utils import concat as j2_concat
 
+# FIXME: Need to account for older Jinja versions here if this is always needed
+from ansible.utils.native_jinja import NativeJinjaText
+from ansible.template.native_helpers import ansible_native_concat
 
 USE_JINJA2_NATIVE = False
 if C.DEFAULT_JINJA2_NATIVE:
     try:
         from jinja2.nativetypes import NativeEnvironment
-        from ansible.template.native_helpers import ansible_native_concat
-        from ansible.utils.native_jinja import NativeJinjaText
         USE_JINJA2_NATIVE = True
     except ImportError:
-        from jinja2 import Environment  # noqa: F811
-        from jinja2.utils import concat as j2_concat  # noqa: F811
         display.warning(
             'jinja2_native requires Jinja 2.10 and above. '
             'Version detected: %s. Falling back to default.' % j2_version
@@ -1114,7 +1112,7 @@ class Templar:
                 if self.jinja2_native:
                     res = ansible_native_concat(rf)
                 else:
-                    res = j2_concat(rf)
+                    res = ansible_native_concat(rf, False)
                 if getattr(new_context, 'unsafe', False):
                     res = wrap_var(res)
             except TypeError as te:

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -447,7 +447,7 @@ class JinjaPluginIntercept(MutableMapping):
 
         if self._pluginloader.class_name == 'FilterModule':
             for plugin_name, plugin in self._delegatee.items():
-                if self._jinja2_native and plugin_name in C.STRING_TYPE_FILTERS:
+                if plugin_name in C.STRING_TYPE_FILTERS:
                     self._delegatee[plugin_name] = _wrap_native_text(plugin)
                 else:
                     self._delegatee[plugin_name] = _unroll_iterator(plugin)

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -848,7 +848,7 @@ class Templar:
 
             if not self.jinja2_native:
                 unsafe = hasattr(result, '__UNSAFE__')
-                if convert_data:
+                if convert_data and not isinstance(result, NativeJinjaText):
                     # If this looks like a dictionary or list, convert it to such using safe_eval()
                     if (result.startswith("{") and not result.startswith(self.environment.variable_start_string)) \
                             or result.startswith("[") \

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -562,8 +562,7 @@ class JinjaPluginIntercept(MutableMapping):
                     fq_name = '.'.join((parent_prefix, func_name))
                     # FIXME: detect/warn on intra-collection function name collisions
                     if self._pluginloader.class_name == 'FilterModule':
-                        if self._jinja2_native and fq_name.startswith(('ansible.builtin.', 'ansible.legacy.')) and \
-                                func_name in C.STRING_TYPE_FILTERS:
+                        if fq_name.startswith(('ansible.builtin.', 'ansible.legacy.')) and func_name in C.STRING_TYPE_FILTERS:
                             self._collection_jinja_func_cache[fq_name] = _wrap_filter_text(func)
                         else:
                             self._collection_jinja_func_cache[fq_name] = _unroll_iterator(func)

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -297,7 +297,7 @@ def _update_wrapper(wrapper, func):
 def _wrap_filter_text(func):
     """Wrapper function, that intercepts the result of a filter
     and wraps it into NativeJinjaText which is then used
-    in ``ansible_native_concat`` to indicate that it is a text
+    in ``ansible_native_concat`` to indicate that it is text
     which should not be passed into ``literal_eval``.
     """
     def wrapper(*args, **kwargs):
@@ -674,8 +674,6 @@ class Templar:
 
         # FIXME these regular expressions should be re-compiled each time variable_start_string and variable_end_string are changed
         self.SINGLE_VAR = re.compile(r"^%s\s*(\w*)\s*%s$" % (self.environment.variable_start_string, self.environment.variable_end_string))
-        self._no_type_regex = re.compile(r'.*?\|\s*(?:%s)(?:\([^\|]*\))?\s*\)?\s*(?:%s)' %
-                                         ('|'.join(C.STRING_TYPE_FILTERS), self.environment.variable_end_string))
 
     @property
     def jinja2_native(self):

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -93,8 +93,8 @@ if C.DEFAULT_JINJA2_NATIVE:
         from ansible.utils.native_jinja import NativeJinjaText
         USE_JINJA2_NATIVE = True
     except ImportError:
-        from jinja2 import Environment
-        from jinja2.utils import concat as j2_concat
+        from jinja2 import Environment  # noqa: F811
+        from jinja2.utils import concat as j2_concat  # noqa: F811
         display.warning(
             'jinja2_native requires Jinja 2.10 and above. '
             'Version detected: %s. Falling back to default.' % j2_version
@@ -258,9 +258,9 @@ def _is_rolled(value):
     iterator, or similar object
     """
     return (
-        isinstance(value, Iterator) or
-        isinstance(value, MappingView) or
-        isinstance(value, RANGE_TYPE)
+        isinstance(value, Iterator)
+        or isinstance(value, MappingView)
+        or isinstance(value, RANGE_TYPE)
     )
 
 
@@ -826,10 +826,10 @@ class Templar:
                 variable_hash = sha1(text_type(variable).encode('utf-8'))
                 options_hash = sha1(
                     (
-                        text_type(preserve_trailing_newlines) +
-                        text_type(escape_backslashes) +
-                        text_type(fail_on_undefined) +
-                        text_type(overrides)
+                        text_type(preserve_trailing_newlines)
+                        + text_type(escape_backslashes)
+                        + text_type(fail_on_undefined)
+                        + text_type(overrides)
                     ).encode('utf-8')
                 )
                 sha1_hash = variable_hash.hexdigest() + options_hash.hexdigest()

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -294,7 +294,7 @@ def _update_wrapper(wrapper, func):
     return wrapper
 
 
-def _wrap_native_text(func):
+def _wrap_filter_text(func):
     """Wrapper function, that intercepts the result of a filter
     and wraps it into NativeJinjaText which is then used
     in ``ansible_native_concat`` to indicate that it is a text
@@ -448,7 +448,7 @@ class JinjaPluginIntercept(MutableMapping):
         if self._pluginloader.class_name == 'FilterModule':
             for plugin_name, plugin in self._delegatee.items():
                 if plugin_name in C.STRING_TYPE_FILTERS:
-                    self._delegatee[plugin_name] = _wrap_native_text(plugin)
+                    self._delegatee[plugin_name] = _wrap_filter_text(plugin)
                 else:
                     self._delegatee[plugin_name] = _unroll_iterator(plugin)
 
@@ -564,7 +564,7 @@ class JinjaPluginIntercept(MutableMapping):
                     if self._pluginloader.class_name == 'FilterModule':
                         if self._jinja2_native and fq_name.startswith(('ansible.builtin.', 'ansible.legacy.')) and \
                                 func_name in C.STRING_TYPE_FILTERS:
-                            self._collection_jinja_func_cache[fq_name] = _wrap_native_text(func)
+                            self._collection_jinja_func_cache[fq_name] = _wrap_filter_text(func)
                         else:
                             self._collection_jinja_func_cache[fq_name] = _unroll_iterator(func)
                     else:

--- a/lib/ansible/template/native_helpers.py
+++ b/lib/ansible/template/native_helpers.py
@@ -43,7 +43,7 @@ def _fail_on_undefined(data):
     return data
 
 
-def ansible_native_concat(nodes):
+def ansible_native_concat(nodes, eval=True):
     """Return a native Python type from the list of compiled nodes. If the
     result is a single node, its value is returned. Otherwise, the nodes are
     concatenated as strings. If the result can be parsed with
@@ -78,11 +78,17 @@ def ansible_native_concat(nodes):
             nodes = chain(head, nodes)
         out = u''.join([to_text(_fail_on_undefined(v)) for v in nodes])
 
-    try:
-        out = literal_eval(out)
-        if PY2:
-            # ensure bytes are not returned back into Ansible from templating
-            out = container_to_text(out)
-        return out
-    except (ValueError, SyntaxError, MemoryError):
-        return out
+    if eval:
+        try:
+            out = literal_eval(out)
+            if PY2:
+                # ensure bytes are not returned back into Ansible from templating
+                out = container_to_text(out)
+            return out
+        except (ValueError, SyntaxError, MemoryError):
+            return out
+
+    return out
+
+def preserve_concat(nodes):
+    pass


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Using a regexp to try and find `STRING_TYPE_FILTERS` in a Jinja expression is a losing proposition. Explicitly marking it is more accurate and should give more predictable results.

Fixes #37615
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/template/__init__.py`