### PR TITLE
slurp - handle error when path is a directory

### DIFF
--- a/changelogs/fragments/slurp-handle-error-with-dir.yml
+++ b/changelogs/fragments/slurp-handle-error-with-dir.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- slurp - handle error when ``path`` is a directory and not a file (https://github.com/ansible/ansible/pull/74930).

--- a/lib/ansible/modules/slurp.py
+++ b/lib/ansible/modules/slurp.py
@@ -81,6 +81,7 @@ import errno
 import os
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_native
 
 
 def main():
@@ -101,6 +102,10 @@ def main():
             module.fail_json(msg="file not found: %s" % source)
         elif e.errno == errno.EACCES:
             module.fail_json(msg="file is not readable: %s" % source)
+        elif e.errno == errno.EISDIR:
+            module.fail_json(msg="source is a directory and must be a file: %s" % source)
+        else:
+            module.fail_json(msg="unable to slurp file: %s" % to_native(e, errors='surrogate_then_replace'))
 
     data = base64.b64encode(source_content)
 

--- a/test/integration/targets/slurp/tasks/main.yml
+++ b/test/integration/targets/slurp/tasks/main.yml
@@ -81,9 +81,9 @@
 - name: check slurp directory result
   assert:
     that:
-      - "slurp_dir is failed"
-      - "slurp_dir.msg"
-      - "slurp_dir is not changed"
+      - slurp_dir is failed
+      - slurp_dir.msg is search('source is a directory and must be a file')
+      - slurp_dir is not changed
 
 - name: test slurp with missing argument
   action: slurp

--- a/test/integration/targets/slurp/tasks/test_unreadable.yml
+++ b/test/integration/targets/slurp/tasks/test_unreadable.yml
@@ -8,13 +8,13 @@
 - name: create unreadable file
   copy:
     content: "Hello, World!"
-    dest: /tmp/qux.txt
-    mode: 0600
+    dest: "{{ output_dir }}/qux.txt"
+    mode: '0600'
     owner: root
 
 - name: test slurp unreadable file
   slurp:
-    src: '/tmp/qux.txt'
+    src: "{{ output_dir }}/qux.txt"
   register: slurp_unreadable_file
   become: true
   become_user: "{{ become_test_user }}"
@@ -30,14 +30,14 @@
 
 - name: create unreadable directory
   file:
-    path: /tmp/test_data
+    path: "{{ output_dir }}/test_data"
     state: directory
     mode: 0700
     owner: root
 
 - name: test slurp unreadable directory
   slurp:
-    src: /tmp/test_data
+    src: "{{ output_dir }}/test_data"
   register: slurp_unreadable_dir
   become: true
   become_user: "{{ become_test_user }}"


### PR DESCRIPTION
##### SUMMARY
Handle the exception and return a nice error message rather than a traceback. Also add a catch all for unanticipated failures.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/slurp.py`