### PR TITLE
Don't mutate os.environ in AnsibleModule.run_command, make a copy, and pass to Popen

### DIFF
--- a/changelogs/fragments/74783-run-command-thread-safety.yml
+++ b/changelogs/fragments/74783-run-command-thread-safety.yml
@@ -1,4 +1,5 @@
 bugfixes:
-- ``AnsibleModule.run_command`` - Address thread safety issues, concerning mutating the environment,
-  current working directory, and umask.
-  (https://github.com/ansible/ansible/issues/74783)
+  - >
+    ``AnsibleModule.run_command`` - Address thread safety issues, concerning mutating the environment,
+    current working directory, and umask.
+    (https://github.com/ansible/ansible/issues/74783)

--- a/changelogs/fragments/74783-run-command-thread-safety.yml
+++ b/changelogs/fragments/74783-run-command-thread-safety.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- ``AnsibleModule.run_command`` - Address thread safety issues, concerning mutating the environment,
+  current working directory, and umask.
+  (https://github.com/ansible/ansible/issues/74783)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1988,7 +1988,8 @@ class AnsibleModule(object):
 
         def preexec():
             self._restore_signal_handlers()
-            os.umask(umask)
+            if umask:
+                os.umask(umask)
 
         kwargs = dict(
             executable=executable,

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1977,10 +1977,11 @@ class AnsibleModule(object):
         # Clean out python paths set by ansiballz
         if 'PYTHONPATH' in env:
             pypaths = [x for x in env['PYTHONPATH'].split(':')
+                       if x and
                        if not x.endswith('/ansible_modlib.zip') and
                        not x.endswith('/debug_dir')]
             if pypaths and any(pypaths):
-                env['PYTHONPATH'] = ':'.join(p for p in pypaths if p)
+                env['PYTHONPATH'] = ':'.join(pypaths)
 
         if data:
             st_in = subprocess.PIPE

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1960,11 +1960,8 @@ class AnsibleModule(object):
 
         env = os.environ.copy()
         # We can set this from both an attribute and per call
-        for key, val in self.run_command_environ_update.items():
-            env[key] = val
-        if environ_update:
-            for key, val in environ_update.items():
-                env[key] = val
+        env.update(self.run_command_environ_update or {})
+        env.update(environ_update or {})
         if path_prefix:
             path = env.get('PATH', '')
             if path:
@@ -1979,13 +1976,11 @@ class AnsibleModule(object):
 
         # Clean out python paths set by ansiballz
         if 'PYTHONPATH' in env:
-            pypaths = env['PYTHONPATH'].split(':')
-            pypaths = [x for x in pypaths
+            pypaths = [x for x in env['PYTHONPATH'].split(':')
                        if not x.endswith('/ansible_modlib.zip') and
                        not x.endswith('/debug_dir')]
-            env['PYTHONPATH'] = ':'.join(pypaths)
-            if not env['PYTHONPATH']:
-                del env['PYTHONPATH']
+            if pypaths and any(pypaths):
+                env['PYTHONPATH'] = ':'.join(p for p in pypaths if p)
 
         if data:
             st_in = subprocess.PIPE


### PR DESCRIPTION
##### SUMMARY
Don't mutate os.environ in AnsibleModule.run_command, make a copy, and pass to Popen. Fixes #74783

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py

##### ADDITIONAL INFORMATION
This PR has been extended to address a few other thread safety issues, specifically with `os.chdir` and `os.umask`
