### PR TITLE
fix: action _fixup_perms2 macos +a remote_paths in list() as it can b…

### DIFF
--- a/changelogs/fragments/74613-actionfixup_perms2_macos_remote_paths_ensure_list.yml
+++ b/changelogs/fragments/74613-actionfixup_perms2_macos_remote_paths_ensure_list.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "remote tmpdir permissions - fix type error in macOS chmod ACL fallback (https://github.com/ansible/ansible/pull/74613)."

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -630,7 +630,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         # pass that argument as the first element of remote_paths. So we end
         # up running `chmod +a [that argument] [file 1] [file 2] ...`
         try:
-            res = self._remote_chmod([chmod_acl_mode] + remote_paths, '+a')
+            res = self._remote_chmod([chmod_acl_mode] + list(remote_paths), '+a')
         except AnsibleAuthenticationFailure as e:
             # Solaris-based chmod will return 5 when it sees an invalid mode,
             # and +a is invalid there. Because it returns 5, which is the same


### PR DESCRIPTION
…e a tuple (#74613)

* fix: action _fixup_perms2 macos +a remote_paths in list() as it can be tuple

in `lib/ansible/plugin/action/__init__.py`'s `_fixup_perms2`,
`remote_paths` can be a list or tuple. however, the macos
specific attempt to use chmod +a attempts to concatenate
`remote_paths` with a list, which will fail if it is a tuple.
wrapping `remote_paths` in `list()` fixes this error.

* Update changelogs/fragments/74613-actionfixup_perms2_macos_remote_paths_ensure_list.yml

Co-authored-by: Rick Elrod <rick@elrod.me>
(cherry picked from commit df6554c4ec8b1256067bc2510134ac49cfc3003c)

#
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
-
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
action base