### PR TITLE
systemd: Consider enabled-runtime status

### DIFF
--- a/changelogs/fragments/72451_systemd.yml
+++ b/changelogs/fragments/72451_systemd.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- systemd - consider 'enable-runtime' condition while enabling service units (https://github.com/ansible/ansible/issues/72451).

--- a/lib/ansible/modules/systemd.py
+++ b/lib/ansible/modules/systemd.py
@@ -493,7 +493,11 @@ def main():
 
             # check systemctl result or if it is a init script
             if rc == 0:
-                enabled = True
+                if out.strip() in ('enabled-runtime',):
+                    # enable-runtime is 'enable for only this boot of the system'
+                    enabled = False
+                else:
+                    enabled = True
             elif rc == 1:
                 # if not a user or global user service and both init script and unit file exist stdout should have enabled/disabled, otherwise use rc entries
                 if module.params['scope'] == 'system' and \

--- a/test/integration/targets/systemd/handlers/main.yml
+++ b/test/integration/targets/systemd/handlers/main.yml
@@ -1,4 +1,7 @@
 - name: remove unit file
   file:
-    path: /etc/systemd/system/sleeper@.service
+    path: '{{ item }}'
     state: absent
+  loop:
+    - /etc/systemd/system/test_enable@.service
+    - /etc/systemd/system/sleeper@.service

--- a/test/integration/targets/systemd/tasks/main.yml
+++ b/test/integration/targets/systemd/tasks/main.yml
@@ -118,4 +118,5 @@
       - systemd_enable_ssh_1 is changed
       - systemd_enable_ssh_2 is not changed
 
+- import_tasks: test_enable_runtime.yml
 - import_tasks: test_unit_template.yml

--- a/test/integration/targets/systemd/tasks/test_enable_runtime.yml
+++ b/test/integration/targets/systemd/tasks/test_enable_runtime.yml
@@ -1,0 +1,40 @@
+- name: Copy service file
+  template:
+    src: sleeper@.service
+    dest: /etc/systemd/system/test_enable@.service
+    owner: root
+    group: root
+    mode: '0644'
+  notify: remove unit file
+
+- name: Reload systemd
+  systemd:
+    daemon_reload: yes
+
+- name: Enable Service for current boot (enable-runtime)
+  command: systemctl enable --runtime test_enable@100.service
+
+- name: Enable service
+  systemd:
+    name: test_enable@100.service
+    enabled: true
+  register: enable_test_1
+
+- name: Enable service again
+  systemd:
+    name: test_enable@100.service
+    enabled: true
+  register: enable_test_2
+
+- name: Disable service (clean-up)
+  systemd:
+    name: test_enable@100.service
+    enabled: false
+
+- name:
+  assert:
+    that:
+      - enable_test_1 is changed
+      - enable_test_1 is success
+      - enable_test_2 is not changed
+      - enable_test_2 is success


### PR DESCRIPTION
##### SUMMARY

``is-enabled`` command considers `enabled-runtime` and `enabled`
as `enabled`. But `enabled-runtime` state is for only this boot of
the system. So for next reboot the service unit is not enabled.
Consider `enabled-runtime` status while enabling the service unit.

Fixes: #72451

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/72451_systemd.yml
lib/ansible/modules/systemd.py
test/integration/targets/systemd/handlers/main.yml
test/integration/targets/systemd/tasks/main.yml
test/integration/targets/systemd/tasks/test_enable_runtime.yml
