### PR TITLE
Add JC filter plugin example

### DIFF
--- a/docs/docsite/rst/network/user_guide/cli_parsing.rst
+++ b/docs/docsite/rst/network/user_guide/cli_parsing.rst
@@ -593,6 +593,7 @@ JC is a Python library that converts the output of dozens of common linux/unix/m
 The following is an example using JC to parse the output of the ``dig`` command:
 
 .. code-block:: yaml
+
    - name: "Run dig command and parse with jc"
      hosts: ubuntu
      tasks:

--- a/docs/docsite/rst/network/user_guide/cli_parsing.rst
+++ b/docs/docsite/rst/network/user_guide/cli_parsing.rst
@@ -583,6 +583,28 @@ The task sets the follow fact as the ``interfaces`` fact for the host:
      state: up
 
 
+Parsing with JC
+-----------------
+
+JC is a Python library that converts the output of dozens of common linux/unix/macOS/Windows command-line tools and file-types to python dictionaries or lists of dictionaries for easier parsing. JC is available as a filter plugin in the ``community.general`` collection.
+
+The following is an example using JC to parse the output of the ``dig`` command:
+
+.. code-block:: yaml
+   - name: "Run dig command and parse with jc"
+     hosts: ubuntu
+     tasks:
+     - shell: dig example.com
+       register: result
+     - set_fact:
+       myvar: "{{ result.stdout | community.general.jc('dig') }}"
+     - debug:
+       msg: "The IP is: {{ myvar[0].answer[0].data }}"
+- The JC project and documentation can be found `here <https://github.com/kellyjonbrazil/jc/>`.
+
+- See this `blog entry <https://blog.kellybrazil.com/2020/08/30/parsing-command-output-in-ansible-with-jc/>` for more information.
+
+
 Converting XML
 -----------------
 

--- a/docs/docsite/rst/network/user_guide/cli_parsing.rst
+++ b/docs/docsite/rst/network/user_guide/cli_parsing.rst
@@ -588,7 +588,7 @@ The task sets the follow fact as the ``interfaces`` fact for the host:
 Parsing with JC
 -----------------
 
-JC is a Python library that converts the output of dozens of common linux/unix/macOS/Windows command-line tools and file-types to python dictionaries or lists of dictionaries for easier parsing. JC is available as a filter plugin in the ``community.general`` collection.
+JC is a Python library that converts the output of dozens of common Linux/UNIX/macOS/Windows command-line tools and file-types to python dictionaries or lists of dictionaries for easier parsing. JC is available as a filter plugin in the ``community.general`` collection.
 
 The following is an example using JC to parse the output of the ``dig`` command:
 

--- a/docs/docsite/rst/network/user_guide/cli_parsing.rst
+++ b/docs/docsite/rst/network/user_guide/cli_parsing.rst
@@ -56,6 +56,8 @@ The ``cli_parse`` module includes the following cli_parsing plugins:
   A library for semi-structured text parsing using templates, with added capabilities to simplify the process
 ``pyats``
   Uses the parsers included with the Cisco Test Automation & Validation Solution
+``jc``
+  A python module which converts the output of dozens of popular linux/unix/macOS/Windows commands and file-types to python dictionaries or lists of dictionaries. Note: this filter plugin can be found in the ``community.general`` collection.
 ``json``
   Converts JSON output at the CLI to an Ansible native data structure
 
@@ -600,6 +602,7 @@ The following is an example using JC to parse the output of the ``dig`` command:
        myvar: "{{ result.stdout | community.general.jc('dig') }}"
      - debug:
        msg: "The IP is: {{ myvar[0].answer[0].data }}"
+
 - The JC project and documentation can be found `here <https://github.com/kellyjonbrazil/jc/>`.
 
 - See this `blog entry <https://blog.kellybrazil.com/2020/08/30/parsing-command-output-in-ansible-with-jc/>` for more information.

--- a/docs/docsite/rst/network/user_guide/cli_parsing.rst
+++ b/docs/docsite/rst/network/user_guide/cli_parsing.rst
@@ -588,7 +588,7 @@ The task sets the follow fact as the ``interfaces`` fact for the host:
 Parsing with JC
 -----------------
 
-JC is a Python library that converts the output of dozens of common Linux/UNIX/macOS/Windows command-line tools and file-types to python dictionaries or lists of dictionaries for easier parsing. JC is available as a filter plugin in the ``community.general`` collection.
+JC is a python library that converts the output of dozens of common Linux/UNIX/macOS/Windows command-line tools and file types to python dictionaries or lists of dictionaries for easier parsing. JC is available as a filter plugin in the ``community.general`` collection.
 
 The following is an example using JC to parse the output of the ``dig`` command:
 

--- a/docs/docsite/rst/network/user_guide/cli_parsing.rst
+++ b/docs/docsite/rst/network/user_guide/cli_parsing.rst
@@ -599,13 +599,12 @@ The following is an example using JC to parse the output of the ``dig`` command:
      - shell: dig example.com
        register: result
      - set_fact:
-       myvar: "{{ result.stdout | community.general.jc('dig') }}"
+         myvar: "{{ result.stdout | community.general.jc('dig') }}"
      - debug:
-       msg: "The IP is: {{ myvar[0].answer[0].data }}"
+         msg: "The IP is: {{ myvar[0].answer[0].data }}"
 
-- The JC project and documentation can be found `here <https://github.com/kellyjonbrazil/jc/>`.
-
-- See this `blog entry <https://blog.kellybrazil.com/2020/08/30/parsing-command-output-in-ansible-with-jc/>` for more information.
+- The JC project and documentation can be found `here <https://github.com/kellyjonbrazil/jc/>`_.
+- See this `blog entry <https://blog.kellybrazil.com/2020/08/30/parsing-command-output-in-ansible-with-jc/>`_ for more information.
 
 
 Converting XML

--- a/docs/docsite/rst/network/user_guide/cli_parsing.rst
+++ b/docs/docsite/rst/network/user_guide/cli_parsing.rst
@@ -57,7 +57,7 @@ The ``cli_parse`` module includes the following cli_parsing plugins:
 ``pyats``
   Uses the parsers included with the Cisco Test Automation & Validation Solution
 ``jc``
-  A python module which converts the output of dozens of popular linux/unix/macOS/Windows commands and file-types to python dictionaries or lists of dictionaries. Note: this filter plugin can be found in the ``community.general`` collection.
+  A python module that converts the output of dozens of popular Linux/UNIX/macOS/Windows commands and file types to python dictionaries or lists of dictionaries. Note: this filter plugin can be found in the ``community.general`` collection.
 ``json``
   Converts JSON output at the CLI to an Ansible native data structure
 


### PR DESCRIPTION
##### SUMMARY
Added an example using the JC filter plugin.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
The JC filter plugin has been available in the community.general collection for some time now, so I thought it would be good to add an example to the existing documentation site.

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
community.general.jc

##### ADDITIONAL INFORMATION
This is a documentation addition. Let me know if there is a better place for this example. Thanks!
