### PR TITLE
Use antsibull-docs devel for devel docs

### DIFF
--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -197,8 +197,6 @@ keywords: ../templates/playbooks_keywords.rst.j2
 config: ../templates/config.rst.j2
 	$(CONFIG_DUMPER) --template-file=../templates/config.rst.j2 --output-dir=rst/reference_appendices/ ../../lib/ansible/config/base.yml
 
-# For now, if we're building on devel, just build base docs.  In the future we'll want to build docs that
-# are the latest versions on galaxy (using a different antsibull-docs subcommand)
 plugins:
 	$(PLUGIN_FORMATTER) full -o rst $(ANSIBLE_VERSION_ARGS) $(PLUGIN_ARGS);\
 

--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -1,7 +1,7 @@
 # pip packages required to build docsite
 # tested June 9 2021
 
-antsibull==0.33.0
+antsibull==0.34.0
 docutils==0.16
 # check unordered lists when testing more recent docutils versions
 # see https://github.com/readthedocs/sphinx_rtd_theme/issues/1115

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -3,7 +3,7 @@
 # if you want known good versions of these dependencies
 # use known_good_reqs.txt instead 
 
-antsibull >= 0.25.0
+antsibull >= 0.34.0
 docutils == 0.16 # pin for now until the problem with unordered lists is fixed
 # see https://github.com/readthedocs/sphinx_rtd_theme/issues/1115jinja2==3.0.1
 jinja2


### PR DESCRIPTION
##### SUMMARY
Use `antsibull-docs devel` for devel docs. Needs ansible-community/antsibull#282.

CC @abadger

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
hacking/build_library/build_ansible/command_plugins/docs_build.py
