### PR TITLE
restores delegated vars that were not passed (#74371)

### DIFF
--- a/changelogs/fragments/missing_delegate_vars.yml
+++ b/changelogs/fragments/missing_delegate_vars.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - callbacks, restores missing delegate_vars
+  - callback default, now uses task delegate_to instead of delegate vars to display delegate to host

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -801,6 +801,10 @@ class TaskExecutor:
             for k in plugin_vars:
                 result["_ansible_delegated_vars"][k] = cvars.get(k)
 
+            for requireshed in ('ansible_host', 'ansible_port', 'ansible_user', 'ansible_connection'):
+                if requireshed not in result["_ansible_delegated_vars"] and requireshed in cvars:
+                    result["_ansible_delegated_vars"][requireshed] = cvars.get(requireshed)
+
         # and return
         display.debug("attempt loop complete, returning result")
         return result

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -77,7 +77,6 @@ class CallbackModule(CallbackBase):
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
 
-        delegated_vars = result._result.get('_ansible_delegated_vars', None)
         self._clean_results(result._result, result._task.action)
 
         if self._last_task_banner != result._task._uuid:
@@ -90,8 +89,8 @@ class CallbackModule(CallbackBase):
             self._process_items(result)
 
         else:
-            if delegated_vars:
-                self._display.display("fatal: [%s -> %s]: FAILED! => %s" % (result._host.get_name(), delegated_vars['ansible_host'],
+            if result._task.delegate_to:
+                self._display.display("fatal: [%s -> %s]: FAILED! => %s" % (result._host.get_name(), result._task.delegate_to,
                                                                             self._dump_results(result._result)),
                                       color=C.COLOR_ERROR, stderr=self.display_failed_stderr)
             else:
@@ -103,16 +102,14 @@ class CallbackModule(CallbackBase):
 
     def v2_runner_on_ok(self, result):
 
-        delegated_vars = result._result.get('_ansible_delegated_vars', None)
-
         if isinstance(result._task, TaskInclude):
             return
         elif result._result.get('changed', False):
             if self._last_task_banner != result._task._uuid:
                 self._print_task_banner(result._task)
 
-            if delegated_vars:
-                msg = "changed: [%s -> %s]" % (result._host.get_name(), delegated_vars['ansible_host'])
+            if result._task.delegate_to:
+                msg = "changed: [%s -> %s]" % (result._host.get_name(), result._task.delegate_to)
             else:
                 msg = "changed: [%s]" % result._host.get_name()
             color = C.COLOR_CHANGED
@@ -123,8 +120,8 @@ class CallbackModule(CallbackBase):
             if self._last_task_banner != result._task._uuid:
                 self._print_task_banner(result._task)
 
-            if delegated_vars:
-                msg = "ok: [%s -> %s]" % (result._host.get_name(), delegated_vars['ansible_host'])
+            if result._task.delegate_to:
+                msg = "ok: [%s -> %s]" % (result._host.get_name(), result._task.delegate_to)
             else:
                 msg = "ok: [%s]" % result._host.get_name()
             color = C.COLOR_OK
@@ -161,9 +158,8 @@ class CallbackModule(CallbackBase):
         if self._last_task_banner != result._task._uuid:
             self._print_task_banner(result._task)
 
-        delegated_vars = result._result.get('_ansible_delegated_vars', None)
-        if delegated_vars:
-            msg = "fatal: [%s -> %s]: UNREACHABLE! => %s" % (result._host.get_name(), delegated_vars['ansible_host'], self._dump_results(result._result))
+        if result._task.delegate_to:
+            msg = "fatal: [%s -> %s]: UNREACHABLE! => %s" % (result._host.get_name(), result._task.delegate_to, self._dump_results(result._result))
         else:
             msg = "fatal: [%s]: UNREACHABLE! => %s" % (result._host.get_name(), self._dump_results(result._result))
         self._display.display(msg, color=C.COLOR_UNREACHABLE, stderr=self.display_failed_stderr)
@@ -273,7 +269,6 @@ class CallbackModule(CallbackBase):
 
     def v2_runner_item_on_ok(self, result):
 
-        delegated_vars = result._result.get('_ansible_delegated_vars', None)
         if isinstance(result._task, TaskInclude):
             return
         elif result._result.get('changed', False):
@@ -292,8 +287,8 @@ class CallbackModule(CallbackBase):
             msg = 'ok'
             color = C.COLOR_OK
 
-        if delegated_vars:
-            msg += ": [%s -> %s]" % (result._host.get_name(), delegated_vars['ansible_host'])
+        if result._task.delegate_to:
+            msg += ": [%s -> %s]" % (result._host.get_name(), result._task.delegate_to)
         else:
             msg += ": [%s]" % result._host.get_name()
 
@@ -308,13 +303,12 @@ class CallbackModule(CallbackBase):
         if self._last_task_banner != result._task._uuid:
             self._print_task_banner(result._task)
 
-        delegated_vars = result._result.get('_ansible_delegated_vars', None)
         self._clean_results(result._result, result._task.action)
         self._handle_exception(result._result)
 
         msg = "failed: "
-        if delegated_vars:
-            msg += "[%s -> %s]" % (result._host.get_name(), delegated_vars['ansible_host'])
+        if result._task.delegate_to:
+            msg += "[%s -> %s]" % (result._host.get_name(), result._task.delegate_to)
         else:
             msg += "[%s]" % (result._host.get_name())
 


### PR DESCRIPTION
* restores delegatd vars that were not passed

   this will restore delegate display on callbacks using the vars
   also moves to use delegate_to directly on the default callback

* clog

(cherry picked from commit cbc83545582d8d7a718140263c465129e0e535d9)
(cherry picked from commit ed456f25f6fb1cdafe78d59f1bf0166afbba0383)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
callback