### PR TITLE
ansible-pull - update help info for --directory option

### DIFF
--- a/changelogs/fragments/ansible-pull-doc-update.yml
+++ b/changelogs/fragments/ansible-pull-doc-update.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-pull - update documentation for ``--directory`` option to clarify path must be absolute.

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -94,7 +94,7 @@ class PullCLI(CLI):
                                       'This is a useful way to disperse git requests')
         self.parser.add_argument('-f', '--force', dest='force', default=False, action='store_true',
                                  help='run the playbook even if the repository could not be updated')
-        self.parser.add_argument('-d', '--directory', dest='dest', default=None, help='directory to checkout repository to')
+        self.parser.add_argument('-d', '--directory', dest='dest', default=None, help='absolute path of repository checkout directory (relative paths are not supported)')
         self.parser.add_argument('-U', '--url', dest='url', default=None, help='URL of the playbook repository')
         self.parser.add_argument('--full', dest='fullclone', action='store_true', help='Do a full clone, instead of a shallow one.')
         self.parser.add_argument('-C', '--checkout', dest='checkout',

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -94,7 +94,8 @@ class PullCLI(CLI):
                                       'This is a useful way to disperse git requests')
         self.parser.add_argument('-f', '--force', dest='force', default=False, action='store_true',
                                  help='run the playbook even if the repository could not be updated')
-        self.parser.add_argument('-d', '--directory', dest='dest', default=None, help='absolute path of repository checkout directory (relative paths are not supported)')
+        self.parser.add_argument('-d', '--directory', dest='dest', default=None,
+                                 help='absolute path of repository checkout directory (relative paths are not supported)')
         self.parser.add_argument('-U', '--url', dest='url', default=None, help='URL of the playbook repository')
         self.parser.add_argument('--full', dest='fullclone', action='store_true', help='Do a full clone, instead of a shallow one.')
         self.parser.add_argument('-C', '--checkout', dest='checkout',


### PR DESCRIPTION
##### SUMMARY

Clarify that only absolute paths are supported for `-d` or `--directory` option.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
ansible-pull

