### PR TITLE
Fix sequence lookup message and add tests

### DIFF
--- a/changelogs/fragments/74472-sequence-lookup.yaml
+++ b/changelogs/fragments/74472-sequence-lookup.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - sequence - Fix error message so that unrecognized options to the plugin display correctly as a list
+    and normalize error messages.

--- a/changelogs/fragments/74472-sequence-lookup.yaml
+++ b/changelogs/fragments/74472-sequence-lookup.yaml
@@ -1,3 +1,3 @@
 bugfixes:
-  - sequence - Fix error message so that unrecognized options to the plugin display correctly as a list
+  - sequence - fix error message so that unrecognized options to the plugin display correctly as a list
     and normalize error messages.

--- a/lib/ansible/plugins/lookup/sequence.py
+++ b/lib/ansible/plugins/lookup/sequence.py
@@ -159,14 +159,14 @@ class LookupModule(LookupBase):
                 setattr(self, arg, arg_cooked)
             except ValueError:
                 raise AnsibleError(
-                    "can't parse %s=%r as integer"
+                    "can't parse %s=%s as integer"
                     % (arg, arg_raw)
                 )
         if 'format' in args:
             self.format = args.pop("format")
         if args:
             raise AnsibleError(
-                "unrecognized arguments to with_sequence: %r"
+                "unrecognized arguments to with_sequence: %s"
                 % list(args.keys())
             )
 

--- a/lib/ansible/plugins/lookup/sequence.py
+++ b/lib/ansible/plugins/lookup/sequence.py
@@ -167,7 +167,7 @@ class LookupModule(LookupBase):
         if args:
             raise AnsibleError(
                 "unrecognized arguments to with_sequence: %r"
-                % args.keys()
+                % list(args.keys())
             )
 
     def parse_simple_args(self, term):

--- a/lib/ansible/plugins/lookup/sequence.py
+++ b/lib/ansible/plugins/lookup/sequence.py
@@ -159,7 +159,7 @@ class LookupModule(LookupBase):
                 setattr(self, arg, arg_cooked)
             except ValueError:
                 raise AnsibleError(
-                    "can't parse arg %s=%r as integer"
+                    "can't parse %s=%r as integer"
                     % (arg, arg_raw)
                 )
         if 'format' in args:

--- a/test/integration/targets/lookup_sequence/tasks/main.yml
+++ b/test/integration/targets/lookup_sequence/tasks/main.yml
@@ -1,69 +1,3 @@
-- block:
-    - name: EXPECTED FAILURE - test invalid arg
-      set_fact: "{{ 'x' + item }}={{ item }}"
-      with_sequence: start=0 junk=3
-
-    - fail:
-        msg: "should not get here"
-  rescue:
-    - assert:
-        that:
-          - ansible_failed_task.name == "EXPECTED FAILURE - test invalid arg"
-          - ansible_failed_result.msg == "unrecognized arguments to with_sequence: \['junk'\]"
-
-- block:
-    - name: EXPECTED FAILURE - test bad kv value
-      set_fact: "{{ 'x' + item }}={{ item }}"
-      with_sequence: start=A end=3
-
-    - fail:
-        msg: "should not get here"
-  rescue:
-    - debug: var=ansible_failed_result
-    - assert:
-        that:
-          - ansible_failed_task.name == "EXPECTED FAILURE - test bad kv value"
-          - ansible_failed_result.msg == "can't parse start='A' as integer"
-
-- block:
-    - name: EXPECTED FAILURE - test bad simple form start value
-      set_fact: "{{ 'x' + item }}={{ item }}"
-      with_sequence: A-4/2
-
-    - fail:
-        msg: "should not get here"
-  rescue:
-    - assert:
-        that:
-          - ansible_failed_task.name == "EXPECTED FAILURE - test bad simple form start value"
-          - ansible_failed_result.msg == "can't parse start=A as integer"
-
-- block:
-    - name: EXPECTED FAILURE - test bad simple form end value
-      set_fact: "{{ 'x' + item }}={{ item }}"
-      with_sequence: 1-B/2
-
-    - fail:
-        msg: "should not get here"
-  rescue:
-    - assert:
-        that:
-          - ansible_failed_task.name == "EXPECTED FAILURE - test bad simple form end value"
-          - ansible_failed_result.msg == "can't parse end=B as integer"
-
-- block:
-    - name: EXPECTED FAILURE - test bad simple form stride value
-      set_fact: "{{ 'x' + item }}={{ item }}"
-      with_sequence: 1-4/C
-
-    - fail:
-        msg: "should not get here"
-  rescue:
-    - assert:
-        that:
-          - ansible_failed_task.name == "EXPECTED FAILURE - test bad simple form stride value"
-          - ansible_failed_result.msg == "can't parse stride=C as integer"
-
 - name: test with_sequence
   set_fact: "{{ 'x' + item }}={{ item }}"
   with_sequence: start=0 end=3
@@ -127,3 +61,137 @@
         - "ws_z_6 == 'stride_6'"
         - "ws_z_host07 == 'host07'"
         - "ws_z_host08 == 'host08'"
+
+- block:
+    - name: EXPECTED FAILURE - test invalid arg
+      set_fact: "{{ 'x' + item }}={{ item }}"
+      with_sequence: start=0 junk=3
+
+    - fail:
+        msg: "should not get here"
+  rescue:
+    - assert:
+        that:
+          - ansible_failed_task.name == "EXPECTED FAILURE - test invalid arg"
+          - ansible_failed_result.msg == expected
+      vars:
+        expected: "unrecognized arguments to with_sequence: ['junk']"
+
+- block:
+    - name: EXPECTED FAILURE - test bad kv value
+      set_fact: "{{ 'x' + item }}={{ item }}"
+      with_sequence: start=A end=3
+
+    - fail:
+        msg: "should not get here"
+  rescue:
+    - assert:
+        that:
+          - ansible_failed_task.name == "EXPECTED FAILURE - test bad kv value"
+          - ansible_failed_result.msg == "can't parse start=A as integer"
+
+- block:
+    - name: EXPECTED FAILURE - test bad simple form start value
+      set_fact: "{{ 'x' + item }}={{ item }}"
+      with_sequence: A-4/2
+
+    - fail:
+        msg: "should not get here"
+  rescue:
+    - assert:
+        that:
+          - ansible_failed_task.name == "EXPECTED FAILURE - test bad simple form start value"
+          - ansible_failed_result.msg == "can't parse start=A as integer"
+
+- block:
+    - name: EXPECTED FAILURE - test bad simple form end value
+      set_fact: "{{ 'x' + item }}={{ item }}"
+      with_sequence: 1-B/2
+
+    - fail:
+        msg: "should not get here"
+  rescue:
+    - assert:
+        that:
+          - ansible_failed_task.name == "EXPECTED FAILURE - test bad simple form end value"
+          - ansible_failed_result.msg == "can't parse end=B as integer"
+
+- block:
+    - name: EXPECTED FAILURE - test bad simple form stride value
+      set_fact: "{{ 'x' + item }}={{ item }}"
+      with_sequence: 1-4/C
+
+    - fail:
+        msg: "should not get here"
+  rescue:
+    - assert:
+        that:
+          - ansible_failed_task.name == "EXPECTED FAILURE - test bad simple form stride value"
+          - ansible_failed_result.msg == "can't parse stride=C as integer"
+
+- block:
+    - name: EXPECTED FAILURE - test no count or end
+      set_fact: "{{ 'x' + item }}={{ item }}"
+      with_sequence: start=1
+
+    - fail:
+        msg: "should not get here"
+  rescue:
+    - assert:
+        that:
+          - ansible_failed_task.name == "EXPECTED FAILURE - test no count or end"
+          - ansible_failed_result.msg == "must specify count or end in with_sequence"
+
+- block:
+    - name: EXPECTED FAILURE - test both count and end
+      set_fact: "{{ 'x' + item }}={{ item }}"
+      with_sequence: start=1 end=4 count=2
+
+    - fail:
+        msg: "should not get here"
+  rescue:
+    - assert:
+        that:
+          - ansible_failed_task.name == "EXPECTED FAILURE - test both count and end"
+          - ansible_failed_result.msg == "can't specify both count and end in with_sequence"
+
+- block:
+    - name: EXPECTED FAILURE - test count backwards message
+      set_fact: "{{ 'x' + item }}={{ item }}"
+      with_sequence: start=4 end=1 stride=2
+
+    - fail:
+        msg: "should not get here"
+  rescue:
+    - assert:
+        that:
+          - ansible_failed_task.name == "EXPECTED FAILURE - test count backwards message"
+          - ansible_failed_result.msg == "to count backwards make stride negative"
+
+- block:
+    - name: EXPECTED FAILURE - test count forward message
+      set_fact: "{{ 'x' + item }}={{ item }}"
+      with_sequence: start=1 end=4 stride=-2
+
+    - fail:
+        msg: "should not get here"
+  rescue:
+    - assert:
+        that:
+          - ansible_failed_task.name == "EXPECTED FAILURE - test count forward message"
+          - ansible_failed_result.msg == "to count forward don't make stride negative"
+
+- block:
+    - name: EXPECTED FAILURE - test bad format string message
+      set_fact: "{{ 'x' + item }}={{ item }}"
+      with_sequence: start=1 end=4 format=d
+
+    - fail:
+        msg: "should not get here"
+  rescue:
+    - assert:
+        that:
+          - ansible_failed_task.name == "EXPECTED FAILURE - test bad format string message"
+          - ansible_failed_result.msg == expected
+      vars:
+        expected: "bad formatting string: d"

--- a/test/integration/targets/lookup_sequence/tasks/main.yml
+++ b/test/integration/targets/lookup_sequence/tasks/main.yml
@@ -73,9 +73,10 @@
     - assert:
         that:
           - ansible_failed_task.name == "EXPECTED FAILURE - test invalid arg"
-          - ansible_failed_result.msg == expected
+          - ansible_failed_result.msg in [expected1, expected2]
       vars:
-        expected: "unrecognized arguments to with_sequence: ['junk']"
+        expected1: "unrecognized arguments to with_sequence: ['junk']"
+        expected2: "unrecognized arguments to with_sequence: [u'junk']"
 
 - block:
     - name: EXPECTED FAILURE - test bad kv value

--- a/test/integration/targets/lookup_sequence/tasks/main.yml
+++ b/test/integration/targets/lookup_sequence/tasks/main.yml
@@ -12,7 +12,7 @@
           - ansible_failed_result.msg == "unrecognized arguments to with_sequence: \['junk'\]"
 
 - block:
-    - name: EXPECTED FAILURE - test bad start kv value
+    - name: EXPECTED FAILURE - test bad kv value
       set_fact: "{{ 'x' + item }}={{ item }}"
       with_sequence: start=A end=3
 
@@ -21,8 +21,47 @@
   rescue:
     - assert:
         that:
-          - ansible_failed_task.name == "EXPECTED FAILURE - test bad start kv value"
-          - ansible_failed_result.msg == "can't parse arg start='A' as integer"
+          - ansible_failed_task.name == "EXPECTED FAILURE - test bad kv value"
+          - ansible_failed_result.msg == "can't parse start='A' as integer"
+
+- block:
+    - name: EXPECTED FAILURE - test bad simple form start value
+      set_fact: "{{ 'x' + item }}={{ item }}"
+      with_sequence: A-4/2
+
+    - fail:
+        msg: "should not get here"
+  rescue:
+    - assert:
+        that:
+          - ansible_failed_task.name == "EXPECTED FAILURE - test bad simple form start value"
+          - ansible_failed_result.msg == "can't parse start=A as integer"
+
+- block:
+    - name: EXPECTED FAILURE - test bad simple form end value
+      set_fact: "{{ 'x' + item }}={{ item }}"
+      with_sequence: 1-B/2
+
+    - fail:
+        msg: "should not get here"
+  rescue:
+    - assert:
+        that:
+          - ansible_failed_task.name == "EXPECTED FAILURE - test bad simple form end value"
+          - ansible_failed_result.msg == "can't parse end=B as integer"
+
+- block:
+    - name: EXPECTED FAILURE - test bad simple form stride value
+      set_fact: "{{ 'x' + item }}={{ item }}"
+      with_sequence: 1-4/C
+
+    - fail:
+        msg: "should not get here"
+  rescue:
+    - assert:
+        that:
+          - ansible_failed_task.name == "EXPECTED FAILURE - test bad simple form stride value"
+          - ansible_failed_result.msg == "can't parse stride=C as integer"
 
 - name: test with_sequence
   set_fact: "{{ 'x' + item }}={{ item }}"

--- a/test/integration/targets/lookup_sequence/tasks/main.yml
+++ b/test/integration/targets/lookup_sequence/tasks/main.yml
@@ -1,3 +1,16 @@
+- block:
+    - name: EXPECTED FAILURE - test bad arg
+      set_fact: "{{ 'x' + item }}={{ item }}"
+      with_sequence: start=0 junk=3
+
+    - fail:
+        msg: "should not get here"
+  rescue:
+    - assert:
+        that:
+          - ansible_failed_task.name == "EXPECTED FAILURE - test bad arg"
+          - ansible_failed_result.msg == "unrecognized arguments to with_sequence: \['junk'\]"
+
 - name: test with_sequence
   set_fact: "{{ 'x' + item }}={{ item }}"
   with_sequence: start=0 end=3

--- a/test/integration/targets/lookup_sequence/tasks/main.yml
+++ b/test/integration/targets/lookup_sequence/tasks/main.yml
@@ -1,5 +1,5 @@
 - block:
-    - name: EXPECTED FAILURE - test bad arg
+    - name: EXPECTED FAILURE - test invalid arg
       set_fact: "{{ 'x' + item }}={{ item }}"
       with_sequence: start=0 junk=3
 
@@ -8,8 +8,21 @@
   rescue:
     - assert:
         that:
-          - ansible_failed_task.name == "EXPECTED FAILURE - test bad arg"
+          - ansible_failed_task.name == "EXPECTED FAILURE - test invalid arg"
           - ansible_failed_result.msg == "unrecognized arguments to with_sequence: \['junk'\]"
+
+- block:
+    - name: EXPECTED FAILURE - test bad start kv value
+      set_fact: "{{ 'x' + item }}={{ item }}"
+      with_sequence: start=A end=3
+
+    - fail:
+        msg: "should not get here"
+  rescue:
+    - assert:
+        that:
+          - ansible_failed_task.name == "EXPECTED FAILURE - test bad start kv value"
+          - ansible_failed_result.msg == "can't parse arg start='A' as integer"
 
 - name: test with_sequence
   set_fact: "{{ 'x' + item }}={{ item }}"

--- a/test/integration/targets/lookup_sequence/tasks/main.yml
+++ b/test/integration/targets/lookup_sequence/tasks/main.yml
@@ -19,6 +19,7 @@
     - fail:
         msg: "should not get here"
   rescue:
+    - debug: var=ansible_failed_result
     - assert:
         that:
           - ansible_failed_task.name == "EXPECTED FAILURE - test bad kv value"


### PR DESCRIPTION
##### SUMMARY

- Fix error message so that unrecognized options to the plugin display correctly as a list.
- Make value parsing error messages the same between simple form and k-v form (`can't parse X` vs. `can't parse arg X`)
- Improve coverage tests of sequence lookup plugin.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Test Pull Request

##### COMPONENT NAME
sequence
