### PR TITLE
Update network_resources.rst

### DIFF
--- a/docs/docsite/rst/network/getting_started/network_resources.rst
+++ b/docs/docsite/rst/network/getting_started/network_resources.rst
@@ -43,4 +43,4 @@ Join us on:
 
 * Freenode IRC - ``#ansible-network`` Freenode channel
 
-* Slack - `<https://ansiblenetwork.slack.com>`_
+* `Join Ansible Network Slack <https://join.slack.com/t/ansiblenetwork/shared_invite/zt-3zeqmhhx-zuID9uJqbbpZ2KdVeTwvzw>`_ - Network & Security Automation Slack community.  Check out the #devel channel for discussions on module and plugin development.


### PR DESCRIPTION
##### SUMMARY
small patch update to fix documentation to permanent slack invite link so that anyone can join (community, customers, Red Hat employees, partners).

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
network getting started documentation 

##### ADDITIONAL INFORMATION
N/A, came up in conversation related to deprecating irc on freenode