### PR TITLE
Update indentation for example in playbooks_handlers.rst

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_handlers.rst
+++ b/docs/docsite/rst/user_guide/playbooks_handlers.rst
@@ -50,7 +50,7 @@ In this example playbook, the second task notifies the handler. A single task ca
 
 .. code-block:: yaml
 
-
+    tasks:
     - name: Template configuration file
       ansible.builtin.template:
         src: template.j2

--- a/docs/docsite/rst/user_guide/playbooks_handlers.rst
+++ b/docs/docsite/rst/user_guide/playbooks_handlers.rst
@@ -23,28 +23,28 @@ This playbook, ``verify-apache.yml``, contains a single play with a handler.
         max_clients: 200
       remote_user: root
       tasks:
-      - name: Ensure apache is at the latest version
-        ansible.builtin.yum:
-          name: httpd
-          state: latest
+        - name: Ensure apache is at the latest version
+          ansible.builtin.yum:
+            name: httpd
+            state: latest
 
-      - name: Write the apache config file
-        ansible.builtin.template:
-          src: /srv/httpd.j2
-          dest: /etc/httpd.conf
-        notify:
-        - Restart apache
+        - name: Write the apache config file
+          ansible.builtin.template:
+            src: /srv/httpd.j2
+            dest: /etc/httpd.conf
+          notify:
+          - Restart apache
 
-      - name: Ensure apache is running
-        ansible.builtin.service:
-          name: httpd
-          state: started
-
-      handlers:
-        - name: Restart apache
+        - name: Ensure apache is running
           ansible.builtin.service:
             name: httpd
-            state: restarted
+            state: started
+
+        handlers:
+          - name: Restart apache
+            ansible.builtin.service:
+              name: httpd
+              state: restarted
 
 In this example playbook, the second task notifies the handler. A single task can notify more than one handler.
 

--- a/docs/docsite/rst/user_guide/playbooks_handlers.rst
+++ b/docs/docsite/rst/user_guide/playbooks_handlers.rst
@@ -40,17 +40,17 @@ This playbook, ``verify-apache.yml``, contains a single play with a handler.
             name: httpd
             state: started
 
-        handlers:
-          - name: Restart apache
-            ansible.builtin.service:
-              name: httpd
-              state: restarted
+      handlers:
+        - name: Restart apache
+          ansible.builtin.service:
+            name: httpd
+            state: restarted
 
-In this example playbook, the second task notifies the handler. A single task can notify more than one handler.
+In this example playbook, the second task notifies the handler. A single task can notify more than one handler:
 
 .. code-block:: yaml
 
-    tasks:
+
     - name: Template configuration file
       ansible.builtin.template:
         src: template.j2
@@ -59,16 +59,16 @@ In this example playbook, the second task notifies the handler. A single task ca
         - Restart memcached
         - Restart apache
 
-      handlers:
-        - name: Restart memcached
-          ansible.builtin.service:
-            name: memcached
-            state: restarted
+    handlers:
+      - name: Restart memcached
+        ansible.builtin.service:
+          name: memcached
+          state: restarted
 
-        - name: Restart apache
-          ansible.builtin.service:
-            name: apache
-            state: restarted
+      - name: Restart apache
+        ansible.builtin.service:
+          name: apache
+          state: restarted
 
 Controlling when handlers run
 -----------------------------
@@ -119,6 +119,7 @@ Instead, place variables in the task parameters of your handler. You can load th
 Handlers can also "listen" to generic topics, and tasks can notify those topics as follows:
 
 .. code-block:: yaml
+
 
     handlers:
       - name: Restart memcached


### PR DESCRIPTION
##### SUMMARY
The indentation was off for the tasks list in the example. I am not sure what the indentation should be for the handler, but I think this is correct.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr