### PR TITLE
Update Python versions for controller-only tests.

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -147,8 +147,9 @@ stages:
           nameFormat: Python {0}
           testFormat: galaxy/{0}/1
           targets:
-            - test: 2.7
-            - test: 3.6
+            - test: 3.8
+            - test: 3.9
+            - test: '3.10'
   - stage: Generic
     dependsOn: []
     jobs:
@@ -157,8 +158,9 @@ stages:
           nameFormat: Python {0}
           testFormat: generic/{0}/1
           targets:
-            - test: 2.7
+            - test: 3.8
             - test: 3.9
+            - test: '3.10'
   - stage: Incidental_Remote
     displayName: Incidental Remote
     dependsOn: []

--- a/test/integration/targets/ansible-test-docker/collection-tests/docker.sh
+++ b/test/integration/targets/ansible-test-docker/collection-tests/docker.sh
@@ -7,7 +7,7 @@ cd "${WORK_DIR}/ansible_collections/ns/col"
 
 # common args for all tests
 # because we are running in shippable/generic/ we are already in the default docker container
-common=(--python "${ANSIBLE_TEST_PYTHON_VERSION}" --color --truncate 0 "${@}")
+common=(--python "${ANSIBLE_TEST_PYTHON_VERSION}" --venv --venv-system-site-packages --color --truncate 0 "${@}")
 
 # prime the venv to work around issue with PyYAML detection in ansible-test
 ansible-test sanity "${common[@]}" --test ignores


### PR DESCRIPTION
##### SUMMARY

Update Python versions for controller-only tests.

Both `ansible-galaxy` and `ansible-test` integration tests only run on the controller.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

.azure-pipelines/azure-pipelines.yml