### PR TITLE
[stable-2.9] Skip msyql_variables task for CentOS 8 as well

### DIFF
--- a/test/integration/targets/mysql_variables/tasks/main.yml
+++ b/test/integration/targets/mysql_variables/tasks/main.yml
@@ -145,11 +145,11 @@
   register: result
   ignore_errors: true
   when:
-    - not (ansible_distribution == 'RedHat' and ansible_distribution_major_version is version('8', '=='))
+    - not (ansible_facts.os_family == 'RedHat' and ansible_distribution_major_version is version('8', '=='))
 
 - include: assert_fail_msg.yml output={{result}}  msg='Truncated incorrect'
   when:
-    - not (ansible_distribution == 'RedHat' and ansible_distribution_major_version is version('8', '=='))
+    - not (ansible_facts.os_family == 'RedHat' and ansible_distribution_major_version is version('8', '=='))
 
 # ============================================================
 # Verify mysql_variable fails when setting an incorrect value (incorrect type)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Something changed in the packages that was failing on RHEL a few weeks ago. Now it is failing in CentOS 8 as well
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/mysql_variables/tasks/main.yml`