### PR TITLE
Add a link to Jinja 2 templates

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_templating.rst
+++ b/docs/docsite/rst/user_guide/playbooks_templating.rst
@@ -49,6 +49,8 @@ fmt
        Playbook organization by roles
    :ref:`playbooks_best_practices`
        Tips and tricks for playbooks
+   `Jinja2 Docs <https://jinja.palletsprojects.com/en/master/templates/>`_
+      Jinja2 documentation, includes the syntax and semantics of the templates
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    `irc.freenode.net <http://irc.freenode.net>`_


### PR DESCRIPTION
##### SUMMARY

Added a link to Jinja 2 templates in playbooks_templating
documentation page.

Fixes: #74313

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/user_guide/playbooks_templating.rst
