### PR TITLE
fix: action _fixup_perms2 macos +a remote_paths in list() as it can be a tuple

### DIFF
--- a/changelogs/fragments/74613-actionfixup_perms2_macos_remote_paths_ensure_list.yml
+++ b/changelogs/fragments/74613-actionfixup_perms2_macos_remote_paths_ensure_list.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "In lib/ansible/plugin/action/__init__.py's _fixup_perms2, wrap ``remote_paths`` in ``list()`` before appending it to another list as it can be a list or tuple (https://github.com/ansible/ansible/pull/74613)."

--- a/changelogs/fragments/74613-actionfixup_perms2_macos_remote_paths_ensure_list.yml
+++ b/changelogs/fragments/74613-actionfixup_perms2_macos_remote_paths_ensure_list.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "In lib/ansible/plugin/action/__init__.py's _fixup_perms2, wrap ``remote_paths`` in ``list()`` before appending it to another list as it can be a list or tuple (https://github.com/ansible/ansible/pull/74613)."
+  - "remote tmpdir permissions - fix type error in macOS chmod ACL fallback (https://github.com/ansible/ansible/pull/74613)."

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -630,7 +630,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         # pass that argument as the first element of remote_paths. So we end
         # up running `chmod +a [that argument] [file 1] [file 2] ...`
         try:
-            res = self._remote_chmod([chmod_acl_mode] + remote_paths, '+a')
+            res = self._remote_chmod([chmod_acl_mode] + list(remote_paths), '+a')
         except AnsibleAuthenticationFailure as e:
             # Solaris-based chmod will return 5 when it sees an invalid mode,
             # and +a is invalid there. Because it returns 5, which is the same


### PR DESCRIPTION

##### SUMMARY
in `lib/ansible/plugin/action/__init__.py`'s `_fixup_perms2`, `remote_paths` can be a list or tuple. however, the macos specific attempt to use chmod +a attempts to concatenate `remote_paths` with a list, which will fail if it is a tuple. wrapping `remote_paths` in `list()` fixes this error.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action

##### ADDITIONAL INFORMATION
Traceback before fix:

```
The full traceback is:
Traceback (most recent call last):
  File "/home/user/miniconda3/envs/ansible-keryx-2-11/lib/python3.8/site-packages/ansible/executor/task_executor.py", line 159, in run
    res = self._execute()
  File "/home/user/miniconda3/envs/ansible-keryx-2-11/lib/python3.8/site-packages/ansible/executor/task_executor.py", line 583, in _execute
    result = self._handler.run(task_vars=variables)
  File "/home/user/miniconda3/envs/ansible-keryx-2-11/lib/python3.8/site-packages/ansible/plugins/action/template.py", line 186, in run
    result.update(copy_action.run(task_vars=task_vars))
  File "/home/user/miniconda3/envs/ansible-keryx-2-11/lib/python3.8/site-packages/ansible/plugins/action/copy.py", line 519, in run
    module_return = self._copy_file(source_full, source_rel, content, content_tempfile, dest, task_vars, follow)
  File "/home/user/miniconda3/envs/ansible-keryx-2-11/lib/python3.8/site-packages/ansible/plugins/action/copy.py", line 316, in _copy_file
    self._fixup_perms2((self._connection._shell.tmpdir, remote_path))
  File "/home/user/miniconda3/envs/ansible-keryx-2-11/lib/python3.8/site-packages/ansible/plugins/action/__init__.py", line 627, in _fixup_perms2
    res = self._remote_chmod([chmod_acl_mode] + remote_paths, '+a')
TypeError: can only concatenate list (not "tuple") to list

```