### PR TITLE
Misc typo fixes

### DIFF
--- a/docs/docsite/rst/locales/ja/LC_MESSAGES/reference_appendices.po
+++ b/docs/docsite/rst/locales/ja/LC_MESSAGES/reference_appendices.po
@@ -4422,7 +4422,7 @@ msgstr "OLD_PLUGIN_CACHE_CLEARING"
 
 #: ../../rst/reference_appendices/config.rst:2656
 #: ../../rst/reference_appendices/config.rst:4421
-msgid "Previouslly Ansible would only clear some of the plugin loading caches when loading new roles, this led to some behaviours in which a plugin loaded in prevoius plays would be unexpectedly 'sticky'. This setting allows to return to that behaviour."
+msgid "Previously Ansible would only clear some of the plugin loading caches when loading new roles, this led to some behaviours in which a plugin loaded in prevoius plays would be unexpectedly 'sticky'. This setting allows to return to that behaviour."
 msgstr "以前の Ansible は、新しいロールを読み込むときにプラグインの読み込みキャッシュの一部のみを削除していました。これにより、以前のプレイで読み込まれたプラグインが予期せず「スティッキー」になる動作が発生しました。この設定により、その動作に戻ることができます。"
 
 #: ../../rst/reference_appendices/config.rst:2662

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1668,7 +1668,7 @@ MODULE_IGNORE_EXTS:
   - {key: module_ignore_exts, section: defaults}
   type: list
 OLD_PLUGIN_CACHE_CLEARING:
-  description: Previouslly Ansible would only clear some of the plugin loading caches when loading new roles, this led to some behaviours in which a plugin loaded in prevoius plays would be unexpectedly 'sticky'. This setting allows to return to that behaviour.
+  description: Previously Ansible would only clear some of the plugin loading caches when loading new roles, this led to some behaviours in which a plugin loaded in prevoius plays would be unexpectedly 'sticky'. This setting allows to return to that behaviour.
   env: [{name: ANSIBLE_OLD_PLUGIN_CACHE_CLEAR}]
   ini:
   - {key: old_plugin_cache_clear, section: defaults}


### PR DESCRIPTION
##### SUMMARY

Changed `Previouslly` to `Previously`.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/locales/ja/LC_MESSAGES/reference_appendices.po
lib/ansible/config/base.yml
