### PR TITLE
PowerShell - Support optional module util imports

### DIFF
--- a/changelogs/fragments/pwsh-optional-imp.yml
+++ b/changelogs/fragments/pwsh-optional-imp.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- PowerShell - Added support for optional module_util imports by scanning for ``-Optional`` at the end of the import declaration

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/MyCSMUOptional.cs
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/MyCSMUOptional.cs
@@ -1,0 +1,19 @@
+using System;
+
+using ansible_collections.testns.testcoll.plugins.module_utils.AnotherCSMU;
+using ansible_collections.testns.testcoll.plugins.module_utils.subpkg.subcs;
+
+//TypeAccelerator -Name MyCSMU -TypeName CustomThing
+
+namespace ansible_collections.testns.testcoll.plugins.module_utils.MyCSMU
+{
+    public class CustomThing
+    {
+        public static string HelloWorld()
+        {
+            string res1 = AnotherThing.CallMe();
+            string res2 = NestedUtil.HelloWorld();
+            return String.Format("Hello from user_mu collection-hosted MyCSMUOptional, also {0} and {1}", res1, res2);
+        }
+    }
+}

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/MyPSMUOptional.psm1
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/module_utils/MyPSMUOptional.psm1
@@ -1,0 +1,16 @@
+#AnsibleRequires -CSharpUtil Ansible.Invalid -Optional
+#AnsibleRequires -Powershell Ansible.ModuleUtils.Invalid -Optional
+#AnsibleRequires -CSharpUtil ansible_collections.testns.testcoll.plugins.module_utils.invalid -Optional
+#AnsibleRequires -CSharpUtil ansible_collections.testns.testcoll.plugins.module_utils.invalid.invalid -Optional
+#AnsibleRequires -Powershell ansible_collections.testns.testcoll.plugins.module_utils.invalid -Optional
+#AnsibleRequires -Powershell ansible_collections.testns.testcoll.plugins.module_utils.invalid.invalid -Optional
+
+Function Invoke-FromUserPSMU {
+    <#
+    .SYNOPSIS
+    Test function
+    #>
+    return "from optional user_mu"
+}
+
+Export-ModuleMember -Function Invoke-FromUserPSMU

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_uses_optional.ps1
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_uses_optional.ps1
@@ -1,0 +1,33 @@
+#!powershell
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Test builtin C# still works with -Optional
+#AnsibleRequires -CSharpUtil Ansible.Basic -Optional
+
+# Test no failure when importing an invalid builtin C# and pwsh util with -Optional
+#AnsibleRequires -CSharpUtil Ansible.Invalid -Optional
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Invalid -Optional
+
+# Test valid module_util still works with -Optional
+#AnsibleRequires -CSharpUtil ansible_collections.testns.testcoll.plugins.module_utils.MyCSMUOptional -Optional
+#AnsibleRequires -Powershell ansible_collections.testns.testcoll.plugins.module_utils.MyPSMUOptional -Optional
+
+# Test no failure when importing an invalid collection C# and pwsh util with -Optional
+#AnsibleRequires -CSharpUtil ansible_collections.testns.testcoll.plugins.module_utils.invalid -Optional
+#AnsibleRequires -CSharpUtil ansible_collections.testns.testcoll.plugins.module_utils.invalid.invalid -Optional
+#AnsibleRequires -Powershell ansible_collections.testns.testcoll.plugins.module_utils.invalid -Optional
+#AnsibleRequires -Powershell ansible_collections.testns.testcoll.plugins.module_utils.invalid.invalid -Optional
+
+$spec = @{
+    options = @{
+        data = @{ type = "str"; default = "called $(Invoke-FromUserPSMU)" }
+    }
+    supports_check_mode = $true
+}
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$module.Result.data = $module.Params.data
+$module.Result.csharp = [MyCSMU]::HelloWorld()
+
+$module.ExitJson()

--- a/test/integration/targets/collections/windows.yml
+++ b/test/integration/targets/collections/windows.yml
@@ -12,6 +12,9 @@
   - testns.testcoll.win_uses_coll_csmu:
     register: uses_coll_csmu
 
+  - testns.testcoll.win_uses_optional:
+    register: uses_coll_optional
+
   - assert:
       that:
       - selfcontained_out.source == 'user'
@@ -26,3 +29,6 @@
       - "'Hello from subpkg.subcs' in uses_coll_csmu.ping"
       - uses_coll_csmu.subpkg == 'Hello from subpkg.subcs'
       - uses_coll_csmu.type_accelerator == uses_coll_csmu.ping
+      # win_uses_optional
+      - uses_coll_optional.data == "called from optional user_mu"
+      - uses_coll_optional.csharp == "Hello from user_mu collection-hosted MyCSMUOptional, also Hello from nested user-collection-hosted AnotherCSMU and Hello from subpkg.subcs"

--- a/test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/module_utils/PSRel4.psm1
+++ b/test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/module_utils/PSRel4.psm1
@@ -1,0 +1,12 @@
+#AnsibleRequires -CSharpUtil .sub_pkg.CSRel5 -Optional
+#AnsibleRequires -PowerShell .sub_pkg.PSRelInvalid -Optional
+
+Function Invoke-FromPSRel4 {
+    <#
+    .SYNOPSIS
+    Test function
+    #>
+    return "Invoke-FromPSRel4"
+}
+
+Export-ModuleMember -Function Invoke-FromPSRel4

--- a/test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/modules/win_relative_optional.ps1
+++ b/test/integration/targets/collections_relative_imports/collection_root/ansible_collections/my_ns/my_col/plugins/modules/win_relative_optional.ps1
@@ -1,0 +1,17 @@
+#!powershell
+
+#AnsibleRequires -CSharpUtil Ansible.Basic -Optional
+#AnsibleRequires -PowerShell ..module_utils.PSRel4 -optional
+
+# These do not exist
+#AnsibleRequires -CSharpUtil ..invalid_package.name -Optional
+#AnsibleRequires -CSharpUtil ..module_utils.InvalidName -optional
+#AnsibleRequires -PowerShell ..invalid_package.pwsh_name -optional
+#AnsibleRequires -PowerShell ..module_utils.InvalidPwshName -Optional
+
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, @{})
+
+$module.Result.data = Invoke-FromPSRel4
+
+$module.ExitJson()

--- a/test/integration/targets/collections_relative_imports/windows.yml
+++ b/test/integration/targets/collections_relative_imports/windows.yml
@@ -9,3 +9,12 @@
     assert:
       that:
       - win_relative.data == 'CSRel4.Invoke() -> Invoke-FromPSRel3 -> Invoke-FromPSRel2 -> Invoke-FromPSRel1'
+
+  - name: test out relative imports on Windows modules with optional import
+    my_ns.my_col.win_relative_optional:
+    register: win_relative_optional
+
+  - name: assert relative imports on Windows modules with optional import
+    assert:
+      that:
+      - win_relative_optional.data == 'Invoke-FromPSRel4'


### PR DESCRIPTION
##### SUMMARY
Adds the ability for PowerShell modules to conditonally import a module util like Python modules can. This allows a module to support features that may not or may not be present as a module util in another package without having to bump the minimum supported constraint on that package.

An example where this is needed will be with the upcoming tagged data support from a module. Modules can optionally import the module utils that support the tagged data and determine if it can return the tagged data or not based on whether the module util was imported or not.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
PowerShell modules