### PR TITLE
[cli] remove superfluous trailing space from help

### DIFF
--- a/changelogs/fragments/cli-space-after-help-text.yml
+++ b/changelogs/fragments/cli-space-after-help-text.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cli scripts - remove trailing blank space in help after newline when outputting.

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -375,7 +375,7 @@ class CLI(with_metaclass(ABCMeta, object)):
             options = self.parser.parse_args(self.args[1:])
         except SystemExit as e:
             if(e.code != 0):
-                self.parser.exit(status=2, message=" \n%s " % self.parser.format_help())
+                self.parser.exit(status=2, message=" \n%s" % self.parser.format_help())
             raise
         options = self.post_process_args(options)
         context._init_global_context(options)


### PR DESCRIPTION
##### SUMMARY

Change:
- After we output the newline in help text, we also added a space. This
  caused either a space to show up before the shell prompt (in shells
  like bash), or " %" and a newline before the next prompt on shells
  like zsh that automatically force commands to end with a newline.
- This change removes the extra space, so that peace can be restored in
  the minds of many.
- This only showed up when running commands with no arguments or invalid
  arguments.

Test Plan:
- Ran `ansible`, `ansible -h`, `ansible-playbook`, `ansible-galaxy`, and
  `ansible-galaxy -h`.

Tickets:
- Introduced in #69458

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

cli