### PR TITLE
Add support for MIRACLE LINUX for hostname module

### DIFF
--- a/changelogs/fragments/75232-hostname-miraclelinux-support.yml
+++ b/changelogs/fragments/75232-hostname-miraclelinux-support.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hostname - add MIRACLE LINUX support (https://github.com/ansible/ansible/pull/75232)

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -779,6 +779,12 @@ class AmazonLinuxHostname(Hostname):
     strategy_class = RedHatStrategy
 
 
+class MiracleLinuxHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Miraclelinux'
+    strategy_class = SystemdStrategy
+
+
 class DebianHostname(Hostname):
     platform = 'Linux'
     distribution = 'Debian'


### PR DESCRIPTION
##### SUMMARY
Add MIRACLE LINUX support for hostname module

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/hostname.py

##### ADDITIONAL INFORMATION
before:
```
PLAY [localhost] ***********************************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************************************
ok: [localhost]

TASK [test-hostname-module] ************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "hostname module cannot be used on platform Linux (Miraclelinux)"}

PLAY RECAP *****************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```
after:
```
PLAY [localhost] ***********************************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************************************
ok: [localhost]

TASK [test-hostname-module] ************************************************************************************************************
ok: [localhost]

PLAY RECAP *****************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

```