### PR TITLE
2.11: Apply display_failed_stderr on loop item results (#74865)

### DIFF
--- a/changelogs/fragments/74864-display_failed_stderr-per-item.yml
+++ b/changelogs/fragments/74864-display_failed_stderr-per-item.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Apply ``display_failed_stderr`` callback option on loop item results. (https://github.com/ansible/ansible/issues/74864)

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -309,7 +309,7 @@ class CallbackModule(CallbackBase):
             self._print_task_banner(result._task)
 
         self._clean_results(result._result, result._task.action)
-        self._handle_exception(result._result)
+        self._handle_exception(result._result, use_stderr=self.display_failed_stderr)
 
         msg = "failed: "
         if result._task.delegate_to:
@@ -318,7 +318,11 @@ class CallbackModule(CallbackBase):
             msg += "[%s]" % (result._host.get_name())
 
         self._handle_warnings(result._result)
-        self._display.display(msg + " (item=%s) => %s" % (self._get_item_label(result._result), self._dump_results(result._result)), color=C.COLOR_ERROR)
+        self._display.display(
+            msg + " (item=%s) => %s" % (self._get_item_label(result._result), self._dump_results(result._result)),
+            color=C.COLOR_ERROR,
+            stderr=self.display_failed_stderr
+        )
 
     def v2_runner_item_on_skipped(self, result):
         if self.display_skipped_hosts:

--- a/test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stderr
+++ b/test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stderr
@@ -1,5 +1,8 @@
 + ansible-playbook -i inventory test.yml
 ++ set +x
 fatal: [testhost]: FAILED! => {"changed": false, "msg": "no reason"}
+failed: [testhost] (item=debug-2) => {
+    "msg": "debug-2"
+}
 fatal: [testhost]: FAILED! => {"msg": "One or more items failed"}
 fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed as requested from task"}

--- a/test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stdout
@@ -25,9 +25,6 @@ TASK [debug loop] **************************************************************
 changed: [testhost] => (item=debug-1) => {
     "msg": "debug-1"
 }
-failed: [testhost] (item=debug-2) => {
-    "msg": "debug-2"
-}
 ok: [testhost] => (item=debug-3) => {
     "msg": "debug-3"
 }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #74865

(cherry picked from commit 01ab6c6ec73915412f1a1d00f7c247147ccfd606)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/plugins/callback/default.py`
