### PR TITLE
Fix Sphinx 4.0 support for docsite

### DIFF
--- a/docs/docsite/_extensions/pygments_lexer.py
+++ b/docs/docsite/_extensions/pygments_lexer.py
@@ -135,7 +135,7 @@ class AnsibleOutputPrimaryLexer(RegexLexer):
 
         'host-result': [
             (r'\n', token.Text, '#pop'),
-            (r'( +)(ok|changed|failed|skipped|unreachable)(=)([0-9]+)',
+            (r'( +)(ok|changed|failed|skipped|unreachable|rescued|ignored)(=)([0-9]+)',
                 bygroups(token.Text, token.Keyword, token.Punctuation, token.Number.Integer)),
         ],
 

--- a/docs/docsite/_extensions/pygments_lexer.py
+++ b/docs/docsite/_extensions/pygments_lexer.py
@@ -179,7 +179,7 @@ def setup(app):
         See http://www.sphinx-doc.org/en/stable/extdev/index.html#dev-extensions.
     """
     for lexer in [
-        AnsibleOutputLexer(startinline=True)
+        AnsibleOutputLexer
     ]:
         app.add_lexer(lexer.name, lexer)
         for alias in lexer.aliases:


### PR DESCRIPTION
##### SUMMARY
Port of ansible-community/antsibull#273. Sphinx 4 no longer accepts instantiated lexer classes.

CC @abadger @acozine @relrod 

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/_extensions/pygments_lexer.py
