### PR TITLE
module_common - handle cache directory creation collision

### DIFF
--- a/changelogs/fragments/concurrency-cache-dir-collision.yml
+++ b/changelogs/fragments/concurrency-cache-dir-collision.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - module_common - handle exception when multiple workers try to create the cache directory

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1192,12 +1192,9 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
                             os.makedirs(lookup_path)
                         except FileExistsError:
                             # Multiple workers tried to create the directory concurrently.
-                            # Try again to make sure it exists.
+                            # Check again to make sure it exists. If it still doesn't exist, there is a problem.
                             if not os.path.exists(lookup_path):
-                                try:
-                                    os.makedirs(lookup_path)
-                                except Exception:
-                                    raise
+                                raise
                     display.debug('ANSIBALLZ: Writing module')
                     with open(cached_module_filename + '-part', 'wb') as f:
                         f.write(zipdata)

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1186,15 +1186,11 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
                     # so that no one looking for the file reads a partially
                     # written file)
                     if not os.path.exists(lookup_path):
-                        try:
-                            # Note -- if we have a global function to setup, that would
-                            # be a better place to run this
-                            os.makedirs(lookup_path)
-                        except FileExistsError:
-                            # Multiple workers tried to create the directory concurrently.
-                            # Check again to make sure it exists. If it still doesn't exist, there is a problem.
-                            if not os.path.exists(lookup_path):
-                                raise
+                        # Note -- if we have a global function to setup, that would
+                        # be a better place to run this
+                        #
+                        # Use exist_ok=True in case multiple workers try to create the same directory.
+                        os.makedirs(lookup_path, exist_ok=True)
                     display.debug('ANSIBALLZ: Writing module')
                     with open(cached_module_filename + '-part', 'wb') as f:
                         f.write(zipdata)

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1184,12 +1184,19 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
                     # Write the assembled module to a temp file (write to temp
                     # so that no one looking for the file reads a partially
                     # written file)
+                    #
+                    # FIXME: Once split controller/remote is merged, this can be simplified to
+                    #        os.makedirs(lookup_path, exist_ok=True)
                     if not os.path.exists(lookup_path):
-                        # Note -- if we have a global function to setup, that would
-                        # be a better place to run this
-                        #
-                        # Use exist_ok=True in case multiple workers try to create the same directory.
-                        os.makedirs(lookup_path, exist_ok=True)
+                        try:
+                            # Note -- if we have a global function to setup, that would
+                            # be a better place to run this
+                            os.makedirs(lookup_path)
+                        except OSError:
+                            # Multiple processes tried to create the directory. If it still does not
+                            # exist, raise the original exception.
+                            if not os.path.exists(lookup_path):
+                                raise
                     display.debug('ANSIBALLZ: Writing module')
                     with open(cached_module_filename + '-part', 'wb') as f:
                         f.write(zipdata)

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -34,7 +34,7 @@ from io import BytesIO
 
 from ansible.release import __version__, __author__
 from ansible import constants as C
-from ansible.errors import AnsibleError, AnsiblePluginRemovedError
+from ansible.errors import AnsibleError
 from ansible.executor.interpreter_discovery import InterpreterDiscoveryRequiredError
 from ansible.executor.powershell import module_manifest as ps_manifest
 from ansible.module_utils.common.json import AnsibleJSONEncoder
@@ -1115,7 +1115,6 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
         return b_module_data, module_style, shebang
 
     output = BytesIO()
-    py_module_names = set()
 
     try:
         remote_module_fqn = _get_ansible_module_fqn(module_path)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Occasionally multiple workers will try to create the cache directory if it exists. This is more likely to happen when using the free strategy with a higher fork count. Catch the exception and handle it.

Closes #74895. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/executor/module_common.py`