### PR TITLE
Use --docker to generate coverage XML reports.

### DIFF
--- a/.azure-pipelines/scripts/report-coverage.sh
+++ b/.azure-pipelines/scripts/report-coverage.sh
@@ -12,4 +12,4 @@ if ! ansible-test --help >/dev/null 2>&1; then
     pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
 fi
 
-ansible-test coverage xml --stub --venv --venv-system-site-packages --color -v
+ansible-test coverage xml --stub --docker --color -v


### PR DESCRIPTION
##### SUMMARY

Use `--docker` to generate coverage XML reports.

This is needed to provide `pwsh` for generating PowerShell coverage stubs.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

.azure-pipelines/scripts/report-coverage.sh

##### ADDITIONAL INFORMATION

The coverage stubs are created by `ansible-test` from the `devel` branch, which has been updated to require `pwsh` to generate PowerShell coverage stubs when there are PowerShell files present. Since the Azure Pipelines environment does not provide `pwsh`, the `default` container provided by the `--docker` option is used to enable stub generation.