### PR TITLE
[bp-2.11] Fix small typo in playbook_filters doc

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1664,9 +1664,9 @@ To concatenate a list into a string::
 
 To split a sting into a list::
 
-.. versionadded:: 2.11
-
     {{ csv_string | split(",") }}
+
+.. versionadded:: 2.11
 
 To work with Base64 encoded strings::
 


### PR DESCRIPTION
##### SUMMARY

Move versionadded to next line to render correctly.

(cherry picked from commit 888fea69e547f49a9267d2c8df71fac38e383ed4)


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/user_guide/playbooks_filters.rst
