### PR TITLE
pause - ensure control characters are always set appropriately

### DIFF
--- a/changelogs/fragments/73264-pause-emacs.yml
+++ b/changelogs/fragments/73264-pause-emacs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pause - ensure control characters are always set to an appropriate value (https://github.com/ansible/ansible/issues/73264)

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -51,12 +51,12 @@ try:
 except ImportError:
     HAS_CURSES = False
 
+MOVE_TO_BOL = b'\r'
+CLEAR_TO_EOL = b'\x1b[K'
 if HAS_CURSES:
-    MOVE_TO_BOL = curses.tigetstr('cr')
-    CLEAR_TO_EOL = curses.tigetstr('el')
-else:
-    MOVE_TO_BOL = b'\r'
-    CLEAR_TO_EOL = b'\x1b[K'
+    # curses.tigetstr() returns None in some circumstances
+    MOVE_TO_BOL = curses.tigetstr('cr') or MOVE_TO_BOL
+    CLEAR_TO_EOL = curses.tigetstr('el') or CLEAR_TO_EOL
 
 
 class AnsibleTimeoutExceeded(Exception):

--- a/test/units/plugins/action/test_pause.py
+++ b/test/units/plugins/action/test_pause.py
@@ -6,8 +6,8 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import curses
-import io
 import importlib
+import io
 import pytest
 import sys
 

--- a/test/units/plugins/action/test_pause.py
+++ b/test/units/plugins/action/test_pause.py
@@ -11,10 +11,14 @@ import io
 import pytest
 import sys
 
-controller_minversion = pytest.mark.skipif(sys.version_info < (3, 8), reason="Requires Python 3.8 or later")
+from ansible.plugins.action import pause  # noqa: F401
+from ansible.module_utils.six import PY2
+
+builtin_import = 'builtins.__import__'
+if PY2:
+    builtin_import = '__builtin__.__import__'
 
 
-@controller_minversion
 def test_pause_curses_tigetstr_none(mocker, monkeypatch):
     monkeypatch.delitem(sys.modules, 'ansible.plugins.action.pause')
 
@@ -29,7 +33,7 @@ def test_pause_curses_tigetstr_none(mocker, monkeypatch):
         else:
             return dunder_import(*args, **kwargs)
 
-    mocker.patch('builtins.__import__', _import)
+    mocker.patch(builtin_import, _import)
 
     mod = importlib.import_module('ansible.plugins.action.pause')
 
@@ -38,7 +42,6 @@ def test_pause_curses_tigetstr_none(mocker, monkeypatch):
     assert mod.CLEAR_TO_EOL == b'\x1b[K'
 
 
-@controller_minversion
 def test_pause_missing_curses(mocker, monkeypatch):
     monkeypatch.delitem(sys.modules, 'ansible.plugins.action.pause')
 
@@ -50,7 +53,7 @@ def test_pause_missing_curses(mocker, monkeypatch):
         else:
             return dunder_import(*args, **kwargs)
 
-    mocker.patch('builtins.__import__', _import)
+    mocker.patch(builtin_import, _import)
 
     mod = importlib.import_module('ansible.plugins.action.pause')
 
@@ -62,7 +65,6 @@ def test_pause_missing_curses(mocker, monkeypatch):
     assert mod.CLEAR_TO_EOL == b'\x1b[K'
 
 
-@controller_minversion
 @pytest.mark.parametrize('exc', (curses.error, TypeError, io.UnsupportedOperation))
 def test_pause_curses_setupterm_error(mocker, monkeypatch, exc):
     monkeypatch.delitem(sys.modules, 'ansible.plugins.action.pause')
@@ -78,7 +80,7 @@ def test_pause_curses_setupterm_error(mocker, monkeypatch, exc):
         else:
             return dunder_import(*args, **kwargs)
 
-    mocker.patch('builtins.__import__', _import)
+    mocker.patch(builtin_import, _import)
 
     mod = importlib.import_module('ansible.plugins.action.pause')
 

--- a/test/units/plugins/action/test_pause.py
+++ b/test/units/plugins/action/test_pause.py
@@ -11,9 +11,10 @@ import io
 import pytest
 import sys
 
-from ansible.plugins.action import pause  # noqa: F401
+controller_minversion = pytest.mark.skipif(sys.version_info < (3, 8), reason="Requires Python 3.8 or later")
 
 
+@controller_minversion
 def test_pause_curses_tigetstr_none(mocker, monkeypatch):
     monkeypatch.delitem(sys.modules, 'ansible.plugins.action.pause')
 
@@ -25,8 +26,8 @@ def test_pause_curses_tigetstr_none(mocker, monkeypatch):
             mock_curses.setupterm = mocker.Mock(return_value=True)
             mock_curses.tigetstr = mocker.Mock(return_value=None)
             return mock_curses
-
-        return dunder_import(*args, **kwargs)
+        else:
+            return dunder_import(*args, **kwargs)
 
     mocker.patch('builtins.__import__', _import)
 
@@ -37,6 +38,7 @@ def test_pause_curses_tigetstr_none(mocker, monkeypatch):
     assert mod.CLEAR_TO_EOL == b'\x1b[K'
 
 
+@controller_minversion
 def test_pause_missing_curses(mocker, monkeypatch):
     monkeypatch.delitem(sys.modules, 'ansible.plugins.action.pause')
 
@@ -60,6 +62,7 @@ def test_pause_missing_curses(mocker, monkeypatch):
     assert mod.CLEAR_TO_EOL == b'\x1b[K'
 
 
+@controller_minversion
 @pytest.mark.parametrize('exc', (curses.error, TypeError, io.UnsupportedOperation))
 def test_pause_curses_setupterm_error(mocker, monkeypatch, exc):
     monkeypatch.delitem(sys.modules, 'ansible.plugins.action.pause')
@@ -72,8 +75,8 @@ def test_pause_curses_setupterm_error(mocker, monkeypatch, exc):
             mock_curses.setupterm = mocker.Mock(side_effect=exc)
             mock_curses.error = curses.error
             return mock_curses
-
-        return dunder_import(*args, **kwargs)
+        else:
+            return dunder_import(*args, **kwargs)
 
     mocker.patch('builtins.__import__', _import)
 

--- a/test/units/plugins/action/test_pause.py
+++ b/test/units/plugins/action/test_pause.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import curses
+import io
+import importlib
+import pytest
+import sys
+
+from ansible.plugins.action import pause  # noqa: F401
+
+
+def test_pause_curses_tigetstr_none(mocker, monkeypatch):
+    monkeypatch.delitem(sys.modules, 'ansible.plugins.action.pause')
+
+    dunder_import = __import__
+
+    def _import(*args, **kwargs):
+        if args[0] == 'curses':
+            mock_curses = mocker.Mock()
+            mock_curses.setupterm = mocker.Mock(return_value=True)
+            mock_curses.tigetstr = mocker.Mock(return_value=None)
+            return mock_curses
+
+        return dunder_import(*args, **kwargs)
+
+    mocker.patch('builtins.__import__', _import)
+
+    mod = importlib.import_module('ansible.plugins.action.pause')
+
+    assert mod.HAS_CURSES is True
+    assert mod.MOVE_TO_BOL == b'\r'
+    assert mod.CLEAR_TO_EOL == b'\x1b[K'
+
+
+def test_pause_missing_curses(mocker, monkeypatch):
+    monkeypatch.delitem(sys.modules, 'ansible.plugins.action.pause')
+
+    dunder_import = __import__
+
+    def _import(*args, **kwargs):
+        if args[0] == 'curses':
+            raise ImportError
+        else:
+            return dunder_import(*args, **kwargs)
+
+    mocker.patch('builtins.__import__', _import)
+
+    mod = importlib.import_module('ansible.plugins.action.pause')
+
+    with pytest.raises(AttributeError):
+        mod.curses
+
+    assert mod.HAS_CURSES is False
+    assert mod.MOVE_TO_BOL == b'\r'
+    assert mod.CLEAR_TO_EOL == b'\x1b[K'
+
+
+@pytest.mark.parametrize('exc', (curses.error, TypeError, io.UnsupportedOperation))
+def test_pause_curses_setupterm_error(mocker, monkeypatch, exc):
+    monkeypatch.delitem(sys.modules, 'ansible.plugins.action.pause')
+
+    dunder_import = __import__
+
+    def _import(*args, **kwargs):
+        if args[0] == 'curses':
+            mock_curses = mocker.Mock()
+            mock_curses.setupterm = mocker.Mock(side_effect=exc)
+            mock_curses.error = curses.error
+            return mock_curses
+
+        return dunder_import(*args, **kwargs)
+
+    mocker.patch('builtins.__import__', _import)
+
+    mod = importlib.import_module('ansible.plugins.action.pause')
+
+    assert mod.HAS_CURSES is False
+    assert mod.MOVE_TO_BOL == b'\r'
+    assert mod.CLEAR_TO_EOL == b'\x1b[K'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
On some systems, `curses.tigetstr()` returns `None`, which does not work as a control character.
Fixes #73264.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/action/pause.py`