### PR TITLE
apt_key: add --recv argument as last one

### DIFF
--- a/changelogs/fragments/74949-apt_key_recv_last_arg.yml
+++ b/changelogs/fragments/74949-apt_key_recv_last_arg.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - apt_key - set --recv argument as last one in apt-key command when using env var HTTP_PROXY (https://github.com/ansible/ansible/issues/74946)

--- a/lib/ansible/modules/apt_key.py
+++ b/lib/ansible/modules/apt_key.py
@@ -313,12 +313,15 @@ def import_key(module, keyring, keyserver, key_id):
 
     global lang_env
     if keyring:
-        cmd = "%s --keyring %s adv --no-tty --keyserver %s --recv %s" % (apt_key_bin, keyring, keyserver, key_id)
+        cmd = "%s --keyring %s adv --no-tty --keyserver %s" % (apt_key_bin, keyring, keyserver)
     else:
-        cmd = "%s adv --no-tty --keyserver %s --recv %s" % (apt_key_bin, keyserver, key_id)
+        cmd = "%s adv --no-tty --keyserver %s" % (apt_key_bin, keyserver)
 
     # check for proxy
     cmd = add_http_proxy(cmd)
+
+    # add recv argument as last one
+    cmd = "%s --recv %s" % (cmd, key_id)
 
     for retry in range(5):
         (rc, out, err) = module.run_command(cmd, environ_update=lang_env)

--- a/test/units/modules/test_apt_key.py
+++ b/test/units/modules/test_apt_key.py
@@ -1,3 +1,6 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import os
 
 from units.compat import mock

--- a/test/units/modules/test_apt_key.py
+++ b/test/units/modules/test_apt_key.py
@@ -1,0 +1,24 @@
+import os
+
+from units.compat import mock
+from units.compat import unittest
+
+from ansible.modules import apt_key
+
+
+class AptKeyTestCase(unittest.TestCase):
+
+    @mock.patch.object(apt_key, 'apt_key_bin', '/usr/bin/apt-key')
+    @mock.patch.dict(os.environ, {'HTTP_PROXY': 'proxy.example.com'})
+    def test_import_key_with_http_proxy(self):
+        m_mock = mock.Mock()
+        m_mock.run_command.return_value = (0, '', '')
+        apt_key.import_key(
+            m_mock, keyring=None, keyserver='keyserver.example.com',
+            key_id='0xDEADBEEF')
+        self.assertEqual(
+            m_mock.run_command.call_args_list[0][0][0],
+            '/usr/bin/apt-key adv --no-tty --keyserver keyserver.example.com'
+            ' --keyserver-options http-proxy=proxy.example.com'
+            ' --recv 0xDEADBEEF'
+        )


### PR DESCRIPTION
##### SUMMARY
Fixes #74946 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
apt_key

##### ADDITIONAL INFORMATION
> Problem is arguments order, last need to be the recv key:
> 
> ```shell
> $ /usr/bin/apt-key adv --no-tty --keyserver hkp://keyserver.ubuntu.com:80 --keyserver-options http-proxy=http://prodsif-pack.infra.domain.fr:3128 --recv C072A32983A736CF
> Executing: /tmp/apt-key-gpghome.WKs9PEYzb9/gpg.1.sh --no-tty --keyserver hkp://keyserver.ubuntu.com:80 --keyserver-options http-proxy=http://prodsif-pack.infra.domain.fr:3128 --recv C072A32983A736CF
> gpg: clef C072A32983A736CF : « International GeoGebra Institute <office@geogebra.org> » n'est pas modifiée
> gpg: Quantité totale traitée : 1
> gpg:              non modifiées : 1
> ```


