### PR TITLE
ini: Add parameter to allow no value

### DIFF
--- a/changelogs/fragments/50594_ini.yml
+++ b/changelogs/fragments/50594_ini.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ini - added new parameter ``allow_no_value`` to ini lookup plugin (https://github.com/ansible/ansible/issues/50594).

--- a/lib/ansible/plugins/lookup/ini.py
+++ b/lib/ansible/plugins/lookup/ini.py
@@ -43,6 +43,13 @@ DOCUMENTATION = """
           duplicate key errors if keys only differ in case.
         default: False
         version_added: '2.12'
+      allow_no_value:
+        description:
+        - Read ini file which contains key without value and without '=' symbol.
+        type: bool
+        default: False
+        aliases: ['allow_none']
+        version_added: '2.12'
 """
 
 EXAMPLES = """
@@ -54,7 +61,11 @@ EXAMPLES = """
 
 - debug:
     msg: "{{ item }}"
-  loop: "{{q('ini', '.*', section='section1', file='test.ini', re=True)}}"
+  loop: "{{ q('ini', '.*', section='section1', file='test.ini', re=True) }}"
+
+- name: Read ini file with allow_no_value
+  debug:
+    msg: "{{ lookup('ini', 'user', file='mysql.ini', section='mysqld', allow_no_value=True) }}"
 """
 
 RETURN = """
@@ -127,7 +138,7 @@ class LookupModule(LookupBase):
         self.set_options(var_options=variables, direct=kwargs)
         paramvals = self.get_options()
 
-        self.cp = configparser.ConfigParser()
+        self.cp = configparser.ConfigParser(allow_no_value=paramvals.get('allow_no_value', paramvals.get('allow_none')))
         if paramvals['case_sensitive']:
             self.cp.optionxform = to_native
 

--- a/test/integration/targets/lookup_ini/mysql.ini
+++ b/test/integration/targets/lookup_ini/mysql.ini
@@ -1,0 +1,8 @@
+[mysqld]
+user = mysql
+pid-file = /var/run/mysqld/mysqld.pid
+skip-external-locking
+old_passwords = 1
+skip-bdb
+# we don't need ACID today
+skip-innodb

--- a/test/integration/targets/lookup_ini/test_allow_no_value.yml
+++ b/test/integration/targets/lookup_ini/test_allow_no_value.yml
@@ -1,0 +1,23 @@
+- name: Lookup test
+  hosts: testhost
+  tasks:
+    - name: "Read mysql.ini allow_none=False (default)"
+      set_fact:
+        test1: "{{ lookup('ini', 'user', file='mysql.ini', section='mysqld') }}"
+      register: result
+      ignore_errors: true
+
+    - name: "Read mysql.ini allow_no_value=True"
+      set_fact:
+        test2: "{{ lookup('ini', 'user', file='mysql.ini', section='mysqld', allow_no_value=True) }}"
+
+    - name: "Read mysql.ini allow_none=True"
+      set_fact:
+        test3: "{{ lookup('ini', 'skip-innodb', file='mysql.ini', section='mysqld', allow_none=True) }}"
+
+    - assert:
+        that:
+          - result is failed
+          - test2 == 'mysql'
+          - test3 == []
+          - test3|length == 0

--- a/test/integration/targets/lookup_ini/test_ini.yml
+++ b/test/integration/targets/lookup_ini/test_ini.yml
@@ -1,3 +1,4 @@
 - import_playbook: test_lookup_properties.yml
 - import_playbook: test_errors.yml
 - import_playbook: test_case_sensitive.yml
+- import_playbook: test_allow_no_value.yml


### PR DESCRIPTION
##### SUMMARY

ConfigParser allows to read key with no value.

Fixes: #50594

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/50594_ini.yml
lib/ansible/plugins/lookup/ini.py
test/integration/targets/lookup_ini/mysql.ini
test/integration/targets/lookup_ini/test_allow_no_value.yml
