### PR TITLE
Add hostname class for Rocky Linux

### DIFF
--- a/changelogs/fragments/support_rocky_linux_hostname.yml
+++ b/changelogs/fragments/support_rocky_linux_hostname.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hostname - Add Rocky Linux support

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -1001,6 +1001,12 @@ class PopHostname(Hostname):
     strategy_class = DebianStrategy
 
 
+class RockyHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Rocky'
+    strategy_class = SystemdStrategy
+
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(


### PR DESCRIPTION
##### SUMMARY
Adding support for Rocky Linux to the hostname module. This PR is opened to separate from #74530 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/modules/hostname.py`

##### ADDITIONAL INFORMATION
