### PR TITLE
[stable-2.11] Restrict packaging to < 21.0 for Python < 3.6. (#75186)

### DIFF
--- a/changelogs/fragments/75186-ansible-test-packaging-constraint.yml
+++ b/changelogs/fragments/75186-ansible-test-packaging-constraint.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-test - restrict ``packaging`` to ``< 21.0`` for Python ``< 3.6`` (https://github.com/ansible/ansible/pull/75186)."

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -1,3 +1,4 @@
+packaging < 21.0 ; python_version < '3.6' # packaging 21.0 requires Python 3.6 or newer
 resolvelib >= 0.5.3, < 0.6.0  # keep in sync with `requirements.txt`
 coverage >= 4.5.1, < 5.0.0 ; python_version <  '3.7' # coverage 4.4 required for "disable_warnings" support but 4.5.1 needed for bug fixes, coverage 5.0+ incompatible
 coverage >= 4.5.2, < 5.0.0 ; python_version == '3.7' # coverage 4.5.2 fixes bugs in support for python 3.7, coverage 5.0+ incompatible


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #75186 for Ansible 2.11.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/lib/ansible_test/_data/requirements/constraints.txt`