### PR TITLE
Expose `unredirected_headers` to uri and get_url modules

### DIFF
--- a/changelogs/fragments/expose-unredirected-headers.yml
+++ b/changelogs/fragments/expose-unredirected-headers.yml
@@ -1,0 +1,5 @@
+minor_changes:
+- >
+  ``uri``/``get_url`` - Expose ``unredirected_headers`` to modules to allow user control
+bugfixes:
+- urls - Fix logic in matching ``unredirected_headers`` to perform case insensitive matching

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -165,6 +165,14 @@ options:
       - Header to identify as, generally appears in web server logs.
     type: str
     default: ansible-httpget
+  unredirected_headers:
+    description:
+      - A list of header names that will not be sent on subsequent redirected requests. This list is case
+        insensitive. By default all headers will be redirected. In some cases it may be beneficial to list
+        headers such as C(Authorization) here to avoid potential credential exposure.
+    default: []
+    type: list
+    version_added: '2.12'
   use_gssapi:
     description:
       - Use GSSAPI to perform the authentication, typically this is for Kerberos or Kerberos through Negotiate
@@ -357,7 +365,7 @@ def url_filename(url):
     return fn
 
 
-def url_get(module, url, dest, use_proxy, last_mod_time, force, timeout=10, headers=None, tmp_dest='', method='GET'):
+def url_get(module, url, dest, use_proxy, last_mod_time, force, timeout=10, headers=None, tmp_dest='', method='GET', unredirected_headers=None):
     """
     Download data from the url and store in a temporary file.
 
@@ -365,7 +373,8 @@ def url_get(module, url, dest, use_proxy, last_mod_time, force, timeout=10, head
     """
 
     start = datetime.datetime.utcnow()
-    rsp, info = fetch_url(module, url, use_proxy=use_proxy, force=force, last_mod_time=last_mod_time, timeout=timeout, headers=headers, method=method)
+    rsp, info = fetch_url(module, url, use_proxy=use_proxy, force=force, last_mod_time=last_mod_time, timeout=timeout, headers=headers, method=method,
+                          unredirected_headers=unredirected_headers)
     elapsed = (datetime.datetime.utcnow() - start).seconds
 
     if info['status'] == 304:
@@ -450,6 +459,7 @@ def main():
         timeout=dict(type='int', default=10),
         headers=dict(type='dict'),
         tmp_dest=dict(type='path'),
+        unredirected_headers=dict(type='list', elements='str', default=[]),
     )
 
     module = AnsibleModule(
@@ -478,6 +488,7 @@ def main():
     timeout = module.params['timeout']
     headers = module.params['headers']
     tmp_dest = module.params['tmp_dest']
+    unredirected_headers = module.params['unredirected_headers']
 
     result = dict(
         changed=False,
@@ -505,7 +516,8 @@ def main():
         if is_url(checksum):
             checksum_url = checksum
             # download checksum file to checksum_tmpsrc
-            checksum_tmpsrc, checksum_info = url_get(module, checksum_url, dest, use_proxy, last_mod_time, force, timeout, headers, tmp_dest)
+            checksum_tmpsrc, checksum_info = url_get(module, checksum_url, dest, use_proxy, last_mod_time, force, timeout, headers, tmp_dest,
+                                                     unredirected_headers=unredirected_headers)
             with open(checksum_tmpsrc) as f:
                 lines = [line.rstrip('\n') for line in f]
             os.remove(checksum_tmpsrc)
@@ -576,7 +588,7 @@ def main():
     # download to tmpsrc
     start = datetime.datetime.utcnow()
     method = 'HEAD' if module.check_mode else 'GET'
-    tmpsrc, info = url_get(module, url, dest, use_proxy, last_mod_time, force, timeout, headers, tmp_dest, method)
+    tmpsrc, info = url_get(module, url, dest, use_proxy, last_mod_time, force, timeout, headers, tmp_dest, method, unredirected_headers=unredirected_headers)
     result['elapsed'] = (datetime.datetime.utcnow() - start).seconds
     result['src'] = tmpsrc
 

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -172,6 +172,7 @@ options:
         headers such as C(Authorization) here to avoid potential credential exposure.
     default: []
     type: list
+    elements: str
     version_added: '2.12'
   use_gssapi:
     description:

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -181,6 +181,14 @@ options:
       - Header to identify as, generally appears in web server logs.
     type: str
     default: ansible-httpget
+  unredirected_headers:
+    description:
+      - A list of header names that will not be sent on subsequent redirected requests. This list is case
+        insensitive. By default all headers will be redirected. In some cases it may be beneficial to list
+        headers such as C(Authorization) here to avoid potential credential exposure.
+    default: []
+    type: list
+    version_added: '2.12'
   use_gssapi:
     description:
       - Use GSSAPI to perform the authentication, typically this is for Kerberos or Kerberos through Negotiate
@@ -553,7 +561,7 @@ def form_urlencoded(body):
     return body
 
 
-def uri(module, url, dest, body, body_format, method, headers, socket_timeout, ca_path):
+def uri(module, url, dest, body, body_format, method, headers, socket_timeout, ca_path, unredirected_headers):
     # is dest is set and is a directory, let's check if we get redirected and
     # set the filename from that url
     redirected = False
@@ -598,7 +606,7 @@ def uri(module, url, dest, body, body_format, method, headers, socket_timeout, c
 
     resp, info = fetch_url(module, url, data=data, headers=headers,
                            method=method, timeout=socket_timeout, unix_socket=module.params['unix_socket'],
-                           ca_path=ca_path,
+                           ca_path=ca_path, unredirected_headers=unredirected_headers,
                            **kwargs)
 
     try:
@@ -642,6 +650,7 @@ def main():
         unix_socket=dict(type='path'),
         remote_src=dict(type='bool', default=False),
         ca_path=dict(type='path', default=None),
+        unredirected_headers=dict(type='list', elements='str', default=[]),
     )
 
     module = AnsibleModule(
@@ -666,6 +675,7 @@ def main():
     socket_timeout = module.params['timeout']
     ca_path = module.params['ca_path']
     dict_headers = module.params['headers']
+    unredirected_headers = module.params['unredirected_headers']
 
     if not re.match('^[A-Z]+$', method):
         module.fail_json(msg="Parameter 'method' needs to be a single word in uppercase, like GET or POST.")
@@ -708,7 +718,7 @@ def main():
     # Make the request
     start = datetime.datetime.utcnow()
     resp, content, dest = uri(module, url, dest, body, body_format, method,
-                              dict_headers, socket_timeout, ca_path)
+                              dict_headers, socket_timeout, ca_path, unredirected_headers)
     resp['elapsed'] = (datetime.datetime.utcnow() - start).seconds
     resp['status'] = int(resp['status'])
     resp['changed'] = False

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -188,6 +188,7 @@ options:
         headers such as C(Authorization) here to avoid potential credential exposure.
     default: []
     type: list
+    elements: str
     version_added: '2.12'
   use_gssapi:
     description:

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -579,6 +579,24 @@
       - '(result.content | b64decode) == "ansible.http.tests:SUCCESS"'
   when: has_httptester
 
+- name: test unredrected_headers
+  get_url:
+    url: 'https://{{ httpbin_host }}/redirect-to?status_code=301&url=/basic-auth/user/passwd'
+    username: user
+    password: passwd
+    force_basic_auth: true
+    unredirected_headers:
+      - authorization
+    dest: "{{ remote_tmp_dir }}/doesnt_matter"
+  ignore_errors: true
+  register: unredirected_headers
+
+- name: ensure unredirected_headers caused auth to fail
+  assert:
+    that:
+      - unredirected_headers is failed
+      - unredirected_headers.status_code == 401
+
 - name: Test use_gssapi=True
   include_tasks:
     file: use_gssapi.yml

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -579,7 +579,7 @@
       - '(result.content | b64decode) == "ansible.http.tests:SUCCESS"'
   when: has_httptester
 
-- name: test unredrected_headers
+- name: test unredirected_headers
   get_url:
     url: 'https://{{ httpbin_host }}/redirect-to?status_code=301&url=/basic-auth/user/passwd'
     username: user
@@ -591,11 +591,22 @@
   ignore_errors: true
   register: unredirected_headers
 
+- name: test unredirected_headers
+  get_url:
+    url: 'https://{{ httpbin_host }}/redirect-to?status_code=301&url=/basic-auth/user/passwd'
+    username: user
+    password: passwd
+    force_basic_auth: true
+    dest: "{{ remote_tmp_dir }}/doesnt_matter"
+  register: redirected_headers
+
 - name: ensure unredirected_headers caused auth to fail
   assert:
     that:
       - unredirected_headers is failed
       - unredirected_headers.status_code == 401
+      - redirected_headers is successful
+      - redirected_headers.status_code == 200
 
 - name: Test use_gssapi=True
   include_tasks:

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -228,7 +228,7 @@
     headers:
       Cookie: "fake=fake_value"
 
-- name: test unredrected_headers
+- name: test unredirected_headers
   uri:
     url: 'https://{{ httpbin_host }}/redirect-to?status_code=301&url=/basic-auth/user/passwd'
     user: user
@@ -239,11 +239,21 @@
   ignore_errors: true
   register: unredirected_headers
 
+- name: test omitting unredirected headers
+  uri:
+    url: 'https://{{ httpbin_host }}/redirect-to?status_code=301&url=/basic-auth/user/passwd'
+    user: user
+    password: passwd
+    force_basic_auth: true
+  register: redirected_headers
+
 - name: ensure unredirected_headers caused auth to fail
   assert:
     that:
       - unredirected_headers is failed
       - unredirected_headers.status == 401
+      - redirected_headers is successful
+      - redirected_headers.status == 200
 
 - name: test PUT
   uri:

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -228,6 +228,23 @@
     headers:
       Cookie: "fake=fake_value"
 
+- name: test unredrected_headers
+  uri:
+    url: 'https://{{ httpbin_host }}/redirect-to?status_code=301&url=/basic-auth/user/passwd'
+    user: user
+    password: passwd
+    force_basic_auth: true
+    unredirected_headers:
+      - authorization
+  ignore_errors: true
+  register: unredirected_headers
+
+- name: ensure unredirected_headers caused auth to fail
+  assert:
+    that:
+      - unredirected_headers is failed
+      - unredirected_headers.status == 401
+
 - name: test PUT
   uri:
     url: 'https://{{ httpbin_host }}/put'

--- a/test/units/module_utils/urls/test_fetch_url.py
+++ b/test/units/module_utils/urls/test_fetch_url.py
@@ -67,7 +67,7 @@ def test_fetch_url(open_url_mock, fake_ansible_module):
     open_url_mock.assert_called_once_with('http://ansible.com/', client_cert=None, client_key=None, cookies=kwargs['cookies'], data=None,
                                           follow_redirects='urllib2', force=False, force_basic_auth='', headers=None,
                                           http_agent='ansible-httpget', last_mod_time=None, method=None, timeout=10, url_password='', url_username='',
-                                          use_proxy=True, validate_certs=True, use_gssapi=False, unix_socket=None, ca_path=None)
+                                          use_proxy=True, validate_certs=True, use_gssapi=False, unix_socket=None, ca_path=None, unredirected_headers=None)
 
 
 def test_fetch_url_params(open_url_mock, fake_ansible_module):
@@ -89,7 +89,7 @@ def test_fetch_url_params(open_url_mock, fake_ansible_module):
     open_url_mock.assert_called_once_with('http://ansible.com/', client_cert='client.pem', client_key='client.key', cookies=kwargs['cookies'], data=None,
                                           follow_redirects='all', force=False, force_basic_auth=True, headers=None,
                                           http_agent='ansible-test', last_mod_time=None, method=None, timeout=10, url_password='passwd', url_username='user',
-                                          use_proxy=True, validate_certs=False, use_gssapi=False, unix_socket=None, ca_path=None)
+                                          use_proxy=True, validate_certs=False, use_gssapi=False, unix_socket=None, ca_path=None, unredirected_headers=None)
 
 
 def test_fetch_url_cookies(mocker, fake_ansible_module):


### PR DESCRIPTION
##### SUMMARY
This PR exposes `unredirected_headers` to the `uri` and `get_url` modules, to allow users to specify headers that should only be sent on the initial request.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/get_url.py
lib/ansible/modules/uri.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
