### PR TITLE
validate role_name for documented criteria

### DIFF
--- a/lib/ansible/playbook/role/definition.py
+++ b/lib/ansible/playbook/role/definition.py
@@ -132,9 +132,6 @@ class RoleDefinition(Base, Conditional, Taggable, CollectionSearch):
             templar = Templar(loader=self._loader, variables=all_vars)
             role_name = templar.template(role_name)
 
-        # check if role name contains any illegal characters
-        self._validate_role_name(role_name)
-
         return role_name
 
     def _load_role_path(self, role_name):
@@ -230,22 +227,6 @@ class RoleDefinition(Base, Conditional, Taggable, CollectionSearch):
                 role_def[key] = value
 
         return (role_def, role_params)
-
-    def _validate_role_name(self, role_name):
-        '''
-        split role_name into parts and validate independently for criteria documented in
-        https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_structure.html#roles-directory and
-        raise a distinct AnsibleError in case of violation
-        '''
-
-        parts = role_name.split(".")
-        for part in parts:
-            # make sure each part starts alphanumerical
-            # remove legal special character before checking if it's alphanumerical
-            # make sure each part is fully lowercase
-            if not part.startswith('_') and not part.replace('_', '').isalnum() and part.islower():
-                # raise more distinct error in case of name violates
-                raise AnsibleError("the role '%s' must consist of only alphanumerical characters" % role_name, obj=self._ds)
 
     def get_role_params(self):
         return self._role_params.copy()


### PR DESCRIPTION
add function to validate role names

##### SUMMARY
I added a little function that is validating the role_name according to the criteria documented in https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_structure.html#roles-directory

This is my first contribution so pelase feel free to come up with plenty of corrections and/or let me know what I have not considered.

Fixes #75023

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
update of RoleDefinition error handling

##### ADDITIONAL INFORMATION
Normally, I would solve this issue using a regular expression in python. However, I did not want to add the re module. If this would have been the way to go, let me know and I apply the changes accordingly.
