### PR TITLE
service_mgr: Detect runit, even if unable to read /proc/1/comm

### DIFF
--- a/changelogs/fragments/74867-service_mgr_runit_detection_fallback.yaml
+++ b/changelogs/fragments/74867-service_mgr_runit_detection_fallback.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - module_utils - detect symlinked init systems, even if unable to read /proc/1/comm (https://github.com/ansible/ansible/issues/74866).

--- a/lib/ansible/module_utils/facts/system/service_mgr.py
+++ b/lib/ansible/module_utils/facts/system/service_mgr.py
@@ -98,6 +98,9 @@ class ServiceMgrFactCollector(BaseFactCollector):
         if proc_1 == "COMMAND\n":
             proc_1 = None
 
+        if proc_1 is None and os.path.islink('/sbin/init'):
+            proc_1 = os.readlink('/sbin/init')
+
         # FIXME: empty string proc_1 staus empty string
         if proc_1 is not None:
             proc_1 = os.path.basename(proc_1)


### PR DESCRIPTION
##### SUMMARY

* service_mgr=runit if detection via /proc/1/comm fails and /sbin/runit exists
* Fixes #74866.

##### ISSUE TYPE

* Bugfix Pull Request

##### COMPONENT NAME

* module_utils
