### PR TITLE
[stable-2.11] Add packaging to requirement of ansible-test (#75356)

### DIFF
--- a/changelogs/fragments/75356-add-requirement-to-ansible-test.yml
+++ b/changelogs/fragments/75356-add-requirement-to-ansible-test.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-test - add packaging python module to ``ansible-doc`` sanity test requirements.

--- a/test/integration/targets/ansible-test/ansible_collections/ns/col/meta/runtime.yml
+++ b/test/integration/targets/ansible-test/ansible_collections/ns/col/meta/runtime.yml
@@ -1,3 +1,4 @@
+requires_ansible: '>=2.11'  # force ansible-doc to check the Ansible version (requires packaging)
 plugin_routing:
   modules:
     hi:

--- a/test/lib/ansible_test/_data/requirements/sanity.ansible-doc.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.ansible-doc.txt
@@ -1,2 +1,3 @@
 jinja2  # ansible-core requirement
 pyyaml  # ansible-core requirement
+packaging  # ansible-doc requirement


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/75356

* Add packaging to requirement of ansible-test

Fix #75353

After requires_ansible field was added as mandatory to runtime.yml
file, ansible-test fails to check this field if it doesn't have
packaging module.

[1] https://github.com/ansible/galaxy-importer/pull/124

(cherry picked from commit 40ca87a963736ac1420f3b62b37a8a3bae93da50)

Co-authored-by: Sergey <sshnaidm@users.noreply.github.com>

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
