### PR TITLE
Fix combinated run of unarchive and uri tests under centos 6

### DIFF
--- a/test/integration/targets/unarchive/tasks/test_download.yml
+++ b/test/integration/targets/unarchive/tasks/test_download.yml
@@ -4,31 +4,41 @@
     path: '{{remote_tmp_dir}}/test-unarchive-tar-gz'
     state: directory
 
-- name: Install packages to make TLS connections work on CentOS 6
-  pip:
-    name:
-      - urllib3==1.10.2
-      - ndg_httpsclient==0.4.4
-      - pyOpenSSL==16.2.0
-    state: present
-  when:
-    - ansible_facts.distribution == 'CentOS'
-    - not ansible_facts.python.has_sslcontext
-
-- name: unarchive a tar from an URL
-  unarchive:
-    src: "https://releases.ansible.com/ansible/ansible-latest.tar.gz"
-    dest: "{{ remote_tmp_dir }}/test-unarchive-tar-gz"
-    mode: "0700"
-    remote_src: yes
-  register: unarchive13
-
-- name: Test that unarchive succeeded
-  assert:
-    that:
-      - "unarchive13.changed == true"
-
-- name: remove our tar.gz unarchive destination
-  file:
-    path: '{{ remote_tmp_dir }}/test-unarchive-tar-gz'
-    state: absent
+- name: Test TLS download
+  block:
+  - name: Install packages to make TLS connections work on CentOS 6
+    pip:
+      name:
+        - urllib3==1.10.2
+        - ndg_httpsclient==0.4.4
+        - pyOpenSSL==16.2.0
+      state: present
+    when:
+      - ansible_facts.distribution == 'CentOS'
+      - not ansible_facts.python.has_sslcontext
+  - name: unarchive a tar from an URL
+    unarchive:
+      src: "https://releases.ansible.com/ansible/ansible-latest.tar.gz"
+      dest: "{{ remote_tmp_dir }}/test-unarchive-tar-gz"
+      mode: "0700"
+      remote_src: yes
+    register: unarchive13
+  - name: Test that unarchive succeeded
+    assert:
+      that:
+        - "unarchive13.changed == true"
+  always:
+    - name: Uninstall CentOS 6 TLS connections packages
+      pip:
+        name:
+          - urllib3
+          - ndg_httpsclient
+          - pyOpenSSL
+        state: absent
+      when:
+        - ansible_facts.distribution == 'CentOS'
+        - not ansible_facts.python.has_sslcontext
+    - name: remove our tar.gz unarchive destination
+      file:
+        path: '{{ remote_tmp_dir }}/test-unarchive-tar-gz'
+        state: absent


### PR DESCRIPTION
##### SUMMARY
The unarchive integration test installs pinned packages via pip,
the uri test installs them from system packages. This explodes.
PR lets unarchive uninstall packages after test ran.


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
- unarchive
- uri
- 
##### ADDITIONAL INFORMATION

