### PR TITLE
Fix typo in developing_plugins_network.rst

### DIFF
--- a/docs/docsite/rst/network/dev_guide/developing_plugins_network.rst
+++ b/docs/docsite/rst/network/dev_guide/developing_plugins_network.rst
@@ -211,7 +211,7 @@ The following sample shows the start of a custom cli_parser plugin:
        """ Sample cli_parser plugin
        """
 
-       # Use the follow extention when loading a template
+       # Use the follow extension when loading a template
        DEFAULT_TEMPLATE_EXTENSION = "txt"
        # Provide the contents of the template to the parse function
        PROVIDE_TEMPLATE_CONTENTS = True


### PR DESCRIPTION


##### SUMMARY
Fixed minor typo.

```
extention -> extension
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
