### PR TITLE
[stable-2.9] Prevent ansible_failed_task from further templating (#74290)

### DIFF
--- a/changelogs/fragments/74036-unsafe-ansible_failed_task.yml
+++ b/changelogs/fragments/74036-unsafe-ansible_failed_task.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Prevent ``ansible_failed_task`` from further templating (https://github.com/ansible/ansible/issues/74036)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -49,6 +49,7 @@ from ansible.playbook.task_include import TaskInclude
 from ansible.plugins import loader as plugin_loader
 from ansible.template import Templar
 from ansible.utils.display import Display
+from ansible.utils.unsafe_proxy import wrap_var
 from ansible.utils.vars import combine_vars
 from ansible.vars.clean import strip_internal_keys, module_response_deepcopy
 
@@ -577,7 +578,7 @@ class StrategyBase:
                         self._variable_manager.set_nonpersistent_facts(
                             original_host.name,
                             dict(
-                                ansible_failed_task=original_task.serialize(),
+                                ansible_failed_task=wrap_var(original_task.serialize()),
                                 ansible_failed_result=task_result._result,
                             ),
                         )

--- a/test/integration/targets/blocks/runme.sh
+++ b/test/integration/targets/blocks/runme.sh
@@ -94,9 +94,6 @@ cat rc_test.out
 [ "$(grep -c 'failed=0' rc_test.out)" -eq 1 ]
 rm -f rc_test.out
 
-# test notify inheritance
-ansible-playbook inherit_notify.yml "$@"
-
 ansible-playbook unsafe_failed_task.yml "$@"
 
 ansible-playbook finalized_task.yml "$@"

--- a/test/integration/targets/blocks/runme.sh
+++ b/test/integration/targets/blocks/runme.sh
@@ -94,4 +94,9 @@ cat rc_test.out
 [ "$(grep -c 'failed=0' rc_test.out)" -eq 1 ]
 rm -f rc_test.out
 
+# test notify inheritance
+ansible-playbook inherit_notify.yml "$@"
+
+ansible-playbook unsafe_failed_task.yml "$@"
+
 ansible-playbook finalized_task.yml "$@"

--- a/test/integration/targets/blocks/unsafe_failed_task.yml
+++ b/test/integration/targets/blocks/unsafe_failed_task.yml
@@ -1,0 +1,17 @@
+- hosts: localhost
+  gather_facts: false
+  vars:
+    - data: {}
+  tasks:
+    - block:
+        - name: template error
+          debug:
+            msg: "{{ data.value }}"
+      rescue:
+        - debug:
+            msg: "{{ ansible_failed_task.action }}"
+
+        - assert:
+            that:
+              - ansible_failed_task.name == "template error"
+              - ansible_failed_task.action == "debug"


### PR DESCRIPTION
* Prevent ansible_failed_task from further templating

Fixes #74036

Backport of #74290 for Ansible 2.9.

* Add changelog.
(cherry picked from commit 664531d7d6253d5bdb182727501c08e3b5aea0c1)

Co-authored-by: Martin Krizek <martin.krizek@gmail.com>