### PR TITLE
Add packaging to requirement of ansible-test

### DIFF
--- a/changelogs/fragments/75356-add-requirement-to-ansible-test.txt
+++ b/changelogs/fragments/75356-add-requirement-to-ansible-test.txt
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-test - add packaging python module to ansible-test requirements.

--- a/changelogs/fragments/75356-add-requirement-to-ansible-test.txt
+++ b/changelogs/fragments/75356-add-requirement-to-ansible-test.txt
@@ -1,2 +1,0 @@
-bugfixes:
-- ansible-test - add packaging python module to ansible-test requirements.

--- a/changelogs/fragments/75356-add-requirement-to-ansible-test.yml
+++ b/changelogs/fragments/75356-add-requirement-to-ansible-test.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-test - add packaging python module to ``ansible-doc`` sanity test requirements.

--- a/test/integration/targets/ansible-test/ansible_collections/ns/col/meta/runtime.yml
+++ b/test/integration/targets/ansible-test/ansible_collections/ns/col/meta/runtime.yml
@@ -1,3 +1,4 @@
+requires_ansible: '>=2.11'  # force ansible-doc to check the Ansible version (requires packaging)
 plugin_routing:
   modules:
     hi:

--- a/test/lib/ansible_test/_data/requirements/sanity.ansible-doc.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.ansible-doc.txt
@@ -1,3 +1,3 @@
 jinja2  # ansible-core requirement
 pyyaml  # ansible-core requirement
-packaging # galaxy-importer requirement
+packaging  # ansible-doc requirement

--- a/test/lib/ansible_test/_data/requirements/sanity.ansible-doc.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.ansible-doc.txt
@@ -1,2 +1,3 @@
 jinja2  # ansible-core requirement
 pyyaml  # ansible-core requirement
+packaging # galaxy-importer requirement


### PR DESCRIPTION
Fix #75353

[1] https://github.com/ansible/galaxy-importer/pull/124

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
After requires_ansible field was added as mandatory to runtime.yml
file, ansible-test fails to check this field if it doesn't have
packaging module.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-test

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
