### PR TITLE
[module_utils] make to_bits actually return

### DIFF
--- a/changelogs/fragments/to_bits-does-nothing.yml
+++ b/changelogs/fragments/to_bits-does-nothing.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - network module_utils - fix bug where ``to_bits()`` returned the ``str`` type instead of a useful value.

--- a/lib/ansible/module_utils/common/network.py
+++ b/lib/ansible/module_utils/common/network.py
@@ -146,7 +146,7 @@ def to_bits(val):
     bits = ''
     for octet in val.split('.'):
         bits += bin(int(octet))[2:].zfill(8)
-    return str
+    return bits
 
 
 def is_mac(mac_address):

--- a/test/units/module_utils/common/test_network.py
+++ b/test/units/module_utils/common/test_network.py
@@ -68,6 +68,7 @@ def test_to_ipv6_network():
     assert '2001:0db8:85a3::' == to_ipv6_network('2001:0db8:85a3:0000:0000:8a2e:0370:7334')
     assert '2001:0db8:85a3::' == to_ipv6_network('2001:0db8:85a3:0:0:8a2e:0370:7334')
 
+
 def test_to_bits():
     assert to_bits('0') == '00000000'
     assert to_bits('1') == '00000001'

--- a/test/units/module_utils/common/test_network.py
+++ b/test/units/module_utils/common/test_network.py
@@ -9,6 +9,7 @@ __metaclass__ = type
 import pytest
 
 from ansible.module_utils.common.network import (
+    to_bits,
     to_masklen,
     to_netmask,
     to_subnet,
@@ -66,3 +67,12 @@ def test_to_ipv6_network():
     assert '2001:db8::' == to_ipv6_network('2001:db8::')
     assert '2001:0db8:85a3::' == to_ipv6_network('2001:0db8:85a3:0000:0000:8a2e:0370:7334')
     assert '2001:0db8:85a3::' == to_ipv6_network('2001:0db8:85a3:0:0:8a2e:0370:7334')
+
+def test_to_bits():
+    assert to_bits('0') == '00000000'
+    assert to_bits('1') == '00000001'
+    assert to_bits('2') == '00000010'
+    assert to_bits('1337') == '10100111001'
+    assert to_bits('127.0.0.1') == '01111111000000000000000000000001'
+    assert to_bits('255.255.255.255') == '11111111111111111111111111111111'
+    assert to_bits('255.255.255.0') == '11111111111111111111111100000000'


### PR DESCRIPTION
##### SUMMARY

Change:
- Instead of returning the `str` type, return the value that was
  calculated.

Test Plan:
- New unit tests.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
module_utils