### PR TITLE
[ansible-test] Sync opensuse containers with 2.10

### DIFF
--- a/changelogs/fragments/ansible-test-opensuse-15-2.yml
+++ b/changelogs/fragments/ansible-test-opensuse-15-2.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Use version 1.21.0 of opensuse test containers which is 15.2, since 15.1 is now EOL.

--- a/test/integration/targets/iso_extract/vars/Suse.yml
+++ b/test/integration/targets/iso_extract/vars/Suse.yml
@@ -1,1 +1,1 @@
-iso_extract_7zip_package: p7zip
+iso_extract_7zip_package: p7zip-full

--- a/test/integration/targets/setup_docker/vars/Suse.yml
+++ b/test/integration/targets/setup_docker/vars/Suse.yml
@@ -1,2 +1,2 @@
 docker_packages:
-  - docker=19.03.1_ce
+  - docker=19.03.15_ce

--- a/test/integration/targets/setup_mysql_db/vars/Suse-py3.yml
+++ b/test/integration/targets/setup_mysql_db/vars/Suse-py3.yml
@@ -4,3 +4,6 @@ mysql_packages:
     - mariadb
     - python3-PyMySQL
     - bzip2
+
+mysql_cleanup_packages:
+    - mariadb*

--- a/test/integration/targets/setup_mysql_db/vars/Suse-py3.yml
+++ b/test/integration/targets/setup_mysql_db/vars/Suse-py3.yml
@@ -6,4 +6,6 @@ mysql_packages:
     - bzip2
 
 mysql_cleanup_packages:
-    - mariadb*
+    - mariadb-errormessages
+    - mariadb-client
+    - libmariadb3

--- a/test/integration/targets/setup_mysql_db/vars/Suse.yml
+++ b/test/integration/targets/setup_mysql_db/vars/Suse.yml
@@ -4,3 +4,7 @@ mysql_packages:
     - mariadb
     - python-PyMySQL
     - bzip2
+
+mysql_cleanup_packages:
+    - mariadb*
+    - "*python3*"

--- a/test/integration/targets/setup_mysql_db/vars/Suse.yml
+++ b/test/integration/targets/setup_mysql_db/vars/Suse.yml
@@ -6,5 +6,8 @@ mysql_packages:
     - bzip2
 
 mysql_cleanup_packages:
-    - mariadb*
-    - "*python3*"
+    - mariadb-errormessages
+    - mariadb-client
+    - libmariadb3
+    - python3-base
+    - python3-mysqlclient

--- a/test/integration/targets/zypper/tasks/zypper.yml
+++ b/test/integration/targets/zypper/tasks/zypper.yml
@@ -1,5 +1,5 @@
 - name: get hello package version
-  shell: zypper --xml se -svx hello | grep 'name="hello"' | grep 'repository="Main Repository"' | sed 's/.*edition="\([^ ]*\)".*/\1/'
+  shell: zypper -x se -svx hello | grep 'name="hello"' | grep 'repository="Main Repository"' | sed 's/.*edition="\([^ ]*\)".*/\1/'
   register: hello_version
 
 - name: set URL of test package

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -4,7 +4,7 @@ centos7 name=quay.io/ansible/centos7-test-container:1.8.0 python=2.7 seccomp=unc
 centos8 name=quay.io/ansible/centos8-test-container:1.10.0 python=3.6 seccomp=unconfined
 fedora30 name=quay.io/ansible/fedora30-test-container:1.9.2 python=3.7
 fedora31 name=quay.io/ansible/fedora31-test-container:1.11.0 python=3.7
-opensuse15py2 name=quay.io/ansible/opensuse15py2-test-container:1.14.0 python=2.7
-opensuse15 name=quay.io/ansible/opensuse15-test-container:1.14.0 python=3.6
+opensuse15py2 name=quay.io/ansible/opensuse15py2-test-container:1.21.0 python=2.7
+opensuse15 name=quay.io/ansible/opensuse15-test-container:1.21.0 python=3.6
 ubuntu1604 name=quay.io/ansible/ubuntu1604-test-container:1.8.0 python=2.7 seccomp=unconfined
 ubuntu1804 name=quay.io/ansible/ubuntu1804-test-container:1.8.0 python=3.6 seccomp=unconfined


### PR DESCRIPTION
##### SUMMARY

Change:
- OpenSuSE 15.1 is now EOL
- Switch containers to use what 2.10 uses, which has 15.2.

Test Plan:
- ci_complete

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME

ansible-test