### PR TITLE
Revert "use versioned doclink for url references (#74245)"

### DIFF
--- a/changelogs/fragments/doclink_refs.yml
+++ b/changelogs/fragments/doclink_refs.yml
@@ -1,4 +1,0 @@
-bugfixes:
-  - ansible-doc will now correcty handle relative refs to 'current' ansible version
-  - set_fact module, removed hardcoded url to relative reference
-  - user module, removed hardcoded url to relative reference

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -5,6 +5,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import datetime
 import json
 import pkgutil
 import os
@@ -23,7 +24,7 @@ from ansible.cli.arguments import option_helpers as opt_help
 from ansible.collections.list import list_collection_dirs
 from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
 from ansible.module_utils._text import to_native, to_text
-from ansible.module_utils.common._collections_compat import Sequence
+from ansible.module_utils.common._collections_compat import Container, Sequence
 from ansible.module_utils.common.json import AnsibleJSONEncoder
 from ansible.module_utils.common.yaml import yaml_dump
 from ansible.module_utils.compat import importlib
@@ -37,6 +38,7 @@ from ansible.utils.collection_loader._collection_finder import _get_collection_n
 from ansible.utils.display import Display
 from ansible.utils.plugin_docs import (
     REJECTLIST,
+    remove_current_collection_from_versions_and_dates,
     get_docstring,
     get_versioned_doclink,
 )
@@ -326,13 +328,6 @@ class RoleMixin(object):
         return result
 
 
-def _doclink(url):
-    # assume that if it is relative, it is for docsite, ignore rest
-    if not url.startswith(("http", "..")):
-        url = get_versioned_doclink(url)
-    return url
-
-
 class DocCLI(CLI, RoleMixin):
     ''' displays information on modules installed in Ansible libraries.
         It displays a terse listing of plugins and their short descriptions,
@@ -371,6 +366,8 @@ class DocCLI(CLI, RoleMixin):
         t = cls._ITALIC.sub(r"`\1'", text)    # I(word) => `word'
         t = cls._BOLD.sub(r"*\1*", t)         # B(word) => *word*
         t = cls._MODULE.sub("[" + r"\1" + "]", t)       # M(word) => [word]
+        t = cls._URL.sub(r"\1", t)                      # U(word) => word
+        t = cls._LINK.sub(r"\1 <\2>", t)                # L(word, url) => word <url>
         t = cls._REF.sub(r"\1", t)            # R(word, sphinx-ref) => word
         t = cls._CONST.sub(r"`\1'", t)        # C(word) => `word'
         t = cls._RULER.sub("\n{0}\n".format("-" * 13), t)   # HORIZONTALLINE => -------
@@ -380,12 +377,6 @@ class DocCLI(CLI, RoleMixin):
         t = cls._RST_NOTE.sub(r"Note:", t)                 # .. note:: to note:
         t = cls._RST_ROLES.sub(r"website for `", t)        # remove :ref: and other tags
         t = cls._RST_DIRECTIVES.sub(r"", t)                # remove .. stuff:: in general
-
-        # handle docsite refs
-        # U(word) => word
-        t = re.sub(cls._URL, lambda m: r"%s" % _doclink(m.group(1)), t)
-        # L(word, url) => word <url>
-        t = re.sub(cls._LINK, lambda m: r"%s <%s>" % (m.group(1), _doclink(m.group(2))), t)
 
         return t
 

--- a/lib/ansible/modules/set_fact.py
+++ b/lib/ansible/modules/set_fact.py
@@ -31,7 +31,7 @@ options:
       - This boolean converts the variable into an actual 'fact' which will also be added to the fact cache, if fact caching is enabled.
       - Normally this module creates 'host level variables' and has much higher precedence, this option changes the nature and precedence
         (by 7 steps) of the variable created.
-        U(user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable)
+        U(https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable)
       - "This actually creates 2 copies of the variable, a normal 'set_fact' host variable with high precedence and
         a lower 'ansible_fact' one that is available for persistance via the facts cache plugin.
         This creates a possibly confusing interaction with C(meta: clear_facts) as it will remove the 'ansible_fact' but not the host variable."

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -89,7 +89,7 @@ options:
             - On macOS systems, this value has to be cleartext. Beware of security issues.
             - To create a disabled account on Linux systems, set this to C('!') or C('*').
             - To create a disabled account on OpenBSD, set this to C('*************').
-            - See L(FAQ entry, reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
+            - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
               for details on various ways to generate these password values.
         type: str
     state:


### PR DESCRIPTION
This reverts commit c1879a5011cbc8dacc5be44d55940cf0a05deecd.

This commit has the following problems:
* It uses an incorrect format for relative links in plugin docs.
  relative links in plugin docs are relative to the page, not to the
  toplevel of the documentation.
* It mixes ansible package url with ansible-core version.
  * An attempt to mitigate this was done by changing the base url to the
    ansible-core url but that then broke relative links in collections.
    * The change to the base url is appropriate for error messages in
      ansible which pass through versioned doclink because those always
      come from ansible-core, not from collections so that change was
      left in rather than reverted.  It should be noted, though, that
      leaving it in means that trying to get ansible-doc to handle
      relative links will need to use a different code path than
      versioned doclink to get the proper base url + version.
* It handles relative links that begin with `..` differently than other
  relative links.  This makes for a hidden trigger that the
  documentation writer can trip over.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request


##### COMPONENT NAME
* lib/ansible/cli/doc.py

##### ADDITIONAL INFORMATION

/CC @acozine @samccann

Approved this strategy at the 5/18/2021 docs meeting.