### PR TITLE
Use our own copy of the Codecov uploader

### DIFF
--- a/.azure-pipelines/scripts/publish-codecov.sh
+++ b/.azure-pipelines/scripts/publish-codecov.sh
@@ -7,7 +7,7 @@ set -o pipefail -eu
 
 output_path="$1"
 
-curl --silent --show-error https://ansible-ci-files.s3.us-east-1.amazonaws.com/ansible-test/codecov.sh > codecov.sh
+curl --silent --show-error https://ansible-ci-files.s3.us-east-1.amazonaws.com/codecov/codecov.sh > codecov.sh
 
 for file in "${output_path}"/reports/coverage*.xml; do
     name="${file}"

--- a/.azure-pipelines/scripts/publish-codecov.sh
+++ b/.azure-pipelines/scripts/publish-codecov.sh
@@ -8,7 +8,6 @@ set -o pipefail -eu
 output_path="$1"
 
 curl --silent --show-error https://ansible-ci-files.s3.us-east-1.amazonaws.com/ansible-test/codecov.sh > codecov.sh
-curl --silent --show-error https://ansible-ci-files.s3.us-east-1.amazonaws.com/ansible-test/codecov.sh-sha256sum | shasum --check --algorithm 256
 
 for file in "${output_path}"/reports/coverage*.xml; do
     name="${file}"

--- a/.azure-pipelines/scripts/publish-codecov.sh
+++ b/.azure-pipelines/scripts/publish-codecov.sh
@@ -7,7 +7,7 @@ set -o pipefail -eu
 
 output_path="$1"
 
-curl --silent --show-error https://ansible-ci-files.s3.us-east-1.amazonaws.com/ansible-test/codecov > codecov.sh
+curl --silent --show-error https://ansible-ci-files.s3.us-east-1.amazonaws.com/ansible-test/codecov.sh > codecov.sh
 
 for file in "${output_path}"/reports/coverage*.xml; do
     name="${file}"

--- a/.azure-pipelines/scripts/publish-codecov.sh
+++ b/.azure-pipelines/scripts/publish-codecov.sh
@@ -7,7 +7,7 @@ set -o pipefail -eu
 
 output_path="$1"
 
-curl --silent --show-error https://codecov.io/bash > codecov.sh
+curl --silent --show-error https://ansible-ci-files.s3.us-east-1.amazonaws.com/ansible-test/codecov > codecov.sh
 
 for file in "${output_path}"/reports/coverage*.xml; do
     name="${file}"

--- a/.azure-pipelines/scripts/publish-codecov.sh
+++ b/.azure-pipelines/scripts/publish-codecov.sh
@@ -8,6 +8,7 @@ set -o pipefail -eu
 output_path="$1"
 
 curl --silent --show-error https://ansible-ci-files.s3.us-east-1.amazonaws.com/ansible-test/codecov.sh > codecov.sh
+curl --silent --show-error https://ansible-ci-files.s3.us-east-1.amazonaws.com/ansible-test/codecov.sh-sha256sum | shasum --check --algorithm 256
 
 for file in "${output_path}"/reports/coverage*.xml; do
     name="${file}"

--- a/test/utils/shippable/shippable.sh
+++ b/test/utils/shippable/shippable.sh
@@ -117,7 +117,7 @@ function cleanup
                     flags="${flags//=/,}"
                     flags="${flags//[^a-zA-Z0-9_,]/_}"
 
-                    bash <(curl -s https://codecov.io/bash) \
+                    bash <(curl -s https://ansible-ci-files.s3.us-east-1.amazonaws.com/ansible-test/codecov) \
                         -f "${file}" \
                         -F "${flags}" \
                         -n "${test}" \

--- a/test/utils/shippable/shippable.sh
+++ b/test/utils/shippable/shippable.sh
@@ -117,7 +117,7 @@ function cleanup
                     flags="${flags//=/,}"
                     flags="${flags//[^a-zA-Z0-9_,]/_}"
 
-                    bash <(curl -s https://ansible-ci-files.s3.us-east-1.amazonaws.com/ansible-test/codecov) \
+                    bash <(curl -s https://codecov.io/bash) \
                         -f "${file}" \
                         -F "${flags}" \
                         -n "${test}" \


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Due to the [recent security incident](https://about.codecov.io/security-update/), use our own copy hosted in S3 to mitigate future risk from running an arbitrary script downloaded from a remote and untrtusted server.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/utils/shippable/shippable.sh`

##### ADDITIONAL INFORMATION

  I [wrote up some notes](https://ansible-ci-files.s3.us-east-1.amazonaws.com/codecov/README.md) on testing the integrity of the script as well as where updates are posted.
