### PR TITLE
[stable-2.10] allow env to override unspecified unsafe_writes (#73282)

### DIFF
--- a/changelogs/fragments/unsafe_writes_env.yml
+++ b/changelogs/fragments/unsafe_writes_env.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Allow unsafe_writes to be set on target via env var, for those targets that need a blanket setting.

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -237,6 +237,15 @@ _literal_eval = literal_eval
 # is an internal implementation detail
 _ANSIBLE_ARGS = None
 
+
+def env_fallback(*args, **kwargs):
+    ''' Load value from environment '''
+    for arg in args:
+        if arg in os.environ:
+            return os.environ[arg]
+    raise AnsibleFallbackNotFound
+
+
 FILE_COMMON_ARGUMENTS = dict(
     # These are things we want. About setting metadata (mode, ownership, permissions in general) on
     # created files (these are used by set_fs_attributes_if_different and included in
@@ -249,7 +258,7 @@ FILE_COMMON_ARGUMENTS = dict(
     selevel=dict(type='str'),
     setype=dict(type='str'),
     attributes=dict(type='str', aliases=['attr']),
-    unsafe_writes=dict(type='bool', default=False),  # should be available to any module using atomic_move
+    unsafe_writes=dict(type='bool', default=False, fallback=(env_fallback, ['ANSIBLE_UNSAFE_WRITES'])),  # should be available to any module using atomic_move
 )
 
 PASSWD_ARG_RE = re.compile(r'^[-]{0,2}pass[-]?(word|wd)?')
@@ -633,14 +642,6 @@ def _load_params():
         print('\n{"msg": "Error: Module unable to locate ANSIBLE_MODULE_ARGS in json data from stdin.  Unable to figure out what parameters were passed", '
               '"failed": true}')
         sys.exit(1)
-
-
-def env_fallback(*args, **kwargs):
-    ''' Load value from environment '''
-    for arg in args:
-        if arg in os.environ:
-            return os.environ[arg]
-    raise AnsibleFallbackNotFound
 
 
 def missing_required_lib(library, reason=None, url=None):

--- a/test/integration/targets/unsafe_writes/basic.yml
+++ b/test/integration/targets/unsafe_writes/basic.yml
@@ -38,7 +38,7 @@
                 - copy_without is failed
 
           - name: test overwriting file with unsafe
-            copy: content=NEW dest={{testufile}} unsafe_writes=True
+            copy: content=NEWNOREALLY dest={{testufile}} unsafe_writes=True
             register: copy_with
 
           - name: ensure we properly changed
@@ -46,6 +46,21 @@
               that:
                 - copy_with is changed
 
+          - name: test fallback env var
+            when: lookup('env', 'ANSIBLE_UNSAFE_WRITES') not in ('', None)
+            vars:
+              env_enabled: "{{lookup('env', 'ANSIBLE_UNSAFE_WRITES')|bool}}"
+            block:
+            - name: test overwriting file with unsafe depending on fallback environment setting
+              copy: content=NEWBUTNOTDIFFERENT dest={{testufile}}
+              register: copy_with_env
+              ignore_errors: True
+
+            - name: ensure we properly follow env var
+              assert:
+                msg: "Failed with envvar: {{env_enabled}}, due AUW: to {{q('env', 'ANSIBLE_UNSAFE_WRITES')}}"
+                that:
+                  - env_enabled and copy_with_env is changed or not env_enabled and copy_with_env is failed
       always:
       - name: remove immutable flag from dir to prevent issues with cleanup
         file: path={{testudir}} state=directory attributes="-i"

--- a/test/integration/targets/unsafe_writes/runme.sh
+++ b/test/integration/targets/unsafe_writes/runme.sh
@@ -2,4 +2,11 @@
 
 set -eux
 
+# test w/o fallback env var
 ansible-playbook basic.yml -i ../../inventory -e "output_dir=${OUTPUT_DIR}" "$@"
+
+# test enabled fallback env var
+ANSIBLE_UNSAFE_WRITES=1 ansible-playbook basic.yml -i ../../inventory -e "output_dir=${OUTPUT_DIR}" "$@"
+
+# test disnabled fallback env var
+ANSIBLE_UNSAFE_WRITES=0 ansible-playbook basic.yml -i ../../inventory -e "output_dir=${OUTPUT_DIR}" "$@"


### PR DESCRIPTION
* allow env var for fallback value for unspecified unsafe_writes
(cherry picked from commit c7d4acc)


Co-authored-by: Brian Coca <bcoca@users.noreply.github.com>