### PR TITLE
set host_key_checking check to False, rather than if not (which captures False and None)

### DIFF
--- a/changelogs/fragments/set-ssh-host_key_checking-defaults.yaml
+++ b/changelogs/fragments/set-ssh-host_key_checking-defaults.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - set ssh host_key_checking defaults to True, restoring original behaviour (https://github.com/ansible/ansible/issues/75168)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -692,7 +692,7 @@ class Connection(ConnectionBase):
             self._add_args(b_command, b_args, u"ansible.cfg set ssh_args")
 
         # Now we add various arguments that have their own specific settings defined in docs above.
-        if self.get_option('host_key_checking') == False:
+        if self.get_option('host_key_checking') is False:
             b_args = (b"-o", b"StrictHostKeyChecking=no")
             self._add_args(b_command, b_args, u"ANSIBLE_HOST_KEY_CHECKING/host_key_checking disabled")
 

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -692,7 +692,7 @@ class Connection(ConnectionBase):
             self._add_args(b_command, b_args, u"ansible.cfg set ssh_args")
 
         # Now we add various arguments that have their own specific settings defined in docs above.
-        if not self.get_option('host_key_checking'):
+        if self.get_option('host_key_checking') == False:
             b_args = (b"-o", b"StrictHostKeyChecking=no")
             self._add_args(b_command, b_args, u"ANSIBLE_HOST_KEY_CHECKING/host_key_checking disabled")
 

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -33,6 +33,7 @@ DOCUMENTATION = '''
                - name: delegated_vars['ansible_ssh_host']
       host_key_checking:
           description: Determines if ssh should check host keys
+          default: True
           type: boolean
           ini:
               - section: defaults


### PR DESCRIPTION
##### SUMMARY
The current ssh.py check for host_key_checking captures both False and None (i.e. if the parameter is not used), this has an undesired outcome as by default, Ansible automatically accepts all host keys which is a security concern.

Fixes #75167

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/connection/ssh.py

##### ADDITIONAL INFORMATION
See https://github.com/ansible/ansible/issues/75167 for more details 



