### PR TITLE
Recover unix load average into an ansible_loadavg fact

### DIFF
--- a/lib/ansible/module_utils/facts/default_collectors.py
+++ b/lib/ansible/module_utils/facts/default_collectors.py
@@ -44,6 +44,7 @@ from ansible.module_utils.facts.system.date_time import DateTimeFactCollector
 from ansible.module_utils.facts.system.env import EnvFactCollector
 from ansible.module_utils.facts.system.dns import DnsFactCollector
 from ansible.module_utils.facts.system.fips import FipsFactCollector
+from ansible.module_utils.facts.system.loadavg import LoadAvgFactCollector
 from ansible.module_utils.facts.system.local import LocalFactCollector
 from ansible.module_utils.facts.system.lsb import LSBFactCollector
 from ansible.module_utils.facts.system.pkg_mgr import PkgMgrFactCollector
@@ -116,6 +117,7 @@ _general = [
     CmdLineFactCollector,
     DateTimeFactCollector,
     EnvFactCollector,
+    LoadAvgFactCollector,
     SshPubKeyFactCollector,
     UserFactCollector
 ]  # type: t.List[t.Type[BaseFactCollector]]

--- a/lib/ansible/module_utils/facts/system/loadavg.py
+++ b/lib/ansible/module_utils/facts/system/loadavg.py
@@ -1,0 +1,29 @@
+# (c) 2021 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+
+from ansible.module_utils.facts.collector import BaseFactCollector
+
+
+class LoadAvgFactCollector(BaseFactCollector):
+    name = 'loadavg'
+    _fact_ids = set()
+
+    def collect(self, module=None, collected_facts=None):
+        facts = {}
+        try:
+            # (0.58, 0.82, 0.98)
+            loadavg = os.getloadavg()
+            facts['loadavg'] = {
+                '1m': loadavg[0],
+                '5m': loadavg[1],
+                '15m': loadavg[2]
+            }
+        except OSError:
+            pass
+
+        return facts

--- a/lib/ansible/module_utils/facts/system/loadavg.py
+++ b/lib/ansible/module_utils/facts/system/loadavg.py
@@ -6,12 +6,14 @@ __metaclass__ = type
 
 import os
 
+import ansible.module_utils.compat.typing as t
+
 from ansible.module_utils.facts.collector import BaseFactCollector
 
 
 class LoadAvgFactCollector(BaseFactCollector):
     name = 'loadavg'
-    _fact_ids = set()
+    _fact_ids = set()  # type: t.Set[str]
 
     def collect(self, module=None, collected_facts=None):
         facts = {}

--- a/test/integration/targets/gathering_facts/test_gathering_facts.yml
+++ b/test/integration/targets/gathering_facts/test_gathering_facts.yml
@@ -104,6 +104,22 @@
           - 'ansible_mounts|default("UNDEF_MOUNT") != "UNDEF_MOUNT" or ansible_distribution == "MacOSX"'
           - 'ansible_virtualization_role|default("UNDEF_VIRT") != "UNDEF_VIRT"'
 
+- hosts: facthost1
+  tags: [ 'fact_min' ]
+  connection: local
+  gather_facts: no
+  tasks:
+    - name: Test that we can retrieve the loadavg fact
+      setup:
+        filter: "ansible_loadavg"
+
+    - name: Test the contents of the loadavg fact
+      assert:
+        that:
+          - 'ansible_loadavg|default("UNDEF_ENV") != "UNDEF_ENV"'
+          - '"1m" in ansible_loadavg and ansible_loadavg["1m"] is float'
+          - '"5m" in ansible_loadavg and ansible_loadavg["5m"] is float'
+          - '"15m" in ansible_loadavg and ansible_loadavg["15m"] is float'
 
 - hosts: facthost19
   tags: [ 'fact_min' ]


### PR DESCRIPTION
##### SUMMARY

It's simple and inexpensive to recover and parse.
It adds useful context to the existing ansible_memory_mb and ansible_mounts facts that provide size and utilization.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

 lib/ansible/module_utils/facts/default_collectors.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
> ansible localhost -m setup -a "filter=ansible_loadavg"
[WARNING]: No inventory was parsed, only implicit localhost is available
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_loadavg": {
            "15m": 0.72,
            "1m": 0.64,
            "5m": 0.91
        }
    },
    "changed": false
}
```