### PR TITLE
Exclude unreachable hosts in ansible_play_batch between plays

### DIFF
--- a/changelogs/fragments/74625-fix-ansible_play_batch-between-plays.yml
+++ b/changelogs/fragments/74625-fix-ansible_play_batch-between-plays.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Save unreachable hosts between plays by marking them as failed for the PlayIterator (https://github.com/ansible/ansible/issues/66945).
+  - Save unreachable hosts between plays by adding them to the PlayIterator's _play._removed_hosts (https://github.com/ansible/ansible/issues/66945).

--- a/changelogs/fragments/74625-fix-ansible_play_batch-between-plays.yml
+++ b/changelogs/fragments/74625-fix-ansible_play_batch-between-plays.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Save unreachable hosts between plays by marking them as failed for the PlayIterator (https://github.com/ansible/ansible/issues/66945).

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -298,7 +298,7 @@ class TaskQueueManager:
         # any hosts as failed in the iterator here which may have been marked
         # as failed in previous runs. Then we clear the internal list of failed
         # hosts so we know what failed this round.
-        for host_name in self._failed_hosts.keys():
+        for host_name in list(self._failed_hosts) + list(self._unreachable_hosts):
             host = self._inventory.get_host(host_name)
             iterator.mark_host_failed(host)
 

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -298,9 +298,11 @@ class TaskQueueManager:
         # any hosts as failed in the iterator here which may have been marked
         # as failed in previous runs. Then we clear the internal list of failed
         # hosts so we know what failed this round.
-        for host_name in list(self._failed_hosts) + list(self._unreachable_hosts):
+        for host_name in self._failed_hosts.keys():
             host = self._inventory.get_host(host_name)
             iterator.mark_host_failed(host)
+        for host_name in self._unreachable_hosts.keys():
+            iterator._play._removed_hosts.append(host_name)
 
         self.clear_failed_hosts()
 

--- a/test/integration/targets/special_vars_hosts/aliases
+++ b/test/integration/targets/special_vars_hosts/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group5

--- a/test/integration/targets/special_vars_hosts/inventory
+++ b/test/integration/targets/special_vars_hosts/inventory
@@ -1,0 +1,3 @@
+successful ansible_connection=local ansible_host=127.0.0.1 ansible_python_interpreter="{{ ansible_playbook_python }}"
+failed ansible_connection=local ansible_host=127.0.0.1 ansible_python_interpreter="{{ ansible_playbook_python }}"
+unreachable ansible_connection=ssh ansible_host=127.0.0.1 ansible_port=1011  # IANA Reserved port

--- a/test/integration/targets/special_vars_hosts/playbook.yml
+++ b/test/integration/targets/special_vars_hosts/playbook.yml
@@ -1,0 +1,53 @@
+---
+- hosts: all
+  gather_facts: no
+  tasks:
+    - name: test magic vars for hosts without any failed/unreachable (no serial)
+      assert:
+        that:
+          - ansible_play_batch | length == 3
+          - ansible_play_hosts | length == 3
+          - ansible_play_hosts_all | length == 3
+      run_once: True
+
+    - ping:
+      failed_when: "inventory_hostname == 'failed'"
+
+    - meta: clear_host_errors
+
+- hosts: all
+  gather_facts: no
+  tasks:
+    - name: test host errors were cleared
+      assert:
+        that:
+          - ansible_play_batch | length == 3
+          - ansible_play_hosts | length == 3
+          - ansible_play_hosts_all | length == 3
+      run_once: True
+
+    - ping:
+      failed_when: "inventory_hostname == 'failed'"
+
+    - name: test magic vars exclude failed/unreachable hosts
+      assert:
+        that:
+          - ansible_play_batch | length == 1
+          - ansible_play_hosts | length == 1
+          - "ansible_play_batch == ['successful']"
+          - "ansible_play_hosts == ['successful']"
+          - ansible_play_hosts_all | length == 3
+      run_once: True
+
+- hosts: all
+  gather_facts: no
+  tasks:
+    - name: test failed/unreachable persists between plays
+      assert:
+        that:
+          - ansible_play_batch | length == 1
+          - ansible_play_hosts | length == 1
+          - "ansible_play_batch == ['successful']"
+          - "ansible_play_hosts == ['successful']"
+          - ansible_play_hosts_all | length == 3
+      run_once: True

--- a/test/integration/targets/special_vars_hosts/runme.sh
+++ b/test/integration/targets/special_vars_hosts/runme.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ansible-playbook -i ./inventory playbook.yml "$@" | tee out.txt
+grep 'unreachable=2' out.txt
+grep 'failed=2' out.txt


### PR DESCRIPTION
##### SUMMARY
Fixes #66945

Unreachable hosts are marked as failed by the PlayIterator, but the PlayIterator is reinstantiated for every Play. Failed hosts are carried over from the TaskQueueManager (which persists for the whole playbook) but unreachable hosts were not. This fixes that.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/task_queue_manager.py
