### PR TITLE
fix unsafe preservation across newlines (#74960)

### DIFF
--- a/changelogs/fragments/fix_unsafe_newline.yml
+++ b/changelogs/fragments/fix_unsafe_newline.yml
@@ -1,0 +1,2 @@
+security_fixes:
+  - templating engine fix for not preserving usnafe status when trying to preserve newlines. CVE-2021-3583

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -875,7 +875,8 @@ class Templar:
 
             try:
                 res = j2_concat(rf)
-                if getattr(new_context, 'unsafe', False):
+                unsafe = getattr(new_context, 'unsafe', False)
+                if unsafe:
                     res = wrap_var(res)
             except TypeError as te:
                 if 'AnsibleUndefined' in to_native(te):
@@ -905,6 +906,8 @@ class Templar:
                 res_newlines = _count_newlines_from_end(res)
                 if data_newlines > res_newlines:
                     res += self.environment.newline_sequence * (data_newlines - res_newlines)
+                    if unsafe:
+                        res = wrap_var(res)
             return res
         except (UndefinedError, AnsibleUndefinedVariable) as e:
             if fail_on_undefined:

--- a/test/integration/targets/template/runme.sh
+++ b/test/integration/targets/template/runme.sh
@@ -34,3 +34,7 @@ ansible-playbook 6653.yml -v "$@"
 
 # https://github.com/ansible/ansible/issues/72262
 ansible-playbook 72262.yml -v "$@"
+
+# ensure unsafe is preserved, even with extra newlines
+ansible-playbook unsafe.yml -v "$@"
+

--- a/test/integration/targets/template/unsafe.yml
+++ b/test/integration/targets/template/unsafe.yml
@@ -1,0 +1,19 @@
+- hosts: localhost
+  gather_facts: false
+  vars:
+    nottemplated: this should not be seen
+    imunsafe: !unsafe '{{ nottemplated }}'
+  tasks:
+
+    - set_fact:
+        this_was_unsafe: >
+          {{ imunsafe }}
+
+    - set_fact:
+          this_always_safe: '{{ imunsafe }}'
+
+    - name: ensure nothing was templated
+      assert:
+        that:
+        - this_always_safe == imunsafe
+        - imunsafe == this_was_unsafe.strip()


### PR DESCRIPTION
* fix unsafe preservation across newlines

  CVE-2021-3583
  ensure we always have unsafe

Co-authored-by: Rick Elrod <rick@elrod.me>
(cherry picked from commit 4c8c40fd3d4a58defdc80e7d22aa8d26b731353e)


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
temlpate