### PR TITLE
fallback to uid when no username

### DIFF
--- a/changelogs/fragments/75177-fallback-to-uid-when-no-username.yml
+++ b/changelogs/fragments/75177-fallback-to-uid-when-no-username.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Use ``uid=…`` as username when there is none in ``/etc/passwd`` (https://github.com/ansible/ansible/pull/75177)

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -8,7 +8,6 @@ __metaclass__ = type
 
 import atexit
 import cmd
-import getpass
 import readline
 import os
 import sys
@@ -18,6 +17,7 @@ from ansible import context
 from ansible.cli import CLI
 from ansible.cli.arguments import option_helpers as opt_help
 from ansible.executor.task_queue_manager import TaskQueueManager
+from ansible.module_utils.basic import get_username
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.parsing.splitter import parse_kv
@@ -133,7 +133,7 @@ class ConsoleCLI(CLI, cmd.Cmd):
             self.do_exit(self)
 
     def set_prompt(self):
-        login_user = self.remote_user or getpass.getuser()
+        login_user = self.remote_user or get_username()
         self.selected = self.inventory.list_hosts(self.cwd)
         prompt = "%s@%s (%d)[f:%s]" % (login_user, self.cwd, len(self.selected), self.forks)
         if self.become and self.become_user in [None, 'root']:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -36,6 +36,7 @@ import __main__
 import atexit
 import errno
 import datetime
+import getpass
 import grp
 import fcntl
 import locale
@@ -2145,3 +2146,16 @@ class AnsibleModule(object):
 
 def get_module_path():
     return os.path.dirname(os.path.realpath(__file__))
+
+
+def get_username():
+    ''' Returns "login name" of current user.
+
+    Synthetises one if passwd file doesn't contain the name for current uid,
+    which may happen in containerized environments.
+    '''
+
+    try:
+        return getpass.getuser()
+    except KeyError:
+        return 'uid=%s' % os.getuid()

--- a/lib/ansible/module_utils/facts/system/user.py
+++ b/lib/ansible/module_utils/facts/system/user.py
@@ -16,10 +16,10 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import getpass
 import os
 import pwd
 
+from ansible.module_utils.basic import get_username
 from ansible.module_utils.facts.collector import BaseFactCollector
 
 
@@ -33,10 +33,10 @@ class UserFactCollector(BaseFactCollector):
     def collect(self, module=None, collected_facts=None):
         user_facts = {}
 
-        user_facts['user_id'] = getpass.getuser()
+        user_facts['user_id'] = get_username()
 
         try:
-            pwent = pwd.getpwnam(getpass.getuser())
+            pwent = pwd.getpwnam(get_username())
         except KeyError:
             pwent = pwd.getpwuid(os.getuid())
 

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -23,10 +23,10 @@ import pty
 import shutil
 import subprocess
 import fcntl
-import getpass
 
 import ansible.constants as C
 from ansible.errors import AnsibleError, AnsibleFileNotFound
+from ansible.module_utils.basic import get_username
 from ansible.module_utils.compat import selectors
 from ansible.module_utils.six import text_type, binary_type
 from ansible.module_utils._text import to_bytes, to_native, to_text
@@ -47,7 +47,7 @@ class Connection(ConnectionBase):
 
         super(Connection, self).__init__(*args, **kwargs)
         self.cwd = None
-        self.default_user = getpass.getuser()
+        self.default_user = get_username()
 
     def _connect(self):
         ''' connect to the local host; nothing to do here '''

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -36,6 +36,7 @@ from termios import TIOCGWINSZ
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleAssertionError
+from ansible.module_utils.basic import get_username
 from ansible.module_utils._text import to_bytes, to_text, to_native
 from ansible.module_utils.six import with_metaclass, text_type
 from ansible.utils.color import stringc
@@ -158,11 +159,7 @@ class FilterUserInjector(logging.Filter):
     to all logger handlers so that 3rd party libraries won't print an exception due to user not being defined.
     """
 
-    try:
-        username = getpass.getuser()
-    except KeyError:
-        # people like to make containers w/o actual valid passwd/shadow and use host uids
-        username = 'uid=%s' % os.getuid()
+    username = get_username()
 
     def filter(self, record):
         record.user = FilterUserInjector.username

--- a/test/support/network-integration/collections/ansible_collections/ansible/netcommon/plugins/connection/network_cli.py
+++ b/test/support/network-integration/collections/ansible_collections/ansible/netcommon/plugins/connection/network_cli.py
@@ -258,7 +258,6 @@ options:
 """
 
 from functools import wraps
-import getpass
 import json
 import logging
 import re
@@ -270,6 +269,7 @@ import traceback
 from io import BytesIO
 
 from ansible.errors import AnsibleConnectionFailure
+from ansible.module_utils.basic import get_username
 from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves import cPickle
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (
@@ -384,7 +384,7 @@ class Connection(NetworkConnectionBase):
         return self._paramiko_conn
 
     def _get_log_channel(self):
-        name = "p=%s u=%s | " % (os.getpid(), getpass.getuser())
+        name = "p=%s u=%s | " % (os.getpid(), get_username())
         name += "paramiko [%s]" % self._play_context.remote_addr
         return name
 

--- a/test/units/module_utils/basic/test_get_username.py
+++ b/test/units/module_utils/basic/test_get_username.py
@@ -1,0 +1,16 @@
+
+from units.mock.procenv import ModuleTestCase
+
+from units.compat.mock import patch
+
+import sys
+
+class TestGetUsername(ModuleTestCase):
+    def test_module_utils_basic_get_username(self):
+        from ansible.module_utils.basic import get_username
+
+        with patch('os.getuid', return_value=(0)):
+            self.assertEqual(get_username(), 'root')
+
+        with patch('os.getuid', return_value=sys.maxsize):
+            self.assertEqual(get_username(), f"uid={sys.maxsize}")


### PR DESCRIPTION
##### SUMMARY
When running ansible in a container, with `delegate_to: localhost`, it is possible the container is run as a random UID without corresponding entry in `/etc/passwd`. In such situation `getpass.getuser()` will throw an exception:
`An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'getpwuid(): uid not found: 1000'`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
Connection plugin: local

##### ADDITIONAL INFORMATION
Identical fix was done in `display.py`: https://github.com/ansible/ansible/pull/68521/commits/0a1d8835605f139ba3c4cb66aba1feef33d61790

There are few more places where ansible calls `getpass.getuser()`, but they do not need this fix.