### PR TITLE
functional backport of 74448

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -278,7 +278,7 @@
 # choice but to create world readable temporary files to execute a module on
 # the remote machine. This option is False by default for security. Users may
 # turn this on to have behaviour more like Ansible prior to 2.1.x. See
-# https://docs.ansible.com/ansible/latest/user_guide/become.html#becoming-an-unprivileged-user
+# https://docs.ansible.com/ansible/latest/user_guide/become.html#risks-of-becoming-an-unprivileged-user
 # for more secure ways to fix this than enabling this option.
 #
 #allow_world_readable_tmpfiles = False

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -660,7 +660,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                         'allow_world_readable_tmpfiles is a no-op. See this '
                         'URL for more details: '
                         'https://docs.ansible.com/ansible/become.html'
-                        '#becoming-an-unprivileged-user')
+                        '#risks-of-becoming-an-unprivileged-user')
                 if execute:
                     group_mode = 'g+rwx'
                 else:
@@ -695,7 +695,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             'to create when becoming an unprivileged user '
             '(rc: %s, err: %s}). For information on working around this, see '
             'https://docs.ansible.com/ansible/become.html'
-            '#becoming-an-unprivileged-user' % (
+            '#risks-of-becoming-an-unprivileged-user' % (
                 res['rc'],
                 to_native(res['stderr'])))
 


### PR DESCRIPTION
##### SUMMARY
#74448 won't backport cleanly because we are not backporting #74324.

Instead of wrestling with the merge conflict and trying to get this into a Docs Backportapalooza, we opened this PR as a functional backport of commit c63b867836fb84c32f81258d716779b0e3787776.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
