### PR TITLE
Correct splitext() description, and example

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1622,12 +1622,12 @@ To get the root and extension of a path or file name (new in version 2.0)::
     # with path == 'nginx.conf' the return would be ('nginx', '.conf')
     {{ path | splitext }}
 
-The ``splitext`` filter returns a string. The individual components can be accessed by using the ``first`` and ``last`` filters::
+The ``splitext`` filter always returns a pair of strings. The individual components can be accessed by using the ``first`` and ``last`` filters::
 
     # with path == 'nginx.conf' the return would be 'nginx'
     {{ path | splitext | first }}
 
-    # with path == 'nginx.conf' the return would be 'conf'
+    # with path == 'nginx.conf' the return would be '.conf'
     {{ path | splitext | last }}
 
 To join one or more path components::


### PR DESCRIPTION
##### SUMMARY
`splitext()` returns a 2-tuple of strings, and the last element of the return value includes the `.`

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

```
$ v/bin/ansible localhost -mdebug -a msg="{{ 'foo.bar' | splitext }}"
localhost | SUCCESS => {
    "msg": "('foo', '.bar')"
}
$  v/bin/ansible --version
ansible 2.10.8
  config file = /home/alex/.ansible.cfg
  configured module search path = ['/home/alex/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/alex/src/ansible-jq-filter/v/lib/python3.8/site-packages/ansible
  executable location = v/bin/ansible
  python version = 3.8.5 (default, Jan 27 2021, 15:41:15) [GCC 9.3.0]
```

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
