### PR TITLE
Handle failures in ansible-connection instead of returning None

### DIFF
--- a/changelogs/fragments/75313-ansible-connection-returns-none.yaml
+++ b/changelogs/fragments/75313-ansible-connection-returns-none.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- ansible-connection - handle errors when passing methods to persistent connection instead of closing connection (https://github.com/ansible-collections/ansible.netcommon/issues/301).

--- a/lib/ansible/utils/jsonrpc.py
+++ b/lib/ansible/utils/jsonrpc.py
@@ -72,6 +72,24 @@ class JsonRpcServer(object):
 
         return response
 
+    def make_error(self, request, error_msg):
+        """Produce a correct error payload based on request
+
+        This is here to allow a caller to produce an error response with the
+        correct format and response id outside of handle_request, say if an
+        error has occurred before handle_request could be called.
+        """
+        request = json.loads(to_text(request, errors='surrogate_then_replace'))
+
+        setattr(self, '_identifier', request.get('id'))
+
+        error = self.internal_error(data=to_text(error_msg))
+        response = json.dumps(error)
+
+        delattr(self, '_identifier')
+
+        return response
+
     def register(self, obj):
         self._objects.add(obj)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes modules that use `exec_command` on a persistent connection when they probably shouldn't sometimes just blowing up with no feedback
See https://github.com/ansible-collections/ansible.netcommon/issues/301

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-connection