### PR TITLE
Update cron test

### DIFF
--- a/test/integration/targets/cron/tasks/main.yml
+++ b/test/integration/targets/cron/tasks/main.yml
@@ -215,7 +215,24 @@
   - assert:
       that: not cron_file_stats.stat.exists
 
+- name: System cron tab can not be managed
+  when: ansible_distribution != 'Alpine'
+  block:
+  - name: Add cron job
+    cron:
+      cron_file: "{{ system_crontab }}"
+      user: root
+      name: "integration test cron"
+      job: 'ls'
+    ignore_errors: yes
+    register: result
+
+  - assert:
+      that: "result.msg == 'Will not manage /etc/crontab via cron_file, see documentation.'"
+
+# TODO: restrict other root crontab locations
 - name: System cron tab does not get removed
+  when: ansible_distribution == 'Alpine'
   block:
   - name: Add cron job
     cron:


### PR DESCRIPTION
##### SUMMARY
the cron module can't be used to manage /etc/crontab as of #73591. The PR that added the test didn't run with those changes - race condition :)

Fixes https://dev.azure.com/ansible/ansible/_build/results?buildId=14876&view=logs&jobId=b55b5f30-ede1-571e-6966-5f94dd03a7c6&j=a00789c5-8412-587b-63fc-93dbdf0cd470&t=e049f74a-b955-5412-bd69-ba41533160f3

##### ISSUE TYPE
- Test Pull Request
