### PR TITLE
[2.10] Do not show empty version_added_collection values in ansible-doc text output

### DIFF
--- a/changelogs/fragments/74999-ansible-doc-version_added_collection.yml
+++ b/changelogs/fragments/74999-ansible-doc-version_added_collection.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-doc - in text output, do not show empty ``version_added_collection`` values (https://github.com/ansible/ansible/pull/74999)."

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -599,6 +599,10 @@ class DocCLI(CLI):
             if conf:
                 text.append(DocCLI._dump_yaml({'set_via': conf}, opt_indent))
 
+            # Remove empty version_added_collection
+            if opt.get('version_added_collection') == '':
+                opt.pop('version_added_collection')
+
             for k in sorted(opt):
                 if k.startswith('_'):
                     continue


### PR DESCRIPTION
##### SUMMARY
Backport of #74999 to stable-2.10.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-doc
