### PR TITLE
Replace self.module by my_module in test examples

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_units_modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_units_modules.rst
@@ -369,7 +369,7 @@ Here is a simple mock of :meth:`AnsibleModule.run_command` (taken from :file:`te
         with patch.object(basic.AnsibleModule, 'run_command') as run_command:
             run_command.return_value = 0, '', ''  # successful execution, no output
                 with self.assertRaises(AnsibleExitJson) as result:
-                    self.module.main()
+                    my_module.main()
                 self.assertFalse(result.exception.args[0]['changed'])
         # Check that run_command has been called
         run_command.assert_called_once_with('/usr/bin/command args')
@@ -443,7 +443,7 @@ mock for :meth:`Ansible.get_bin_path`::
         def test_module_fail_when_required_args_missing(self):
             with self.assertRaises(AnsibleFailJson):
                 set_module_args({})
-                self.module.main()
+                my_module.main()
 
 
         def test_ensure_command_called(self):
@@ -508,7 +508,7 @@ This now makes it possible to run tests against the module initiation function::
          })
 
         with self.assertRaises(AnsibleFailJson) as result:
-            self.module.setup_json
+            my_module.setup_json
 
 See also ``test/units/module_utils/aws/test_rds.py``
 


### PR DESCRIPTION
##### SUMMARY
While implementing basic Ansible module testing I realised that the `self.module` used in some places is not actually a thing, and I changed to `my_module` to make it work as I understand it was expected.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
