### PR TITLE
interpreter_discovery: Hide warning in auto_silent

### DIFF
--- a/changelogs/fragments/74274_interpreter_discovery.yml
+++ b/changelogs/fragments/74274_interpreter_discovery.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- interpreter_discovery - hide warning 'No python interpreters...' when ANSIBLE_PYTHON_INTERPRETER=auto_silent (https://github.com/ansible/ansible/issues/74274).

--- a/lib/ansible/executor/interpreter_discovery.py
+++ b/lib/ansible/executor/interpreter_discovery.py
@@ -82,7 +82,9 @@ def discover_interpreter(action, interpreter_name, discovery_mode, task_vars):
         display.debug(u"found interpreters: {0}".format(found_interpreters), host=host)
 
         if not found_interpreters:
-            action._discovery_warnings.append(u'No python interpreters found for host {0} (tried {1})'.format(host, bootstrap_python_list))
+            if not is_silent:
+                action._discovery_warnings.append(u'No python interpreters found for '
+                                                  u'host {0} (tried {1})'.format(host, bootstrap_python_list))
             # this is lame, but returning None or throwing an exception is uglier
             return u'/usr/bin/python'
 


### PR DESCRIPTION
##### SUMMARY

Hide warning "No python interpreters" in auto_silent mode.

Fixes: #74274

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/74274_interpreter_discovery.yml
lib/ansible/executor/interpreter_discovery.py
