### PR TITLE
[stable-2.9] Add constraints for new ruamel release

### DIFF
--- a/test/integration/targets/k8s/files/constraints.txt
+++ b/test/integration/targets/k8s/files/constraints.txt
@@ -1,3 +1,2 @@
-setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require python 3.5 or later
 ruamel.yaml < 0.17 ; python_version <= '2.7'  # ruamel.yaml 0.17 and later are not tested with Python 2.7
 ruamel.yaml.clib <= 0.2.2 ; python_version < '3.5'  # ruamel.yaml.clib 0.2.3 and later requires Python 3.5 or later

--- a/test/integration/targets/k8s/tasks/main.yml
+++ b/test/integration/targets/k8s/tasks/main.yml
@@ -17,6 +17,8 @@
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
     virtualenv_site_packages: no
+    extra_args:
+      -c {{ role_path }}/files/constraints.txt
 
 - include_tasks: validate_not_installed.yml
   vars:
@@ -37,6 +39,8 @@
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
     virtualenv_site_packages: no
+    extra_args:
+      -c {{ role_path }}/files/constraints.txt
 
 - include_tasks: validate_installed.yml
   vars:
@@ -58,6 +62,8 @@
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
     virtualenv_site_packages: no
+    extra_args:
+      -c {{ role_path }}/files/constraints.txt
 
 - include_tasks: older_openshift_fail.yml
   vars:
@@ -80,6 +86,8 @@
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
     virtualenv_site_packages: no
+    extra_args:
+      -c {{ role_path }}/files/constraints.txt
 
 - include_tasks: basic_validation.yml
 
@@ -96,6 +104,8 @@
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
     virtualenv_site_packages: no
+    extra_args:
+      -c {{ role_path }}/files/constraints.txt
 
 - include_tasks: basic_validation.yml
 
@@ -113,6 +123,8 @@
     virtualenv: "{{ virtualenv }}"
     virtualenv_command: "{{ virtualenv_command }}"
     virtualenv_site_packages: no
+    extra_args:
+      -c {{ role_path }}/files/constraints.txt
 
 - include_tasks: full_test.yml
   vars:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Recent releases of `ruamel.yaml` and `ruamel.yaml.clib` require newer Python versions. Add constraints to prevent test failures.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/inventory_kubevirt_conformance`
`test/integration/targets/k8s`