### PR TITLE
[stable-2.9] Skip docker_container test when running in a container

### DIFF
--- a/test/integration/targets/docker_container/aliases
+++ b/test/integration/targets/docker_container/aliases
@@ -1,4 +1,5 @@
 shippable/posix/group4
 skip/osx
 skip/freebsd
+skip/docker
 destructive


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The test started failing recently when run in a Fedora 30 container. Since the test is still run on RHEL, disabling it when running in containers is ok.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/docker_container`