### PR TITLE
Add the --playbook-dir option to galaxy cli

### DIFF
--- a/changelogs/fragments/74986-ansible-galaxy-playbook-dir.yaml
+++ b/changelogs/fragments/74986-ansible-galaxy-playbook-dir.yaml
@@ -1,3 +1,2 @@
-bugfixes:
-  - "Adds --playbook-dir to ansible-galaxy CLI"
-  - "Fixes issue #74942"
+minor_changes:
+  - "Adds --playbook-dir to ansible-galaxy CLI (https://github.com/ansible/ansible/issues/74942)"

--- a/changelogs/fragments/74986-ansible-galaxy-playbook-dir.yaml
+++ b/changelogs/fragments/74986-ansible-galaxy-playbook-dir.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "Adds --playbook-dir to ansible-galaxy CLI"
+  - "Fixes issue #74942"

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -305,6 +305,7 @@ class GalaxyCLI(CLI):
         if galaxy_type == 'collection':
             list_parser.add_argument('--format', dest='output_format', choices=('human', 'yaml', 'json'), default='human',
                                      help="Format to display the list of collections in.")
+            opt_help.add_basedir_options(list_parser)
 
     def add_search_options(self, parser, parents=None):
         search_parser = parser.add_parser('search', parents=parents,
@@ -1396,8 +1397,10 @@ class GalaxyCLI(CLI):
 
         output_format = context.CLIARGS['output_format']
         collections_search_paths = set(context.CLIARGS['collections_path'])
+        if context.CLIARGS['basedir']:
+            collections_search_paths.update([context.CLIARGS['basedir']])
         collection_name = context.CLIARGS['collection']
-        default_collections_path = AnsibleCollectionConfig.collection_paths
+        default_collections_path = AnsibleCollectionConfig.collection_paths + [context.CLIARGS['basedir']]
         collections_in_paths = {}
 
         warnings = []

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1400,7 +1400,7 @@ class GalaxyCLI(CLI):
         if context.CLIARGS['basedir']:
             collections_search_paths.update([context.CLIARGS['basedir']])
         collection_name = context.CLIARGS['collection']
-        default_collections_path = AnsibleCollectionConfig.collection_paths + [context.CLIARGS['basedir']]
+        default_collections_path = [context.CLIARGS['basedir']] + AnsibleCollectionConfig.collection_paths
         collections_in_paths = {}
 
         warnings = []

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1402,8 +1402,9 @@ class GalaxyCLI(CLI):
         collections_in_paths = {}
 
         if context.CLIARGS.get('basedir', None):
-            collections_search_paths.update([context.CLIARGS['basedir']])
-            default_collections_path = [context.CLIARGS['basedir']] + default_collections_path
+            b_basedir = to_bytes(context.CLIARGS['basedir'])
+            collections_search_paths.update([b_basedir])
+            default_collections_path = [b_basedir] + default_collections_path
 
         warnings = []
         path_found = False

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1397,11 +1397,13 @@ class GalaxyCLI(CLI):
 
         output_format = context.CLIARGS['output_format']
         collections_search_paths = set(context.CLIARGS['collections_path'])
-        if context.CLIARGS['basedir']:
-            collections_search_paths.update([context.CLIARGS['basedir']])
         collection_name = context.CLIARGS['collection']
-        default_collections_path = [context.CLIARGS['basedir']] + AnsibleCollectionConfig.collection_paths
+        default_collections_path = AnsibleCollectionConfig.collection_paths
         collections_in_paths = {}
+        
+        if context.CLIARGS.get('basedir', None):
+            collections_search_paths.update([context.CLIARGS['basedir']])
+            default_collections_path = [context.CLIARGS['basedir']] + default_collections_path
 
         warnings = []
         path_found = False

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1400,7 +1400,7 @@ class GalaxyCLI(CLI):
         collection_name = context.CLIARGS['collection']
         default_collections_path = AnsibleCollectionConfig.collection_paths
         collections_in_paths = {}
-        
+
         if context.CLIARGS.get('basedir', None):
             collections_search_paths.update([context.CLIARGS['basedir']])
             default_collections_path = [context.CLIARGS['basedir']] + default_collections_path

--- a/test/units/cli/galaxy/test_execute_list_collection.py
+++ b/test/units/cli/galaxy/test_execute_list_collection.py
@@ -48,12 +48,12 @@ def cliargs(collections_paths=None, collection_name=None, basedir=None):
 
 @pytest.fixture
 def mock_collection_objects(mocker):
-    mocker.patch('ansible.cli.galaxy.GalaxyCLI._resolve_path', 
+    mocker.patch('ansible.cli.galaxy.GalaxyCLI._resolve_path',
                  side_effect=['/root/.ansible/collections', '/usr/share/ansible/collections', '/foo/collections'])
     mocker.patch('ansible.cli.galaxy.validate_collection_path',
                  side_effect=[
-                     '/root/.ansible/collections/ansible_collections', 
-                     '/usr/share/ansible/collections/ansible_collections', 
+                     '/root/.ansible/collections/ansible_collections',
+                     '/usr/share/ansible/collections/ansible_collections',
                      '/foo/collections/ansible_collections'])
 
     collection_args_1 = (
@@ -105,7 +105,7 @@ def mock_collection_objects(mocker):
     collections_path_2 = [Requirement(*cargs) for cargs in collection_args_2]
     collections_path_3 = [Requirement(*cargs) for cargs in collection_args_3]
 
-    mocker.patch('ansible.cli.galaxy.find_existing_collections', 
+    mocker.patch('ansible.cli.galaxy.find_existing_collections',
                  side_effect=[collections_path_1, collections_path_2, collections_path_3])
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #74942 

@sivel, did just like you suggested
by the way, I realy liked the `option_helpers` module (I've never noticed before) 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-galaxy CLI

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```shell
$ pwd
/home/henrique/Documents/contribuicoes/ansible

$ ansible-galaxy collection list | grep ^#                 
# /usr/lib/python3.9/site-packages/ansible_collections

$ ansible-galaxy collection list --playbook-dir $PWD | grep ^#
# /usr/lib/python3.9/site-packages/ansible_collections
# /home/henrique/Documents/contribuicoes/ansible/ansible_collections

```
