### PR TITLE
role argspec - tag role argspec validation task with 'always'

### DIFF
--- a/changelogs/fragments/role_argspec_tagged_always.yml
+++ b/changelogs/fragments/role_argspec_tagged_always.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - roles - make sure argspec validation task is tagged with ``always``.

--- a/changelogs/fragments/role_argspec_tagged_always.yml
+++ b/changelogs/fragments/role_argspec_tagged_always.yml
@@ -1,2 +1,2 @@
 bugfixes:
-    - roles - make sure argspec validation task is tagged with ``always``.
+    - roles - make sure argspec validation task is tagged with ``always`` (https://github.com/ansible/ansible/pull/74994).

--- a/docs/docsite/rst/user_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tags.rst
@@ -305,6 +305,10 @@ For example:
      you apply a tag and then use a different tag in ``--tags`` or the same
      tag in ``--skip-tags``.
 
+.. warning::
+   * The role argument specification validation task is tagged with 'always' by default. This validation
+     will be skipped if you use ``--skip-tags always``.
+
 .. versionadded:: 2.5
 
 If you assign the ``never`` tag to a task or play, Ansible will skip that task or play unless you specifically request it (``--tags never``).

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -358,6 +358,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
                 },
             },
             'name': task_name,
+            'tags': ['always'],
         }
 
     def _load_role_yaml(self, subdir, main=None, allow_dir=False):

--- a/test/integration/targets/roles_arg_spec/runme.sh
+++ b/test/integration/targets/roles_arg_spec/runme.sh
@@ -25,3 +25,8 @@ set +e
 ansible-playbook test_play_level_role_fails.yml -i ../../inventory "$@"
 test $? -ne 0
 set -e
+
+# Test the validation task is tagged with 'always' by specifying an unused tag.
+# The task is tagged with 'foo' but we use 'bar' in the call below and expect
+# the validation task to run anyway since it is tagged 'always'.
+ansible-playbook test_tags.yml -i ../../inventory "$@" --tags bar | grep "a : Validating arguments against arg spec 'main' - Main entry point for role A."

--- a/test/integration/targets/roles_arg_spec/test_tags.yml
+++ b/test/integration/targets/roles_arg_spec/test_tags.yml
@@ -1,0 +1,11 @@
+---
+- hosts: localhost
+  gather_facts: false
+  tasks:
+      - name: "Tag test #1"
+        import_role:
+            name: a
+        vars:
+            a_str: "tag test #1"
+        tags:
+            - foo


### PR DESCRIPTION
##### SUMMARY

The role argspec validation task did not have the `always` tag applied to it, so it was being skipped if any tags were specified. We always want this task to run, regardless of tagging, unless the user explicitly opts out of role validation entirely.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
roles
