### PR TITLE
ansible-test: allow to enable/disable sanity tests with config

### DIFF
--- a/changelogs/fragments/74989-ansible_test-sanity-config.yml
+++ b/changelogs/fragments/74989-ansible_test-sanity-config.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "ansible-test config - allow to specify sanity tests which should always be enabled or disabled in the config (https://github.com/ansible/ansible/pull/74989)."

--- a/test/lib/ansible_test/_internal/commands/sanity/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/__init__.py
@@ -153,8 +153,15 @@ def command_sanity(args):  # type: (SanityConfig) -> None
         disabled = []
         tests = [target for target in tests if target.name in args.test]
     else:
-        disabled = [target.name for target in tests if not target.enabled and not args.allow_disabled]
-        tests = [target for target in tests if target.enabled or args.allow_disabled]
+        disable_sanity_tests = get_content_config().tests.disable_sanity_tests
+        enable_sanity_tests = get_content_config().tests.enable_sanity_tests
+        disabled = {
+            target.name for target in tests
+            if (not target.enabled or target.name in disable_sanity_tests)
+            and not args.allow_disabled
+            and target.name not in enable_sanity_tests
+        }
+        tests = [target for target in tests if target.name not in disabled]
 
     if args.skip_test:
         tests = [target for target in tests if target.name not in args.skip_test]

--- a/test/lib/ansible_test/config/config.yml
+++ b/test/lib/ansible_test/config/config.yml
@@ -39,3 +39,22 @@ modules:
   # These settings only apply to modules/module_utils.
   # It is not possible to declare supported Python versions for controller-only code.
   # All Python versions supported by the controller must be supported by controller-only code.
+
+tests:
+  # Configuration for tests.
+
+  enable_sanity_tests: []
+  # Sanity Tests that should be enabled by default.
+  # This setting is optional.
+  #
+  # Specifying a sanity test here will enable the test by default when `ansible-test sanity` is used. Such tests can be explicitly skipped by specifying `--skip-test`.
+  #
+  # You can get a list of valid values by running `ansible-test sanity --list-tests` inside a collection.
+
+  disable_sanity_tests: []
+  # Sanity Tests that should be disabled by default.
+  # This setting is optional.
+  #
+  # Specifying a sanity test here will disable the test by default when `ansible-test sanity` is used. Such tests can be explicitly run by specifying `--test` or `--allow-disabled`.
+  #
+  # You can get a list of valid values by running `ansible-test sanity --list-tests` inside a collection.


### PR DESCRIPTION
##### SUMMARY
This PR adds two config settings to the ansible-test config file which allow to enable and disable sanity tests.

The purpose of this PR is twofold:
1. I want to try out adding new options :)
2. This can be really useful for collections, for example to disable the `pep8` test by default if they are using `blake` for code formatting (which is not compatible to `flake8`) (CC @tadeboro). With this option, contributors can simply run `ansible-test sanity --docker` to run all sanity tests and not have to care about explicitly specifying `--skip-test pep8` or ignoring the `pep8` failures.

About the implementation: I decided to make it a warning (and not an error) if a sanity test is specified that does not exist. This is important since the sam config file will be used by different ansible-test versions, some of them potentially having other tests available than others.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test
