### PR TITLE
Makefile: Allow one to specify python version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 .github/ export-ignore
-hacking/ export-ignore

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ else
 ASCII2MAN = @echo "ERROR: rst2man from docutils command is not installed but is required to build $(MANPAGES)" && exit 1
 endif
 
-PYTHON=python
+PYTHON ?= python
 GENERATE_CLI = hacking/build-ansible.py generate-man
 
 # fetch version from project release.py as single source-of-truth


### PR DESCRIPTION
/cc @Spredzy 

##### SUMMARY

Change:
- Allow overriding python version as env var for Makefile
- Including hacking directory in git export, for manpage generation

Test Plan:
- Tested as part of recent downstream work

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME

releng