### PR TITLE
Fix devel docs build to use latest .deps file for 4.x.y releases instead of for the 4.0.0 release

### DIFF
--- a/hacking/build_library/build_ansible/command_plugins/docs_build.py
+++ b/hacking/build_library/build_ansible/command_plugins/docs_build.py
@@ -54,6 +54,13 @@ def find_latest_ansible_dir(build_data_working):
         except InvalidVersion:
             continue
 
+        # Check if it contains any other .deps files than ancestor.deps
+        deps_files = [
+            df for df in glob.glob(os.path.join(directory_name, '*.deps'))
+            if os.path.basename(df) != 'ancestor.deps']
+        if not deps_files:
+            continue
+
         if new_version > latest_ver:
             latest_ver = new_version
             latest = directory_name


### PR DESCRIPTION
##### SUMMARY
Since https://github.com/ansible-community/ansible-build-data/tree/main/5 was added, the devel docs build will use its `ancestor.deps` file for building the latest devel docs. Since that's a symlink to the 4.0.0 deps file, the devel docs will use the 4.0.0 collections until the first 5.0.0 alpha is released.

This PR slightly extends the logic to skip directories for major versions which do not contain 'real' `.deps` files.

(This needs to be rewritten once the 'real' devel docs build is implemented, but IMO this suffices until then.)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
devel docs build
