### PR TITLE
unarchive - log errors from underlying commands

### DIFF
--- a/changelogs/fragments/64612-unarchive-log-command-output.yml
+++ b/changelogs/fragments/64612-unarchive-log-command-output.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - unarchive - log errors from commands to assist in debugging (https://github.com/ansible/ansible/issues/64612)

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -336,6 +336,8 @@ class ZipArchive(object):
     def _legacy_file_list(self):
         rc, out, err = self.module.run_command([self.cmd_path, '-v', self.src])
         if rc:
+            if self.module._debug:
+                self.module.log(err)
             raise UnarchiveError('Neither python zipfile nor unzip can read %s' % self.src)
 
         for line in out.splitlines()[3:-2]:
@@ -416,6 +418,8 @@ class ZipArchive(object):
         if self.include_files:
             cmd.extend(self.include_files)
         rc, out, err = self.module.run_command(cmd)
+        if self.module._debug:
+            self.module.log(err)
 
         old_out = out
         diff = ''
@@ -744,6 +748,10 @@ class ZipArchive(object):
         rc, out, err = self.module.run_command(cmd)
         if rc == 0:
             return True, None
+
+        if self.module._debug:
+            self.module.log(err)
+
         return False, 'Command "%s" could not handle archive: %s' % (self.cmd_path, err)
 
 
@@ -793,6 +801,8 @@ class TgzArchive(object):
         locale = get_best_parsable_locale(self.module)
         rc, out, err = self.module.run_command(cmd, cwd=self.b_dest, environ_update=dict(LANG=locale, LC_ALL=locale, LC_MESSAGES=locale, LANGUAGE=locale))
         if rc != 0:
+            if self.module._debug:
+                self.module.log(err)
             raise UnarchiveError('Unable to list files in the archive: %s' % err)
 
         for filename in out.splitlines():

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -336,8 +336,7 @@ class ZipArchive(object):
     def _legacy_file_list(self):
         rc, out, err = self.module.run_command([self.cmd_path, '-v', self.src])
         if rc:
-            if self.module._debug:
-                self.module.log(err)
+            self.module.debug(err)
             raise UnarchiveError('Neither python zipfile nor unzip can read %s' % self.src)
 
         for line in out.splitlines()[3:-2]:
@@ -418,8 +417,7 @@ class ZipArchive(object):
         if self.include_files:
             cmd.extend(self.include_files)
         rc, out, err = self.module.run_command(cmd)
-        if self.module._debug:
-            self.module.log(err)
+        self.module.debug(err)
 
         old_out = out
         diff = ''
@@ -749,8 +747,7 @@ class ZipArchive(object):
         if rc == 0:
             return True, None
 
-        if self.module._debug:
-            self.module.log(err)
+        self.module.debug(err)
 
         return False, 'Command "%s" could not handle archive: %s' % (self.cmd_path, err)
 
@@ -801,8 +798,7 @@ class TgzArchive(object):
         locale = get_best_parsable_locale(self.module)
         rc, out, err = self.module.run_command(cmd, cwd=self.b_dest, environ_update=dict(LANG=locale, LC_ALL=locale, LC_MESSAGES=locale, LANGUAGE=locale))
         if rc != 0:
-            if self.module._debug:
-                self.module.log(err)
+            self.module.debug(err)
             raise UnarchiveError('Unable to list files in the archive: %s' % err)
 
         for filename in out.splitlines():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When a command run by the module fails, log the errors if debugging is enabled.

Related to #64612.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/unarchive.py`