### PR TITLE
Add description for modules in section `seealso`

### DIFF
--- a/lib/ansible/modules/_include.py
+++ b/lib/ansible/modules/_include.py
@@ -44,10 +44,15 @@ notes:
   - B(This module will still be supported for some time but we are looking at deprecating it in the near future.)
 seealso:
 - module: ansible.builtin.import_playbook
+  description: Import a playbook.
 - module: ansible.builtin.import_role
+  description: Import a role into a play.
 - module: ansible.builtin.import_tasks
+  description: Import a file containing tasks into a play.
 - module: ansible.builtin.include_role
+  description: Include an ansible role into a play.
 - module: ansible.builtin.include_tasks
+  description: Include a file containing tasks into a play.
 - ref: playbooks_reuse_includes
   description: More information related to including and importing playbooks, roles and tasks.
 '''

--- a/lib/ansible/modules/add_host.py
+++ b/lib/ansible/modules/add_host.py
@@ -42,6 +42,7 @@ notes:
   They are still available from hostvars and for delegation as a normal part of the inventory.
 seealso:
 - module: ansible.builtin.group_by
+  description: Create in-memory Ansible group based on facts.
 author:
 - Ansible Core Team
 - Seth Vidal (@skvidal)

--- a/lib/ansible/modules/apt_key.py
+++ b/lib/ansible/modules/apt_key.py
@@ -72,6 +72,9 @@ options:
               on personally controlled sites using self-signed certificates.
         type: bool
         default: 'yes'
+seealso:
+- module: ansible.builtin.apt
+  description: Manage packages using apt package manager.
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/assemble.py
+++ b/lib/ansible/modules/assemble.py
@@ -76,8 +76,11 @@ options:
     version_added: '2.0'
 seealso:
 - module: ansible.builtin.copy
+  description: Copy a file from the controller to a target.
 - module: ansible.builtin.template
+  description: Write file from a Jinja template in a target.
 - module: ansible.windows.win_copy
+  description: Copy a file from the controller to a Windows target.
 author:
 - Stephen Fromm (@sfromm)
 extends_documentation_fragment:

--- a/lib/ansible/modules/assert.py
+++ b/lib/ansible/modules/assert.py
@@ -44,8 +44,11 @@ notes:
      - This module is also supported for Windows targets.
 seealso:
 - module: ansible.builtin.debug
+  description: Print a text or the content of a variable during a play.
 - module: ansible.builtin.fail
+  description: Fail a play under a condition.
 - module: ansible.builtin.meta
+  description: Trigger special actions in a play.
 author:
     - Ansible Core Team
     - Michael DeHaan

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -97,10 +97,14 @@ notes:
     -  For Windows targets, use the M(ansible.windows.win_command) module instead.
     -  For rebooting systems, use the M(ansible.builtin.reboot) or M(ansible.windows.win_reboot) module.
 seealso:
-- module: ansible.builtin.raw
-- module: ansible.builtin.script
 - module: ansible.builtin.shell
+  description: Execute a command interpreted by a shell.
+- module: ansible.builtin.raw
+  description: Run a command directly from SSH.
+- module: ansible.builtin.script
+  description: Run a local script on a target after transferring it.
 - module: ansible.windows.win_command
+  description: Execute a command on a Windows target.
 author:
     - Ansible Core Team
     - Michael DeHaan

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -126,11 +126,17 @@ notes:
 - The M(ansible.builtin.copy) module recursively copy facility does not scale to lots (>hundreds) of files.
 seealso:
 - module: ansible.builtin.assemble
+  description: Create a file out of text fragments.
 - module: ansible.builtin.fetch
+  description: Retrieve a file from a target on the controller.
 - module: ansible.builtin.file
+  description: Create a file or set a file properties.
 - module: ansible.builtin.template
+  description: Write file from a Jinja template in a target.
 - module: ansible.posix.synchronize
+  description: Copy several files using rsync.
 - module: ansible.windows.win_copy
+  description: Copy a file from the controller to a Windows target.
 author:
 - Ansible Core Team
 - Michael DeHaan

--- a/lib/ansible/modules/debug.py
+++ b/lib/ansible/modules/debug.py
@@ -42,7 +42,9 @@ notes:
     - This module is also supported for Windows targets.
 seealso:
 - module: ansible.builtin.assert
+  description: Assert expression is true.
 - module: ansible.builtin.fail
+  description: Fail a play under a condition.
 author:
 - Dag Wieers (@dagwieers)
 - Michael DeHaan

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -246,6 +246,11 @@ requirements:
   - "python >= 2.6"
   - python-dnf
   - for the autoremove option you need dnf >= 2.0.1"
+seealso:
+- module: ansible.builtin.yum
+  description: Manage packages with the yum package manager.
+- module: ansible.builtin.package
+  description: Manage packages using the discovered package manager of the target.
 author:
   - Igor Gnatenko (@ignatenkobrain) <i.gnatenko.brain@gmail.com>
   - Cristian van Ee (@DJMuggs) <cristian at cvee.org>

--- a/lib/ansible/modules/expect.py
+++ b/lib/ansible/modules/expect.py
@@ -75,7 +75,9 @@ notes:
     or M(ansible.builtin.script) modules. (An example is part of the M(ansible.builtin.shell) module documentation).
 seealso:
 - module: ansible.builtin.script
+  description: Run a local script on a target after transferring it.
 - module: ansible.builtin.shell
+  description: Execute a command interpreted by a shell.
 author: "Matt Martz (@sivel)"
 '''
 

--- a/lib/ansible/modules/fail.py
+++ b/lib/ansible/modules/fail.py
@@ -28,8 +28,11 @@ notes:
     - This module is also supported for Windows targets.
 seealso:
 - module: ansible.builtin.assert
+  description: Assert expression is true.
 - module: ansible.builtin.debug
+  description: Print a text or the content of a variable during a play.
 - module: ansible.builtin.meta
+  description: Trigger special actions in a play.
 author:
 - Dag Wieers (@dagwieers)
 '''

--- a/lib/ansible/modules/fetch.py
+++ b/lib/ansible/modules/fetch.py
@@ -74,7 +74,9 @@ notes:
 - Supports C(check_mode).
 seealso:
 - module: ansible.builtin.copy
+  description: Copy a file from the controller to a target.
 - module: ansible.builtin.slurp
+  description: Retrieve a file encoded in base64 from a target.
 author:
 - Ansible Core Team
 - Michael DeHaan

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -107,10 +107,15 @@ options:
     version_added: '2.7'
 seealso:
 - module: ansible.builtin.assemble
+  description: Create a file out of text fragments.
 - module: ansible.builtin.copy
+  description: Copy a file from the controller to a target.
 - module: ansible.builtin.stat
+  description: Retrieve state of a file on a filesystem.
 - module: ansible.builtin.template
+  description: Write file from a Jinja template in a target.
 - module: ansible.windows.win_file
+  description: Create a file or set a file properties for Windows target.
 notes:
 - Supports C(check_mode).
 author:

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -131,6 +131,7 @@ options:
         version_added: "2.6"
 seealso:
 - module: ansible.windows.win_find
+  description: Find files on a Windows target.
 '''
 
 

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -192,7 +192,9 @@ notes:
      - For Windows targets, use the M(ansible.windows.win_get_url) module instead.
 seealso:
 - module: ansible.builtin.uri
+  description: Interact with a webservices.
 - module: ansible.windows.win_get_url
+  description: Download files from HTTP, HTTPS, or FTP to Windows target.
 author:
 - Jan-Piet Mens (@jpmens)
 '''

--- a/lib/ansible/modules/group.py
+++ b/lib/ansible/modules/group.py
@@ -59,7 +59,9 @@ options:
         version_added: "2.8"
 seealso:
 - module: ansible.builtin.user
+  description: Manage users on a target.
 - module: ansible.windows.win_group
+  description: Manage groups on a target.
 author:
 - Stephen Fromm (@sfromm)
 notes:

--- a/lib/ansible/modules/group_by.py
+++ b/lib/ansible/modules/group_by.py
@@ -36,6 +36,7 @@ notes:
   for those trying to track inventory changes.
 seealso:
 - module: ansible.builtin.add_host
+  description: Add a host to the in-memory Ansible inventory.
 author:
 - Jeroen Hoekx (@jhoekx)
 '''

--- a/lib/ansible/modules/import_playbook.py
+++ b/lib/ansible/modules/import_playbook.py
@@ -47,9 +47,13 @@ notes:
   - This is a core feature of Ansible, rather than a module, and cannot be overridden like a module.
 seealso:
 - module: ansible.builtin.import_role
+  description: Import a role into a play.
 - module: ansible.builtin.import_tasks
+  description: Import a file containing tasks into a play.
 - module: ansible.builtin.include_role
+  description: Include an ansible role into a play.
 - module: ansible.builtin.include_tasks
+  description: Include a file containing tasks into a play.
 - ref: playbooks_reuse_includes
   description: More information related to including and importing playbooks, roles and tasks.
 '''

--- a/lib/ansible/modules/import_role.py
+++ b/lib/ansible/modules/import_role.py
@@ -87,8 +87,6 @@ notes:
 seealso:
 - module: ansible.builtin.import_playbook
   description: Import a playbook.
-- module: ansible.builtin.import_role
-  description: Import a role into a play.
 - module: ansible.builtin.import_tasks
   description: Import a file containing tasks into a play.
 - module: ansible.builtin.include_role

--- a/lib/ansible/modules/import_role.py
+++ b/lib/ansible/modules/import_role.py
@@ -86,9 +86,15 @@ notes:
   - Unlike M(ansible.builtin.include_role) variable exposure is not configurable, and will always be exposed.
 seealso:
 - module: ansible.builtin.import_playbook
+  description: Import a playbook.
+- module: ansible.builtin.import_role
+  description: Import a role into a play.
 - module: ansible.builtin.import_tasks
+  description: Import a file containing tasks into a play.
 - module: ansible.builtin.include_role
+  description: Include an ansible role into a play.
 - module: ansible.builtin.include_tasks
+  description: Include a file containing tasks into a play.
 - ref: playbooks_reuse_includes
   description: More information related to including and importing playbooks, roles and tasks.
 '''

--- a/lib/ansible/modules/import_tasks.py
+++ b/lib/ansible/modules/import_tasks.py
@@ -47,9 +47,13 @@ notes:
   - This is a core feature of Ansible, rather than a module, and cannot be overridden like a module.
 seealso:
 - module: ansible.builtin.import_playbook
+  description: Import a playbook.
 - module: ansible.builtin.import_role
+  description: Import a role into a play.
 - module: ansible.builtin.include_role
+  description: Include an ansible role into a play.
 - module: ansible.builtin.include_tasks
+  description: Include a file containing tasks into a play.
 - ref: playbooks_reuse_includes
   description: More information related to including and importing playbooks, roles and tasks.
 '''

--- a/lib/ansible/modules/include_role.py
+++ b/lib/ansible/modules/include_role.py
@@ -81,9 +81,13 @@ notes:
   - After Ansible 2.4, you can use M(ansible.builtin.import_role) for C(static) behaviour and this action for C(dynamic) one.
 seealso:
 - module: ansible.builtin.import_playbook
+  description: Import a playbook.
 - module: ansible.builtin.import_role
+  description: Import a role into a play.
 - module: ansible.builtin.import_tasks
+  description: Import a file containing tasks into a play.
 - module: ansible.builtin.include_tasks
+  description: Include a file containing tasks into a play.
 - ref: playbooks_reuse_includes
   description: More information related to including and importing playbooks, roles and tasks.
 '''

--- a/lib/ansible/modules/include_tasks.py
+++ b/lib/ansible/modules/include_tasks.py
@@ -38,9 +38,13 @@ notes:
   - This is a core feature of the Ansible, rather than a module, and cannot be overridden like a module.
 seealso:
 - module: ansible.builtin.import_playbook
+  description: Import a playbook.
 - module: ansible.builtin.import_role
+  description: Import a role into a play.
 - module: ansible.builtin.import_tasks
+  description: Import a file containing tasks into a play.
 - module: ansible.builtin.include_role
+  description: Include an ansible role into a play.
 - ref: playbooks_reuse_includes
   description: More information related to including and importing playbooks, roles and tasks.
 '''

--- a/lib/ansible/modules/include_vars.py
+++ b/lib/ansible/modules/include_vars.py
@@ -86,6 +86,7 @@ notes:
   - This module is also supported for Windows targets.
 seealso:
 - module: ansible.builtin.set_fact
+  description: Set target variables and facts.
 - ref: playbooks_delegation
   description: More information related to task delegation.
 '''

--- a/lib/ansible/modules/lineinfile.py
+++ b/lib/ansible/modules/lineinfile.py
@@ -139,12 +139,18 @@ notes:
   - As of Ansible 2.3, the I(dest) option has been changed to I(path) as default, but I(dest) still works as well.
   - Supports C(check_mode).
 seealso:
-- module: ansible.builtin.blockinfile
-- module: ansible.builtin.copy
-- module: ansible.builtin.file
 - module: ansible.builtin.replace
+  description: Replace all occurences of a line in a file.
+- module: ansible.builtin.blockinfile
+  description: Insert a block of text in a file.
+- module: ansible.builtin.copy
+  description: Copy a file from controller to target.
+- module: ansible.builtin.file
+  description: Create a file or set a file properties.
 - module: ansible.builtin.template
+  description: Write a file out of a Jinja template.
 - module: community.windows.win_lineinfile
+  description: Manage a specific line in a file on Windows target.
 author:
     - Daniel Hokka Zakrissoni (@dhozac)
     - Ahti Kitsik (@ahtik)

--- a/lib/ansible/modules/meta.py
+++ b/lib/ansible/modules/meta.py
@@ -46,7 +46,9 @@ notes:
     - This module is also supported for Windows targets.
 seealso:
 - module: ansible.builtin.assert
+  description: Assert expression is true.
 - module: ansible.builtin.fail
+  description: Fail a play under a condition.
 author:
     - Ansible Core Team
 '''

--- a/lib/ansible/modules/package_facts.py
+++ b/lib/ansible/modules/package_facts.py
@@ -41,6 +41,9 @@ author:
   - Matthew Jones (@matburt)
   - Brian Coca (@bcoca)
   - Adam Miller (@maxamillion)
+seealso:
+- module: ansible.builtin.package
+  description: Manage packages using the discovered package manager of the target.
 notes:
   - Supports C(check_mode).
 '''

--- a/lib/ansible/modules/ping.py
+++ b/lib/ansible/modules/ping.py
@@ -30,7 +30,9 @@ options:
     default: pong
 seealso:
   - module: ansible.netcommon.net_ping
+    description: Test host reachability using ping from a network device.
   - module: ansible.windows.win_ping
+    description: Ping a host from a Windows target.
 author:
   - Ansible Core Team
   - Michael DeHaan

--- a/lib/ansible/modules/raw.py
+++ b/lib/ansible/modules/raw.py
@@ -51,9 +51,13 @@ notes:
     - This module is also supported for Windows targets.
 seealso:
 - module: ansible.builtin.command
+  description: Execute a command.
 - module: ansible.builtin.shell
+  description: Execute a command interpreted by a shell.
 - module: ansible.windows.win_command
+  description: Execute a command on a Windows target.
 - module: ansible.windows.win_shell
+  description: Execute a command on a Windows target interpreted by a shell.
 author:
     - Ansible Core Team
     - Michael DeHaan

--- a/lib/ansible/modules/reboot.py
+++ b/lib/ansible/modules/reboot.py
@@ -82,6 +82,7 @@ options:
     version_added: '2.11'
 seealso:
 - module: ansible.windows.win_reboot
+  description: Reboot a Windows target.
 author:
     - Matt Davis (@nitzmahone)
     - Sam Doran (@samdoran)

--- a/lib/ansible/modules/script.py
+++ b/lib/ansible/modules/script.py
@@ -50,7 +50,9 @@ notes:
   - Does not support C(check_mode).
 seealso:
   - module: ansible.builtin.shell
+    description: Execute a command interpreted by a shell.
   - module: ansible.windows.win_shell
+    description: Execute a command on a Windows target interpreted by a shell.
 author:
   - Ansible Core Team
   - Michael DeHaan

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -89,8 +89,12 @@ notes:
     - For AIX, group subsystem names can be used.
     - Supports C(check_mode).
 seealso:
-    - module: ansible.windows.win_service
-      description: Manage a service on a Windows target.
+- module: ansible.builtin.sysvinit
+  description: Manage SysV services.
+- module: ansible.builtin.systemd
+  description: Manage unit (including service) using systemd.
+- module: ansible.windows.win_service
+  description: Manage a service on a Windows target.
 author:
     - Ansible Core Team
     - Michael DeHaan

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -90,6 +90,7 @@ notes:
     - Supports C(check_mode).
 seealso:
     - module: ansible.windows.win_service
+      description: Manage a service on a Windows target.
 author:
     - Ansible Core Team
     - Michael DeHaan

--- a/lib/ansible/modules/set_fact.py
+++ b/lib/ansible/modules/set_fact.py
@@ -50,6 +50,7 @@ notes:
     - This action does not use a connection and always executes on the controller.
 seealso:
 - module: ansible.builtin.include_vars
+  description: Load variables from a file.
 - ref: ansible_variable_precedence
   description: More information related to variable precedence and which type of variable wins over others.
 author:

--- a/lib/ansible/modules/shell.py
+++ b/lib/ansible/modules/shell.py
@@ -89,9 +89,13 @@ notes:
   - For rebooting systems, use the M(ansible.builtin.reboot) or M(ansible.windows.win_reboot) module.
 seealso:
 - module: ansible.builtin.command
+  description: Execute a command.
 - module: ansible.builtin.raw
+  description: Run a command directly from SSH.
 - module: ansible.builtin.script
+  description: Run a local script on a target after transferring it.
 - module: ansible.windows.win_shell
+  description: Execute a command on a Windows target interpreted by a shell.
 author:
     - Ansible Core Team
     - Michael DeHaan

--- a/lib/ansible/modules/slurp.py
+++ b/lib/ansible/modules/slurp.py
@@ -31,6 +31,7 @@ notes:
    - Supports C(check_mode).
 seealso:
 - module: ansible.builtin.fetch
+  description: Retrieve a file from a target on the controller.
 author:
     - Ansible Core Team
     - Michael DeHaan (@mpdehaan)

--- a/lib/ansible/modules/stat.py
+++ b/lib/ansible/modules/stat.py
@@ -63,7 +63,9 @@ options:
     version_added: "2.3"
 seealso:
 - module: ansible.builtin.file
+  description: Create a file or set a file properties.
 - module: ansible.windows.win_stat
+  description: Retrieve state of a file on a filesystem on a Windows target.
 notes:
 - Supports C(check_mode).
 author: Bruce Pennypacker (@bpennypacker)

--- a/lib/ansible/modules/systemd.py
+++ b/lib/ansible/modules/systemd.py
@@ -83,8 +83,15 @@ notes:
     - Before 2.4 you always required C(name).
     - Globs are not supported in name, i.e ``postgres*.service``.
     - Supports C(check_mode).
+seealso:
+- module: ansible.builtin.sysvinit
+  description: Manage SysV services.
+- module: ansible.windows.win_service
+  description: Manage a service on a Windows target.
+- module: ansible.builtin.service
+  description: Generic module to manage a service.
 requirements:
-    - A system managed by systemd.
+    - The target must be managed by systemd.
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/sysvinit.py
+++ b/lib/ansible/modules/sysvinit.py
@@ -68,6 +68,13 @@ options:
         default: no
 notes:
     - One option other than name is required.
+seealso:
+- module: ansible.builtin.systemd
+  description: Manage unit (including service) using systemd.
+- module: ansible.builtin.service
+  description: Generic module to manage a service.
+- module: ansible.windows.win_service
+  description: Manage a service on a Windows target.
 requirements:
     - That the service managed has a corresponding init script.
 '''

--- a/lib/ansible/modules/tempfile.py
+++ b/lib/ansible/modules/tempfile.py
@@ -43,7 +43,9 @@ options:
     default: ""
 seealso:
 - module: ansible.builtin.file
+  description: Create a file or set a file properties.
 - module: ansible.windows.win_tempfile
+  description: Create a temporary file on a Windows target.
 author:
   - Krzysztof Magosa (@krzysztof-magosa)
 '''

--- a/lib/ansible/modules/template.py
+++ b/lib/ansible/modules/template.py
@@ -29,8 +29,11 @@ notes:
 - For Windows you can use M(ansible.windows.win_template) which uses '\\r\\n' as C(newline_sequence) by default.
 seealso:
 - module: ansible.builtin.copy
+  description: Copy a file from the controller to a target.
 - module: ansible.windows.win_copy
+  description: Copy a file from the controller to a Windows target.
 - module: ansible.windows.win_template
+  description: Template a file out to a target host with '\\r\\n' as C(newline_sequence) by default.
 author:
 - Ansible Core Team
 - Michael DeHaan

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -128,8 +128,11 @@ notes:
     - Supports C(check_mode).
 seealso:
 - module: community.general.archive
+  description: Create a compressed archive.
 - module: community.general.iso_extract
+  description: Extract files from an ISO image.
 - module: community.windows.win_unzip
+  description: Unzip compressed files and archives on the Windows target.
 author: Michael DeHaan
 '''
 

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -207,7 +207,9 @@ notes:
   - For Windows targets, use the M(ansible.windows.win_uri) module instead.
 seealso:
 - module: ansible.builtin.get_url
+  description: Download files from HTTP, HTTPS, or FTP on a target.
 - module: ansible.windows.win_uri
+  description: Interact with webservices on a Windows target.
 author:
 - Romeo Theriault (@romeotheriault)
 extends_documentation_fragment: files

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -275,8 +275,11 @@ notes:
   - Supports C(check_mode).
 seealso:
 - module: ansible.posix.authorized_key
+  description: Manage keys in SSH authorized key file.
 - module: ansible.builtin.group
+  description: Manage groups on a target.
 - module: ansible.windows.win_user
+  description: Manage users on a Windows target.
 author:
 - Stephen Fromm (@sfromm)
 '''

--- a/lib/ansible/modules/wait_for.py
+++ b/lib/ansible/modules/wait_for.py
@@ -108,8 +108,11 @@ notes:
     so operations on the path using other modules may not work exactly as expected.
 seealso:
 - module: ansible.builtin.wait_for_connection
+  description: Wait until remote system is reachable/usable.
 - module: ansible.windows.win_wait_for
+  description: Wait until a condition is met on a Windows target.
 - module: community.windows.win_wait_for_process
+  description: Wait until a condition is met on processes on a Windows target.
 author:
     - Jeroen Hoekx (@jhoekx)
     - John Jarvis (@jarv)

--- a/lib/ansible/modules/wait_for_connection.py
+++ b/lib/ansible/modules/wait_for_connection.py
@@ -44,8 +44,11 @@ notes:
 - This module is also supported for Windows targets.
 seealso:
 - module: ansible.builtin.wait_for
+  description: Wait until a condition is met.
 - module: ansible.windows.win_wait_for
+  description: Wait until a condition is met on a Windows target.
 - module: community.windows.win_wait_for_process
+  description: Wait until a condition is met on processes on a Windows target.
 author:
 - Dag Wieers (@dagwieers)
 '''

--- a/lib/ansible/modules/yum.py
+++ b/lib/ansible/modules/yum.py
@@ -267,6 +267,11 @@ notes:
     command directly, namely "command: yum clean all"
     https://github.com/ansible/ansible/pull/31450#issuecomment-352889579'
 # informational: requirements for nodes
+seealso:
+- module: ansible.builtin.dnf
+  description: Manage packages with dnf package manager.
+- module: ansible.builtin.package
+  description: Manage packages using the discovered package manager of the target.
 requirements:
 - yum
 author:


### PR DESCRIPTION
##### SUMMARY
Add description for modules in section `seealso`.
Of course that would be better if the code could use the value of `short_description` of the target module.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docsite
