### PR TITLE
[stable-2.10] validate-modules: don't error on valid Ansible YAML in EXAMPLES

### DIFF
--- a/changelogs/fragments/74384-validate-modules-yaml.yml
+++ b/changelogs/fragments/74384-validate-modules-yaml.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-test validate-modules - EXAMPLES will no longer be marked as invalid YAML when it uses Ansible-specific YAML tags (https://github.com/ansible/ansible/pull/74384).

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -1047,7 +1047,8 @@ class ModuleValidator(Validator):
             else:
                 _doc, errors, traces = parse_yaml(doc_info['EXAMPLES']['value'],
                                                   doc_info['EXAMPLES']['lineno'],
-                                                  self.name, 'EXAMPLES', load_all=True)
+                                                  self.name, 'EXAMPLES', load_all=True,
+                                                  ansible_loader=True)
                 for error in errors:
                     self.reporter.error(
                         path=self.object_path,

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/utils.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/utils.py
@@ -32,6 +32,7 @@ import yaml.reader
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import string_types
+from ansible.parsing.yaml.loader import AnsibleLoader
 
 
 class AnsibleTextIOWrapper(TextIOWrapper):
@@ -133,18 +134,26 @@ def get_module_name_from_filename(filename, collection):
     return name
 
 
-def parse_yaml(value, lineno, module, name, load_all=False):
+def parse_yaml(value, lineno, module, name, load_all=False, ansible_loader=False):
     traces = []
     errors = []
     data = None
 
     if load_all:
-        loader = yaml.safe_load_all
+        yaml_load = yaml.load_all
     else:
-        loader = yaml.safe_load
+        yaml_load = yaml.load
+
+    if ansible_loader:
+        loader = AnsibleLoader
+    else:
+        try:
+            loader = yaml.CSafeLoader
+        except AttributeError:
+            loader = yaml.SafeLoader
 
     try:
-        data = loader(value)
+        data = yaml_load(value, Loader=loader)
         if load_all:
             data = list(data)
     except yaml.MarkedYAMLError as e:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #74384

(cherry picked from commit 7b5dad23214804c79d318784460c5d365f04e852)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
validate-modules