### PR TITLE
[2.11] Basic: don't call lstat when check_mode

### DIFF
--- a/changelogs/fragments/61185-basic.py-fix-check_mode.yaml
+++ b/changelogs/fragments/61185-basic.py-fix-check_mode.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- AnsibleModule.set_mode_if_different - don't check file existence when check_mode is activated (https://github.com/ansible/ansible/issues/61185).

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -882,10 +882,11 @@ class AnsibleModule(object):
         b_path = to_bytes(path, errors='surrogate_or_strict')
         if expand:
             b_path = os.path.expanduser(os.path.expandvars(b_path))
-        path_stat = os.lstat(b_path)
 
         if self.check_file_absent_if_check_mode(b_path):
             return True
+
+        path_stat = os.lstat(b_path)
 
         if not isinstance(mode, int):
             try:

--- a/test/units/module_utils/basic/test_set_mode_if_different.py
+++ b/test/units/module_utils/basic/test_set_mode_if_different.py
@@ -100,6 +100,13 @@ def test_mode_unchanged_when_already_0660(am, mock_stats, mocker, mode, check_mo
     assert not m_lchmod.called
 
 
+@pytest.mark.parametrize('mode, stdin', product(SYNONYMS_0660, ({},)), indirect=['stdin'])
+def test_mode_changed_to_0660_check_mode_no_file(am, mocker, mode):
+    am.check_mode = True
+    mocker.patch('os.path.exists', return_value=False)
+    assert am.set_mode_if_different('/path/to/file', mode, False)
+
+
 @pytest.mark.parametrize('check_mode, stdin',
                          product((True, False), ({},)),
                          indirect=['stdin'])


### PR DESCRIPTION
##### SUMMARY
Backport of #64279 to stable-2.11.

(See also ansible-collections/community.crypto#242, another crash caused by this bug.)

CC @logistic-bot

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py
