### PR TITLE
Fix ansible-test coverage traceback when no data.

### DIFF
--- a/changelogs/fragments/ansible-test-coverage-traceback.yml
+++ b/changelogs/fragments/ansible-test-coverage-traceback.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Fix traceback when generating coverage reports and no coverage directory exists.

--- a/test/lib/ansible_test/_internal/coverage/__init__.py
+++ b/test/lib/ansible_test/_internal/coverage/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import errno
 import os
 import re
 
@@ -123,8 +124,15 @@ def get_powershell_coverage_files(path=None):  # type: (t.Optional[str]) -> t.Li
 def get_coverage_files(language, path=None):  # type: (str, t.Optional[str]) -> t.List[str]
     """Return the list of coverage file paths for the given language."""
     coverage_dir = path or ResultType.COVERAGE.path
-    coverage_files = [os.path.join(coverage_dir, f) for f in os.listdir(coverage_dir)
-                      if '=coverage.' in f and '=%s' % language in f]
+
+    try:
+        coverage_files = [os.path.join(coverage_dir, f) for f in os.listdir(coverage_dir)
+                          if '=coverage.' in f and '=%s' % language in f]
+    except IOError as ex:
+        if ex.errno == errno.ENOENT:
+            return []
+
+        raise
 
     return coverage_files
 


### PR DESCRIPTION
##### SUMMARY

If no coverage directory exists, ansible-test coverage would traceback.

Now it silently continues just as if the directory was present but empty.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

Fixes the traceback reported in https://github.com/ansible/ansible/issues/74350