### PR TITLE
Ensure Jinja2 template header overrides are used

### DIFF
--- a/changelogs/fragments/75275-ensure-jinja2-header-overrides-used.yml
+++ b/changelogs/fragments/75275-ensure-jinja2-header-overrides-used.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - template - ensure Jinja2 overrides from template header are used (https://github.com/ansible/ansible/issues/75275)

--- a/test/integration/targets/template/in_template_overrides.j2
+++ b/test/integration/targets/template/in_template_overrides.j2
@@ -1,0 +1,5 @@
+#jinja2:variable_start_string:'<<' , variable_end_string:'>>'
+var_a: << var_a >>
+var_b: << var_b >>
+var_c: << var_c >>
+var_d: << var_d >>

--- a/test/integration/targets/template/in_template_overrides.yml
+++ b/test/integration/targets/template/in_template_overrides.yml
@@ -1,0 +1,28 @@
+- hosts: localhost
+  gather_facts: false
+  vars:
+    var_a: "value"
+    var_b: "{{ var_a }}"
+    var_c: "<< var_a >>"
+  tasks:
+    - set_fact:
+        var_d: "{{ var_a }}"
+
+    - block:
+        - template:
+            src: in_template_overrides.j2
+            dest: out.txt
+
+        - command: cat out.txt
+          register: out
+
+        - assert:
+            that:
+              - "'var_a: value' in out.stdout"
+              - "'var_b: value' in out.stdout"
+              - "'var_c: << var_a >>' in out.stdout"
+              - "'var_d: value' in out.stdout"
+      always:
+        - file:
+            path: out.txt
+            state: absent

--- a/test/integration/targets/template/runme.sh
+++ b/test/integration/targets/template/runme.sh
@@ -38,3 +38,5 @@ ansible-playbook 72262.yml -v "$@"
 # ensure unsafe is preserved, even with extra newlines
 ansible-playbook unsafe.yml -v "$@"
 
+# ensure Jinja2 overrides from a template are used
+ansible-playbook in_template_overrides.yml -v "$@"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Introduced in https://github.com/ansible/ansible/pull/71463. Needs to be backported to 2.11.

Fixes #75275

ci_complete
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/template/__init__.py`
