### PR TITLE
fix doc: add possible state 'inactive'

### DIFF
--- a/lib/ansible/modules/service_facts.py
+++ b/lib/ansible/modules/service_facts.py
@@ -62,7 +62,8 @@ ansible_facts:
         state:
           description:
           - State of the service.
-          - Either C(failed), C(running), C(stopped), or C(unknown).
+          - 'This commonly includes (but is not limited to) the following: C(failed), C(running), C(stopped) or C(unknown).'
+          - Depending on the used init system additional states might be returned.
           returned: always
           type: str
           sample: running


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The ansible builtin `service_facts` returning service state information as fact data lists the following possible return values for the service state:
- `failed`
- `running`
- `stopped`
- `unknown`

This list is missing one additional service state:
- `inactive`


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

service_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Example from a RHEL machine.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
"services": {
    "kpatch.service": {
        "name": "kpatch.service",
        "source": "systemd",
        "state": "inactive",
        "status": "disabled"
    }
}
```