### PR TITLE
Make rpm_key aware of multiple keys in a keyfile

### DIFF
--- a/changelogs/fragments/50615-rpm_key.yml
+++ b/changelogs/fragments/50615-rpm_key.yml
@@ -1,0 +1,7 @@
+minor_changes:
+  - >
+    rpm_key - Check for multiple signing keys in a single GPG key file. 
+    (https://github.com/ansible/ansible/issues/50615).
+  - rpm_key - ``fingerprint`` now allows for a list of key fingerprints to be specified.
+    The fingerprints of all keys in a file should be specified for key import to be successful.
+    (https://github.com/ansible/ansible/issues/50615).

--- a/test/integration/targets/rpm_key/tasks/rpm_key.yaml
+++ b/test/integration/targets/rpm_key/tasks/rpm_key.yaml
@@ -176,6 +176,35 @@
       - result is success
       - result is not changed
 
+- name: Issue 50615 - Verify key fingerprints. This should fail due to multiple key signatures
+  rpm_key:
+    # TODO: This needs to be rehosted on ansible CI infra
+    key: https://dl.google.com/linux/linux_signing_key.pub
+    fingerprint: EB4C 1BFD 4F04 2F6D DDCC EC91 7721 F63B D38B 4796
+  register: result
+  ignore_errors: true
+
+- name: Issue 50615 - Assert Verify fingerprints of keys, insufficent fingerprints
+  assert:
+    that:
+       - result is not success
+       - result is not changed
+
+- name: Issue 50615 - Add Google GPG keys to system
+  rpm_key:
+    # TODO: This needs to be rehosted on ansible CI infra
+    key: https://dl.google.com/linux/linux_signing_key.pub
+    fingerprint:
+      - 4CCA 1EAF 950C EE4A B839 76DC A040 830F 7FAC 5991
+      - EB4C 1BFD 4F04 2F6D DDCC EC91 7721 F63B D38B 4796
+  register: result
+
+- name: Issue 50615 - Assert Verify fingerprints of keys, valid fingerprints
+  assert:
+    that:
+      - result is success
+      - result is changed
+
 #
 # Cleanup
 #

--- a/test/integration/targets/rpm_key/tasks/rpm_key.yaml
+++ b/test/integration/targets/rpm_key/tasks/rpm_key.yaml
@@ -178,8 +178,7 @@
 
 - name: Issue 50615 - Verify key fingerprints. This should fail due to multiple key signatures
   rpm_key:
-    # TODO: This needs to be rehosted on ansible CI infra
-    key: https://dl.google.com/linux/linux_signing_key.pub
+    key: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/rpm_key/linux_signing_key.pub
     fingerprint: EB4C 1BFD 4F04 2F6D DDCC EC91 7721 F63B D38B 4796
   register: result
   ignore_errors: true
@@ -192,8 +191,7 @@
 
 - name: Issue 50615 - Add Google GPG keys to system
   rpm_key:
-    # TODO: This needs to be rehosted on ansible CI infra
-    key: https://dl.google.com/linux/linux_signing_key.pub
+    key: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/rpm_key/linux_signing_key.pub
     fingerprint:
       - 4CCA 1EAF 950C EE4A B839 76DC A040 830F 7FAC 5991
       - EB4C 1BFD 4F04 2F6D DDCC EC91 7721 F63B D38B 4796


### PR DESCRIPTION
##### SUMMARY
Fixes #50615.

Make `rpm_key` module use lists for key ids since a single key file can contain multiple keys.

I also made the fingerprint option accept lists of fingerprints since they correspond with key ids. All fingerprints in a keyfile should be present when the fingerprints option is set for task success.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rpm_key

##### ADDITIONAL INFORMATION
Example:
```yaml
- name: Add Google GPG keys to system
  rpm_key:
    key: https://dl.google.com/linux/linux_signing_key.pub
    fingerprint:
      # First key in keyfile
      - 4CCA 1EAF 950C EE4A B839 76DC A040 830F 7FAC 5991
      # Second key in keyfile
      - EB4C 1BFD 4F04 2F6D DDCC EC91 7721 F63B D38B 4796
```

The rpm_key module only checked for the presence of the first key in a file when importing keys from files. This meant that in cases where a single file contained multiple keys it was possible for later keys to not be imported if the first key in a key file was already installed. It could also mean that multiple keys could be installed even when only expecting a single key in a file.