### PR TITLE
Add fallback for coverage report generation.

### DIFF
--- a/.azure-pipelines/scripts/report-coverage.sh
+++ b/.azure-pipelines/scripts/report-coverage.sh
@@ -12,4 +12,6 @@ if ! ansible-test --help >/dev/null 2>&1; then
     pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
 fi
 
-ansible-test coverage xml --stub --docker --color -v
+# Generate stubs using docker (if supported) otherwise fall back to using a virtual environment instead.
+# The use of docker is required when Powershell code is present, but Ansible 2.12 was the first version to support --docker with coverage.
+ansible-test coverage xml --stub --docker --color -v || ansible-test coverage xml --stub --venv --venv-system-site-packages --color -v


### PR DESCRIPTION
##### SUMMARY

This should allow the same script to be used for two different scenarios:

- ansible-core across multiple versions (not all of which support `--docker` for coverage reports)
- collections (which should always use the `devel` branch for coverage reports)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

.azure-pipelines/scripts/report-coverage.sh
