### PR TITLE
Allow omit to work with include_role from_args

### DIFF
--- a/changelogs/fragments/66349-include-role-omit.yml
+++ b/changelogs/fragments/66349-include-role-omit.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- >-
+  ``include_role`` - Allow use of ``omit`` in the ``from_*`` arguments
+  (https://github.com/ansible/ansible/issues/66349)

--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -23,6 +23,7 @@ import os
 
 from ansible import constants as C
 from ansible.errors import AnsibleError
+from ansible.executor.task_executor import remove_omit
 from ansible.module_utils._text import to_text
 from ansible.playbook.handler import Handler
 from ansible.playbook.task_include import TaskInclude
@@ -190,6 +191,10 @@ class IncludedFile:
                             if from_arg in include_args:
                                 from_key = from_arg.replace('_from', '')
                                 new_task._from_files[from_key] = templar.template(include_args.pop(from_arg))
+
+                        omit_token = task_vars.get('omit')
+                        if omit_token:
+                            new_task._from_files = remove_omit(new_task._from_files, omit_token)
 
                         inc_file = IncludedFile(role_name, include_args, special_vars, new_task, is_role=True)
 

--- a/test/integration/targets/include_import/include_role_omit/playbook.yml
+++ b/test/integration/targets/include_import/include_role_omit/playbook.yml
@@ -1,0 +1,12 @@
+- hosts: localhost
+  gather_facts: false
+  vars:
+    include_role_omit: false
+  tasks:
+    - include_role:
+        name: foo
+        tasks_from: '{{ omit }}'
+
+    - assert:
+        that:
+          - include_role_omit is sameas(true)

--- a/test/integration/targets/include_import/include_role_omit/roles/foo/tasks/main.yml
+++ b/test/integration/targets/include_import/include_role_omit/roles/foo/tasks/main.yml
@@ -1,0 +1,2 @@
+- set_fact:
+    include_role_omit: true

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -126,3 +126,5 @@ ANSIBLE_HOST_PATTERN_MISMATCH=error ansible-playbook empty_group_warning/playboo
 
 ansible-playbook test_include_loop.yml "$@"
 ansible-playbook test_include_loop_fqcn.yml "$@"
+
+ansible-playbook include_role_omit/playbook.yml "$@"


### PR DESCRIPTION
##### SUMMARY
Allow omit to work with include_role from_args. Fixes #66349

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/playbook/included_file.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
