### PR TITLE
plugin attributes: make validate-modules strict again, improve version_added support

### DIFF
--- a/changelogs/fragments/plugin_attributes-extension.yml
+++ b/changelogs/fragments/plugin_attributes-extension.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- "ansible-test - validate-modules now properly checks ``attributes`` for plugins (https://github.com/ansible/ansible/pull/74602)."
+- "ansible-doc - ``version_added`` in ``attributes`` now comes with ``version_added_collection`` (https://github.com/ansible/ansible/pull/74602)."

--- a/lib/ansible/utils/plugin_docs.py
+++ b/lib/ansible/utils/plugin_docs.py
@@ -89,6 +89,13 @@ def _process_versions_and_dates(fragment, is_module, return_docs, callback):
             if isinstance(return_value.get('contains'), MutableMapping):
                 process_return_values(return_value['contains'])
 
+    def process_attributes(attributes):
+        for attribute in attributes.values():
+            if not isinstance(attribute, MutableMapping):
+                continue
+            if 'version_added' in attribute:
+                callback(attribute, 'version_added', 'version_added_collection')
+
     if not fragment:
         return
 
@@ -102,6 +109,8 @@ def _process_versions_and_dates(fragment, is_module, return_docs, callback):
         process_deprecation(fragment['deprecated'], top_level=True)
     if isinstance(fragment.get('options'), MutableMapping):
         process_options(fragment['options'])
+    if isinstance(fragment.get('attributes'), MutableMapping):
+        process_attributes(fragment['attributes'])
 
 
 def add_collection_to_versions_and_dates(fragment, collection_name, is_module, return_docs=False):

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -550,13 +550,13 @@ def doc_schema(module_name, for_collection=False, deprecated_module=False):
             Schema({
                 any_string_types: add_default_attributes(),
                 'action_group': add_default_attributes({
-                    'membership': list_string_types,
+                    Required('membership'): list_string_types,
                 }),
                 'forced_action_plugin': add_default_attributes({
-                    'action_plugin': any_string_types,
+                    Required('action_plugin'): any_string_types,
                 }),
                 'proprietary': add_default_attributes({
-                    'platforms': list_string_types,
+                    Required('platforms'): list_string_types,
                 }),
             }, extra=PREVENT_EXTRA),
         )

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -524,6 +524,18 @@ def doc_schema(module_name, for_collection=False, deprecated_module=False):
         }
 
         doc_schema_dict.update(deprecation_required_scheme)
+
+    def add_default_attributes(more=None):
+        schema = {
+            'description': any_string_types,
+            'support': any_string_types,
+            'version_added_collection': any_string_types,
+            'version_added': any_string_types,
+        }
+        if more:
+            schema.update(more)
+        return schema
+
     doc_schema_dict['attributes'] = Schema(
         All(
             Schema({
@@ -532,9 +544,21 @@ def doc_schema(module_name, for_collection=False, deprecated_module=False):
                     Required('support'): Any('full', 'partial', 'none'),
                     'version_added_collection': collection_name,
                     'version_added': version(for_collection=for_collection),
-                }
-            }, extra=PREVENT_EXTRA),
+                },
+            }, extra=ALLOW_EXTRA),
             partial(version_added, error_code='attribute-invalid-version-added', accept_historical=False),
+            Schema({
+                any_string_types: add_default_attributes(),
+                'action_group': add_default_attributes({
+                    'membership': list_string_types,
+                }),
+                'forced_action_plugin': add_default_attributes({
+                    'action_plugin': any_string_types,
+                }),
+                'proprietary': add_default_attributes({
+                    'platforms': list_string_types,
+                }),
+            }, extra=PREVENT_EXTRA),
         )
     )
     return Schema(

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -524,11 +524,24 @@ def doc_schema(module_name, for_collection=False, deprecated_module=False):
         }
 
         doc_schema_dict.update(deprecation_required_scheme)
+    doc_schema_dict['attributes'] = Schema(
+        All(
+            Schema({
+                any_string_types: {
+                    Required('description'): any_string_types,
+                    Required('support'): Any('full', 'partial', 'none'),
+                    'version_added_collection': collection_name,
+                    'version_added': version(for_collection=for_collection),
+                }
+            }, extra=PREVENT_EXTRA),
+            partial(version_added, error_code='attribute-invalid-version-added', accept_historical=False),
+        )
+    )
     return Schema(
         All(
             Schema(
                 doc_schema_dict,
-                extra=ALLOW_EXTRA
+                extra=PREVENT_EXTRA
             ),
             partial(version_added, error_code='module-invalid-version-added', accept_historical=not for_collection),
         )


### PR DESCRIPTION
##### SUMMARY
This extends #73707:
1. #73707 allowed extra keys the `DOCUMENTATION` schema for plugins to avoid specifying a schema for `attributes`; this PR adds a schema and makes schema validation for `DOCUMENTATION` strict again.
2. Since `attributes` can have `version_added`, `version_added_collection` should be added as well (same as for all other `version_added`s).
3. The strict sanity test already found one error: in `copy`, the `diff` attribute was misspelled (`diff_mode`) :)

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
validate-modules
ansible-doc
copy
