### PR TITLE
user - set current expiration correctly when no shadow entry exists

### DIFF
--- a/changelogs/fragments/71916-user-expires-int.yml
+++ b/changelogs/fragments/71916-user-expires-int.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - set expiration value correctly when unable to retrieve the current value from the system (https://github.com/ansible/ansible/issues/71916)

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -919,7 +919,8 @@ class User(object):
 
         if self.expires is not None:
 
-            current_expires = int(self.user_password()[1])
+            current_expires = self.user_password()[1] or '0'
+            current_expires = int(current_expires)
 
             if self.expires < time.gmtime(0):
                 if current_expires >= 0:
@@ -1562,7 +1563,8 @@ class FreeBsdUser(User):
 
         if self.expires is not None:
 
-            current_expires = int(self.user_password()[1])
+            current_expires = self.user_password()[1] or '0'
+            current_expires = int(current_expires)
 
             # If expiration is negative or zero and the current expiration is greater than zero, disable expiration.
             # In OpenBSD, setting expiration to zero disables expiration. It does not expire the account.

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -31,6 +31,7 @@
 - import_tasks: test_expires.yml
 - import_tasks: test_expires_new_account.yml
 - import_tasks: test_expires_new_account_epoch_negative.yml
+- import_tasks: test_expires_no_shadow.yml
 - import_tasks: test_expires_min_max.yml
 - import_tasks: test_expires_warn.yml
 - import_tasks: test_shadow_backup.yml

--- a/test/integration/targets/user/tasks/test_expires_no_shadow.yml
+++ b/test/integration/targets/user/tasks/test_expires_no_shadow.yml
@@ -1,0 +1,47 @@
+# https://github.com/ansible/ansible/issues/71916
+- name: Test setting expiration for a user account that does not have an /etc/shadow entry
+  when: ansible_facts.os_family in ['RedHat', 'Debian', 'Suse']
+  block:
+    - name: Remove ansibulluser
+      user:
+        name: ansibulluser
+        state: absent
+        remove: yes
+
+    - name: Create user account entry in /etc/passwd
+      lineinfile:
+        path: /etc/passwd
+        line: "ansibulluser::575:575::/home/dummy:/bin/bash"
+        regexp: "^ansibulluser.*"
+        state: present
+
+    - name: Create user with negative expiration
+      user:
+        name: ansibulluser
+        uid: 575
+        expires: -1
+      register: user_test_expires_no_shadow_1
+
+    - name: Create user with negative expiration again
+      user:
+        name: ansibulluser
+        uid: 575
+        expires: -1
+      register: user_test_expires_no_shadow_2
+
+    - name: Ensure changes were made appropriately
+      assert:
+        that:
+          - user_test_expires_no_shadow_1 is changed
+          - user_test_expires_no_shadow_2 is not changed
+
+    - name: Get expiration date for ansibulluser
+      getent:
+        database: shadow
+        key: ansibulluser
+
+    - name: LINUX | Ensure proper expiration date was set
+      assert:
+        msg: "expiry is supposed to be empty or -1, not {{ getent_shadow['ansibulluser'][6] }}"
+        that:
+          - not getent_shadow['ansibulluser'][6] or getent_shadow['ansibulluser'][6] | int < 0


### PR DESCRIPTION
##### SUMMARY
If no entry for a user account exists in `/etc/shadow` an empty string is returned for the expiration value. Trying to convert that to an `int` raises a `ValueError`.

Ensure the value for expiration is set to `0` if unable to read the shadow file.

Fixes #71916.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/user.py`