### PR TITLE
Fix resolution of action/module names in module_defaults

### DIFF
--- a/changelogs/fragments/75284-fix-legacy-module_defaults.yaml
+++ b/changelogs/fragments/75284-fix-legacy-module_defaults.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - module_defaults - Fix action defaults for legacy actions/modules (https://github.com/ansible/ansible/issues/75279).

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -381,16 +381,12 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
                     action_names = []
                     if len(defaults_entry.split('.')) < 3:
                         defaults_entry = 'ansible.legacy.' + defaults_entry
-                    action_names.append(defaults_entry)
-                    if defaults_entry.startswith('ansible.legacy.'):
-                        action_names.append(defaults_entry.replace('ansible.legacy.', 'ansible.builtin.'))
 
                     # Replace the module_defaults action entry with the canonical name,
                     # so regardless of how the action is called, the defaults will apply
-                    for action_name in action_names:
-                        resolved_action = self._resolve_action(action_name)
-                        if resolved_action:
-                            validated_defaults_dict[resolved_action] = defaults
+                    resolved_action = self._resolve_action(defaults_entry)
+                    if resolved_action:
+                        validated_defaults_dict[resolved_action] = defaults
 
             validated_module_defaults.append(validated_defaults_dict)
 

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -382,11 +382,20 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
                     if len(defaults_entry.split('.')) < 3:
                         defaults_entry = 'ansible.legacy.' + defaults_entry
 
-                    # Replace the module_defaults action entry with the canonical name,
-                    # so regardless of how the action is called, the defaults will apply
                     resolved_action = self._resolve_action(defaults_entry)
                     if resolved_action:
                         validated_defaults_dict[resolved_action] = defaults
+
+                    # If the defaults_entry is an ansible.legacy plugin, these defaults
+                    # are inheritable by the 'ansible.builtin' subset, but are not
+                    # required to exist.
+                    if defaults_entry.startswith('ansible.legacy.'):
+                        resolved_action = self._resolve_action(
+                            defaults_entry.replace('ansible.legacy.', 'ansible.builtin.'),
+                            mandatory=False
+                        )
+                        if resolved_action:
+                            validated_defaults_dict[resolved_action] = defaults
 
             validated_module_defaults.append(validated_defaults_dict)
 

--- a/test/integration/targets/module_defaults/action_plugins/debug.py
+++ b/test/integration/targets/module_defaults/action_plugins/debug.py
@@ -1,0 +1,80 @@
+# Copyright 2012, Dag Wieers <dag@wieers.com>
+# Copyright 2016, Toshio Kuratomi <tkuratomi@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.errors import AnsibleUndefinedVariable
+from ansible.module_utils.six import string_types
+from ansible.module_utils._text import to_text
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+    ''' Print statements during execution '''
+
+    TRANSFERS_FILES = False
+    _VALID_ARGS = frozenset(('msg', 'var', 'verbosity'))
+
+    def run(self, tmp=None, task_vars=None):
+        if task_vars is None:
+            task_vars = dict()
+
+        if 'msg' in self._task.args and 'var' in self._task.args:
+            return {"failed": True, "msg": "'msg' and 'var' are incompatible options"}
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        # get task verbosity
+        verbosity = int(self._task.args.get('verbosity', 0))
+
+        if verbosity <= self._display.verbosity:
+            if 'msg' in self._task.args:
+                result['msg'] = self._task.args['msg']
+
+            elif 'var' in self._task.args:
+                try:
+                    results = self._templar.template(self._task.args['var'], convert_bare=True, fail_on_undefined=True)
+                    if results == self._task.args['var']:
+                        # if results is not str/unicode type, raise an exception
+                        if not isinstance(results, string_types):
+                            raise AnsibleUndefinedVariable
+                        # If var name is same as result, try to template it
+                        results = self._templar.template("{{" + results + "}}", convert_bare=True, fail_on_undefined=True)
+                except AnsibleUndefinedVariable as e:
+                    results = u"VARIABLE IS NOT DEFINED!"
+                    if self._display.verbosity > 0:
+                        results += u": %s" % to_text(e)
+
+                if isinstance(self._task.args['var'], (list, dict)):
+                    # If var is a list or dict, use the type as key to display
+                    result[to_text(type(self._task.args['var']))] = results
+                else:
+                    result[self._task.args['var']] = results
+            else:
+                result['msg'] = 'Hello world!'
+
+            # force flag to make debug output module always verbose
+            result['_ansible_verbose_always'] = True
+        else:
+            result['skipped_reason'] = "Verbosity threshold not met."
+            result['skipped'] = True
+
+        result['failed'] = False
+
+        return result

--- a/test/integration/targets/module_defaults/test_defaults.yml
+++ b/test/integration/targets/module_defaults/test_defaults.yml
@@ -44,6 +44,30 @@
 
   - debug: var=echo1_fq
 
+  - legacy_ping:
+    register: legacy_ping_1
+    module_defaults:
+      legacy_ping:
+        data: from task
+
+  - legacy_ping:
+    register: legacy_ping_2
+    module_defaults:
+      ansible.legacy.legacy_ping:
+        data: from task
+
+  - ansible.legacy.legacy_ping:
+    register: legacy_ping_3
+    module_defaults:
+      legacy_ping:
+        data: from task
+
+  - ansible.legacy.legacy_ping:
+    register: legacy_ping_4
+    module_defaults:
+      ansible.legacy.legacy_ping:
+        data: from task
+
   - assert:
       that:
         - "echoaction_fq.args_in == {'task_arg': 'from task', 'explicit_module_default': 'from playbook', 'group_module_default': 'from playbook' }"
@@ -56,5 +80,9 @@
         - "other_echoaction_unq.args_in == {'task_arg': 'from task', 'group_module_default': 'from playbook' }"
         - "other_echo1_fq.args_in == {'task_arg': 'from task', 'group_module_default': 'from playbook' }"
         - "other_echo1_unq.args_in == {'task_arg': 'from task', 'group_module_default': 'from playbook' }"
+        - "legacy_ping_1.ping == 'from task'"
+        - "legacy_ping_2.ping == 'from task'"
+        - "legacy_ping_3.ping == 'from task'"
+        - "legacy_ping_4.ping == 'from task'"
 
   - include_tasks: tasks/main.yml

--- a/test/integration/targets/module_defaults/test_defaults.yml
+++ b/test/integration/targets/module_defaults/test_defaults.yml
@@ -68,6 +68,27 @@
       ansible.legacy.legacy_ping:
         data: from task
 
+  - name: builtin uses legacy defaults
+    ansible.builtin.debug:
+    module_defaults:
+      debug:
+        msg: legacy default
+    register: builtin_legacy_defaults_1
+
+  - name: builtin uses legacy defaults
+    ansible.builtin.debug:
+    module_defaults:
+      ansible.legacy.debug:
+        msg: legacy default
+    register: builtin_legacy_defaults_2
+
+  - name: legacy does not use builtin defaults
+    ansible.legacy.debug:
+    register: legacy_builtin_defaults
+    module_defaults:
+      ansible.builtin.debug:
+        msg: legacy default
+
   - assert:
       that:
         - "echoaction_fq.args_in == {'task_arg': 'from task', 'explicit_module_default': 'from playbook', 'group_module_default': 'from playbook' }"
@@ -84,5 +105,8 @@
         - "legacy_ping_2.ping == 'from task'"
         - "legacy_ping_3.ping == 'from task'"
         - "legacy_ping_4.ping == 'from task'"
+        - "legacy_builtin_defaults.msg == 'Hello world!'"
+        - "builtin_legacy_defaults_1.msg == 'legacy default'"
+        - "builtin_legacy_defaults_2.msg == 'legacy default'"
 
   - include_tasks: tasks/main.yml


### PR DESCRIPTION
##### SUMMARY
This is just fixing top-level `module_defaults` action/module entries, does not affect actions/modules in action_groups.

Both builtin and legacy plugins should use non-fqcn module_defaults action/module entries, but if a legacy entry is requested, the builtin is not required to exist.

Fixes #75279

##### ISSUE TYPE
- Bugfix Pull Request
