### PR TITLE
Set ansible-test min controller Python to 3.8.

### DIFF
--- a/changelogs/fragments/ansible-test-min-controller-python.yml
+++ b/changelogs/fragments/ansible-test-min-controller-python.yml
@@ -1,0 +1,3 @@
+major_changes:
+  - ansible-test - Version neutral sanity tests now require Python 3.8 or later.
+  - ansible-test - Unit tests for controller-only code now require Python 3.8 or later.

--- a/test/integration/targets/ansible-test/collection-tests/coverage.sh
+++ b/test/integration/targets/ansible-test/collection-tests/coverage.sh
@@ -7,8 +7,8 @@ cd "${WORK_DIR}/ansible_collections/ns/col"
 
 # rename the sanity ignore file to match the current ansible version and update import ignores with the python version
 ansible_version="$(python -c 'import ansible.release; print(".".join(ansible.release.__version__.split(".")[:2]))')"
-if [ "${ANSIBLE_TEST_PYTHON_VERSION}" == "2.6" ]; then
-    # Non-module/module_utils plugins are not checked on this remote-only Python versions
+if [[ "${ANSIBLE_TEST_PYTHON_VERSION}" =~ ^2\. ]] || [[ "${ANSIBLE_TEST_PYTHON_VERSION}" =~ ^3\.[567] ]]; then
+    # Non-module/module_utils plugins are not checked on these remote-only Python versions
     sed "s/ import$/ import-${ANSIBLE_TEST_PYTHON_VERSION}/;" < "tests/sanity/ignore.txt" | grep -v 'plugins/[^m].* import' > "tests/sanity/ignore-${ansible_version}.txt"
 else
     sed "s/ import$/ import-${ANSIBLE_TEST_PYTHON_VERSION}/;" < "tests/sanity/ignore.txt" > "tests/sanity/ignore-${ansible_version}.txt"

--- a/test/integration/targets/ansible-test/collection-tests/venv.sh
+++ b/test/integration/targets/ansible-test/collection-tests/venv.sh
@@ -7,8 +7,8 @@ cd "${WORK_DIR}/ansible_collections/ns/col"
 
 # rename the sanity ignore file to match the current ansible version and update import ignores with the python version
 ansible_version="$(python -c 'import ansible.release; print(".".join(ansible.release.__version__.split(".")[:2]))')"
-if [ "${ANSIBLE_TEST_PYTHON_VERSION}" == "2.6" ]; then
-    # Non-module/module_utils plugins are not checked on this remote-only Python versions
+if [[ "${ANSIBLE_TEST_PYTHON_VERSION}" =~ ^2\. ]] || [[ "${ANSIBLE_TEST_PYTHON_VERSION}" =~ ^3\.[567] ]]; then
+    # Non-module/module_utils plugins are not checked on these remote-only Python versions
     sed "s/ import$/ import-${ANSIBLE_TEST_PYTHON_VERSION}/;" < "tests/sanity/ignore.txt" | grep -v 'plugins/[^m].* import' > "tests/sanity/ignore-${ansible_version}.txt"
 else
     sed "s/ import$/ import-${ANSIBLE_TEST_PYTHON_VERSION}/;" < "tests/sanity/ignore.txt" > "tests/sanity/ignore-${ansible_version}.txt"

--- a/test/lib/ansible_test/_internal/sanity/__init__.py
+++ b/test/lib/ansible_test/_internal/sanity/__init__.py
@@ -31,6 +31,8 @@ from ..util import (
     paths_to_dirs,
     get_ansible_version,
     str_to_version,
+    SUPPORTED_PYTHON_VERSIONS,
+    CONTROLLER_PYTHON_VERSIONS,
 )
 
 from ..util_common import (
@@ -54,7 +56,6 @@ from ..executor import (
     AllTargetsSkipped,
     Delegate,
     install_command_requirements,
-    SUPPORTED_PYTHON_VERSIONS,
 )
 
 from ..config import (
@@ -659,7 +660,7 @@ class SanityTest(ABC):
     @property
     def supported_python_versions(self):  # type: () -> t.Optional[t.Tuple[str, ...]]
         """A tuple of supported Python versions or None if the test does not depend on specific Python versions."""
-        return tuple(python_version for python_version in SUPPORTED_PYTHON_VERSIONS if str_to_version(python_version) >= (3, 6))
+        return CONTROLLER_PYTHON_VERSIONS
 
     def filter_targets(self, targets):  # type: (t.List[TestTarget]) -> t.List[TestTarget]  # pylint: disable=unused-argument
         """Return the given list of test targets, filtered to include only those relevant for the test."""

--- a/test/lib/ansible_test/_internal/sanity/import.py
+++ b/test/lib/ansible_test/_internal/sanity/import.py
@@ -87,6 +87,10 @@ class ImportTest(SanityMultipleVersion):
         :type python_version: str
         :rtype: TestResult
         """
+        settings = self.load_processor(args, python_version)
+
+        paths = [target.path for target in targets.include]
+
         capture_pip = args.verbosity < 2
 
         python = find_python(python_version)
@@ -96,10 +100,6 @@ class ImportTest(SanityMultipleVersion):
             # on Python 3.x we can use the built-in venv
             pip = generate_pip_command(python)
             run_command(args, generate_pip_install(pip, '', packages=['virtualenv']), capture=capture_pip)
-
-        settings = self.load_processor(args, python_version)
-
-        paths = [target.path for target in targets.include]
 
         env = ansible_environment(args, color=False)
 

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -113,9 +113,7 @@ MODE_FILE_WRITE = MODE_FILE | stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH
 MODE_DIRECTORY = MODE_READ | stat.S_IWUSR | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
 MODE_DIRECTORY_WRITE = MODE_DIRECTORY | stat.S_IWGRP | stat.S_IWOTH
 
-REMOTE_ONLY_PYTHON_VERSIONS = (
-    '2.6',
-)
+CONTROLLER_MIN_PYTHON_VERSION = '3.8'
 
 SUPPORTED_PYTHON_VERSIONS = (
     '2.6',
@@ -904,3 +902,6 @@ def get_host_ip():
 
 
 display = Display()  # pylint: disable=locally-disabled, invalid-name
+
+CONTROLLER_PYTHON_VERSIONS = tuple(version for version in SUPPORTED_PYTHON_VERSIONS if str_to_version(version) >= str_to_version(CONTROLLER_MIN_PYTHON_VERSION))
+REMOTE_ONLY_PYTHON_VERSIONS = tuple(version for version in SUPPORTED_PYTHON_VERSIONS if str_to_version(version) < str_to_version(CONTROLLER_MIN_PYTHON_VERSION))


### PR DESCRIPTION
##### SUMMARY

Set ansible-test min controller Python to 3.8.

- Version neutral sanity tests now require Python 3.8 or later.
- Unit tests for controller-only code now require Python 3.8 or later.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
