### PR TITLE
[bp-2.11] Clarify Vault password client naming requirements

### DIFF
--- a/docs/docsite/rst/user_guide/vault.rst
+++ b/docs/docsite/rst/user_guide/vault.rst
@@ -94,7 +94,7 @@ You can store your vault passwords on the system keyring, in a database, or in a
 
 To create a vault password client script:
 
-  * Create a file with a name ending in ``-client.py``
+  * Create a file with a name ending in either ``-client`` or ``-client.EXTENSION``
   * Make the file executable
   * Within the script itself:
       * Print the passwords to standard output


### PR DESCRIPTION
##### SUMMARY

(cherry picked from commit aedc82da9825b6c687cbff36a94c6a065f8af5f8)


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/user_guide/vault.rst
