### PR TITLE
GnuPG key import error by 'apt_key' module did not contain command line and environment variables

### DIFF
--- a/lib/ansible/modules/apt_key.py
+++ b/lib/ansible/modules/apt_key.py
@@ -293,7 +293,14 @@ def get_key_id_from_file(module, filename, data=None):
 
     (rc, out, err) = module.run_command(cmd, environ_update=lang_env, data=(native_data if is_armored else data), binary_data=not is_armored)
     if rc != 0:
-        module.fail_json(msg="Unable to extract key from '%s'" % ('inline data' if data is not None else filename), stdout=out, stderr=err)
+        module.fail_json(
+            msg="Unable to extract key from '%s'"
+            % ("inline data" if data is not None else filename),
+            cmd=cmd,
+            forced_environment=lang_env,
+            stdout=out,
+            stderr=err,
+        )
 
     keys = parse_output_for_keys(out)
     # assume we only want first key?

--- a/test/integration/targets/apt_key/tasks/apt_key_import_lack_error_details.yml
+++ b/test/integration/targets/apt_key/tasks/apt_key_import_lack_error_details.yml
@@ -1,0 +1,5 @@
+- name: "Ensure error message (on import of a deliberately corrupted GnuPG key) contains the following data: command line and environment variables"
+  apt_key:
+    url: https://ansible-ci-files.s3.us-east-1.amazonaws.com/test/integration/targets/apt_key/apt-key-corrupt-zeros-2k.gpg
+  register: gpg_import_error_result
+  failed_when: not gpg_import_error_result.cmd is defined or not gpg_import_error_result.forced_environment is defined

--- a/test/integration/targets/apt_key/tasks/main.yml
+++ b/test/integration/targets/apt_key/tasks/main.yml
@@ -35,3 +35,6 @@
 
 - import_tasks: 'apt_key_binary.yml'
   when: ansible_distribution in ('Ubuntu', 'Debian')
+
+- import_tasks: 'apt_key_import_lack_error_details.yml'
+  when: ansible_distribution in ('Ubuntu', 'Debian')


### PR DESCRIPTION
##### SUMMARY

If there were an error on the GnuPG key import error by the `apt_key` module, the details about these errors did not contain command line and environment variables. 

However, the other GnuPG errors rather than the key import did contain such information.

I could not fix this within the https://github.com/ansible/ansible/pull/74478 because the relevant line of code also contained another bug of a greater significance than this one which is more of a feature request. That another bug is https://github.com/ansible/ansible/pull/74476

So I thought it would be better to first fix https://github.com/ansible/ansible/pull/74476 (which can even be backported) which contained evidently incorrect information, and then add the missing pieces of information.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`apt_key.py`

##### ADDITIONAL INFORMATION
This is a minor feature, so I didn't add the changelog piece. Besides that, the https://github.com/ansible/ansible/pull/74478 contains the description that is also relevant for the present pull request. Therefore, to avoid multiple duplicate changelog entries, I didn't add the entry at all for the current pull request.

However, I have added the test case, so you could see that the present pull request actually fixes this issue. If you try this test case with a code that existed before applying this pull request, you will get an error.
