### PR TITLE
Remove deprecated cache support from script inventory plugin

### DIFF
--- a/changelogs/fragments/74143-remove-script-cache.yml
+++ b/changelogs/fragments/74143-remove-script-cache.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- script inventory plugin - Remove deprecated caching support
+  (https://github.com/ansible/ansible/issues/74143)

--- a/lib/ansible/plugins/inventory/script.py
+++ b/lib/ansible/plugins/inventory/script.py
@@ -10,18 +10,6 @@ DOCUMENTATION = '''
     version_added: "2.4"
     short_description: Executes an inventory script that returns JSON
     options:
-      cache:
-        deprecated:
-          why: This option has never been in use. External scripts must implement their own caching.
-          version: "2.12"
-        description:
-          - This option has no effect. The plugin will not cache results because external inventory scripts
-            are responsible for their own caching. This option will be removed in 2.12.
-        ini:
-           - section: inventory_plugin_script
-             key: cache
-        env:
-           - name: ANSIBLE_INVENTORY_PLUGIN_SCRIPT_CACHE
       always_show_stderr:
         description: Toggle display of stderr even when script was successful
         version_added: "2.5.1"
@@ -50,13 +38,13 @@ from ansible.module_utils.basic import json_dict_bytes_to_unicode
 from ansible.module_utils.six import iteritems
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.common._collections_compat import Mapping
-from ansible.plugins.inventory import BaseInventoryPlugin, Cacheable
+from ansible.plugins.inventory import BaseInventoryPlugin
 from ansible.utils.display import Display
 
 display = Display()
 
 
-class InventoryModule(BaseInventoryPlugin, Cacheable):
+class InventoryModule(BaseInventoryPlugin):
     ''' Host inventory parser for ansible using external inventory scripts. '''
 
     NAME = 'script'
@@ -92,13 +80,6 @@ class InventoryModule(BaseInventoryPlugin, Cacheable):
 
         super(InventoryModule, self).parse(inventory, loader, path)
         self.set_options()
-
-        if self.get_option('cache') is not None:
-            display.deprecated(
-                msg="The 'cache' option is deprecated for the script inventory plugin. "
-                "External scripts implement their own caching and this option has never been used",
-                version="2.12", collection_name='ansible.builtin'
-            )
 
         # Support inventory scripts that are not prefixed with some
         # path information but happen to be in the current working

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -121,7 +121,6 @@ lib/ansible/plugins/action/__init__.py pylint:ansible-deprecated-version
 lib/ansible/plugins/action/async_status.py pylint:ansible-deprecated-version
 lib/ansible/plugins/action/normal.py action-plugin-docs # default action plugin for modules without a dedicated action plugin
 lib/ansible/plugins/cache/base.py ansible-doc!skip  # not a plugin, but a stub for backwards compatibility
-lib/ansible/plugins/inventory/script.py pylint:ansible-deprecated-version
 lib/ansible/plugins/lookup/sequence.py pylint:blacklisted-name
 lib/ansible/plugins/strategy/__init__.py pylint:blacklisted-name
 lib/ansible/plugins/strategy/linear.py pylint:blacklisted-name


### PR DESCRIPTION
##### SUMMARY
Remove deprecated cache support from script inventory plugin. Fixes #74143

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/script.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
