### PR TITLE
user module password expiration fixes

### DIFF
--- a/changelogs/fragments/75017-user-password-expiry.yml
+++ b/changelogs/fragments/75017-user-password-expiry.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - can set password_expiry_min to 0
+  - can set password_expiry_max to 0
+  - can set both password_expiry_min and password_expiry_max at the same time
+  - checks the output from `chage` calls to see if the task failed

--- a/changelogs/fragments/75017-user-password-expiry.yml
+++ b/changelogs/fragments/75017-user-password-expiry.yml
@@ -1,5 +1,3 @@
 bugfixes:
-  - can set password_expiry_min to 0
-  - can set password_expiry_max to 0
-  - can set both password_expiry_min and password_expiry_max at the same time
-  - checks the output from `chage` calls to see if the task failed
+  - user - allow ``password_expiry_min`` and ``password_expiry_min`` to be set to ``0`` (https://github.com/ansible/ansible/issues/75017)
+  - user - allow password min and max to be set at the same time (https://github.com/ansible/ansible/issues/75017)

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -3207,27 +3207,25 @@ def main():
 
         # deal with password expire max
         if user.password_expire_max is not None:
-            if user.user_exists():
-                (rc, out, err) = user.set_password_expire_max()
-                if rc is None:
-                    pass  # target state reached, nothing to do
+            (rc, out, err) = user.set_password_expire_max()
+            if rc is None:
+                pass  # target state reached, nothing to do
+            else:
+                if rc != 0:
+                    module.fail_json(name=user.name, msg=err, rc=rc)
                 else:
-                    if rc != 0:
-                        module.fail_json(name=user.name, msg=err, rc=rc)
-                    else:
-                        result['changed'] = True
+                    result['changed'] = True
 
         # deal with password expire min
         if user.password_expire_min is not None:
-            if user.user_exists():
-                (rc, out, err) = user.set_password_expire_min()
-                if rc is None:
-                    pass  # target state reached, nothing to do
+            (rc, out, err) = user.set_password_expire_min()
+            if rc is None:
+                pass  # target state reached, nothing to do
+            else:
+                if rc != 0:
+                    module.fail_json(name=user.name, msg=err, rc=rc)
                 else:
-                    if rc != 0:
-                        module.fail_json(name=user.name, msg=err, rc=rc)
-                    else:
-                        result['changed'] = True
+                    result['changed'] = True
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1055,10 +1055,11 @@ class User(object):
         cmd.append(self.password_expire_max)
         cmd.append(self.name)
         if self.password_expire_max == spwd.getspnam(self.name).sp_max:
-            self.module.exit_json(changed=False)
+            return (0, '', '')
+            # self.module.exit_json(changed=False)
         else:
-            self.execute_command(cmd)
-            self.module.exit_json(changed=True)
+            return self.execute_command(cmd)
+            # self.module.exit_json(changed=True)
 
     def set_password_expire_min(self):
         command_name = 'chage'
@@ -1067,10 +1068,11 @@ class User(object):
         cmd.append(self.password_expire_min)
         cmd.append(self.name)
         if self.password_expire_min == spwd.getspnam(self.name).sp_min:
-            self.module.exit_json(changed=False)
+            return (0, '', '')
+            # self.module.exit_json(changed=False)
         else:
-            self.execute_command(cmd)
-            self.module.exit_json(changed=True)
+            return self.execute_command(cmd)
+            # self.module.exit_json(changed=True)
 
     def user_password(self):
         passwd = ''

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -3205,29 +3205,29 @@ def main():
             result['ssh_key_file'] = user.get_ssh_key_path()
             result['ssh_public_key'] = user.get_ssh_public_key()
 
-    # deal with password expire max
-    if user.password_expire_max is not None:
-        if user.user_exists():
-            (rc, out, err) = user.set_password_expire_max()
-            if rc is None:
-                pass  # target state reached, nothing to do
-            else:
-                if rc != 0:
-                    module.fail_json(name=user.name, msg=err, rc=rc)
+        # deal with password expire max
+        if user.password_expire_max is not None:
+            if user.user_exists():
+                (rc, out, err) = user.set_password_expire_max()
+                if rc is None:
+                    pass  # target state reached, nothing to do
                 else:
-                    result['changed'] = True
+                    if rc != 0:
+                        module.fail_json(name=user.name, msg=err, rc=rc)
+                    else:
+                        result['changed'] = True
 
-    # deal with password expire min
-    if user.password_expire_min is not None:
-        if user.user_exists():
-            (rc, out, err) = user.set_password_expire_min()
-            if rc is None:
-                pass  # target state reached, nothing to do
-            else:
-                if rc != 0:
-                    module.fail_json(name=user.name, msg=err, rc=rc)
+        # deal with password expire min
+        if user.password_expire_min is not None:
+            if user.user_exists():
+                (rc, out, err) = user.set_password_expire_min()
+                if rc is None:
+                    pass  # target state reached, nothing to do
                 else:
-                    result['changed'] = True
+                    if rc != 0:
+                        module.fail_json(name=user.name, msg=err, rc=rc)
+                    else:
+                        result['changed'] = True
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -3208,12 +3208,12 @@ def main():
             result['ssh_public_key'] = user.get_ssh_public_key()
 
     # deal with password expire max
-    if user.password_expire_max:
+    if user.password_expire_max is not None:
         if user.user_exists():
             user.set_password_expire_max()
 
     # deal with password expire min
-    if user.password_expire_min:
+    if user.password_expire_min is not None:
         if user.user_exists():
             user.set_password_expire_min()
 

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -3205,9 +3205,8 @@ def main():
             result['ssh_key_file'] = user.get_ssh_key_path()
             result['ssh_public_key'] = user.get_ssh_public_key()
 
-        # deal with password expire max
-        if user.password_expire_max is not None:
-            (rc, out, err) = user.set_password_expire_max()
+        def _handle_set_password_expire_return(command_return):
+            (rc, out, err) = command_return
             if rc is None:
                 pass  # target state reached, nothing to do
             else:
@@ -3216,16 +3215,10 @@ def main():
                 else:
                     result['changed'] = True
 
-        # deal with password expire min
+        if user.password_expire_max is not None:
+            _handle_set_password_expire_return(user.set_password_expire_max())
         if user.password_expire_min is not None:
-            (rc, out, err) = user.set_password_expire_min()
-            if rc is None:
-                pass  # target state reached, nothing to do
-            else:
-                if rc != 0:
-                    module.fail_json(name=user.name, msg=err, rc=rc)
-                else:
-                    result['changed'] = True
+            _handle_set_password_expire_return(user.set_password_expire_min())
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -3208,12 +3208,26 @@ def main():
     # deal with password expire max
     if user.password_expire_max is not None:
         if user.user_exists():
-            user.set_password_expire_max()
+            (rc, out, err) = user.set_password_expire_max()
+            if rc is None:
+                pass  # target state reached, nothing to do
+            else:
+                if rc != 0:
+                    module.fail_json(name=user.name, msg=err, rc=rc)
+                else:
+                    result['changed'] = True
 
     # deal with password expire min
     if user.password_expire_min is not None:
         if user.user_exists():
-            user.set_password_expire_min()
+            (rc, out, err) = user.set_password_expire_min()
+            if rc is None:
+                pass  # target state reached, nothing to do
+            else:
+                if rc != 0:
+                    module.fail_json(name=user.name, msg=err, rc=rc)
+                else:
+                    result['changed'] = True
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1055,11 +1055,9 @@ class User(object):
         cmd.append(self.password_expire_max)
         cmd.append(self.name)
         if self.password_expire_max == spwd.getspnam(self.name).sp_max:
-            return (0, '', '')
-            # self.module.exit_json(changed=False)
+            return (None, '', '')
         else:
             return self.execute_command(cmd)
-            # self.module.exit_json(changed=True)
 
     def set_password_expire_min(self):
         command_name = 'chage'
@@ -1068,11 +1066,9 @@ class User(object):
         cmd.append(self.password_expire_min)
         cmd.append(self.name)
         if self.password_expire_min == spwd.getspnam(self.name).sp_min:
-            return (0, '', '')
-            # self.module.exit_json(changed=False)
+            return (None, '', '')
         else:
             return self.execute_command(cmd)
-            # self.module.exit_json(changed=True)
 
     def user_password(self):
         passwd = ''

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -21,6 +21,11 @@
   meta: end_host
   when: ansible_distribution == 'Alpine'
 
+- name: ensure output directory exists
+  file:
+    dest: "{{ output_dir }}"
+    state: directory
+
 - import_tasks: test_create_user.yml
 - import_tasks: test_create_system_user.yml
 - import_tasks: test_create_user_uid.yml

--- a/test/integration/targets/user/tasks/test_expires_min_max.yml
+++ b/test/integration/targets/user/tasks/test_expires_min_max.yml
@@ -53,3 +53,21 @@
         that:
           - ansible_facts.getent_shadow['ansibulluser'][2] == '5'
           - ansible_facts.getent_shadow['ansibulluser'][3] == '10'
+
+    - name: Set min and max at the same time
+      user:
+        name: ansibulluser
+        # also checks that assigning 0 works
+        password_expire_min: 0
+        password_expire_max: 0
+
+    - name: Get shadow data for ansibulluser
+      getent:
+        database: shadow
+        key: ansibulluser
+
+    - name: Ensure password expiration was set properly
+      assert:
+        that:
+          - ansible_facts.getent_shadow['ansibulluser'][2] == '0'
+          - ansible_facts.getent_shadow['ansibulluser'][3] == '0'


### PR DESCRIPTION
##### SUMMARY
Fixes #75017

- can set password_expiry_min to 0 (any time)
- can set password_expire_max to 0 (always, seems mean)
bonus:
- can set both password_expiry_min *and* password_expiry_max at the same time
- checks the output of `chage` calls to see if the task failed


##### ISSUE TYPE
Bugfix Pull Request


##### COMPONENT NAME
ansible.builtin.user

##### ADDITIONAL INFORMATION

This time with the right issue number! so now the other issue doesn't have a reference to an irrelevant PR. Sorry again about that.