### PR TITLE
Add missing 'why:' to 'deprecated:'

### DIFF
--- a/lib/ansible/plugins/doc_fragments/inventory_cache.py
+++ b/lib/ansible/plugins/doc_fragments/inventory_cache.py
@@ -71,6 +71,7 @@ options:
         key: fact_caching_prefix
         deprecated:
           alternatives: Use the 'defaults' section instead
+          why: Fixes typing error in INI section name
           version: '2.16'
       - section: defaults
         key: fact_caching_prefix


### PR DESCRIPTION
##### SUMMARY
Update to #74523.

The missing `why:` causes antsibull-docs to render an error page instead for every inventory plugin including that docs fragment (see https://ansible.fontein.de/collections/community/hrobot/robot_inventory.html).

(We really need #71734...)

CC @s-hertel @abadger 

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/plugins/doc_fragments/inventory_cache.py
