### PR TITLE
modules: get_url: Fix checksum binary validation

### DIFF
--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -518,7 +518,7 @@ def main():
 
             # Look through each line in the checksum file for a hash corresponding to
             # the filename in the url, returning the first hash that is found.
-            for cksum in (s for (s, f) in checksum_map if f.strip('./') == filename):
+            for cksum in (s for (s, f) in checksum_map if f.strip('./*') == filename):
                 checksum = cksum
                 break
             else:


### PR DESCRIPTION
##### SUMMARY

From the sha512sum man page:

... The default mode is to print a line with checksum, a character indicating type ('*' for binary, ' ' for text), and name for each FILE.

That is why a leading asterisk is valid but should be ignored in
filename comparison.

https://linux.die.net/man/1/sha512sum

One example https://downloads.apache.org/lucene/solr/8.8.2/solr-8.8.2.tgz.sha512

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
get_url

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
---
- hosts: localhost
  tasks:
  - get_url:
      url: https://downloads.apache.org/lucene/solr/8.8.2/solr-8.8.2.tgz
      dest: /tmp
      checksum: sha512:https://downloads.apache.org/lucene/solr/8.8.2/solr-8.8.2.tgz.sha512
```

```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unable to find a checksum for file 'solr-8.8.2.tgz' in 'https://downloads.apache.org/lucene/solr/8.8.2/solr-8.8.2.tgz.sha512'"}
```
