### PR TITLE
git module: add list of configuration variables for clone

### DIFF
--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -580,8 +580,8 @@ def clone(git_path, module, repo, dest, remote, depth, version, bare,
             cmd.append('--separate-git-dir=%s' % separate_git_dir)
 
     for c in config:
-        pos=c.find(" ")
-        cmd.extend(['--config', "{}={}".format(c[:pos], c[pos+1:])])
+        pos = c.find(" ")
+        cmd.extend(['--config', "{0}={1}".format(c[:pos], c[pos + 1:])])
 
     cmd.extend([repo, dest])
     module.run_command(cmd, check_rc=True, cwd=dest_dirname)


### PR DESCRIPTION
- a list of git-config key value pairs will be passed on to clone command

##### SUMMARY
pass git configuration values as "--config <key>=<value>" to the git clone command

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
git module

##### ADDITIONAL INFORMATION
Git provides the possibility to pass project local configuration values with the clone command.

git help clone:

       -c <key>=<value>, --config <key>=<value>
           Set a configuration variable in the newly-created repository; this takes effect immediately after the
           repository is initialized, but before the remote history is fetched or any files checked out. The key is in
           the same format as expected by git-config(1) (e.g., core.eol=true). If multiple values are given for the same
           key, each value will be written to the config file. This makes it safe, for example, to add additional fetch
           refspecs to the origin remote.

In the playbook these are provided as a list:

    - name: clone a git repo
      git:
        repo: https://github.com/user/repo.git
        dest: ~/path/to/repo
        config:
          - user.name My Name
          - user.email user@users.noreply.github.com
