### PR TITLE
`ansible_virtualization_type`: docker does not always appear in cgroups anymore

### DIFF
--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -68,6 +68,14 @@ class LinuxVirtual(Virtual):
                         virtual_facts['virtualization_role'] = 'guest'
                         found_virt = True
 
+        # docker does not always appear in cgroups anymore but does always create the file '/.dockerenv'
+        if os.path.exists('/.dockerenv'):
+            guest_tech.add('docker')
+            if not found_virt:
+                virtual_facts['virtualization_type'] = 'docker'
+                virtual_facts['virtualization_role'] = 'guest'
+                found_virt = True
+
         # lxc does not always appear in cgroups anymore but sets 'container=lxc' environment var, requires root privs
         if os.path.exists('/proc/1/environ'):
             for line in get_file_lines('/proc/1/environ', line_sep='\x00'):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When running ansible within a Docker container, `docker` is not always detected as the `virtualization_type`. This can be resolved by also looking to see if the file `/.dockerenv` exists (which is present within every Docker container):
https://github.com/moby/moby/blob/v20.10.7/daemon/initlayer/setup_unix.go#L29
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #75118

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible.builtin.setup

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```shell
$ ansible localhost -c localhost -m ansible.builtin.setup | grep "ansible_virtualization_type"
[DEPRECATION WARNING]: Ansible will require Python 3.8 or newer on the 
controller starting with Ansible 2.12. Current version: 3.6.8 (default, Nov 16 
2020, 16:55:22) [GCC 4.8.5 20150623 (Red Hat 4.8.5-44)]. This feature will be 
removed from ansible-core in version 2.12. Deprecation warnings can be disabled
 by setting deprecation_warnings=False in ansible.cfg.
[WARNING]: No inventory was parsed, only implicit localhost is available
        "ansible_virtualization_type": "kvm",
```
After:
```shell
# Insert code from this pull request
$ sed -i "71 i \        if os.path.exists('/.dockerenv'):\n            guest_tech.add('docker')\n            if not found_virt:\n                virtual_facts['virtualization_type'] = 'docker'\n                virtual_facts['virtualization_role'] = 'guest'\n                found_virt = True\n" /usr/local/lib/python3.6/site-packages/ansible/module_utils/facts/virtual/linux.py
$ ansible localhost -c localhost -m ansible.builtin.setup | grep "ansible_virtualization_type"
[DEPRECATION WARNING]: Ansible will require Python 3.8 or newer on the 
controller starting with Ansible 2.12. Current version: 3.6.8 (default, Nov 16 
2020, 16:55:22) [GCC 4.8.5 20150623 (Red Hat 4.8.5-44)]. This feature will be 
removed from ansible-core in version 2.12. Deprecation warnings can be disabled
 by setting deprecation_warnings=False in ansible.cfg.
[WARNING]: No inventory was parsed, only implicit localhost is available
        "ansible_virtualization_type": "docker",
```
