### PR TITLE
Async task change handling

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_async.rst
+++ b/docs/docsite/rst/user_guide/playbooks_async.rst
@@ -121,7 +121,7 @@ If you need a synchronization point with an async task, you can register it to o
 
 .. note::
    Asynchronous playbook tasks always return changed. If the task is using a module
-   that requires the user to annotate changes with ``changed_when``, ``creates``, etc.
+   that requires the user to annotate changes with ``changed_when``, ``creates``,  and so on,
    then those should be added to the following ``async_status`` task.
 
 To run multiple asynchronous tasks while limiting the number of tasks running concurrently::

--- a/docs/docsite/rst/user_guide/playbooks_async.rst
+++ b/docs/docsite/rst/user_guide/playbooks_async.rst
@@ -119,6 +119,11 @@ If you need a synchronization point with an async task, you can register it to o
    "check on it later" task to fail because the temporary status file that
    the ``async_status:`` is looking for will not have been written or no longer exist
 
+.. note::
+   Asynchronous playbook tasks always return changed. If the task is using a module
+   that requires the user to annotate changes with ``changed_when``, ``creates``, etc.
+   then those should be added to the following ``async_status`` task.
+
 To run multiple asynchronous tasks while limiting the number of tasks running concurrently::
 
     #####################


### PR DESCRIPTION
##### SUMMARY
Async task changes should be handled in the async_status task.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
After discussing async tasks in ansible-lint in https://github.com/ansible-community/ansible-lint/pull/1625 it was noted that documentation around async tasks change handling could be improved.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`user_guide/playbooks_async.rst`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

This PR adds a small note about async tasks change handling:
- The task itself by default always reports "changed".
- Processing the change with `changed_when` etc should be done in the following `async_status` task.

Please note I am not familiar with style expected in ansible documentation. It could use some editing so change suggestions in review are much appreciated.