### PR TITLE
unarchive - properly handle relative path for `dest`

### DIFF
--- a/changelogs/fragments/64612-unarchive-relative-path-dest.yml
+++ b/changelogs/fragments/64612-unarchive-relative-path-dest.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - unarchive - allow relative path for ``dest`` (https://github.com/ansible/ansible/issues/64612)

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -1021,7 +1021,12 @@ def main():
 
     src = module.params['src']
     dest = module.params['dest']
-    b_dest = os.path.abspath(to_bytes(dest, errors='surrogate_or_strict'))
+    abs_dest = os.path.abspath(dest)
+    b_dest = to_bytes(abs_dest, errors='surrogate_or_strict')
+
+    if not os.path.isabs(dest):
+        module.warn("Relative destination path '{dest}' was resolved to absolute path '{abs_dest}'.".format(dest=dest, abs_dest=abs_dest))
+
     remote_src = module.params['remote_src']
     file_args = module.load_file_common_arguments(module.params)
 

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -336,10 +336,7 @@ class ZipArchive(object):
     def _legacy_file_list(self):
         rc, out, err = self.module.run_command([self.cmd_path, '-v', self.src])
         if rc:
-            msg = 'Neither python zipfile nor unzip can read {src}.'.format(src=self.src)
-            if self.module._verbosity >= 3:
-                msg = '{msg}: {err}'.format(msg=msg.rstrip('.'), err=to_native(err, errors='surrogate_or_replace'))
-            raise UnarchiveError(msg)
+            raise UnarchiveError('Neither python zipfile nor unzip can read %s' % self.src)
 
         for line in out.splitlines()[3:-2]:
             fields = line.split(None, 7)
@@ -797,9 +794,6 @@ class TgzArchive(object):
         rc, out, err = self.module.run_command(cmd, cwd=self.b_dest, environ_update=dict(LANG=locale, LC_ALL=locale, LC_MESSAGES=locale, LANGUAGE=locale))
         if rc != 0:
             raise UnarchiveError('Unable to list files in the archive: %s' % err)
-            if self.module._verbosity >= 3:
-                msg = '{msg}: {err}'.format(msg=msg, err=to_native(err, errors='surrogate_or_replace'))
-            raise UnarchiveError(msg)
 
         for filename in out.splitlines():
             # Compensate for locale-related problems in gtar output (octal unicode representation) #11348
@@ -920,9 +914,6 @@ class TgzArchive(object):
                 return True, None
         except UnarchiveError as e:
             return False, 'Command "%s" could not handle archive: %s' % (self.cmd_path, to_native(e))
-            if self.module._verbosity >= 3:
-                msg = '{msg}: {err}'.format(msg=msg.rstrip('.'), err=to_native(ue, errors='surrogate_or_replace'))
-            return False, msg
         # Errors and no files in archive assume that we weren't able to
         # properly unarchive it
         return False, 'Command "%s" found no files in archive. Empty archive files are not supported.' % self.cmd_path
@@ -996,9 +987,6 @@ def pick_handler(src, dest, file_args, module):
         if can_handle:
             return obj
         reasons.add(reason)
-    joiner = ' '
-    if module._verbosity >= 3:
-        joiner = '\n'
     reason_msg = '\n'.join(reasons)
     module.fail_json(msg='Failed to find handler for "%s". Make sure the required command to extract the file is installed.\n%s' % (src, reason_msg))
 

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -336,7 +336,10 @@ class ZipArchive(object):
     def _legacy_file_list(self):
         rc, out, err = self.module.run_command([self.cmd_path, '-v', self.src])
         if rc:
-            raise UnarchiveError('Neither python zipfile nor unzip can read %s' % self.src)
+            msg = 'Neither python zipfile nor unzip can read {src}.'.format(src=self.src)
+            if self.module._verbosity >= 3:
+                msg = '{msg}: {err}'.format(msg=msg.rstrip('.'), err=to_native(err, errors='surrogate_or_replace'))
+            raise UnarchiveError(msg)
 
         for line in out.splitlines()[3:-2]:
             fields = line.split(None, 7)
@@ -794,6 +797,9 @@ class TgzArchive(object):
         rc, out, err = self.module.run_command(cmd, cwd=self.b_dest, environ_update=dict(LANG=locale, LC_ALL=locale, LC_MESSAGES=locale, LANGUAGE=locale))
         if rc != 0:
             raise UnarchiveError('Unable to list files in the archive: %s' % err)
+            if self.module._verbosity >= 3:
+                msg = '{msg}: {err}'.format(msg=msg, err=to_native(err, errors='surrogate_or_replace'))
+            raise UnarchiveError(msg)
 
         for filename in out.splitlines():
             # Compensate for locale-related problems in gtar output (octal unicode representation) #11348
@@ -914,6 +920,9 @@ class TgzArchive(object):
                 return True, None
         except UnarchiveError as e:
             return False, 'Command "%s" could not handle archive: %s' % (self.cmd_path, to_native(e))
+            if self.module._verbosity >= 3:
+                msg = '{msg}: {err}'.format(msg=msg.rstrip('.'), err=to_native(ue, errors='surrogate_or_replace'))
+            return False, msg
         # Errors and no files in archive assume that we weren't able to
         # properly unarchive it
         return False, 'Command "%s" found no files in archive. Empty archive files are not supported.' % self.cmd_path
@@ -987,6 +996,9 @@ def pick_handler(src, dest, file_args, module):
         if can_handle:
             return obj
         reasons.add(reason)
+    joiner = ' '
+    if module._verbosity >= 3:
+        joiner = '\n'
     reason_msg = '\n'.join(reasons)
     module.fail_json(msg='Failed to find handler for "%s". Make sure the required command to extract the file is installed.\n%s' % (src, reason_msg))
 

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -1021,7 +1021,7 @@ def main():
 
     src = module.params['src']
     dest = module.params['dest']
-    b_dest = to_bytes(dest, errors='surrogate_or_strict')
+    b_dest = os.path.abspath(to_bytes(dest, errors='surrogate_or_strict'))
     remote_src = module.params['remote_src']
     file_args = module.load_file_common_arguments(module.params)
 

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -20,3 +20,4 @@
 - import_tasks: test_different_language_var.yml
 - import_tasks: test_invalid_options.yml
 - import_tasks: test_ownership_top_folder.yml
+- import_tasks: test_relative_dest.yml

--- a/test/integration/targets/unarchive/tasks/test_relative_dest.yml
+++ b/test/integration/targets/unarchive/tasks/test_relative_dest.yml
@@ -1,0 +1,24 @@
+- name: Create relative test directory
+  file:
+    path: test-unarchive-relative
+    state: directory
+
+- name: Unarchive a file using a relative destination path
+  unarchive:
+    src: "{{ remote_tmp_dir }}/test-unarchive.tar"
+    dest: test-unarchive-relative
+    remote_src: yes
+  register: relative_dest_1
+
+- name: Unarchive a file using a relative destination path again
+  unarchive:
+    src: "{{ remote_tmp_dir }}/test-unarchive.tar"
+    dest: test-unarchive-relative
+    remote_src: yes
+  register: relative_dest_2
+
+- name: Ensure changes were made correctly
+  assert:
+    that:
+      - relative_dest_1 is changed
+      - relative_dest_2 is not changed

--- a/test/integration/targets/unarchive/tasks/test_relative_dest.yml
+++ b/test/integration/targets/unarchive/tasks/test_relative_dest.yml
@@ -21,4 +21,6 @@
   assert:
     that:
       - relative_dest_1 is changed
+      - relative_dest_1.warnings | length > 0
+      - relative_dest_1.warnings[0] is search('absolute path')
       - relative_dest_2 is not changed


### PR DESCRIPTION
##### SUMMARY
The call to `run_command()` passes in `dest` for `cwd` (the command actually runs inside the absolute path to `dest` since it is resolved inside of `run_command())` looking for the relative path to `dest`, and will never be able to find the directory from within itself. Errors from the underlying commands are hidden, making it harder to track down the real issue.

An example of a command that fails:
```
kwargs['cwd']=b'/Users/sdoran/Projects/Ansible/Lab/issues/64612/crawler-stuff',
args=[b'/usr/local/bin/gtar', b'--list', b'-C', b'crawler-stuff', b'-z', b'-f', b'/Users/sdoran/.ansible/tmp/ansible-tmp-1626385460.670061-80125-178978912864109/geckodriver-v0.26.0-linux64.tarc6317o51.gz']
```

Resolving the `dest` path to an absolute path fixes the issue.

Fixes #64612.

- [x] Add tests

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/unarchive.py`