### PR TITLE
ansible-inventory: Handle exception in toml parsing

### DIFF
--- a/changelogs/fragments/74404_ansible_inventory.yml
+++ b/changelogs/fragments/74404_ansible_inventory.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-inventory - handle an exception while parsing inventory in toml format (https://github.com/ansible/ansible/issues/74404).

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -179,7 +179,15 @@ class InventoryCLI(CLI):
                 raise AnsibleError(
                     'The python "toml" library is required when using the TOML output format'
                 )
-            results = toml_dumps(stuff)
+            try:
+                results = toml_dumps(stuff)
+            except KeyError as e:
+                raise AnsibleError(
+                    'The source inventory contains a non-string key (%s) which cannot be represented in TOML. '
+                    'The specified key will need to be converted to a string. Be aware that if your playbooks '
+                    'expect this key to be non-string, your playbooks will need to be modified to support this '
+                    'change.' % e.args[0]
+                )
         else:
             import json
             from ansible.parsing.ajson import AnsibleJSONEncoder

--- a/test/integration/targets/ansible-inventory/files/invalid_sample.yml
+++ b/test/integration/targets/ansible-inventory/files/invalid_sample.yml
@@ -1,0 +1,7 @@
+all:
+  children:
+    somegroup:
+      hosts:
+        something:
+          7.2: bar
+    ungrouped: {}

--- a/test/integration/targets/ansible-inventory/files/valid_sample.yml
+++ b/test/integration/targets/ansible-inventory/files/valid_sample.yml
@@ -1,0 +1,7 @@
+all:
+  children:
+    somegroup:
+      hosts:
+        something:
+          foo: bar
+    ungrouped: {}

--- a/test/integration/targets/ansible-inventory/tasks/main.yml
+++ b/test/integration/targets/ansible-inventory/tasks/main.yml
@@ -81,3 +81,27 @@
     that:
         - result is failed
         - '"ERROR! Could not match supplied host pattern, ignoring: invalid" in result.stderr'
+
+- name: Install toml package
+  pip:
+    name:
+      - toml
+    state: present
+
+- name: "test option: --toml with valid group name"
+  command: ansible-inventory --list --toml -i {{ role_path }}/files/valid_sample.yml
+  register: result
+
+- assert:
+    that:
+        - result is succeeded
+
+- name: "test option: --toml with invalid group name"
+  command: ansible-inventory --list --toml -i {{ role_path }}/files/invalid_sample.yml
+  ignore_errors: true
+  register: result
+
+- assert:
+    that:
+        - result is failed
+        - '"ERROR! The source inventory contains a non-string key" in result.stderr'


### PR DESCRIPTION
##### SUMMARY

Handle stacktrace raise while parsing inventory in toml format

Fixes: #74404

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/74404_ansible_inventory.yml
lib/ansible/cli/inventory.py
test/integration/targets/ansible-inventory/files/invalid_sample.yml
test/integration/targets/ansible-inventory/files/valid_sample.yml
test/integration/targets/ansible-inventory/tasks/main.yml
