### PR TITLE
Fix baseurl handling in yum_repository test

### DIFF
--- a/test/integration/targets/yum_repository/tasks/main.yml
+++ b/test/integration/targets/yum_repository/tasks/main.yml
@@ -167,7 +167,7 @@
         description: Testing list feature
         baseurl:
           - "{{ yum_repository_test_repo.baseurl }}"
-          - "{{ yum_repository_test_repo.baseurl | replace('download[0-9]?\\.', 'download2\\.', 1) }}"
+          - "{{ yum_repository_test_repo.baseurl ~ 'another_baseurl' }}"
         gpgkey:
           - gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_facts.distribution_major_version }}
           - gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG2-KEY-EPEL-{{ ansible_facts.distribution_major_version }}
@@ -187,13 +187,12 @@
     - name: Assert that lists were properly inserted
       assert:
         that:
-          - url_hostname in repofile
-          - url_hostname2 in repofile
+          - yum_repository_test_repo.baseurl in repofile
+          - another_baseurl in repofile
           - "'RPM-GPG-KEY-EPEL' in repofile"
           - "'RPM-GPG2-KEY-EPEL' in repofile"
           - "'aaa bbb' in repofile"
           - "'ccc ddd' in repofile"
       vars:
         repofile: "{{ slurp.content | b64decode }}"
-        url_hostname: "{{ yum_repository_test_repo.baseurl | urlsplit('hostname') }}"
-        url_hostname2: "{{ url_hostname | replace('download[0-9]?\\.', 'download2\\.', 1) }}"
+        another_baseurl: "{{ yum_repository_test_repo.baseurl ~ 'another_baseurl' }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Since we moved yum_repository_test_repo.baseurl to file:/// format,
using urlsplit filter on it returned an empty string. Using an empty
string as a left operand of `in` was then always evaluated to True.

This was discovered with native jinja being on where urlsplit returns
None which results in a hard fail as None cannot be a left
operand of `in <string>`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/yum_repository/tasks/main.yml`