### PR TITLE
[bp-2.11]: apt_key - update error message while importing gpg key

### DIFF
--- a/changelogs/fragments/74476-apt_key-gpg-inline-data.yaml
+++ b/changelogs/fragments/74476-apt_key-gpg-inline-data.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - The error message about the failure to import a ``gpg`` key by the ``apt_key`` module was incorrect (https://github.com/ansible/ansible/issues/74423).

--- a/lib/ansible/modules/apt_key.py
+++ b/lib/ansible/modules/apt_key.py
@@ -290,7 +290,7 @@ def get_key_id_from_file(module, filename, data=None):
 
     (rc, out, err) = module.run_command(cmd, environ_update=lang_env, data=to_native(data))
     if rc != 0:
-        module.fail_json(msg="Unable to extract key from '%s'" % ('inline data' if data is None else filename), stdout=out, stderr=err)
+        module.fail_json(msg="Unable to extract key from '%s'" % ('inline data' if data is not None else filename), stdout=out, stderr=err)
 
     keys = parse_output_for_keys(out)
     # assume we only want first key?

--- a/test/integration/targets/apt_key/tasks/apt_key_inline_data.yml
+++ b/test/integration/targets/apt_key/tasks/apt_key_inline_data.yml
@@ -1,0 +1,5 @@
+- name: "Ensure import of a deliberately corrupted downloaded GnuPG binary key results in an 'inline data' occurence in the message"
+  apt_key:
+    url: https://ansible-ci-files.s3.us-east-1.amazonaws.com/test/integration/targets/apt_key/apt-key-corrupt-zeros-2k.gpg
+  register: gpg_inline_result
+  failed_when: "not ('inline data' in gpg_inline_result.msg)"

--- a/test/integration/targets/apt_key/tasks/main.yml
+++ b/test/integration/targets/apt_key/tasks/main.yml
@@ -26,6 +26,9 @@
 
 - import_tasks: 'apt_key.yml'
   when: ansible_distribution in ('Ubuntu', 'Debian')
-  
+
+- import_tasks: 'apt_key_inline_data.yml'
+  when: ansible_distribution in ('Ubuntu', 'Debian')
+ 
 - import_tasks: 'file.yml'
   when: ansible_distribution in ('Ubuntu', 'Debian')


### PR DESCRIPTION
##### SUMMARY

The error message about the failure to import a 'gpg' key by the 'ansible.builtin.apt_key' module was incorrect.

This is a backport of https://github.com/ansible/ansible/pull/74476/ into the 2.11.

The backport to 2.10 is not needed, since this bug didn't yet exist in 2.10.

When importing a key by the `apt_key ` module, in case of error, the error message was incorrect, because the logic to distinguish between the file name and the explicit data was inversed.

The error message was:

`
Unable to extract key from '-'
`

While it should have been:

`
Unable to extract key from 'inline data'
`

The relevant code is in the following line from: `/lib/ansible/modules/apt_key.py`

`
module.fail_json(msg="Unable to extract key from '%s'" % ('inline data' if data is None else filename), stdout=out, stderr=err)
`

(it should have been `if data is None`)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/modules/apt_key`

##### ADDITIONAL INFORMATION

Fixes: https://github.com/ansible/ansible/issues/74423

To reproduce this error, see the associated test .yml from the present commit.

Alternatively, you can reproduce the error by the following files:

The `Vagrantfile` file:

```
Vagrant.configure("2") do |config|
  config.vm.synced_folder ".", "/vagrant", disabled: false

  config.vm.define "test-host" do |n|
    n.vm.box = "ubuntu/bionic64"
    n.vm.hostname = "test-host"
    n.vm.provision :ansible do |ansible|
      ansible.limit = "all"
      ansible.playbook = "test.yaml"
    end
  end
end

```
The `test.yaml` file:

```
- name: Test Playbook
  hosts: test-host
  become: yes
  tasks:
    - name: Add binary key
      apt_key: url=https://packages.cloud.google.com/apt/doc/apt-key.gpg
```

and run `vagrant up`


Expected Results:

`
Unable to extract key from 'inline data'
`


Actual Results:

`
Unable to extract key from '-'
`

@Akasurde - please review

