### PR TITLE
2.10 docs: Fix pygments_lexer for sphinx 4

### DIFF
--- a/docs/docsite/_extensions/pygments_lexer.py
+++ b/docs/docsite/_extensions/pygments_lexer.py
@@ -178,7 +178,7 @@ def setup(app):
         See http://www.sphinx-doc.org/en/stable/extdev/index.html#dev-extensions.
     """
     for lexer in [
-        AnsibleOutputLexer(startinline=True)
+        AnsibleOutputLexer
     ]:
         app.add_lexer(lexer.name, lexer)
         for alias in lexer.aliases:


### PR DESCRIPTION
##### SUMMARY

Sphinx 4 no longer accepts instantiated lexer classes.
This allows to unblock building documentation with sphinx 4.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### ADDITIONAL INFORMATION

This was originally proposed in https://github.com/ansible/ansible/pull/74798 which was closed in favor of https://github.com/ansible/ansible/pull/74318.

This specific fix for the lexer was not backported to 2.10 and 2.9, though, which results in documentation failing to build when using sphinx 4.

Discussed at the end of today's docs meeting: https://meetbot.fedoraproject.org/ansible-docs/2021-07-20/docs_working_group_aka_dawgs.2021-07-20-15.00.log.html