### PR TITLE
modules: get_url: Fix checksum binary validation

### DIFF
--- a/changelogs/fragments/74502-get_url-filx-checksum-binary.yml
+++ b/changelogs/fragments/74502-get_url-filx-checksum-binary.yml
@@ -1,3 +1,2 @@
----
 bugfixes:
   - get_url - Fixed checksum validation for binary files (leading asterisk) in checksum files (https://github.com/ansible/ansible/pull/74502).

--- a/changelogs/fragments/74502-get_url-filx-checksum-binary.yml
+++ b/changelogs/fragments/74502-get_url-filx-checksum-binary.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - get_url - Fixed checksum validation for binary files (leading asterisk) in checksum files (https://github.com/ansible/ansible/pull/74502).

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -511,14 +511,17 @@ def main():
             os.remove(checksum_tmpsrc)
             checksum_map = []
             for line in lines:
-                parts = line.split(None, 1)
+                # Split by one whitespace to keep the leading type char ' ' (whitespace) for text and '*' for binary
+                parts = line.split(" ", 1)
                 if len(parts) == 2:
-                    checksum_map.append((parts[0], parts[1]))
+                    # Remove the leading type char and use basename
+                    checksum_map.append((parts[0], os.path.basename(parts[1][1:])))
+
             filename = url_filename(url)
 
             # Look through each line in the checksum file for a hash corresponding to
             # the filename in the url, returning the first hash that is found.
-            for cksum in (s for (s, f) in checksum_map if f.strip('./') == filename):
+            for cksum in (s for (s, f) in checksum_map if f == filename):
                 checksum = cksum
                 break
             else:

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -514,8 +514,12 @@ def main():
                 # Split by one whitespace to keep the leading type char ' ' (whitespace) for text and '*' for binary
                 parts = line.split(" ", 1)
                 if len(parts) == 2:
-                    # Remove the leading type char and use basename
-                    checksum_map.append((parts[0], os.path.basename(parts[1][1:])))
+                    # Remove the leading type char, we expect
+                    if parts[1].startswith((" ", "*",)):
+                        parts[1] = parts[1][1:]
+
+                    # Append checksum and path without potential leading './'
+                    checksum_map.append((parts[0], parts[1].lstrip("./")))
 
             filename = url_filename(url)
 

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -367,6 +367,15 @@
       30949cc401e30ac494d695ab8764a9f76aae17c5d73c67f65e9b558f47eff892  ./not_target1.txt
       d0dbfc1945bc83bf6606b770e442035f2c4e15c886ee0c22fb3901ba19900b5b  ./not_target2.txt
 
+- name: create sha256 checksum file of src with a * leading path
+  copy:
+    dest: '{{ files_dir }}/sha256sum_with_asterisk.txt'
+    content: |
+      b1b6ce5073c8fac263a8fc5edfffdbd5dec1980c784e09c5bc69f8fb6056f006. *27617.txt
+      b1b6ce5073c8fac263a8fc5edfffdbd5dec1980c784e09c5bc69f8fb6056f006. *71420.txt
+      30949cc401e30ac494d695ab8764a9f76aae17c5d73c67f65e9b558f47eff892 *not_target1.txt
+      d0dbfc1945bc83bf6606b770e442035f2c4e15c886ee0c22fb3901ba19900b5b *not_target2.txt
+
 - copy:
     src: "testserver.py"
     dest: "{{ remote_tmp_dir }}/testserver.py"
@@ -423,6 +432,17 @@
     path: "{{ remote_tmp_dir }}/27617sha256_with_dot.txt"
   register: stat_result_sha256_with_dot
 
+- name: download src with sha256 checksum url with asterisk leading paths
+  get_url:
+    url: 'http://localhost:{{ http_port }}/27617.txt'
+    dest: '{{ remote_tmp_dir }}/27617sha256_with_asterisk.txt'
+    checksum: 'sha256:http://localhost:{{ http_port }}/sha256sum_with_asterisk.txt'
+  register: result_sha256_with_asterisk
+
+- stat:
+    path: "{{ remote_tmp_dir }}/27617sha256_with_asterisk.txt"
+  register: stat_result_sha256_with_asterisk
+
 - name: download src with sha256 checksum url with file scheme
   get_url:
     url: 'http://localhost:{{ http_port }}/27617.txt'
@@ -467,6 +487,17 @@
     path: "{{ remote_tmp_dir }}/71420sha256_with_dot.txt"
   register: stat_result_sha256_with_dot_71420
 
+- name: download 71420.txt with sha256 checksum url with asterisk leading paths
+  get_url:
+    url: 'http://localhost:{{ http_port }}/71420.txt'
+    dest: '{{ remote_tmp_dir }}/71420sha256_with_asterisk.txt'
+    checksum: 'sha256:http://localhost:{{ http_port }}/sha256sum_with_asterisk.txt'
+  register: result_sha256_with_asterisk_71420
+
+- stat:
+    path: "{{ remote_tmp_dir }}/71420sha256_with_asterisk.txt"
+  register: stat_result_sha256_with_asterisk_71420
+
 - name: download 71420.txt with sha256 checksum url with file scheme
   get_url:
     url: 'http://localhost:{{ http_port }}/71420.txt'
@@ -485,18 +516,22 @@
       - result_sha1 is changed
       - result_sha256 is changed
       - result_sha256_with_dot is changed
+      - result_sha256_with_asterisk is changed
       - result_sha256_with_file_scheme is changed
       - "stat_result_sha1.stat.exists == true"
       - "stat_result_sha256.stat.exists == true"
       - "stat_result_sha256_with_dot.stat.exists == true"
+      - "stat_result_sha256_with_asterisk.stat.exists == true"
       - "stat_result_sha256_with_file_scheme.stat.exists == true"
       - result_sha1_71420 is changed
       - result_sha256_71420 is changed
       - result_sha256_with_dot_71420 is changed
+      - result_sha256_with_asterisk_71420 is changed
       - result_sha256_with_file_scheme_71420 is changed
       - "stat_result_sha1_71420.stat.exists == true"
       - "stat_result_sha256_71420.stat.exists == true"
       - "stat_result_sha256_with_dot_71420.stat.exists == true"
+      - "stat_result_sha256_with_asterisk_71420.stat.exists == true"
       - "stat_result_sha256_with_file_scheme_71420.stat.exists == true"
 
 #https://github.com/ansible/ansible/issues/16191


### PR DESCRIPTION
##### SUMMARY

Replaces #72000 fixes #71999


From the sha512sum man page:

... The default mode is to print a line with checksum, a character indicating type ('*' for binary, ' ' for text), and name for each FILE.

https://linux.die.net/man/1/sha512sum

One example https://downloads.apache.org/lucene/solr/8.8.2/solr-8.8.2.tgz.sha512

The checksum and file are separated by _one_ whitespace with and the file either have a prefix whitespace or asterisk dependent of file type (text, binary). . 


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
get_url

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
---
- hosts: localhost
  tasks:
  - get_url:
      url: https://downloads.apache.org/lucene/solr/8.8.2/solr-8.8.2.tgz
      dest: /tmp
      checksum: sha512:https://downloads.apache.org/lucene/solr/8.8.2/solr-8.8.2.tgz.sha512
```

```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unable to find a checksum for file 'solr-8.8.2.tgz' in 'https://downloads.apache.org/lucene/solr/8.8.2/solr-8.8.2.tgz.sha512'"}
```

```
