### PR TITLE
incidental_setup_rabbitmq test - Use official repo for rabbitmq-erlang

### DIFF
--- a/test/integration/targets/incidental_setup_rabbitmq/tasks/ubuntu.yml
+++ b/test/integration/targets/incidental_setup_rabbitmq/tasks/ubuntu.yml
@@ -25,7 +25,7 @@
 
 - name: Add RabbitMQ Erlang repository
   apt_repository:
-    repo: "deb https://dl.bintray.com/rabbitmq-erlang/debian {{ ansible_distribution_release }} erlang-20.x"
+    repo: ppa:rabbitmq/rabbitmq-erlang
     filename: 'rabbitmq-erlang'
     state: present
     update_cache: yes
@@ -37,7 +37,7 @@
 
 - name: Install RabbitMQ Server
   apt:
-    deb: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/setup_rabbitmq/rabbitmq-server_3.7.14-1_all.deb
+    deb: https://ansible-ci-files.s3.us-east-1.amazonaws.com/test/integration/targets/setup_rabbitmq/rabbitmq-server_3.8.14-1_all.deb
 
 - name: Install RabbitMQ TLS dependencies
   apt:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Previously it was hosted on bintray, but that service is [shutting down on May 1](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/). Using the new repository also required using a newer version of RabbitMQ.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/incidental_setup_rabbitmq`