### PR TITLE
dnf - properly ignore packages to uninstall not installed (#75021)

### DIFF
--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -1168,6 +1168,8 @@ class DnfModule(YumDnf):
                     if '*' in pkg_spec:
                         try:
                             self.base.remove(pkg_spec)
+                        except dnf.exceptions.PackagesNotInstalledError:
+                            response['results'].append("Ignore packages not installed: {0}".format(pkg_spec))
                         except dnf.exceptions.MarkingError as e:
                             is_failure, handled_remove_error = self._sanitize_dnf_error_msg_remove(pkg_spec, to_native(e))
                             if is_failure:


### PR DESCRIPTION
dnf - properly ignore packages to uninstall not installed (#75021)

##### SUMMARY

dnf module tries to detect errors to uninstall packages by matching the error messages from dnf with the expected messages in _sanitize_dnf_error_msg_remove but it does not succeed because the error messages should vary depends on the locale configuration.

This change fixes this issue by catching an exception dnf.exceptions.PackagesNotInstalledError raised from dnf in such cases properly instead of matching with messages.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #75021

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

dnf

##### ADDITIONAL INFORMATION

There is another PR  to fix the same issue but I believe this PR is much better to fix this specific issue.

And it works as expected as far as I tested in my environment like below.

```
$ locale                                                  ~
LANG=ja_JP.UTF-8
LC_CTYPE="ja_JP.UTF-8"
LC_NUMERIC="ja_JP.UTF-8"
LC_TIME="ja_JP.UTF-8"
LC_COLLATE="ja_JP.UTF-8"
LC_MONETARY="ja_JP.UTF-8"
LC_MESSAGES="ja_JP.UTF-8"
LC_PAPER="ja_JP.UTF-8"
LC_NAME="ja_JP.UTF-8"
LC_ADDRESS="ja_JP.UTF-8"
LC_TELEPHONE="ja_JP.UTF-8"
LC_MEASUREMENT="ja_JP.UTF-8"
LC_IDENTIFICATION="ja_JP.UTF-8"
LC_ALL=
$
```
