### PR TITLE
ansible-test: exposes tiny_prefix variable

### DIFF
--- a/changelogs/fragments/aws_tiny_prefix.yaml
+++ b/changelogs/fragments/aws_tiny_prefix.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- ansible-test - aws creates and exposes a new tiny_prefix variable to provide a shorter prefix for the AWS tests. 

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/aws.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/aws.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
+import uuid
 
 from .... import types as t
 
@@ -100,6 +101,7 @@ class AwsCloudEnvironment(CloudEnvironment):
 
         ansible_vars = dict(
             resource_prefix=self.resource_prefix,
+            tiny_prefix=uuid.uuid4().hex[0:12]
         )
 
         # noinspection PyTypeChecker


### PR DESCRIPTION
ansible-test aws provider now creates and exposes a new tiny_prefix
variable to provide a shorter prefix for the AWS tests.