### PR TITLE
callback_default test - Reduce sleep time to correct CI failures

### DIFF
--- a/test/integration/targets/callback_default/inventory
+++ b/test/integration/targets/callback_default/inventory
@@ -5,6 +5,6 @@ testhost ansible_connection=local ansible_python_interpreter="{{ ansible_playboo
 testhost5 ansible_host=169.254.199.200  # no connection is ever established with this host
 
 [nonlockstep]
-testhost10 i=0.5 ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"
+testhost10 i=0 ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"
 testhost11 i=3.0 ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"
 testhost12 i=12.0 ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
For unknown reasons, these tests started failing recently because the results from testhost11 are being returned before testhost10, but only when coverage is enabled and only when run in Azure pipelines. I am unable to reproduce this locally, even when putting the machine running the test under extreme load.

Setting the initial host sleep time to 0 fixes this failure.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/callback_default`