### PR TITLE
config: small typo fix

### DIFF
--- a/changelogs/fragments/70028-config-small-typo-fix.yml
+++ b/changelogs/fragments/70028-config-small-typo-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - config - use ``callbacks_enabled`` instead ``callback_enabled`` in a deprecated message (https://github.com/ansible/ansible/issues/70028).

--- a/docs/docsite/rst/plugins/callback.rst
+++ b/docs/docsite/rst/plugins/callback.rst
@@ -34,7 +34,7 @@ Most callbacks shipped with Ansible are disabled by default and need to be enabl
 
 .. code-block:: ini
 
-  #callback_enabled = timer, mail, profile_roles, collection_namespace.collection_name.custom_callback
+  #callbacks_enabled = timer, mail, profile_roles, collection_namespace.collection_name.custom_callback
 
 Setting a callback plugin for ``ansible-playbook``
 --------------------------------------------------

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -84,7 +84,7 @@
 # by default.
 #
 # Enable callback plugins, they can output to stdout but cannot be 'stdout' type.
-#callback_enabled = timer, mail
+#callbacks_enabled = timer, mail
 
 # Determine whether includes in tasks and handlers are "static" by
 # default. As of 2.0, includes are dynamic by default. Setting these

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -574,7 +574,7 @@ CALLBACKS_ENABLED:
     deprecated:
       why: normalizing names to new standard
       version: "2.15"
-      alternatives: 'callback_enabled'
+      alternatives: 'callbacks_enabled'
   - key: callbacks_enabled
     section: defaults
     version_added: '2.11'


### PR DESCRIPTION
##### SUMMARY
After 4b673484f06fa9464601c27706c8a43d1e11bbcb the deprecated message points to non-existent option `callback_enabled` instead `callbacks_enabled`.

#70028

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
config, examples

##### ADDITIONAL INFORMATION
Before:
```
[DEPRECATION WARNING]: [defaults]callback_whitelist option, normalizing names to new standard, use callback_enabled instead. This feature will be removed from ansible-core in version 
2.15. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```
After
```
[DEPRECATION WARNING]: [defaults]callback_whitelist option, normalizing names to new standard, use callbacks_enabled instead. This feature will be removed from ansible-core in version 
2.15. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```
