### PR TITLE
wait_for_connection timeout/retries fixes

### DIFF
--- a/changelogs/fragments/75388_wait_for_connection.yml
+++ b/changelogs/fragments/75388_wait_for_connection.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - wait_for_connection - fix `timeout` parameter being ignored
+  - wait_for_connection - truncates last connection attempt timeout (of length `connect_timeout`) to have task not exceed total `timeout`
+  - wait_for_connection - will no longer wait forever when `timeout` <= 0

--- a/lib/ansible/modules/wait_for_connection.py
+++ b/lib/ansible/modules/wait_for_connection.py
@@ -56,6 +56,8 @@ attributes:
     platform:
         details: As long as there is a connection plugin
         platforms: all
+notes:
+- The reported C(elapsed) may be slightly less than the C(timeout) because of integer truncation (for example, reporting C("elpased": 2) for a C(timeout) of 3) 
 seealso:
 - module: ansible.builtin.wait_for
 - module: ansible.windows.win_wait_for

--- a/lib/ansible/modules/wait_for_connection.py
+++ b/lib/ansible/modules/wait_for_connection.py
@@ -57,7 +57,7 @@ attributes:
         details: As long as there is a connection plugin
         platforms: all
 notes:
-- The reported C(elapsed) may be slightly less than the C(timeout) because of integer truncation (for example, reporting C("elpased": 2) for a C(timeout) of 3) 
+- The reported C(elapsed) may be slightly less than the C(timeout) because of integer truncation; for example, reporting elpased of 2 for a C(timeout) of 3
 seealso:
 - module: ansible.builtin.wait_for
 - module: ansible.windows.win_wait_for

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -49,7 +49,7 @@ class ActionModule(ActionBase):
         # We check that there is at least 1 second remaining,
         # since that's the minimum we can specify to a timeout to ping.
         # If we pass 0 seconds as the timeout to ping, it never times out.
-        while (max_end_time - datetime.utcnow()).seconds > 0:
+        while (max_end_time - datetime.utcnow()) > timedelta(seconds=0):
             # The effective timeout ensures that we don't exceed the timeout value
             # as an example without it, if timeout is 10 and connect_timeout is 8,
             # 2 attempts will be made with a timeout of 8s for a total of 16s, > timeout

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -45,7 +45,7 @@ class ActionModule(ActionBase):
     def do_until_success_or_timeout(self, what, timeout, ping_connect_timeout, what_desc, sleep=1):
         max_end_time = datetime.utcnow() + timedelta(seconds=timeout)
 
-        error = None
+        error = ValueError("already timed out with timeout %s" % timeout)
         # We check that there is at least 1 second remaining,
         # since that's the minimum we can specify to a timeout to ping.
         # If we pass 0 seconds as the timeout to ping, it never times out.

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -45,7 +45,7 @@ class ActionModule(ActionBase):
     def do_until_success_or_timeout(self, what, timeout, ping_connect_timeout, what_desc, sleep=1):
         max_end_time = datetime.utcnow() + timedelta(seconds=timeout)
 
-        e = None
+        error = None
         # We check that there is at least 1 second remaining,
         # since that's the minimum we can specify to a timeout to ping.
         # If we pass 0 seconds as the timeout to ping, it never times out.

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -50,8 +50,19 @@ class ActionModule(ActionBase):
         # since that's the minimum we can specify to a timeout to ping.
         # If we pass 0 seconds as the timeout to ping, it never times out.
         while (max_end_time - datetime.utcnow()).seconds > 0:
+            # The effective timeout ensures that we don't exceed the timeout value
+            # as an example without it, if timeout is 10 and connect_timeout is 8,
+            # 2 attempts will be made with a timeout of 8s for a total of 16s, > timeout
+            # so we use effective timeout to have attempts of 8s and 2s < timeout
+            seconds_remaining = (max_end_time - datetime.now()).seconds
+            if ping_connect_timeout == 0:
+                # this prevents the edge case of ping never timing out
+                effective_timeout = seconds_remaining
+            else:
+                effective_timeout = min(ping_connect_timeout, seconds_remaining)
+
             try:
-                what(ping_connect_timeout)
+                what(effective_timeout)
                 if what_desc:
                     display.debug("wait_for_connection: %s success" % what_desc)
                 return

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -42,13 +42,13 @@ class ActionModule(ActionBase):
     DEFAULT_SLEEP = 1
     DEFAULT_TIMEOUT = 600
 
-    def do_until_success_or_timeout(self, what, timeout, connect_timeout, what_desc, sleep=1):
+    def do_until_success_or_timeout(self, what, timeout, ping_connect_timeout, what_desc, sleep=1):
         max_end_time = datetime.utcnow() + timedelta(seconds=timeout)
 
         e = None
         while datetime.utcnow() < max_end_time:
             try:
-                what(connect_timeout)
+                what(ping_connect_timeout)
                 if what_desc:
                     display.debug("wait_for_connection: %s success" % what_desc)
                 return
@@ -76,7 +76,7 @@ class ActionModule(ActionBase):
         result = super(ActionModule, self).run(tmp, task_vars)
         del tmp  # tmp no longer has any effect
 
-        def ping_module_test(connect_timeout):
+        def ping_module_test(ping_connect_timeout):
             ''' Test ping module, if available '''
             display.vvv("wait_for_connection: attempting ping module test")
             # re-run interpreter discovery if we ran it in the first iteration
@@ -87,6 +87,9 @@ class ActionModule(ActionBase):
                 self._connection.reset()
             except AttributeError:
                 pass
+
+            self._connection.set_option('timeout', ping_connect_timeout)
+            self._connection.set_option('retries', False)
 
             ping_result = self._execute_module(module_name='ansible.legacy.ping', module_args=dict(), task_vars=task_vars)
 

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -33,6 +33,11 @@ class TimedOutException(Exception):
     pass
 
 
+def _total_seconds(td):
+    """shim for total_seconds only existing after python 3.2 and after python 2.7"""
+    return (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) / 10**6
+
+
 class ActionModule(ActionBase):
     TRANSFERS_FILES = False
     _VALID_ARGS = frozenset(('connect_timeout', 'delay', 'sleep', 'timeout'))
@@ -49,12 +54,12 @@ class ActionModule(ActionBase):
         # We check that there is at least 1 second remaining,
         # since that's the minimum we can specify to a timeout to ping.
         # If we pass 0 seconds as the timeout to ping, it never times out.
-        while int((max_end_time - datetime.utcnow()).total_seconds()) > 0:
+        while int(_total_seconds(max_end_time - datetime.utcnow())) > 0:
             # The effective timeout ensures that we don't exceed the timeout value
             # as an example without it, if timeout is 10 and connect_timeout is 8,
             # 2 attempts will be made with a timeout of 8s for a total of 16s, > timeout
             # so we use effective timeout to have attempts of 8s and 2s < timeout
-            seconds_remaining = int((max_end_time - datetime.utcnow()).total_seconds())
+            seconds_remaining = int(_total_seconds(max_end_time - datetime.utcnow()))
             if ping_connect_timeout == 0:
                 # this prevents the edge case of ping never timing out
                 effective_timeout = seconds_remaining

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -49,12 +49,12 @@ class ActionModule(ActionBase):
         # We check that there is at least 1 second remaining,
         # since that's the minimum we can specify to a timeout to ping.
         # If we pass 0 seconds as the timeout to ping, it never times out.
-        while (max_end_time - datetime.utcnow()) > timedelta(seconds=0):
+        while int((max_end_time - datetime.utcnow()).total_seconds()) > 0:
             # The effective timeout ensures that we don't exceed the timeout value
             # as an example without it, if timeout is 10 and connect_timeout is 8,
             # 2 attempts will be made with a timeout of 8s for a total of 16s, > timeout
             # so we use effective timeout to have attempts of 8s and 2s < timeout
-            seconds_remaining = (max_end_time - datetime.now()).seconds
+            seconds_remaining = int((max_end_time - datetime.utcnow()).total_seconds())
             if ping_connect_timeout == 0:
                 # this prevents the edge case of ping never timing out
                 effective_timeout = seconds_remaining

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -46,7 +46,10 @@ class ActionModule(ActionBase):
         max_end_time = datetime.utcnow() + timedelta(seconds=timeout)
 
         e = None
-        while datetime.utcnow() < max_end_time:
+        # We check that there is at least 1 second remaining,
+        # since that's the minimum we can specify to a timeout to ping.
+        # If we pass 0 seconds as the timeout to ping, it never times out.
+        while (max_end_time - datetime.utcnow()).seconds > 0:
             try:
                 what(ping_connect_timeout)
                 if what_desc:

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -33,11 +33,6 @@ class TimedOutException(Exception):
     pass
 
 
-def _total_seconds(td):
-    """shim for total_seconds only existing after python 3.2 and after python 2.7"""
-    return (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) / 10**6
-
-
 class ActionModule(ActionBase):
     TRANSFERS_FILES = False
     _VALID_ARGS = frozenset(('connect_timeout', 'delay', 'sleep', 'timeout'))
@@ -54,12 +49,12 @@ class ActionModule(ActionBase):
         # We check that there is at least 1 second remaining,
         # since that's the minimum we can specify to a timeout to ping.
         # If we pass 0 seconds as the timeout to ping, it never times out.
-        while int(_total_seconds(max_end_time - datetime.utcnow())) > 0:
+        while int((max_end_time - datetime.utcnow()).total_seconds()) > 0:
             # The effective timeout ensures that we don't exceed the timeout value
             # as an example without it, if timeout is 10 and connect_timeout is 8,
             # 2 attempts will be made with a timeout of 8s for a total of 16s, > timeout
             # so we use effective timeout to have attempts of 8s and 2s < timeout
-            seconds_remaining = int(_total_seconds(max_end_time - datetime.utcnow()))
+            seconds_remaining = int((max_end_time - datetime.utcnow()).total_seconds())
             if ping_connect_timeout == 0:
                 # this prevents the edge case of ping never timing out
                 effective_timeout = seconds_remaining

--- a/test/integration/targets/wait_for_connection/tasks/main.yml
+++ b/test/integration/targets/wait_for_connection/tasks/main.yml
@@ -28,3 +28,17 @@
     that:
     - invalid_parameter is failed
     - "invalid_parameter.msg == 'Invalid options for wait_for_connection: foo'"
+
+
+- name: Test timeout with unreachable host
+  wait_for_connection:
+    timeout: 3
+    connect_timeout: 1
+  register: timeout_unreachable
+  delegate_to: 198.51.100.2  # address is in TEST-NET-2 (RFC-5737), which should not have hosts in it
+  ignore_errors: true
+
+- name: Verify timeout honoured
+  assert:
+    that:
+      - timeout_unreachable.elapsed < 4

--- a/test/integration/targets/wait_for_connection/tasks/main.yml
+++ b/test/integration/targets/wait_for_connection/tasks/main.yml
@@ -35,23 +35,25 @@
     timeout: 3
     connect_timeout: 1
   register: timeout_unreachable
-  delegate_to: 198.51.100.2  # address is in TEST-NET-2 (RFC-5737), which should not have hosts in it
+  delegate_to: 198.51.100.2 # address is in TEST-NET-2 (RFC-5737), which should not have hosts in it
   ignore_errors: true
 
 - name: Verify timeout honoured
   assert:
     that:
       - timeout_unreachable.elapsed <= 4
+      - timeout_unreachable is failed
 
 - name: Test timeout respects maximum timeout
   wait_for_connection:
     timeout: 7
     connect_timeout: 4
   register: maximum_timeout
-  delegate_to: 198.51.100.2  # address is in TEST-NET-2 (RFC-5737), which should not have hosts in it
+  delegate_to: 198.51.100.2 # address is in TEST-NET-2 (RFC-5737), which should not have hosts in it
   ignore_errors: true
 
 - name: Verify timeout honoured
   assert:
     that:
       - maximum_timeout.elapsed <= 7
+      - maximum_timeout is failed

--- a/test/integration/targets/wait_for_connection/tasks/main.yml
+++ b/test/integration/targets/wait_for_connection/tasks/main.yml
@@ -41,4 +41,17 @@
 - name: Verify timeout honoured
   assert:
     that:
-      - timeout_unreachable.elapsed < 4
+      - timeout_unreachable.elapsed <= 4
+
+- name: Test timeout respects maximum timeout
+  wait_for_connection:
+    timeout: 7
+    connect_timeout: 4
+  register: maximum_timeout
+  delegate_to: 198.51.100.2  # address is in TEST-NET-2 (RFC-5737), which should not have hosts in it
+  ignore_errors: true
+
+- name: Verify timeout honoured
+  assert:
+    that:
+      - maximum_timeout.elapsed <= 7


### PR DESCRIPTION
##### SUMMARY

fixes #74237

Sets the `timeout` and disables `retries` on the connection.
Also improves the timeout behaviour so it won't exceed the maximum timeout specified.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
wait_for_connection

##### ADDITIONAL INFORMATION
Before:
```sh
time ansible -i 10.99.99.99, -m wait_for_connection -a '{{ {"timeout": 3, "connect_timeout": 1} }}' all
10.99.99.99 | FAILED! => {
    "changed": false,
    "elapsed": 11,
    "msg": "timed out waiting for ping module test: Failed to connect to the host via ssh: ssh: connect to host 10.99.99.99 port 22: Connection timed out"
}
Command exited with non-zero status 2
2.42user 0.20system 0:12.24elapsed 21%CPU (0avgtext+0avgdata 46592maxresident)k
0inputs+16outputs (0major+30820minor)pagefaults 0swaps
```
After:
```sh
time ansible -i 10.99.99.99, -m wait_for_connection -a '{{ {"timeout": 3, "connect_timeout": 1} }}' all
10.99.99.99 | FAILED! => {
    "changed": false,
    "elapsed": 2,
    "msg": "timed out waiting for ping module test: Failed to connect to the host via ssh: ssh: connect to host 10.99.99.99 port 22: Connection timed out"
}
Command exited with non-zero status 2
1.30user 0.14system 0:03.35elapsed 43%CPU (0avgtext+0avgdata 46864maxresident)k
41912inputs+16outputs (117major+30787minor)pagefaults 0swaps
```
We can see that the elapsed time no longer exceeds the timeout