### PR TITLE
[stable-2.9] Fix ansible-test docker container IP detection.

### DIFF
--- a/changelogs/fragments/ansible-test-docker-network-detect.yml
+++ b/changelogs/fragments/ansible-test-docker-network-detect.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Fix docker container IP address detection. The ``bridge`` network is no longer assumed to be the default.

--- a/test/lib/ansible_test/_internal/docker_util.py
+++ b/test/lib/ansible_test/_internal/docker_util.py
@@ -106,7 +106,13 @@ def get_docker_container_ip(args, container_id):
     networks = network_settings.get('Networks')
 
     if networks:
-        network_name = get_docker_preferred_network_name(args) or 'bridge'
+        network_name = get_docker_preferred_network_name(args)
+
+        if not network_name:
+            # Sort networks and use the first available.
+            # This assumes all containers will have access to the same networks.
+            network_name = sorted(networks.keys()).pop(0)
+
         ipaddress = networks[network_name]['IPAddress']
     else:
         # podman doesn't provide Networks, fall back to using IPAddress


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/74387

(cherry picked from commit 14ff5e213cd084480d628ec0562200b174b6fa79)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
