### PR TITLE
Remove PyYAML warning filter in import test.

### DIFF
--- a/changelogs/fragments/ansible-test-import-pyyaml-warning.yml
+++ b/changelogs/fragments/ansible-test-import-pyyaml-warning.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Removed the warning filter for ``PyYAML`` in the ``import`` sanity test.

--- a/test/lib/ansible_test/_data/sanity/import/importer.py
+++ b/test/lib/ansible_test/_data/sanity/import/importer.py
@@ -539,11 +539,6 @@ def main():
                     r"The distutils package is deprecated and slated for removal in Python 3\.12\. .*",
                 )
 
-            warnings.filterwarnings(
-                "ignore",
-                "The _yaml extension module is now located at yaml._yaml and its location is subject to change.  To use the "
-                "LibYAML-based parser and emitter, import from `yaml`: `from yaml import CLoader as Loader, CDumper as Dumper`.")
-
             try:
                 yield
             finally:


### PR DESCRIPTION
##### SUMMARY

Remove PyYAML warning filter in import test.

The filter is obsolete now that PyYAML imports go through our compat layer.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
