### PR TITLE
[bp-2.10] service - compare version without LooseVersion

### DIFF
--- a/changelogs/fragments/74488_solaris_looseversion.yml
+++ b/changelogs/fragments/74488_solaris_looseversion.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- service - compare version without LooseVersion API (https://github.com/ansible/ansible/issues/74488).

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -1356,8 +1356,8 @@ class SunOSService(Service):
         # Support for synchronous restart/refresh is only supported on
         # Oracle Solaris >= 11.2
         for line in open('/etc/release', 'r').readlines():
-            m = re.match(r'\s+Oracle Solaris (\d+\.\d+).*', line.rstrip())
-            if m and m.groups()[0] >= 11.2:
+            m = re.match(r'\s+Oracle Solaris (\d+)\.(\d+).*', line.rstrip())
+            if m and m.groups() >= ('11', '2'):
                 return True
 
     def get_service_status(self):


### PR DESCRIPTION
##### SUMMARY

The distutils module is not shipped with SUNWPython on Solaris.
It's in the SUNWPython-devel package. Do not use LooseVersion.

Fixes: #74488

(cherry picked from commit 4d7dc15d4e1e214e5091abc554eddb6974b72830)
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/74488_solaris_looseversion.yml
lib/ansible/modules/service.py
