### PR TITLE
[validate-modules] Make sure self doesn't end up in fake.args

### DIFF
--- a/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/module_args.py
+++ b/test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/module_args.py
@@ -57,7 +57,12 @@ class _FakeAnsibleModuleInit:
         self.called = False
 
     def __call__(self, *args, **kwargs):
-        self.args = args
+        if args and isinstance(args[0], AnsibleModule):
+            # Make sure, due to creative calling, that we didn't end up with
+            # ``self`` in ``args``
+            self.args = args[1:]
+        else:
+            self.args = args
         self.kwargs = kwargs
         self.called = True
         raise AnsibleModuleCallError('AnsibleModuleCallError')


### PR DESCRIPTION
##### SUMMARY
See https://dashboard.zuul.ansible.com/t/ansible/build/517b65efa1064f68a5338a2ddd9935a2/log/job-output.txt#629

This was exposed by https://github.com/ansible/ansible/pull/75332

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/lib/ansible_test/_data/sanity/validate-modules/validate_modules/module_args.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
