### PR TITLE
ansible-pull - make relative repo paths work correctly

### DIFF
--- a/changelogs/fragments/74893-ansible-pull-relative-dirs.yml
+++ b/changelogs/fragments/74893-ansible-pull-relative-dirs.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-pull - relative paths now work with the ``--d`` option for the repo destination
+    directory (https://github.com/ansible/ansible/issues/74893).


### PR DESCRIPTION
##### SUMMARY

If the `-d` option value (the repo destination directory) was a relative path, there were two bugs:

- The playbook to run was not found.
- Purging of the repo did not work.

Both of these problems occurred because the code was changing the current working directory and not adjusting for the change.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #74893 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-pull

