### PR TITLE
Fix ansible-test docker container IP detection.

### DIFF
--- a/changelogs/fragments/ansible-test-docker-network-detect.yml
+++ b/changelogs/fragments/ansible-test-docker-network-detect.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Fix docker container IP address detection. The ``bridge`` network is no longer assumed to be the default.

--- a/test/lib/ansible_test/_internal/docker_util.py
+++ b/test/lib/ansible_test/_internal/docker_util.py
@@ -423,7 +423,13 @@ class DockerInspect:
     def get_ip_address(self):  # type: () -> t.Optional[str]
         """Return the IP address of the container for the preferred docker network."""
         if self.networks:
-            network_name = get_docker_preferred_network_name(self.args) or 'bridge'
+            network_name = get_docker_preferred_network_name(self.args)
+
+            if not network_name:
+                # Sort networks and use the first available.
+                # This assumes all containers will have access to the same networks.
+                network_name = sorted(self.networks.keys()).pop(0)
+
             ipaddress = self.networks[network_name]['IPAddress']
         else:
             ipaddress = self.network_settings['IPAddress']


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test docker container IP detection.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

Resolves issue reported in https://github.com/ansible/ansible/pull/74335