### PR TITLE
[validate-modules] Allow argspec modifiers to be a part of docstring

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -342,6 +342,7 @@ class DocCLI(CLI, RoleMixin):
 
     # default ignore list for detailed views
     IGNORE = ('module', 'docuri', 'version_added', 'short_description', 'now_date', 'plainexamples', 'returndocs', 'collection')
+    ARGUMENT_SPEC_MODIFIERS = ('mutually_exclusive', 'required_together', 'required_one_of', 'required_if', 'required_by',)
 
     # Warning: If you add more elements here, you also need to add it to the docsite build (in the
     # ansible-community/antsibull repo)
@@ -1215,8 +1216,17 @@ class DocCLI(CLI, RoleMixin):
         if doc.pop('has_action', False):
             text.append("  * note: %s\n" % "This module has a corresponding action plugin.")
 
+        if doc.pop('supports_check_mode', False):
+            text.append("  * note: %s\n" % "This module supports check mode.")
+
         if doc.get('options', False):
             text.append("OPTIONS (= is mandatory):\n")
+
+            for k in DocCLI.ARGUMENT_SPEC_MODIFIERS:
+                if doc.get(k):
+                    text.append(DocCLI._dump_yaml({k: doc[k]}, ""))
+                    doc.pop(k)
+
             DocCLI.add_fields(text, doc.pop('options'), limit, opt_indent)
             text.append('')
 

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -317,23 +317,24 @@ def version_added(v, error_code='version-added-invalid', accept_historical=False
 
 
 def list_dict_option_schema(for_collection):
+    subop_schema = {
+        Required('description'): Any(list_string_types, *string_types),
+        'required': bool,
+        'choices': list,
+        'aliases': Any(list_string_types),
+        'version_added': version(for_collection),
+        'version_added_collection': collection_name,
+        'default': json_value,
+        # Note: Types are strings, not literal bools, such as True or False
+        'type': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
+        # in case of type='list' elements define type of individual item in list
+        'elements': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
+        # Recursive suboptions
+        'suboptions': Any(None, *list({str_type: Self} for str_type in string_types)),
+    }
+    subop_schema.update(argument_spec_modifiers)
     suboption_schema = Schema(
-        {
-            Required('description'): Any(list_string_types, *string_types),
-            'required': bool,
-            'choices': list,
-            'aliases': Any(list_string_types),
-            'version_added': version(for_collection),
-            'version_added_collection': collection_name,
-            'default': json_value,
-            # Note: Types are strings, not literal bools, such as True or False
-            'type': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
-            # in case of type='list' elements define type of individual item in list
-            'elements': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
-            # Recursive suboptions
-            'suboptions': Any(None, *list({str_type: Self} for str_type in string_types)),
-            **argument_spec_modifiers,
-        },
+        subop_schema,
         extra=PREVENT_EXTRA
     )
 
@@ -341,22 +342,23 @@ def list_dict_option_schema(for_collection):
     # for example in Python 3: {str: suboption_schema}
     list_dict_suboption_schema = [{str_type: suboption_schema} for str_type in string_types]
 
+    op_schema = {
+        Required('description'): Any(list_string_types, *string_types),
+        'required': bool,
+        'choices': list,
+        'aliases': Any(list_string_types),
+        'version_added': version(for_collection),
+        'version_added_collection': collection_name,
+        'default': json_value,
+        'suboptions': Any(None, *list_dict_suboption_schema),
+        # Note: Types are strings, not literal bools, such as True or False
+        'type': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
+        # in case of type='list' elements define type of individual item in list
+        'elements': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
+    }
+    op_schema.update(argument_spec_modifiers)
     option_schema = Schema(
-        {
-            Required('description'): Any(list_string_types, *string_types),
-            'required': bool,
-            'choices': list,
-            'aliases': Any(list_string_types),
-            'version_added': version(for_collection),
-            'version_added_collection': collection_name,
-            'default': json_value,
-            'suboptions': Any(None, *list_dict_suboption_schema),
-            # Note: Types are strings, not literal bools, such as True or False
-            'type': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
-            # in case of type='list' elements define type of individual item in list
-            'elements': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
-            **argument_spec_modifiers,
-        },
+        op_schema,
         extra=PREVENT_EXTRA
     )
 

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -332,6 +332,7 @@ def list_dict_option_schema(for_collection):
             'elements': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
             # Recursive suboptions
             'suboptions': Any(None, *list({str_type: Self} for str_type in string_types)),
+            **argument_spec_modifiers,
         },
         extra=PREVENT_EXTRA
     )
@@ -354,6 +355,7 @@ def list_dict_option_schema(for_collection):
             'type': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
             # in case of type='list' elements define type of individual item in list
             'elements': Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str'),
+            **argument_spec_modifiers,
         },
         extra=PREVENT_EXTRA
     )


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- In order to dynamically generate the module argspec from docstring we would require all keys that argspec supports to be a valid in docstring as well. 
- Currently, `validate-modules` complains if docstring contains any of the argspec modifiers since those are not a part of the defined schema. This patch attempts to add it there.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
validate_modules/schema.py
