### PR TITLE
[2.10] ansible-test: allow to ignore rstcheck errors

### DIFF
--- a/changelogs/fragments/ansible-test-rstcheck-ignore.yml
+++ b/changelogs/fragments/ansible-test-rstcheck-ignore.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-test - allow to ignore ``rstcheck`` errors (https://github.com/ansible/ansible/pull/75272)."

--- a/test/lib/ansible_test/_internal/sanity/rstcheck.py
+++ b/test/lib/ansible_test/_internal/sanity/rstcheck.py
@@ -87,7 +87,7 @@ class RstcheckTest(SanitySingleVersion):
             level=r['level'],
         ) for r in results]
 
-        settings.process_errors(results, paths)
+        results = settings.process_errors(results, paths)
 
         if results:
             return SanityFailure(self.name, messages=results)


### PR DESCRIPTION
##### SUMMARY
While implementing semantic markup in a collection (https://github.com/ansible-collections/community.dns/pull/23), I found out that the rstcheck sanity test in ansible-base 2.10 does not allow to ignore its errors since it forgets to store the return value of `settings.process_errors` for that test.

The test has been moved to ansible/ansible internal tests for stable-2.11 (https://github.com/ansible/ansible/blob/devel/test/sanity/code-smell/rstcheck.py) where error processing happens in the same place where all (internal?) code-smell tests are handled, so it's only a problem for 2.10 (and possibly 2.9).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test
