### PR TITLE
psrp - Fix reset connection on failed scenarios

### DIFF
--- a/changelogs/fragments/psrp-reset.yml
+++ b/changelogs/fragments/psrp-reset.yml
@@ -1,3 +1,3 @@
 bugfixes:
-- psrp - Fix error when resetting a connection that was initialised but not connected - https://github.com/ansible/ansible/issues/74092
+- psrp - Fix error when resetting a connection that was initialised but not connected - (https://github.com/ansible/ansible/issues/74092).
 - psrp - Try to clean up any server side resources when resetting a connection

--- a/changelogs/fragments/psrp-reset.yml
+++ b/changelogs/fragments/psrp-reset.yml
@@ -1,3 +1,3 @@
 bugfixes:
 - psrp - Fix error when resetting a connection that was initialised but not connected - (https://github.com/ansible/ansible/issues/74092).
-- psrp - Try to clean up any server side resources when resetting a connection
+- psrp - Try to clean up any server-side resources when resetting a connection.

--- a/changelogs/fragments/psrp-reset.yml
+++ b/changelogs/fragments/psrp-reset.yml
@@ -1,4 +1,3 @@
 bugfixes:
 - psrp - Fix error when resetting a connection that was initialised but not connected - https://github.com/ansible/ansible/issues/74092
 - psrp - Try to clean up any server side resources when resetting a connection
-

--- a/changelogs/fragments/psrp-reset.yml
+++ b/changelogs/fragments/psrp-reset.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- psrp - Fix error when resetting a connection that was initialised but not connected - https://github.com/ansible/ansible/issues/74092
+- psrp - Try to clean up any server side resources when resetting a connection
+

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -410,7 +410,16 @@ class Connection(ConnectionBase):
 
     def reset(self):
         if not self._connected:
+            self.runspace = None
             return
+
+        # Try out best to ensure the runspace is closed to free up server side resources
+        try:
+            self.close()
+        except Exception as e:
+            # There's a good chance the connection was already closed so just log the error and move on
+            display.debug("PSRP reset - failed to closed runspace: %s" % to_text(e))
+
         display.vvvvv("PSRP: Reset Connection", host=self._psrp_host)
         self.runspace = None
         self._connect()


### PR DESCRIPTION
##### SUMMARY
When a connection is reset but it was not able to successfully create the initial connection the runspace state is in an invalid state. We make sure we clear out the existing runspace object if no connection was made before attempting to connect again.

Also tries to cleanup any existing runspaces if the connection is still active to avoid leaving any server side resources alive. Errors are expected in this step because the underlying connection could be closed so we just log any errors here and continue on as normal.

Fixes https://github.com/ansible/ansible/issues/74092

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
psrp