### PR TITLE
Docs: communication.rst - add ansible-community to the IRC channel list

### DIFF
--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -48,6 +48,7 @@ General channels
 
 - ``#ansible`` - For general use questions and support.
 - ``#ansible-devel`` - For discussions on developer topics and code related to features or bugs.
+- ``#ansible-community`` - For discussions on community and collections related topics. 
 - ``#ansible-meeting`` - For public community meetings. We will generally announce these on one or more of the above mailing lists. See the `meeting schedule and agenda page <https://github.com/ansible/community/blob/master/meetings/README.md>`_
 
 .. _working_group_list:


### PR DESCRIPTION
##### SUMMARY
Docs: communication.rst - add ansible-community to the IRC channel list

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`docs/docsite/rst/community/communication.rst`