### PR TITLE
service: Document internal working of the module

### DIFF
--- a/changelogs/fragments/74507_service.yml
+++ b/changelogs/fragments/74507_service.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- service - add description how service module works internally (https://github.com/ansible/ansible/issues/74507).

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -16,6 +16,14 @@ short_description:  Manage services
 description:
     - Controls services on remote hosts. Supported init systems include BSD init,
       OpenRC, SysV, Solaris SMF, systemd, upstart.
+    - This module acts as a proxy to the underlying service manager module. While all arguments will be passed to the
+      underlying module, not all modules support the same arguments. This documentation only covers the minimum intersection
+      of module arguments that all service manager modules support.
+    - This module is a proxy for multiple more specific service manager modules
+      (such as M(ansible.builtin.systemd) and M(ansible.builtin.sysvinit)).
+      This allows management of a heterogeneous environment of machines without creating a specific task for
+      each service manager. The module to be executed is determined by the I(use) option, which defaults to the
+      service manager discovered by M(ansible.builtin.setup).  If `setup` was not yet run, this module may run it.
     - For Windows targets, use the M(ansible.windows.win_service) module instead.
 options:
     name:


### PR DESCRIPTION
##### SUMMARY

service module acts as proxy module for all service manager modules,
just like `package` module.
This is helpful in heterogeneous environments to manage services.

Fixes: #74507

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/74507_service.yml
lib/ansible/modules/service.py
