### PR TITLE
Fix mistaken detection of atomic_container when rpm-ostree is present (fixes #74578)

### DIFF
--- a/changelogs/fragments/74578-fix-ostree-detection.yml
+++ b/changelogs/fragments/74578-fix-ostree-detection.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pkg_mgr.py - Lower the priority of rpm-ostree detection to avoid false positives on systems not using it as the main package manager (https://github.com/ansible/ansible/issues/74578)

--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -13,7 +13,8 @@ from ansible.module_utils.facts.collector import BaseFactCollector
 # A list of dicts.  If there is a platform with more than one
 # package manager, put the preferred one last.  If there is an
 # ansible module, use that as the value for the 'name' key.
-PKG_MGRS = [{'path': '/usr/bin/yum', 'name': 'yum'},
+PKG_MGRS = [{'path': '/usr/bin/rpm-ostree', 'name': 'atomic_container'},
+            {'path': '/usr/bin/yum', 'name': 'yum'},
             {'path': '/usr/bin/dnf', 'name': 'dnf'},
             {'path': '/usr/bin/apt-get', 'name': 'apt'},
             {'path': '/usr/bin/zypper', 'name': 'zypper'},
@@ -36,7 +37,6 @@ PKG_MGRS = [{'path': '/usr/bin/yum', 'name': 'yum'},
             {'path': '/usr/local/sbin/pkg', 'name': 'pkgng'},
             {'path': '/usr/bin/swupd', 'name': 'swupd'},
             {'path': '/usr/sbin/sorcery', 'name': 'sorcery'},
-            {'path': '/usr/bin/rpm-ostree', 'name': 'atomic_container'},
             {'path': '/usr/bin/installp', 'name': 'installp'},
             {'path': '/QOpenSys/pkgs/bin/yum', 'name': 'yum'},
             ]


### PR DESCRIPTION
##### SUMMARY
Fixes #74578

For some modules, notably the package module, Ansible relies on the `ansible_pkg_mgr" fact to decide which package manager it should be using.

On systems where rpm-ostree is present at /usr/bin/rpm-ostree, Ansible makes the assumption that the system's dominant package manager is rpm-ostree and returns atomic_container as the entry for the ansible_pkg_mgr fact.

This isn't always a safe assumption to make, however. On systems with OSBuild installed, particularly OSBuild Composer, there's a dependency tree that leads to rpm-ostree being pulled in. There are probably other reasons to have it installed that don't involve it being the system's actual package manager.

This PR addresses the problem by moving `atomic_container` to the lowest priority in the list of dicts that `pkg_mgr.py` uses to evaluate the system's dominant package manager. I have moved it to the lowest priority, below `yum` and `dnf` because this is a problem that is primarily going to affect `rpm` based distributions (since it involves `rpm-ostree` being wrongly detected).

It's fairly safe to move this to the lowest point on the list because we now have #73445 merged, which becomes the first check that runs inside `class PkgMgrFactCollector(BaseFactCollector)`.

See below for the current code in `devel`:
```py
    def _check_rh_versions(self, pkg_mgr_name, collected_facts):
        if os.path.exists('/run/ostree-booted'):
            return "atomic_container"
```

With the above in mind, we already have a much more reliable method of determining whether a system is _actually_ using rpm-ostree as its dominant package manager running as the first step in the pkg_mgr detection process. For this reason, I don't think we risk breaking anything by moving atomic_container down to the bottom of the priority list.

Either way, it has to be lower priority than `yum` or `dnf` to properly resolve #74578, so we either need to de-prioritise `rpm-ostree` or bump up the priority of `yum` and `dnf`. I think this is the preferred approach.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible_pkg_mgr fact (via pkg_mgr.py)

##### ADDITIONAL INFORMATION
Please see the bug description in #74578 
