### PR TITLE
fix remote user home expansion when user line ends

### DIFF
--- a/changelogs/fragments/remote_user_fix.yml
+++ b/changelogs/fragments/remote_user_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - actionbase fix to handle remote_users with domain/user that can conflict with line ends.

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -841,9 +841,10 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             # We will really not hit this since remote_tmp handling should already account for this case. Hack kept JIC
             if not getattr(self._connection, '_remote_is_local', False):
 
+                become_user = self.get_become_option('become_user')
                 # remote user depends on privilege escalation or not
                 if sudoable and self._connection.become and become_user:
-                    user = self.get_become_option('become_user')
+                    user = become_user
                 else:
                     # use remote user instead, if none set default to current user
                     user = self._get_remote_user() or ''

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -163,9 +163,9 @@ class ShellBase(AnsiblePlugin):
         basetmp = self.join_path(basetmpdir, basefile)
 
         # use mkdir -p to ensure parents exist, but mkdir fullpath to ensure last one is created by us
-        cmd = 'mkdir -p %s echo %s %s' % (self._SHELL_SUB_LEFT, basetmpdir, self._SHELL_SUB_RIGHT)
-        cmd += '%s mkdir %s echo %s %s' % (self._SHELL_AND, self._SHELL_SUB_LEFT, basetmp, self._SHELL_SUB_RIGHT)
-        cmd += ' %s echo %s=%s echo %s %s' % (self._SHELL_AND, basefile, self._SHELL_SUB_LEFT, basetmp, self._SHELL_SUB_RIGHT)
+        cmd = 'mkdir -p %s echo %s %s' % (self._SHELL_SUB_LEFT, shlex_quote(basetmpdir), self._SHELL_SUB_RIGHT)
+        cmd += '%s mkdir %s echo %s %s' % (self._SHELL_AND, self._SHELL_SUB_LEFT, shlex_quote(basetmp), self._SHELL_SUB_RIGHT)
+        cmd += ' %s echo %s=%s echo %s %s' % (self._SHELL_AND, shlex_quote(basefile), self._SHELL_SUB_LEFT, shlex_quote(basetmp), self._SHELL_SUB_RIGHT)
 
         # change the umask in a subshell to achieve the desired mode
         # also for directories created with `mkdir -p`


### PR DESCRIPTION
   line endings can appear in user names with domain\user
   if user name startswith r or n

  fixes #74957

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
action base