### PR TITLE
[WIP] gather_facts should not mutate config base definition

### DIFF
--- a/lib/ansible/plugins/action/gather_facts.py
+++ b/lib/ansible/plugins/action/gather_facts.py
@@ -62,7 +62,7 @@ class ActionModule(ActionBase):
         result = super(ActionModule, self).run(tmp, task_vars)
         result['ansible_facts'] = {}
 
-        modules = C.config.get_config_value('FACTS_MODULES', variables=task_vars)
+        modules = list(C.config.get_config_value('FACTS_MODULES', variables=task_vars))
         parallel = task_vars.pop('ansible_facts_parallel', self._task.args.pop('parallel', None))
         if 'smart' in modules:
             connection_map = C.config.get_config_value('CONNECTION_FACTS_MODULES', variables=task_vars)

--- a/test/units/plugins/action/test_gather_facts.py
+++ b/test/units/plugins/action/test_gather_facts.py
@@ -63,7 +63,7 @@ class TestNetworkFacts(unittest.TestCase):
         self.assertEqual(mod_args['gather_subset'], 'min')
 
         facts_modules = C.config.get_config_value('FACTS_MODULES', variables=self.task_vars)
-        self.assertEqual(facts_modules, ['ansible.legacy.ios_facts'])
+        self.assertEqual(facts_modules, ['smart'])
 
     @patch.object(module_common, '_get_collection_metadata', return_value={})
     def test_network_gather_facts_fqcn(self, mock_collection_metadata):
@@ -84,4 +84,4 @@ class TestNetworkFacts(unittest.TestCase):
         self.assertEqual(mod_args['gather_subset'], 'min')
 
         facts_modules = C.config.get_config_value('FACTS_MODULES', variables=self.fqcn_task_vars)
-        self.assertEqual(facts_modules, ['cisco.ios.ios_facts'])
+        self.assertEqual(facts_modules, ['smart'])


### PR DESCRIPTION
##### SUMMARY
Do we want our action plugins mutating config base definitions?

##### ISSUE TYPE
- Bugfix Pull Request
