### PR TITLE
winrm - Add explicit env vars to pass into kinit

### DIFF
--- a/changelogs/fragments/winrm-kinit-env.yml
+++ b/changelogs/fragments/winrm-kinit-env.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- winrm - Allow explicit environment variables to be passed through to the ``kinit`` call for Kerberos authentication

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -96,9 +96,14 @@ DOCUMENTATION = """
         description:
         - A list of environment variables to pass through to C(kinit) when getting the Kerberos authentication ticket.
         - By default no environment variables are passed through and C(kinit) is run with a blank slate.
+        - The environment variable C(KRB5CCNAME) cannot be specified here as it's used to store the temp Kerberos
+          ticket used by WinRM.
         type: list
         elements: str
         default: []
+        ini:
+        - section: winrm
+          key: kinit_env_vars
         vars:
           - name: ansible_winrm_kinit_env_vars
         version_added: '2.12'
@@ -319,7 +324,7 @@ class Connection(ConnectionBase):
         # Add any explicit environment vars into the krb5env block
         kinit_env_vars = self.get_option('kinit_env_vars')
         for var in kinit_env_vars:
-            if var in os.environ:
+            if var not in krb5env and var in os.environ:
                 krb5env[var] = os.environ[var]
 
         # Stores various flags to call with kinit, these could be explicit args set by 'ansible_winrm_kinit_args' OR

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -92,6 +92,16 @@ DOCUMENTATION = """
         vars:
           - name: ansible_winrm_kinit_args
         version_added: '2.11'
+      kinit_env_vars:
+        description:
+        - A list of environment variables to pass through to C(kinit) when getting the Kerberos authentication ticket.
+        - By default no environment variables are passed through and C(kinit) is run with a blank slate.
+        type: list
+        elements: str
+        default: []
+        vars:
+          - name: ansible_winrm_kinit_env_vars
+        version_added: '2.12'
       kerberos_mode:
         description:
             - kerberos usage mode.
@@ -305,6 +315,12 @@ class Connection(ConnectionBase):
         krb5ccname = "FILE:%s" % self._kerb_ccache.name
         os.environ["KRB5CCNAME"] = krb5ccname
         krb5env = dict(KRB5CCNAME=krb5ccname)
+
+        # Add any explicit environment vars into the krb5env block
+        kinit_env_vars = self.get_option('kinit_env_vars')
+        for var in kinit_env_vars:
+            if var in os.environ:
+                krb5env[var] = os.environ[var]
 
         # Stores various flags to call with kinit, these could be explicit args set by 'ansible_winrm_kinit_args' OR
         # '-f' if kerberos delegation is requested (ansible_winrm_kerberos_delegation).


### PR DESCRIPTION
##### SUMMARY
Adds the option to the `winrm` connection plugin` that specifies a bunch of environment variables in the current process to pass into the `kinit` call. This allows a user to run `kinit` with a custom `KRB5_CONFIG` but only when opting in.

It was considered to always pass in `KRB5_CONFIG` if set or just use the existing environment block but they have the potential to break existing playbooks who rely on the current behaviour. The middle ground was this method where the caller explicitly sets the env vars they wish to pass through.

An alternative for people is to

* Use the [psrp](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/psrp_connection.html) connection plugin which doesn't rely on `kinit` at all for Kerberos auth and will thus use the existing environment settings
* Set `ansible_winrm_kinit_cmd` to an executable script that does `KRB5_CONFIG=/my/krb5.conf kinit "@$"` to force the use of the env var

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
winrm