### PR TITLE
unarchive: handle exception

### DIFF
--- a/test/units/modules/test_unarchive.py
+++ b/test/units/modules/test_unarchive.py
@@ -3,74 +3,47 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-import pytest
-
 from ansible.modules.unarchive import ZipArchive, TgzArchive
 
 
-class AnsibleModuleExit(Exception):
-    def __init__(self, *args, **kwargs):
-        self.args = args
-        self.kwargs = kwargs
-
-
-class ExitJson(AnsibleModuleExit):
-    pass
-
-
-class FailJson(AnsibleModuleExit):
-    pass
-
-
-@pytest.fixture
-def fake_ansible_module():
-    return FakeAnsibleModule()
-
-
-class FakeAnsibleModule:
-    def __init__(self):
-        self.params = {}
-        self.tmpdir = None
-
-    def exit_json(self, *args, **kwargs):
-        raise ExitJson(*args, **kwargs)
-
-    def fail_json(self, *args, **kwargs):
-        raise FailJson(*args, **kwargs)
-
-
 class TestCaseZipArchive:
-    def test_no_zip_binary(self, mocker, fake_ansible_module):
-        mocker.patch("ansible.modules.unarchive.get_bin_path", side_effect=ValueError)
+    def test_no_zip_binary(self, mocker):
+        fake_ansible_module = mocker.Mock()
+        fake_ansible_module.get_bin_path = mocker.Mock(return_value=None)
         fake_ansible_module.params = {
             "extra_opts": "",
             "exclude": "",
             "include": "",
         }
-        with pytest.raises(FailJson) as exec_info:
-            z = ZipArchive(
-                src="",
-                b_dest="",
-                file_args="",
-                module=fake_ansible_module,
-            )
-        assert "Unable to find required" in exec_info.value.kwargs["msg"]
+
+        zip_obj = ZipArchive(
+            src="",
+            b_dest="",
+            file_args="",
+            module=fake_ansible_module,
+        )
+        status, msg = zip_obj.can_handle_archive()
+        assert not status
+        assert 'Command "unzip"' in msg
 
 
 class TestCaseTgzArchive:
-    def test_no_tar_binary(self, mocker, fake_ansible_module):
-        mocker.patch("ansible.modules.unarchive.get_bin_path", side_effect=ValueError)
+    def test_no_tar_binary(self, mocker):
+        fake_ansible_module = mocker.Mock()
+        fake_ansible_module.get_bin_path = mocker.Mock(return_value=None)
+        fake_ansible_module.check_mode = False
         fake_ansible_module.params = {
             "extra_opts": "",
             "exclude": "",
             "include": "",
         }
-        fake_ansible_module.check_mode = False
-        with pytest.raises(FailJson) as exec_info:
-            z = TgzArchive(
-                src="",
-                b_dest="",
-                file_args="",
-                module=fake_ansible_module,
-            )
-        assert "Unable to find required" in exec_info.value.kwargs["msg"]
+        tgz_obj = TgzArchive(
+            src="",
+            b_dest="",
+            file_args="",
+            module=fake_ansible_module,
+        )
+
+        status, msg = tgz_obj.can_handle_archive()
+        assert not status
+        assert 'Command "gtar"' in msg


### PR DESCRIPTION
##### SUMMARY

Do not use ``fail_json`` API if ``get_bin_path`` does not find
required binaries.

Resolves regression introduced by #74632

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/unarchive.py
test/units/modules/test_unarchive.py
