### PR TITLE
Clarify Vault password client naming requirements

### DIFF
--- a/docs/docsite/rst/user_guide/vault.rst
+++ b/docs/docsite/rst/user_guide/vault.rst
@@ -94,7 +94,7 @@ You can store your vault passwords on the system keyring, in a database, or in a
 
 To create a vault password client script:
 
-  * Create a file with a name ending in ``-client.py``
+  * Create a file with a name ending in either ``-client`` or ``-client.EXTENSION``
   * Make the file executable
   * Within the script itself:
       * Print the passwords to standard output


### PR DESCRIPTION
##### SUMMARY

See also [ansible.parsing.vault.script_is_client()][1]

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Vault

[1]: https://github.com/ansible/ansible/blob/ec408a69f19052190f1766a357c882fc86cfeada/lib/ansible/parsing/vault/__init__.py#L339-L350