### PR TITLE
Eol the 2.8 docs

### DIFF
--- a/docs/docsite/_themes/sphinx_rtd_theme/layout.html
+++ b/docs/docsite/_themes/sphinx_rtd_theme/layout.html
@@ -143,7 +143,6 @@
             {% endif %}
           {% endif %}
 
-          {% include "ansible_versions.html" %}
           {% include "searchbox.html" %}
 
           {% endblock %}
@@ -195,7 +194,7 @@
         <div class="rst-content">
         {% endif %}
           {% include "breadcrumbs.html" %}
-          {% include "ansible_banner.html" %}
+          {% include "ansible_eol_banner.html" %}
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
           {%- block document %}
            <div itemprop="articleBody">

--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -146,9 +146,9 @@ html_context = {
     'github_version': 'devel/docs/docsite/rst/',
     'github_module_version': 'devel/lib/ansible/modules/',
     'current_version': version,
-    'latest_version': '2.10',
+    'latest_version': '3',
     # list specifically out of order to make latest work
-    'available_versions': ('latest', '2.9', '2.9_ja', '2.8', 'devel'),
+    'available_versions': ('latest'),
     'css_files': ('_static/ansible.css',  # overrides to the standard theme
                   ),
 }


### PR DESCRIPTION
##### SUMMARY
Part of #74422.

Adds the end-of-life banner to the 2.8 documentation.
Removes the version-switcher from the 2.8 documentation.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
