### PR TITLE
update collection_finder with warning for bad role names

### DIFF
--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -17,7 +17,7 @@ import os.path
 import pkgutil
 import re
 import sys
-import warnings
+from ansible.utils.display import Display
 from keyword import iskeyword
 from tokenize import Name as _VALID_IDENTIFIER_REGEX
 
@@ -30,6 +30,8 @@ from ._collection_config import AnsibleCollectionConfig
 
 from contextlib import contextmanager
 from types import ModuleType
+
+display = Display()
 
 try:
     from importlib import import_module
@@ -741,8 +743,8 @@ class AnsibleCollectionRef:
 
         if self.ref_type == u'role':
             if not self.is_valid_role_name(resource):
-                warnings.warn("Role names are now limited to contain only lowercase alphanumeric characters, "
-                              "plus _ and start with an alpha character. Please check %s" % resource)
+                display.warning("Role names are now limited to contain only lowercase alphanumeric characters, "
+                                "plus _ and start with an alpha character. Please check %s" % resource)
             package_components.append(u'roles')
         elif self.ref_type == u'playbook':
             package_components.append(u'playbooks')

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -17,6 +17,7 @@ import os.path
 import pkgutil
 import re
 import sys
+import warnings
 from keyword import iskeyword
 from tokenize import Name as _VALID_IDENTIFIER_REGEX
 
@@ -739,6 +740,9 @@ class AnsibleCollectionRef:
         self.n_python_collection_package_name = to_native('.'.join(package_components))
 
         if self.ref_type == u'role':
+            if not self.is_valid_role_name(resource):
+                warnings.warn("Role names are now limited to contain only lowercase alphanumeric characters, "
+                              "plus _ and start with an alpha character. Please check %s" % resource)
             package_components.append(u'roles')
         elif self.ref_type == u'playbook':
             package_components.append(u'playbooks')
@@ -875,6 +879,18 @@ class AnsibleCollectionRef:
             not iskeyword(ns_or_name) and is_python_identifier(ns_or_name)
             for ns_or_name in collection_name.split(u'.')
         )
+
+    @staticmethod
+    def is_valid_role_name(role_name):
+        """
+        Validates if the given string is a well-formed role name
+        :param role_name: name of the individual role within the collection
+        (a valid role name only contains lowercase alphanumeric characters, plus _ and start with an alpha character.)
+        :return: True if the role passed is well-formed, False otherwise
+        """
+
+        # NOTE: keywords and identifiers are different in different Pythons
+        return not iskeyword(role_name) and is_python_identifier(role_name)
 
 
 def _get_collection_playbook_path(playbook):


### PR DESCRIPTION
add function to validate role names
SUMMARY

I added a little function that is validating the role_name according to the criteria documented in https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_structure.html#roles-directory

This is my first contribution so pelase feel free to come up with plenty of corrections and/or let me know what I have not considered.

Fixes #75023
ISSUE TYPE

    Bugfix Pull Request

COMPONENT NAME

update of RoleDefinition error handling
ADDITIONAL INFORMATION

Normally, I would solve this issue using a regular expression in python. However, I did not want to add the re module. If this would have been the way to go, let me know and I apply the changes accordingly.

This PR is a cleaned up version of: https://github.com/ansible/ansible/pull/75263