### PR TITLE
ansible-test - Improve __main__ checks.

### DIFF
--- a/changelogs/fragments/ansible-test-main-check.yml
+++ b/changelogs/fragments/ansible-test-main-check.yml
@@ -1,0 +1,6 @@
+minor_changes:
+  - ansible-test - The ``validate-modules`` sanity test no longer enforces the ``missing-if-name-main``, ``last-line-main-call`` or ``missing-main-call`` checks
+                   on non-deleted Ansible modules. Modules are still required to instantiate ``AnsibleModule`` when ``__name__ == '__main__'``.
+  - ansible-test - The ``import`` sanity test now requires that Ansible modules guard instantiation of ``AnsibleModule`` with a ``if __name__ == '__main__'``
+                   conditional, or equivalent logic.
+  - ansible-test - The ``import`` sanity test now requires that non-modules do not instantiate ``AnsibleModule`` on import.

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -545,7 +545,7 @@ class ModuleValidator(Validator):
                                 **options['error']
                             )
 
-    def _find_module_utils(self, main):
+    def _find_module_utils(self):
         linenos = []
         found_basic = False
         for child in self.ast.body:
@@ -2228,8 +2228,7 @@ class ModuleValidator(Validator):
             self._validate_ansible_module_call(docs)
             self._check_for_sys_exit()
             self._find_rejectlist_imports()
-            main = self._find_main_call()
-            self._find_module_utils(main)
+            self._find_module_utils()
             self._find_has_import()
             first_callable = self._get_first_callable()
             self._ensure_imports_below_docs(doc_info, first_callable)


### PR DESCRIPTION
##### SUMMARY

- The `validate-modules` sanity test no longer enforces the `missing-if-name-main`, `last-line-main-call` or `missing-main-call` checks on non-deleted Ansible modules. Modules are still required to instantiate `AnsibleModule` when `__name__ == '__main__'`.
- The `import` sanity test now requires that Ansible modules guard instantiation of `AnsibleModule` with a `if __name__ == '__main__'` conditional, or equivalent logic.
- The `import` sanity test now requires that non-modules do not instantiate `AnsibleModule` on import.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
