### PR TITLE
pylint: accepts ansible.errors in module_utils

### DIFF
--- a/changelogs/fragments/pylint_accept_import_errors.yaml
+++ b/changelogs/fragments/pylint_accept_import_errors.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- "pylint - accept import of ansible.errors in module_utils"

--- a/test/integration/targets/ansible-test/ansible_collections/ns/col/plugins/module_utils/my_util.py
+++ b/test/integration/targets/ansible-test/ansible_collections/ns/col/plugins/module_utils/my_util.py
@@ -2,5 +2,10 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
+from ansible.errors import AnsibleModule
+
+
 def hello(name):
+    if 1 == 2:
+        raise AnsibleModule()
     return 'Hello %s' % name

--- a/test/lib/ansible_test/_data/sanity/pylint/plugins/unwanted.py
+++ b/test/lib/ansible_test/_data/sanity/pylint/plugins/unwanted.py
@@ -231,6 +231,9 @@ class AnsibleUnwantedChecker(BaseChecker):
         if modname == 'ansible.module_utils' or modname.startswith('ansible.module_utils.'):
             return
 
+        if modname == 'ansible.errors':
+            return
+
         if modname == 'ansible' or modname.startswith('ansible.'):
             self.add_message(self.BAD_MODULE_IMPORT, args=(modname,), node=node)
 


### PR DESCRIPTION
##### SUMMARY

Accept the import of ansible.errors in collection module_utils.

We've got a case where we import ansible.errors in a module_utils file to get access to the AnsibleModule exception. This currently raises an error.
I believe this is an error and ansible.errors is public.

```
ERROR: Found 1 pylint issue(s) which need to be resolved:
ERROR: plugins/module_utils/inventory.py:43:4: ansible-bad-module-import: Import external package or ansible.module_utils not ansible.errors
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test
pylint