### PR TITLE
Update platform_index.rst to include Palo Alto Networks

### DIFF
--- a/docs/docsite/rst/network/user_guide/platform_index.rst
+++ b/docs/docsite/rst/network/user_guide/platform_index.rst
@@ -84,6 +84,7 @@ Settings by Platform
     `Meraki`_                                                                                         ✓
     `MikroTik RouterOS`_             ``community.network.routeros``    ✓
     `Nokia SR OS`_                                                                                    ✓
+    `Palo Alto PAN-OS`_                                                                       ✓       ✓
     `Pluribus Netvisor`_             ``community.network.netvisor``    ✓
     `Ruckus ICX`_                    ``community.network.icx``         ✓
     `VyOS`_ `[†]`_                   ``vyos.vyos.vyos``                ✓                              ✓
@@ -115,6 +116,7 @@ Settings by Platform
 .. _Meraki: https://galaxy.ansible.com/cisco/meraki
 .. _MikroTik RouterOS: https://galaxy.ansible.com/community/network
 .. _Nokia SR OS: https://galaxy.ansible.com/community/network
+.. _Palo Alto PAN-OS: https://galaxy.ansible.com/paloaltonetworks/panos
 .. _Pluribus Netvisor: https://galaxy.ansible.com/community/network
 .. _Ruckus ICX: https://galaxy.ansible.com/community/network
 .. _VyOS: https://galaxy.ansible.com/vyos/vyos


### PR DESCRIPTION
Added Palo Alto to the platform_index.rst documentation

##### SUMMARY
I noticed that there exists Palo Alto Networks PAN-OS Ansible Galaxy Collection and wanted to add it

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Palo Alto Networks collection addition to the doc for those who may be searching for it.

##### ADDITIONAL INFORMATION
N/A