### PR TITLE
Skip interpreter discovery for network OSs(#74012)

### DIFF
--- a/changelogs/fragments/tweaking_interpreter_discovery.yaml
+++ b/changelogs/fragments/tweaking_interpreter_discovery.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+    - interpreter discovery is now handling special (ansible_network_os) cases in less noisy ways.

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -619,6 +619,12 @@ class TaskExecutor:
         plugin_vars = self._set_connection_options(cvars, templar)
         templar.available_variables = orig_vars
 
+        # TODO: eventually remove this block as this should be a 'consequence' of 'forced_local' modules
+        # special handling for python interpreter for network_os, default to ansible python unless overriden
+        if 'ansible_network_os' in cvars and 'ansible_python_interpreter' not in cvars:
+            # this also avoids 'python discovery'
+            cvars['ansible_python_interpreter'] = sys.executable
+
         # get handler
         self._handler = self._get_action_handler(connection=self._connection, templar=templar)
 


### PR DESCRIPTION
skip python interpreter discovery on network os being set as this indicates a 'forced local' module and should use sys.executable.

(cherry picked from commit 173d0a8)
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
task_executor