### PR TITLE
Allow subdirs in playbook collections  (#74301)

### DIFF
--- a/changelogs/fragments/coll_pb_subdir_fixes.yml
+++ b/changelogs/fragments/coll_pb_subdir_fixes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - playbook loaded from collection subdir now does not ignore subdirs.

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -891,6 +891,12 @@ def _get_collection_playbook_path(playbook):
 
         if pkg:
             cpath = os.path.join(sys.modules[acr.n_python_collection_package_name].__file__.replace('__synthetic__', 'playbooks'))
+
+            if acr.subdirs:
+                paths = [to_native(x) for x in acr.subdirs.split(u'.')]
+                paths.insert(0, cpath)
+                cpath = os.path.join(*paths)
+
             path = os.path.join(cpath, to_native(acr.resource))
             if os.path.exists(to_bytes(path)):
                 return acr.resource, path, acr.collection

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/playbooks/play.yml
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/playbooks/play.yml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - set_fact: play='tldr'

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/playbooks/type/play.yml
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/playbooks/type/play.yml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - set_fact: play_type='in type subdir'

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/playbooks/type/subtype/play.yml
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/playbooks/type/subtype/play.yml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - set_fact: play_type_subtype='in subtype subdir'

--- a/test/integration/targets/collections/import_collection_pb.yml
+++ b/test/integration/targets/collections/import_collection_pb.yml
@@ -1,2 +1,17 @@
 - import_playbook: testns.testcoll.default_collection_playbook.yml
 - import_playbook: testns.testcoll.default_collection_playbook
+
+# test subdirs
+- import_playbook: "testns.testcoll.play"
+- import_playbook: "testns.testcoll.type.play"
+- import_playbook: "testns.testcoll.type.subtype.play"
+
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: check values from imports
+      assert:
+        that:
+          - play is defined
+          - play_type is defined
+          - play_type_subtype is defined


### PR DESCRIPTION
* fix subdir parsing for plays

  fixes #74283

  Co-authored-by: Nikolaos Kakouros <nkak@kth.se>

(cherry picked from commit 6418f368e3d13c404cc2d53a6d5dab68f2809996)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
collections