### PR TITLE
vault: Handle directory value to vault password file

### DIFF
--- a/changelogs/fragments/42960_vault_password.yml
+++ b/changelogs/fragments/42960_vault_password.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- vault - handle vault password file value when it is directory (https://github.com/ansible/ansible/issues/42960).

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -356,6 +356,9 @@ def get_file_vault_secret(filename=None, vault_id=None, encoding=None, loader=No
     if not os.path.exists(this_path):
         raise AnsibleError("The vault password file %s was not found" % this_path)
 
+    if os.path.isdir(this_path):
+        raise AnsibleError("The vault password file %s cannot be directory" % this_path)
+
     if loader.is_executable(this_path):
         if script_is_client(filename):
             display.vvvv(u'The vault password file %s is a client script.' % to_text(filename))

--- a/test/integration/targets/vault/runme.sh
+++ b/test/integration/targets/vault/runme.sh
@@ -185,6 +185,12 @@ WRONG_RC=$?
 echo "rc was $WRONG_RC (1 is expected)"
 [ $WRONG_RC -eq 1 ]
 
+# test if vault password file is not a directory
+ANSIBLE_VAULT_PASSWORD_FILE='' ansible-vault view "$@" format_1_1_AES.yml && :
+WRONG_RC=$?
+echo "rc was $WRONG_RC (1 is expected)"
+[ $WRONG_RC -eq 1 ]
+
 # test with a default vault-id list set via config/env, right password
 ANSIBLE_VAULT_PASSWORD_FILE=wrong@vault-password-wrong,correct@vault-password ansible-vault view "$@" format_1_1_AES.yml && :
 


### PR DESCRIPTION
##### SUMMARY

When vault password file env variable is set to blank,
this value is converted to CWD and passed for further
processing.
Check if ANSIBLE_VAULT_PASSWORD_FILE is not a directory.

Fixes: #42960

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/42960_vault_password.yml
lib/ansible/parsing/vault/__init__.py
test/integration/targets/vault/runme.sh
