### PR TITLE
Update docs requirements list

### DIFF
--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -1,0 +1,14 @@
+# pip packages required to build docsite
+# tested June 9 2021
+jinja2==3.0.1
+PyYAML==5.4.1
+rstcheck==3.3.1
+sphinx==4.0.2
+sphinx-notfound-page==0.7.1 # must be >= 0.6
+sphinx-intl==2.0.1
+sphinx_ansible_theme==0.6.0
+resolvelib==0.5.4
+Pygments==2.9.0 # must be >= 2.4.0
+straight.plugin==1.5.0 # Needed for hacking/build-ansible.py which is the backend build script
+antsibull==0.33.0 # must be >= 0.25.0
+docutils==0.16 # pinned globally until the problem with unordered lists is fixed, see https://github.com/readthedocs/sphinx_rtd_theme/issues/1115

--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -1,14 +1,17 @@
 # pip packages required to build docsite
 # tested June 9 2021
+
+antsibull==0.33.0
+docutils==0.16
+# check unordered lists when testing more recent docutils versions
+# see https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
 jinja2==3.0.1
+Pygments==2.9.0
 PyYAML==5.4.1
+resolvelib==0.5.4
 rstcheck==3.3.1
 sphinx==4.0.2
 sphinx-notfound-page==0.7.1 # must be >= 0.6
 sphinx-intl==2.0.1
 sphinx_ansible_theme===0.6.0
-resolvelib==0.5.4
-Pygments==2.9.0 # must be >= 2.4.0
 straight.plugin==1.5.0 # Needed for hacking/build-ansible.py which is the backend build script
-antsibull==0.33.0 # must be >= 0.25.0
-docutils==0.16 # pinned globally until the problem with unordered lists is fixed, see https://github.com/readthedocs/sphinx_rtd_theme/issues/1115

--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -6,7 +6,7 @@ rstcheck==3.3.1
 sphinx==4.0.2
 sphinx-notfound-page==0.7.1 # must be >= 0.6
 sphinx-intl==2.0.1
-sphinx_ansible_theme==0.6.0
+sphinx_ansible_theme===0.6.0
 resolvelib==0.5.4
 Pygments==2.9.0 # must be >= 2.4.0
 straight.plugin==1.5.0 # Needed for hacking/build-ansible.py which is the backend build script

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -1,13 +1,16 @@
-#pip packages required to build docsite
+# pip packages required to build docsite
+# these requirements are as loosely defined as possible
+# if you want known good versions of these dependencies
+# use known_good_reqs.txt instead 
 jinja2
 PyYAML
 rstcheck
 sphinx
 sphinx-notfound-page >= 0.6
 sphinx-intl
-sphinx_ansible_theme === 0.6.0
+sphinx_ansible_theme == 0.6.0
 resolvelib
 Pygments >= 2.4.0
 straight.plugin # Needed for hacking/build-ansible.py which is the backend build script
 antsibull >= 0.25.0
-docutils==0.16 # pin for now until sphinx_rtd_theme is compatible with 0.17 or later
+docutils == 0.16 # pin for now until sphinx_rtd_theme is compatible with 0.17 or later

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -2,7 +2,12 @@
 # these requirements are as loosely defined as possible
 # if you want known good versions of these dependencies
 # use known_good_reqs.txt instead 
+
+antsibull >= 0.25.0
+docutils == 0.16 # pin for now until the problem with unordered lists is fixed
+# see https://github.com/readthedocs/sphinx_rtd_theme/issues/1115jinja2==3.0.1
 jinja2
+Pygments >= 2.4.0
 PyYAML
 rstcheck
 sphinx
@@ -10,7 +15,4 @@ sphinx-notfound-page >= 0.6
 sphinx-intl
 sphinx_ansible_theme === 0.6.0
 resolvelib
-Pygments >= 2.4.0
 straight.plugin # Needed for hacking/build-ansible.py which is the backend build script
-antsibull >= 0.25.0
-docutils == 0.16 # pin for now until sphinx_rtd_theme is compatible with 0.17 or later

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -8,7 +8,7 @@ rstcheck
 sphinx
 sphinx-notfound-page >= 0.6
 sphinx-intl
-sphinx_ansible_theme == 0.6.0
+sphinx_ansible_theme === 0.6.0
 resolvelib
 Pygments >= 2.4.0
 straight.plugin # Needed for hacking/build-ansible.py which is the backend build script

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -2,7 +2,7 @@
 jinja2
 PyYAML
 rstcheck
-sphinx==2.1.2
+sphinx
 sphinx-notfound-page >= 0.6
 sphinx-intl
 sphinx_ansible_theme === 0.6.0

--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -74,22 +74,7 @@ Setting up your environment to build documentation locally
 
 To build documentation locally, ensure you have a working :ref:`development environment <environment_setup>`.
 
-To work with documentation on your local machine, you need to have python-3.5 or greater and the following packages installed:
-
-    - ``gcc``
-    - ``jinja2``
-    - ``libyaml``
-    - ``make``
-    - ``Pygments``
-    - ``pyparsing``
-    - ``PyYAML``
-    - ``rstcheck``
-    - ``six``
-    - ``sphinx``
-    - ``sphinx-notfound-page``
-    - ``straight.plugin``
-
-These required packages are listed in our :file:`requirements.txt` files to make installation easier:
+To work with documentation on your local machine, you need to have python-3.5 or greater and install the `Ansible dependencies <https://github.com/ansible/ansible/blob/devel/requirements.txt>`_ and `documentation dependencies<https://github.com/ansible/ansible/blob/devel/docs/docsite/requirements.txt>`_, which are listed in two :file:`requirements.txt` files to make installation easier:
 
 .. code-block:: bash
 
@@ -107,6 +92,12 @@ You can drop ``--user`` if you have set up a virtual environment (venv/virtenv).
 
 .. note::
 
+    You may need to install these general pre-requisites separately on some systems:
+    - ``gcc``
+    - ``libyaml``
+    - ``make``
+    - ``pyparsing``
+    - ``six``
     On macOS with Xcode, you may need to install ``six`` and ``pyparsing`` with ``--ignore-installed`` to get versions that work with ``sphinx``.
 
 .. note::

--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -74,7 +74,10 @@ Setting up your environment to build documentation locally
 
 To build documentation locally, ensure you have a working :ref:`development environment <environment_setup>`.
 
-To work with documentation on your local machine, you need to have python-3.5 or greater and install the `Ansible dependencies <https://github.com/ansible/ansible/blob/devel/requirements.txt>`_ and `documentation dependencies<https://github.com/ansible/ansible/blob/devel/docs/docsite/requirements.txt>`_, which are listed in two :file:`requirements.txt` files to make installation easier:
+To work with documentation on your local machine, you need to have python-3.5 or greater and install the `Ansible dependencies`_ and `documentation dependencies`_, which are listed in two :file:`requirements.txt` files to make installation easier:
+
+.. _Ansible dependencies: https://github.com/ansible/ansible/blob/devel/requirements.txt
+.. _documentation dependencies: https://github.com/ansible/ansible/blob/devel/docs/docsite/requirements.txt
 
 .. code-block:: bash
 

--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -74,8 +74,7 @@ Setting up your environment to build documentation locally
 
 To build documentation locally, ensure you have a working :ref:`development environment <environment_setup>`.
 
-To work with documentation on your local machine, you need to have python-3.5 or greater and the
-following packages installed:
+To work with documentation on your local machine, you need to have python-3.5 or greater and the following packages installed:
 
     - ``gcc``
     - ``jinja2``
@@ -90,14 +89,21 @@ following packages installed:
     - ``sphinx-notfound-page``
     - ``straight.plugin``
 
-These required packages are listed in two :file:`requirements.txt` files to make installation easier:
+These required packages are listed in our :file:`requirements.txt` files to make installation easier:
 
 .. code-block:: bash
 
     pip install --user -r requirements.txt
     pip install --user -r docs/docsite/requirements.txt
 
-You can drop ``--user`` if you have set up a virtual environment (venv/virtenv).
+The :file:`docs/docsite/requirements.txt` file allows a wide range of versions and may install new releases of required packages. New releases of these packages may cause problems with the Ansible docs build. If you want to install tested versions of these dependencies, use :file:`docs/docsite/known_good_reqs.txt` instead:
+
+.. code-block:: bash
+
+    pip install --user -r requirements.txt
+    pip install --user -r docs/docsite/known_good_reqs.txt
+
+You can drop ``--user`` if you have set up a virtual environment (venv/virtenv). 
 
 .. note::
 


### PR DESCRIPTION
##### SUMMARY

In the Docs Working Group meeting on [25 May 2021](https://github.com/ansible/community/issues/579#issuecomment-847958129) we agreed to maintain two requirements files for the docs build:
- one with as few version pins as possible 
- a second one pinned to known good versions for use with the publication pipeline

The plan is to "unleash" the known good versions, test the most recent available packages, and update the. known_good_reqs. file on a quarterly basis going forward, so the versions don't get too stale.

This PR:
- creates the second requirements file
- removes the pin on the Sphinx version

Related to #74318
Closes #74194 
Closes #71395

Tested on a mac running macOS Catalina.  Pip package versions listed below. Test if you have time and report any issues you find!

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ADDITIONAL INFORMATION
Versions installed from the main (unpinned) `requirements.txt`:

```
Package                       Version
----------------------------- -----------
aiofiles                      0.7.0
aiohttp                       3.7.4.post0
alabaster                     0.7.12
antsibull                     0.33.0
antsibull-changelog           0.10.0
async-timeout                 3.0.1
asyncio-pool                  0.5.2
attrs                         21.2.0
Babel                         2.9.1
certifi                       2021.5.30
cffi                          1.14.5
chardet                       4.0.0
click                         8.0.1
cryptography                  3.4.7
docutils                      0.16
idna                          2.10
imagesize                     1.2.0
Jinja2                        3.0.1
MarkupSafe                    2.0.1
multidict                     5.1.0
packaging                     20.9
perky                         0.5.5
pip                           21.0.1
pycparser                     2.20
pydantic                      1.8.2
Pygments                      2.9.0
pyparsing                     2.4.7
pytz                          2021.1
PyYAML                        5.4.1
requests                      2.25.1
resolvelib                    0.5.4
rstcheck                      3.3.1
semantic-version              2.8.5
setuptools                    54.2.0
sh                            1.14.2
six                           1.16.0
snowballstemmer               2.1.0
Sphinx                        4.0.2
sphinx-ansible-theme          0.6.0
sphinx-intl                   2.0.1
sphinx-notfound-page          0.7.1
sphinx-rtd-theme              0.5.2
sphinxcontrib-applehelp       1.0.2
sphinxcontrib-devhelp         1.0.2
sphinxcontrib-htmlhelp        2.0.0
sphinxcontrib-jsmath          1.0.1
sphinxcontrib-qthelp          1.0.3
sphinxcontrib-serializinghtml 1.1.5
straight.plugin               1.5.0
Twiggy                        0.5.1
typing-extensions             3.10.0.0
urllib3                       1.26.5
yarl                          1.6.3
```
