### PR TITLE
role argspec docs: fix name of subkey

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
@@ -344,7 +344,7 @@ role ``meta/argument_specs.yml`` file. All fields are lower-case.
 
            * Specifies the data type for list elements when type is ``list``.
 
-        :suboptions:
+        :options:
 
            * If this option takes a dict or list of dicts, you can define the structure here.
 


### PR DESCRIPTION
##### SUMMARY
According to the code and the integration tests, it's called `options`, not `suboptions` (i.e. the same as for modules).

CC @Shrews

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
