### PR TITLE
Update intro_bsd.rst

### DIFF
--- a/docs/docsite/rst/user_guide/intro_bsd.rst
+++ b/docs/docsite/rst/user_guide/intro_bsd.rst
@@ -26,7 +26,7 @@ Bootstrapping BSD
 
 Ansible is agentless by default, however, it requires Python on managed nodes. Only the :ref:`raw <raw_module>` module will operate without Python. Although this module can be used to bootstrap Ansible and install Python on BSD variants (see below), it is very limited and the use of Python is required to make full use of Ansible's features.
 
-The following example installs Python 2.7 which includes the json library required for full functionality of Ansible.
+The following example installs Python which includes the json library required for full functionality of Ansible.
 On your control machine you can execute the following for most versions of FreeBSD:
 
 .. code-block:: bash
@@ -37,7 +37,7 @@ Or for OpenBSD:
 
 .. code-block:: bash
 
-    ansible -m raw -a "pkg_add python%3.7"
+    ansible -m raw -a "pkg_add python%3.8"
 
 Once this is done you can now use other Ansible modules apart from the ``raw`` module.
 
@@ -56,7 +56,7 @@ To support a variety of Unix-like operating systems and distributions, Ansible c
     [freebsd:vars]
     ansible_python_interpreter=/usr/local/bin/python2.7
     [openbsd:vars]
-    ansible_python_interpreter=/usr/local/bin/python3.7
+    ansible_python_interpreter=/usr/local/bin/python3.8
 
 If you use additional plugins beyond those bundled with Ansible, you can set similar variables for ``bash``, ``perl`` or ``ruby``, depending on how the plugin is written. For example:
 


### PR DESCRIPTION
##### SUMMARY
OpenBSD 6.9 is out and the default version of Python is 3.8, with no more 3.7. So this entry should be adjusted. I tested it with a rather large playbook and it seems to work seamlessly.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
Python 3.7 is no longer available per default on current OpenBSD, instead it's 3.8 (or 2.7 if one wishes to do that).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs

##### ADDITIONAL INFORMATION
Installing Python 3.7 on a stock OpenBSD 6.9 doesn't work as there are no packages for that.
