### PR TITLE
Update vendored copy of `six` to 1.16.0

### DIFF
--- a/changelogs/fragments/74659-update-six.yml
+++ b/changelogs/fragments/74659-update-six.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- Update vendored copy of ``six`` to 1.16.0 to eliminate warnings for deprecated
+  python loader methods in Python 3.10+
+  (https://github.com/ansible/ansible/issues/74659)

--- a/lib/ansible/module_utils/six/__init__.py
+++ b/lib/ansible/module_utils/six/__init__.py
@@ -2,8 +2,8 @@
 # long, etc) but they are all shielded by version checks.  This is also an
 # upstream vendored file that we're not going to modify on our own
 # pylint: disable=undefined-variable
-
-# Copyright (c) 2010-2019 Benjamin Peterson
+#
+# Copyright (c) 2010-2020 Benjamin Peterson
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -35,11 +35,13 @@ import types
 
 # The following makes it easier for us to script updates of the bundled code.  It is not part of
 # upstream six
-# CANT_UPDATE due to py2.6 drop: https://github.com/benjaminp/six/pull/314
-_BUNDLED_METADATA = {"pypi_name": "six", "version": "1.13.0"}
+# six 1.13.0 was the last release to officially support Python 2.6, as long as ansible-core
+# supports python2.6 for target nodes, this file may require Python 2.6 compatibility added
+# when updating to newer versions of six
+_BUNDLED_METADATA = {"pypi_name": "six", "version": "1.16.0"}
 
 __author__ = "Benjamin Peterson <benjamin@python.org>"
-__version__ = "1.13.0"
+__version__ = "1.16.0"
 
 
 # Useful for very coarse version differentiation.
@@ -80,6 +82,11 @@ else:
             # 64-bit
             MAXSIZE = int((1 << 63) - 1)
         del X
+
+if PY34:
+    from importlib.util import spec_from_loader
+else:
+    spec_from_loader = None
 
 
 def _add_doc(func, doc):
@@ -196,6 +203,11 @@ class _SixMetaPathImporter(object):
             return self
         return None
 
+    def find_spec(self, fullname, path, target=None):
+        if fullname in self.known_modules:
+            return spec_from_loader(fullname, self)
+        return None
+
     def __get_module(self, fullname):
         try:
             return self.known_modules[fullname]
@@ -233,6 +245,11 @@ class _SixMetaPathImporter(object):
         return None
     get_source = get_code  # same as get_code
 
+    def create_module(self, spec):
+        return self.load_module(spec.name)
+
+    def exec_module(self, module):
+        pass
 
 _importer = _SixMetaPathImporter(__name__)
 
@@ -270,7 +287,7 @@ _moved_attributes = [
     MovedModule("copyreg", "copy_reg"),
     MovedModule("dbm_gnu", "gdbm", "dbm.gnu"),
     MovedModule("dbm_ndbm", "dbm", "dbm.ndbm"),
-    MovedModule("_dummy_thread", "dummy_thread", "_dummy_thread"),
+    MovedModule("_dummy_thread", "dummy_thread", "_dummy_thread" if sys.version_info < (3, 9) else "_thread"),
     MovedModule("http_cookiejar", "cookielib", "http.cookiejar"),
     MovedModule("http_cookies", "Cookie", "http.cookies"),
     MovedModule("html_entities", "htmlentitydefs", "html.entities"),
@@ -498,7 +515,6 @@ class Module_six_moves_urllib(types.ModuleType):
     def __dir__(self):
         return ['parse', 'error', 'request', 'response', 'robotparser']
 
-
 _importer._add_module(Module_six_moves_urllib(__name__ + ".moves.urllib"),
                       "moves.urllib")
 
@@ -656,9 +672,11 @@ if PY3:
     if sys.version_info[1] <= 1:
         _assertRaisesRegex = "assertRaisesRegexp"
         _assertRegex = "assertRegexpMatches"
+        _assertNotRegex = "assertNotRegexpMatches"
     else:
         _assertRaisesRegex = "assertRaisesRegex"
         _assertRegex = "assertRegex"
+        _assertNotRegex = "assertNotRegex"
 else:
     def b(s):
         return s
@@ -680,6 +698,7 @@ else:
     _assertCountEqual = "assertItemsEqual"
     _assertRaisesRegex = "assertRaisesRegexp"
     _assertRegex = "assertRegexpMatches"
+    _assertNotRegex = "assertNotRegexpMatches"
 _add_doc(b, """Byte literal""")
 _add_doc(u, """Text literal""")
 
@@ -694,6 +713,10 @@ def assertRaisesRegex(self, *args, **kwargs):
 
 def assertRegex(self, *args, **kwargs):
     return getattr(self, _assertRegex)(*args, **kwargs)
+
+
+def assertNotRegex(self, *args, **kwargs):
+    return getattr(self, _assertNotRegex)(*args, **kwargs)
 
 
 if PY3:
@@ -731,16 +754,7 @@ else:
 """)
 
 
-if sys.version_info[:2] == (3, 2):
-    exec_("""def raise_from(value, from_value):
-    try:
-        if from_value is None:
-            raise value
-        raise value from from_value
-    finally:
-        value = None
-""")
-elif sys.version_info[:2] > (3, 2):
+if sys.version_info[:2] > (3,):
     exec_("""def raise_from(value, from_value):
     try:
         raise value from from_value
@@ -820,13 +834,33 @@ if sys.version_info[:2] < (3, 3):
 _add_doc(reraise, """Reraise an exception.""")
 
 if sys.version_info[0:2] < (3, 4):
+    # This does exactly the same what the :func:`py3:functools.update_wrapper`
+    # function does on Python versions after 3.2. It sets the ``__wrapped__``
+    # attribute on ``wrapper`` object and it doesn't raise an error if any of
+    # the attributes mentioned in ``assigned`` and ``updated`` are missing on
+    # ``wrapped`` object.
+    def _update_wrapper(wrapper, wrapped,
+                        assigned=functools.WRAPPER_ASSIGNMENTS,
+                        updated=functools.WRAPPER_UPDATES):
+        for attr in assigned:
+            try:
+                value = getattr(wrapped, attr)
+            except AttributeError:
+                continue
+            else:
+                setattr(wrapper, attr, value)
+        for attr in updated:
+            getattr(wrapper, attr).update(getattr(wrapped, attr, {}))
+        wrapper.__wrapped__ = wrapped
+        return wrapper
+    _update_wrapper.__doc__ = functools.update_wrapper.__doc__
+
     def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
               updated=functools.WRAPPER_UPDATES):
-        def wrapper(f):
-            f = functools.wraps(wrapped, assigned, updated)(f)
-            f.__wrapped__ = wrapped
-            return f
-        return wrapper
+        return functools.partial(_update_wrapper, wrapped=wrapped,
+                                 assigned=assigned, updated=updated)
+    wraps.__doc__ = functools.wraps.__doc__
+
 else:
     wraps = functools.wraps
 
@@ -884,12 +918,11 @@ def ensure_binary(s, encoding='utf-8', errors='strict'):
       - `str` -> encoded to `bytes`
       - `bytes` -> `bytes`
     """
+    if isinstance(s, binary_type):
+        return s
     if isinstance(s, text_type):
         return s.encode(encoding, errors)
-    elif isinstance(s, binary_type):
-        return s
-    else:
-        raise TypeError("not expecting type '%s'" % type(s))
+    raise TypeError("not expecting type '%s'" % type(s))
 
 
 def ensure_str(s, encoding='utf-8', errors='strict'):
@@ -903,12 +936,15 @@ def ensure_str(s, encoding='utf-8', errors='strict'):
       - `str` -> `str`
       - `bytes` -> decoded to `str`
     """
-    if not isinstance(s, (text_type, binary_type)):
-        raise TypeError("not expecting type '%s'" % type(s))
+    # Optimization: Fast return for the common case.
+    if type(s) is str:
+        return s
     if PY2 and isinstance(s, text_type):
-        s = s.encode(encoding, errors)
+        return s.encode(encoding, errors)
     elif PY3 and isinstance(s, binary_type):
-        s = s.decode(encoding, errors)
+        return s.decode(encoding, errors)
+    elif not isinstance(s, (text_type, binary_type)):
+        raise TypeError("not expecting type '%s'" % type(s))
     return s
 
 
@@ -933,7 +969,7 @@ def ensure_text(s, encoding='utf-8', errors='strict'):
 
 def python_2_unicode_compatible(klass):
     """
-    A decorator that defines __unicode__ and __str__ methods under Python 2.
+    A class decorator that defines __unicode__ and __str__ methods under Python 2.
     Under Python 3 it does nothing.
 
     To support Python 2 and 3 with a single code base, define a __str__ method

--- a/lib/ansible/module_utils/six/__init__.py
+++ b/lib/ansible/module_utils/six/__init__.py
@@ -251,6 +251,7 @@ class _SixMetaPathImporter(object):
     def exec_module(self, module):
         pass
 
+
 _importer = _SixMetaPathImporter(__name__)
 
 
@@ -514,6 +515,7 @@ class Module_six_moves_urllib(types.ModuleType):
 
     def __dir__(self):
         return ['parse', 'error', 'request', 'response', 'robotparser']
+
 
 _importer._add_module(Module_six_moves_urllib(__name__ + ".moves.urllib"),
                       "moves.urllib")

--- a/lib/ansible/module_utils/six/__init__.py
+++ b/lib/ansible/module_utils/six/__init__.py
@@ -33,11 +33,8 @@ import operator
 import sys
 import types
 
-# The following makes it easier for us to script updates of the bundled code.  It is not part of
+# The following makes it easier for us to script updates of the bundled code. It is not part of
 # upstream six
-# six 1.13.0 was the last release to officially support Python 2.6, as long as ansible-core
-# supports python2.6 for target nodes, this file may require Python 2.6 compatibility added
-# when updating to newer versions of six
 _BUNDLED_METADATA = {"pypi_name": "six", "version": "1.16.0"}
 
 __author__ = "Benjamin Peterson <benjamin@python.org>"

--- a/test/lib/ansible_test/_data/sanity/import/importer.py
+++ b/test/lib/ansible_test/_data/sanity/import/importer.py
@@ -518,19 +518,6 @@ def main():
                     r"_Ansible.*Loader\.exec_module\(\) not found; falling back to load_module\(\)",
                 )
 
-                # Temporary solution until we have a vendored version of six that avoids the warnings on Python 3.10.
-                # The warning text is: _SixMetaPathImporter.find_spec() not found; falling back to find_module()
-                warnings.filterwarnings(
-                    "ignore",
-                    r"_SixMetaPathImporter\.find_spec\(\) not found; falling back to find_module\(\)",
-                )
-                # Temporary solution until we have a vendored version of six that avoids the warnings on Python 3.10.
-                # The warning text is: _SixMetaPathImporter.exec_module() not found; falling back to load_module()
-                warnings.filterwarnings(
-                    "ignore",
-                    r"_SixMetaPathImporter\.exec_module\(\) not found; falling back to load_module\(\)",
-                )
-
                 # Temporary solution until there is a vendored copy of distutils.version in module_utils.
                 # Some of our dependencies such as packaging.tags also import distutils, which we have no control over
                 # The warning text is: The distutils package is deprecated and slated for removal in Python 3.12.


### PR DESCRIPTION
##### SUMMARY

Update vendored copy of `six` to 1.16.0 to eliminate warnings for deprecated python loader methods in Python 3.10+

Fixes https://github.com/ansible/ansible/issues/74659

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/six/

##### ADDITIONAL INFORMATION

Although six officially dropped support for Python 2.6 after 1.13.0, there have been no incompatible changes since then that would prevent it from working with Python 2.6.
