### PR TITLE
fix error if path had wildcard in it 

### DIFF
--- a/changelogs/fragments/74723-support-wildcard-win_fetch.yml
+++ b/changelogs/fragments/74723-support-wildcard-win_fetch.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- win_fetch - Add support for using file with wildcards in file name.
+  (https://github.com/ansible/ansible/issues/73128)

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -689,7 +689,7 @@ class Connection(ConnectionBase):
                 try:
                     script = '''
                         $path = '%(path)s'
-                        If (Test-Path -Path $path -PathType Leaf)
+                        If (Test-Path -LiteralPath $path -PathType Leaf)
                         {
                             $buffer_size = %(buffer_size)d
                             $offset = %(offset)d
@@ -704,7 +704,7 @@ class Connection(ConnectionBase):
                             }
                             $stream.Close() > $null
                         }
-                        ElseIf (Test-Path -Path $path -PathType Container)
+                        ElseIf (Test-Path -LiteralPath $path -PathType Container)
                         {
                             Write-Host "[DIR]";
                         }

--- a/test/integration/targets/win_fetch/tasks/main.yml
+++ b/test/integration/targets/win_fetch/tasks/main.yml
@@ -210,3 +210,18 @@
     - fetch_special_file.checksum == '34d4150adc3347f1dd8ce19fdf65b74d971ab602'
     - fetch_special_file.dest == host_output_dir + "/abc$not var'quote‘"
     - fetch_special_file_actual.stdout == 'abc'
+
+- name: create file with wildcard characters
+  raw: Set-Content -LiteralPath '{{ remote_tmp_dir }}\abc[].txt' -Value 'abc'
+
+- name: fetch file with wildcard characters
+  fetch:
+    src: '{{ remote_tmp_dir }}\abc[].txt'
+    dest: '{{ host_output_dir }}/'
+  register: fetch_wildcard_file_nofail
+
+- name: assert fetch file with wildcard characters
+  assert:
+    that:
+    - "fetch_wildcard_file_nofail is not failed"
+   


### PR DESCRIPTION
##### SUMMARY
Fixes issue #73128. Code changes same as proposed by the issue Author.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`fetch.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
### play
![image](https://user-images.githubusercontent.com/12897753/118387342-a5727700-b63b-11eb-81a9-b609270b4219.png)

### before
![image](https://user-images.githubusercontent.com/12897753/118387388-ef5b5d00-b63b-11eb-8096-c8601f16bfa4.png)

### after
![image](https://user-images.githubusercontent.com/12897753/118387591-da32fe00-b63c-11eb-9877-6d2cc157186d.png)

