### PR TITLE
Call initialize_locale() automatically if it hasn't run.

### DIFF
--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -130,7 +130,7 @@ def get_text_width(text):
             w = 0
         width += w
 
-    if width == 0 and counter and _LOCALE_INITIALIZED_ERR:
+    if width == 0 and counter and _LOCALE_INITIALIZATION_ERR:
         raise EnvironmentError(
             'ansible.utils.display.initialize_locale failed, '
             'and get_text_width could not calculate text width of %r' % text


### PR DESCRIPTION
##### SUMMARY
This attempts to call `initialize_locale()` when necessary, rather than simply printing an error message.

It should deal with the warning I keep seeing when running Ansible from Python on a Raspberry Pi 4 via `ansible-runner`:
```
[WARNING]: ansible.utils.display.initialize_locale has not been called, this
may result in incorrectly calculated text widths that can cause Display to
print incorrect line lengths
```

##### ISSUE TYPE
- Bugfix/Feature (?) Pull Request

##### COMPONENT NAME
utils

##### ADDITIONAL INFORMATION
This changes the meaning of the `_LOCALE_INITIALIZED` variable slightly.  In the old version, it was set to true only if the `initialize_locale()` call succeeded; it's now set to true whenever the call is _attempted_ and the presence of `_LOCALE_INITIALIZATION_ERR` indicates that the call failed.
