### PR TITLE
Use a manager object when storing module locks

### DIFF
--- a/changelogs/fragments/manager-object-for-locks.yaml
+++ b/changelogs/fragments/manager-object-for-locks.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    action_write_locks - use a manager dictionary object allowing resources to
+    be shared across processes.

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -63,7 +63,9 @@ class _DeprecatedSequenceConstant(Sequence):
 # CONSTANTS ### yes, actual ones
 
 # The following are hard-coded action names
+_ACTION_COPY = add_internal_fqcns(('copy', ))
 _ACTION_DEBUG = add_internal_fqcns(('debug', ))
+_ACTION_FILE = add_internal_fqcns(('file', ))
 _ACTION_IMPORT_PLAYBOOK = add_internal_fqcns(('import_playbook', ))
 _ACTION_IMPORT_ROLE = add_internal_fqcns(('import_role', ))
 _ACTION_IMPORT_TASKS = add_internal_fqcns(('import_tasks', ))
@@ -74,6 +76,8 @@ _ACTION_INCLUDE_VARS = add_internal_fqcns(('include_vars', ))
 _ACTION_META = add_internal_fqcns(('meta', ))
 _ACTION_SET_FACT = add_internal_fqcns(('set_fact', ))
 _ACTION_SETUP = add_internal_fqcns(('setup', ))
+_ACTION_SLURP = add_internal_fqcns(('slurp', ))
+_ACTION_STAT = add_internal_fqcns(('stat', ))
 _ACTION_HAS_CMD = add_internal_fqcns(('command', 'shell', 'script'))
 _ACTION_ALLOWS_RAW_ARGS = _ACTION_HAS_CMD + add_internal_fqcns(('raw', ))
 _ACTION_ALL_INCLUDES = _ACTION_INCLUDE + _ACTION_INCLUDE_TASKS + _ACTION_INCLUDE_ROLE

--- a/lib/ansible/executor/action_write_locks.py
+++ b/lib/ansible/executor/action_write_locks.py
@@ -21,24 +21,38 @@ __metaclass__ = type
 
 from multiprocessing import Lock
 
+from ansible.module_utils import six
 from ansible.module_utils.facts.system.pkg_mgr import PKG_MGRS
+from ansible.utils.multiprocessing import context as multiprocessing_context
 
-if 'action_write_locks' not in globals():
-    # Do not initialize this more than once because it seems to bash
-    # the existing one.  multiprocessing must be reloading the module
-    # when it forks?
-    action_write_locks = dict()
+
+try:
+    action_write_locks
+except (NameError, UnboundLocalError):
+    action_manager = multiprocessing_context.Manager()
+    if six.PY2:
+        action_dict = dict
+        action_lock = Lock
+    else:
+        action_dict = action_manager.dict
+        action_lock = action_manager.Lock
+
+    # These plugins are known to be called directly by action plugins
+    # with names differing from the action plugin name. We precreate
+    # them here as an optimization.
+    action_write_locks = action_dict(
+        copy=action_lock(),
+        file=action_lock(),
+        setup=action_lock(),
+        slurp=action_lock(),
+        stat=action_lock(),
+    )
 
     # Below is a Lock for use when we weren't expecting a named module.  It gets used when an action
     # plugin invokes a module whose name does not match with the action's name.  Slightly less
     # efficient as all processes with unexpected module names will wait on this lock
-    action_write_locks[None] = Lock()
+    action_write_locks[None] = action_lock()
 
-    # These plugins are known to be called directly by action plugins with names differing from the
-    # action plugin name.  We precreate them here as an optimization.
     # If a list of service managers is created in the future we can do the same for them.
-    mods = set(p['name'] for p in PKG_MGRS)
-
-    mods.update(('copy', 'file', 'setup', 'slurp', 'stat'))
-    for mod_name in mods:
-        action_write_locks[mod_name] = Lock()
+    for p in PKG_MGRS:
+        action_write_locks[p["name"]] = action_lock()

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -345,7 +345,7 @@ class StrategyBase:
 
         if task.action not in action_write_locks.action_write_locks:
             display.debug('Creating lock for %s' % task.action)
-            action_write_locks.action_write_locks[task.action] = Lock()
+            action_write_locks.action_write_locks[task.action] = action_write_locks.action_lock()
 
         # create a templar and template things we need later for the queuing process
         templar = Templar(loader=self._loader, variables=task_vars)

--- a/test/units/executor/test_action_write_locks.py
+++ b/test/units/executor/test_action_write_locks.py
@@ -1,0 +1,83 @@
+# (c) 2021, Kevin Carter <kecarter@redhat.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from multiprocessing import Process
+from multiprocessing.managers import DictProxy
+
+import pytest
+
+from ansible.executor import action_write_locks
+from ansible.module_utils import six
+
+
+ACTION_LOCK = action_write_locks.action_lock
+ACTION_WRITE_LOCKS = action_write_locks.action_write_locks
+
+
+def _acquire_in_thread_lock(test_int):
+    """Run thread test.
+
+    Test that that the original value is in our shared
+    dictionary and that we can add items into the cache
+    from within a process.
+    """
+    assert "testX" in ACTION_WRITE_LOCKS
+    ACTION_WRITE_LOCKS["test%i" % test_int] = ACTION_LOCK()
+
+
+def test_write_lock():
+    """Test that the write lock is created with default items."""
+    default_locks = {
+        "copy",
+        "file",
+        "setup",
+        "slurp",
+        "stat",
+    }
+    assert default_locks <= set(ACTION_WRITE_LOCKS)
+
+    expected_type = dict if six.PY2 else DictProxy
+    assert type(ACTION_WRITE_LOCKS) == expected_type
+
+
+def test_new_lock():
+    """Test a new lock can be created."""
+    assert "test" not in ACTION_WRITE_LOCKS
+    ACTION_WRITE_LOCKS["test"] = ACTION_LOCK()
+    assert "test" in ACTION_WRITE_LOCKS
+
+
+@pytest.mark.skipif(six.PY2, reason="Test requires python 3")
+def test_new_lock_with_threads_and_reimport():
+    """Test that a new lock can be created within a Process."""
+    ACTION_WRITE_LOCKS["testX"] = ACTION_LOCK()
+
+    processes = [
+        Process(target=_acquire_in_thread_lock, args=(item,))
+        for item in range(1, 6)
+    ]
+    for t in processes:
+        t.daemon = True
+        t.start()
+
+    for t in processes:
+        t.join()
+
+    # Assert the test items added in processes are still within the cache.
+    test_process_lock_names = {"test{num}".format(num=item) for item in range(1, 6)}
+    test_process_lock_names.add("testX")
+    assert test_process_lock_names <= set(action_write_locks.action_write_locks)


### PR DESCRIPTION
Use a manager object when storing module locks

This change will allow Ansible to use a manager object when
multiprocessing to ensure cached modules are cached as expected,
and are not creating multiple locks when multiprocessing, which
can result the race condition  `FileExistsError: [Errno 17] File exists`.

Module cache will now be stored in the manager, using the same fork
multiprocessing context which will now allow `Locks` to be shared
across processes. Because locks are only intended to be shared through
inheritance, all locks are also using a manager and built using the
same global manager as the module container.

- Tests have been added to ensure the manager dictionary is
  functioning as expected.

- This change adds a couple action constants which were missing from
  the constants file.

- This change only resolves the locking problems when running under py3.
  In py2 the original code remains effective, meaning cached modules will
  still not be a member of the write lock container when added from within
  a sub-process.

- Bugfix Pull Request

rhbz: [1950050](https://bugzilla.redhat.com/show_bug.cgi?id=1950050)
Signed-off-by: Kevin Carter <kecarter@redhat.com>
Co-authored-by: Sviatoslav Sydorenko <wk.cvs.github@sydorenko.org.ua>
