### PR TITLE
Docs memory testing support

### DIFF
--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -184,25 +184,25 @@ clean:
 .PHONY: docs clean
 
 collections_meta: ../templates/collections_galaxy_meta.rst.j2
-	$(COLLECTION_DUMPER) --template-file=../templates/collections_galaxy_meta.rst.j2 --output-dir=rst/dev_guide/ ../../lib/ansible/galaxy/data/collections_galaxy_meta.yml
+	$(COLLECTION_DUMPER) --template-file=../templates/collections_galaxy_meta.rst.j2 --output-dir=rst/dev_guide/ $(EXTRA_COLLECTION_META_ARGS) ../../lib/ansible/galaxy/data/collections_galaxy_meta.yml
 
 # TODO: make generate_man output dir cli option
 cli:
 	mkdir -p rst/cli
-	$(GENERATE_CLI) --template-file=../templates/cli_rst.j2 --output-dir=rst/cli/ --output-format rst ../../lib/ansible/cli/*.py
+	$(GENERATE_CLI) --template-file=../templates/cli_rst.j2 --output-dir=rst/cli/ --output-format rst $(EXTRA_CLI_DUMPER_ARGS) ../../lib/ansible/cli/*.py
 
 keywords: ../templates/playbooks_keywords.rst.j2
-	$(KEYWORD_DUMPER) --template-dir=../templates --output-dir=rst/reference_appendices/ ../../lib/ansible/keyword_desc.yml
+	$(KEYWORD_DUMPER) --template-dir=../templates --output-dir=rst/reference_appendices/ ../../lib/ansible/keyword_desc.yml $(EXTRA_KEYWORD_DUMPER_ARGS)
 
 config: ../templates/config.rst.j2
-	$(CONFIG_DUMPER) --template-file=../templates/config.rst.j2 --output-dir=rst/reference_appendices/ ../../lib/ansible/config/base.yml
+	$(CONFIG_DUMPER) --template-file=../templates/config.rst.j2 --output-dir=rst/reference_appendices/ $(EXTRA_CONFIG_DUMPER_ARGS) ../../lib/ansible/config/base.yml
 
 plugins:
-	$(PLUGIN_FORMATTER) full -o rst $(ANSIBLE_VERSION_ARGS) $(PLUGIN_ARGS);\
+	$(PLUGIN_FORMATTER) full -o rst $(ANSIBLE_VERSION_ARGS) $(EXTRA_PLUGIN_FORMATTER_ARGS) $(PLUGIN_ARGS)
 
 # This only builds the plugin docs included with ansible-core
 base_plugins:
-	$(PLUGIN_FORMATTER) base -o rst $(PLUGIN_ARGS);\
+	$(PLUGIN_FORMATTER) base -o rst $(EXTRA_PLUGIN_FORMATTER_ARGS) $(PLUGIN_ARGS)
 
 testing:
 	$(TESTING_FORMATTER)

--- a/hacking/build_library/build_ansible/command_plugins/docs_build.py
+++ b/hacking/build_library/build_ansible/command_plugins/docs_build.py
@@ -143,6 +143,8 @@ def generate_full_docs(args):
         # this would be the place to do it.
 
         build_data_working = os.path.join(tmp_dir, 'ansible-build-data')
+        if args.ansible_build_data:
+            build_data_working = args.build_data_working
 
         ansible_version = args.ansible_version
         if ansible_version is None:
@@ -211,6 +213,10 @@ class CollectionPluginDocs(Command):
                             dest='ansible_version', default=None,
                             help='The version of the ansible package to make documentation for.'
                             '  This only makes sense when used with full.')
+        parser.add_argument('--ansible-buid-data', action='store',
+                            dest='ansible_build_data', default=None,
+                            help='A checkout of the ansible-build-data repo.  Useful for'
+                            ' debugging.')
 
     @staticmethod
     def main(args):


### PR DESCRIPTION
##### SUMMARY
We're testing to get an idea of how quickly docs-build RAM usage will grow as we add new collections.  To do that, we need the ability to specify a local copy of ansible-build-data where we modify the list of collections that will be included in the docs build.  This PR adds a command line switch to hacking/build-ansible.py docs-build to do that and adds support to the docs/docsite/Makefile for adding your own args to the call to build-ansible.py

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request
- Feature Pull Request


##### COMPONENT NAME
CC: @samccann 