### PR TITLE
user - Use -n instead of -N for luseradd on all distros

### DIFF
--- a/changelogs/fragments/75042-lowercase-dash-n-with-luseradd-on-all-distros.yml
+++ b/changelogs/fragments/75042-lowercase-dash-n-with-luseradd-on-all-distros.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - fix creating a local user if the user group already exists (https://github.com/ansible/ansible/pull/75042)

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -664,22 +664,26 @@ class User(object):
             # exists with the same name as the user to prevent
             # errors from useradd trying to create a group when
             # USERGROUPS_ENAB is set in /etc/login.defs.
-            if os.path.exists('/etc/redhat-release'):
-                dist = distro.version()
-                major_release = int(dist.split('.')[0])
-                if major_release <= 5 or self.local:
-                    cmd.append('-n')
+            if self.local:
+                # luseradd uses -n instead of -N
+                cmd.append('-n')
+            else:
+                if os.path.exists('/etc/redhat-release'):
+                    dist = distro.version()
+                    major_release = int(dist.split('.')[0])
+                    if major_release <= 5:
+                        cmd.append('-n')
+                    else:
+                        cmd.append('-N')
+                elif os.path.exists('/etc/SuSE-release'):
+                    # -N did not exist in useradd before SLE 11 and did not
+                    # automatically create a group
+                    dist = distro.version()
+                    major_release = int(dist.split('.')[0])
+                    if major_release >= 12:
+                        cmd.append('-N')
                 else:
                     cmd.append('-N')
-            elif os.path.exists('/etc/SuSE-release'):
-                # -N did not exist in useradd before SLE 11 and did not
-                # automatically create a group
-                dist = distro.version()
-                major_release = int(dist.split('.')[0])
-                if major_release >= 12:
-                    cmd.append('-N')
-            else:
-                cmd.append('-N')
 
         if self.groups is not None and len(self.groups):
             groups = self.get_groups_set()

--- a/test/integration/targets/user/tasks/test_local.yml
+++ b/test/integration/targets/user/tasks/test_local.yml
@@ -86,6 +86,7 @@
     - testgroup3
     - testgroup4
     - testgroup5
+    - local_ansibulluser
   tags:
     - user_test_local_mode
 
@@ -163,6 +164,7 @@
     - testgroup3
     - testgroup4
     - testgroup5
+    - local_ansibulluser
   tags:
     - user_test_local_mode
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When the `user` module is invoked with `local: true`, `luseradd` is called instead of `useradd`. When the users primary group already exists, `luseradd` needs to be called with `-n` instead of `-N` on all distros.  Previously, this worked only on RedHat derivatives.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
user module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Here's how the updated integration test fails on Ubuntu 20.04 before the fix:
```paste below
$ ansible-test integration --allow-destructive user --tags user_test_local_mode --python 3.8 --docker ubuntu2004
...
TASK [user : Create test groups] ***********************************************
changed: [testhost] => (item=testgroup1)
changed: [testhost] => (item=testgroup2)
changed: [testhost] => (item=testgroup3)
changed: [testhost] => (item=testgroup4)
changed: [testhost] => (item=local_ansibulluser)

TASK [user : Create local_ansibulluser with groups] ****************************
fatal: [testhost]: FAILED! => {"changed": false, "msg": "Error parsing arguments: unknown option.\nUsage: luseradd [-irMn?] [-i|--interactive] [-r|--reserved]\n        [-c|--gecos=STRING] [-d|--directory=STRING] [-k|--skeleton=STRING]\n        [-s|--shell=STRING] [-u|--uid=NUM] [-g|--gid=STRING]\n        [-M|--nocreatehome] [-n|--nocreategroup] [-P|--plainpassword=STRING]\n        [-p|--password=STRING] [--commonname=STRING] [--givenname=STRING]\n        [--surname=STRING] [--roomnumber=STRING] [--telephonenumber=STRING]\n        [--homephone=STRING] [-?|--help] [--usage] [OPTION...] user\n", "name": "local_ansibulluser", "rc": 1}
...
```
And after the fix:
```
$ ansible-test integration --allow-destructive user --tags user_test_local_mode --python 3.8 --docker ubuntu2004
...
TASK [user : Create test groups] ***********************************************
changed: [testhost] => (item=testgroup1)
changed: [testhost] => (item=testgroup2)
changed: [testhost] => (item=testgroup3)
changed: [testhost] => (item=testgroup4)
changed: [testhost] => (item=local_ansibulluser)

TASK [user : Create local_ansibulluser with groups] ****************************
changed: [testhost]
...
```