### PR TITLE
Include parent role vars as well as _role_vars

### DIFF
--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -456,6 +456,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
 
         if dep_chain:
             for parent in dep_chain:
+                inherited_vars = combine_vars(inherited_vars, parent.vars)
                 inherited_vars = combine_vars(inherited_vars, parent._role_vars)
         return inherited_vars
 

--- a/test/integration/targets/roles_var_inheritance/aliases
+++ b/test/integration/targets/roles_var_inheritance/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group5

--- a/test/integration/targets/roles_var_inheritance/play.yml
+++ b/test/integration/targets/roles_var_inheritance/play.yml
@@ -1,0 +1,4 @@
+- hosts: localhost
+  roles:
+    - A
+    - B

--- a/test/integration/targets/roles_var_inheritance/roles/A/meta/main.yml
+++ b/test/integration/targets/roles_var_inheritance/roles/A/meta/main.yml
@@ -1,0 +1,4 @@
+dependencies:
+  - role: common_dep
+    vars:
+      test_var: A

--- a/test/integration/targets/roles_var_inheritance/roles/B/meta/main.yml
+++ b/test/integration/targets/roles_var_inheritance/roles/B/meta/main.yml
@@ -1,0 +1,4 @@
+dependencies:
+  - role: common_dep
+    vars:
+      test_var: B

--- a/test/integration/targets/roles_var_inheritance/roles/child_nested_dep/vars/main.yml
+++ b/test/integration/targets/roles_var_inheritance/roles/child_nested_dep/vars/main.yml
@@ -1,0 +1,1 @@
+var_precedence: dependency

--- a/test/integration/targets/roles_var_inheritance/roles/common_dep/meta/main.yml
+++ b/test/integration/targets/roles_var_inheritance/roles/common_dep/meta/main.yml
@@ -1,0 +1,4 @@
+dependencies:
+  - role: nested_dep
+    vars:
+      nested_var: "{{ test_var }}"

--- a/test/integration/targets/roles_var_inheritance/roles/common_dep/vars/main.yml
+++ b/test/integration/targets/roles_var_inheritance/roles/common_dep/vars/main.yml
@@ -1,0 +1,1 @@
+var_precedence: parent

--- a/test/integration/targets/roles_var_inheritance/roles/nested_dep/meta/main.yml
+++ b/test/integration/targets/roles_var_inheritance/roles/nested_dep/meta/main.yml
@@ -1,0 +1,3 @@
+allow_duplicates: yes
+dependencies:
+  - child_nested_dep

--- a/test/integration/targets/roles_var_inheritance/roles/nested_dep/tasks/main.yml
+++ b/test/integration/targets/roles_var_inheritance/roles/nested_dep/tasks/main.yml
@@ -1,0 +1,5 @@
+- debug:
+    var: nested_var
+
+- debug:
+    var: var_precedence

--- a/test/integration/targets/roles_var_inheritance/runme.sh
+++ b/test/integration/targets/roles_var_inheritance/runme.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ansible-playbook -i ../../inventory play.yml "$@" | tee out.txt
+
+test "$(grep out.txt -ce '"nested_var": "A"')" == 1
+test "$(grep out.txt -ce '"nested_var": "B"')" == 1
+test "$(grep out.txt -ce '"var_precedence": "dependency"')" == 2


### PR DESCRIPTION
##### SUMMARY
Fixes `vars:` inheritance issues like #74733

There's a related PR, #69040, that would make the variables undefined instead of incorrect. That PR + this one (tweaked to use the exports_only parameter in `get_inherited_vars`) fixes #73921.

##### ISSUE TYPE
- Bugfix Pull Request
