### PR TITLE
Update pylint sanity test to work on Python 3.10.

### DIFF
--- a/changelogs/fragments/ansible-test-pylint-typed-ast.yml
+++ b/changelogs/fragments/ansible-test-pylint-typed-ast.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Update ``typed-ast`` constraint to version 1.4.3 for compatibility with Python 3.10.

--- a/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
@@ -8,5 +8,5 @@ lazy-object-proxy == 1.4.3
 mccabe == 0.6.1
 six  # not frozen due to usage outside sanity tests
 toml == 0.10.2
-typed-ast == 1.4.2
+typed-ast == 1.4.3
 wrapt == 1.12.1


### PR DESCRIPTION
##### SUMMARY

Update pylint sanity test to work on Python 3.10.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
