### PR TITLE
Update default containers to 3.4.0.

### DIFF
--- a/changelogs/fragments/ansible-test-default-container.yml
+++ b/changelogs/fragments/ansible-test-default-container.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ansible-test - The ``default`` test container has been updated to version 3.3.0 and now uses Python 3.9 by default instead of Python 3.6.
+  - ansible-test - The ``default`` test container has been updated to version 3.4.0 and now uses Python 3.9 by default instead of Python 3.6.

--- a/hacking/build-ansible.py
+++ b/hacking/build-ansible.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # coding: utf-8
 # PYTHON_ARGCOMPLETE_OK
 # Copyright: (c) 2019, Ansible Project

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,5 +1,5 @@
-default name=quay.io/ansible/default-test-container:3.3.0 python=3.9,2.6,2.7,3.5,3.6,3.7,3.8 seccomp=unconfined context=collection
-default name=quay.io/ansible/ansible-core-test-container:3.3.0 python=3.9,2.6,2.7,3.5,3.6,3.7,3.8 seccomp=unconfined context=ansible-core
+default name=quay.io/ansible/default-test-container:3.4.0 python=3.9,2.6,2.7,3.5,3.6,3.7,3.8 seccomp=unconfined context=collection
+default name=quay.io/ansible/ansible-core-test-container:3.4.0 python=3.9,2.6,2.7,3.5,3.6,3.7,3.8 seccomp=unconfined context=ansible-core
 alpine3 name=quay.io/ansible/alpine3-test-container:2.0.2 python=3.8
 centos6 name=quay.io/ansible/centos6-test-container:2.0.2 python=2.6 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:2.0.2 python=2.7 seccomp=unconfined

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -6,7 +6,6 @@ examples/scripts/my_test_facts.py shebang # example module but not in a normal m
 examples/scripts/my_test_info.py shebang # example module but not in a normal module location
 examples/scripts/upgrade_to_ps3.ps1 pslint:PSCustomUseLiteralPath
 examples/scripts/upgrade_to_ps3.ps1 pslint:PSUseApprovedVerbs
-hacking/build-ansible.py shebang # only run by release engineers, Python 3.6+ required
 hacking/build_library/build_ansible/announce.py compile-2.6!skip # release process only, 3.6+ required
 hacking/build_library/build_ansible/announce.py compile-2.7!skip # release process only, 3.6+ required
 hacking/build_library/build_ansible/announce.py compile-3.5!skip # release process only, 3.6+ required


### PR DESCRIPTION
##### SUMMARY

The 3.4.0 containers use Python 3.6 (the system Python) for `/usr/bin/python3`.

Python 3.9 continues to be the default Python version selected by `ansible-test` for these containers.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
