### PR TITLE
Update role directories in docs

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
@@ -78,10 +78,13 @@ Roles may also include modules and other plugin types in a directory called ``li
 Storing and finding roles
 =========================
 
-By default, Ansible looks for roles in two locations:
+By default, Ansible looks for roles in a number of locations:
 
 - in a directory called ``roles/``, relative to the playbook file
-- in ``/etc/ansible/roles``
+- in the ``DEFAULT_ROLES_PATH``. this defaults to:
+  - ``~/.ansible/roles``
+  - ``/usr/share/ansible/roles``
+  - ``/etc/ansible/roles``
 
 If you store your roles in a different location, set the :ref:`roles_path <DEFAULT_ROLES_PATH>` configuration option so Ansible can find your roles. Checking shared roles into a single location makes them easier to use in multiple playbooks. See :ref:`intro_configuration` for details about managing settings in ansible.cfg.
 


### PR DESCRIPTION
The default path is stated to hold 4 directories in 2 places:

- https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-roles-path
- https://github.com/ansible/ansible/blob/devel/examples/ansible.cfg#L67

But this document said there were only 2.

For development, `~/.ansible/roles` seems like a good spot to put shared code.
In production, both `/etc/` and `/usr/share` seem like great spots to put shared roles. (I lean more towards share for rpms)

This PR updates the document to be more consistent.

If I missed the intent of the original document, please just close. Thank you

- Docs Pull Request

+label: docsite_pr

fixes #75120
