### PR TITLE
Update cli_parsing.rst

### DIFF
--- a/docs/docsite/rst/network/user_guide/cli_parsing.rst
+++ b/docs/docsite/rst/network/user_guide/cli_parsing.rst
@@ -145,8 +145,8 @@ The following example task uses ``cli_parse`` with the native parser and the exa
    - name: "Run command and parse with native"
      ansible.netcommon.cli_parse:
        command: show interface
-         parser:
-           name: ansible.netcommon.native
+       parser:
+         name: ansible.netcommon.native
        set_fact: interfaces
 
 Taking a deeper dive into this task:


### PR DESCRIPTION
##### SUMMARY
Bad indent in an example


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Documentation code example has an extra set of indentations that makes the example wrong.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
parser documentation example code fix

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
BEFORE----
ERROR! We were unable to read either as JSON nor YAML, these are the errors we got from each:
JSON: Expecting value: line 1 column 1 (char 0)

Syntax Error while loading YAML.
  mapping values are not allowed in this context

The error appears to be in '/home/ignw/netops/test_parser.yml': line 9, column 17, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

        command: show interface
          parser:
                ^ here

--- AFTER
no errors, it runs

```
