### PR TITLE
[stable-2.11] module_common - handle cache directory creation collision (#75106)

### DIFF
--- a/changelogs/fragments/concurrency-cache-dir-collision.yml
+++ b/changelogs/fragments/concurrency-cache-dir-collision.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - module_common - handle exception when multiple workers try to create the cache directory

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -34,7 +34,7 @@ from io import BytesIO
 
 from ansible.release import __version__, __author__
 from ansible import constants as C
-from ansible.errors import AnsibleError, AnsiblePluginRemovedError
+from ansible.errors import AnsibleError
 from ansible.executor.interpreter_discovery import InterpreterDiscoveryRequiredError
 from ansible.executor.powershell import module_manifest as ps_manifest
 from ansible.module_utils.common.json import AnsibleJSONEncoder
@@ -1115,7 +1115,6 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
         return b_module_data, module_style, shebang
 
     output = BytesIO()
-    py_module_names = set()
 
     try:
         remote_module_fqn = _get_ansible_module_fqn(module_path)
@@ -1186,9 +1185,15 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
                     # so that no one looking for the file reads a partially
                     # written file)
                     if not os.path.exists(lookup_path):
-                        # Note -- if we have a global function to setup, that would
-                        # be a better place to run this
-                        os.makedirs(lookup_path)
+                        try:
+                            # Note -- if we have a global function to setup, that would
+                            # be a better place to run this
+                            os.makedirs(lookup_path)
+                        except OSError:
+                            # Multiple processes tried to create the directory. If it still does not
+                            # exist, raise the original exception.
+                            if not os.path.exists(lookup_path):
+                                raise
                     display.debug('ANSIBALLZ: Writing module')
                     with open(cached_module_filename + '-part', 'wb') as f:
                         f.write(zipdata)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #75106 for Ansible 2.11.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/executor/module_common.py`