### PR TITLE
Update developing_collections_distributing.rst

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
@@ -216,6 +216,12 @@ To upload the collection artifact with the ``ansible-galaxy`` command:
 
 The ``ansible-galaxy collection publish`` command triggers an import process, just as if you uploaded the collection through the Galaxy website. The command waits until the import process completes before reporting the status back. If you want to continue without waiting for the import result, use the ``--no-wait`` argument and manually look at the import progress in your `My Imports <https://galaxy.ansible.com/my-imports/>`_ page.
 
+Alternatively tt is also possible to publish to Galaxy without configuring the token in :file:`ansible.cfg`.  Use the ``--token`` argument directly on the command line.
+
+.. code-block:: bash
+
+     ansible-galaxy collection publish path/to/my_namespace-my_collection-1.0.0.tar.gz --token abcdefghijklmnopqrtuvwxyz
+
 
 .. _upload_collection_galaxy:
 

--- a/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
@@ -221,7 +221,11 @@ Alternatively, it is also possible to publish to Galaxy without configuring the 
 .. code-block:: bash
 
      ansible-galaxy collection publish path/to/my_namespace-my_collection-1.0.0.tar.gz --token abcdefghijklmnopqrtuvwxyz
+     
+.. note::
 
+	Using the ``--token`` argument is not recommended because passing secrets on the command line may lead to exposing them to others on the system
+	
 
 .. _upload_collection_galaxy:
 

--- a/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
@@ -216,7 +216,7 @@ To upload the collection artifact with the ``ansible-galaxy`` command:
 
 The ``ansible-galaxy collection publish`` command triggers an import process, just as if you uploaded the collection through the Galaxy website. The command waits until the import process completes before reporting the status back. If you want to continue without waiting for the import result, use the ``--no-wait`` argument and manually look at the import progress in your `My Imports <https://galaxy.ansible.com/my-imports/>`_ page.
 
-Alternatively tt is also possible to publish to Galaxy without configuring the token in :file:`ansible.cfg`.  Use the ``--token`` argument directly on the command line.
+Alternatively, it is also possible to publish to Galaxy without configuring the token in :file:`ansible.cfg`.  Use the ``--token`` argument directly on the command line.
 
 .. code-block:: bash
 

--- a/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
@@ -216,7 +216,7 @@ To upload the collection artifact with the ``ansible-galaxy`` command:
 
 The ``ansible-galaxy collection publish`` command triggers an import process, just as if you uploaded the collection through the Galaxy website. The command waits until the import process completes before reporting the status back. If you want to continue without waiting for the import result, use the ``--no-wait`` argument and manually look at the import progress in your `My Imports <https://galaxy.ansible.com/my-imports/>`_ page.
 
-Alternatively, it is also possible to publish to Galaxy without configuring the token in :file:`ansible.cfg`.  Use the ``--token`` argument directly on the command line.
+Alternately, you can publish to Galaxy without configuring the token in :file:`ansible.cfg`.  Use the ``--token`` argument directly on the command line.
 
 .. code-block:: bash
 


### PR DESCRIPTION
##### SUMMARY
It is not clear that you can publish without configuring an ansible.cfg.  The `--token` can be displayed with the `ansible-galaxy collection publish -h` 

```
➜  toolkit git:(master) ✗ ansible-galaxy collection publish -h
usage: ansible-galaxy collection publish [-h] [-s API_SERVER] [--token API_KEY] [-c] [-v] [--no-wait] [--import-timeout IMPORT_TIMEOUT] collection_path

positional arguments:
  collection_path       The path to the collection tarball to publish.

optional arguments:
  -h, --help            show this help message and exit
  -s API_SERVER, --server API_SERVER
                        The Galaxy API server URL
  --token API_KEY, --api-key API_KEY
                        The Ansible Galaxy API key which can be found at https://galaxy.ansible.com/me/preferences.
  -c, --ignore-certs    Ignore SSL certificate validation errors.
  -v, --verbose         verbose mode (-vvv for more, -vvvv to enable connection debugging)
  --no-wait             Don't wait for import validation results.
  --import-timeout IMPORT_TIMEOUT
                        The time to wait for the collection import process to finish.
```

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
https://docs.ansible.com/ansible/devel/dev_guide/developing_collections_distributing.html

##### ADDITIONAL INFORMATION
N/A, trying to increase adoption of Ansible Collections
