### PR TITLE
Fix skeleton issue in user module

### DIFF
--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1218,6 +1218,9 @@ class User(object):
 
     def create_homedir(self, path):
         if not os.path.exists(path):
+            if path == '/dev/null':
+                return
+
             if self.skeleton is not None:
                 skeleton = self.skeleton
             else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes #75063, when inputting `/dev/null` as the user home directory skeleton would result in a error stating that `/dev/null` is not a directory.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request