### PR TITLE
Added the playbook_files magic variable

### DIFF
--- a/docs/docsite/rst/reference_appendices/special_variables.rst
+++ b/docs/docsite/rst/reference_appendices/special_variables.rst
@@ -121,6 +121,11 @@ ansible_play_name
 playbook_dir
     The path to the directory of the playbook that was passed to the ``ansible-playbook`` command line.
 
+playbook_files
+    List of playbook files that were passed to the ``ansible-playbook`` command line. 
+    Since you can pass playbooks from different directories, the list contains the full path of each file.
+    Added after ``2.11.0``
+
 role_name
     The name of the role currently being executed.
 

--- a/docs/docsite/rst/user_guide/playbooks_vars_facts.rst
+++ b/docs/docsite/rst/user_guide/playbooks_vars_facts.rst
@@ -660,6 +660,8 @@ The batch size is defined by ``serial``, when not set it is equivalent to the wh
 
 ``playbook_dir`` contains the playbook base directory.
 
+``playbook_files`` is a list with the full path of all received playbooks files (added after 2.11.0)
+
 ``role_path`` contains the current role's pathname and only works inside a role.
 
 ``ansible_check_mode`` is a boolean, set to ``True`` if you run Ansible with ``--check``.

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -32,6 +32,7 @@ except ImportError:
 from jinja2.exceptions import UndefinedError
 
 from ansible import constants as C
+from ansible import context
 from ansible.errors import AnsibleError, AnsibleParserError, AnsibleUndefinedVariable, AnsibleFileNotFound, AnsibleAssertionError, AnsibleTemplateError
 from ansible.inventory.host import Host
 from ansible.inventory.helpers import sort_groups, get_group_vars
@@ -451,6 +452,7 @@ class VariableManager:
         '''
 
         variables = {}
+        variables['playbook_files'] = [os.path.join(os.path.abspath(os.getcwd()), p) for p in context.CLIARGS["args"]]
         variables['playbook_dir'] = os.path.abspath(self._loader.get_basedir())
         variables['ansible_playbook_python'] = sys.executable
         variables['ansible_config_file'] = C.CONFIG_FILE


### PR DESCRIPTION
##### SUMMARY
Added a new magic variable `playbook_files` that contains a list of playbook files passed as arguments to the CLI.
Corresponding documentation is also updated

Fixes #72712 


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
Component files:
- lib/ansible/vars/manager.py

Documentation Files:
- docs/docsite/rst/reference_appendices/special_variables.rst
- docs/docsite/rst/user_guide/playbooks_vars_facts.rst


##### ADDITIONAL INFORMATION
Since playbooks can come from different directories, the variable returns the complete path for 
all received files
