### PR TITLE
paramiko_ssh - mark connection as connected when successful

### DIFF
--- a/changelogs/fragments/74081-paramiko-mark-connected.yml
+++ b/changelogs/fragments/74081-paramiko-mark-connected.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - paramiko_ssh - mark connection as connected when ``_connect()`` is called (https://github.com/ansible/ansible/issues/74081)

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -241,6 +241,8 @@ class Connection(ConnectionBase):
             self.ssh = SSH_CONNECTION_CACHE[cache_key]
         else:
             self.ssh = SSH_CONNECTION_CACHE[cache_key] = self._connect_uncached()
+
+        self._connected = True
         return self
 
     def _set_log_channel(self, name):

--- a/test/units/plugins/connection/test_paramiko.py
+++ b/test/units/plugins/connection/test_paramiko.py
@@ -23,7 +23,6 @@ __metaclass__ = type
 from io import StringIO
 import pytest
 
-from ansible.errors import AnsibleError
 from ansible.plugins.connection import paramiko_ssh
 from ansible.playbook.play_context import PlayContext
 

--- a/test/units/plugins/connection/test_paramiko.py
+++ b/test/units/plugins/connection/test_paramiko.py
@@ -23,20 +23,35 @@ __metaclass__ = type
 from io import StringIO
 import pytest
 
-from units.compat import unittest
+from ansible.errors import AnsibleError
 from ansible.plugins.connection import paramiko_ssh
 from ansible.playbook.play_context import PlayContext
 
 
-class TestParamikoConnectionClass(unittest.TestCase):
+@pytest.fixture
+def play_context():
+    play_context = PlayContext()
+    play_context.prompt = (
+        '[sudo via ansible, key=ouzmdnewuhucvuaabtjmweasarviygqq] password: '
+    )
 
-    def test_paramiko_connection_module(self):
-        play_context = PlayContext()
-        play_context.prompt = (
-            '[sudo via ansible, key=ouzmdnewuhucvuaabtjmweasarviygqq] password: '
-        )
-        in_stream = StringIO()
+    return play_context
 
-        self.assertIsInstance(
-            paramiko_ssh.Connection(play_context, in_stream),
-            paramiko_ssh.Connection)
+
+@pytest.fixture()
+def in_stream():
+    return StringIO()
+
+
+def test_paramiko_connection_module(play_context, in_stream):
+    assert isinstance(
+        paramiko_ssh.Connection(play_context, in_stream),
+        paramiko_ssh.Connection)
+
+
+def test_paramiko_connect(play_context, in_stream, mocker):
+    mocker.patch.object(paramiko_ssh.Connection, '_connect_uncached')
+    connection = paramiko_ssh.Connection(play_context, in_stream)._connect()
+
+    assert isinstance(connection, paramiko_ssh.Connection)
+    assert connection._connected is True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It looks like this connection plugin never marked `self._connected = True` when the connection was successful. This tripped up the logic added in #72688.

Fixes #74081.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/connection/paramiko_ssh.py`