### PR TITLE
ansible-galaxy: Clone git collections using shallow clones

### DIFF
--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -346,8 +346,8 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
         dir=b_path,
         prefix=to_bytes(name, errors='surrogate_or_strict'),
     )  # type: bytes
-    git_clone_cmd = 'git', 'clone', git_url, to_text(b_checkout_path)
-    # FIXME: '--depth', '1', '--branch', version
+    git_clone_cmd = 'git', 'clone', '--depth=1', git_url, to_text(b_checkout_path)
+    # FIXME: '--branch', version
     try:
         subprocess.check_call(git_clone_cmd)
     except subprocess.CalledProcessError as proc_err:

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -346,8 +346,14 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
         dir=b_path,
         prefix=to_bytes(name, errors='surrogate_or_strict'),
     )  # type: bytes
-    git_clone_cmd = 'git', 'clone', '--depth=1', git_url, to_text(b_checkout_path)
+    git_clone_cmd = (
+        'git', 'clone',
+        *(('--depth=1',) if version == 'HEAD' else tuple()),
+        git_url,
+        to_text(b_checkout_path)
+    )
     # FIXME: '--branch', version
+
     try:
         subprocess.check_call(git_clone_cmd)
     except subprocess.CalledProcessError as proc_err:

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -346,12 +346,12 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
         dir=b_path,
         prefix=to_bytes(name, errors='surrogate_or_strict'),
     )  # type: bytes
-    git_clone_cmd = (
-        'git', 'clone',
-        *(('--depth=1',) if version == 'HEAD' else tuple()),
-        git_url,
-        to_text(b_checkout_path)
-    )
+
+    git_clone_cmd = ['git', 'clone']
+    # Perform a shallow clone if simply cloning HEAD
+    if version == 'HEAD':
+        git_clone_cmd.append('--depth=1')
+    git_clone_cmd.extend([git_url, to_text(b_checkout_path)])
     # FIXME: '--branch', version
 
     try:


### PR DESCRIPTION
##### SUMMARY

This ensures the collection obtained via git url is a result of a
shallow git clone (git clone --depth=1). The git history of the
collection is not used by ansible, and as such, cloning the entire
history of the repo is unnecessary.

Signed-off-by: Tomas Babej

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-galaxy