### PR TITLE
ansible-galaxy - Fix Python2 UnicodeEncodeError for collection paths

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -77,7 +77,7 @@ def with_collection_artifacts_manager(wrapped_method):
 
 
 def _display_header(path, h1, h2, w1=10, w2=7):
-    display.display('\n# {0}\n{1:{cwidth}} {2:{vwidth}}\n{3} {4}\n'.format(
+    display.display(u'\n# {0}\n{1:{cwidth}} {2:{vwidth}}\n{3} {4}\n'.format(
         path,
         h1,
         h2,
@@ -99,7 +99,7 @@ def _display_role(gr):
 
 
 def _display_collection(collection, cwidth=10, vwidth=7, min_cwidth=10, min_vwidth=7):
-    display.display('{fqcn:{cwidth}} {version:{vwidth}}'.format(
+    display.display(u'{fqcn:{cwidth}} {version:{vwidth}}'.format(
         fqcn=to_text(collection.fqcn),
         version=collection.ver,
         cwidth=max(cwidth, min_cwidth),  # Make sure the width isn't smaller than the header
@@ -1346,7 +1346,7 @@ class GalaxyCLI(CLI):
             if os.path.isdir(path):
                 path_found = True
             else:
-                warnings.append("- the configured path {0} does not exist.".format(path))
+                warnings.append(u"- the configured path {0} does not exist.".format(path))
                 continue
 
             if role_name:
@@ -1409,11 +1409,11 @@ class GalaxyCLI(CLI):
                 if path in default_collections_path:
                     # don't warn for missing default paths
                     continue
-                warnings.append("- the configured path {0} does not exist.".format(collection_path))
+                warnings.append(u"- the configured path {0} does not exist.".format(collection_path))
                 continue
 
             if not os.path.isdir(collection_path):
-                warnings.append("- the configured path {0}, exists, but it is not a directory.".format(collection_path))
+                warnings.append(u"- the configured path {0}, exists, but it is not a directory.".format(collection_path))
                 continue
 
             path_found = True
@@ -1431,8 +1431,12 @@ class GalaxyCLI(CLI):
                     warnings.append("- unable to find {0} in collection paths".format(collection_name))
                     continue
 
-                if not os.path.isdir(collection_path):
-                    warnings.append("- the configured path {0}, exists, but it is not a directory.".format(collection_path))
+                if not os.path.isdir(b_collection_path):
+                    warnings.append(
+                        u"- the configured path {0}, exists, but it is not a directory.".format(
+                            to_text(b_collection_path, errors='surrogate_or_strict')
+                        )
+                    )
                     continue
 
                 collection_found = True
@@ -1461,18 +1465,18 @@ class GalaxyCLI(CLI):
                 # list all collections
                 collection_path = validate_collection_path(path)
                 if os.path.isdir(collection_path):
-                    display.vvv("Searching {0} for collections".format(collection_path))
+                    display.vvv(u"Searching {0} for collections".format(collection_path))
                     collections = list(find_existing_collections(
                         collection_path, artifacts_manager,
                     ))
                 else:
                     # There was no 'ansible_collections/' directory in the path, so there
                     # or no collections here.
-                    display.vvv("No 'ansible_collections' directory found at {0}".format(collection_path))
+                    display.vvv(u"No 'ansible_collections' directory found at {0}".format(collection_path))
                     continue
 
                 if not collections:
-                    display.vvv("No collections found at {0}".format(collection_path))
+                    display.vvv(u"No collections found at {0}".format(collection_path))
                     continue
 
                 if output_format in {'yaml', 'json'}:

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -324,7 +324,7 @@ def download_collections(
 
     requirements = []
     with _display_progress(
-            "Starting collection download process to '{path!s}'".
+            u"Starting collection download process to '{path!s}'".
             format(path=output_path),
     ):
         for fqcn, concrete_coll_pin in dep_map.copy().items():  # FIXME: move into the provider
@@ -1164,7 +1164,7 @@ def install_src(
     )
 
     display.display(
-        'Created collection for {coll!s} at {path!s}'.
+        u'Created collection for {coll!s} at {path!s}'.
         format(coll=collection, path=collection_output_path)
     )
 


### PR DESCRIPTION
##### SUMMARY
Fixing encoding issues. The paths are unicode but the strings were not. Since this affects Python 2.7 I'd like to backport it.
```
$ python2.7 $(which ansible-galaxy) collection list -p ÅÑŚÌβŁÈ_nonexistent -vvv
Traceback (most recent call last):
  File "/home/liveuser/ansible/bin/ansible-galaxy", line 133, in <module>
    exit_code = cli.run()
  File "/home/liveuser/ansible/lib/ansible/cli/galaxy.py", line 552, in run
    return context.CLIARGS['func']()
  File "/home/liveuser/ansible/lib/ansible/cli/galaxy.py", line 1331, in execute_list
    self.execute_list_collection()
  File "/home/liveuser/ansible/lib/ansible/cli/galaxy.py", line 75, in method_wrapper
    return wrapped_method(*args, **kwargs)
  File "/home/liveuser/ansible/lib/ansible/cli/galaxy.py", line 1412, in execute_list_collection
    warnings.append("- the configured path {0} does not exist.".format(collection_path))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 23-29: ordinal not in range(128)
```
%s formatting doesn't have this issue:
```
>>> '{0}'.format(u'ÅÑŚÌβŁÈ')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-6: ordinal not in range(128)
>>> 
>>> '%s' % u'ÅÑŚÌβŁÈ'
u'\xc5\xd1\u015a\xcc\u03b2\u0141\xc8'
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
