### PR TITLE
apt module: add option to allow package downgrades

### DIFF
--- a/changelogs/fragments/74852-apt-allow-downgrade.yaml
+++ b/changelogs/fragments/74852-apt-allow-downgrade.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - apt - added an ``allow_downgrade`` option to enable safe downgrade of packages without using ``force`` which doesn't verify signatures.
+  - apt - added an ``allow_downgrade`` option to enable safe downgrade of packages without using ``force`` which doesn't verify signatures (https://github.com/ansible/ansible/issues/29451, https://github.com/ansible/ansible/pull/74852).

--- a/changelogs/fragments/74852-apt-allow-downgrade.yaml
+++ b/changelogs/fragments/74852-apt-allow-downgrade.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - apt - added an ``allow_downgrade`` option to enable safe downgrade of packages without using ``force`` which doesn't verify signatures.

--- a/changelogs/fragments/apt_allow_downgrade.yml
+++ b/changelogs/fragments/apt_allow_downgrade.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - apt, added an 'allow_downgrade' option to enable downgrade of packages without using 'force' dangerously which doesn't verify signatures

--- a/changelogs/fragments/apt_allow_downgrade.yml
+++ b/changelogs/fragments/apt_allow_downgrade.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - apt, added an 'allow_downgrade' option to enable downgrade of packages without using 'force' dangerously which doesn't verify signatures

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -75,7 +75,7 @@ options:
     type: bool
   force:
     description:
-      - 'Corresponds to the C(--force-yes) to I(apt-get) and implies C(allow_unauthenticated: yes)'
+      - 'Corresponds to the C(--force-yes) to I(apt-get) and implies C(allow_unauthenticated: yes) and C(allow_downgrade: yes)'
       - "This option will disable checking both the packages' signatures and the certificates of the
         web servers they are downloaded from."
       - 'This option *is not* the equivalent of passing the C(-f) flag to I(apt-get) on the command line'
@@ -91,6 +91,16 @@ options:
     type: bool
     default: 'no'
     version_added: "2.1"
+  allow_downgrade:
+    description:
+      - Corresponds to the C(--allow-downgrades) option for I(apt)
+      - This option enables the named package and version to replace an already installed higher version of that package.
+      - Note that setting allow_downgrade=True can make this module behave in a non-idempotent way.
+      - (The task could end up with a set of packages that does not match the complete list of specified packages to install).
+    aliases: [ allow-downgrade, allow_downgrades, allow-downgrades ]
+    type: bool
+    default: 'no'
+    version_added: "2.12"
   upgrade:
     description:
       - If yes or safe, performs an aptitude safe-upgrade.
@@ -217,6 +227,12 @@ EXAMPLES = '''
     state: latest
     default_release: squeeze-backports
     update_cache: yes
+
+- name: Install the version '1.18.0' of package "nginx" and allow potential downgrades
+  apt:
+    name: nginx=1.18.0
+    state: present
+    allow_downgrade: yes
 
 - name: Install zfsutils-linux with ensuring conflicted packages (e.g. zfs-fuse) will not be removed.
   apt:
@@ -654,7 +670,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
             install_recommends=None, force=False,
             dpkg_options=expand_dpkg_options(DPKG_OPTIONS),
             build_dep=False, fixed=False, autoremove=False, fail_on_autoremove=False, only_upgrade=False,
-            allow_unauthenticated=False):
+            allow_unauthenticated=False, allow_downgrade=False):
     pkg_list = []
     packages = ""
     pkgspec = expand_pkgspec_from_fnmatches(m, pkgspec, cache)
@@ -729,6 +745,9 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         if allow_unauthenticated:
             cmd += " --allow-unauthenticated"
 
+        if allow_downgrade:
+            cmd += " --allow-downgrades"
+
         with PolicyRcD(m):
             rc, out, err = m.run_command(cmd)
 
@@ -765,7 +784,7 @@ def get_field_of_deb(m, deb_file, field="Version"):
     return to_native(stdout).strip('\n')
 
 
-def install_deb(m, debs, cache, force, fail_on_autoremove, install_recommends, allow_unauthenticated, dpkg_options):
+def install_deb(m, debs, cache, force, fail_on_autoremove, install_recommends, allow_unauthenticated, allow_downgrade, dpkg_options):
     changed = False
     deps_to_install = []
     pkgs_to_install = []
@@ -789,8 +808,11 @@ def install_deb(m, debs, cache, force, fail_on_autoremove, install_recommends, a
                 # Must not be installed, continue with installation
                 pass
             # Check if package is installable
-            if not pkg.check() and not force:
-                m.fail_json(msg=pkg._failure_string)
+            if not pkg.check():
+                if force or ("later version" in pkg._failure_string and allow_downgrade):
+                    pass
+                else:
+                    m.fail_json(msg=pkg._failure_string)
 
             # add any missing deps to the list of deps we need
             # to install so they're all done in one shot
@@ -809,6 +831,7 @@ def install_deb(m, debs, cache, force, fail_on_autoremove, install_recommends, a
                                      install_recommends=install_recommends,
                                      fail_on_autoremove=fail_on_autoremove,
                                      allow_unauthenticated=allow_unauthenticated,
+                                     allow_downgrade=allow_downgrade,
                                      dpkg_options=expand_dpkg_options(dpkg_options))
         if not success:
             m.fail_json(**retvals)
@@ -939,6 +962,7 @@ def upgrade(m, mode="yes", force=False, default_release=None,
             use_apt_get=False,
             dpkg_options=expand_dpkg_options(DPKG_OPTIONS), autoremove=False, fail_on_autoremove=False,
             allow_unauthenticated=False,
+            allow_downgrade=False,
             ):
 
     if autoremove:
@@ -986,6 +1010,8 @@ def upgrade(m, mode="yes", force=False, default_release=None,
 
     allow_unauthenticated = '--allow-unauthenticated' if allow_unauthenticated else ''
 
+    allow_downgrade = '--allow-downgrades' if allow_downgrade else ''
+
     if apt_cmd is None:
         if use_apt_get:
             apt_cmd = APT_GET_CMD
@@ -994,7 +1020,16 @@ def upgrade(m, mode="yes", force=False, default_release=None,
                             "to have APTITUDE in path or use 'force_apt_get=True'")
     apt_cmd_path = m.get_bin_path(apt_cmd, required=True)
 
-    cmd = '%s -y %s %s %s %s %s %s' % (apt_cmd_path, dpkg_options, force_yes, fail_on_autoremove, allow_unauthenticated, check_arg, upgrade_command)
+    cmd = '%s -y %s %s %s %s %s %s %s' % (
+        apt_cmd_path,
+        dpkg_options,
+        force_yes,
+        fail_on_autoremove,
+        allow_unauthenticated,
+        allow_downgrade,
+        check_arg,
+        upgrade_command,
+    )
 
     if default_release:
         cmd += " -t '%s'" % (default_release,)
@@ -1085,6 +1120,7 @@ def main():
             only_upgrade=dict(type='bool', default=False),
             force_apt_get=dict(type='bool', default=False),
             allow_unauthenticated=dict(type='bool', default=False, aliases=['allow-unauthenticated']),
+            allow_downgrade=dict(type='bool', default=False, aliases=['allow-downgrade', 'allow_downgrades', 'allow-downgrades']),
             lock_timeout=dict(type='int', default=60),
         ),
         mutually_exclusive=[['deb', 'package', 'upgrade']],
@@ -1168,6 +1204,7 @@ def main():
     updated_cache_time = 0
     install_recommends = p['install_recommends']
     allow_unauthenticated = p['allow_unauthenticated']
+    allow_downgrade = p['allow_downgrade']
     dpkg_options = expand_dpkg_options(p['dpkg_options'])
     autoremove = p['autoremove']
     fail_on_autoremove = p['fail_on_autoremove']
@@ -1238,7 +1275,18 @@ def main():
             force_yes = p['force']
 
             if p['upgrade']:
-                upgrade(module, p['upgrade'], force_yes, p['default_release'], use_apt_get, dpkg_options, autoremove, fail_on_autoremove, allow_unauthenticated)
+                upgrade(
+                    module,
+                    p['upgrade'],
+                    force_yes,
+                    p['default_release'],
+                    use_apt_get,
+                    dpkg_options,
+                    autoremove,
+                    fail_on_autoremove,
+                    allow_unauthenticated,
+                    allow_downgrade
+                )
 
             if p['deb']:
                 if p['state'] != 'present':
@@ -1248,6 +1296,7 @@ def main():
                 install_deb(module, p['deb'], cache,
                             install_recommends=install_recommends,
                             allow_unauthenticated=allow_unauthenticated,
+                            allow_downgrade=allow_downgrade,
                             force=force_yes, fail_on_autoremove=fail_on_autoremove, dpkg_options=p['dpkg_options'])
 
             unfiltered_packages = p['package'] or ()
@@ -1258,7 +1307,18 @@ def main():
             if latest and all_installed:
                 if packages:
                     module.fail_json(msg='unable to install additional packages when upgrading all installed packages')
-                upgrade(module, 'yes', force_yes, p['default_release'], use_apt_get, dpkg_options, autoremove, fail_on_autoremove, allow_unauthenticated)
+                upgrade(
+                    module,
+                    'yes',
+                    force_yes,
+                    p['default_release'],
+                    use_apt_get,
+                    dpkg_options,
+                    autoremove,
+                    fail_on_autoremove,
+                    allow_unauthenticated,
+                    allow_downgrade
+                )
 
             if packages:
                 for package in packages:
@@ -1298,7 +1358,8 @@ def main():
                     autoremove=autoremove,
                     fail_on_autoremove=fail_on_autoremove,
                     only_upgrade=p['only_upgrade'],
-                    allow_unauthenticated=allow_unauthenticated
+                    allow_unauthenticated=allow_unauthenticated,
+                    allow_downgrade=allow_downgrade
                 )
 
                 # Store if the cache has been updated

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -95,7 +95,7 @@ options:
     description:
       - Corresponds to the C(--allow-downgrades) option for I(apt).
       - This option enables the named package and version to replace an already installed higher version of that package.
-      - Note that setting allow_downgrade=True can make this module behave in a non-idempotent way.
+      - Note that setting I(allow_downgrade=true) can make this module behave in a non-idempotent way.
       - (The task could end up with a set of packages that does not match the complete list of specified packages to install).
     aliases: [ allow-downgrade, allow_downgrades, allow-downgrades ]
     type: bool

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -93,7 +93,7 @@ options:
     version_added: "2.1"
   allow_downgrade:
     description:
-      - Corresponds to the C(--allow-downgrades) option for I(apt)
+      - Corresponds to the C(--allow-downgrades) option for I(apt).
       - This option enables the named package and version to replace an already installed higher version of that package.
       - Note that setting allow_downgrade=True can make this module behave in a non-idempotent way.
       - (The task could end up with a set of packages that does not match the complete list of specified packages to install).

--- a/test/integration/targets/apt/tasks/downgrade.yml
+++ b/test/integration/targets/apt/tasks/downgrade.yml
@@ -1,0 +1,77 @@
+- block:
+  - name: Disable ubuntu repos so system packages are not upgraded and do not change testing env
+    command: mv /etc/apt/sources.list /etc/apt/sources.list.backup
+
+  - name: install latest foo
+    apt:
+      name: foo
+      state: latest
+      allow_unauthenticated: yes
+
+  - name: check foo version
+    shell: dpkg -s foo | grep Version | awk '{print $2}'
+    register: apt_downgrade_foo_version
+
+  - name: ensure the correct version of foo has been installed
+    assert:
+      that:
+        - "'1.0.1' in apt_downgrade_foo_version.stdout"
+
+  - name: try to downgrade foo
+    apt:
+      name: foo=1.0.0
+      state: present
+      allow_unauthenticated: yes
+    ignore_errors: yes
+    register: apt_downgrade_foo_fail
+
+  - name: verify failure of downgrading without allow downgrade flag
+    assert:
+      that:
+        - apt_downgrade_foo_fail is failed
+
+  - name: try to downgrade foo with flag
+    apt:
+      name: foo=1.0.0
+      state: present
+      allow_downgrade: yes
+      allow_unauthenticated: yes
+    register: apt_downgrade_foo_succeed
+
+  - name: verify success of downgrading with allow downgrade flag
+    assert:
+      that:
+        - apt_downgrade_foo_succeed is success
+
+  - name: check foo version
+    shell: dpkg -s foo | grep Version | awk '{print $2}'
+    register: apt_downgrade_foo_version
+
+  - name: check that version downgraded correctly
+    assert:
+      that:
+        - "'1.0.0' in apt_downgrade_foo_version.stdout"
+        - "{{ apt_downgrade_foo_version.changed }}"
+
+  - name: downgrade foo with flag again
+    apt:
+      name: foo=1.0.0
+      state: present
+      allow_downgrade: yes
+      allow_unauthenticated: yes
+    register: apt_downgrade_second_downgrade
+
+  - name: check that nothing has changed (idempotent)
+    assert:
+      that:
+        - "apt_downgrade_second_downgrade.changed == false"
+
+  always:
+    - name: Clean up
+      apt:
+        pkg: foo,foobar
+        state: absent
+        autoclean: yes
+
+    - name: Restore ubuntu repos
+      command: mv /etc/apt/sources.list.backup /etc/apt/sources.list

--- a/test/integration/targets/apt/tasks/repo.yml
+++ b/test/integration/targets/apt/tasks/repo.yml
@@ -210,6 +210,8 @@
     - name: Restore ubuntu repos
       command: mv /etc/apt/sources.list.backup /etc/apt/sources.list
 
+- name: Downgrades
+  import_tasks: "downgrade.yml"
 
 - name: Upgrades
   block:


### PR DESCRIPTION
##### SUMMARY
Adds an `allow_downgrade` option to the apt module so that package downgrades can be safely performed without using `force: yes`.

On Ansible codebase audits I have seen organizations use `force: yes` when needing to downgrade a package. It's suggested online as the solution whenever the question of how to perform apt downgrades is asked e.g. [this](https://stackoverflow.com/questions/56332649/is-there-a-way-to-allow-downgrades-with-apt-ansible-module) and [this](https://groups.google.com/g/ansible-project/c/EGDNG1XzzOA). This is bad since `force: yes` also disables package signatures, and as the docs say, should almost never be used. It makes an organization vulnerable to supply-chain attacks from their package mirror, and man-in-the-middle attackers if HTTP transport is used.

Apt(-get) has an `--allow-downgrades` option so this PR just adds a way to use that, as well as integration tests based on the package upgrade tests. `allow_downgrade` was chosen as the canonical option name so it matches the option in the yum and dnf modules, but the plural is set as an alias.

Fixes https://github.com/ansible/ansible/issues/29451

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
apt module

##### ADDITIONAL INFORMATION
Two previous PRs were opened a while ago and stuck in limbo for this feature as integration tests were never added: https://github.com/ansible/ansible/pull/21514 https://github.com/ansible/ansible/pull/33677

From the amount of activity on those PRs, the popularity of allow-downgrades can be seen, and I believe this is important for improving the security of Ansible users.