### PR TITLE
Update hacking `env_setup` to prefer Python 3

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -1,4 +1,4 @@
-
+#!/bin/sh
 # usage: source hacking/env-setup [-q]
 #    modifies environment for running Ansible from checkout
 

--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -22,7 +22,7 @@ prepend_path()
 PYTHONPATH=${PYTHONPATH-""}
 PATH=${PATH-""}
 MANPATH=${MANPATH-$(manpath)}
-PYTHON=$(command -v python || command -v python3)
+PYTHON=$(command -v python3 || command -v python)
 PYTHON_BIN=${PYTHON_BIN-$PYTHON}
 
 verbosity=${1-info} # Defaults to `info' if unspecified

--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -47,10 +47,10 @@ end
 
 # Set PYTHON_BIN
 if not set -q PYTHON_BIN
-    if test (which python)
-        set -gx PYTHON_BIN (which python)
-    else if test (which python3)
+    if test (which python3)
         set -gx PYTHON_BIN (which python3)
+    else if test (which python)
+        set -gx PYTHON_BIN (which python)
     else
         echo "No valid Python found"
         exit 1


### PR DESCRIPTION
##### SUMMARY

Prefer the `python3` binary over the `python` binary. This shouldn't matter when using a virtual environment but will matter if there are both Python 2 and Python 3 versions available.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`hacking/env-setup`
`hacking/env-setup.fish`