### PR TITLE
items2dict: handle exception

### DIFF
--- a/changelogs/fragments/items2dict.yml
+++ b/changelogs/fragments/items2dict.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- items2dict - handle exception in items2dict filter.

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -179,7 +179,7 @@ In this example, you must pass the ``key_name`` and ``value_name`` arguments to 
 
     {{ tags | items2dict(key_name='fruit', value_name='color') }}
 
-If you do not pass these arguments, or do not pass the correct values for your list, you will see ``KeyError: key`` or ``KeyError: my_typo`` prior to 2.12 and ``items2dict failed`` from 2.12 and onwards.
+If you do not pass these arguments, or do not pass the correct values for your list, you will see ``items2dict failed``.
 
 Forcing the data type
 ---------------------

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -179,7 +179,7 @@ In this example, you must pass the ``key_name`` and ``value_name`` arguments to 
 
     {{ tags | items2dict(key_name='fruit', value_name='color') }}
 
-If you do not pass these arguments, or do not pass the correct values for your list, you will see ``KeyError: key`` or ``KeyError: my_typo``.
+If you do not pass these arguments, or do not pass the correct values for your list, you will see ``KeyError: key`` or ``KeyError: my_typo`` prior to 2.12 and ``items2dict failed`` from 2.12 and onwards.
 
 Forcing the data type
 ---------------------

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -546,7 +546,11 @@ def list_of_dict_key_value_elements_to_dict(mylist, key_name='key', value_name='
     if not is_sequence(mylist):
         raise AnsibleFilterTypeError("items2dict requires a list, got %s instead." % type(mylist))
 
-    return dict((item[key_name], item[value_name]) for item in mylist)
+    try:
+        return dict((item[key_name], item[value_name]) for item in mylist)
+    except KeyError:
+        raise AnsibleFilterError("items2dict failed, key: '%s' and/or value '%s' "
+                                 "are not available in all the members of list" % (key_name, value_name))
 
 
 def path_join(paths):

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -572,12 +572,24 @@
   ignore_errors: yes
   register: items2dict_fail
 
+- name: Verify items2dict throws error on KeyError
+  set_fact:
+    foo: "{{ files | dict2items | items2dict(key_name='file', value_name='path') }}"
+  vars:
+    files:
+      users: /etc/passwd
+      groups: /etc/group
+  ignore_errors: yes
+  register: items2dict_fail2
+
 - name: Verify items2dict
   assert:
     that:
       - '[{"key": "foo", "value": "bar"}, {"key": "banana", "value": "fruit"}]|items2dict == {"foo": "bar", "banana": "fruit"}'
       - items2dict_fail is failed
       - '"items2dict requires a list" in items2dict_fail.msg'
+      - items2dict_fail2 is failed
+      - '"items2dict failed" in items2dict_fail2.msg'
 
 - name: Verify path_join throws on non-string and non-sequence
   set_fact:


### PR DESCRIPTION
##### SUMMARY

When key_name and value_name are not present in dict,
it raises KeyError. Handle this error using AnsibleFilterError.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/items2dict.yml
lib/ansible/plugins/filter/core.py
test/integration/targets/filter_core/tasks/main.yml
