### PR TITLE
Fix small typo in playbook_filters doc

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1664,9 +1664,9 @@ To concatenate a list into a string::
 
 To split a sting into a list::
 
-.. versionadded:: 2.11
-
     {{ csv_string | split(",") }}
+    
+.. versionadded:: 2.11
 
 To work with Base64 encoded strings::
 


### PR DESCRIPTION
##### SUMMARY
Wrong ordering of code example and version added note caused improper rendering of the code block.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/user_guide/playbooks_filters.rst 
