### PR TITLE
[2.11] ansible-galaxy - increase page size and add retry decorator

### DIFF
--- a/test/units/galaxy/test_api.py
+++ b/test/units/galaxy/test_api.py
@@ -791,9 +791,10 @@ def test_get_collection_versions(api_version, token_type, token_ins, response, m
     actual = api.get_collection_versions('namespace', 'collection')
     assert actual == [u'1.0.0', u'1.0.1']
 
+    page_query = '?limit=100' if api_version == 'v3' else '?page_size=100'
     assert mock_open.call_count == 1
     assert mock_open.mock_calls[0][1][0] == 'https://galaxy.server.com/api/%s/collections/namespace/collection/' \
-                                            'versions/' % api_version
+                                            'versions/%s' % (api_version, page_query)
     if token_ins:
         assert mock_open.mock_calls[0][2]['headers']['Authorization'] == '%s my token' % token_type
 
@@ -802,9 +803,9 @@ def test_get_collection_versions(api_version, token_type, token_ins, response, m
     ('v2', None, None, [
         {
             'count': 6,
-            'next': 'https://galaxy.server.com/api/v2/collections/namespace/collection/versions/?page=2',
+            'next': 'https://galaxy.server.com/api/v2/collections/namespace/collection/versions/?page=2&page_size=100',
             'previous': None,
-            'results': [
+            'results': [  # Pay no mind, using more manageable results than page_size would indicate
                 {
                     'version': '1.0.0',
                     'href': 'https://galaxy.server.com/api/v2/collections/namespace/collection/versions/1.0.0',
@@ -817,7 +818,7 @@ def test_get_collection_versions(api_version, token_type, token_ins, response, m
         },
         {
             'count': 6,
-            'next': 'https://galaxy.server.com/api/v2/collections/namespace/collection/versions/?page=3',
+            'next': 'https://galaxy.server.com/api/v2/collections/namespace/collection/versions/?page=3&page_size=100',
             'previous': 'https://galaxy.server.com/api/v2/collections/namespace/collection/versions',
             'results': [
                 {
@@ -833,7 +834,7 @@ def test_get_collection_versions(api_version, token_type, token_ins, response, m
         {
             'count': 6,
             'next': None,
-            'previous': 'https://galaxy.server.com/api/v2/collections/namespace/collection/versions/?page=2',
+            'previous': 'https://galaxy.server.com/api/v2/collections/namespace/collection/versions/?page=2&page_size=100',
             'results': [
                 {
                     'version': '1.0.4',
@@ -850,7 +851,8 @@ def test_get_collection_versions(api_version, token_type, token_ins, response, m
         {
             'count': 6,
             'links': {
-                'next': '/api/v3/collections/namespace/collection/versions/?page=2',
+                # v3 links are relative and the limit is included during pagination
+                'next': '/api/v3/collections/namespace/collection/versions/?limit=100&offset=100',
                 'previous': None,
             },
             'data': [
@@ -867,7 +869,7 @@ def test_get_collection_versions(api_version, token_type, token_ins, response, m
         {
             'count': 6,
             'links': {
-                'next': '/api/v3/collections/namespace/collection/versions/?page=3',
+                'next': '/api/v3/collections/namespace/collection/versions/?limit=100&offset=200',
                 'previous': '/api/v3/collections/namespace/collection/versions',
             },
             'data': [
@@ -885,7 +887,7 @@ def test_get_collection_versions(api_version, token_type, token_ins, response, m
             'count': 6,
             'links': {
                 'next': None,
-                'previous': '/api/v3/collections/namespace/collection/versions/?page=2',
+                'previous': '/api/v3/collections/namespace/collection/versions/?limit=100&offset=100',
             },
             'data': [
                 {
@@ -916,12 +918,22 @@ def test_get_collection_versions_pagination(api_version, token_type, token_ins, 
     assert actual == [u'1.0.0', u'1.0.1', u'1.0.2', u'1.0.3', u'1.0.4', u'1.0.5']
 
     assert mock_open.call_count == 3
+
+    if api_version == 'v3':
+        query_1 = 'limit=100'
+        query_2 = 'limit=100&offset=100'
+        query_3 = 'limit=100&offset=200'
+    else:
+        query_1 = 'page_size=100'
+        query_2 = 'page=2&page_size=100'
+        query_3 = 'page=3&page_size=100'
+
     assert mock_open.mock_calls[0][1][0] == 'https://galaxy.server.com/api/%s/collections/namespace/collection/' \
-                                            'versions/' % api_version
+                                            'versions/?%s' % (api_version, query_1)
     assert mock_open.mock_calls[1][1][0] == 'https://galaxy.server.com/api/%s/collections/namespace/collection/' \
-                                            'versions/?page=2' % api_version
+                                            'versions/?%s' % (api_version, query_2)
     assert mock_open.mock_calls[2][1][0] == 'https://galaxy.server.com/api/%s/collections/namespace/collection/' \
-                                            'versions/?page=3' % api_version
+                                            'versions/?%s' % (api_version, query_3)
 
     if token_type:
         assert mock_open.mock_calls[0][2]['headers']['Authorization'] == '%s my token' % token_type


### PR DESCRIPTION
##### SUMMARY
Backport #74240 - cherry-picked cleanly

* Get available collection versions with page_size=100 for v2 and limit=100 for v3

* Update unit tests for larger page sizes

* Add a generic retry decorator in module_utils/api.py that accepts an Iterable of delays and a callable to determine if an exception inheriting from Exception should be retried

* Use the new decorator to handle Galaxy API rate limiting

* Add unit tests for new retry decorator

* Preserve the decorated function's metadata with functools.wraps

ci_complete

Co-authored-by: Matt Martz <matt@sivel.net>
Co-authored-by: Sviatoslav Sydorenko <wk.cvs.github@sydorenko.org.ua>
(cherry picked from commit ee725846f070fc6b0dd79b5e8c5199ec652faf87)

##### ISSUE TYPE
- Bugfix Pull Request
