### PR TITLE
add another fallback layer to atomic move

### DIFF
--- a/changelogs/fragments/atomic_move_yet_another_fallback.yml
+++ b/changelogs/fragments/atomic_move_yet_another_fallback.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - atomic_move, another fallback case for when the failure to copy is due to incompatible fs attributes, use shutil.copy, which ignores these.

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1788,7 +1788,7 @@ class AnsibleModule(object):
     def _copy_wo_attribs(self, src, dest):
         try:
             shutil.copy(src, dest)
-        except:
+        except Exception:
             return False
         return True
 


### PR DESCRIPTION
  try copy w/o attributes as last resort for when filesystem support differs


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/basic.py