### PR TITLE
Backport PR to fix missing "changed" in net_get to stable-2.9

### DIFF
--- a/changelogs/fragments/74802_net_get_missing_changed.yml
+++ b/changelogs/fragments/74802_net_get_missing_changed.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Backport to fix missing ``changed`` in net_get (https://github.com/ansible/ansible/issues/74802)

--- a/lib/ansible/plugins/action/net_get.py
+++ b/lib/ansible/plugins/action/net_get.py
@@ -36,6 +36,7 @@ display = Display()
 class ActionModule(ActionBase):
 
     def run(self, tmp=None, task_vars=None):
+        changed = False
         socket_path = None
         network_os = self._get_network_os(task_vars)
         persistent_connection = self._play_context.connection.split('.')[-1]


### PR DESCRIPTION
##### SUMMARY

This PR is backporting request to fix net_get module does not initialize ``changed`` value. It will avoid to the following problem:

- Fixes #74802

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/ansible/executor/task_executor.py", line 147, in run
    res = self._execute()
  File "/usr/lib/python2.7/site-packages/ansible/executor/task_executor.py", line 665, in _execute
    result = self._handler.run(task_vars=variables)
  File "/usr/lib/python2.7/site-packages/ansible/plugins/action/net_get.py", line 94, in run
    result['changed'] = changed
UnboundLocalError: local variable 'changed' referenced before assignment
fatal: [192.168.100.100]: FAILED! => {
    "msg": "Unexpected failure during module execution.", 
    "stdout": ""
}
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- net_get on stable-2.9

##### ADDITIONAL INFORMATION
N/A