### PR TITLE
Become: Change use of "yes" to "true" to promote ansible-lint compliance

### DIFF
--- a/docs/docsite/rst/user_guide/become.rst
+++ b/docs/docsite/rst/user_guide/become.rst
@@ -22,10 +22,10 @@ Become directives
 You can set the directives that control ``become`` at the play or task level. You can override these by setting connection variables, which often differ from one host to another. These variables and directives are independent. For example, setting ``become_user`` does not set ``become``.
 
 become
-    set to ``yes`` to activate privilege escalation.
+    set to ``true`` to activate privilege escalation.
 
 become_user
-    set to user with desired privileges — the user you `become`, NOT the user you login as. Does NOT imply ``become: yes``, to allow it to be set at host level. Default value is ``root``.
+    set to user with desired privileges — the user you `become`, NOT the user you login as. Does NOT imply ``become: true``, to allow it to be set at host level. Default value is ``root``.
 
 become_method
     (at play or task level) overrides the default method set in ansible.cfg, set to use any of the :ref:`become_plugins`.
@@ -41,7 +41,7 @@ For example, to manage a system service (which requires ``root`` privileges) whe
       service:
         name: httpd
         state: started
-      become: yes
+      become: true
 
 To run a command as the ``apache`` user:
 
@@ -49,7 +49,7 @@ To run a command as the ``apache`` user:
 
     - name: Run a command as the apache user
       command: somecommand
-      become: yes
+      become: true
       become_user: apache
 
 To do something as the ``nobody`` user when the shell is nologin:
@@ -58,7 +58,7 @@ To do something as the ``nobody`` user when the shell is nologin:
 
     - name: Run a command as nobody
       command: somecommand
-      become: yes
+      become: true
       become_method: su
       become_user: nobody
       become_flags: '-s /bin/sh'
@@ -78,7 +78,7 @@ ansible_become_method
     which privilege escalation method should be used
 
 ansible_become_user
-    set the user you become through privilege escalation; does not imply ``ansible_become: yes``
+    set the user you become through privilege escalation; does not imply ``ansible_become: true``
 
 ansible_become_password
     set the privilege escalation password. See :ref:`playbooks_vault` for details on how to avoid having secrets in plain text
@@ -90,7 +90,7 @@ For example, if you want to run all tasks as ``root`` on a server named ``webser
 
 .. code-block:: text
 
-    webserver ansible_user=manager ansible_become=yes
+    webserver ansible_user=manager ansible_become=true
 
 .. note::
     The variables defined above are generic for all become plugins but plugin specific ones can also be set instead.
@@ -293,7 +293,7 @@ As of version 2.6, Ansible supports ``become`` for privilege escalation (enterin
 
 You must set the connection type to either ``connection: ansible.netcommon.network_cli`` or ``connection: ansible.netcommon.httpapi`` to use ``become`` for privilege escalation on network devices. Check the :ref:`platform_options` documentation for details.
 
-You can use escalated privileges on only the specific tasks that need them, on an entire play, or on all plays. Adding ``become: yes`` and ``become_method: enable`` instructs Ansible to enter ``enable`` mode before executing the task, play, or playbook where those parameters are set.
+You can use escalated privileges on only the specific tasks that need them, on an entire play, or on all plays. Adding ``become: true`` and ``become_method: enable`` instructs Ansible to enter ``enable`` mode before executing the task, play, or playbook where those parameters are set.
 
 If you see this error message, the task that generated it requires ``enable`` mode to succeed:
 
@@ -309,7 +309,7 @@ To set ``enable`` mode for a specific task, add ``become`` at the task level:
      arista.eos.eos_facts:
        gather_subset:
          - "!hardware"
-     become: yes
+     become: true
      become_method: enable
 
 To set enable mode for all tasks in a single play, add ``become`` at the play level:
@@ -317,7 +317,7 @@ To set enable mode for all tasks in a single play, add ``become`` at the play le
 .. code-block:: yaml
 
    - hosts: eos-switches
-     become: yes
+     become: true
      become_method: enable
      tasks:
        - name: Gather facts (eos)
@@ -337,7 +337,7 @@ Often you wish for all tasks in all plays to run using privilege mode, that is b
    ansible_connection: ansible.netcommon.network_cli
    ansible_network_os: arista.eos.eos
    ansible_user: myuser
-   ansible_become: yes
+   ansible_become: true
    ansible_become_method: enable
 
 Passwords for enable mode
@@ -367,7 +367,7 @@ Ansible still supports ``enable`` mode with ``connection: local`` for legacy net
            gather_subset:
              - "!hardware"
          provider:
-           authorize: yes
+           authorize: true
            auth_pass: " {{ secret_auth_pass }}"
 
 We recommend updating your playbooks to use ``become`` for network-device ``enable`` mode consistently. The use of ``authorize`` and of ``provider`` dictionaries will be deprecated in future. Check the :ref:`platform_options` and :ref:`network_modules` documentation for details.
@@ -409,7 +409,7 @@ task:
 
     - Check my user name
       ansible.windows.win_whoami:
-      become: yes
+      become: true
 
 The output will look something similar to the below:
 
@@ -711,9 +711,9 @@ Here are some examples of how to use ``become_flags`` with Windows tasks:
     ansible.windows.win_copy:
       src: \\server\share\data\file.txt
       dest: C:\temp\file.txt
-      remote_src: yes
+      remote_src: true
     vars:
-      ansible_become: yes
+      ansible_become: true
       ansible_become_method: runas
       ansible_become_user: DOMAIN\user
       ansible_become_password: Password01
@@ -721,12 +721,12 @@ Here are some examples of how to use ``become_flags`` with Windows tasks:
 
   - name: run a command under a batch logon
     ansible.windows.win_whoami:
-    become: yes
+    become: true
     become_flags: logon_type=batch
 
   - name: run a command and not load the user profile
     ansible.windows.win_whomai:
-    become: yes
+    become: true
     become_flags: logon_flags=
 
 


### PR DESCRIPTION
##### SUMMARY
The [ansible-lint project](https://github.com/ansible-community/ansible-lint) leverages [yamllint](https://github.com/adrienverge/yamllint) rules by default. Yamllint has a [truthy rule](https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy), which will alert on the `become: yes` statement (among others) that is used heavily in Ansible documentation. This PR changes values of `yes` to `true` (which is `ansible-lint` compliant) in the "Understanding privilege escalation: become" chapter of the Ansible User Guide.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
"Become" chapter in Ansible User Guide

##### ADDITIONAL INFORMATION
Other sections of the Ansible documentation contain similar `ansible-lint` compliance issues. It may be worth analyzing popular core documentation for non-compliance and correcting those documents first, then propagating similar changes to downstream modules.
