### PR TITLE
[ansible-test] Add Fedora 34, update Fedora 33

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -120,10 +120,10 @@ stages:
               test: centos7
             - name: CentOS 8
               test: centos8
-            - name: Fedora 32
-              test: fedora32
             - name: Fedora 33
               test: fedora33
+            - name: Fedora 34
+              test: fedora34
             - name: openSUSE 15 py2
               test: opensuse15py2
             - name: openSUSE 15 py3
@@ -192,10 +192,10 @@ stages:
               test: centos7
             - name: CentOS 8
               test: centos8
-            - name: Fedora 32
-              test: fedora32
             - name: Fedora 33
               test: fedora33
+            - name: Fedora 34
+              test: fedora34
             - name: openSUSE 15 py2
               test: opensuse15py2
             - name: openSUSE 15 py3

--- a/changelogs/fragments/ansible-test-fedora-34.yml
+++ b/changelogs/fragments/ansible-test-fedora-34.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ansible-test - Fedora 34 (``fedora34``) container has been added.
+  - ansible-test - Fedora 32 and 33 (``fedora32`` and ``fedora33``) containers have been updated and now allow for ssh in more container environments.

--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -1,10 +1,3 @@
-# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=726661
-- name: Work around vixie-cron/PAM issue on old distros
-  command: sed -i '/pam_loginuid/ s/^/#/' /etc/pam.d/crond
-  when:
-    - ansible_distribution in ('RedHat', 'CentOS')
-    - ansible_distribution_major_version is version('6', '==')
-
 - name: add cron task (check mode enabled, cron task not already created)
   cron:
     name: test cron task

--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -63,9 +63,14 @@
 
 # TODO: Construct our own instance where 'nobest' applies, so we can stop using
 #       a third-party repo to test this behavior.
+#
+# This fails due to conflicts on Fedora 34, but we can nuke this entirely once
+# #74224 lands, because it covers nobest cases.
 - include_tasks: nobest.yml
-  when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('24', '>=')) or
+  when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('24', '>=') and
+          ansible_distribution_major_version is version('34', '!=')) or
         (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
+
 
 - include_tasks: cacheonly.yml
   when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('23', '>=')) or

--- a/test/integration/targets/dnf/vars/Fedora-34.yml
+++ b/test/integration/targets/dnf/vars/Fedora-34.yml
@@ -1,0 +1,2 @@
+astream_name: '@httpd:2.4/common'
+astream_name_no_stream: '@httpd/common'

--- a/test/integration/targets/setup_cron/tasks/main.yml
+++ b/test/integration/targets/setup_cron/tasks/main.yml
@@ -82,3 +82,15 @@
     FAKETIME: "+0y x10"
     LD_PRELOAD: "/usr/lib/faketime/libfaketime.so.1"
   when: ansible_distribution == 'Alpine'
+
+- name: See if /etc/pam.d/crond exists
+  stat:
+    path: /etc/pam.d/crond
+  register: pamd
+
+# https://github.com/lxc/lxc/issues/661#issuecomment-222444916
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=726661
+- name: Work around containers not being able to write to /proc/self/loginuid
+  command: sed -i '/pam_loginuid\.so$/ s/required/optional/' /etc/pam.d/crond
+  when:
+    - pamd.stat.exists

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -4,8 +4,9 @@ alpine3 name=quay.io/ansible/alpine3-test-container:2.0.2 python=3.8
 centos6 name=quay.io/ansible/centos6-test-container:2.0.2 python=2.6 seccomp=unconfined
 centos7 name=quay.io/ansible/centos7-test-container:2.0.2 python=2.7 seccomp=unconfined
 centos8 name=quay.io/ansible/centos8-test-container:2.0.2 python=3.6 seccomp=unconfined
-fedora32 name=quay.io/ansible/fedora32-test-container:2.0.2 python=3.8
-fedora33 name=quay.io/ansible/fedora33-test-container:2.0.2 python=3.9
+fedora32 name=quay.io/ansible/fedora32-test-container:2.1.0 python=3.8
+fedora33 name=quay.io/ansible/fedora33-test-container:2.1.0 python=3.9
+fedora34 name=quay.io/ansible/fedora34-test-container:2.1.0 python=3.9 seccomp=unconfined
 opensuse15py2 name=quay.io/ansible/opensuse15py2-test-container:2.0.2 python=2.7
 opensuse15 name=quay.io/ansible/opensuse15-test-container:2.0.2 python=3.6
 ubuntu1804 name=quay.io/ansible/ubuntu1804-test-container:2.0.2 python=3.6 seccomp=unconfined


### PR DESCRIPTION
Change:
- Added Fedora 34 container image to docker.txt
- Dropped Fedora 32 from CI
- Added Fedora 34 to CI
- Updated Fedora 33 container for ssh-related fixes
- Move cron fix from 698eae3f3d5e3a1ad0931def5078823d2da16803 into
  cron_setup and make it more generic; it can affect modern distros too.

Test Plan:
- ci_complete

Signed-off-by: Rick Elrod <rick@elrod.me>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME

ansible-test