### PR TITLE
Use /usr/bin/python3 on rhelish 9+

### DIFF
--- a/changelogs/fragments/74547-use-python3-on-rhel-9.yaml
+++ b/changelogs/fragments/74547-use-python3-on-rhel-9.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- On RHEL 9, CentOS Stream 9 etc., use /usr/bin/python3 as the default interpreter; /usr/libexec/platform-python is just a backwards-compatibility symbolic link there.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1486,6 +1486,7 @@ INTERPRETER_PYTHON_DISTRO_MAP:
     centos: &rhelish
       '6': /usr/bin/python
       '8': /usr/libexec/platform-python
+      '9': /usr/bin/python3
     debian:
       '8': /usr/bin/python
       '10': /usr/bin/python3


### PR DESCRIPTION
##### SUMMARY

Use /usr/bin/python3 on rhelish 9+

The /usr/libexec/platform-python symbolic link is just a backwards compatibility shim there.

See https://gitlab.com/redhat/centos-stream/rpms/python3.9/-/commit/ce226d00fa630afff06b0b6a7058d3038d9f7a7f

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

lib.ansible.config.base

##### ADDITIONAL INFORMATION

I've seen this message on an internal CI:

```
[DEPRECATION WARNING]: Distribution rhel 9.0 on host sut should use 
/usr/libexec/platform-python, but is using /usr/bin/python for backward 
compatibility with prior Ansible releases.
...
```

But `/usr/libexec/platform-python` should not be used on RHEL 9.
This is my attempt to fix this.

cc @torsava