### PR TITLE
make collection warning message clearer

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1203,7 +1203,7 @@ class GalaxyCLI(CLI):
         if len([p for p in collections_path if p.startswith(path)]) == 0:
             display.warning("The specified collections path '%s' is not part of the configured Ansible "
                             "collections paths '%s'. The installed collection won't be picked up in an Ansible "
-                            "run." % (to_text(path), to_text(":".join(collections_path))))
+                            "run, unless within a playbook adjacent collections directory." % (to_text(path), to_text(":".join(collections_path))))
 
         output_path = validate_collection_path(path)
         b_output_path = to_bytes(output_path, errors='surrogate_or_strict')

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1203,7 +1203,7 @@ class GalaxyCLI(CLI):
         if len([p for p in collections_path if p.startswith(path)]) == 0:
             display.warning("The specified collections path '%s' is not part of the configured Ansible "
                             "collections paths '%s'. The installed collection will not be picked up in an Ansible "
-                            "run, unless adjacent to a playbook." % (to_text(path), to_text(":".join(collections_path))))
+                            "run, unless within a playbook-adjacent collections directory." % (to_text(path), to_text(":".join(collections_path))))
 
         output_path = validate_collection_path(path)
         b_output_path = to_bytes(output_path, errors='surrogate_or_strict')

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1202,8 +1202,8 @@ class GalaxyCLI(CLI):
         collections_path = C.COLLECTIONS_PATHS
         if len([p for p in collections_path if p.startswith(path)]) == 0:
             display.warning("The specified collections path '%s' is not part of the configured Ansible "
-                            "collections paths '%s'. The installed collection won't be picked up in an Ansible "
-                            "run, unless within a playbook adjacent collections directory." % (to_text(path), to_text(":".join(collections_path))))
+                            "collections paths '%s'. The installed collection will not be picked up in an Ansible "
+                            "run, unless adjacent to a playbook." % (to_text(path), to_text(":".join(collections_path))))
 
         output_path = validate_collection_path(path)
         b_output_path = to_bytes(output_path, errors='surrogate_or_strict')


### PR DESCRIPTION
##### SUMMARY
Fix for #74767 collection warning message 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/cli

##### ADDITIONAL INFORMATION
Make the warning message state clearer and state that it will pick up a collection if it's within a playbook adjacent directory.
