### PR TITLE
Add prefix_path variable to the group module

### DIFF
--- a/test/integration/targets/group/files/get_free_gid.py
+++ b/test/integration/targets/group/files/get_free_gid.py
@@ -3,10 +3,28 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import grp
+import os
+import sys
+
+GROUPFILE = "/etc/group"
 
 
 def main():
-    gids = [g.gr_gid for g in grp.getgrall()]
+    prefix_path = None
+    if len(sys.argv) >= 2:
+        prefix_path = sys.argv[1]
+
+    gids = []
+
+    if prefix_path is not None:
+        group_file = os.path.normpath(prefix_path + GROUPFILE)
+        with open(group_file, 'rb') as f:
+            lines = f.readlines()
+            for line in lines:
+                entries = line.split(b':')
+                gids.append(int(entries[2]))  # 2 == group id
+    else:
+        gids = [g.gr_gid for g in grp.getgrall()]
 
     # Start the gid numbering with 1
     # FreeBSD doesn't support the usage of gid 0, it doesn't fail (rc=0) but instead a number in the normal

--- a/test/integration/targets/group/files/get_gid_for_group.py
+++ b/test/integration/targets/group/files/get_gid_for_group.py
@@ -3,7 +3,10 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import grp
+import os
 import sys
+
+GROUPFILE = "/etc/group"
 
 
 def main():
@@ -11,7 +14,21 @@ def main():
     if len(sys.argv) >= 2:
         group_name = sys.argv[1]
 
-    print(grp.getgrnam(group_name).gr_gid)
+    prefix_path = None
+    if len(sys.argv) >= 3:
+        prefix_path = sys.argv[2]
+
+    if prefix_path is not None:
+        group_file = os.path.normpath(prefix_path + GROUPFILE)
+        with open(group_file, 'r') as f:
+            lines = f.readlines()
+            for line in lines:
+                if line.startswith('{0}:'.format(group_name)):
+                    entries = line.split(':')
+                    print(entries[2])  # Print the gid
+                    break
+    else:
+        print(grp.getgrnam(group_name).gr_gid)
 
 
 if __name__ == '__main__':

--- a/test/integration/targets/group/files/grouplist.sh
+++ b/test/integration/targets/group/files/grouplist.sh
@@ -11,10 +11,15 @@
 #  register: group_names
 #  when: 'ansible_distribution == "MacOSX"'
 
-DISTRO="$*"
+DISTRO="$1"
+PREFIX_PATH="$2"
 
-if [[ "$DISTRO" == "MacOSX" ]]; then
+if [[ "${DISTRO}" == "MacOSX" ]]; then
     dscl localhost -list /Local/Default/Groups
 else
-    grep -E -v ^\# /etc/group | cut -d: -f1
+    GROUPFILE="/etc/group"
+    if [[ -n "${PREFIX_PATH}" ]]; then
+        GROUPFILE="${PREFIX_PATH}${GROUPFILE}"
+    fi
+    grep -E -v ^\# "${GROUPFILE}" | cut -d: -f1
 fi

--- a/test/integration/targets/group/tasks/main.yml
+++ b/test/integration/targets/group/tasks/main.yml
@@ -17,3 +17,16 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 - import_tasks: tests.yml
+
+- block:
+    - name: get home directory for user
+      command: "echo $HOME"
+      register: user_home
+    - import_tasks: tests_with_prefix_path.yml
+      vars:
+        prefix_path: "{{ user_home.stdout_lines[0] }}/custom_group_dir"
+  when:
+    - not (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version | int <= 18)
+    - not (ansible_os_family == 'RedHat' and ansible_distribution_major_version | int <= 6)
+    - not (ansible_distribution == 'Alpine')
+    - not (ansible_distribution == 'MacOSX')

--- a/test/integration/targets/group/tasks/tests_with_prefix_path.yml
+++ b/test/integration/targets/group/tasks/tests_with_prefix_path.yml
@@ -1,0 +1,315 @@
+---
+- name: setup test environment
+  block:
+  - name: ensure custom root exists
+    command: "mkdir -p \"{{ prefix_path }}/etc/\""
+
+  - name: ensure custom auth files exist
+    command: "touch \"{{ prefix_path }}/etc/{{ item }}\""
+    loop:
+      - group
+      - passwd
+
+- name: ensure test groups are deleted before the test
+  group:
+    name: '{{ item }}'
+    state: absent
+    prefix_path: "{{ prefix_path }}"
+  loop:
+    - ansibullgroup
+    - ansibullgroup2
+    - ansibullgroup3
+
+- block:
+    ##
+    ## group add
+    ##
+
+    - name: create group (check mode)
+      group:
+        name: ansibullgroup
+        state: present
+        prefix_path: "{{ prefix_path }}"
+      register: create_group_check
+      check_mode: true
+
+    - name: get result of create group (check mode)
+      script: 'grouplist.sh "{{ ansible_distribution }}" "{{ prefix_path }}"'
+      register: create_group_actual_check
+
+    - name: assert create group (check mode)
+      assert:
+        that:
+          - create_group_check is changed
+          - '"ansibullgroup" not in create_group_actual_check.stdout_lines'
+
+    - name: create group
+      group:
+        name: ansibullgroup
+        state: present
+        prefix_path: "{{ prefix_path }}"
+      register: create_group
+
+    - name: get result of create group
+      script: 'grouplist.sh "{{ ansible_distribution }}" "{{ prefix_path }}"'
+      register: create_group_actual
+
+    - name: assert create group
+      assert:
+        that:
+          - create_group is changed
+          - create_group.gid is defined
+          - '"ansibullgroup" in create_group_actual.stdout_lines'
+
+    - name: create group (idempotent)
+      group:
+        name: ansibullgroup
+        state: present
+        prefix_path: "{{ prefix_path }}"
+      register: create_group_again
+
+    - name: assert create group (idempotent)
+      assert:
+        that:
+          - not create_group_again is changed
+
+    ##
+    ## group check
+    ##
+
+    - name: run existing group check tests
+      group:
+        name: "{{ create_group_actual.stdout_lines|random }}"
+        state: present
+        prefix_path: "{{ prefix_path }}"
+      with_sequence: start=1 end=5
+      register: group_test1
+
+    - name: validate results for testcase 1
+      assert:
+        that:
+          - group_test1.results is defined
+          - group_test1.results|length == 5
+
+    - name: validate change results for testcase 1
+      assert:
+        that:
+          - not group_test1 is changed
+
+    ##
+    ## group add with gid
+    ##
+
+    - name: get the next available gid
+      script: 'get_free_gid.py "{{ prefix_path }}"'
+      args:
+        executable: '{{ ansible_python_interpreter }}'
+      register: gid
+
+    - name: create a group with a gid (check mode)
+      group:
+        name: ansibullgroup2
+        gid: '{{ gid.stdout_lines[0] }}'
+        state: present
+        prefix_path: "{{ prefix_path }}"
+      register: create_group_gid_check
+      check_mode: true
+
+    - name: get result of create a group with a gid (check mode)
+      script: 'grouplist.sh "{{ ansible_distribution }}" "{{ prefix_path }}"'
+      register: create_group_gid_actual_check
+
+    - name: assert create group with a gid (check mode)
+      assert:
+        that:
+          - create_group_gid_check is changed
+          - '"ansibullgroup2" not in create_group_gid_actual_check.stdout_lines'
+
+    - name: create a group with a gid
+      group:
+        name: ansibullgroup2
+        gid: '{{ gid.stdout_lines[0] }}'
+        state: present
+        prefix_path: "{{ prefix_path }}"
+      register: create_group_gid
+
+    - name: get gid of created group
+      script: 'get_gid_for_group.py ansibullgroup2 "{{ prefix_path }}"'
+      args:
+        executable: '{{ ansible_python_interpreter }}'
+      register: create_group_gid_actual
+
+    - name: assert create group with a gid
+      assert:
+        that:
+          - create_group_gid is changed
+          - create_group_gid.gid | int == gid.stdout_lines[0] | int
+          - create_group_gid_actual.stdout | trim | int == gid.stdout_lines[0] | int
+
+    - name: create a group with a gid (idempotent)
+      group:
+        name: ansibullgroup2
+        gid: '{{ gid.stdout_lines[0] }}'
+        state: present
+        prefix_path: "{{ prefix_path }}"
+      register: create_group_gid_again
+
+    - name: assert create group with a gid (idempotent)
+      assert:
+        that:
+          - not create_group_gid_again is changed
+          - create_group_gid_again.gid | int == gid.stdout_lines[0] | int
+
+    - block:
+        - name: create a group with a non-unique gid
+          group:
+            name: ansibullgroup3
+            gid: '{{ gid.stdout_lines[0] }}'
+            non_unique: true
+            state: present
+            prefix_path: "{{ prefix_path }}"
+          register: create_group_gid_non_unique
+
+        - name: validate gid required with non_unique
+          group:
+            name: foo
+            non_unique: true
+            prefix_path: "{{ prefix_path }}"
+          register: missing_gid
+          ignore_errors: true
+
+        - name: assert create group with a non unique gid
+          assert:
+            that:
+              - create_group_gid_non_unique is changed
+              - create_group_gid_non_unique.gid | int == gid.stdout_lines[0] | int
+              - missing_gid is failed
+      when: ansible_facts.distribution not in ['MacOSX', 'Alpine']
+
+    ##
+    ## group remove
+    ##
+
+    - name: delete group (check mode)
+      group:
+        name: ansibullgroup
+        state: absent
+        prefix_path: "{{ prefix_path }}"
+      register: delete_group_check
+      check_mode: true
+
+    - name: get result of delete group (check mode)
+      script: 'grouplist.sh "{{ ansible_distribution }}" "{{ prefix_path }}"'
+      register: delete_group_actual_check
+
+    - name: assert delete group (check mode)
+      assert:
+        that:
+          - delete_group_check is changed
+          - '"ansibullgroup" in delete_group_actual_check.stdout_lines'
+
+    - name: delete group
+      group:
+        name: ansibullgroup
+        state: absent
+        prefix_path: "{{ prefix_path }}"
+      register: delete_group
+
+    - name: get result of delete group
+      script: 'grouplist.sh "{{ ansible_distribution }}" "{{ prefix_path }}"'
+      register: delete_group_actual
+
+    - name: assert delete group
+      assert:
+        that:
+          - delete_group is changed
+          - '"ansibullgroup" not in delete_group_actual.stdout_lines'
+
+    - name: delete group (idempotent)
+      group:
+        name: ansibullgroup
+        state: absent
+        prefix_path: "{{ prefix_path }}"
+      register: delete_group_again
+
+    - name: assert delete group (idempotent)
+      assert:
+        that:
+          - not delete_group_again is changed
+
+    # https://github.com/ansible/ansible/pull/78172
+    - block:
+        - name: Create a group
+          group:
+            name: groupdeltest
+            state: present
+            gid: 1042 # random number
+            prefix_path: "{{ prefix_path }}"
+
+        - name: Create user with primary group of groupdeltest
+          lineinfile:
+            path: "{{ prefix_path }}/etc/passwd"
+            regexp: '^groupdeluser:'
+            line: "groupdeluser:x:1042:1042::/home/groupdeluser:/sbin/nologin"
+
+        - name: Show we can't delete the group usually
+          group:
+            name: groupdeltest
+            state: absent
+            prefix_path: "{{ prefix_path }}"
+          ignore_errors: true
+          register: failed_delete
+
+        - name: assert we couldn't delete the group
+          assert:
+            that:
+              - failed_delete is failed
+
+        - name: force delete the group
+          group:
+            name: groupdeltest
+            force: true
+            state: absent
+            prefix_path: "{{ prefix_path }}"
+      always:
+        - name: Cleanup user
+          lineinfile:
+            path: "{{ prefix_path }}/etc/passwd"
+            state: absent
+            regexp: '^groupdeluser:'
+
+        - name: Cleanup group
+          group:
+            name: groupdeltest
+            state: absent
+            prefix_path: "{{ prefix_path }}"
+      when: ansible_distribution not in ["MacOSX", "Alpine", "FreeBSD"]
+
+    # create system group
+
+    - name: remove group
+      group:
+        name: ansibullgroup
+        state: absent
+        prefix_path: "{{ prefix_path }}"
+
+    - name: create system group
+      group:
+        name: ansibullgroup
+        state: present
+        system: true
+        prefix_path: "{{ prefix_path }}"
+
+  always:
+    - name: remove test groups after test
+      group:
+        name: '{{ item }}'
+        state: absent
+        prefix_path: "{{ prefix_path }}"
+      loop:
+        - ansibullgroup
+        - ansibullgroup2
+        - ansibullgroup3
+
+    - name: ensure custom prefix path is removed
+      command: "rm -rf \"{{ prefix_path }}\""


### PR DESCRIPTION
##### SUMMARY
This adds the `prefix_path` option to the group module. The group module currently is only able to create groups using `groupadd` after which the group is added to `/etc/group`. To also support another location for these auth files, the `group[add,mod,del]` commands already support the `-P` option.

The description of this `-P` option is as follows:

> Apply changes in the PREFIX_DIR directory and use the configuration files from the PREFIX_DIR directory. This option does not chroot and is intended for preparing a cross-compilation target. Some limitations: NIS and LDAP users/groups are not verified. PAM authentication is using the host files. No SELINUX support.

Having this option added to the group module allows for preparing targets other than the current target Ansible is running on.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
group

##### ADDITIONAL INFORMATION
I tried `-R` (chroot_dir) at first, for the group module that worked but `useradd` fails when an existing `gid` is specified when creating a new user. `-P` worked in that case. To keep the variables across modules consistent I went for the `-P` / prefix_path option.

A follow up pull request will be created to apply these changes to the user module as well.

The large diff for the integration test is to move part of the logic from the `main.yml` into a separate task. This allowed for having multiple task files for different purposes (same structure which is already present in the user module).