### PR TITLE
expand doc snippets to lookups and other plugins

### DIFF
--- a/changelogs/fragments/snippets.yml
+++ b/changelogs/fragments/snippets.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansbile-doc now also shows snippets for inventory and lookup, adding to existing modules.

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -842,6 +842,9 @@ class DocCLI(CLI, RoleMixin):
         if context.CLIARGS['show_snippet']:
             if plugin_type not in SNIPPETS:
                 raise AnsibleError("Snippets are only available for the following plugin types: %s" % ', '.join(SNIPPETS))
+            if plugin_type == 'inventory' and plugin in ('yaml', 'toml'):
+                # not usable as other inventory plugins
+                del doc['options']
             text = DocCLI.get_snippet_text(doc, plugin_type)
         else:
             try:
@@ -966,7 +969,7 @@ class DocCLI(CLI, RoleMixin):
 
         if ptype == 'lookup':
             _do_lookup_snippet(text, doc)
-        else:
+        elif 'options' in doc:
             _do_yaml_snippet(text, doc)
 
         text.append('')

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -1323,7 +1323,7 @@ def _do_ini_snippet(text, doc):
                 sections[entry['section']] = []
 
             if required:
-                default = '# <REQUIRED>'
+                default = '  # <REQUIRED>'
             else:
                 default = opt.get('default', '')
 

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -1296,8 +1296,6 @@ def _do_yaml_snippet(text, doc):
 
 def _do_ini_snippet(text, doc):
 
-    #text.append("# %s:" % doc.get('plugin', doc.get('name')).upper())
-
     subdent = "# "
     limit = display.columns - 20
 

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -47,8 +47,7 @@ display = Display()
 TARGET_OPTIONS = C.DOCUMENTABLE_PLUGINS + ('role', 'keyword',)
 PB_OBJECTS = ['Play', 'Role', 'Block', 'Task']
 PB_LOADED = {}
-SNIPPETS = {'module', 'lookup'}
-
+SNIPPETS = ['module', 'lookup']
 
 def jdump(text):
     try:

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -419,7 +419,6 @@ class DocCLI(CLI, RoleMixin):
                                  action=opt_help.PrependListAction,
                                  help='The path to the directory containing your roles.')
 
-
         # modifiers
         exclusive = self.parser.add_mutually_exclusive_group()
         # TODO: wanr if not used with -t roles
@@ -437,7 +436,6 @@ class DocCLI(CLI, RoleMixin):
                                help='List available plugins. %s' % coll_filter)
         exclusive.add_argument("--metadata-dump", action="store_true", default=False, dest='dump',
                                help='**For internal testing only** Dump json metadata for all plugins.')
-
 
     def post_process_args(self, options):
         options = super(DocCLI, self).post_process_args(options)
@@ -964,13 +962,14 @@ class DocCLI(CLI, RoleMixin):
 
         text = []
 
-        # ('become', 'cache', 'callback', 'cliconf', 'connection', 'httpapi', 'inventory', 'lookup', 'netconf', 'shell', 'vars', 'module', 'strategy', 'role', 'keyword')
+        # ('become', 'cache', 'callback', 'cliconf', 'connection', 'httpapi', 'inventory',
+        #  'lookup', 'netconf', 'shell', 'vars', 'module', 'strategy', 'role', 'keyword')
         # those that support YAML format
         if ptype in ('inventory', 'module') and 'options' in doc:
             _do_yaml_snippet(text, doc)
         elif ptype == 'lookup':
             _do_lookup_snippet(text, doc)
-        else:
+        elif not in ('role', 'keyword'):
             _do_ini_snippet(text, doc)
 
         # show something for those that really wont work any other way (ini/toml/script inventories)

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -840,7 +840,7 @@ class DocCLI(CLI, RoleMixin):
         doc['metadata'] = metadata
 
         if context.CLIARGS['show_snippet']:
-            text = DocCLI.get_snippet_text(plugin_type, doc)
+            text = DocCLI.get_snippet_text(doc, plugin_type)
         else:
             try:
                 text = DocCLI.get_man_text(doc, collection_name, plugin_type)
@@ -958,7 +958,7 @@ class DocCLI(CLI, RoleMixin):
         return os.pathsep.join(ret)
 
     @staticmethod
-    def get_snippet_text(ptype, doc):
+    def get_snippet_text(doc, pytpe='module'):
 
         text = []
 
@@ -1266,7 +1266,7 @@ def _do_yaml_snippet(text, doc):
         text.append("# %s:" % doc.get('plugin', doc.get('name')))
 
     pad = 29
-    subdent = " " * pad + '# '
+    subdent = '# '.rjust(pad + 2)
     limit = display.columns - pad
 
     for o in sorted(doc['options'].keys()):

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -1337,14 +1337,17 @@ def _do_ini_snippet(text, doc):
 
 def _do_lookup_snippet(text, doc):
 
-    snippet = "lookup('%s'," % doc.get('plugin', doc.get('name'))
+    snippet = "lookup('%s', " % doc.get('plugin', doc.get('name'))
+    comment = ''
     for o in sorted(doc['options'].keys()):
 
+        opt = doc['options'][o]
         if o in ('_terms', '_raw', '_list'):
-            snippet += '<list of arguments>'
+            # these are 'list of arguments'
+            snippet += '< %s >' % (o)
+            comment = '# %s: %s' % (o, opt.get('description', ''))
             continue
 
-        opt = doc['options'][o]
         required = opt.get('required', False)
         if not isinstance(required, bool):
             raise("Incorrect value for 'Required', a boolean is needed.: %s" % required)
@@ -1360,4 +1363,6 @@ def _do_lookup_snippet(text, doc):
             snippet += ', %s=%s' % (o, default)
 
     snippet += ")"
+    if comment:
+        text.append(comment)
     text.append(snippet)

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -47,7 +47,7 @@ display = Display()
 TARGET_OPTIONS = C.DOCUMENTABLE_PLUGINS + ('role', 'keyword',)
 PB_OBJECTS = ['Play', 'Role', 'Block', 'Task']
 PB_LOADED = {}
-SNIPPETS = ['module', 'lookup']
+SNIPPETS = ['inventory', 'lookup', 'module']
 
 
 def jdump(text):
@@ -966,7 +966,7 @@ class DocCLI(CLI, RoleMixin):
 
         if ptype == 'lookup':
             _do_lookup_snippet(text, doc)
-        elif ptype == 'module':
+        else:
             _do_yaml_snippet(text, doc)
 
         text.append('')

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -1301,14 +1301,14 @@ def _do_lookup_snippet(text, doc):
 
     text.append('## PLAYBOOK ##')
     snippet = "lookup('%s', " % doc.get('plugin', doc.get('name'))
-    comment = ''
+    comment = []
     for o in sorted(doc['options'].keys()):
 
         opt = doc['options'][o]
+        comment.append('# %s(%s): %s' % (o, opt.get('type', 'string'), opt.get('description', '')))
         if o in ('_terms', '_raw', '_list'):
             # these are 'list of arguments'
             snippet += '< %s >' % (o)
-            comment = '# %s: %s' % (o, opt.get('description', ''))
             continue
 
         required = opt.get('required', False)
@@ -1327,7 +1327,7 @@ def _do_lookup_snippet(text, doc):
 
     snippet += ")"
     if comment:
-        text.append(comment)
+        text.extend(comment)
     text.append(snippet)
 
 

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -1323,7 +1323,7 @@ def _do_ini_snippet(text, doc):
                 sections[entry['section']] = []
 
             if required:
-                default = '(required)'
+                default = '(REQUIRED)'
             else:
                 default = opt.get('default', '')
 
@@ -1356,7 +1356,7 @@ def _do_lookup_snippet(text, doc):
             raise("Incorrect value for 'Required', a boolean is needed.: %s" % required)
 
         if required:
-            default = '<required>'
+            default = '<REQUIRED>'
         else:
             default = opt.get('default', 'None')
 

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -1295,7 +1295,7 @@ def _do_yaml_snippet(text, doc):
             else:
                 default = opt.get('default', 'None')
 
-            text.append("%s %-9s # %s" % (o, default, textwrap.fill(desc, limit, subsequent_indent=subdent)))
+            text.append("%s %-9s # %s" % (o, default, textwrap.fill(desc, limit, subsequent_indent=subdent, max_lines=3)))
 
 
 def _do_ini_snippet(text, doc):
@@ -1332,7 +1332,7 @@ def _do_ini_snippet(text, doc):
                 default = opt.get('default', 'None')
             key = '%s=%s' % (entry['key'], default)
 
-            text.append("%-26s   # %s" % (key, textwrap.fill(desc, limit, subsequent_indent=subdent)))
+            text.append("%-26s   # %s" % (key, textwrap.fill(desc, limit, subsequent_indent=subdent, max_lines=3)))
 
 
 def _do_lookup_snippet(text, doc):

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -421,7 +421,7 @@ class DocCLI(CLI, RoleMixin):
 
         # modifiers
         exclusive = self.parser.add_mutually_exclusive_group()
-        # TODO: wanr if not used with -t roles
+        # TODO: warn if not used with -t roles
         exclusive.add_argument("-e", "--entry-point", dest="entry_point",
                                help="Select the entry point for role(s).")
 

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -1354,7 +1354,7 @@ def _do_lookup_snippet(text, doc):
         else:
             default = opt.get('default', 'None')
 
-        if opt.get('type') == 'string':
+        if opt.get('type') in ('string', 'str'):
             snippet += ", %s='%s'" % (o, default)
         else:
             snippet += ', %s=%s' % (o, default)

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -49,6 +49,7 @@ PB_OBJECTS = ['Play', 'Role', 'Block', 'Task']
 PB_LOADED = {}
 SNIPPETS = ['module', 'lookup']
 
+
 def jdump(text):
     try:
         display.display(json.dumps(text, cls=AnsibleJSONEncoder, sort_keys=True, indent=4))

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -958,7 +958,7 @@ class DocCLI(CLI, RoleMixin):
         return os.pathsep.join(ret)
 
     @staticmethod
-    def get_snippet_text(doc, pytpe='module'):
+    def get_snippet_text(doc, ptype='module'):
 
         text = []
 

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -1323,7 +1323,7 @@ def _do_ini_snippet(text, doc):
                 sections[entry['section']] = []
 
             if required:
-                default = '(REQUIRED)'
+                default = '# <REQUIRED>'
             else:
                 default = opt.get('default', '')
 

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -1300,13 +1300,12 @@ def _do_yaml_snippet(text, doc):
 
 def _do_ini_snippet(text, doc):
 
-    text.append("# %s settings:" % doc.get('plugin', doc.get('name')).upper())
+    #text.append("# %s:" % doc.get('plugin', doc.get('name')).upper())
 
-    pad = 31
-    subdent = " " * pad + '# '
-    limit = display.columns - pad
+    subdent = "# "
+    limit = display.columns - 20
 
-    prev_section = None
+    sections = {}
     for o in sorted(doc['options'].keys()):
         opt = doc['options'][o]
         if isinstance(opt['description'], string_types):
@@ -1320,19 +1319,23 @@ def _do_ini_snippet(text, doc):
 
         if 'ini' in opt:
             entry = opt['ini'][-1]
-
-            # deal with sections
-            if prev_section != entry['section']:
-                text.append('[%s]' % entry['section'])
-                prev_section = entry['section']
+            if entry['section'] not in sections:
+                sections[entry['section']] = []
 
             if required:
                 default = '(required)'
             else:
-                default = opt.get('default', 'None')
-            key = '%s=%s' % (entry['key'], default)
+                default = opt.get('default', '')
 
-            text.append("%-26s   # %s" % (key, textwrap.fill(desc, limit, subsequent_indent=subdent, max_lines=3)))
+            key = textwrap.fill('# ' + desc, limit, max_lines=3, subsequent_indent=subdent) + '\n' + '%s=%s' % (entry['key'], default)
+            sections[entry['section']].append(key)
+
+    for section in sections.keys():
+        text.append('[%s]' % section)
+        for key in sections[section]:
+            text.append(key)
+            text.append('')
+        text.append('')
 
 
 def _do_lookup_snippet(text, doc):


### PR DESCRIPTION
Make snippets work for other plugins

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-doc

##### ADDITIONAL INFO
for lookups:
``` 
ansible-doc -t lookup url -s
```
outputs:
```yaml
# _terms(string): urls to query
# ca_path(string): String of file system path to CA cert bundle to use
# follow_redirects(string): String of urllib2, all/yes, safe, none to determine how redirects are followed, see RedirectHandlerFactory for more information
# force(boolean): Whether or not to set "cache-control" header with value "no-cache"
# force_basic_auth(boolean): Force basic authentication
# headers(dictionary): HTTP request headers
# http_agent(string): User-Agent to use in the request. The default was changed in 2.11 to C(ansible-httpget).
# password(string): Password to use for HTTP authentication.
# split_lines(boolean): Flag to control if content is returned as a list of lines or as a single text blob
# timeout(float): How long to wait for the server to send data before giving up
# unix_socket(string): String of file system path to unix socket file to use when establishing connection to the provided url
# unredirected_headers(list): A list of headers to not attach on a redirected request
# use_gssapi(boolean): ['Use GSSAPI handler of requests', 'As of Ansible 2.11, GSSAPI credentials can be specified with I(username) and I(password).']
# use_proxy(boolean): Flag to control if the lookup will observe HTTP proxy environment variables when present.
# username(string): Username to use for HTTP authentication.
# validate_certs(boolean): Flag to control SSL certificate validation

lookup('url', < _terms >, ca_path='None', follow_redirects='urllib2', force=False, force_basic_auth=False, headers={}, http_agent='ansible-httpget', password='None', split_lines=True, timeout=10, unix_socket='None', unredirected_headers=None, use_gssapi=False, use_proxy=True, username='None', validate_certs=True)
```

for inventory
```
 ansible-doc -s -t inventory community.general.nmap
```
outputs:
```yaml
# nmap:
address: (required) # Network IP or range of IPs to scan, you can use a simple range (10.2.2.15-25) or CIDR notation.
cache: False     # Toggle to enable/disable the caching of the inventory's source data, requires a cache plugin setup to work.
cache_connection: None      # Cache connection data or path, read cache plugin documentation for specifics.
cache_plugin: memory    # Cache plugin to use for the inventory's source data.
cache_prefix: ansible_inventory_ # Prefix to use for cache plugin files/tables
cache_timeout: 3600      # Cache duration in seconds
compose: {}        # Create vars from jinja2 expressions.
exclude: None      # list of addresses to exclude
groups: {}        # Add hosts to group based on Jinja2 conditionals.
ipv4: True      # use IPv4 type addresses
ipv6: True      # use IPv6 type addresses
keyed_groups: []        # Add hosts to group based on the values of a variable.
leading_separator: True      # Use in conjunction with keyed_groups. By default, a keyed group that does not have a prefix or a separator provided will have a name that starts with an
                             # underscore. This is because the default prefix is "" and the default separator is "_". Set this option to False to omit
                             # the leading underscore (or other separator) if no prefix is given. If the group name is derived from a mapping the [...]
plugin: (required) # token that ensures this is a source file for the 'nmap' plugin.
ports: True      # Enable/disable scanning for open ports
strict: False     # If `yes' make invalid entries a fatal error, otherwise skip and continue. Since it is possible to use facts in the expressions they might not always be
                             # available and we ignore those errors by default.
use_extra_vars: False     # Merge extra vars into the available variables for composition (highest precedence).
```