### PR TITLE
[bp-2.11]: apt_key  - Binary GnuPG keys downloaded via URL were corrupted

### DIFF
--- a/changelogs/fragments/74474-apt_key-gpg-binary-import.yaml
+++ b/changelogs/fragments/74474-apt_key-gpg-binary-import.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Binary GnuPG keys downloaded via URLs by the ansible.builtin.apt_key module were corrupted so GnuPG could not import them (https://github.com/ansible/ansible/issues/74424).

--- a/changelogs/fragments/74474-apt_key-gpg-binary-import.yaml
+++ b/changelogs/fragments/74474-apt_key-gpg-binary-import.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Binary GnuPG keys downloaded via URLs by the ansible.builtin.apt_key module were corrupted so GnuPG could not import them (https://github.com/ansible/ansible/issues/74424).
+  - apt_key - Binary GnuPG keys downloaded via URLs were corrupted so GnuPG could not import them (https://github.com/ansible/ansible/issues/74424).

--- a/lib/ansible/modules/apt_key.py
+++ b/lib/ansible/modules/apt_key.py
@@ -283,12 +283,15 @@ def download_key(module, url):
 
 def get_key_id_from_file(module, filename, data=None):
 
+    native_data = to_native(data)
+    is_armored = native_data.find("-----BEGIN PGP PUBLIC KEY BLOCK-----") >= 0
+
     global lang_env
     key = None
 
     cmd = [gpg_bin, '--with-colons', filename]
 
-    (rc, out, err) = module.run_command(cmd, environ_update=lang_env, data=to_native(data))
+    (rc, out, err) = module.run_command(cmd, environ_update=lang_env, data=(native_data if is_armored else data), binary_data=not is_armored)
     if rc != 0:
         module.fail_json(msg="Unable to extract key from '%s'" % ('inline data' if data is None else filename), stdout=out, stderr=err)
 

--- a/test/integration/targets/apt_key/tasks/apt_key_binary.yml
+++ b/test/integration/targets/apt_key/tasks/apt_key_binary.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Ensure import of binary key downloaded using URLs works
+  apt_key:
+    url: https://ansible-ci-files.s3.us-east-1.amazonaws.com/test/integration/targets/apt_key/apt-key-example-binary.gpg
+  register: apt_key_binary_test
+
+- name: Validate the results
+  assert:
+      that:
+          - 'apt_key_binary_test.changed is defined'
+          - 'apt_key_binary_test.changed'

--- a/test/integration/targets/apt_key/tasks/main.yml
+++ b/test/integration/targets/apt_key/tasks/main.yml
@@ -29,3 +29,6 @@
   
 - import_tasks: 'file.yml'
   when: ansible_distribution in ('Ubuntu', 'Debian')
+
+- import_tasks: 'apt_key_binary.yml'
+  when: ansible_distribution in ('Ubuntu', 'Debian')


### PR DESCRIPTION
##### SUMMARY

When importing a key by the `apt_key` module, it gets corrupted and not imported in the case of a binary key (not a textual “armored” key). Ansible tries to convert string data, but some data is lost on conversion, which results in a GnuPG error. This is a bug because binary data should not be converted using the `to_native` function.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`ansible.builtin.apt_key module`

##### ADDITIONAL INFORMATION

Fixes https://github.com/ansible/ansible/issues/74424

This is a backport for https://github.com/ansible/ansible/pull/74474 for the version 2.11.

To reproduce this error, use the associated test case.

You can also reproduce this error if you ccreate the following files:

Fie `Vagrantfile` file:


```
Vagrant.configure("2") do |config|
  config.vm.synced_folder ".", "/vagrant", disabled: false

  config.vm.define "test-host" do |n|
    n.vm.box = "ubuntu/bionic64"
    n.vm.hostname = "test-host"
    n.vm.provision :ansible do |ansible|
      ansible.limit = "all"
      ansible.playbook = "test.yaml"
    end
  end
end
```

The `test.yaml` file:

```
- name: Test Playbook
  hosts: test-host
  become: yes
  tasks:
    - name: Add binary key
      apt_key: url=https://packages.cloud.google.com/apt/doc/apt-key.gpg
      register: apt_key_binary_test

    - name: Validate the results
      assert:
        that:
          - 'apt_key_binary_test.changed is defined'
          - 'apt_key_binary_test.changed'
```

and run `vagrant up`




Expected Results:

Key imported without a problem


Actual Results:

```console
fatal: [master]: FAILED! => {"changed": false, "msg": "Unable to extract key from '-'", "stderr": "gpg: WARNING: no command supplied.  Trying to guess what you mean ...\ngpg: [don't know]: invalid packet (ctb=0a)\n", "stderr_lines": ["gpg: WARNING: no command supplied.  Trying to guess what you mean ...", "gpg: [don't know]: invalid packet (ctb=0a)"], "stdout": "pub:-:2048:1:FEEA9169307EA071:1614614617:1677728521::-:\nuid:::::::::Rapture Automatic Signing Key (cloud-rapture-signing-key-2021-03-01-08_01_09.pub):\nsub:-:2048:1:AA42F36EE8BEEE0E:1614614617::::\npub:-:2048:1:8B57C5C2836F4BEB:1607040606:1670154510::-:\nuid:::::::::gLinux Rapture Automatic Signing Key (//depot/google3/production/borg/cloud-rapture/keys/cloud-rapture-pubkeys/cloud-rapture-signing-key-2020-12-03-16_08_05.pub) <glinux-team@google.com>:\nsub:-:2048:1:48419E688DD52AC0:1607040606::::\n", "stdout_lines": ["pub:-:2048:1:FEEA9169307EA071:1614614617:1677728521::-:", "uid:::::::::Rapture Automatic Signing Key (cloud-rapture-signing-key-2021-03-01-08_01_09.pub):", "sub:-:2048:1:AA42F36EE8BEEE0E:1614614617::::", "pub:-:2048:1:8B57C5C2836F4BEB:1607040606:1670154510::-:", "uid:::::::::gLinux Rapture Automatic Signing Key (//depot/google3/production/borg/cloud-rapture/keys/cloud-rapture-pubkeys/cloud-rapture-signing-key-2020-12-03-16_08_05.pub) <glinux-team@google.com>:", "sub:-:2048:1:48419E688DD52AC0:1607040606::::"]}
```

Relevant file: 
`lib/ansible/modules/apt_key.py`
