### PR TITLE
Add python 3.10 constraint for pyspnego

### DIFF
--- a/changelogs/fragments/pyspnego-py310.yaml
+++ b/changelogs/fragments/pyspnego-py310.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-test - Add constraint for ``pyspnego>=0.1.6`` for Python 3.10 - https://github.com/ansible/ansible/pull/74612

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -46,3 +46,4 @@ botocore >= 1.10.0 ; python_version >= '2.7' # adds support for the following AW
 setuptools < 37 ; python_version == '2.6' # setuptools 37 and later require python 2.7 or later
 setuptools < 45 ; python_version == '2.7' # setuptools 45 and later require python 3.5 or later
 gssapi < 1.6.0 ; python_version <= '2.7' # gssapi 1.6.0 and later require python 3 or later
+pyspnego >= 0.1.6 ; python_version >= '3.10' # bug in older releases breaks on Python 3.10


### PR DESCRIPTION
##### SUMMARY
A bug in pyspnego caused a failure when trying to import it on Python 3.10. The fix was https://github.com/jborean93/pyspnego/pull/11 and has been included in the `0.1.6` release. This adds a constraint to ensure Python 3.10 uses this version or newer.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test