### PR TITLE
ansible-test - add ssh debugging logging

### DIFF
--- a/changelogs/fragments/ansible-test-add-ssh-debug-logging.yml
+++ b/changelogs/fragments/ansible-test-add-ssh-debug-logging.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - display recent ``ssh`` debug logs after connection failures (https://github.com/ansible/ansible/pull/75374)

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -697,7 +697,8 @@ class SubprocessError(ApplicationError):
         self.stderr = stderr
         self.runtime = runtime
 
-        error_callback(self)
+        if callable(error_callback):
+            error_callback(self)
 
         self.message = self.message.strip()
 

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -269,7 +269,7 @@ def generate_pip_command(python):
 
 
 def raw_command(cmd, capture=False, env=None, data=None, cwd=None, explain=False, stdin=None, stdout=None,
-                cmd_verbosity=1, str_errors='strict'):
+                cmd_verbosity=1, str_errors='strict', error_callback=None):
     """
     :type cmd: collections.Iterable[str]
     :type capture: bool
@@ -281,6 +281,7 @@ def raw_command(cmd, capture=False, env=None, data=None, cwd=None, explain=False
     :type stdout: file | None
     :type cmd_verbosity: int
     :type str_errors: str
+    :type error_callback: t.Callable[[SubprocessError], None]
     :rtype: str | None, str | None
     """
     if not cwd:
@@ -361,7 +362,7 @@ def raw_command(cmd, capture=False, env=None, data=None, cwd=None, explain=False
     if status == 0:
         return stdout_text, stderr_text
 
-    raise SubprocessError(cmd, status, stdout_text, stderr_text, runtime)
+    raise SubprocessError(cmd, status, stdout_text, stderr_text, runtime, error_callback)
 
 
 def common_environment():
@@ -670,13 +671,14 @@ class ApplicationWarning(Exception):
 
 class SubprocessError(ApplicationError):
     """Error resulting from failed subprocess execution."""
-    def __init__(self, cmd, status=0, stdout=None, stderr=None, runtime=None):
+    def __init__(self, cmd, status=0, stdout=None, stderr=None, runtime=None, error_callback=None):
         """
         :type cmd: list[str]
         :type status: int
         :type stdout: str | None
         :type stderr: str | None
         :type runtime: float | None
+        :type error_callback: t.Callable[[SubprocessError], None]
         """
         message = 'Command "%s" returned exit status %s.\n' % (' '.join(cmd_quote(c) for c in cmd), status)
 
@@ -688,16 +690,18 @@ class SubprocessError(ApplicationError):
             message += '>>> Standard Output\n'
             message += '%s%s\n' % (stdout.strip(), Display.clear)
 
-        message = message.strip()
-
-        super(SubprocessError, self).__init__(message)
-
         self.cmd = cmd
         self.message = message
         self.status = status
         self.stdout = stdout
         self.stderr = stderr
         self.runtime = runtime
+
+        error_callback(self)
+
+        self.message = self.message.strip()
+
+        super(SubprocessError, self).__init__(self.message)
 
 
 class MissingEnvironmentVariable(ApplicationError):

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -678,7 +678,7 @@ class SubprocessError(ApplicationError):
         :type stdout: str | None
         :type stderr: str | None
         :type runtime: float | None
-        :type error_callback: t.Callable[[SubprocessError], None]
+        :type error_callback: t.Optional[t.Callable[[SubprocessError], None]]
         """
         message = 'Command "%s" returned exit status %s.\n' % (' '.join(cmd_quote(c) for c in cmd), status)
 
@@ -697,7 +697,7 @@ class SubprocessError(ApplicationError):
         self.stderr = stderr
         self.runtime = runtime
 
-        if callable(error_callback):
+        if error_callback:
             error_callback(self)
 
         self.message = self.message.strip()

--- a/test/lib/ansible_test/_internal/util_common.py
+++ b/test/lib/ansible_test/_internal/util_common.py
@@ -31,6 +31,7 @@ from .util import (
     ANSIBLE_TEST_DATA_ROOT,
     ApplicationError,
     cmd_quote,
+    SubprocessError,
 )
 
 from .io import (
@@ -457,7 +458,7 @@ def resolve_csharp_ps_util(import_name, path):
 
 
 def run_command(args, cmd, capture=False, env=None, data=None, cwd=None, always=False, stdin=None, stdout=None,
-                cmd_verbosity=1, str_errors='strict'):
+                cmd_verbosity=1, str_errors='strict', error_callback=None):
     """
     :type args: CommonConfig
     :type cmd: collections.Iterable[str]
@@ -470,8 +471,9 @@ def run_command(args, cmd, capture=False, env=None, data=None, cwd=None, always=
     :type stdout: file | None
     :type cmd_verbosity: int
     :type str_errors: str
+    :type error_callback: t.Callable[[SubprocessError], None]
     :rtype: str | None, str | None
     """
     explain = args.explain and not always
     return raw_command(cmd, capture=capture, env=env, data=data, cwd=cwd, explain=explain, stdin=stdin, stdout=stdout,
-                       cmd_verbosity=cmd_verbosity, str_errors=str_errors)
+                       cmd_verbosity=cmd_verbosity, str_errors=str_errors, error_callback=error_callback)


### PR DESCRIPTION
##### SUMMARY
We are seeing increasing but still intermittent failures between Azure and external instances in MacStadium and AWS. This adds a callback to display `ssh` debugging information when we receive an error code 255 from `ssh`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/lib/ansible_test/_internal/manage_ci.py`
`test/lib/ansible_test/_internal/util.py`
`test/lib/ansible_test/_internal/util_common.py`

##### ADDITIONAL INFORMATION
Upon closer look at both the failure and the output from `ssh` debug logs, this may not provide enough information about what the actual failure is. But this does create a callback entry point where more information about the failure could potentially be gathered.