### PR TITLE
[2.9]ansible-test: exposes tiny_prefix variable

### DIFF
--- a/changelogs/fragments/aws_tiny_prefix.yaml
+++ b/changelogs/fragments/aws_tiny_prefix.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- ansible-test - aws creates and exposes a new tiny_prefix variable to provide a shorter prefix for the AWS tests. 

--- a/test/lib/ansible_test/_internal/cloud/aws.py
+++ b/test/lib/ansible_test/_internal/cloud/aws.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
+import uuid
 
 from ..util import (
     ApplicationError,
@@ -95,6 +96,7 @@ class AwsCloudEnvironment(CloudEnvironment):
 
         ansible_vars = dict(
             resource_prefix=self.resource_prefix,
+            tiny_prefix=uuid.uuid4().hex[0:12]
         )
 
         ansible_vars.update(dict(parser.items('default')))


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/74997/

ansible-test aws provider now creates and exposes a new tiny_prefix
variable to provide a shorter prefix for the AWS tests.

(cherry picked from commit 5b8fb4dcd3d84aad77330644a7326bc16dd02a3b)


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
ansible-test