### PR TITLE
update backporting instructions to reflect stable-2.11 as latest stable branch

### DIFF
--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -22,8 +22,7 @@ If you want to follow the conversation about what features will be added to ``an
 * the :ref:`Ansible Release Schedule <release_and_maintenance>`
 * various GitHub `projects <https://github.com/ansible/ansible/projects>`_ - for example:
 
-   * the `2.10 release project <https://github.com/ansible/ansible/projects/39>`_
-   * the `network bugs project <https://github.com/ansible/ansible/projects/20>`_
+   * the `2.12 release project <https://github.com/ansible/ansible/projects/43>`_
    * the `core documentation project <https://github.com/ansible/ansible/projects/27>`_
 
 .. _community_pull_requests:
@@ -224,7 +223,7 @@ Here are some examples:
       remote_src=True even if mode was not set as a parameter.  This failed on
       filesystems which do not have permission bits (https://github.com/ansible/ansible/issues/29444).
 
-You can find more example changelog fragments in the `changelog directory <https://github.com/ansible/ansible/tree/stable-2.10/changelogs/fragments>`_ for the 2.10 release.
+You can find more example changelog fragments in the `changelog directory <https://github.com/ansible/ansible/tree/stable-2.11/changelogs/fragments>`_ for the 2.11 release.
 
 After you have written the changelog fragment for your PR, commit the file and include it with the pull request.
 
@@ -241,23 +240,18 @@ We do **not** backport features.
 
    These instructions assume that:
 
-    * ``stable-2.10`` is the targeted release branch for the backport
-    * ``https://github.com/ansible/ansible.git`` is configured as a
-      ``git remote`` named ``upstream``. If you do not use
-      a ``git remote`` named ``upstream``, adjust the instructions accordingly.
-    * ``https://github.com/<yourgithubaccount>/ansible.git``
-      is configured as a ``git remote`` named ``origin``. If you do not use
-      a ``git remote`` named ``origin``, adjust the instructions accordingly.
+    * ``stable-2.11`` is the targeted release branch for the backport
+    * ``https://github.com/ansible/ansible.git`` is configured as a ``git remote`` named ``upstream``. If you do not use a ``git remote`` named ``upstream``, adjust the instructions accordingly.
+    * ``https://github.com/<yourgithubaccount>/ansible.git`` is configured as a ``git remote`` named ``origin``. If you do not use a ``git remote`` named ``origin``, adjust the instructions accordingly.
 
 #. Prepare your devel, stable, and feature branches:
 
    ::
 
        git fetch upstream
-       git checkout -b backport/2.10/[PR_NUMBER_FROM_DEVEL] upstream/stable-2.10
+       git checkout -b backport/2.11/[PR_NUMBER_FROM_DEVEL] upstream/stable-2.11
 
-#. Cherry pick the relevant commit SHA from the devel branch into your feature
-   branch, handling merge conflicts as necessary:
+#. Cherry pick the relevant commit SHA from the devel branch into your feature branch, handling merge conflicts as necessary:
 
    ::
 
@@ -269,27 +263,16 @@ We do **not** backport features.
 
    ::
 
-       git push origin backport/2.10/[PR_NUMBER_FROM_DEVEL]
+       git push origin backport/2.11/[PR_NUMBER_FROM_DEVEL]
 
-#. Submit the pull request for ``backport/2.10/[PR_NUMBER_FROM_DEVEL]``
-   against the ``stable-2.10`` branch
+#. Submit the pull request for ``backport/2.11/[PR_NUMBER_FROM_DEVEL]`` against the ``stable-2.11`` branch
 
-#. The Release Manager will decide whether to merge the backport PR before
-   the next minor release. There isn't any need to follow up. Just ensure that the automated
-   tests (CI) are green.
+#. The Release Manager will decide whether to merge the backport PR before the next minor release. There isn't any need to follow up. Just ensure that the automated tests (CI) are green.
 
 .. note::
 
-    The choice to use ``backport/2.10/[PR_NUMBER_FROM_DEVEL]`` as the
-    name for the feature branch is somewhat arbitrary, but conveys meaning
-    about the purpose of that branch. It is not required to use this format,
-    but it can be helpful, especially when making multiple backport PRs for
-    multiple stable branches.
+    The branch name ``backport/2.11/[PR_NUMBER_FROM_DEVEL]`` is somewhat arbitrary, but conveys meaning about the purpose of the branch. This branch name format is not required, but it can be helpful, especially when making multiple backport PRs for multiple stable branches.
 
 .. note::
 
-    If you prefer, you can use CPython's cherry-picker tool
-    (``pip install --user 'cherry-picker >= 1.3.2'``) to backport commits
-    from devel to stable branches in Ansible. Take a look at the `cherry-picker
-    documentation <https://pypi.org/p/cherry-picker#cherry-picking>`_ for
-    details on installing, configuring, and using it.
+    If you prefer, you can use CPython's cherry-picker tool (``pip install --user 'cherry-picker >= 1.3.2'``) to backport commits from devel to stable branches in Ansible. Take a look at the `cherry-picker documentation <https://pypi.org/p/cherry-picker#cherry-picking>`_ for details on installing, configuring, and using it.


### PR DESCRIPTION
##### SUMMARY
Related to #74422.

Updates the backporting instructions in the devel docs to use stable-2.11 as the target branch.

Also edits the page by making most paragraphs a single line. This makes translation easier.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
