### PR TITLE
hostname: add support for Anolis distro

### DIFF
--- a/changelogs/fragments/add-anolis-distro-in-hostname.yaml
+++ b/changelogs/fragments/add-anolis-distro-in-hostname.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- modules - add Anolis distro in hostname.py. project website https://openanolis.org/

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -803,6 +803,12 @@ class CentOSHostname(Hostname):
     strategy_class = RedHatStrategy
 
 
+class AnolisOSHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Anolis'
+    strategy_class = RedHatStrategy
+
+
 class ClearLinuxHostname(Hostname):
     platform = 'Linux'
     distribution = 'Clear-linux-os'


### PR DESCRIPTION
Signed-off-by: Liwei Ge <geliwei@openanolis.org>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
run following command on Anolis OS

ansible -i config localhost -m hostname -a 'name=geliwei'

ansible report platform not support

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
modules/hostname
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
before 
localhost | FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python3.6"
    },
    "changed": false,
    "msg": "hostname module cannot be used on platform Linux (Anolis)"
}

after
localhost | CHANGED => {
    "ansible_facts": {
        "ansible_domain": "",
        "ansible_fqdn": "geliwei",
        "ansible_hostname": "geliwei",
        "ansible_nodename": "geliwei",
        "discovered_interpreter_python": "/usr/bin/python3.6"
    },
    "changed": true,
    "name": "geliwei"
}
```
