### PR TITLE
Update ActionBase._make_tmp_path()

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -421,7 +421,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             self._cleanup_remote_tmp = True
 
         try:
-            stdout_parts = result['stdout'].strip().split('%s=' % basefile, 1)
+            stdout_parts = result['stdout'].strip().replace('\r', '').replace('\n', '').split('%s=' % basefile, 1)
             rc = self._connection._shell.join_path(stdout_parts[-1], u'').splitlines()[-1]
         except IndexError:
             # stdout was empty or just space, set to / to trigger error in next if


### PR DESCRIPTION
Fix parsing output of ActionBase._low_level_execute_command. On several versions of PowerShell we get \r\n or \n in result['output'] due to console buffersize param which affects on maximum output line length and autoinsertion of line separators. (https://stackoverflow.com/questions/978777/powershell-output-column-width)

##### SUMMARY
Removes line separators while parsing path to a remote script file.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible/plugins/action/\_\_init\_\_.py:ActionBase
