### PR TITLE
validate-modules: ensure that _info and _facts modules set supports_check_mode=True

### DIFF
--- a/changelogs/fragments/75324-ansible-test-validate-modules-info-facts-check_mode.yml
+++ b/changelogs/fragments/75324-ansible-test-validate-modules-info-facts-check_mode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "ansible-test validate-modules - enforce that ``_info`` and ``_facts`` modules set ``supports_check_mode=True`` (https://github.com/ansible/ansible/pull/75324)."

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -1173,8 +1173,8 @@ class ModuleValidator(Validator):
             )
             return
 
-        self._validate_docs_schema(kwargs, ansible_module_kwargs_schema(for_collection=bool(self.collection)),
-                                   'AnsibleModule', 'invalid-ansiblemodule-schema')
+        schema = ansible_module_kwargs_schema(self.object_name.split('.')[0], for_collection=bool(self.collection))
+        self._validate_docs_schema(kwargs, schema, 'AnsibleModule', 'invalid-ansiblemodule-schema')
 
         self._validate_argument_spec(docs, spec, kwargs)
 

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/schema.py
@@ -253,7 +253,7 @@ def argument_spec_schema(for_collection):
     return Schema(schemas)
 
 
-def ansible_module_kwargs_schema(for_collection):
+def ansible_module_kwargs_schema(module_name, for_collection):
     schema = {
         'argument_spec': argument_spec_schema(for_collection),
         'bypass_checks': bool,
@@ -262,6 +262,9 @@ def ansible_module_kwargs_schema(for_collection):
         'add_file_common_args': bool,
         'supports_check_mode': bool,
     }
+    if module_name.endswith(('_info', '_facts')):
+        del schema['supports_check_mode']
+        schema[Required('supports_check_mode')] = True
     schema.update(argument_spec_modifiers)
     return Schema(schema)
 


### PR DESCRIPTION
##### SUMMARY
At least in community.general, there are quite a few `_info` and `_facts` modules which do not declare `supports_check_mode`, or explicitly claim `supports_check_mode=False` (https://github.com/ansible-collections/community.general/pull/3084).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
validate-modules
