### PR TITLE
basic: Skip over module parameters similar to journal.send arguments

### DIFF
--- a/changelogs/fragments/71343_yum_repository.yml
+++ b/changelogs/fragments/71343_yum_repository.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- basic - skip over module parameters which are used in ``journal.send`` API call (https://github.com/ansible/ansible/issues/71343).

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1338,7 +1338,16 @@ class AnsibleModule(object):
             if has_journal:
                 journal_args = [("MODULE", os.path.basename(__file__))]
                 for arg in log_args:
-                    journal_args.append((arg.upper(), str(log_args[arg])))
+                    name, value = (arg.upper(), str(log_args[arg]))
+                    if name in (
+                        'PRIORITY', 'MESSAGE', 'MESSAGE_ID',
+                        'CODE_FILE', 'CODE_LINE', 'CODE_FUNC',
+                        'SYSLOG_FACILITY', 'SYSLOG_IDENTIFIER',
+                        'SYSLOG_PID',
+                    ):
+                        name = "_%s" % name
+                    journal_args.append((name, value))
+
                 try:
                     if HAS_SYSLOG:
                         # If syslog_facility specified, it needs to convert


### PR DESCRIPTION
##### SUMMARY

While logging, journal.send accepts module parameters.
If module parameters similar to arguments in journal.send,
rename the parameter names before sending to journal.send

Fixes: #71343

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/71343_yum_repository.yml
lib/ansible/module_utils/basic.py
