### PR TITLE
[stable-2.9] setup_rabbitmq test - Use official repo for rabbitmq-erlang (#74445)

### DIFF
--- a/test/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
+++ b/test/integration/targets/setup_rabbitmq/tasks/ubuntu.yml
@@ -25,7 +25,7 @@
 
 - name: Add RabbitMQ Erlang repository
   apt_repository:
-    repo: "deb https://dl.bintray.com/rabbitmq-erlang/debian {{ ansible_distribution_release }} erlang-20.x"
+    repo: ppa:rabbitmq/rabbitmq-erlang
     filename: 'rabbitmq-erlang'
     state: present
     update_cache: yes
@@ -37,7 +37,7 @@
 
 - name: Install RabbitMQ Server
   apt:
-    deb: https://s3.amazonaws.com/ansible-ci-files/test/integration/targets/setup_rabbitmq/rabbitmq-server_3.7.14-1_all.deb
+    deb: https://ansible-ci-files.s3.us-east-1.amazonaws.com/test/integration/targets/setup_rabbitmq/rabbitmq-server_3.8.14-1_all.deb
 
 - name: Install RabbitMQ TLS dependencies
   apt:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #74445 for Ansible 2.9.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/setup_rabbitmq/`