### PR TITLE
[stable-2.11] Add Rocky Linux to the family of Red Hat-like operating systems (#74530)

### DIFF
--- a/changelogs/fragments/support_rockylinux.yml
+++ b/changelogs/fragments/support_rockylinux.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Add Rocky Linux to fact gathering (https://github.com/ansible/ansible/pull/74530)

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -480,7 +480,7 @@ class Distribution(object):
     OS_FAMILY_MAP = {'RedHat': ['RedHat', 'Fedora', 'CentOS', 'Scientific', 'SLC',
                                 'Ascendos', 'CloudLinux', 'PSBM', 'OracleLinux', 'OVS',
                                 'OEL', 'Amazon', 'Virtuozzo', 'XenServer', 'Alibaba',
-                                'EulerOS', 'openEuler', 'AlmaLinux'],
+                                'EulerOS', 'openEuler', 'AlmaLinux', 'Rocky'],
                      'Debian': ['Debian', 'Ubuntu', 'Raspbian', 'Neon', 'KDE neon',
                                 'Linux Mint', 'SteamOS', 'Devuan', 'Kali', 'Cumulus Linux',
                                 'Pop!_OS', 'Parrot', 'Pardus GNU/Linux'],

--- a/test/units/module_utils/facts/system/distribution/fixtures/rockylinux_8_3.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/rockylinux_8_3.json
@@ -1,0 +1,46 @@
+{
+    "name": "Rocky 8.3",
+    "distro": {
+        "codename": "",
+        "id": "rocky",
+        "name": "Rocky Linux",
+        "version": "8.3",
+        "version_best": "8.3",
+        "lsb_release_info": {},
+        "os_release_info": {
+            "name": "Rocky Linux",
+            "version": "8.3",
+            "id": "rocky",
+            "id_like": "rhel fedora",
+            "version_id": "8.3",
+            "platform_id": "platform:el8",
+            "pretty_name": "Rocky Linux 8.3",
+            "ansi_color": "0;31",
+            "cpe_name": "cpe:/o:rocky:rocky:8",
+            "home_url": "https://rockylinux.org/",
+            "bug_report_url": "https://bugs.rockylinux.org/",
+            "rocky_support_product": "Rocky Linux",
+            "rocky_support_product_version": "8"
+        }
+    },
+    "input": {
+        "/etc/redhat-release": "Rocky Linux release 8.3\n",
+        "/etc/system-release": "Rocky Linux release 8.3\n",
+        "/etc/rocky-release": "Rocky Linux release 8.3\n",
+        "/etc/os-release": "NAME=\"Rocky Linux\"\nVERSION=\"8.3\"\nID=\"rocky\"\nID_LIKE=\"rhel fedora\"\nVERSION_ID=\"8.3\"\nPLATFORM_ID=\"platform:el8\"\nPRETTY_NAME=\"Rocky Linux 8.3\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:rocky:rocky:8\"\nHOME_URL=\"https://rockylinux.org/\"\nBUG_REPORT_URL=\"https://bugs.rockylinux.org/\"\nROCKY_SUPPORT_PRODUCT=\"Rocky Linux\"\nROCKY_SUPPORT_PRODUCT_VERSION=\"8\"\n",
+        "/usr/lib/os-release": "NAME=\"Rocky Linux\"\nVERSION=\"8.3\"\nID=\"rocky\"\nID_LIKE=\"rhel fedora\"\nVERSION_ID=\"8.3\"\nPLATFORM_ID=\"platform:el8\"\nPRETTY_NAME=\"Rocky Linux 8.3\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:rocky:rocky:8\"\nHOME_URL=\"https://rockylinux.org/\"\nBUG_REPORT_URL=\"https://bugs.rockylinux.org/\"\nROCKY_SUPPORT_PRODUCT=\"Rocky Linux\"\nROCKY_SUPPORT_PRODUCT_VERSION=\"8\"\n"
+    },
+    "platform.dist": [
+        "rocky",
+        "8.3",
+        ""
+    ],
+    "result": {
+        "distribution": "Rocky",
+        "distribution_version": "8.3",
+        "distribution_release": "NA",
+        "distribution_major_version": "8",
+        "os_family": "RedHat"
+    },
+    "platform.release": "4.18.0-240.22.1.el8.x86_64"
+}


### PR DESCRIPTION
##### SUMMARY
Adds Rocky Linux support to ansible stable 2.11. This is to match the current PR for latest development (#74530)
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/module_utils/facts/system/distribution.py`

##### ADDITIONAL INFORMATION

No other changes required when [latest release package](https://kojidev.rockylinux.org/koji/buildinfo?buildID=7923) is installed. Major and minor version should report accurately. 