### PR TITLE
documents community 'extra docs' option in collections

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections_structure.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_structure.rst
@@ -65,8 +65,8 @@ For community collections included in the Ansible PyPI package, docs.ansible.com
    ---
    sections:
    - title: Scenario Guide
-   toctree:
-     - scenario_guide
+     toctree:
+       - scenario_guide
 
 The index page of the documentation for your collection displays the title you define in ``docs/docsite/extra-docs.yml`` with a link to your extra documentation. For an example, see the `community.docker collection repo <https://github.com/ansible-collections/community.docker/tree/main/docs/docsite>`_ and the `community.docker collection documentation <https://docs.ansible.com/ansible/latest/collections/community/docker/index.html>`_. 
 

--- a/docs/docsite/rst/dev_guide/developing_collections_structure.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_structure.rst
@@ -56,7 +56,7 @@ docs directory
 
 Use the ``docs`` folder to describe how to use the roles and plugins the collection provides, role requirements, and so on.
 
-For certified collections, Automation Hub displays documents written in markdown in the main ``docs`` directory.
+For certified collections, Automation Hub displays documents written in markdown in the main ``docs`` directory with no subdirectories. This will not display on https://docs.ansible.com.
 
 For community collections included in the Ansible PyPI package, docs.ansible.com displays documents written in reStructuredText (.rst) in a docsite/rst/ subdirectory. Define the structure of your extra documentation in ``docs/docsite/extra-docs.yml``:
 

--- a/docs/docsite/rst/dev_guide/developing_collections_structure.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_structure.rst
@@ -52,11 +52,28 @@ A collection must have a ``galaxy.yml`` file that contains the necessary informa
 .. _collections_doc_dir:
 
 docs directory
----------------
+--------------
 
-Put general documentation for the collection here. Keep the specific documentation for plugins and modules embedded as Python docstrings. Use the ``docs`` folder to describe how to use the roles and plugins the collection provides, role requirements, and so on. Use markdown and do not add subfolders.
+Use the ``docs`` folder to describe how to use the roles and plugins the collection provides, role requirements, and so on.
 
-Use ``ansible-doc`` to view documentation for plugins inside a collection:
+For certified collections, Automation Hub displays documents written in markdown in the main ``docs``directory.
+
+For community collections included in the Ansible PyPI package, docs.ansible.com displays documents written in reStructuredText (.rst) in a docsite/rst/ subdirectory. Define the structure of your extra documentation in ``docs/docsite/extra-docs.yml``:
+
+.. code-block:: yaml
+
+   ---
+   sections:
+   - title: Scenario Guide
+   toctree:
+     - scenario_guide
+
+The index page of the documentation for your collection displays the title you define in ``docs/docsite/extra-docs.yml`` with a link to your extra documentation. For an example, see the `community.docker collection repo <https://github.com/ansible-collections/community.docker/tree/main/docs/docsite>`_ and the `community.docker collection documentation <https://docs.ansible.com/ansible/latest/collections/community/docker/index.html>`_. 
+
+Plugin and module documentation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Keep the specific documentation for plugins and modules embedded as Python docstrings. Use ``ansible-doc`` to view documentation for plugins inside a collection:
 
 .. code-block:: bash
 

--- a/docs/docsite/rst/dev_guide/developing_collections_structure.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_structure.rst
@@ -56,7 +56,7 @@ docs directory
 
 Use the ``docs`` folder to describe how to use the roles and plugins the collection provides, role requirements, and so on.
 
-For certified collections, Automation Hub displays documents written in markdown in the main ``docs``directory.
+For certified collections, Automation Hub displays documents written in markdown in the main ``docs`` directory.
 
 For community collections included in the Ansible PyPI package, docs.ansible.com displays documents written in reStructuredText (.rst) in a docsite/rst/ subdirectory. Define the structure of your extra documentation in ``docs/docsite/extra-docs.yml``:
 


### PR DESCRIPTION
##### SUMMARY

Since https://github.com/ansible-community/antsibull/pull/255 was merged, community collection maintainers can add reStructuredText documentation to their collections. This PR documents how to do that.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com/collections
