### PR TITLE
docs: example hosts should match play

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_strategies.rst
+++ b/docs/docsite/rst/user_guide/playbooks_strategies.rst
@@ -82,7 +82,7 @@ In the above example, if we had 6 hosts in the group 'webservers', Ansible would
     TASK [second task] ***************************************
     changed: [web4]
     changed: [web5]
-    changed: [web2]
+    changed: [web6]
 
     PLAY RECAP ***********************************************
     web1      : ok=2    changed=2    unreachable=0    failed=0


### PR DESCRIPTION
##### SUMMARY
in the example from "Setting the batch size with serial", the first batch of hosts is [web1, web2, web3], and the second batch of hosts is [web4, web5, web6].  the second task for the second batch was incorrectly listing a hosts from the first batch (web2), instead of a host from the second batch (web6).


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

