### PR TITLE
[stable-2.10] hostname - Add Rocky Linux support (#74530)

### DIFF
--- a/changelogs/fragments/74530-hostname-rocky-linux-support.yml
+++ b/changelogs/fragments/74530-hostname-rocky-linux-support.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hostname - Add Rocky Linux support (https://github.com/ansible/ansible/pull/74530)

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -830,6 +830,12 @@ class PopHostname(Hostname):
     strategy_class = DebianStrategy
 
 
+class RockyHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Rocky'
+    strategy_class = SystemdStrategy
+
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(


### PR DESCRIPTION
##### SUMMARY
Adds Rocky Linux support to ansible stable 2.10. This is to match the current PR for latest development (#74530)
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/modules/hostname.py`