### PR TITLE
Changed to file instead path for touch choice in state parameter docs

### DIFF
--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -41,7 +41,7 @@ options:
       Set to C(touch) or use the M(ansible.builtin.copy) or M(ansible.builtin.template) module if you want to create the file if it does not exist.
     - If C(hard), the hard link will be created or changed.
     - If C(link), the symbolic link will be created or changed.
-    - If C(touch) (new in 1.4), an empty file will be created if the C(file) does not
+    - If C(touch) (new in 1.4), an empty file will be created if the file does not
       exist, while an existing file or directory will receive updated file access and
       modification times (similar to the way C(touch) works from the command line).
     type: str

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -41,7 +41,7 @@ options:
       Set to C(touch) or use the M(ansible.builtin.copy) or M(ansible.builtin.template) module if you want to create the file if it does not exist.
     - If C(hard), the hard link will be created or changed.
     - If C(link), the symbolic link will be created or changed.
-    - If C(touch) (new in 1.4), an empty file will be created if the C(path) does not
+    - If C(touch) (new in 1.4), an empty file will be created if the C(file) does not
       exist, while an existing file or directory will receive updated file access and
       modification times (similar to the way C(touch) works from the command line).
     type: str


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Changed to `file` instead to `path` for touch choice in `state` parameter for module documentation. The code doesn't seems to be able to create the path if it does not exists.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
file.py documentation

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
```
    - If C(touch) (new in 1.4), an empty file will be created if the C(path) does not
      exist, while an existing file or directory will receive updated file access and
      modification times (similar to the way C(touch) works from the command line).
```

After
```
    - If C(touch) (new in 1.4), an empty file will be created if the C(file) does not
      exist, while an existing file or directory will receive updated file access and
      modification times (similar to the way C(touch) works from the command line).
```


