### PR TITLE
file integration test - cleanup testing users and group

### DIFF
--- a/test/integration/targets/file/handlers/main.yml
+++ b/test/integration/targets/file/handlers/main.yml
@@ -1,0 +1,19 @@
+- name: remove users
+  user:
+    name: "{{ item }}"
+    state: absent
+    remove: yes
+  loop:
+    - test1
+    - test_uid
+    - nonexistent
+    - "{{ remote_unprivileged_user }}"
+
+- name: remove groups
+  group:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - test1
+    - test_gid
+    - nonexistent1

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -183,11 +183,13 @@
   user:
     name: test1
     uid: 1234
+  notify: remove users
 
 - name: create group
   group:
     name: test1
     gid: 1234
+  notify: remove groups
 
 - name: change ownership and group
   file: path={{output_dir}}/baz.txt owner=1234 group=1234
@@ -604,6 +606,7 @@
 - name: create owner
   user:
     name: nonexistent
+  notify: remove users
 
 # I don't use state=touch here intentionally to fail and catch warnings
 - name: owner exist in check_mode
@@ -627,6 +630,7 @@
   user:
     name: test_uid
     uid: 111111
+  notify: remove users
 
 # I don't use state=touch here intentionally to fail and catch warnings
 - name: owner exists in check_mode, using uid
@@ -650,6 +654,7 @@
 - name: create group
   group:
     name: nonexistent1
+  notify: remove groups
 
 # I don't use state=touch here intentionally to fail and catch warnings
 - name: group exists in check_mode
@@ -673,6 +678,7 @@
   group:
     name: test_gid
     gid: 111112
+  notify: remove groups
 
 # I don't use state=touch here intentionally to fail and catch warnings
 - name: group exists in check_mode, using gid

--- a/test/integration/targets/file/tasks/state_link.yml
+++ b/test/integration/targets/file/tasks/state_link.yml
@@ -125,6 +125,7 @@
       user:
         name: '{{ remote_unprivileged_user }}'
       register: user
+      notify: remove users
 
     - name: Create a local temporary directory
       tempfile:


### PR DESCRIPTION
##### SUMMARY
The `file` inetgration test does not fully cleanup the users and groups it creates during the test. Some are cleaned up, but not all.

Create handlers to ensure that all users and groups created by the `file` integration test are cleanup up.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/file`