### PR TITLE
Cap jinja2 to < 3

### DIFF
--- a/changelogs/fragments/cap_jinja2.yml
+++ b/changelogs/fragments/cap_jinja2.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cap jinja2 requirement.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 # packages.  Thus, this should be the loosest set possible (only required
 # packages, not optional ones, and with the widest range of versions that could
 # be suitable)
-jinja2
+jinja2 < 3
 PyYAML
 cryptography
 packaging


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
With the release of jinja2 3.0.0, pip install of packages failed, due to incompatibility.

Capping it to < 3.0.0 version, resolves the conflicts.

```
ERROR: aiohttp-swagger 1.0.15 has requirement jinja2~=2.11.2, but you'll have jinja2 3.0.0 which is incompatible.
ERROR: aiohttp-swagger 1.0.15 has requirement markupsafe~=1.1.1, but you'll have markupsafe 2.0.0 which is incompatible.
ERROR: pyats-log 21.4 has requirement Jinja2==2.11.3, but you'll have jinja2 3.0.0 which is incompatible.
ERROR: pyats-utils 21.4 has requirement cryptography<=3.3.1, but you'll have cryptography 3.4.7 which is incompatible.

```


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
