### PR TITLE
Auth token galaxy ng

### DIFF
--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -407,7 +407,7 @@ def _download_file(url, b_path, expected_hash, validate_certs, token=None):
         validate_certs=validate_certs,
         headers=None if token is None else token.headers(),
         unredirected_headers=['Authorization'] if "s3.amazonaws" in url else None,
-	    http_agent=user_agent(),
+        http_agent=user_agent(),
     )
 
     with open(b_file_path, 'wb') as download_file:  # type: BinaryIO

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -401,11 +401,13 @@ def _download_file(url, b_path, expected_hash, validate_certs, token=None):
     display.display("Downloading %s to %s" % (url, to_text(b_tarball_dir)))
     # NOTE: Galaxy redirects downloads to S3 which rejects the request
     # NOTE: if an Authorization header is attached so don't redirect it
+    # NOTE: But Authorization header is needed if using on-premise Galaxy, such as "galaxy-ng"
     resp = open_url(
         to_native(url, errors='surrogate_or_strict'),
         validate_certs=validate_certs,
         headers=None if token is None else token.headers(),
-        unredirected_headers=['Authorization'], http_agent=user_agent(),
+        unredirected_headers=['Authorization'] if "s3.amazonaws" in url else None,
+	    http_agent=user_agent(),
     )
 
     with open(b_file_path, 'wb') as download_file:  # type: BinaryIO


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
While installing collection from on-premise Galaxy-ng repository, **ansible-galaxy** returns error with 403 HTTP status code.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- ansible-galaxy
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
There is a problem when using Galaxy-ng on-premise collections repository.
_**ansible-galaxy collection install**_ returns HTTP 403 status code, because HTTP Header "Authorization" is removed.
By default, galaxy-ng return to client "http" URL with .tar.gz archieve and when client tries to get this, galaxy-ng redirects to the same URL but with "https".
After that ansible-galaxy removes HTTP Header "Authorization", but galaxy-ng requires it.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
