### PR TITLE
Refactor safe_eval, re-enable ast.Call path

### DIFF
--- a/changelogs/fragments/75068-safe-eval-refactor.yml
+++ b/changelogs/fragments/75068-safe-eval-refactor.yml
@@ -1,0 +1,5 @@
+minor_changes:
+- Templating - refactor ``safe_eval`` to improve performance and correctness, also re-enable the path to allow
+  callables. No callables are enabled, but may be utilized in the future (https://github.com/ansible/ansible/pull/75068)
+breaking_changes:
+- Templating - ``safe_eval`` no longer allows performing arithmetic and concatenation operations outside of the jinja template (https://github.com/ansible/ansible/pull/75068)

--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.12.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.12.rst
@@ -19,7 +19,17 @@ This document is part of a collection on porting. The complete list of porting g
 Playbook
 ========
 
-No notable changes
+* Templating - ``safe_eval`` no longer allows performing arithmetic and concatenation operations outside of the jinja template. The following statement will need to be rewritten to produce ``[1, 2]``:
+
+.. code-block:: yaml
+
+    - name: Prior to 2.12
+      debug:
+        msg: '[1] + {{ [2] }}'
+
+    - name: 2.12 and forward
+      debug:
+        msg: '{{ [1] + [2] }}'
 
 
 Command Line

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -513,29 +513,6 @@ DEFAULT_CACHE_PLUGIN_PATH:
   ini:
   - {key: cache_plugins, section: defaults}
   type: pathspec
-CALLABLE_ACCEPT_LIST:
-  name: Template 'callable' accept list
-  default: []
-  description: Whitelist of callable methods to be made available to template evaluation
-  env:
-  - name: ANSIBLE_CALLABLE_WHITELIST
-    deprecated:
-      why: normalizing names to new standard
-      version: "2.15"
-      alternatives: 'ANSIBLE_CALLABLE_ENABLED'
-  - name: ANSIBLE_CALLABLE_ENABLED
-    version_added: '2.11'
-  ini:
-  - key: callable_whitelist
-    section: defaults
-    deprecated:
-      why: normalizing names to new standard
-      version: "2.15"
-      alternatives: 'callable_enabled'
-  - key: callable_enabled
-    section: defaults
-    version_added: '2.11'
-  type: list
 CONTROLLER_PYTHON_WARNING:
   name: Running Older than Python 3.8 Warning
   default: True

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -325,7 +325,11 @@ class AnsibleUndefined(StrictUndefined):
         return self
 
     def __repr__(self):
-        return 'AnsibleUndefined'
+        return 'AnsibleUndefined(hint={0!r}, obj={1!r}, name={2!r})'.format(
+            self._undefined_hint,
+            self._undefined_obj,
+            self._undefined_name
+        )
 
     def __contains__(self, item):
         # Return original Undefined object to preserve the first failure context

--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -58,6 +58,7 @@ if PY2:
     _OUR_GLOBALS.update({
         'True': True,
         'False': False,
+        'None': None,
     })
 
 # Set of global names for callables that we will allow
@@ -133,8 +134,8 @@ class CleansingNodeVisitor(ast.NodeVisitor):
             # as safe.  Other functions are excluded by setting locals in
             # the call to eval() later on
             raise Exception("invalid function: {0}".format(node.id))
-        if node.id == '__builtins__':
-            raise Exception("invalid name: __builtins__")
+        if node.id == '__builtins__' or node.id not in _OUR_GLOBALS:
+            raise Exception("invalid name: {0}".format(node.id))
         self._is_call = False
         self.generic_visit(node)
 

--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -22,6 +22,9 @@ import ast
 
 from ansible.module_utils.common.text.converters import container_to_text, to_native
 from ansible.module_utils.six import PY2, string_types
+from ansible.utils.display import Display
+
+display = Display()
 
 # define certain JSON types
 # eg. JSON booleans are unknown to python eval()
@@ -146,13 +149,15 @@ def safe_eval(expr, locals=None, include_exceptions=False):
             return (result, None)
         else:
             return result
-    except SyntaxError:
+    except SyntaxError as e:
         # special handling for syntax errors, we just return
         # the expression string back as-is to support late evaluation
+        display.warning('Unable to safely evaluate %r: %s' % (expr, e))
         if include_exceptions:
             return (expr, None)
         return expr
     except Exception as e:
+        display.warning('Unable to safely evaluate %r: %s' % (expr, e))
         if include_exceptions:
             return (expr, e)
         return expr

--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -191,14 +191,14 @@ def safe_eval(expr, locals=None, include_exceptions=False):
         # TODO: Maybe provide a note here that this is likely due to some
         #       repr that cannot be safely evaluated, either a callable, or something like
         #       a generator repr
-        display.warning('Unable to safely evaluate {0!r}: {1}'.format((expr, e)))
+        display.warning('Unable to safely evaluate {0!r}: {1}'.format(expr, e))
         if include_exceptions:
             return (expr, None)
         return expr
     except UndefinedError:
         raise
     except Exception as e:
-        display.warning('Unable to safely evaluate {0!r}: {1}'.format((expr, e)))
+        display.warning('Unable to safely evaluate {0!r}: {1}'.format(expr, e))
         if include_exceptions:
             return (expr, e)
         return expr

--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -19,11 +19,11 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import ast
+import copy
 
 from ansible.module_utils.common.text.converters import container_to_text, to_native
 from ansible.module_utils.six import PY2, string_types
 from ansible.utils.display import Display
-from ansible.vars.clean import module_response_deepcopy
 
 display = Display()
 
@@ -124,7 +124,7 @@ def safe_eval(expr, locals=None, include_exceptions=False):
     Based on:
     http://stackoverflow.com/questions/12523516/using-ast-and-whitelists-to-make-pythons-eval-safe
     '''
-    locals = {} if locals is None else module_response_deepcopy(locals)
+    locals = {} if locals is None else copy.deepcopy(locals)
 
     if not isinstance(expr, string_types):
         # already templated to a datastructure, perhaps?
@@ -140,7 +140,7 @@ def safe_eval(expr, locals=None, include_exceptions=False):
         # Note: passing our own globals and locals here constrains what
         # callables (and other identifiers) are recognized.  this is in
         # addition to the filtering of callables done in CleansingNodeVisitor
-        result = eval(compiled, module_response_deepcopy(_OUR_GLOBALS), locals)
+        result = eval(compiled, copy.deepcopy(_OUR_GLOBALS), locals)
         if PY2:
             # On Python 2 u"{'key': 'value'}" is evaluated to {'key': 'value'},
             # ensure it is converted to {u'key': u'value'}.

--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -78,6 +78,7 @@ _SAFE_NODES = frozenset(
         ast.USub,
         ast.Tuple,
         ast.UnaryOp,
+        ast.keyword,
     ) + tuple(_optional_nodes)
 )
 

--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -39,6 +39,7 @@ _OUR_GLOBALS = {
 }
 
 if PY2:
+    # TODO: remove this
     _OUR_GLOBALS.update({
         'True': True,
         'False': False,
@@ -49,11 +50,12 @@ _CALL_ENABLED = frozenset(k for k, v in _OUR_GLOBALS.items() if callable(v))
 
 _optional_nodes = []
 # These node types are dependent on Python version
-# Set - 3.7
+# Set - 2.7
 # NameConstant - 3.4 - Deprecated in 3.8
 # Constant - 3.6
 # Str - Deprecated in 3.8
 # Num - Deprecated in 3.8
+# TODO: Move these directly into _SAFE_NODES
 for _name in ('Set', 'NameConstant', 'Constant', 'Str', 'Num'):
     try:
         _optional_nodes.append(getattr(ast, _name))
@@ -66,18 +68,12 @@ for _name in ('Set', 'NameConstant', 'Constant', 'Str', 'Num'):
 # visitor class defined below.
 _SAFE_NODES = frozenset(
     (
-        # ast.Add,
-        # ast.BinOp,
         ast.Call,
-        # ast.Compare,
         ast.Dict,
-        # ast.Div,
         ast.Expression,
         ast.List,
         ast.Load,
-        # ast.Mult,
         ast.Name,
-        # ast.Sub,
         ast.UAdd,
         ast.USub,
         ast.Tuple,
@@ -158,6 +154,7 @@ def safe_eval(expr, locals=None, include_exceptions=False):
         # addition to the filtering of callables done in CleansingNodeVisitor
         result = eval(compiled, copy.deepcopy(_OUR_GLOBALS), locals)
         if PY2:
+            # TODO: Remove this
             # On Python 2 u"{'key': 'value'}" is evaluated to {'key': 'value'},
             # ensure it is converted to {u'key': u'value'}.
             result = container_to_text(result)
@@ -169,6 +166,9 @@ def safe_eval(expr, locals=None, include_exceptions=False):
     except SyntaxError as e:
         # special handling for syntax errors, we just return
         # the expression string back as-is to support late evaluation
+        # TODO: Maybe provide a note here that this is likely due to some
+        #       repr that cannot be safely evaluated, either a callable, or something like
+        #       a generator repr
         display.warning('Unable to safely evaluate %r: %s' % (expr, e))
         if include_exceptions:
             return (expr, None)

--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -23,6 +23,7 @@ import ast
 from ansible.module_utils.common.text.converters import container_to_text, to_native
 from ansible.module_utils.six import PY2, string_types
 from ansible.utils.display import Display
+from ansible.vars.clean import module_response_deepcopy
 
 display = Display()
 
@@ -123,7 +124,7 @@ def safe_eval(expr, locals=None, include_exceptions=False):
     Based on:
     http://stackoverflow.com/questions/12523516/using-ast-and-whitelists-to-make-pythons-eval-safe
     '''
-    locals = {} if locals is None else locals
+    locals = {} if locals is None else module_response_deepcopy(locals)
 
     if not isinstance(expr, string_types):
         # already templated to a datastructure, perhaps?
@@ -139,7 +140,7 @@ def safe_eval(expr, locals=None, include_exceptions=False):
         # Note: passing our own globals and locals here constrains what
         # callables (and other identifiers) are recognized.  this is in
         # addition to the filtering of callables done in CleansingNodeVisitor
-        result = eval(compiled, _OUR_GLOBALS, locals)
+        result = eval(compiled, module_response_deepcopy(_OUR_GLOBALS), locals)
         if PY2:
             # On Python 2 u"{'key': 'value'}" is evaluated to {'key': 'value'},
             # ensure it is converted to {u'key': u'value'}.

--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -120,7 +120,9 @@ class CleansingNodeVisitor(ast.NodeVisitor):
         else:
             raise Exception("invalid object: %s" % node.value.__class__.__name__)
         if self._is_call and name not in _CALL_ENABLED:
-            # Disallow calls to any attribute
+            # Disallow calls to functions that we have not vetted
+            # as safe.  Other functions are excluded by setting locals in
+            # the call to eval() later on
             raise Exception("invalid function: %s" % name)
         if self._is_call:
             self._is_call = False

--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -27,10 +27,12 @@ from ansible.utils.display import Display
 
 display = Display()
 
-# define certain JSON types
-# eg. JSON booleans are unknown to python eval()
+# Define globals that we understand and can convert to a Python type
+# or are used to limit functionality
 _OUR_GLOBALS = {
     '__builtins__': {},  # avoid global builtins as per eval docs
+
+    # JSON: These are included to automatically convert JSON objects to python
     'false': False,
     'null': None,
     'true': True,
@@ -42,6 +44,7 @@ if PY2:
         'False': False,
     })
 
+# Set of global names for callables that we will allow
 _CALL_ENABLED = frozenset(k for k, v in _OUR_GLOBALS.items() if callable(v))
 
 _optional_nodes = []
@@ -84,7 +87,8 @@ _SAFE_NODES = frozenset(
 
 
 class CleansingNodeVisitor(ast.NodeVisitor):
-    """ast.NodeVisitor subclass that will raise an exception on
+    """
+    ast.NodeVisitor subclass that will raise an exception on
     disallowed Nodes or disallowed callables
     """
 

--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -32,6 +32,12 @@ _OUR_GLOBALS = {
     'true': True,
 }
 
+if PY2:
+    _OUR_GLOBALS.update({
+        'True': True,
+        'False': False,
+    })
+
 _CALL_ENABLED = frozenset(k for k, v in _OUR_GLOBALS.items() if callable(v))
 
 _optional_nodes = []

--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -21,11 +21,11 @@ __metaclass__ = type
 import ast
 import copy
 
-from jinja2 import StrictUndefined, UndefinedError
-
 from ansible.module_utils.common.text.converters import container_to_text, to_native
 from ansible.module_utils.six import PY2, string_types
 from ansible.utils.display import Display
+
+from jinja2 import StrictUndefined, UndefinedError
 
 display = Display()
 
@@ -111,19 +111,19 @@ class CleansingNodeVisitor(ast.NodeVisitor):
 
     def generic_visit(self, node):
         if type(node) not in _SAFE_NODES:
-            raise Exception("invalid expression (%s)" % self._expr)
+            raise Exception("invalid expression ({0})".format(self._expr))
         super(CleansingNodeVisitor, self).generic_visit(node)
 
     def visit_Attribute(self, node):
         if isinstance(node.value, ast.Name):
             name = '{0}.{1}'.format(node.value.id, node.attr)
         else:
-            raise Exception("invalid object: %s" % node.value.__class__.__name__)
+            raise Exception("invalid object: {0}".format(node.value.__class__.__name__))
         if self._is_call and name not in _CALL_ENABLED:
             # Disallow calls to functions that we have not vetted
             # as safe.  Other functions are excluded by setting locals in
             # the call to eval() later on
-            raise Exception("invalid function: %s" % name)
+            raise Exception("invalid function: {0}".format(name))
         if self._is_call:
             self._is_call = False
         self.generic_visit(node)
@@ -133,7 +133,7 @@ class CleansingNodeVisitor(ast.NodeVisitor):
             # Disallow calls to functions that we have not vetted
             # as safe.  Other functions are excluded by setting locals in
             # the call to eval() later on
-            raise Exception("invalid function: %s" % node.id)
+            raise Exception("invalid function: {0}".format(node.id))
         if self._is_call:
             self._is_call = False
         self.generic_visit(node)
@@ -170,7 +170,7 @@ def safe_eval(expr, locals=None, include_exceptions=False):
     try:
         parsed_tree = ast.parse(expr, mode='eval')
         cnv.visit(parsed_tree)
-        compiled = compile(parsed_tree, '<expr %s>' % to_native(expr), 'eval')
+        compiled = compile(parsed_tree, '<expr {0}>'.format(to_native(expr)), 'eval')
         # Note: passing our own globals and locals here constrains what
         # callables (and other identifiers) are recognized.  this is in
         # addition to the filtering of callables done in CleansingNodeVisitor
@@ -191,14 +191,14 @@ def safe_eval(expr, locals=None, include_exceptions=False):
         # TODO: Maybe provide a note here that this is likely due to some
         #       repr that cannot be safely evaluated, either a callable, or something like
         #       a generator repr
-        display.warning('Unable to safely evaluate %r: %s' % (expr, e))
+        display.warning('Unable to safely evaluate {0!r}: {1}'.format((expr, e)))
         if include_exceptions:
             return (expr, None)
         return expr
     except UndefinedError:
         raise
     except Exception as e:
-        display.warning('Unable to safely evaluate %r: %s' % (expr, e))
+        display.warning('Unable to safely evaluate {0!r}: {1}'.format((expr, e)))
         if include_exceptions:
             return (expr, e)
         return expr

--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -123,6 +123,8 @@ class CleansingNodeVisitor(ast.NodeVisitor):
             # as safe.  Other functions are excluded by setting locals in
             # the call to eval() later on
             raise Exception("invalid function: %s" % node.id)
+        if self._inside_call:
+            self._inside_call = False
         self.generic_visit(node)
 
     def visit_Call(self, node):

--- a/lib/ansible/vars/clean.py
+++ b/lib/ansible/vars/clean.py
@@ -47,7 +47,6 @@ def module_response_deepcopy(v):
     * ``ansible.executor.task_result.TaskResult.clean_copy``
     * ``ansible.vars.clean.clean_facts``
     * ``ansible.vars.namespace_facts``
-    * ``ansible.template.safe_eval``
     """
     if isinstance(v, dict):
         ret = v.copy()

--- a/lib/ansible/vars/clean.py
+++ b/lib/ansible/vars/clean.py
@@ -47,6 +47,7 @@ def module_response_deepcopy(v):
     * ``ansible.executor.task_result.TaskResult.clean_copy``
     * ``ansible.vars.clean.clean_facts``
     * ``ansible.vars.namespace_facts``
+    * ``ansible.template.safe_eval``
     """
     if isinstance(v, dict):
         ret = v.copy()

--- a/test/integration/targets/find/tasks/main.yml
+++ b/test/integration/targets/find/tasks/main.yml
@@ -264,7 +264,7 @@
 - set_fact:
     find_test3_list: >-
       [ {% for f in find_test3.files %}
-      {{ f.path }}
+      "{{ f.path }}"
       {% if not loop.last %},{% endif %}
       {% endfor %}
       ]
@@ -305,7 +305,7 @@
 - set_fact:
     astest_list: >-
       [ {% for f in result.files %}
-      {{ f.path }}
+      "{{ f.path }}"
       {% if not loop.last %},{% endif %}
       {% endfor %}
       ]
@@ -325,7 +325,7 @@
 - set_fact:
     astest_list: >-
       [ {% for f in result.files %}
-      {{ f.path }}
+      "{{ f.path }}"
       {% if not loop.last %},{% endif %}
       {% endfor %}
       ]
@@ -350,7 +350,7 @@
 - set_fact:
     astest_list: >-
       [ {% for f in result.files %}
-      {{ f.path }}
+      "{{ f.path }}"
       {% if not loop.last %},{% endif %}
       {% endfor %}
       ]
@@ -374,7 +374,7 @@
 - set_fact:
     astest_list: >-
       [ {% for f in result.files %}
-      {{ f.path }}
+      "{{ f.path }}"
       {% if not loop.last %},{% endif %}
       {% endfor %}
       ]

--- a/test/integration/targets/template/corner_cases.yml
+++ b/test/integration/targets/template/corner_cases.yml
@@ -12,10 +12,14 @@
             - '"I SHOULD NOT BE TEMPLATED" not in adjacent'
             - globals1 == "[[], globals()]"
             - globals2 == "[[], globals]"
+            - left_hand == '[1] + [2]'
+            - left_hand_2 == '[1 + 2 * 3 / 4] + [-2.5, 2.5, 3.5]'
       vars:
         adjacent: "{{ empty_list }} + [dont]"
         globals1: "[{{ empty_list }}, globals()]"
         globals2: "[{{ empty_list }}, globals]"
+        left_hand: '[1] + {{ [2] }}'
+        left_hand_2: '[1 + 2 * 3 / 4] + {{ [-2.5, +2.5, 1 + 2.5] }}'
 
     - name: 'ensure we can add lists'
       assert:

--- a/test/integration/targets/undefined/tasks/main.yml
+++ b/test/integration/targets/undefined/tasks/main.yml
@@ -8,11 +8,11 @@
           - name: two
           - notname: three
           - name: four
+      ignore_errors: true
+      register: undefined_set_fact
 
     - assert:
         that:
-          - '"%r"|format(undef) == "AnsibleUndefined"'
-          # The existence of AnsibleUndefined in a templating result
-          # prevents safe_eval from turning the value into a python object
-          - names is string
-          - '", AnsibleUndefined," in names'
+          - '("%r"|format(undef)).startswith("AnsibleUndefined")'
+          - undefined_set_fact is failed
+          - undefined_set_fact.msg is contains 'undefined variable'

--- a/test/units/template/test_safe_eval.py
+++ b/test/units/template/test_safe_eval.py
@@ -19,28 +19,79 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import sys
 from collections import defaultdict
+from functools import partial
 
-from units.compat import unittest
 from ansible.template.safe_eval import safe_eval
 
+from jinja2 import UndefinedError
 
-class TestSafeEval(unittest.TestCase):
+import pytest
 
-    def test_safe_eval_usage(self):
-        # test safe eval calls with different possible types for the
-        # locals dictionary, to ensure we don't run into problems like
-        # ansible/ansible/issues/12206 again
-        for locals_vars in (dict(), defaultdict(dict)):
-            self.assertEqual(safe_eval('True', locals=locals_vars), True)
-            self.assertEqual(safe_eval('False', locals=locals_vars), False)
-            self.assertEqual(safe_eval('0', locals=locals_vars), 0)
-            self.assertEqual(safe_eval('[]', locals=locals_vars), [])
-            self.assertEqual(safe_eval('{}', locals=locals_vars), {})
-            self.assertEqual(safe_eval('[1] + [2]', locals=locals_vars), '[1] + [2]')
-            self.assertEqual(safe_eval('len("foo")', locals=locals_vars), 'len("foo")')
 
-    @unittest.skipUnless(sys.version_info[:2] >= (2, 7), "Python 2.6 has no set literals")
-    def test_set_literals(self):
-        self.assertEqual(safe_eval('{0}'), set([0]))
+TESTS = [v + (l,) for v in [
+    # Valid
+    (True, True, None),
+    ({}, {}, None),
+    ('True', True, None),
+    ('False', False, None),
+    ('0', 0, None),
+    ('1.0', 1.0, None),
+    ('[]', [], None),
+    ('[True]', [True], None),
+    ('{}', {}, None),
+    ('{"foo": "bar"}', {"foo": "bar"}, None),
+    ('{0}', set([0]), None),
+
+    # Invalid
+    ('[1] + [2]', '[1] + [2]', 'invalid expression ([1] + [2])'),
+    ('len("foo")', 'len("foo")', 'invalid function: len'),
+    ('Foo.bar("baz")', 'Foo.bar("baz")', 'invalid attribute: Foo.bar'),
+    ('{}.fromkeys(["foo"])', '{}.fromkeys(["foo"])', 'invalid object: Dict'),
+    ('{}.__name__', '{}.__name__', 'invalid object: Dict'),
+    ('True.__name__', 'True.__name__', 'invalid object: Constant'),
+    ('AnsibleUndefined(len("foo"))', 'AnsibleUndefined(len("foo"))', 'invalid function: len'),
+    ('__builtins__', '__builtins__', 'invalid name: __builtins__'),
+    ('__builtins__.__class__', '__builtins__.__class__', 'invalid attribute: __builtins__.__class__'),
+
+    # Syntax Errors
+    ('<map at 0x109952e80>', '<map at 0x109952e80>', None),
+] for l in (None, dict, partial(defaultdict, dict))]
+
+
+@pytest.mark.parametrize(('test_input', 'expected', 'error_message', 'locals_val'), TESTS)
+def test_safe_eval_exceptions(test_input, expected, error_message, locals_val):
+    if callable(locals_val):
+        locals_val = locals_val()
+    output, exception = safe_eval(test_input, locals=locals_val, include_exceptions=True)
+    assert output == expected
+    if error_message:
+        assert str(exception) == error_message
+    else:
+        assert exception is None
+
+
+@pytest.mark.parametrize(('test_input', 'expected', 'error_message', 'locals_val'), TESTS)
+def test_safe_eval_no_exceptions(test_input, expected, error_message, locals_val):
+    output = safe_eval(test_input, include_exceptions=False)
+    assert output == expected
+
+
+def test_safe_eval_AnsibleUndefined():
+    with pytest.raises(UndefinedError) as excinfo:
+        safe_eval('AnsibleUndefined(hint=None, obj={}, name="foo")', include_exceptions=True)
+
+    assert str(excinfo.value) == "'dict object' has no attribute 'foo'"
+
+    with pytest.raises(UndefinedError) as excinfo:
+        safe_eval('AnsibleUndefined(None, {}, "foo")', include_exceptions=True)
+
+    assert str(excinfo.value) == "'dict object' has no attribute 'foo'"
+
+
+def test_safe_eval_defaultdict():
+    # https://github.com/ansible/ansible/issues/12206
+    # >>> eval('foo', {}, defaultdict(dict))
+    # {}
+    output, exception = safe_eval('foo', locals=defaultdict(dict), include_exceptions=True)
+    assert output == 'foo'

--- a/test/units/template/test_safe_eval.py
+++ b/test/units/template/test_safe_eval.py
@@ -43,6 +43,12 @@ TESTS = [v + (l,) for v in [
     ('{"foo": "bar"}', {"foo": "bar"}, None),
     ('{0}', set([0]), None),
 
+    # Globals
+    ('__name__', '__name__', 'invalid name: __name__'),
+    ('true', True, None),
+    ('false', False, None),
+    ('null', None, None),
+
     # Invalid
     ('[1] + [2]', '[1] + [2]', 'invalid expression ([1] + [2])'),
     ('len("foo")', 'len("foo")', 'invalid function: len'),

--- a/test/units/template/test_safe_eval.py
+++ b/test/units/template/test_safe_eval.py
@@ -38,6 +38,8 @@ class TestSafeEval(unittest.TestCase):
             self.assertEqual(safe_eval('0', locals=locals_vars), 0)
             self.assertEqual(safe_eval('[]', locals=locals_vars), [])
             self.assertEqual(safe_eval('{}', locals=locals_vars), {})
+            self.assertEqual(safe_eval('[1] + [2]', locals=locals_vars), '[1] + [2]')
+            self.assertEqual(safe_eval('len("foo")', locals=locals_vars), 'len("foo")')
 
     @unittest.skipUnless(sys.version_info[:2] >= (2, 7), "Python 2.6 has no set literals")
     def test_set_literals(self):


### PR DESCRIPTION
##### SUMMARY
Refactor safe_eval, re-enable ast.Call path

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/template/safe_eval.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
