### PR TITLE
[stable-2.11] Fix pypi-test-container port conflict.

### DIFF
--- a/changelogs/fragments/ansible-test-pypi-container-no-publish.yml
+++ b/changelogs/fragments/ansible-test-pypi-container-no-publish.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-test - Avoid publishing the port used by the ``pypi-test-container`` since it is only accessed by other containers.
+                   This avoids issues when trying to run tests in parallel on a single host.

--- a/test/lib/ansible_test/_internal/executor.py
+++ b/test/lib/ansible_test/_internal/executor.py
@@ -1436,7 +1436,6 @@ def run_pypi_proxy(args):  # type: (EnvironmentConfig) -> t.Tuple[t.Optional[str
 
     options = [
         '--detach',
-        '-p', '%d:%d' % (port, port),
     ]
 
     docker_pull(args, proxy_image)


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/74430

(cherry picked from commit cb7f4f19717e91930f695fe0be5adc6cacf5162f)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
