### PR TITLE
command - remove unreachable code and achieve full test coverage

### DIFF
--- a/changelogs/fragments/command-remove-unreachable-code.yml
+++ b/changelogs/fragments/command-remove-unreachable-code.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - command - remove unreachable code path when trying to convert the value for ``chdir`` to bytes (https://github.com/ansible/ansible/pull/75036)

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -317,11 +317,7 @@ def main():
         check_command(module, args)
 
     if chdir:
-        try:
-            chdir = to_bytes(chdir, errors='surrogate_or_strict')
-        except ValueError as e:
-            r['msg'] = 'Unable to use supplied chdir from %s: %s ' % (os.getcwd(), to_text(e))
-            module.fail_json(**r)
+        chdir = to_bytes(chdir, errors='surrogate_or_strict')
 
         try:
             os.chdir(chdir)

--- a/test/integration/targets/command_shell/tasks/main.yml
+++ b/test/integration/targets/command_shell/tasks/main.yml
@@ -493,12 +493,22 @@
         - 'parent_dir_cd.stdout == "{{output_dir}}/www"'
         - 'parent_dir_chdir.stdout == "{{output_dir}}/www_root"'
 
+- name: Set print error command for Python 2
+  set_fact:
+    print_error_command: print >> sys.stderr, msg
+  when: ansible_facts.python_version is version('3', '<')
+
+- name: Set print error command for Python 3
+  set_fact:
+    print_error_command: print(msg, file=sys.stderr)
+  when: ansible_facts.python_version is version('3', '>=')
+
 - name: run command with strip
-  command: '{{ ansible_playbook_python}} -c "import sys; msg=''hello \n \r''; print(msg); print(msg, file=sys.stderr)"'
+  command: '{{ ansible_playbook_python}} -c "import sys; msg=''hello \n \r''; print(msg); {{ print_error_command }}"'
   register: command_strip
 
 - name: run command without strip
-  command: '{{ ansible_playbook_python}} -c "import sys; msg=''hello \n \r''; print(msg); print(msg, file=sys.stderr)"'
+  command: '{{ ansible_playbook_python}} -c "import sys; msg=''hello \n \r''; print(msg); {{ print_error_command }}"'
   args:
     strip_empty_ends: no
   register: command_no_strip
@@ -510,4 +520,3 @@
       - command_strip.stderr == 'hello \n '
       - command_no_strip.stdout== 'hello \n \r\n'
       - command_no_strip.stderr == 'hello \n \r\n'
-

--- a/test/integration/targets/command_shell/tasks/main.yml
+++ b/test/integration/targets/command_shell/tasks/main.yml
@@ -132,12 +132,21 @@
     chdir: "{{ output_dir_test }}"
   register: command_result2
 
+- name: Check invalid chdir
+  command: echo
+  args:
+    chdir: "{{ output_dir }}/nope"
+  ignore_errors: yes
+  register: chdir_invalid
+
 - name: assert that the script executed correctly with chdir
   assert:
     that:
       - command_result2.rc == 0
       - command_result2.stderr == ''
       - command_result2.stdout == 'win'
+      - chdir_invalid is failed
+      - chdir_invalid.msg is search('Unable to change directory')
 
 # creates
 
@@ -483,3 +492,22 @@
         - parent_dir_chdir.stdout != parent_dir_cd.stdout
         - 'parent_dir_cd.stdout == "{{output_dir}}/www"'
         - 'parent_dir_chdir.stdout == "{{output_dir}}/www_root"'
+
+- name: run command with strip
+  command: '{{ ansible_playbook_python}} -c "import sys; msg=''hello \n \r''; print(msg); print(msg, file=sys.stderr)"'
+  register: command_strip
+
+- name: run command without strip
+  command: '{{ ansible_playbook_python}} -c "import sys; msg=''hello \n \r''; print(msg); print(msg, file=sys.stderr)"'
+  args:
+    strip_empty_ends: no
+  register: command_no_strip
+
+- name: Verify strip behavior worked as expected
+  assert:
+    that:
+      - command_strip.stdout == 'hello \n '
+      - command_strip.stderr == 'hello \n '
+      - command_no_strip.stdout== 'hello \n \r\n'
+      - command_no_strip.stderr == 'hello \n \r\n'
+


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add a few more tests and remove an unreachable section of code to achieve 100% cover for the `command` module.

`to_bytes()` on the managed node will never be able to raise a `ValueError`. The value of `chdir` is already encoded with `surrogeteescape` on the controller before being transferred to the managed node. Even with a `surrogateescape``d string of bytes from Python 3 on the controller trying to be encoded with Python 2 on the managed node with `strict` will not raise a `ValueError`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/command_shell`