### PR TITLE
Improve handling of AnsibleModule arguments in validate-modules

### DIFF
--- a/changelogs/fragments/75324-ansible-test-validate-modules-AnsibleModule-args.yml
+++ b/changelogs/fragments/75324-ansible-test-validate-modules-AnsibleModule-args.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-test validate-modules - correctly validate positional parameters to ``AnsibleModules`` (https://github.com/ansible/ansible/pull/75324)."

--- a/changelogs/fragments/75324-ansible-test-validate-modules-AnsibleModule-args.yml
+++ b/changelogs/fragments/75324-ansible-test-validate-modules-AnsibleModule-args.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- "ansible-test validate-modules - correctly validate positional parameters to ``AnsibleModules`` (https://github.com/ansible/ansible/pull/75324)."

--- a/changelogs/fragments/75332-ansible-test-validate-modules-AnsibleModule-args.yml
+++ b/changelogs/fragments/75332-ansible-test-validate-modules-AnsibleModule-args.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "ansible-test validate-modules - correctly validate positional parameters to ``AnsibleModules`` (https://github.com/ansible/ansible/pull/75332)."

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/main.py
@@ -1153,7 +1153,7 @@ class ModuleValidator(Validator):
 
     def _validate_ansible_module_call(self, docs):
         try:
-            spec, args, kwargs = get_argument_spec(self.path, self.collection)
+            spec, kwargs = get_argument_spec(self.path, self.collection)
         except AnsibleModuleNotInitialized:
             self.reporter.error(
                 path=self.object_path,

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/module_args.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/module_args.py
@@ -35,7 +35,7 @@ from ansible.module_utils._text import to_bytes, to_text
 from .utils import CaptureStd, find_executable, get_module_name_from_filename
 
 
-ANSIBLE_MODULE_CONSTURCTOR_ARGS = tuple(list(inspect.signature(AnsibleModule.__init__).parameters)[1:])
+ANSIBLE_MODULE_CONSTRUCTOR_ARGS = tuple(list(inspect.signature(AnsibleModule.__init__).parameters)[1:])
 
 
 class AnsibleModuleCallError(RuntimeError):
@@ -151,7 +151,7 @@ def get_py_argument_spec(filename, collection):
 
     try:
         # Convert positional arguments to kwargs to make sure that all parameters are actually checked
-        for arg, arg_name in zip(fake.args, ANSIBLE_MODULE_CONSTURCTOR_ARGS):
+        for arg, arg_name in zip(fake.args, ANSIBLE_MODULE_CONSTRUCTOR_ARGS):
             fake.kwargs[arg_name] = arg
         # for ping kwargs == {'argument_spec':{'data':{'type':'str','default':'pong'}}, 'supports_check_mode':True}
         argument_spec = fake.kwargs.get('argument_spec') or {}

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/module_args.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/module_args.py
@@ -19,6 +19,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import runpy
+import inspect
 import json
 import os
 import subprocess
@@ -27,17 +28,14 @@ import sys
 from contextlib import contextmanager
 
 from ansible.executor.powershell.module_manifest import PSModuleDepFinder
-from ansible.module_utils.basic import FILE_COMMON_ARGUMENTS
+from ansible.module_utils.basic import FILE_COMMON_ARGUMENTS, AnsibleModule
 from ansible.module_utils.six import reraise
 from ansible.module_utils._text import to_bytes, to_text
 
 from .utils import CaptureStd, find_executable, get_module_name_from_filename
 
 
-ANSIBLE_MODULE_CONSTURCTOR_ARGS = (
-    'argument_spec', 'bypass_checks', 'no_log', 'mutually_exclusive', 'required_together',
-    'required_one_of', 'add_file_common_args', 'supports_check_mode', 'required_if', 'required_by',
-)
+ANSIBLE_MODULE_CONSTURCTOR_ARGS = tuple(list(inspect.signature(AnsibleModule.__init__).parameters)[1:])
 
 
 class AnsibleModuleCallError(RuntimeError):

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/module_args.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/module_args.py
@@ -130,7 +130,7 @@ def get_ps_argument_spec(filename, collection):
     # the validate-modules code expects the options spec to be under the argument_spec key not options as set in PS
     kwargs['argument_spec'] = kwargs.pop('options', {})
 
-    return kwargs['argument_spec'], (), kwargs
+    return kwargs['argument_spec'], kwargs
 
 
 def get_py_argument_spec(filename, collection):
@@ -162,9 +162,9 @@ def get_py_argument_spec(filename, collection):
             for k, v in FILE_COMMON_ARGUMENTS.items():
                 if k not in argument_spec:
                     argument_spec[k] = v
-        return argument_spec, [], fake.kwargs
+        return argument_spec, fake.kwargs
     except (TypeError, IndexError):
-        return {}, (), {}
+        return {}, {}
 
 
 def get_argument_spec(filename, collection):

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/module_args.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/module_args.py
@@ -34,6 +34,12 @@ from ansible.module_utils._text import to_bytes, to_text
 from .utils import CaptureStd, find_executable, get_module_name_from_filename
 
 
+ANSIBLE_MODULE_CONSTURCTOR_ARGS = (
+    'argument_spec', 'bypass_checks', 'no_log', 'mutually_exclusive', 'required_together',
+    'required_one_of', 'add_file_common_args', 'supports_check_mode', 'required_if', 'required_by',
+)
+
+
 class AnsibleModuleCallError(RuntimeError):
     pass
 
@@ -146,11 +152,11 @@ def get_py_argument_spec(filename, collection):
             raise AnsibleModuleNotInitialized()
 
     try:
+        # Convert positional arguments to kwargs to make sure that all parameters are actually checked
+        for arg, arg_name in zip(fake.args, ANSIBLE_MODULE_CONSTURCTOR_ARGS):
+            fake.kwargs[arg_name] = arg
         # for ping kwargs == {'argument_spec':{'data':{'type':'str','default':'pong'}}, 'supports_check_mode':True}
-        if 'argument_spec' in fake.kwargs:
-            argument_spec = fake.kwargs['argument_spec']
-        else:
-            argument_spec = fake.args[0]
+        argument_spec = fake.kwargs['argument_spec']
         # If add_file_common_args is truish, add options from FILE_COMMON_ARGUMENTS when not present.
         # This is the only modification to argument_spec done by AnsibleModule itself, and which is
         # not caught by setup_env's AnsibleModule replacement
@@ -158,7 +164,7 @@ def get_py_argument_spec(filename, collection):
             for k, v in FILE_COMMON_ARGUMENTS.items():
                 if k not in argument_spec:
                     argument_spec[k] = v
-        return argument_spec, fake.args, fake.kwargs
+        return argument_spec, [], fake.kwargs
     except (TypeError, IndexError):
         return {}, (), {}
 

--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/module_args.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/module_args.py
@@ -154,7 +154,7 @@ def get_py_argument_spec(filename, collection):
         for arg, arg_name in zip(fake.args, ANSIBLE_MODULE_CONSTURCTOR_ARGS):
             fake.kwargs[arg_name] = arg
         # for ping kwargs == {'argument_spec':{'data':{'type':'str','default':'pong'}}, 'supports_check_mode':True}
-        argument_spec = fake.kwargs['argument_spec']
+        argument_spec = fake.kwargs.get('argument_spec') or {}
         # If add_file_common_args is truish, add options from FILE_COMMON_ARGUMENTS when not present.
         # This is the only modification to argument_spec done by AnsibleModule itself, and which is
         # not caught by setup_env's AnsibleModule replacement


### PR DESCRIPTION
##### SUMMARY
This is the bugfix included in #75324 as an individual PR. It converts provided positional arguments to `AnsibleModule` to keyword arguments that are returned by `get_py_argument_spec`, so that all arguments can be validated. This is necessary since sometimes, modules (or module utils) pass a lot of `AnsibleModule` parameters as positional arguments instead of keyword arguments, which disables validation for most of them. Such an exampe is https://github.com/ansible-collections/community.general/blob/main/plugins/module_utils/utm_utils.py#L52-L54.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
validate-modules
