### PR TITLE
Use explicit keyword for plugin config

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -1059,7 +1059,7 @@ class DocCLI(CLI, RoleMixin):
                     suboptions.append((subkey, opt.pop(subkey)))
 
             conf = {}
-            for config in ('env', 'ini', 'yaml', 'vars', 'keywords'):
+            for config in ('env', 'ini', 'yaml', 'vars', 'keyword'):
                 if config in opt and opt[config]:
                     # Create a copy so we don't modify the original (in case YAML anchors have been used)
                     conf[config] = [dict(item) for item in opt.pop(config)]

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -470,6 +470,12 @@ class ConfigManager(object):
                     origin = 'var: %s' % origin
 
                 # use playbook keywords if you have em
+                if value is None and defs[config].get('keyword') and keys:
+                    value, origin = self._loop_entries(keys, defs[config]['keyword'])
+                    origin = 'keyword: %s' % origin
+
+                # automap to keywords
+                # TODO: deprecate these in favor of explicit keyword above
                 if value is None and keys:
                     if config in keys:
                         value = keys[config]

--- a/lib/ansible/plugins/become/runas.py
+++ b/lib/ansible/plugins/become/runas.py
@@ -25,6 +25,8 @@ DOCUMENTATION = """
             env:
               - name: ANSIBLE_BECOME_USER
               - name: ANSIBLE_RUNAS_USER
+            keyword:
+              - name: become_user
             required: True
         become_flags:
             description: Options to pass to runas, a space delimited list of k=v pairs
@@ -40,6 +42,8 @@ DOCUMENTATION = """
             env:
               - name: ANSIBLE_BECOME_FLAGS
               - name: ANSIBLE_RUNAS_FLAGS
+            keyword:
+              - name: become_flags
         become_pass:
             description: password
             ini:

--- a/lib/ansible/plugins/become/su.py
+++ b/lib/ansible/plugins/become/su.py
@@ -26,6 +26,8 @@ DOCUMENTATION = """
             env:
               - name: ANSIBLE_BECOME_USER
               - name: ANSIBLE_SU_USER
+            keyword:
+              - name: become_user
         become_exe:
             description: Su executable
             default: su
@@ -40,6 +42,8 @@ DOCUMENTATION = """
             env:
               - name: ANSIBLE_BECOME_EXE
               - name: ANSIBLE_SU_EXE
+            keyword:
+              - name: become_exe
         become_flags:
             description: Options to pass to su
             default: ''
@@ -54,6 +58,8 @@ DOCUMENTATION = """
             env:
               - name: ANSIBLE_BECOME_FLAGS
               - name: ANSIBLE_SU_FLAGS
+            keyword:
+              - name: become_flags
         become_pass:
             description: Password to pass to su
             required: False

--- a/lib/ansible/plugins/become/sudo.py
+++ b/lib/ansible/plugins/become/sudo.py
@@ -26,6 +26,8 @@ DOCUMENTATION = """
             env:
               - name: ANSIBLE_BECOME_USER
               - name: ANSIBLE_SUDO_USER
+            keyword:
+              - name: become_user
         become_exe:
             description: Sudo executable
             default: sudo
@@ -40,6 +42,8 @@ DOCUMENTATION = """
             env:
               - name: ANSIBLE_BECOME_EXE
               - name: ANSIBLE_SUDO_EXE
+            keyword:
+              - name: become_exe
         become_flags:
             description: Options to pass to sudo
             default: -H -S -n
@@ -54,6 +58,8 @@ DOCUMENTATION = """
             env:
               - name: ANSIBLE_BECOME_FLAGS
               - name: ANSIBLE_SUDO_FLAGS
+            keyword:
+              - name: become_flags
         become_pass:
             description: Password to pass to sudo
             required: False

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -44,6 +44,8 @@ DOCUMENTATION = """
             - section: paramiko_connection
               key: remote_user
               version_added: '2.5'
+        keyword:
+            - name: remote_user
       password:
         description:
           - Secret used to either login the ssh server or as a passphrase for ssh keys that require it

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -34,6 +34,8 @@ options:
     vars:
     - name: ansible_user
     - name: ansible_psrp_user
+    keyword:
+    - name: remote_user
   remote_password:
     description: Authentication password for the C(remote_user). Can be supplied as CLI option.
     type: str
@@ -52,6 +54,8 @@ options:
     vars:
     - name: ansible_port
     - name: ansible_psrp_port
+    keyword:
+    - name: port
   protocol:
     description:
     - Set the protocol to use for the connection.

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -192,6 +192,8 @@ DOCUMENTATION = '''
           vars:
             - name: ansible_port
             - name: ansible_ssh_port
+          keyword:
+            - name: port
       remote_user:
           description:
               - User name with which to login to the remote server, normally set by the remote_user keyword.
@@ -206,6 +208,8 @@ DOCUMENTATION = '''
             - name: ansible_ssh_user
           cli:
             - name: user
+          keyword:
+            - name: remote_user
       pipelining:
           env:
             - name: ANSIBLE_PIPELINING

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -34,6 +34,8 @@ DOCUMENTATION = """
         vars:
             - name: ansible_user
             - name: ansible_winrm_user
+        keyword:
+            - name: remote_user
         type: str
       remote_password:
         description: Authentication password for the C(remote_user). Can be supplied as CLI option.
@@ -52,6 +54,8 @@ DOCUMENTATION = """
           - name: ansible_port
           - name: ansible_winrm_port
         default: 5986
+        keyword:
+            - name: port
         type: integer
       scheme:
         description:

--- a/lib/ansible/plugins/doc_fragments/shell_common.py
+++ b/lib/ansible/plugins/doc_fragments/shell_common.py
@@ -62,6 +62,8 @@ options:
     default: [{}]
     description:
       - List of dictionaries of environment variables and their values to use when executing commands.
+    keyword:
+      - name: environment
   admin_users:
     type: list
     default: ['root', 'toor']

--- a/lib/ansible/plugins/doc_fragments/shell_windows.py
+++ b/lib/ansible/plugins/doc_fragments/shell_windows.py
@@ -43,6 +43,8 @@ options:
     description:
     - List of dictionaries of environment variables and their values to use when
       executing commands.
+    keyword:
+      - name: environment
     type: list
     default: [{}]
 """


### PR DESCRIPTION
Still falls back to automap, but that should be deprecated and removed in the future.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
config