### PR TITLE
[stable-2.9] Skip `passwordstore` lookup test on OS X

### DIFF
--- a/test/integration/targets/lookup_passwordstore/aliases
+++ b/test/integration/targets/lookup_passwordstore/aliases
@@ -1,3 +1,4 @@
 shippable/posix/group4
 destructive
 skip/rhel
+skip/osx


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There is an issue with the `brew` formula installing `gnugp2` and since we do not update `brew` for other reasons, we need to skip this test.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/lookup_passwordstore`