### PR TITLE
ini lookup - add case sensitive option

### DIFF
--- a/changelogs/fragments/74601-ini-lookup-add-case-sensitive.yml
+++ b/changelogs/fragments/74601-ini-lookup-add-case-sensitive.yml
@@ -1,0 +1,2 @@
+minor_changes:
+   - ini lookup - add case sensitive option (https://github.com/ansible/ansible/issues/74601)

--- a/lib/ansible/plugins/lookup/ini.py
+++ b/lib/ansible/plugins/lookup/ini.py
@@ -37,6 +37,12 @@ DOCUMENTATION = """
       default:
         description: Return value if the key is not in the ini file.
         default: ''
+      case_sensitive:
+        description:
+          Whether key names read from C(file) should be case sensitive. On Python 3,
+          this prevents duplicate key errors that are silently ignored in Python 2.
+        default: False
+        version_added: '2.12'
 """
 
 EXAMPLES = """
@@ -122,6 +128,8 @@ class LookupModule(LookupBase):
         paramvals = self.get_options()
 
         self.cp = configparser.ConfigParser()
+        if paramvals['case_sensitive']:
+            self.cp.optionxform = to_native
 
         ret = []
         for term in terms:

--- a/lib/ansible/plugins/lookup/ini.py
+++ b/lib/ansible/plugins/lookup/ini.py
@@ -39,8 +39,8 @@ DOCUMENTATION = """
         default: ''
       case_sensitive:
         description:
-          Whether key names read from C(file) should be case sensitive. On Python 3,
-          this prevents duplicate key errors that are silently ignored in Python 2.
+          Whether key names read from C(file) should be case sensitive. This prevents
+          duplicate key errors if keys only differ in case.
         default: False
         version_added: '2.12'
 """

--- a/test/integration/targets/lookup_ini/lookup_case_check.properties
+++ b/test/integration/targets/lookup_ini/lookup_case_check.properties
@@ -1,0 +1,2 @@
+name = captain
+NAME = fantastic

--- a/test/integration/targets/lookup_ini/runme.sh
+++ b/test/integration/targets/lookup_ini/runme.sh
@@ -4,3 +4,4 @@ set -eux
 
 ansible-playbook test_lookup_properties.yml -i inventory -v "$@"
 ansible-playbook test_errors.yml -i inventory -v "$@"
+ansible-playbook test_case_sensitive.yml -i inventory -v "$@"

--- a/test/integration/targets/lookup_ini/runme.sh
+++ b/test/integration/targets/lookup_ini/runme.sh
@@ -2,6 +2,4 @@
 
 set -eux
 
-ansible-playbook test_lookup_properties.yml -i inventory -v "$@"
-ansible-playbook test_errors.yml -i inventory -v "$@"
-ansible-playbook test_case_sensitive.yml -i inventory -v "$@"
+ansible-playbook test_ini.yml -i inventory -v "$@"

--- a/test/integration/targets/lookup_ini/test_case_sensitive.yml
+++ b/test/integration/targets/lookup_ini/test_case_sensitive.yml
@@ -1,0 +1,19 @@
+- name: Test case sensitive option
+  hosts: all
+
+  tasks:
+    - name: Lookup a file with keys that differ only in case with case sensitivity enabled
+      debug:
+        msg: "{{ lookup('ini', 'name', file='duplicate_case_check.ini', section='reggae', case_sensitive=True) }}"
+      register: duplicate_case_sensitive_name
+
+    - name: Lookup a file with keys that differ only in case with case sensitivity enabled
+      debug:
+        msg: "{{ lookup('ini', 'NAME', file='duplicate_case_check.ini', section='reggae', case_sensitive=True) }}"
+      register: duplicate_case_sensitive_NAME
+
+    - name: Ensure the correct case-sensitive values were retieved
+      assert:
+        that:
+          - duplicate_case_sensitive_name.msg == 'bob'
+          - duplicate_case_sensitive_NAME.msg == 'marley'

--- a/test/integration/targets/lookup_ini/test_case_sensitive.yml
+++ b/test/integration/targets/lookup_ini/test_case_sensitive.yml
@@ -12,8 +12,20 @@
         msg: "{{ lookup('ini', 'NAME', file='duplicate_case_check.ini', section='reggae', case_sensitive=True) }}"
       register: duplicate_case_sensitive_NAME
 
+    - name: Lookup a properties file with keys that differ only in case with case sensitivity enabled
+      debug:
+        msg: "{{ lookup('ini', 'name', file='lookup_case_check.properties', type='properties', case_sensitive=True) }}"
+      register: duplicate_case_sensitive_properties_name
+
+    - name: Lookup a properties file with keys that differ only in case with case sensitivity enabled
+      debug:
+        msg: "{{ lookup('ini', 'NAME', file='lookup_case_check.properties', type='properties', case_sensitive=True) }}"
+      register: duplicate_case_sensitive_properties_NAME
+
     - name: Ensure the correct case-sensitive values were retieved
       assert:
         that:
           - duplicate_case_sensitive_name.msg == 'bob'
           - duplicate_case_sensitive_NAME.msg == 'marley'
+          - duplicate_case_sensitive_properties_name.msg == 'captain'
+          - duplicate_case_sensitive_properties_NAME.msg == 'fantastic'

--- a/test/integration/targets/lookup_ini/test_errors.yml
+++ b/test/integration/targets/lookup_ini/test_errors.yml
@@ -7,17 +7,17 @@
       block:
         - name: Lookup a file with duplicate keys
           debug:
-            msg: "{{ lookup('ini', 'reggae', file='duplicate.ini', section='reggae') }}"
+            msg: "{{ lookup('ini', 'name', file='duplicate.ini', section='reggae') }}"
           ignore_errors: yes
           register: duplicate
 
         - name: Lookup a file with keys that differ only in case
           debug:
-            msg: "{{ lookup('ini', 'reggae', file='duplicate_case_check.ini', section='reggae') }}"
+            msg: "{{ lookup('ini', 'name', file='duplicate_case_check.ini', section='reggae') }}"
           ignore_errors: yes
           register: duplicate_case_sensitive
 
-        - name: Ensure duplicate key errers were handled properly
+        - name: Ensure duplicate key errors were handled properly
           assert:
             that:
               - duplicate is failed
@@ -27,7 +27,7 @@
 
     - name: Lookup a file with a missing section
       debug:
-        msg: "{{ lookup('ini', 'reggae', file='lookup.ini', section='missing') }}"
+        msg: "{{ lookup('ini', 'name', file='lookup.ini', section='missing') }}"
       ignore_errors: yes
       register: missing_section
 

--- a/test/integration/targets/lookup_ini/test_errors.yml
+++ b/test/integration/targets/lookup_ini/test_errors.yml
@@ -48,3 +48,15 @@
         that:
         - bad_mojo is failed
         - '"No key to lookup was provided as first term with in string inline option" in bad_mojo.msg'
+
+    - name: Test invalid option
+      debug:
+        msg: "{{ lookup('ini', 'invalid=option') }}"
+      ignore_errors: yes
+      register: invalid_option
+
+    - name: Ensure invalid option failed
+      assert:
+        that:
+          - invalid_option is failed
+          - "'is not a valid option' in invalid_option.msg"

--- a/test/integration/targets/lookup_ini/test_ini.yml
+++ b/test/integration/targets/lookup_ini/test_ini.yml
@@ -1,0 +1,3 @@
+- import_playbook: test_lookup_properties.yml
+- import_playbook: test_errors.yml
+- import_playbook: test_case_sensitive.yml


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
By setting `ConfigParser.optionxform` to `to_native`, all keys are passed through that function and case is preserved. The [default behavior](https://docs.python.org/3.9/library/configparser.html#configparser.ConfigParser.optionxform) returns a lower case version of the key name rather than preserving the case.

Fixes #74601.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
`lib/ansible/plugins/lookup/ini.py`
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION

Waiting on #74629 before adding tests to avoid merge conflicts and duplicating the test changes already done there.

On Python 2, duplicate key names are silently ignored. If two key names in a section differ only in case, in Python 2 the last one defined in the file would set the value for the key.
