### PR TITLE
Remove deprecated PlayContext.make_become_cmd

### DIFF
--- a/changelogs/fragments/74136-remove-playcontext-make-become-cmd.yml
+++ b/changelogs/fragments/74136-remove-playcontext-make-become-cmd.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- PlayContext - Remove deprecated ``make_become_cmd`` (https://github.com/ansible/ansible/issues/74136)

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -320,43 +320,6 @@ class PlayContext(Base):
     def set_become_plugin(self, plugin):
         self._become_plugin = plugin
 
-    def make_become_cmd(self, cmd, executable=None):
-        """ helper function to create privilege escalation commands """
-        display.deprecated(
-            "PlayContext.make_become_cmd should not be used, the calling code should be using become plugins instead",
-            version="2.12", collection_name='ansible.builtin'
-        )
-
-        if not cmd or not self.become:
-            return cmd
-
-        become_method = self.become_method
-
-        # load/call become plugins here
-        plugin = self._become_plugin
-
-        if plugin:
-            options = {
-                'become_exe': self.become_exe or become_method,
-                'become_flags': self.become_flags or '',
-                'become_user': self.become_user,
-                'become_pass': self.become_pass
-            }
-            plugin.set_options(direct=options)
-
-            if not executable:
-                executable = self.executable
-
-            shell = get_shell_plugin(executable=executable)
-            cmd = plugin.build_become_command(cmd, shell)
-            # for backwards compat:
-            if self.become_pass:
-                self.prompt = plugin.prompt
-        else:
-            raise AnsibleError("Privilege escalation method not found: %s" % become_method)
-
-        return cmd
-
     def update_vars(self, variables):
         '''
         Adds 'magic' variables relating to connections to the variable dictionary provided.

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -116,7 +116,6 @@ lib/ansible/playbook/base.py pylint:blacklisted-name
 lib/ansible/playbook/collectionsearch.py required-and-default-attributes  # https://github.com/ansible/ansible/issues/61460
 lib/ansible/playbook/helpers.py pylint:ansible-deprecated-version
 lib/ansible/playbook/helpers.py pylint:blacklisted-name
-lib/ansible/playbook/play_context.py pylint:ansible-deprecated-version
 lib/ansible/plugins/action/__init__.py pylint:ansible-deprecated-version
 lib/ansible/plugins/action/async_status.py pylint:ansible-deprecated-version
 lib/ansible/plugins/action/normal.py action-plugin-docs # default action plugin for modules without a dedicated action plugin

--- a/test/units/playbook/test_play_context.py
+++ b/test/units/playbook/test_play_context.py
@@ -92,20 +92,3 @@ def test_play_context(mocker, parser, reset_cli_args):
     mock_task.no_log = False
     play_context = play_context.set_task_and_variable_override(task=mock_task, variables=all_vars, templar=mock_templar)
     assert play_context.no_log is False
-
-
-def test_play_context_make_become_bad(mocker, parser, reset_cli_args):
-    options = parser.parse_args([])
-    context._init_global_context(options)
-    play_context = PlayContext()
-
-    default_cmd = "/bin/foo"
-    default_exe = "/bin/bash"
-
-    play_context.become = True
-    play_context.become_user = 'foo'
-    play_context.set_become_plugin(become_loader.get('bad'))
-    play_context.become_method = 'bad'
-
-    with pytest.raises(AnsibleError):
-        play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)

--- a/test/units/plugins/become/test_su.py
+++ b/test/units/plugins/become/test_su.py
@@ -10,31 +10,21 @@ __metaclass__ = type
 import re
 
 from ansible import context
-from ansible.playbook.play_context import PlayContext
-from ansible.plugins.loader import become_loader
+from ansible.plugins.loader import become_loader, shell_loader
 
 
 def test_su(mocker, parser, reset_cli_args):
     options = parser.parse_args([])
     context._init_global_context(options)
-    play_context = PlayContext()
 
-    default_cmd = "/bin/foo"
-    default_exe = "/bin/bash"
-    su_exe = 'su'
-    su_flags = ''
+    su = become_loader.get('su')
+    sh = shell_loader.get('sh')
+    sh.executable = "/bin/bash"
 
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
-    assert cmd == default_cmd
+    su.set_options(direct={
+        'become_user': 'foo',
+        'become_flags': '',
+    })
 
-    success = 'BECOME-SUCCESS-.+?'
-
-    play_context.become = True
-    play_context.become_user = 'foo'
-    play_context.become_pass = None
-    play_context.become_method = 'su'
-    play_context.set_become_plugin(become_loader.get('su'))
-    play_context.become_flags = su_flags
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
-    assert (re.match("""%s  %s -c '%s -c '"'"'echo %s; %s'"'"''""" % (su_exe, play_context.become_user, default_exe,
-                                                                      success, default_cmd), cmd) is not None)
+    cmd = su.build_become_command('/bin/foo', sh)
+    assert re.match("""su\s+foo -c '/bin/bash -c '"'"'echo BECOME-SUCCESS-.+?; /bin/foo'"'"''""", cmd)

--- a/test/units/plugins/become/test_su.py
+++ b/test/units/plugins/become/test_su.py
@@ -27,4 +27,4 @@ def test_su(mocker, parser, reset_cli_args):
     })
 
     cmd = su.build_become_command('/bin/foo', sh)
-    assert re.match("""su\s+foo -c '/bin/bash -c '"'"'echo BECOME-SUCCESS-.+?; /bin/foo'"'"''""", cmd)
+    assert re.match(r"""su\s+foo -c '/bin/bash -c '"'"'echo BECOME-SUCCESS-.+?; /bin/foo'"'"''""", cmd)

--- a/test/units/plugins/become/test_sudo.py
+++ b/test/units/plugins/become/test_sudo.py
@@ -10,36 +10,31 @@ __metaclass__ = type
 import re
 
 from ansible import context
-from ansible.playbook.play_context import PlayContext
-from ansible.plugins.loader import become_loader
+from ansible.plugins.loader import become_loader, shell_loader
 
 
 def test_sudo(mocker, parser, reset_cli_args):
     options = parser.parse_args([])
     context._init_global_context(options)
-    play_context = PlayContext()
 
-    default_cmd = "/bin/foo"
-    default_exe = "/bin/bash"
-    sudo_exe = 'sudo'
-    sudo_flags = '-H -s -n'
+    sudo = become_loader.get('sudo')
+    sh = shell_loader.get('sh')
+    sh.executable = "/bin/bash"
 
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
-    assert cmd == default_cmd
+    sudo.set_options(direct={
+        'become_user': 'foo',
+        'become_flags': '-n -s -H',
+    })
 
-    success = 'BECOME-SUCCESS-.+?'
+    cmd = sudo.build_become_command('/bin/foo', sh)
 
-    play_context.become = True
-    play_context.become_user = 'foo'
-    play_context.set_become_plugin(become_loader.get('sudo'))
-    play_context.become_flags = sudo_flags
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
+    assert re.match(r"""sudo\s+-n -s -H\s+-u foo /bin/bash -c 'echo BECOME-SUCCESS-.+? ; /bin/foo'""", cmd), cmd
 
-    assert (re.match("""%s %s  -u %s %s -c 'echo %s; %s'""" % (sudo_exe, sudo_flags, play_context.become_user,
-                                                               default_exe, success, default_cmd), cmd) is not None)
+    sudo.set_options(direct={
+        'become_user': 'foo',
+        'become_flags': '-n -s -H',
+        'become_pass': 'testpass',
+    })
 
-    play_context.become_pass = 'testpass'
-    cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
-    assert (re.match("""%s %s -p "%s" -u %s %s -c 'echo %s; %s'""" % (sudo_exe, sudo_flags.replace('-n', ''),
-                                                                      r"\[sudo via ansible, key=.+?\] password:", play_context.become_user,
-                                                                      default_exe, success, default_cmd), cmd) is not None)
+    cmd = sudo.build_become_command('/bin/foo', sh)
+    assert re.match(r"""sudo\s+-s\s-H\s+-p "\[sudo via ansible, key=.+?\] password:" -u foo /bin/bash -c 'echo BECOME-SUCCESS-.+? ; /bin/foo'""", cmd), cmd


### PR DESCRIPTION
##### SUMMARY
Remove deprecated PlayContext.make_become_cmd. Fixes #74136

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/play_context.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
