### PR TITLE
Update ansible-test default container to 3.4.0

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -157,7 +157,7 @@ stages:
           testFormat: generic/{0}/1
           targets:
             - test: 2.7
-            - test: 3.9
+            - test: 3.6
   - stage: Incidental_Remote
     displayName: Incidental Remote
     dependsOn: []

--- a/changelogs/fragments/ansible-test-default-container.yml
+++ b/changelogs/fragments/ansible-test-default-container.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ansible-test - The ``default`` test container has been updated to version 3.3.0 and now uses Python 3.9 by default instead of Python 3.6.
+  - ansible-test - The ``default`` test container has been updated to version 3.4.0, reverting a change to Python 3.9 in 3.3.0 (Python 3.6 remains the default).

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,5 +1,5 @@
-default name=quay.io/ansible/default-test-container:3.3.0 python=3.9,2.6,2.7,3.5,3.6,3.7,3.8 seccomp=unconfined context=collection
-default name=quay.io/ansible/ansible-core-test-container:3.3.0 python=3.9,2.6,2.7,3.5,3.6,3.7,3.8 seccomp=unconfined context=ansible-core
+default name=quay.io/ansible/default-test-container:3.4.0 python=3.6,2.6,2.7,3.5,3.7,3.8,3.9 seccomp=unconfined context=collection
+default name=quay.io/ansible/ansible-core-test-container:3.4.0 python=3.6,2.6,2.7,3.5,3.7,3.8,3.9 seccomp=unconfined context=ansible-core
 alpine3 name=quay.io/ansible/alpine3-test-container:2.0.2 python=3.8
 centos6 name=quay.io/ansible/centos6-test-container:2.0.2 python=2.6 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:2.0.2 python=2.7 seccomp=unconfined


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Set ansible-test to use version 3.4.0 of the default test container.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Following the model from: https://github.com/ansible/ansible/pull/74393

3.4.0 published after merging of: https://github.com/ansible/default-test-container/pull/60

cc @mattclay 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
