### PR TITLE
psrp - cleanup command

### DIFF
--- a/changelogs/fragments/psrp-cleanup.yml
+++ b/changelogs/fragments/psrp-cleanup.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- psrp - Always cleanup the last run pipeline if a second pipeline is invoked to avoid violating any resource limits.


### PR DESCRIPTION
##### SUMMARY
When we run a command on the `psrp` connection plugin we avoid sending the stop/terminate signal to reduce the number of network calls needed. This is fine in most cases but if an action plugin sends a lot of commands in the same connection the connection will fail once it reaches the `MaxProcessesPerShell` option.

Most module invocations will only run 1 command and thus don't need the stop so this PR will close the previous pipeline if a 2nd command was invoked.

Need to do some more in depth testing before merging this in but so far I haven't seen any problems.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
psrp