### PR TITLE
Update playbooks_filters.rst

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1505,7 +1505,7 @@ To search in a string or extract parts of a string with a regular expression, us
     {{ 'server1/database42' | regex_search('database[0-9]+') }}
     # => 'database42'
 
-    # Returns an empty string if it cannot find a match
+    # Returns none if it cannot find a match
     {{ 'ansible' | regex_search('foobar') }}
     # => ''
 


### PR DESCRIPTION
regex_search() filter will return none if not match.  
```shell
- debug:
     msg: |
       #{{ "1234567" | regex_search('9') is none }}#
       #{{ "1234567" | regex_search('9') is not none }}#
       #{{ "1234567" | regex_search('9') == "" }}#
       #{{ "1234567" | regex_search('9') != "" }}#
```
will output:  
```
"msg": "#True#\n#False#\n#False#\n#True#\n"
```
test with empty string `""` will always return confused results.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
