### PR TITLE
Add the missing `list_merge='combine'` option

### DIFF
--- a/changelogs/fragments/75110-combine-option-for-list_merge.yaml
+++ b/changelogs/fragments/75110-combine-option-for-list_merge.yaml
@@ -1,0 +1,4 @@
+
+minor_changes:
+  - >
+    list_merge@combine/merge_hash - ``lib.ansible.utils.vars.merge_hash`` now accepts a `combine` opiton for its `list_merge` parameters, which treats lists as hashes with numeric keys.

--- a/changelogs/fragments/75110-combine-option-for-list_merge.yaml
+++ b/changelogs/fragments/75110-combine-option-for-list_merge.yaml
@@ -1,4 +1,3 @@
-
 minor_changes:
   - >
     list_merge@combine/merge_hash - ``lib.ansible.utils.vars.merge_hash`` now accepts a `combine` opiton for its `list_merge` parameters, which treats lists as hashes with numeric keys.

--- a/changelogs/fragments/75110-combine-option-for-list_merge.yaml
+++ b/changelogs/fragments/75110-combine-option-for-list_merge.yaml
@@ -1,3 +1,3 @@
 minor_changes:
   - >
-    list_merge@combine/merge_hash - ``lib.ansible.utils.vars.merge_hash`` now accepts a `combine` opiton for its `list_merge` parameters, which treats lists as hashes with numeric keys.
+    list_merge@combine/merge_hash - ``lib.ansible.utils.vars.merge_hash`` now accepts a `combine` option for its `list_merge` parameter, which treats lists as hashes with numeric keys.

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -462,7 +462,7 @@ This would result in::
     b: patch
     c: default
 
-If ``list_merge='combine'`` (SHOULD be the default), arrays from the right hash will "combine" with the ones in the left hash in exactly the same way keys in hashes "combine" (i.e. this option essentially treats arrays as hashes with numeric keys)::
+If ``list_merge='combine'`` (not the default), arrays from the right hash will "combine" with the ones in the left hash in exactly the same way keys in hashes "combine" (i.e. this option essentially treats arrays as hashes with numeric keys)::
 
     default:
       a:

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -161,7 +161,7 @@ def merge_hash(x, y, recursive=True, list_merge='replace'):
                 x_hash, y_hash = [dict(enumerate(_list)) for _list in (x_value, y_value)]
                 merged = merge_hash(x_hash, y_hash, recursive, list_merge)
                 # transform back to list
-                x[key] = [merged[i] for i in sorted(merged)]
+                x[key] = [merged[i] for i in range(len(merged))]
             elif list_merge == 'replace':
                 # replace x value by y's one as it has higher priority
                 x[key] = y_value

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -103,7 +103,7 @@ def merge_hash(x, y, recursive=True, list_merge='replace'):
     """
     if list_merge not in LIST_MERGE_OPTIONS:
         raise AnsibleError("merge_hash: 'list_merge' argument can only be equal to '"
-                + "', '".join(LIST_MERGE_OPTIONS[:-1]) + "' or '" + LIST_MERGE_OPTIONS[-1] + "'")
+              + "', '".join(LIST_MERGE_OPTIONS[:-1]) + "' or '" + LIST_MERGE_OPTIONS[-1] + "'")
 
     # verify x & y are dicts
     _validate_mutable_mappings(x, y)

--- a/test/units/utils/test_vars.py
+++ b/test/units/utils/test_vars.py
@@ -101,7 +101,16 @@ class TestVariableUtils(unittest.TestCase):
                     "list": ["low_value"]
                 }
             },
-            "b": [1, 1, 2, 3]
+            "b": [1, 1, 2, 3, 7],
+            "c": {
+                "c'": [
+                    {
+                        "x'": "low_value",
+                        "y'": "low_value",
+                        "list'": ["first_low_value", "second_low_value"]
+                    }
+                ]
+            }
         },
         "high_prio": {
             "a": {
@@ -111,7 +120,16 @@ class TestVariableUtils(unittest.TestCase):
                     "list": ["high_value"]
                 }
             },
-            "b": [3, 4, 4, {"5": "value"}]
+            "b": [3, 4, 4, {"5": "value"}],
+            "c": {
+                "c'": [
+                    {
+                        "y'": "high_value",
+                        "z'": "high_value",
+                        "list'": ["only_high_value"]
+                    }
+                ]
+            }
         }
     }
 
@@ -130,9 +148,20 @@ class TestVariableUtils(unittest.TestCase):
                     "list": ["high_value"]
                 }
             },
-            "b": high['b']
+            "b": high['b'],
+            "c": high['c']
         }
         self.assertEqual(merge_hash(low, high), expected)
+
+    def test_merge_hash_non_recursive_and_list_combine(self):
+        low = self.merge_hash_data['low_prio']
+        high = self.merge_hash_data['high_prio']
+        expected = {
+            "a": high['a'],
+            "b": high['b'] + [7],
+            "c": high['c']
+        }
+        self.assertEqual(merge_hash(low, high, False, 'combine'), expected)
 
     def test_merge_hash_non_recursive_and_list_replace(self):
         low = self.merge_hash_data['low_prio']
@@ -145,7 +174,8 @@ class TestVariableUtils(unittest.TestCase):
         high = self.merge_hash_data['high_prio']
         expected = {
             "a": high['a'],
-            "b": low['b']
+            "b": low['b'],
+            "c": high['c']
         }
         self.assertEqual(merge_hash(low, high, False, 'keep'), expected)
 
@@ -154,7 +184,8 @@ class TestVariableUtils(unittest.TestCase):
         high = self.merge_hash_data['high_prio']
         expected = {
             "a": high['a'],
-            "b": low['b'] + high['b']
+            "b": low['b'] + high['b'],
+            "c": high['c']
         }
         self.assertEqual(merge_hash(low, high, False, 'append'), expected)
 
@@ -163,7 +194,8 @@ class TestVariableUtils(unittest.TestCase):
         high = self.merge_hash_data['high_prio']
         expected = {
             "a": high['a'],
-            "b": high['b'] + low['b']
+            "b": high['b'] + low['b'],
+            "c": high['c']
         }
         self.assertEqual(merge_hash(low, high, False, 'prepend'), expected)
 
@@ -172,7 +204,8 @@ class TestVariableUtils(unittest.TestCase):
         high = self.merge_hash_data['high_prio']
         expected = {
             "a": high['a'],
-            "b": [1, 1, 2] + high['b']
+            "b": [1, 1, 2, 7] + high['b'],
+            "c": high['c']
         }
         self.assertEqual(merge_hash(low, high, False, 'append_rp'), expected)
 
@@ -181,9 +214,36 @@ class TestVariableUtils(unittest.TestCase):
         high = self.merge_hash_data['high_prio']
         expected = {
             "a": high['a'],
-            "b": high['b'] + [1, 1, 2]
+            "b": high['b'] + [1, 1, 2, 7],
+            "c": high['c']
         }
         self.assertEqual(merge_hash(low, high, False, 'prepend_rp'), expected)
+
+    def test_merge_hash_recursive_and_list_combine(self):
+        low = self.merge_hash_data['low_prio']
+        high = self.merge_hash_data['high_prio']
+        expected = {
+            "a": {
+                "a'": {
+                    "x": "low_value",
+                    "y": "high_value",
+                    "z": "high_value",
+                    "list": ["high_value"]
+                }
+            },
+            "b": high['b'] + [7],
+            "c": {
+                "c'": [
+                    {
+                        "x'": "low_value",
+                        "y'": "high_value",
+                        "z'": "high_value",
+                        "list'": ["only_high_value", "second_low_value"]
+                    }
+                ]
+            }
+        }
+        self.assertEqual(merge_hash(low, high, True, 'replace'), expected)
 
     def test_merge_hash_recursive_and_list_replace(self):
         low = self.merge_hash_data['low_prio']
@@ -197,7 +257,8 @@ class TestVariableUtils(unittest.TestCase):
                     "list": ["high_value"]
                 }
             },
-            "b": high['b']
+            "b": high['b'],
+            "c": high['c']
         }
         self.assertEqual(merge_hash(low, high, True, 'replace'), expected)
 
@@ -213,7 +274,8 @@ class TestVariableUtils(unittest.TestCase):
                     "list": ["low_value"]
                 }
             },
-            "b": low['b']
+            "b": low['b'],
+            "c": low['c']
         }
         self.assertEqual(merge_hash(low, high, True, 'keep'), expected)
 
@@ -229,7 +291,10 @@ class TestVariableUtils(unittest.TestCase):
                     "list": ["low_value", "high_value"]
                 }
             },
-            "b": low['b'] + high['b']
+            "b": low['b'] + high['b'],
+            "c": {
+                "c'": low['c']["c'"] + high['c']["c'"]
+            }
         }
         self.assertEqual(merge_hash(low, high, True, 'append'), expected)
 
@@ -245,7 +310,10 @@ class TestVariableUtils(unittest.TestCase):
                     "list": ["high_value", "low_value"]
                 }
             },
-            "b": high['b'] + low['b']
+            "b": high['b'] + low['b'],
+            "c": {
+                "c'": high['c']["c'"] + low['c']["c'"]
+            }
         }
         self.assertEqual(merge_hash(low, high, True, 'prepend'), expected)
 
@@ -261,7 +329,10 @@ class TestVariableUtils(unittest.TestCase):
                     "list": ["low_value", "high_value"]
                 }
             },
-            "b": [1, 1, 2] + high['b']
+            "b": [1, 1, 2, 7] + high['b'],
+            "c": {
+                "c'": low['c']["c'"] + high['c']["c'"]
+            }
         }
         self.assertEqual(merge_hash(low, high, True, 'append_rp'), expected)
 
@@ -277,6 +348,9 @@ class TestVariableUtils(unittest.TestCase):
                     "list": ["high_value", "low_value"]
                 }
             },
-            "b": high['b'] + [1, 1, 2]
+            "b": high['b'] + [1, 1, 2, 7],
+            "c": {
+                "c'": high['c']["c'"] + low['c']["c'"]
+            }
         }
         self.assertEqual(merge_hash(low, high, True, 'prepend_rp'), expected)

--- a/test/units/utils/test_vars.py
+++ b/test/units/utils/test_vars.py
@@ -243,7 +243,7 @@ class TestVariableUtils(unittest.TestCase):
                 ]
             }
         }
-        self.assertEqual(merge_hash(low, high, True, 'replace'), expected)
+        self.assertEqual(merge_hash(low, high, True, 'combine'), expected)
 
     def test_merge_hash_recursive_and_list_replace(self):
         low = self.merge_hash_data['low_prio']


### PR DESCRIPTION
##### SUMMARY

A reasonable expectation when applying `combine` to complex structures/objects
that contain an arbitrary mix of hashes and arrays is that all _paths_ would be
**combined** in a similar fashion.

For clarity, the _path_ to `erlang` in the sample below is `1.tabitha.skills.2`.
Similarly, the _path_ to `python` is `0.martin.skills.0`.
```yaml
# Employee records
- martin:
    name: Martin D'vloper
    job: Developer
    skills:
      - python
      - perl
      - pascal
- tabitha:
    name: Tabitha Bitumen
    job: Developer
    skills:
      - lisp
      - fortran
      - erlang
```

Currently, `combine` either stops at arrays, or treats arrays differently from hashes
as dictated by the `list_merge` parameter.  This PR adds a new option `list_merge='combine'`
that treats arrays essentially as hashes with a numeric key and traverses entire mixed objects
when invoked with `recursive=True`.

The PR is fully backward-compatible, since it introduces an entirely _new_ option
to `list_merge` and doesn't alter the behavior of any of the existing ones.

The PR also includes updated unit tests and documentation.

##### ISSUE TYPE

- Feature Pull Request (includes Docs and Tests as well)

##### COMPONENT NAME

`ansible.utils.vars.merge_hash`

##### ADDITIONAL INFORMATION

Please consult the updated documentation for the `combine` filter for additional details and simple examples.


---

###### INSTRUCTIVE USE CASE AND EXAMPLE

For a more realistic use case, consider the following minimal playbook.
```yaml
---

- hosts: localhost
  connection: local
  gather_facts: false
  vars:
    # complex object returned from API
    #
    # tasks:
    #   - name: Get current policy
    #     command: gcloud dns policies list --format json
    #     register: policies
    #
    #   - name: Parse policy output
    #     set_fact:
    #       original: "{{ policies.stdout }}"
    #
    original:
      - id: '1234567890123456789'
        kind: dns#policy
        name: outbound-dns-policy
        description: Outbound DNS policy
        alternativeNameServerConfig:
          kind: dns#policyAlternativeNameServerConfig
          targetNameServers:
            - forwardingPath: default
              ipv4Address: 300.300.300.300
              kind: dns#policyAlternativeNameServerConfigTargetNameServer
        enableInboundForwarding: false
        enableLogging: false
        networks:
          - kind: dns#policyNetwork
            networkUrl: https://compute.googleapis.com/compute/v1/projects/PROJECT/global/networks/NETWORK

    # simple data manipulation: change a single leaf
    override:
      alternativeNameServerConfig:
        targetNameServers:
          - ipv4Address: 256.256.256.256

  tasks:
    - name: "Override IP"
      set_fact:
        target: "{{ original[0] | combine(override, recursive=True, list_merge='combine') }}"

    - name: "Update, if different"
      debug:
        var: target
      when: target != original[0]
```
Here the results are both meaningful and predictable, and therefore omitted.

For a variant of the same playbook with a skipped update (due to matching field value),
and a different update changing multiple leaves, please expand the following hidden details:
<details><summary>playbook (variant)</summary>

```yaml
---

- hosts: localhost
  connection: local
  gather_facts: false
  vars:
    # complex object returned from API
    #
    # - name: Get current policy
    #   command: gcloud dns policies list --format json
    #   register: policies
    #
    # - name: Parse policy output
    #   set_fact:
    #     original: "{{ policies.stdout }}"
    #
    original:
      - id: '1234567890123456789'
        kind: dns#policy
        name: outbound-dns-policy
        description: Outbound DNS policy
        alternativeNameServerConfig:
          kind: dns#policyAlternativeNameServerConfig
          targetNameServers:
            - forwardingPath: default
              ipv4Address: 300.300.300.300
              kind: dns#policyAlternativeNameServerConfigTargetNameServer
        enableInboundForwarding: false
        enableLogging: false
        networks:
          - kind: dns#policyNetwork
            networkUrl: https://compute.googleapis.com/compute/v1/projects/PROJECT/global/networks/N@ETWORK

    # simple data manipulation: a single leaf with matching IP
    override_noop:
      alternativeNameServerConfig:
        targetNameServers:
          - ipv4Address: 300.300.300.300

    # of course, several leaves could also be changed or new items added in one go
    override_multi:
      alternativeNameServerConfig:
        targetNameServers:
          - ipv4Address: 256.256.256.256
      networks:
        - networkUrl: https://compute.googleapis.com/compute/v1/projects/PROJECT/global/networks/OTH@ER_NET
        - networkUrl: https://compute.googleapis.com/compute/v1/projects/PROJECT/global/networks/NEW@_NET
          kind: dns#policyNetwork

    tasks:
    - name: "Override (NOOP)"
      set_fact:
        target: "{{ original[0] | combine(override_noop, recursive=True, list_merge='combine') }}"

    - name: "Update, if different (NOOP)"
      debug:
        var: target
      when: target != original[0]

    - name: "Override (Multi)"
      set_fact:
        target2: "{{ target | combine(override_multi, recursive=True, list_merge='combine') }}"

    - name: "Update, if different (Multi)"
      debug:
        var: target2
      when: target2 != target
```
</details>

<details><summary>output (variant)</summary>

```console
(ansible) user@host:~/ansible$ ansible-playbook -i localhost, play.yaml
[WARNING]: You are running the development version of Ansible. You should only run Ansible from
"devel" if you are modifying the Ansible engine, or trying out features under development. This is
a rapidly changing source of code and can become unstable at any point.

PLAY [localhost] ***********************************************************************************

TASK [Override (NOOP)] *****************************************************************************
ok: [localhost]

TASK [Update, if different (NOOP)] *****************************************************************
skipping: [localhost]

TASK [Override (Multi)] ****************************************************************************
ok: [localhost]

TASK [Update, if different (Multi)] ****************************************************************
ok: [localhost] => {
    "target2": {
        "alternativeNameServerConfig": {
            "kind": "dns#policyAlternativeNameServerConfig",
            "targetNameServers": [
                {
                    "forwardingPath": "default",
                    "ipv4Address": "256.256.256.256",
                    "kind": "dns#policyAlternativeNameServerConfigTargetNameServer"
                }
            ]
        },
        "description": "Outbound DNS policy",
        "enableInboundForwarding": false,
        "enableLogging": false,
        "id": "1234567890123456789",
        "kind": "dns#policy",
        "name": "outbound-dns-policy",
        "networks": [
            {
                "kind": "dns#policyNetwork",
                "networkUrl": "https://compute.googleapis.com/compute/v1/projects/PROJECT/global/networks/OTHER_NET"
            },
            {
                "kind": "dns#policyNetwork",
                "networkUrl": "https://compute.googleapis.com/compute/v1/projects/PROJECT/global/networks/NEW_NET"
            }
        ]
    }
}

PLAY RECAP *****************************************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   

(ansible) user@host:~/ansible$
```
</details>


To please the naysayers, another example showing the ~~full power~~horrors this PR enables
is also included, albeit hidden from plain view.  Please click to expand!

**CHALLENGE: try to predict the output by only looking at the playbook first!**
_NB: A likely success indicates this operation could be "natural" (i.e. might make sense)._

<details><summary>playbook ("weird")</summary>

```yaml
---

- hosts: localhost
  connection: local
  gather_facts: false
  vars:
    weird_hash:
      list_of_hashes:
        - nested_list:
            - hash1:
                a: 11
                b: 12
            - hash2:
                a: 21
                b: 22
        - nested_list:
            - hash1:
                a: 42
                b: 1337
            - hash2:
                a: 20
                b: 20
      another_list:
        - aa
        - bb

    weird_update:
      list_of_hashes:
        - {}
        - nested_list:
            - {}
            - hash2:
                b: 2021
            - hash3:
                a: 31
                b: 32
      another_list:
        - zz

  tasks:
    - name: Weird
      debug:
        var: weird_hash | combine(weird_update, recursive=True, list_merge='combine')
```
</details>

<details><summary>output ("weird")</summary>

```console
(ansible) user@host:~/ansible$ ansible-playbook -i localhost, play2.yaml 
[WARNING]: You are running the development version of Ansible. You should only run Ansible from
"devel" if you are modifying the Ansible engine, or trying out features under development. This is
a rapidly changing source of code and can become unstable at any point.

PLAY [localhost] ***********************************************************************************

TASK [Weird] ***************************************************************************************
ok: [localhost] => {
    "weird_hash | combine(weird_update, recursive=True, list_merge='combine')": {
        "another_list": [
            "zz",
            "bb"
        ],
        "list_of_hashes": [
            {
                "nested_list": [
                    {
                        "hash1": {
                            "a": 11,
                            "b": 12
                        }
                    },
                    {
                        "hash2": {
                            "a": 21,
                            "b": 22
                        }
                    }
                ]
            },
            {
                "nested_list": [
                    {
                        "hash1": {
                            "a": 42,
                            "b": 1337
                        }
                    },
                    {
                        "hash2": {
                            "a": 20,
                            "b": 2021
                        }
                    },
                    {
                        "hash3": {
                            "a": 31,
                            "b": 32
                        }
                    }
                ]
            }
        ]
    }
}

PLAY RECAP *****************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

(ansible) user@host:~/ansible$
```
</details>

This illustrates that it is possible not only to overwrite/replace,
but also to skip and append hashes in lists.


---

###### ALTERNATIVE IMPLEMENTATION

Naturally, essentially the same functionality can _also_ be implemented as a custom plugin.

```python
def merge(a, b):
    if isinstance(a, list) and isinstance(b, list):
        a_, b_ = [dict(enumerate(_list)) for _list in (a, b)]
        c = merge(a_, b_)
        return [c[i] for i in range(len(c))]
    if isinstance(a, dict) and isinstance(b, dict):
        a = a.copy()
        for key in b:
            a[key] = merge(a.get(key), b[key])
        return a
    return b

class FilterModule(object):
    def filters(self):
        return {'merge': merge}
```

Still, _in my mind_, the simplicity and versatility of this operation speaks for inclusion in Ansible `core`.