### PR TITLE
Disable failing hcloud_server test

### DIFF
--- a/test/integration/targets/hcloud_server/aliases
+++ b/test/integration/targets/hcloud_server/aliases
@@ -1,2 +1,3 @@
+disabled
 cloud/hcloud
 shippable/hcloud/group1


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `hcloud_server` integration test has been failing for a while. They are aware of the issue but the test should be disabled until the problem is resolved.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/hcloud_server`