### PR TITLE
[2.11] Map Debian 8 to Python 2 (#74152)

### DIFF
--- a/changelogs/fragments/debian8_discovery.yml
+++ b/changelogs/fragments/debian8_discovery.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- interpreter discovery - Debian 8 and lower will avoid unsupported Python3 version in interpreter discovery

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1496,6 +1496,7 @@ INTERPRETER_PYTHON_DISTRO_MAP:
       '6': /usr/bin/python
       '8': /usr/libexec/platform-python
     debian:
+      '8': /usr/bin/python
       '10': /usr/bin/python3
     fedora:
       '23': /usr/bin/python3

--- a/test/integration/targets/interpreter_discovery_python/tasks/main.yml
+++ b/test/integration/targets/interpreter_discovery_python/tasks/main.yml
@@ -140,8 +140,11 @@
   - name: debian assertions
     assert:
       that:
-      - auto_out.ansible_facts.discovered_interpreter_python == '/usr/bin/python3'
-    when: distro == 'debian' and distro_version is version('10', '>=')
+      # Debian 8 and older
+      - auto_out.ansible_facts.discovered_interpreter_python == '/usr/bin/python' and distro_version is version('8', '<=') or distro_version is version('8', '>')
+      # Debian 10 and newer
+      - auto_out.ansible_facts.discovered_interpreter_python == '/usr/bin/python3' and distro_version is version('10', '>=') or distro_version is version('10', '<')
+    when: distro == 'debian'
 
   - name: fedora assertions
     assert:


### PR DESCRIPTION
##### SUMMARY
backport of #74152

* Map Debian 8 to Python 2

If Python 3 is installed on Debian 8 Ansible cannot run, as the version
is too old (3.4)

* Add integration test for python interpreter discovery on Debian 8

* fix test issue on Debian 9, add changelog

* un"fix" not broken test :D

Co-authored-by: Fabian Klemp <fabian.klemp@elara-gmbh.de>
Co-authored-by: Matt Davis <mrd@redhat.com>
(cherry picked from commit 437a08eb6de7bf87a8c874e756f9b6b523911e68)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
