### PR TITLE
fix loss of var inheritance in deeply nested includes

### DIFF
--- a/changelogs/fragments/75304-fix-role-depth-inheritance.yml
+++ b/changelogs/fragments/75304-fix-role-depth-inheritance.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - IncludeRole - fix an issue with depth of role var inheritance (https://github.com/ansible/ansible/issues/47023).

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -68,6 +68,15 @@ class IncludeRole(TaskInclude):
         ''' return the name of the task '''
         return self.name or "%s : %s" % (self.action, self._role_name)
 
+    def get_all_role_parents(self, parents, resolved=None):
+        if resolved is None:
+            resolved = []
+        for parent in parents:
+            if parent._parents:
+                self.get_all_role_parents(parent._parents, resolved)
+            resolved.append(parent)
+        return resolved
+
     def get_block_list(self, play=None, variable_manager=None, loader=None):
 
         # only need play passed in when dynamic
@@ -92,10 +101,9 @@ class IncludeRole(TaskInclude):
 
         # compile role with parent roles as dependencies to ensure they inherit
         # variables
-        if not self._parent_role:
-            dep_chain = []
-        else:
-            dep_chain = list(self._parent_role._parents)
+        dep_chain = []
+        if self._parent_role:
+            dep_chain = self.get_all_role_parents(self._parent_role._parents)
             dep_chain.append(self._parent_role)
 
         p_block = self.build_parent_block()

--- a/test/integration/targets/roles/47023.yml
+++ b/test/integration/targets/roles/47023.yml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  gather_facts: no
+  tasks:
+    - include_role: name=role1

--- a/test/integration/targets/roles/roles/role1/defaults/main.yml
+++ b/test/integration/targets/roles/roles/role1/defaults/main.yml
@@ -1,0 +1,1 @@
+my_default: defined

--- a/test/integration/targets/roles/roles/role1/tasks/main.yml
+++ b/test/integration/targets/roles/roles/role1/tasks/main.yml
@@ -1,0 +1,1 @@
+- include_role: name=role2

--- a/test/integration/targets/roles/roles/role1/vars/main.yml
+++ b/test/integration/targets/roles/roles/role1/vars/main.yml
@@ -1,0 +1,1 @@
+my_var: defined

--- a/test/integration/targets/roles/roles/role2/tasks/main.yml
+++ b/test/integration/targets/roles/roles/role2/tasks/main.yml
@@ -1,0 +1,1 @@
+- include_role: name=role3

--- a/test/integration/targets/roles/roles/role3/tasks/main.yml
+++ b/test/integration/targets/roles/roles/role3/tasks/main.yml
@@ -1,0 +1,1 @@
+- include_role: name=role4

--- a/test/integration/targets/roles/roles/role4/tasks/main.yml
+++ b/test/integration/targets/roles/roles/role4/tasks/main.yml
@@ -1,0 +1,5 @@
+- debug:
+    msg: "Var is {{ my_var | default('undefined') }}"
+
+- debug:
+    msg: "Default is {{ my_default | default('undefined') }}"

--- a/test/integration/targets/roles/runme.sh
+++ b/test/integration/targets/roles/runme.sh
@@ -17,3 +17,7 @@ set -eux
 
 # ensure role data is merged correctly
 ansible-playbook data_integrity.yml -i ../../inventory "$@"
+
+
+# test nested includes get parent roles recursively
+[ "$(ansible-playbook 47023.yml -i ../../inventory "$@" | grep '\<\(Default\|Var\)\>' | grep -c 'is defined')" = "2" ]


### PR DESCRIPTION
##### SUMMARY
Fixes #47023 by recursively adding all parent roles to the dep_chain before compiling.

##### ISSUE TYPE
- Bugfix Pull Request