### PR TITLE
regex_search: always return an empty string when no match is found

### DIFF
--- a/changelogs/fragments/regex_search_return_empty_str.yml
+++ b/changelogs/fragments/regex_search_return_empty_str.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "regex_search: always return an empty string when no match is found"

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -163,6 +163,7 @@ def regex_search(value, regex, *args, **kwargs):
                 items.append(match.group(item))
             return items
 
+    return ''
 
 def ternary(value, true_val, false_val, none_val=None):
     '''  value ? true_val : false_val '''

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -165,6 +165,7 @@ def regex_search(value, regex, *args, **kwargs):
 
     return ''
 
+
 def ternary(value, true_val, false_val, none_val=None):
     '''  value ? true_val : false_val '''
     if value is None and none_val is not None:

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -283,6 +283,7 @@
     multi_line: "{{ 'hello\nworld' | regex_search('^world', multiline=true) }}"
     named_groups: "{{ 'goodbye' | regex_search('(?P<first>good)(?P<second>bye)', '\\g<second>', '\\g<first>') }}"
     numbered_groups: "{{ 'goodbye' | regex_search('(good)(bye)', '\\2', '\\1') }}"
+    no_match_empty_str_inline: "{{ 'hello' | regex_search('world') == '' }}"
 
 - name: regex_search unknown argument (failure expected)
   set_fact:
@@ -299,6 +300,7 @@
       - multi_line == 'world'
       - named_groups == ['bye', 'good']
       - numbered_groups == ['bye', 'good']
+      - no_match_empty_str_inline
       - failure is failed
 
 - name: Verify to_bool


### PR DESCRIPTION
##### SUMMARY
The docs state that regex_search returns an empty string when no match
is found. This is a side-effect of our custom implementation of
_finalize method for Jinja's Environment where we explictly convert any
result of templating that is None to an empty string. Which is a case of
regex_search function that the filter uses because it returns None when
no match is found.

The problem here is when the filter is used inline with any comparison
to an empty string like the following:
``{{ 'hello' | regex_search('world') == '' }}``

This would be evaluated to False because the _finalize method is only
called on the final result of templating as opposed to on the
itermediate results, so it would effectivelly be ``None == ''``.

This patch fixes that to explictly return an empty string when no match
is found in the regex_search function.

Related https://github.com/ansible/ansible/pull/75211

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/filter/core.py
