### PR TITLE
ansible-test - allow for the same listening port on multiple interfaces

### DIFF
--- a/changelogs/fragments/ansible-test_inspect-ports-on-all-interfaces.yml
+++ b/changelogs/fragments/ansible-test_inspect-ports-on-all-interfaces.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - allow the same listening port on all container inerfaces

--- a/changelogs/fragments/ansible-test_inspect-ports-on-all-interfaces.yml
+++ b/changelogs/fragments/ansible-test_inspect-ports-on-all-interfaces.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ansible-test - allow the same listening port on all container inerfaces
+  - ansible-test - allow the same listening port on all container interfaces

--- a/test/lib/ansible_test/_internal/containers.py
+++ b/test/lib/ansible_test/_internal/containers.py
@@ -524,7 +524,7 @@ class ContainerDescriptor:
             # inspect the support container to locate the published ports
             tcp_ports = dict((port, container.get_tcp_port(port)) for port in self.ports)
 
-            if any(not config or len(config) != 1 for config in tcp_ports.values()):
+            if any(not config or len(set(conf['HostPort'] for conf in config)) != 1 for config in tcp_ports.values()):
                 raise ApplicationError('Unexpected `docker inspect` results for published TCP ports:\n%s' % json.dumps(tcp_ports, indent=4, sort_keys=True))
 
             published_ports = dict((port, int(config[0]['HostPort'])) for port, config in tcp_ports.items())


### PR DESCRIPTION
##### SUMMARY
On a container host with IPv6 enabled, the listening port will be published on each interface. Since `ansible-test` was only expecting one interface, the tests fail.

This PR allows for the same port to be published on all interfaces.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/lib/ansible_test/_internal/containers.py`
##### ADDITIONAL INFORMATION

Example output of the failure without this change:

```
> ansible-test integration cloud/acme/
Starting new "acme-simulator" container.
ERROR: Unexpected `docker inspect` results for published TCP ports:
{
    "5000": [
        {
            "HostIp": "0.0.0.0",
            "HostPort": "49168"
        },
        {
            "HostIp": "::",
            "HostPort": "49168"
        }
    ],
    "14000": [
        {
            "HostIp": "0.0.0.0",
            "HostPort": "49167"
        },
        {
            "HostIp": "::",
            "HostPort": "49167"
        }
    ]
}
```
