### PR TITLE
facts - Set correct OS family for Rocky Linux

### DIFF
--- a/changelogs/fragments/support_rockylinux.yml
+++ b/changelogs/fragments/support_rockylinux.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - add RockyLinux to fact gathering (https://github.com/ansible/ansible/pull/74530)
+  - Add RockyLinux to fact gathering (https://github.com/ansible/ansible/pull/74530).

--- a/changelogs/fragments/support_rockylinux.yml
+++ b/changelogs/fragments/support_rockylinux.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - add RockyLinux to fact gathering (https://github.com/ansible/ansible/pull/74530)

--- a/changelogs/fragments/support_rockylinux.yml
+++ b/changelogs/fragments/support_rockylinux.yml
@@ -1,3 +1,2 @@
 bugfixes:
   - Add RockyLinux to fact gathering (https://github.com/ansible/ansible/pull/74530).
-  - hostname - Add support for RockyLinux (https://github.com/ansible/ansible/pull/74530).

--- a/changelogs/fragments/support_rockylinux.yml
+++ b/changelogs/fragments/support_rockylinux.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - Add RockyLinux to fact gathering (https://github.com/ansible/ansible/pull/74530).
+  - hostname - Add support for RockyLinux (https://github.com/ansible/ansible/pull/74530).

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -480,7 +480,7 @@ class Distribution(object):
     OS_FAMILY_MAP = {'RedHat': ['RedHat', 'Fedora', 'CentOS', 'Scientific', 'SLC',
                                 'Ascendos', 'CloudLinux', 'PSBM', 'OracleLinux', 'OVS',
                                 'OEL', 'Amazon', 'Virtuozzo', 'XenServer', 'Alibaba',
-                                'EulerOS', 'openEuler', 'AlmaLinux', 'RockyLinux'],
+                                'EulerOS', 'openEuler', 'AlmaLinux', 'Rocky'],
                      'Debian': ['Debian', 'Ubuntu', 'Raspbian', 'Neon', 'KDE neon',
                                 'Linux Mint', 'SteamOS', 'Devuan', 'Kali', 'Cumulus Linux',
                                 'Pop!_OS', 'Parrot', 'Pardus GNU/Linux'],

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -480,7 +480,7 @@ class Distribution(object):
     OS_FAMILY_MAP = {'RedHat': ['RedHat', 'Fedora', 'CentOS', 'Scientific', 'SLC',
                                 'Ascendos', 'CloudLinux', 'PSBM', 'OracleLinux', 'OVS',
                                 'OEL', 'Amazon', 'Virtuozzo', 'XenServer', 'Alibaba',
-                                'EulerOS', 'openEuler', 'AlmaLinux'],
+                                'EulerOS', 'openEuler', 'AlmaLinux', 'RockyLinux'],
                      'Debian': ['Debian', 'Ubuntu', 'Raspbian', 'Neon', 'KDE neon',
                                 'Linux Mint', 'SteamOS', 'Devuan', 'Kali', 'Cumulus Linux',
                                 'Pop!_OS', 'Parrot', 'Pardus GNU/Linux'],

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -1001,12 +1001,6 @@ class PopHostname(Hostname):
     strategy_class = DebianStrategy
 
 
-class RockyHostname(Hostname):
-    platform = 'Linux'
-    distribution = 'Rocky'
-    strategy_class = SystemdStrategy
-
-
 def main():
     module = AnsibleModule(
         argument_spec=dict(

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -1001,6 +1001,12 @@ class PopHostname(Hostname):
     strategy_class = DebianStrategy
 
 
+class RockyLinuxHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'RockyLinux'
+    strategy_class = SystemdStrategy
+
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -1001,7 +1001,7 @@ class PopHostname(Hostname):
     strategy_class = DebianStrategy
 
 
-class RockyLinuxHostname(Hostname):
+class RockyHostname(Hostname):
     platform = 'Linux'
     distribution = 'Rocky'
     strategy_class = SystemdStrategy

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -1003,7 +1003,7 @@ class PopHostname(Hostname):
 
 class RockyLinuxHostname(Hostname):
     platform = 'Linux'
-    distribution = 'RockyLinux'
+    distribution = 'Rocky'
     strategy_class = SystemdStrategy
 
 

--- a/test/units/module_utils/facts/system/distribution/fixtures/rockylinux_8_3.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/rockylinux_8_3.json
@@ -1,39 +1,39 @@
 {
-    "name": "RockyLinux 8.3",
+    "name": "Rocky Linux 8.3",
     "distro": {
         "codename": "",
-        "id": "rockylinux",
-        "name": "RockyLinux",
+        "id": "rocky",
+        "name": "Rocky Linux",
         "version": "8.3",
         "version_best": "8.3",
         "lsb_release_info": {
             "lsb_version": ":core-4.1-amd64:core-4.1-noarch",
-            "distributor_id": "RockyLinux",
-            "description": "RockyLinux release 8.3",
+            "distributor_id": "Rocky",
+            "description": "Rocky Linux release 8.3",
             "release": "8.3",
             "codename": ""
         },
         "os_release_info": {
-            "name": "RockyLinux",
+            "name": "Rocky Linux",
             "version": "8.3",
-            "id": "rockylinux",
+            "id": "rocky",
             "id_like": "rhel fedora",
             "version_id": "8.3",
             "platform_id": "platform:el8",
-            "pretty_name": "RockyLinux 8.3",
+            "pretty_name": "Rocky Linux 8.3",
             "ansi_color": "0;34",
             "cpe_name": "cpe:/o:rockylinux:rockylinux:8.3",
             "home_url": "https://rockylinux.org/",
             "bug_report_url": "https://bugs.rockylinux.org/",
-            "rockylinux_mantisbt_project": "RockyLinux-8",
-            "rockylinux_mantisbt_project_version": "8",
+            "rocky_support_product": "Rocky Linux",
+            "rocky_support_product_version": "8",
             "codename": ""
         }
     },
     "input": {
-        "/etc/centos-release": "RockyLinux release 8.3\n",
-        "/etc/redhat-release": "RockyLinux release 8.3\n",
-        "/etc/system-release": "RockyLinux release 8.3\n",
+        "/etc/rocky-release": "Rocky Linux release 8.3\n",
+        "/etc/redhat-release": "Rocky Linux release 8.3\n",
+        "/etc/system-release": "Rocky Linux release 8.3\n",
         "/etc/os-release": "NAME=\"Rocky Linux\"\nVERSION=\"8\"\nID=\"rocky\"\nID_LIKE=\"rhel fedora\"\nVERSION_ID=\"8\"\nPLATFORM_ID=\"platform:el8\"\nPRETTY_NAME=\"Rocky Linux 8\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:rocky:rocky:8\"\nHOME_URL=\"https://rockylinux.org/\"\nBUG_REPORT_URL=\"https://bugs.rockylinux.org/\"\nROCKY_SUPPORT_PRODUCT=\"Rocky Linux\"\nROCKY_SUPPORT_PRODUCT_VERSION=\"8\"\n",
         "/usr/lib/os-release": "NAME=\"Rocky Linux\"\nVERSION=\"8\"\nID=\"rocky\"\nID_LIKE=\"rhel fedora\"\nVERSION_ID=\"8\"\nPLATFORM_ID=\"platform:el8\"\nPRETTY_NAME=\"Rocky Linux 8\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:rocky:rocky:8\"\nHOME_URL=\"https://rockylinux.org/\"\nBUG_REPORT_URL=\"https://bugs.rockylinux.org/\"\nROCKY_SUPPORT_PRODUCT=\"Rocky Linux\"\nROCKY_SUPPORT_PRODUCT_VERSION=\"8\"\n"
     },
@@ -43,7 +43,7 @@
         ""
     ],
     "result": {
-        "distribution": "RockyLinux",
+        "distribution": "Rocky Linux",
         "distribution_version": "8.3",
         "distribution_release": "NA",
         "distribution_major_version": "8",

--- a/test/units/module_utils/facts/system/distribution/fixtures/rockylinux_8_3.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/rockylinux_8_3.json
@@ -6,13 +6,7 @@
         "name": "Rocky Linux",
         "version": "8.3",
         "version_best": "8.3",
-        "lsb_release_info": {
-            "lsb_version": ":core-4.1-amd64:core-4.1-noarch",
-            "distributor_id": "Rocky",
-            "description": "Rocky Linux release 8.3",
-            "release": "8.3",
-            "codename": ""
-        },
+        "lsb_release_info": {},
         "os_release_info": {
             "name": "Rocky Linux",
             "version": "8.3",
@@ -21,33 +15,32 @@
             "version_id": "8.3",
             "platform_id": "platform:el8",
             "pretty_name": "Rocky Linux 8.3",
-            "ansi_color": "0;34",
-            "cpe_name": "cpe:/o:rockylinux:rockylinux:8.3",
+            "ansi_color": "0;31",
+            "cpe_name": "cpe:/o:rocky:rocky:8",
             "home_url": "https://rockylinux.org/",
             "bug_report_url": "https://bugs.rockylinux.org/",
             "rocky_support_product": "Rocky Linux",
-            "rocky_support_product_version": "8",
-            "codename": ""
+            "rocky_support_product_version": "8"
         }
     },
     "input": {
-        "/etc/rocky-release": "Rocky Linux release 8.3\n",
         "/etc/redhat-release": "Rocky Linux release 8.3\n",
         "/etc/system-release": "Rocky Linux release 8.3\n",
-        "/etc/os-release": "NAME=\"Rocky Linux\"\nVERSION=\"8\"\nID=\"rocky\"\nID_LIKE=\"rhel fedora\"\nVERSION_ID=\"8\"\nPLATFORM_ID=\"platform:el8\"\nPRETTY_NAME=\"Rocky Linux 8\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:rocky:rocky:8\"\nHOME_URL=\"https://rockylinux.org/\"\nBUG_REPORT_URL=\"https://bugs.rockylinux.org/\"\nROCKY_SUPPORT_PRODUCT=\"Rocky Linux\"\nROCKY_SUPPORT_PRODUCT_VERSION=\"8\"\n",
-        "/usr/lib/os-release": "NAME=\"Rocky Linux\"\nVERSION=\"8\"\nID=\"rocky\"\nID_LIKE=\"rhel fedora\"\nVERSION_ID=\"8\"\nPLATFORM_ID=\"platform:el8\"\nPRETTY_NAME=\"Rocky Linux 8\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:rocky:rocky:8\"\nHOME_URL=\"https://rockylinux.org/\"\nBUG_REPORT_URL=\"https://bugs.rockylinux.org/\"\nROCKY_SUPPORT_PRODUCT=\"Rocky Linux\"\nROCKY_SUPPORT_PRODUCT_VERSION=\"8\"\n"
+        "/etc/rocky-release": "Rocky Linux release 8.3\n",
+        "/etc/os-release": "NAME=\"Rocky Linux\"\nVERSION=\"8.3\"\nID=\"rocky\"\nID_LIKE=\"rhel fedora\"\nVERSION_ID=\"8.3\"\nPLATFORM_ID=\"platform:el8\"\nPRETTY_NAME=\"Rocky Linux 8.3\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:rocky:rocky:8\"\nHOME_URL=\"https://rockylinux.org/\"\nBUG_REPORT_URL=\"https://bugs.rockylinux.org/\"\nROCKY_SUPPORT_PRODUCT=\"Rocky Linux\"\nROCKY_SUPPORT_PRODUCT_VERSION=\"8\"\n",
+        "/usr/lib/os-release": "NAME=\"Rocky Linux\"\nVERSION=\"8.3\"\nID=\"rocky\"\nID_LIKE=\"rhel fedora\"\nVERSION_ID=\"8.3\"\nPLATFORM_ID=\"platform:el8\"\nPRETTY_NAME=\"Rocky Linux 8.3\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:rocky:rocky:8\"\nHOME_URL=\"https://rockylinux.org/\"\nBUG_REPORT_URL=\"https://bugs.rockylinux.org/\"\nROCKY_SUPPORT_PRODUCT=\"Rocky Linux\"\nROCKY_SUPPORT_PRODUCT_VERSION=\"8\"\n"
     },
     "platform.dist": [
-        "rockylinux",
+        "rocky",
         "8.3",
         ""
     ],
     "result": {
-        "distribution": "Rocky Linux",
+        "distribution": "Rocky",
         "distribution_version": "8.3",
         "distribution_release": "NA",
         "distribution_major_version": "8",
-        "os_family": "RedHat"
+        "os_family": "Rocky"
     },
     "platform.release": "4.18.0-240.22.1.el8.x86_64"
 }

--- a/test/units/module_utils/facts/system/distribution/fixtures/rockylinux_8_3.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/rockylinux_8_3.json
@@ -1,0 +1,53 @@
+{
+    "name": "RockyLinux 8.3",
+    "distro": {
+        "codename": "",
+        "id": "rockylinux",
+        "name": "RockyLinux",
+        "version": "8.3",
+        "version_best": "8.3",
+        "lsb_release_info": {
+            "lsb_version": ":core-4.1-amd64:core-4.1-noarch",
+            "distributor_id": "RockyLinux",
+            "description": "RockyLinux release 8.3",
+            "release": "8.3",
+            "codename": ""
+        },
+        "os_release_info": {
+            "name": "RockyLinux",
+            "version": "8.3",
+            "id": "rockylinux",
+            "id_like": "rhel fedora",
+            "version_id": "8.3",
+            "platform_id": "platform:el8",
+            "pretty_name": "RockyLinux 8.3",
+            "ansi_color": "0;34",
+            "cpe_name": "cpe:/o:rockylinux:rockylinux:8.3",
+            "home_url": "https://rockylinux.org/",
+            "bug_report_url": "https://bugs.rockylinux.org/",
+            "rockylinux_mantisbt_project": "RockyLinux-8",
+            "rockylinux_mantisbt_project_version": "8",
+            "codename": ""
+        }
+    },
+    "input": {
+        "/etc/centos-release": "RockyLinux release 8.3\n",
+        "/etc/redhat-release": "RockyLinux release 8.3\n",
+        "/etc/system-release": "RockyLinux release 8.3\n",
+        "/etc/os-release": "NAME=\"Rocky Linux\"\nVERSION=\"8\"\nID=\"rocky\"\nID_LIKE=\"rhel fedora\"\nVERSION_ID=\"8\"\nPLATFORM_ID=\"platform:el8\"\nPRETTY_NAME=\"Rocky Linux 8\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:rocky:rocky:8\"\nHOME_URL=\"https://rockylinux.org/\"\nBUG_REPORT_URL=\"https://bugs.rockylinux.org/\"\nROCKY_SUPPORT_PRODUCT=\"Rocky Linux\"\nROCKY_SUPPORT_PRODUCT_VERSION=\"8\"\n",
+        "/usr/lib/os-release": "NAME=\"Rocky Linux\"\nVERSION=\"8\"\nID=\"rocky\"\nID_LIKE=\"rhel fedora\"\nVERSION_ID=\"8\"\nPLATFORM_ID=\"platform:el8\"\nPRETTY_NAME=\"Rocky Linux 8\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:rocky:rocky:8\"\nHOME_URL=\"https://rockylinux.org/\"\nBUG_REPORT_URL=\"https://bugs.rockylinux.org/\"\nROCKY_SUPPORT_PRODUCT=\"Rocky Linux\"\nROCKY_SUPPORT_PRODUCT_VERSION=\"8\"\n"
+    },
+    "platform.dist": [
+        "rockylinux",
+        "8.3",
+        ""
+    ],
+    "result": {
+        "distribution": "RockyLinux",
+        "distribution_version": "8.3",
+        "distribution_release": "NA",
+        "distribution_major_version": "8",
+        "os_family": "RedHat"
+    },
+    "platform.release": "4.18.0-240.22.1.el8.x86_64"
+}

--- a/test/units/module_utils/facts/system/distribution/fixtures/rockylinux_8_3.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/rockylinux_8_3.json
@@ -40,7 +40,7 @@
         "distribution_version": "8.3",
         "distribution_release": "NA",
         "distribution_major_version": "8",
-        "os_family": "Rocky"
+        "os_family": "RedHat"
     },
     "platform.release": "4.18.0-240.22.1.el8.x86_64"
 }

--- a/test/units/module_utils/facts/system/distribution/fixtures/rockylinux_8_3.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/rockylinux_8_3.json
@@ -1,5 +1,5 @@
 {
-    "name": "Rocky Linux 8.3",
+    "name": "Rocky 8.3",
     "distro": {
         "codename": "",
         "id": "rocky",


### PR DESCRIPTION
##### SUMMARY

This change adds support for [RockyLinux](https://rockylinux.org/) and adds it as a member to the RedHat family of operating systems.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/module_utils/facts/system/distribution.py

##### ADDITIONAL INFORMATION

- Don't think we have a codename for this release, but looking at some other distros it seems like this isn't required