### PR TITLE
[stable-2.9] Disable rabbitmq integration tests

### DIFF
--- a/test/integration/targets/rabbitmq_binding/aliases
+++ b/test/integration/targets/rabbitmq_binding/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled # test is no longer passing due to missing package dependencies

--- a/test/integration/targets/rabbitmq_lookup/aliases
+++ b/test/integration/targets/rabbitmq_lookup/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled # test is no longer passing due to missing package dependencies

--- a/test/integration/targets/rabbitmq_plugin/aliases
+++ b/test/integration/targets/rabbitmq_plugin/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled # test is no longer passing due to missing package dependencies

--- a/test/integration/targets/rabbitmq_publish/aliases
+++ b/test/integration/targets/rabbitmq_publish/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled # test is no longer passing due to missing package dependencies

--- a/test/integration/targets/rabbitmq_user/aliases
+++ b/test/integration/targets/rabbitmq_user/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled # test is no longer passing due to missing package dependencies

--- a/test/integration/targets/rabbitmq_vhost/aliases
+++ b/test/integration/targets/rabbitmq_vhost/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled # test is no longer passing due to missing package dependencies

--- a/test/integration/targets/rabbitmq_vhost_limits/aliases
+++ b/test/integration/targets/rabbitmq_vhost_limits/aliases
@@ -3,3 +3,4 @@ shippable/posix/group1
 skip/osx
 skip/freebsd
 skip/rhel
+disabled # test is no longer passing due to missing package dependencies


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The tests are failing due to missing package dependencies. Keeping these tests adds little coverage to Ansible Core.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/rabbitmq_binding/aliases`
`test/integration/targets/rabbitmq_lookup/aliases`
`test/integration/targets/rabbitmq_plugin/aliases`
`test/integration/targets/rabbitmq_publish/aliases`
`test/integration/targets/rabbitmq_user/aliases`
`test/integration/targets/rabbitmq_vhost/aliases`
`test/integration/targets/rabbitmq_vhost_limits/aliases`
