### PR TITLE
docs: Add a note about ansible_date_time

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_vars_facts.rst
+++ b/docs/docsite/rst/user_guide/playbooks_vars_facts.rst
@@ -493,6 +493,8 @@ To reference the system hostname::
 
 You can use facts in conditionals (see :ref:`playbooks_conditionals`) and also in templates. You can also use facts to create dynamic groups of hosts that match particular criteria, see the :ref:`group_by module <group_by_module>` documentation for details.
 
+.. note:: We discourage the use of ``ansible_date_time`` for the long running playbooks. You might want to consider other options like ``pipe`` filter like ``lookup('pipe', 'date +%Y-%m-%d.%H:%M:%S')`` or using :ref:`now() <templating_now>` with a Jinja 2 template.
+
 .. _fact_requirements:
 
 Package requirements for fact gathering

--- a/docs/docsite/rst/user_guide/playbooks_vars_facts.rst
+++ b/docs/docsite/rst/user_guide/playbooks_vars_facts.rst
@@ -493,7 +493,7 @@ To reference the system hostname::
 
 You can use facts in conditionals (see :ref:`playbooks_conditionals`) and also in templates. You can also use facts to create dynamic groups of hosts that match particular criteria, see the :ref:`group_by module <group_by_module>` documentation for details.
 
-.. note:: We discourage the use of ``ansible_date_time`` for the long running playbooks. You might want to consider other options like ``pipe`` filter like ``lookup('pipe', 'date +%Y-%m-%d.%H:%M:%S')`` or using :ref:`now() <templating_now>` with a Jinja 2 template.
+.. note:: Because ``ansible_date_time`` is created and cached when Ansible gathers facts before each playbook run, it can get stale with long-running playbooks. If your playbook takes a long time to run, use the ``pipe`` filter (for example, ``lookup('pipe', 'date +%Y-%m-%d.%H:%M:%S')``) or :ref:`now() <templating_now>` with a Jinja 2 template instead of ``ansible_date_time``.
 
 .. _fact_requirements:
 


### PR DESCRIPTION
##### SUMMARY

For long running playbooks, discourage users from using
`ansible_date_time`. Use `pipe` or `now` as alternative.

Fixes: #22561

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/user_guide/playbooks_vars_facts.rst
