### PR TITLE
validate-modules: don't error on valid Ansible YAML in EXAMPLES

### DIFF
--- a/changelogs/fragments/74384-validate-modules-yaml.yml
+++ b/changelogs/fragments/74384-validate-modules-yaml.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-test validate-modules - EXAMPLES will no longer be marked as invalid YAML when it uses Ansible-specific YAML tags (https://github.com/ansible/ansible/pull/74384).

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -1069,7 +1069,8 @@ class ModuleValidator(Validator):
             else:
                 _doc, errors, traces = parse_yaml(doc_info['EXAMPLES']['value'],
                                                   doc_info['EXAMPLES']['lineno'],
-                                                  self.name, 'EXAMPLES', load_all=True)
+                                                  self.name, 'EXAMPLES', load_all=True,
+                                                  ansible_loader=True)
                 for error in errors:
                     self.reporter.error(
                         path=self.object_path,

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/utils.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/utils.py
@@ -31,7 +31,9 @@ import yaml.reader
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.yaml import SafeLoader
 from ansible.module_utils.six import string_types
+from ansible.parsing.yaml.loader import AnsibleLoader
 
 
 class AnsibleTextIOWrapper(TextIOWrapper):
@@ -133,18 +135,23 @@ def get_module_name_from_filename(filename, collection):
     return name
 
 
-def parse_yaml(value, lineno, module, name, load_all=False):
+def parse_yaml(value, lineno, module, name, load_all=False, ansible_loader=False):
     traces = []
     errors = []
     data = None
 
     if load_all:
-        loader = yaml.safe_load_all
+        yaml_load = yaml.load_all
     else:
-        loader = yaml.safe_load
+        yaml_load = yaml.load
+
+    if ansible_loader:
+        loader = AnsibleLoader
+    else:
+        loader = SafeLoader
 
     try:
-        data = loader(value)
+        data = yaml_load(value, Loader=loader)
         if load_all:
             data = list(data)
     except yaml.MarkedYAMLError as e:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Use Ansible's custom loader to support tags like `!unsafe` during YAML validation.

When a module takes a parameter that usually needs to be marked unsafe, it should be able to provide usable examples in the documentation without failing sanity tests.



<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
validate-modules

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
```yaml
EXAMPLES = '''
- name: Configure LDAP authentication
  flowerysong.hvault.ldap_config:
    url: ldaps://ldap.umich.edu
    userdn: ou=People,dc=umich,dc=edu
    userattr: cn
    groupdn: ou=User Groups,ou=Groups,dc=umich,dc=edu
    groupfilter: !unsafe (member={{.UserDN}})
    groupattr: cn
'''
```

Without this change:
```
Running sanity test 'validate-modules' with Python 3.7
ERROR: Found 1 validate-modules issue(s) which need to be resolved:
ERROR: plugins/modules/ldap_config.py:152:18: invalid-examples: EXAMPLES is not valid YAML
```
