### PR TITLE
hostname: Change "strategy" to "use"

### DIFF
--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -52,7 +52,7 @@ EXAMPLES = '''
 - name: Set a hostname specifying strategy
   ansible.builtin.hostname:
     name: web01
-    strategy: systemd
+    use: systemd
 '''
 
 import os


### PR DESCRIPTION
##### SUMMARY

there is an error in the doc:

https://docs.ansible.com/ansible/latest/collections/ansible/builtin/hostname_module.html#id5

```
- name: Set a hostname specifying strategy
  ansible.builtin.hostname:
    name: web01
    strategy: systemd

```

`fatal: [red-hat-test-1]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (ansible.builtin.hostname) module: strategy Supported parameters include: name, use"}`

##### ISSUE TYPE
- Docs Pull Request

