### PR TITLE
Docs: Add Matrix as a chat option

### DIFF
--- a/docs/docsite/rst/community/code_of_conduct.rst
+++ b/docs/docsite/rst/community/code_of_conduct.rst
@@ -23,7 +23,7 @@ anti-harassment policy. We expect organizers to enforce these guidelines through
 and we expect attendees, speakers, sponsors, and volunteers to help ensure a safe
 environment for our whole community. Specifically, this Code of Conduct covers
 participation in all Ansible-related forums and mailing lists, code and documentation
-contributions, public IRC channels, private correspondence, and public meetings.
+contributions, public chat channels (Matrix, IRC), private correspondence, and public meetings.
 
 Ansible community members are...
 
@@ -69,7 +69,7 @@ encourage our users to ask early and ask often. Rather than asking whether you c
 question (the answer is always yes!), instead, simply ask your question. You are
 encouraged to provide as many specifics as possible. Code snippets in the form of Gists or
 other paste site links are almost always needed in order to get the most helpful answers.
-Refrain from pasting multiple lines of code directly into the IRC channels - instead use
+Refrain from pasting multiple lines of code directly into the chat channels - instead use
 gist.github.com or another paste site to provide code snippets.
 
 **Helpful**
@@ -116,7 +116,7 @@ Policy violations
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by
 contacting `codeofconduct@ansible.com <mailto:codeofconduct@ansible.com>`_, to any channel
-operator in the community IRC channels, or to the local organizers of an event. Meetup
+operator in the community chat (Matrix, IRC) channels, or to the local organizers of an event. Meetup
 organizers are encouraged to prominently display points of contact for reporting unacceptable
 behavior at local events.
 

--- a/docs/docsite/rst/community/code_of_conduct.rst
+++ b/docs/docsite/rst/community/code_of_conduct.rst
@@ -23,7 +23,7 @@ anti-harassment policy. We expect organizers to enforce these guidelines through
 and we expect attendees, speakers, sponsors, and volunteers to help ensure a safe
 environment for our whole community. Specifically, this Code of Conduct covers
 participation in all Ansible-related forums and mailing lists, code and documentation
-contributions, public chat channels (Matrix, IRC), private correspondence, and public meetings.
+contributions, public chat (Matrix, IRC), private correspondence, and public meetings.
 
 Ansible community members are...
 
@@ -115,8 +115,7 @@ Policy violations
 =================
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by
-contacting `codeofconduct@ansible.com <mailto:codeofconduct@ansible.com>`_, to any channel
-operator in the community chat (Matrix, IRC) channels, or to the local organizers of an event. Meetup
+contacting `codeofconduct@ansible.com <mailto:codeofconduct@ansible.com>`_, to anyone with administrative power in community chat (Admins or Moderators on Matrix, ops on IRC), or to the local organizers of an event. Meetup
 organizers are encouraged to prominently display points of contact for reporting unacceptable
 behavior at local events.
 

--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -42,7 +42,7 @@ Ansible community on Matrix
 The Ansible community maintains its own Matrix homeserver at ``ansible.im``. To join the community using Matrix, you need two things:
 
 * a Matrix account (from matrix.org or any other Matrix homeserver)
-* a `Matrix client <https://matrix.org/clients/>`_
+* a `Matrix client <https://matrix.org/clients/>`_ (we recommend `Element Webchat <https://app.element.io>`_)
 
 Matrix chat supports:
 
@@ -86,7 +86,7 @@ General channels
 Working groups
 --------------
 
-Many of our community `Working Groups <https://github.com/ansible/community/wiki#working-groups>`_ meet on Matrix/IRC channels. If you want to get involved in a working group, join the channel where it meets or comment on the agenda.
+Many of our community `Working Groups <https://github.com/ansible/community/wiki#working-groups>`_ meet in chat. If you want to get involved in a working group, join the Matrix room or IRC channel where it meets or comment on the agenda.
 
 - `Amazon (AWS) Working Group <https://github.com/ansible/community/wiki/AWS>`_ - ``#ansible-aws``
 - `Ansible Lockdown Working Group <https://github.com/ansible/community/wiki/Lockdown>`_ | `gh/ansible/ansible-lockdown <https://github.com/ansible/ansible-lockdown>`_ - ``#ansible-lockdown``- Security playbooks/roles

--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -10,33 +10,64 @@ Communicating
 Code of Conduct
 ===============
 
-Please read and understand the :ref:`code_of_conduct`.
+All communication and interactions in the Ansible Community are governed by our :ref:`code_of_conduct`. Please read and understand it!
 
-Mailing list information
-========================
+Asking questions over email
+===========================
 
-Ansible has several mailing lists.  Your first post to the mailing list will be moderated (to reduce spam), so please allow up to a day or so for your first post to appear.
+If you want to keep up with Ansible news, need help, or have a question, you can use one of the Ansible mailing lists. Each list covers a particular topic. Read the descriptions here to find the best list for your question.
+
+Your first post to the mailing list will be moderated (to reduce spam), so please allow up to a day or so for your first post to appear.
 
 * `Ansible Announce list <https://groups.google.com/forum/#!forum/ansible-announce>`_ is a read-only list that shares information about new releases of Ansible, and also rare infrequent event information, such as announcements about an upcoming AnsibleFest, which is our official conference series. Worth subscribing to!
 * `Ansible AWX List <https://groups.google.com/forum/#!forum/awx-project>`_ is for `Ansible AWX <https://github.com/ansible/awx>`_
-* `Ansible Development List <https://groups.google.com/forum/#!forum/ansible-devel>`_ is for learning how to develop on Ansible, asking about prospective feature design, or discussions about extending ansible or features in progress.
+* `Ansible Development List <https://groups.google.com/forum/#!forum/ansible-devel>`_ is for questions about developing Ansible modules (mostly in Python), fixing bugs in the Ansible core code, asking about prospective feature design, or discussions about extending Ansible or features in progress.
 * `Ansible Lockdown List <https://groups.google.com/forum/#!forum/ansible-lockdown>`_ is for all things related to Ansible Lockdown projects, including DISA STIG automation and CIS Benchmarks.
 * `Ansible Outreach List <https://groups.google.com/forum/#!forum/ansible-outreach>`_ help with promoting Ansible and `Ansible Meetups <https://ansible.meetup.com/>`_
-* `Ansible Project List <https://groups.google.com/forum/#!forum/ansible-project>`_ is for sharing Ansible tips, answering questions, and general user discussion.
+* `Ansible Project List <https://groups.google.com/forum/#!forum/ansible-project>`_ is for sharing Ansible tips, answering questions about playbooks and roles, and general user discussion.
 * `Molecule Discussions <https://github.com/ansible-community/molecule/discussions>`_ is designed to aid with the development and testing of Ansible roles with Molecule.
 
-To subscribe to a group from a non-Google account, you can send an email to the subscription address requesting the subscription. For example: ``ansible-devel+subscribe@googlegroups.com``
+The Ansible mailing lists are hosted on Google, but you do not need a Google account to subscribe. To subscribe to a group from a non-Google account, send an email to the subscription address requesting the subscription. For example: ``ansible-devel+subscribe@googlegroups.com``.
 
 .. _communication_irc:
 
-IRC channels
-============
+Real-time chat
+==============
 
-Ansible has several IRC channels on `irc.libera.chat <https://libera.chat/>`_.
+For real-time interactions, conversations in the Ansible community happen over two chat protocols: Matrix and IRC. We maintain a bridge between Matrix and IRC, so you can choose whichever protocol you prefer. All channels exist in both places. Join a channel any time to ask questions, participate in a Working Group meeting, or just say hello.
 
-Our IRC channels may require you to register your nickname. If you receive an error when you connect, see `libera.chat's Nickname Registration guide <https://libera.chat/guides/registration>`_ for instructions.
+Ansible community on Matrix
+---------------------------
 
-To find all ``ansible`` specific channels on the libera.chat network, use the following command in your IRC client::
+The Ansible community maintains its own Matrix homeserver at ``ansible.im``. To join the community using Matrix, you need two things:
+
+* a Matrix account (from matrix.org or any other Matrix homeserver)
+* a `Matrix client <https://matrix.org/clients/>`_
+
+Matrix chat supports:
+
+* persistence (when you log on, you see all messages since you last logged off)
+* edits (so you can fix your typos)
+* replies to individual users
+* reactions/emojis
+* bridging to IRC
+* no line limits
+* images
+
+Ansible community on IRC
+------------------------
+
+The Ansible community maintains several IRC channels on `irc.libera.chat <https://libera.chat/>`_. To join the community using IRC, you need one thing:
+
+* an IRC client
+
+IRC chat supports:
+
+* no persistence (you only see messages when you are logged on, unless you add a bouncer)
+* simple text interface
+* bridging from Matrix
+
+Our IRC channels may require you to register your IRC nickname. If you receive an error when you connect, see `libera.chat's Nickname Registration guide <https://libera.chat/guides/registration>`_ for instructions. To find all ``ansible`` specific channels on the libera.chat network, use the following command in your IRC client::
 
    /msg alis LIST #ansible* -min 5
 
@@ -55,7 +86,7 @@ General channels
 Working groups
 --------------
 
-Many of our community `Working Groups <https://github.com/ansible/community/wiki#working-groups>`_ meet on libera.chat IRC channels. If you want to get involved in a working group, join the channel where it meets or comment on the agenda.
+Many of our community `Working Groups <https://github.com/ansible/community/wiki#working-groups>`_ meet on Matrix/IRC channels. If you want to get involved in a working group, join the channel where it meets or comment on the agenda.
 
 - `Amazon (AWS) Working Group <https://github.com/ansible/community/wiki/AWS>`_ - ``#ansible-aws``
 - `Ansible Lockdown Working Group <https://github.com/ansible/community/wiki/Lockdown>`_ | `gh/ansible/ansible-lockdown <https://github.com/ansible/ansible-lockdown>`_ - ``#ansible-lockdown``- Security playbooks/roles
@@ -90,17 +121,15 @@ Regional and Language-specific channels
 - ``#ansible-fr`` - Channel for French speaking Ansible community.
 - ``#ansiblezh`` - Channel for Zurich/Swiss Ansible community.
 
-IRC meetings
-------------
+Meetings on chat
+----------------
 
-The Ansible community holds regular IRC meetings on various topics, and anyone who is interested is invited to
-participate. For more information about Ansible meetings, consult the `meeting schedule and agenda page <https://github.com/ansible/community/blob/master/meetings/README.md>`_.
+The Ansible community holds regular meetings on various topics on Matrix/IRC, and anyone who is interested is invited to participate. For more information about Ansible meetings, consult the `meeting schedule and agenda page <https://github.com/ansible/community/blob/master/meetings/README.md>`_.
 
 Ansible Automation Platform support questions
 =============================================
 
-Red Hat Ansible `Automation Platform <https://www.ansible.com/products/automation-platform>`_ is a subscription that contains support, certified content, and tooling for Ansible including
-content management, a controller, UI and REST API.
+Red Hat Ansible `Automation Platform <https://www.ansible.com/products/automation-platform>`_ is a subscription that contains support, certified content, and tooling for Ansible including content management, a controller, UI and REST API.
 
 If you have a question about Ansible Automation Platform, visit `Red Hat support <https://access.redhat.com/products/red-hat-ansible-automation-platform/>`_ rather than using the IRC channel or the general project mailing list.
 
@@ -113,4 +142,3 @@ If you have any questions or content you would like to share, please reach out t
 Read past issues `here <https://github.com/ansible/community/wiki/News>`_.
 
 `Subscribe <https://eepurl.com/gZmiEP>`_ to receive it.
-

--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -131,7 +131,7 @@ Ansible Automation Platform support questions
 
 Red Hat Ansible `Automation Platform <https://www.ansible.com/products/automation-platform>`_ is a subscription that contains support, certified content, and tooling for Ansible including content management, a controller, UI and REST API.
 
-If you have a question about Ansible Automation Platform, visit `Red Hat support <https://access.redhat.com/products/red-hat-ansible-automation-platform/>`_ rather than using the IRC channel or the general project mailing list.
+If you have a question about Ansible Automation Platform, visit `Red Hat support <https://access.redhat.com/products/red-hat-ansible-automation-platform/>`_ rather than using a chat channel or the general project mailing list.
 
 The Bullhorn
 ============

--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -213,7 +213,7 @@ Unfortunately, leftover rST-files from previous document-generating can occasion
 Joining the documentation working group
 =======================================
 
-The Documentation Working Group (DaWGs) meets weekly on Tuesdays on the #ansible-docs chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_). For more information, including links to our agenda and a calendar invite, please visit the `working group page in the community repo <https://github.com/ansible/community/wiki/Docs>`_.
+The Documentation Working Group (DaWGs) meets weekly on Tuesdays in the Docs chat (using `Matrix <https://matrix.to/#/#docs:ansible.im>`_ or using IRC at `irc.libera.chat <https://libera.chat/>`_). For more information, including links to our agenda and a calendar invite, please visit the `working group page in the community repo <https://github.com/ansible/community/wiki/Docs>`_.
 
 .. seealso::
    :ref:`More about testing module documentation <testing_module_documentation>`

--- a/docs/docsite/rst/community/documentation_contributions.rst
+++ b/docs/docsite/rst/community/documentation_contributions.rst
@@ -213,7 +213,7 @@ Unfortunately, leftover rST-files from previous document-generating can occasion
 Joining the documentation working group
 =======================================
 
-The Documentation Working Group (DaWGs) meets weekly on Tuesdays on the #ansible-docs channel on the `libera.chat IRC network <https://libera.chat/>`_. For more information, including links to our agenda and a calendar invite, please visit the `working group page in the community repo <https://github.com/ansible/community/wiki/Docs>`_.
+The Documentation Working Group (DaWGs) meets weekly on Tuesdays on the #ansible-docs chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_). For more information, including links to our agenda and a calendar invite, please visit the `working group page in the community repo <https://github.com/ansible/community/wiki/Docs>`_.
 
 .. seealso::
    :ref:`More about testing module documentation <testing_module_documentation>`

--- a/docs/docsite/rst/community/index.rst
+++ b/docs/docsite/rst/community/index.rst
@@ -24,7 +24,7 @@ Getting started
 * I would like to know what I am agreeing to when I contribute to Ansible. Does Ansible have a :ref:`contributor_license_agreement`?
 * I would like to contribute but I am not sure how. Are there :ref:`easy ways to contribute <how_can_i_help>`?
 * I want to talk to other Ansible users. How do I find an `Ansible Meetup near me <https://www.meetup.com/topics/ansible/>`_?
-* I have a question. Which :ref:`Ansible email lists and IRC channels <communication>` will help me find answers?
+* I have a question. Which :ref:`Ansible email lists and chat channels <communication>` will help me find answers?
 * I want to learn more about Ansible. What can I do?
 
   * `Read books <https://www.ansible.com/resources/ebooks>`_.

--- a/docs/docsite/rst/community/reporting_bugs_and_features.rst
+++ b/docs/docsite/rst/community/reporting_bugs_and_features.rst
@@ -20,9 +20,9 @@ Ansible practices responsible disclosure - if this is a security-related bug, em
 Bugs in ansible-core
 --------------------
 
-If you find a bug that affects multiple plugins, a plugin that remained in the ansible/ansible repo, or the overall functioning of Ansible, report it to `github.com/ansible/ansible/issues <https://github.com/ansible/ansible/issues>`_. You need a free GitHub account.  Before reporting a bug, use the bug/issue search to see if the issue has already been reported. If you are not sure if something is a bug yet, you can report the behavior on the :ref:`mailing list or IRC first <communication>`.
+If you find a bug that affects multiple plugins, a plugin that remained in the ansible/ansible repo, or the overall functioning of Ansible, report it to `github.com/ansible/ansible/issues <https://github.com/ansible/ansible/issues>`_. You need a free GitHub account.  Before reporting a bug, use the bug/issue search to see if the issue has already been reported. If you are not sure if something is a bug yet, you can report the behavior on the :ref:`mailing list or community chat first <communication>`.
 
-Do not open issues for "how do I do this" type questions.  These are great topics for IRC or the mailing list, where things are likely to be more of a discussion.
+Do not open issues for "how do I do this" type questions.  These are great topics for community chat channels or a mailing list, where things are likely to be more of a discussion.
 
 If you find a bug, open the issue yourself to ensure we have a record of it. Do not rely on someone else in the community to file the bug report for you. We have created an issue template, which saves time and helps us help everyone with their issues more quickly. Please fill it out as completely and as accurately as possible:
 
@@ -48,7 +48,7 @@ Many bugs only affect a single module or plugin. If you find a bug that affects 
   #. Click on the Issue Tracker link for that collection.
   #. Follow the contributor guidelines or instructions in the collection repo.
 
-If you are not sure whether a bug is in ansible-core or in a collection, you can report the behavior on the :ref:`mailing list or IRC first <communication>`.
+If you are not sure whether a bug is in ansible-core or in a collection, you can report the behavior on the :ref:`mailing list or community chat channel first <communication>`.
 
 .. _request_features:
 

--- a/docs/docsite/rst/dev_guide/developing_api.rst
+++ b/docs/docsite/rst/dev_guide/developing_api.rst
@@ -44,4 +44,4 @@ command line tools (``lib/ansible/cli/``) is `available on GitHub <https://githu
    `Development Mailing List <https://groups.google.com/group/ansible-devel>`_
        Mailing list for development topics
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_api.rst
+++ b/docs/docsite/rst/dev_guide/developing_api.rst
@@ -43,5 +43,5 @@ command line tools (``lib/ansible/cli/``) is `available on GitHub <https://githu
        How to develop plugins
    `Development Mailing List <https://groups.google.com/group/ansible-devel>`_
        Mailing list for development topics
-   `irc.libera.chat <https://libera.chat>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -44,5 +44,5 @@ For instructions on developing modules, see :ref:`developing_modules_general`.
        Current development status of community collections and FAQ
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
-   `irc.libera.chat <https://libera.chat>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -45,4 +45,4 @@ For instructions on developing modules, see :ref:`developing_modules_general`.
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_collections_changelogs.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_changelogs.rst
@@ -76,5 +76,5 @@ If your collection is part of Ansible, use one of the following three options  t
        Guidelines for contributing to selected collections
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+	 :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_collections_changelogs.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_changelogs.rst
@@ -76,5 +76,5 @@ If your collection is part of Ansible, use one of the following three options  t
        Guidelines for contributing to selected collections
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
-	 :ref:`communication_irc`
-       How to join ansible chat channels
+   :ref:`communication_irc`
+       How to join Ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_collections_contributing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_contributing.rst
@@ -55,5 +55,5 @@ You can test your changes by using this checkout of ``community.general`` in pla
        Guidelines for contributing to selected collections
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_collections_contributing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_contributing.rst
@@ -56,4 +56,4 @@ You can test your changes by using this checkout of ``community.general`` in pla
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_collections_creating.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_creating.rst
@@ -54,4 +54,4 @@ To learn more about the ``ansible-galaxy`` command-line tool, see the :ref:`ansi
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_collections_creating.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_creating.rst
@@ -53,5 +53,5 @@ To learn more about the ``ansible-galaxy`` command-line tool, see the :ref:`ansi
        Directories and files included in the collection skeleton
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
@@ -296,5 +296,5 @@ After Galaxy uploads and accepts a collection, the website shows you the **My Im
        Table of fields used in the :file:`galaxy.yml` file 
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
@@ -297,4 +297,4 @@ After Galaxy uploads and accepts a collection, the website shows you the **My Im
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_collections_migrating.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_migrating.rst
@@ -133,4 +133,4 @@ Ansibulbot will know how to redirect existing issues and PRs to the new repo. Th
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_collections_migrating.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_migrating.rst
@@ -132,5 +132,5 @@ Ansibulbot will know how to redirect existing issues and PRs to the new repo. Th
        Guidelines for contributing to selected collections
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_collections_shared.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_shared.rst
@@ -90,5 +90,5 @@ You can use git repositories for collection dependencies during local developmen
        Guidelines for contributing to selected collections
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_collections_shared.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_shared.rst
@@ -91,4 +91,4 @@ You can use git repositories for collection dependencies during local developmen
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_collections_structure.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_structure.rst
@@ -273,4 +273,4 @@ A collection can store some additional metadata in a ``runtime.yml`` file in the
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
         The development mailing list
    :ref:`communication_irc`
-        How to join ansible chat channels
+        How to join Ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_collections_structure.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_structure.rst
@@ -272,5 +272,5 @@ A collection can store some additional metadata in a ``runtime.yml`` file in the
         Guidelines for contributing to selected collections
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
         The development mailing list
-   `irc.libera.chat <https://libera.chat/>`_
-        #ansible IRC chat channel
+   :ref:`communication_irc`
+        How to join ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_collections_testing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_testing.rst
@@ -80,4 +80,4 @@ You can specify multiple target names. Each target name is the name of a directo
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_collections_testing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_testing.rst
@@ -79,5 +79,5 @@ You can specify multiple target names. Each target name is the name of a directo
        Guidelines for contributing to selected collections
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_inventory.rst
+++ b/docs/docsite/rst/dev_guide/developing_inventory.rst
@@ -474,4 +474,4 @@ An easy way to see how this should look is using :ref:`ansible-inventory`, which
    `Development Mailing List <https://groups.google.com/group/ansible-devel>`_
        Mailing list for development topics
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_inventory.rst
+++ b/docs/docsite/rst/dev_guide/developing_inventory.rst
@@ -473,5 +473,5 @@ An easy way to see how this should look is using :ref:`ansible-inventory`, which
        REST API endpoint and GUI for Ansible, syncs with dynamic inventory
    `Development Mailing List <https://groups.google.com/group/ansible-devel>`_
        Mailing list for development topics
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules.rst
@@ -47,5 +47,5 @@ If your use case isn't covered by an existing module, an action plugin, or a rol
        Browse existing collections, modules, and plugins
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        Development mailing list
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules.rst
@@ -48,4 +48,4 @@ If your use case isn't covered by an existing module, an action plugin, or a rol
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        Development mailing list
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
@@ -31,7 +31,7 @@ To contribute a module to most Ansible collections, you must:
 
 Additional requirements may apply for certain collections. Review the individual collection repositories for more information.
 
-Please make sure your module meets these requirements before you submit your PR/proposal. If you have questions, reach out via ``#ansible-devel``, Ansible's IRC chat channel on `irc.libera.chat <https://libera.chat>`_ or the `Ansible development mailing list <https://groups.google.com/group/ansible-devel>`_.
+Please make sure your module meets these requirements before you submit your PR/proposal. If you have questions, reach out via the ``#ansible-devel`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat>`_) or the `Ansible development mailing list <https://groups.google.com/group/ansible-devel>`_.
 
 Contributing to Ansible: subjective requirements
 ================================================

--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -218,13 +218,11 @@ The :ref:`Community Guide <ansible_community_guide>` covers how to open a pull r
 Communication and development support
 =====================================
 
-Join the IRC channel ``#ansible-devel`` on `irc.libera.chat <https://libera.chat/>`_ for
-discussions surrounding Ansible development.
+Join the ``#ansible-devel`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_) for discussions surrounding Ansible development.
 
-For questions and discussions pertaining to using the Ansible product,
-use the ``#ansible`` channel.
+For questions and discussions pertaining to using the Ansible product, join the ``#ansible`` channel.
 
-For more specific IRC channels look at :ref:`Community Guide, Communicating <communication_irc>`.
+To find other topic-specific chat channels, look at :ref:`Community Guide, Communicating <communication_irc>`.
 
 Credit
 ======

--- a/docs/docsite/rst/dev_guide/developing_modules_general_windows.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general_windows.rst
@@ -690,8 +690,7 @@ idempotent and does not report changes. For example:
 Windows communication and development support
 =============================================
 
-Join the ``#ansible-devel`` or ``#ansible-windows`` irc channels on `irc.libera.chat
-<https://libera.chat/>`_ for discussions about Ansible development for Windows.
+Join the ``#ansible-devel`` or ``#ansible-windows`` chat channels (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_) for discussions about Ansible development for Windows.
 
 For questions and discussions pertaining to using the Ansible product,
 use the ``#ansible`` channel.

--- a/docs/docsite/rst/dev_guide/developing_modules_in_groups.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_in_groups.rst
@@ -55,8 +55,8 @@ Ansible has a thriving and knowledgeable community of module developers that is 
 In the :ref:`ansible_community_guide` you can find how to:
 
 * Subscribe to the Mailing Lists - We suggest "Ansible Development List" and "Ansible Announce list"
-* ``#ansible-devel`` - We have found that communicating on the IRC channel, ``#ansible-devel`` on `libera.chat's <https://libera.chat/>`_ IRC network works best for developers so we can have an interactive dialogue.
-* IRC meetings - Join the various weekly IRC meetings `meeting schedule and agenda page <https://github.com/ansible/community/blob/master/meetings/README.md>`_
+* ``#ansible-devel`` - We have found that communicating on the ``#ansible-devel`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_) works best for developers so we can have an interactive dialogue.
+* Working group and other chat channel meetings - Join the various weekly meetings `meeting schedule and agenda page <https://github.com/ansible/community/blob/master/meetings/README.md>`_
 
 Required files
 ==============
@@ -70,7 +70,7 @@ Your collection should include the following files to be usable:
 
 When you have these files ready, review the :ref:`developing_modules_checklist` again. If you are creating a new collection, you are responsible for all procedures related to your repository, including setting rules for contributions, finding reviewers, and testing and maintaining the code in your collection.
 
-If you need help or advice, consider joining the ``#ansible-devel`` IRC channel (see how in the :ref:`Where to get support <developing_in_groups_support>` section).
+If you need help or advice, consider joining the ``#ansible-devel`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_). For more information, see :ref:`developing_in_groups_support` and :ref:`communication`.
 
 New to git or GitHub
 ====================

--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -512,5 +512,5 @@ For example vars plugins, see the source code for the `vars plugins included wit
        Learn about how to write Ansible modules
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -513,4 +513,4 @@ For example vars plugins, see the source code for the `vars plugins included wit
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/dev_guide/developing_rebasing.rst
+++ b/docs/docsite/rst/dev_guide/developing_rebasing.rst
@@ -75,7 +75,7 @@ You should check in on the status of your PR after tests have completed to see i
 Getting help rebasing
 =====================
 
-For help with rebasing your PR, or other development related questions, join us on our #ansible-devel IRC chat channel on `irc.libera.chat <https://libera.chat/>`_.
+For help with rebasing your PR, or other development related questions, join us on the #ansible-devel chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_).
 
 .. seealso::
 

--- a/docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst
+++ b/docs/docsite/rst/dev_guide/platforms/aws_guidelines.rst
@@ -761,7 +761,7 @@ Troubleshooting IAM policies
 - Re-read the AWS documentation, especially the list of `Actions, Resources and Condition Keys <https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_actions-resources-contextkeys.html>`_ for the various AWS services.
 - Look at the `cloudonaut <https://iam.cloudonaut.io>`_ documentation as a troubleshooting cross-reference.
 - Use a search engine.
-- Ask in the Ansible IRC channel #ansible-aws (on `irc.libera.chat <https://libera.chat>`_).
+- Ask in the #ansible-aws chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_).
 
 Unsupported Integration tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/docsite/rst/dev_guide/style_guide/resources.rst
+++ b/docs/docsite/rst/dev_guide/style_guide/resources.rst
@@ -1,7 +1,7 @@
 Resources
 ````````````````
 * Follow the style of the :ref:`Ansible Documentation<ansible_documentation>`
-* Ask for advice on IRC, on the ``#ansible-devel`` `libera.chat channel <https://libera.chat/>`_
+* Ask for advice on the ``#ansible-devel`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_)
 * Review these online style guides:
 
   * `AP Stylebook <https://www.apstylebook.com>`_

--- a/docs/docsite/rst/dev_guide/testing.rst
+++ b/docs/docsite/rst/dev_guide/testing.rst
@@ -96,7 +96,7 @@ If either of these issues appear to be the case, you can rerun the Azure Pipelin
 * closing and re-opening the PR (full rebuild)
 * making another change to the PR and pushing to GitHub
 
-If the issue persists, please contact us in the ``#ansible-devel`` irc channel on the `irc.libera.chat <https://libera.chat/>`_ IRC network.
+If the issue persists, please contact us in the ``#ansible-devel`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_).
 
 
 How to test a PR

--- a/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
@@ -180,4 +180,4 @@ Each issue will be assigned to one of the following projects:
 Questions
 ---------
 
-For questions about integration tests reach out to @mattclay or @gundalow on GitHub or ``#ansible-devel`` on IRC.
+For questions about integration tests reach out to @mattclay or @gundalow on GitHub or the ``#ansible-devel`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_).

--- a/docs/docsite/rst/dev_guide/testing_units_modules.rst
+++ b/docs/docsite/rst/dev_guide/testing_units_modules.rst
@@ -18,7 +18,7 @@ The document doesn't apply to other parts of Ansible for which the recommendatio
 normally closer to the Python standard. There is basic documentation for Ansible unit
 tests in the developer guide :ref:`testing_units`. This document should
 be readable for a new Ansible module author. If you find it incomplete or confusing,
-please open a bug or ask for help on Ansible IRC.
+please open a bug or ask for help on the #ansible-devel chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_).
 
 What Are Unit Tests?
 ====================
@@ -269,8 +269,8 @@ Ansible special cases for unit testing
 
 There are a number of special cases for unit testing the environment of an Ansible module.
 The most common are documented below, and suggestions for others can be found by looking
-at the source code of the existing unit tests or asking on the Ansible IRC channel or mailing
-lists.
+at the source code of the existing unit tests or asking on the Ansible chat channel or mailing
+lists. For more infomration on joining chat channels and subscribing to mailing lists, see :ref:`communication`.
 
 Module argument processing
 --------------------------

--- a/docs/docsite/rst/galaxy/dev_guide.rst
+++ b/docs/docsite/rst/galaxy/dev_guide.rst
@@ -242,5 +242,5 @@ Provide the ID of the integration to be disabled. You can find the ID by using t
     All about ansible roles
   `Mailing List <https://groups.google.com/group/ansible-project>`_
     Questions? Help? Ideas?  Stop by the list on Google Groups
-  `irc.libera.chat <https://libera.chat/>`_
-    #ansible IRC chat channel
+  :ref:`communication_irc`
+    How to join ansible chat channels

--- a/docs/docsite/rst/galaxy/dev_guide.rst
+++ b/docs/docsite/rst/galaxy/dev_guide.rst
@@ -243,4 +243,4 @@ Provide the ID of the integration to be disabled. You can find the ID by using t
   `Mailing List <https://groups.google.com/group/ansible-project>`_
     Questions? Help? Ideas?  Stop by the list on Google Groups
   :ref:`communication_irc`
-    How to join ansible chat channels
+    How to join Ansible chat channels

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -658,7 +658,7 @@ See the `argcomplete documentation <https://kislyuk.github.io/argcomplete/>`_.
        Ansible Installation related to FAQs
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels
 
 .. [1] ``paramiko`` was included in Ansible's ``requirements.txt`` prior to 2.8.

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -659,6 +659,6 @@ See the `argcomplete documentation <https://kislyuk.github.io/argcomplete/>`_.
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels
 
 .. [1] ``paramiko`` was included in Ansible's ``requirements.txt`` prior to 2.8.

--- a/docs/docsite/rst/network/dev_guide/developing_resource_modules_network.rst
+++ b/docs/docsite/rst/network/dev_guide/developing_resource_modules_network.rst
@@ -718,8 +718,7 @@ For more options:
 
   ansible-test network-integration --help
 
-If you need additional help or feedback, reach out in the ``#ansible-network`` IRC channel on the
-`irc.libera.chat <https://libera.chat/>`_ IRC network.
+If you need additional help or feedback, reach out in the ``#ansible-network`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_).
 
 Unit test requirements
 -----------------------

--- a/docs/docsite/rst/network/getting_started/network_resources.rst
+++ b/docs/docsite/rst/network/getting_started/network_resources.rst
@@ -36,11 +36,11 @@ Ansible hosts module code, examples, demonstrations, and other content on GitHub
 
 
 
-IRC and Slack
+Chat channels
 =============
 
-Join us on:
+Got questions? Chat with us on:
 
-* IRC Channel - ``#ansible-network`` on `irc.libera.chat <https://libera.chat/>`_
+* the ``#ansible-network`` channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_)
 
-* `Join Ansible Network Slack <https://join.slack.com/t/ansiblenetwork/shared_invite/zt-3zeqmhhx-zuID9uJqbbpZ2KdVeTwvzw>`_ - Network & Security Automation Slack community.  Check out the #devel channel for discussions on module and plugin development.
+* `Ansible Network Slack <https://join.slack.com/t/ansiblenetwork/shared_invite/zt-3zeqmhhx-zuID9uJqbbpZ2KdVeTwvzw>`_ - Network & Security Automation Slack community.  Check out the #devel channel for discussions on module and plugin development.

--- a/docs/docsite/rst/plugins/action.rst
+++ b/docs/docsite/rst/plugins/action.rst
@@ -52,4 +52,4 @@ Use ``ansible-doc <name>`` to see specific documentation and examples, this shou
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/plugins/action.rst
+++ b/docs/docsite/rst/plugins/action.rst
@@ -51,5 +51,5 @@ Use ``ansible-doc <name>`` to see specific documentation and examples, this shou
        Vars plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/plugins/become.rst
+++ b/docs/docsite/rst/plugins/become.rst
@@ -64,4 +64,4 @@ Use ``ansible-doc -t become <plugin name>`` to see specific documentation and ex
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/plugins/become.rst
+++ b/docs/docsite/rst/plugins/become.rst
@@ -63,5 +63,5 @@ Use ``ansible-doc -t become <plugin name>`` to see specific documentation and ex
        Lookup plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/plugins/cache.rst
+++ b/docs/docsite/rst/plugins/cache.rst
@@ -135,5 +135,5 @@ Use ``ansible-doc -t cache <plugin name>`` to see specific documentation and exa
        Vars plugins
    `User Mailing List <https://groups.google.com/forum/#!forum/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/plugins/cache.rst
+++ b/docs/docsite/rst/plugins/cache.rst
@@ -136,4 +136,4 @@ Use ``ansible-doc -t cache <plugin name>`` to see specific documentation and exa
    `User Mailing List <https://groups.google.com/forum/#!forum/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/plugins/callback.rst
+++ b/docs/docsite/rst/plugins/callback.rst
@@ -94,4 +94,4 @@ Use ``ansible-doc -t callback <plugin name>`` to see specific documents and exam
    `User Mailing List <https://groups.google.com/forum/#!forum/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/plugins/callback.rst
+++ b/docs/docsite/rst/plugins/callback.rst
@@ -93,5 +93,5 @@ Use ``ansible-doc -t callback <plugin name>`` to see specific documents and exam
        Vars plugins
    `User Mailing List <https://groups.google.com/forum/#!forum/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/plugins/connection.rst
+++ b/docs/docsite/rst/plugins/connection.rst
@@ -74,5 +74,5 @@ Use ``ansible-doc -t connection <plugin name>`` to see detailed documentation an
        Vars plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/plugins/connection.rst
+++ b/docs/docsite/rst/plugins/connection.rst
@@ -75,4 +75,4 @@ Use ``ansible-doc -t connection <plugin name>`` to see detailed documentation an
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/plugins/docs_fragment.rst
+++ b/docs/docsite/rst/plugins/docs_fragment.rst
@@ -32,4 +32,4 @@ Only collection developers and maintainers use docs fragments. For more informat
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/plugins/docs_fragment.rst
+++ b/docs/docsite/rst/plugins/docs_fragment.rst
@@ -31,5 +31,5 @@ Only collection developers and maintainers use docs fragments. For more informat
        An guide to creating Ansible collections
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/plugins/filter.rst
+++ b/docs/docsite/rst/plugins/filter.rst
@@ -38,4 +38,4 @@ For information on using filter plugins, see :ref:`playbooks_filters`.
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/plugins/filter.rst
+++ b/docs/docsite/rst/plugins/filter.rst
@@ -37,5 +37,5 @@ For information on using filter plugins, see :ref:`playbooks_filters`.
        Lookup plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -157,5 +157,5 @@ Use ``ansible-doc -t inventory <plugin name>`` to see plugin-specific documentat
        Vars plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -158,4 +158,4 @@ Use ``ansible-doc -t inventory <plugin name>`` to see plugin-specific documentat
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/plugins/lookup.rst
+++ b/docs/docsite/rst/plugins/lookup.rst
@@ -153,5 +153,5 @@ You can use ``ansible-doc -t lookup -l`` to see the list of available plugins. U
        Jinja2 test plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/plugins/lookup.rst
+++ b/docs/docsite/rst/plugins/lookup.rst
@@ -154,4 +154,4 @@ You can use ``ansible-doc -t lookup -l`` to see the list of available plugins. U
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/plugins/plugins.rst
+++ b/docs/docsite/rst/plugins/plugins.rst
@@ -43,5 +43,5 @@ This section covers the various types of plugins that are included with Ansible:
        Ansible tools, description and options
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/plugins/plugins.rst
+++ b/docs/docsite/rst/plugins/plugins.rst
@@ -44,4 +44,4 @@ This section covers the various types of plugins that are included with Ansible:
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/plugins/shell.rst
+++ b/docs/docsite/rst/plugins/shell.rst
@@ -50,4 +50,4 @@ detailed in the plugin themselves (linked below).
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/plugins/shell.rst
+++ b/docs/docsite/rst/plugins/shell.rst
@@ -49,5 +49,5 @@ detailed in the plugin themselves (linked below).
        Lookup plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/plugins/strategy.rst
+++ b/docs/docsite/rst/plugins/strategy.rst
@@ -74,5 +74,5 @@ Use ``ansible-doc -t strategy <plugin name>`` to see plugin-specific specific do
        Lookup plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/plugins/strategy.rst
+++ b/docs/docsite/rst/plugins/strategy.rst
@@ -75,4 +75,4 @@ Use ``ansible-doc -t strategy <plugin name>`` to see plugin-specific specific do
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/plugins/test.rst
+++ b/docs/docsite/rst/plugins/test.rst
@@ -43,4 +43,4 @@ The User Guide offers detailed documentation on :ref:`using test plugins <playbo
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/plugins/test.rst
+++ b/docs/docsite/rst/plugins/test.rst
@@ -42,5 +42,5 @@ The User Guide offers detailed documentation on :ref:`using test plugins <playbo
        Lookup plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/plugins/vars.rst
+++ b/docs/docsite/rst/plugins/vars.rst
@@ -63,5 +63,5 @@ You can use ``ansible-doc -t vars -l`` to see the list of available vars plugins
        Lookup plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/plugins/vars.rst
+++ b/docs/docsite/rst/plugins/vars.rst
@@ -64,4 +64,4 @@ You can use ``ansible-doc -t vars -l`` to see the list of available vars plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
+++ b/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
@@ -234,7 +234,7 @@ value::
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
    :ref:`communication_irc`
-       How to join ansible chat channels (join #yaml for yaml-specific questions)
+       How to join Ansible chat channels (join #yaml for yaml-specific questions)
    `YAML 1.1 Specification <https://yaml.org/spec/1.1/>`_
        The Specification for YAML 1.1, which PyYAML and libyaml are currently
        implementing

--- a/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
+++ b/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
@@ -233,10 +233,8 @@ value::
        A good guide to YAML syntax
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
-   `irc.libera.chat <https://libera.chat/>`_
-       #yaml for YAML specific questions
+   :ref:`communication_irc`
+       How to join ansible chat channels (join #yaml for yaml-specific questions)
    `YAML 1.1 Specification <https://yaml.org/spec/1.1/>`_
        The Specification for YAML 1.1, which PyYAML and libyaml are currently
        implementing

--- a/docs/docsite/rst/reference_appendices/common_return_values.rst
+++ b/docs/docsite/rst/reference_appendices/common_return_values.rst
@@ -248,4 +248,4 @@ This key contains a list of dictionaries that will be presented to the user. Key
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        Development mailing list
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/reference_appendices/common_return_values.rst
+++ b/docs/docsite/rst/reference_appendices/common_return_values.rst
@@ -247,5 +247,5 @@ This key contains a list of dictionaries that will be presented to the user. Key
        Browse source of core and extras modules
    `Mailing List <https://groups.google.com/group/ansible-devel>`_
        Development mailing list
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -21,7 +21,7 @@ In July, 2019, we announced that collections would be the `future of Ansible con
 Where did this specific module go?
 ++++++++++++++++++++++++++++++++++
 
-IF you are searching for a specific module, you can check the `runtime.yml <https://github.com/ansible/ansible/blob/devel/lib/ansible/config/ansible_builtin_runtime.yml>`_ file, which lists the first destination for each module that we extracted from the main ansible/ansible repository. Some modules have moved again since then. You can also search on `Ansible Galaxy <https://galaxy.ansible.com/>`_ or ask on one of our :ref:`IRC channels <communication_irc>`.
+IF you are searching for a specific module, you can check the `runtime.yml <https://github.com/ansible/ansible/blob/devel/lib/ansible/config/ansible_builtin_runtime.yml>`_ file, which lists the first destination for each module that we extracted from the main ansible/ansible repository. Some modules have moved again since then. You can also search on `Ansible Galaxy <https://galaxy.ansible.com/>`_ or ask on one of our :ref:`chat channels <communication_irc>`.
 
 .. _set_environment:
 
@@ -806,7 +806,7 @@ for contributing can be found in the docs README `viewable on GitHub <https://gi
 I don't see my question here
 ++++++++++++++++++++++++++++
 
-Please see the section below for a link to IRC and the Google Group, where you can ask your question there.
+If you have not found an answer to your questions, you can ask on one of our mailing lists or chat channels. For instructions on subscribing to a list or joining a chat channel, see :ref:`communication`.
 
 .. seealso::
 
@@ -816,5 +816,3 @@ Please see the section below for a link to IRC and the Google Group, where you c
        Tips and tricks for playbooks
    `User Mailing List <https://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel

--- a/docs/docsite/rst/reference_appendices/glossary.rst
+++ b/docs/docsite/rst/reference_appendices/glossary.rst
@@ -533,4 +533,4 @@ when a term comes up on the mailing list.
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/reference_appendices/glossary.rst
+++ b/docs/docsite/rst/reference_appendices/glossary.rst
@@ -532,5 +532,5 @@ when a term comes up on the mailing list.
        Tips and tricks for playbooks
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -235,4 +235,4 @@ The deprecation cycle in ``ansible-core`` is normally across 4 feature releases 
    `Development Mailing List <https://groups.google.com/group/ansible-devel>`_
        Mailing list for development topics
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -234,5 +234,5 @@ The deprecation cycle in ``ansible-core`` is normally across 4 feature releases 
        Community information and contributing
    `Development Mailing List <https://groups.google.com/group/ansible-devel>`_
        Mailing list for development topics
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/reference_appendices/test_strategies.rst
+++ b/docs/docsite/rst/reference_appendices/test_strategies.rst
@@ -270,5 +270,5 @@ system.
        Delegation, useful for working with load balancers, clouds, and locally executed steps.
    `User Mailing List <https://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/reference_appendices/test_strategies.rst
+++ b/docs/docsite/rst/reference_appendices/test_strategies.rst
@@ -271,4 +271,4 @@ system.
    `User Mailing List <https://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/roadmap/COLLECTIONS_2_10.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_2_10.rst
@@ -31,7 +31,7 @@ Release Schedule
 - 2020-09-15: ansible-2.10.0 rc1 and final freeze.
 
   - After this date only changes blocking a release are accepted.
-  - Collections will only be updated to a new version if a blocker is approved.  Collection owners should discuss any blockers at the community IRC meeting (on 9-17) to decide whether to bump the version of the collection for a fix. See the `Community IRC meeting agenda <https://github.com/ansible/community/issues/539>`_.
+  - Collections will only be updated to a new version if a blocker is approved.  Collection owners should discuss any blockers at the community meeting (on 9-17) to decide whether to bump the version of the collection for a fix. See the `Community meeting agenda <https://github.com/ansible/community/issues/539>`_.
 
 ** Additional release candidates to be published as needed as blockers are fixed **
 
@@ -48,4 +48,4 @@ Ansible-2.10.x patch releases will occur roughly every three weeks if changes to
 Breaking changes may be introduced in ansible-3.0 although we encourage collection owners to use deprecation periods that will show up in at least one Ansible release before being changed incompatibly.
 
 
-For more information, reach out on a mailing list or an IRC channel - see :ref:`communication` for more details.
+For more information, reach out on a mailing list or a chat channel - see :ref:`communication` for more details.

--- a/docs/docsite/rst/roadmap/COLLECTIONS_3_0.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_3_0.rst
@@ -30,7 +30,7 @@ Release schedule
 .. [1] No new modules or major features accepted after this date. In practice this means we will freeze the semver collection versions to compatible release versions. For example, if the version of community.crypto on this date was community-crypto-2.1.0; ansible-3.0.0 could ship with community-crypto-2.1.1.  It would not ship with community-crypto-2.2.0.
 
 .. [2] After this date only changes blocking a release are accepted.  Accepted changes require creating a new rc and may slip the final release date.
-.. [3] Collections will only be updated to a new version if a blocker is approved.  Collection owners should discuss any blockers at a community IRC meeting (before this freeze) to decide whether to bump the version of the collection for a fix. See the `Community IRC meeting agenda <https://github.com/ansible/community/issues/539>`_.
+.. [3] Collections will only be updated to a new version if a blocker is approved.  Collection owners should discuss any blockers at a community meeting (before this freeze) to decide whether to bump the version of the collection for a fix. See the `Community meeting agenda <https://github.com/ansible/community/issues/539>`_.
 
 
 .. note::
@@ -49,7 +49,7 @@ Ansible 3.x.x minor releases will occur approximately every three weeks if chang
     Minor releases will stop when :ref:`Ansible-4 <ansible_4_roadmap>` is released.  See the :ref:`Release and Maintenance Page <release_and_maintenance>` for more information.
 
 
-For more information, reach out on a mailing list or an IRC channel - see :ref:`communication` for more details.
+For more information, reach out on a mailing list or a chat channel - see :ref:`communication` for more details.
 
 
 ansible-base release

--- a/docs/docsite/rst/roadmap/COLLECTIONS_4.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_4.rst
@@ -20,8 +20,8 @@ Release schedule
 :2021-03-30: Ansible-4.0.0 alpha3
 :2021-04-13: Last day for new collections to be submitted for inclusion in Ansible 4. Note that collections MUST be reviewed and approved before being included. There is no guarantee that we will review every collection. The earlier your collection is submitted, the more likely it will be that your collection will be reviewed and the necessary feedback can be addressed in time for inclusion.
 :2021-04-13: Ansible-4.0.0 alpha4
-:2021-04-14: Community IRC Meeting topic: list any new collection reviews which block release.  List any backwards incompatible collection releases that beta1 should try to accommodate.
-:2021-04-21: Community IRC Meeting topic: Decide what contingencies to activate for any blockers that do not meet the deadline.
+:2021-04-14: Community Meeting topic: list any new collection reviews which block release.  List any backwards incompatible collection releases that beta1 should try to accommodate.
+:2021-04-21: Community Meeting topic: Decide what contingencies to activate for any blockers that do not meet the deadline.
 :2021-04-26: Last day for new collections to be **reviewed and approved** for inclusion in Ansible 4.
 :2021-04-26: Last day for collections to make backwards incompatible releases that will be accepted into Ansible 4.
 :2021-04-27: Ansible-4.0.0 beta1 -- feature freeze [1]_ (weekly beta releases.  Collection owners and interested users should test for bugs).
@@ -33,7 +33,7 @@ Release schedule
 .. [1] No new modules or major features accepted after this date. In practice, this means we will freeze the semver collection versions to compatible release versions. For example, if the version of community.crypto on this date was community-crypto-2.1.0; ansible-3.0.0 could ship with community-crypto-2.1.1.  It would not ship with community-crypto-2.2.0.
 
 .. [2] After this date only changes blocking a release are accepted.  Accepted changes require creating a new rc and may slip the final release date.
-.. [3] Collections will only be updated to a new version if a blocker is approved.  Collection owners should discuss any blockers at a community IRC meeting (before this freeze) to decide whether to bump the version of the collection for a fix. See the `Community IRC meeting agenda <https://github.com/ansible/community/issues/539>`_.
+.. [3] Collections will only be updated to a new version if a blocker is approved.  Collection owners should discuss any blockers at a Community meeting (before this freeze) to decide whether to bump the version of the collection for a fix. See the `Community meeting agenda <https://github.com/ansible/community/issues/539>`_.
 
 
 .. note::
@@ -52,4 +52,4 @@ Ansible 4.x minor releases will occur approximately every three weeks if changes
     Minor releases will stop when Ansible-5 is released.  See the :ref:`Release and Maintenance Page <release_and_maintenance>` for more information.
 
 
-For more information, reach out on a mailing list or an IRC channel - see :ref:`communication` for more details.
+For more information, reach out on a mailing list or a chat channel - see :ref:`communication` for more details.

--- a/docs/docsite/rst/roadmap/COLLECTIONS_5.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_5.rst
@@ -20,9 +20,9 @@ Release schedule
 :2021-10-04: first ansible-core release candidate, stable-2.12 branch created.
 :2021-10-05: Ansible-5.0.0 alpha2.
 :2021-10-12: Last day for new collections to be submitted for inclusion in Ansible-5. Collections MUST be reviewed and approved before being included. There is no guarantee that we will review every collection. The earlier your collection is submitted, the more likely it will be that your collection will be reviewed and the necessary feedback can be addressed in time for inclusion.
-:2021-10-13: Community IRC Meeting topic: List any new collection reviews which block release. List any backwards incompatible collection releases that beta1 should try to accommodate.
+:2021-10-13: Community Meeting topic: List any new collection reviews which block release. List any backwards incompatible collection releases that beta1 should try to accommodate.
 :2021-10-19: Ansible-5.0.0 alpha3.
-:2021-10-20: Community IRC Meeting topic: Decide what contingencies to activate for any blockers that do not meet the deadline.
+:2021-10-20: Community Meeting topic: Decide what contingencies to activate for any blockers that do not meet the deadline.
 :2021-10-25: Last day for new collections to be **reviewed and approved** for inclusion in Ansible-5.
 :2021-10-25: Last day for collections to make backwards incompatible releases that will be accepted into Ansible-5.
 :2021-10-26: Create the ansible-build-data directory and files for Ansible-6; new collection approvals will target this.
@@ -54,4 +54,4 @@ Ansible 5.x minor releases will occur approximately every three weeks if changes
     Minor releases will stop when Ansible-6 is released.  See the :ref:`Release and Maintenance Page <release_and_maintenance>` for more information.
 
 
-For more information, reach out on a mailing list or an IRC channel - see :ref:`communication` for more details.
+For more information, reach out on a mailing list or a chat channel - see :ref:`communication` for more details.

--- a/docs/docsite/rst/roadmap/ansible_core_roadmap_index.rst
+++ b/docs/docsite/rst/roadmap/ansible_core_roadmap_index.rst
@@ -17,11 +17,11 @@ Each roadmap is published both as an idea of what is upcoming in ``ansible-core`
 
 You can submit feedback on the current roadmap in multiple ways:
 
-- Edit the agenda of an IRC `Core Team Meeting <https://github.com/ansible/community/blob/master/meetings/README.md>`_ (preferred)
-- Post on the ``#ansible-devel`` IRC channel on `irc.libera.chat <https://libera.chat/>`_.
+- Edit the agenda of an `Core Team Meeting <https://github.com/ansible/community/blob/master/meetings/README.md>`_ (preferred)
+- Post on the ``#ansible-devel`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_)
 - Email the ansible-devel list
 
-See :ref:`Ansible communication channels <communication>` for details on how to join and use the email lists and IRC channels.
+See :ref:`Ansible communication channels <communication>` for details on how to join and use the email lists and chat channels.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/docsite/rst/roadmap/ansible_roadmap_index.rst
+++ b/docs/docsite/rst/roadmap/ansible_roadmap_index.rst
@@ -13,10 +13,10 @@ Each roadmap is published both as an idea of what is upcoming in Ansible, and as
 
 You can submit feedback on the current roadmap in multiple ways:
 
-- Edit the agenda of an IRC `Ansible Community Meeting <https://github.com/ansible/community/issues/539>`_ (preferred)
-- Post on the ``#ansible-community`` IRC channel on `irc.libera.chat <https://libera.chat/>`_.
+- Edit the agenda of an `Ansible Community Meeting <https://github.com/ansible/community/issues/539>`_ (preferred)
+- Post on the ``#ansible-community`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_)
 
-See :ref:`Ansible communication channels <communication>` for details on how to join and use the IRC channels.
+See :ref:`Ansible communication channels <communication>` for details on how to join and use our chat channels.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/docsite/rst/scenario_guides/guide_aci.rst
+++ b/docs/docsite/rst/scenario_guides/guide_aci.rst
@@ -640,7 +640,7 @@ ACI Ansible community
 ---------------------
 If you have specific issues with the ACI modules, or a feature request, or you like to contribute to the ACI project by proposing changes or documentation updates, look at the Ansible Community wiki ACI page at: https://github.com/ansible/community/wiki/Network:-ACI
 
-You will find our roadmap, an overview of open ACI issues and pull-requests, and more information about who we are. If you have an interest in using ACI with Ansible, feel free to join! We occasionally meet online to track progress and prepare for new Ansible releases.
+You will find our roadmap, an overview of open ACI issues and pull-requests, and more information about who we are. If you have an interest in using ACI with Ansible, feel free to join! We occasionally meet online (on the #ansible-network chat channel, using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_) to track progress and prepare for new Ansible releases.
 
 
 .. seealso::
@@ -655,7 +655,5 @@ You will find our roadmap, an overview of open ACI issues and pull-requests, and
        A detailed guide on how to use Ansible for automating network infrastructure.
    `Network Working Group <https://github.com/ansible/community/tree/master/group-network>`_
        The Ansible Network community page, includes contact information and meeting information.
-   ``#ansible-network`` on `irc.libera.chat <https://libera.chat/>`_
-       The #ansible-network IRC chat channel on libera.chat.
    `User Mailing List <https://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!

--- a/docs/docsite/rst/scenario_guides/guide_aws.rst
+++ b/docs/docsite/rst/scenario_guides/guide_aws.rst
@@ -280,5 +280,5 @@ documentation for a full list with examples.
        Delegation, useful for working with loud balancers, clouds, and locally executed steps.
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/scenario_guides/guide_aws.rst
+++ b/docs/docsite/rst/scenario_guides/guide_aws.rst
@@ -281,4 +281,4 @@ documentation for a full list with examples.
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/become.rst
+++ b/docs/docsite/rst/user_guide/become.rst
@@ -754,4 +754,4 @@ Limitations of become on Windows
    `Mailing List <https://groups.google.com/forum/#!forum/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/become.rst
+++ b/docs/docsite/rst/user_guide/become.rst
@@ -753,5 +753,5 @@ Limitations of become on Windows
 
    `Mailing List <https://groups.google.com/forum/#!forum/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -373,11 +373,12 @@ This will have an implied entry in the ``collections:`` keyword of ``my_namespac
 
 .. seealso::
 
-  :ref:`developing_collections`
-      Develop or modify a collection.
-  :ref:`collections_galaxy_meta`
+   :ref:`developing_collections`
+       Develop or modify a collection.
+   :ref:`collections_galaxy_meta`
        Understand the collections metadata structure.
-  `Mailing List <https://groups.google.com/group/ansible-devel>`_
+   `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels
+

--- a/docs/docsite/rst/user_guide/collections_using.rst
+++ b/docs/docsite/rst/user_guide/collections_using.rst
@@ -379,5 +379,5 @@ This will have an implied entry in the ``collections:`` keyword of ``my_namespac
        Understand the collections metadata structure.
   `Mailing List <https://groups.google.com/group/ansible-devel>`_
        The development mailing list
-  `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/intro_adhoc.rst
+++ b/docs/docsite/rst/user_guide/intro_adhoc.rst
@@ -202,5 +202,5 @@ Now that you understand the basic elements of Ansible execution, you are ready t
        Using Ansible for configuration management & deployment
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/intro_adhoc.rst
+++ b/docs/docsite/rst/user_guide/intro_adhoc.rst
@@ -203,4 +203,4 @@ Now that you understand the basic elements of Ansible execution, you are ready t
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/intro_bsd.rst
+++ b/docs/docsite/rst/user_guide/intro_bsd.rst
@@ -103,4 +103,4 @@ Please feel free to report any issues or incompatibilities you discover with BSD
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/intro_bsd.rst
+++ b/docs/docsite/rst/user_guide/intro_bsd.rst
@@ -102,5 +102,5 @@ Please feel free to report any issues or incompatibilities you discover with BSD
        How to write modules
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/intro_dynamic_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_dynamic_inventory.rst
@@ -246,4 +246,4 @@ the dynamic groups as empty in the static inventory file. For example:
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/intro_dynamic_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_dynamic_inventory.rst
@@ -245,5 +245,5 @@ the dynamic groups as empty in the static inventory file. For example:
        All about static inventory files
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/intro_getting_started.rst
+++ b/docs/docsite/rst/user_guide/intro_getting_started.rst
@@ -194,5 +194,5 @@ also has powerful configuration management and deployment features.
        Labs to provide further knowledge on different topics
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/intro_getting_started.rst
+++ b/docs/docsite/rst/user_guide/intro_getting_started.rst
@@ -195,4 +195,4 @@ also has powerful configuration management and deployment features.
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -788,4 +788,4 @@ their location.
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/intro_inventory.rst
+++ b/docs/docsite/rst/user_guide/intro_inventory.rst
@@ -787,5 +787,5 @@ their location.
        Learning Ansible's configuration, deployment, and orchestration language.
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/intro_patterns.rst
+++ b/docs/docsite/rst/user_guide/intro_patterns.rst
@@ -168,4 +168,4 @@ To apply your knowledge of patterns with Ansible commands and playbooks, read :r
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/intro_patterns.rst
+++ b/docs/docsite/rst/user_guide/intro_patterns.rst
@@ -167,5 +167,5 @@ To apply your knowledge of patterns with Ansible commands and playbooks, read :r
        Learning the Ansible configuration management language
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/modules.rst
+++ b/docs/docsite/rst/user_guide/modules.rst
@@ -33,4 +33,4 @@ like services, packages, or files (anything really), or handle executing system 
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/modules.rst
+++ b/docs/docsite/rst/user_guide/modules.rst
@@ -32,5 +32,5 @@ like services, packages, or files (anything really), or handle executing system 
        Configuring the right Python interpreter on target hosts
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/modules_intro.rst
+++ b/docs/docsite/rst/user_guide/modules_intro.rst
@@ -48,5 +48,5 @@ For a list of all available modules, see the :ref:`Collection docs <list_of_coll
        Examples of using modules with the Python API
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/modules_intro.rst
+++ b/docs/docsite/rst/user_guide/modules_intro.rst
@@ -49,4 +49,4 @@ For a list of all available modules, see the :ref:`Collection docs <list_of_coll
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/modules_support.rst
+++ b/docs/docsite/rst/user_guide/modules_support.rst
@@ -67,4 +67,4 @@ All plugins that remain in ``ansible-core`` and all collections hosted in Automa
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/modules_support.rst
+++ b/docs/docsite/rst/user_guide/modules_support.rst
@@ -47,7 +47,7 @@ If you find a bug that affects a plugin in a Galaxy collection:
 
 Some partner collections may be hosted in private repositories.
 
-If you are not sure whether the behavior you see is a bug, if you have questions, if you want to discuss development-oriented topics, or if you just want to get in touch, use one of our Google groups or IRC channels to :ref:`communicate with Ansiblers <communication>`.
+If you are not sure whether the behavior you see is a bug, if you have questions, if you want to discuss development-oriented topics, or if you just want to get in touch, use one of our Google mailing lists or chat channels (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_) to :ref:`communicate with Ansiblers <communication>`.
 
 If you find a bug that affects a module in an Automation Hub collection:
 

--- a/docs/docsite/rst/user_guide/modules_support.rst
+++ b/docs/docsite/rst/user_guide/modules_support.rst
@@ -66,5 +66,5 @@ All plugins that remain in ``ansible-core`` and all collections hosted in Automa
        Examples of using modules with /usr/bin/ansible-playbook
    `Mailing List <https://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_advanced_syntax.rst
+++ b/docs/docsite/rst/user_guide/playbooks_advanced_syntax.rst
@@ -108,5 +108,5 @@ You've anchored the value of ``version`` with the ``&my_version`` anchor, and re
        Doing complex data manipulation in Ansible
    `User Mailing List <https://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_advanced_syntax.rst
+++ b/docs/docsite/rst/user_guide/playbooks_advanced_syntax.rst
@@ -109,4 +109,4 @@ You've anchored the value of ``version`` with the ``&my_version`` anchor, and re
    `User Mailing List <https://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_async.rst
+++ b/docs/docsite/rst/user_guide/playbooks_async.rst
@@ -171,5 +171,5 @@ To run multiple asynchronous tasks while limiting the number of tasks running co
        An introduction to playbooks
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_async.rst
+++ b/docs/docsite/rst/user_guide/playbooks_async.rst
@@ -172,4 +172,4 @@ To run multiple asynchronous tasks while limiting the number of tasks running co
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_blocks.rst
+++ b/docs/docsite/rst/user_guide/playbooks_blocks.rst
@@ -186,4 +186,4 @@ ansible_failed_result
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_blocks.rst
+++ b/docs/docsite/rst/user_guide/playbooks_blocks.rst
@@ -185,5 +185,5 @@ ansible_failed_result
        Playbook organization by roles
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_conditionals.rst
+++ b/docs/docsite/rst/user_guide/playbooks_conditionals.rst
@@ -505,4 +505,4 @@ Possible values (sample, not complete list)::
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_conditionals.rst
+++ b/docs/docsite/rst/user_guide/playbooks_conditionals.rst
@@ -504,5 +504,5 @@ Possible values (sample, not complete list)::
        All about variables
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_debugger.rst
+++ b/docs/docsite/rst/user_guide/playbooks_debugger.rst
@@ -326,4 +326,4 @@ With the default ``linear`` strategy enabled, Ansible halts execution while the 
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_debugger.rst
+++ b/docs/docsite/rst/user_guide/playbooks_debugger.rst
@@ -325,5 +325,5 @@ With the default ``linear`` strategy enabled, Ansible halts execution while the 
        An introduction to playbooks
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_delegation.rst
+++ b/docs/docsite/rst/user_guide/playbooks_delegation.rst
@@ -134,5 +134,5 @@ use the default remote connection type::
        Many examples of full-stack deployments
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_delegation.rst
+++ b/docs/docsite/rst/user_guide/playbooks_delegation.rst
@@ -135,4 +135,4 @@ use the default remote connection type::
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_environment.rst
+++ b/docs/docsite/rst/user_guide/playbooks_environment.rst
@@ -138,4 +138,4 @@ You can also specify the environment at the task level::
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_environment.rst
+++ b/docs/docsite/rst/user_guide/playbooks_environment.rst
@@ -137,5 +137,5 @@ You can also specify the environment at the task level::
        An introduction to playbooks
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_error_handling.rst
+++ b/docs/docsite/rst/user_guide/playbooks_error_handling.rst
@@ -241,5 +241,5 @@ You can also use blocks to define responses to task errors. This approach is sim
        All about variables
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_error_handling.rst
+++ b/docs/docsite/rst/user_guide/playbooks_error_handling.rst
@@ -242,4 +242,4 @@ You can also use blocks to define responses to task errors. This approach is sim
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1817,4 +1817,4 @@ This can then be used to reference hashes in Pod specifications::
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1816,5 +1816,5 @@ This can then be used to reference hashes in Pod specifications::
        Tips and tricks for playbooks
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
@@ -739,5 +739,5 @@ the filter ``slaac()`` generates an IPv6 address for a given network and a MAC A
          Tips and tricks for playbooks
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+	 :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters_ipaddr.rst
@@ -720,7 +720,6 @@ the filter ``slaac()`` generates an IPv6 address for a given network and a MAC A
 
 .. seealso::
 
-
    `ansible.netcommon <https://galaxy.ansible.com/ansible/netcommon>`_
        Ansible network collection for common code
    :ref:`about_playbooks`
@@ -739,5 +738,6 @@ the filter ``slaac()`` generates an IPv6 address for a given network and a MAC A
          Tips and tricks for playbooks
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-	 :ref:`communication_irc`
-       How to join ansible chat channels
+   :ref:`communication_irc`
+       How to join Ansible chat channels
+

--- a/docs/docsite/rst/user_guide/playbooks_lookups.rst
+++ b/docs/docsite/rst/user_guide/playbooks_lookups.rst
@@ -33,5 +33,5 @@ For more details and a list of lookup plugins in ansible-core, see :ref:`plugins
        Looping in playbooks
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_lookups.rst
+++ b/docs/docsite/rst/user_guide/playbooks_lookups.rst
@@ -34,4 +34,4 @@ For more details and a list of lookup plugins in ansible-core, see :ref:`plugins
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/user_guide/playbooks_loops.rst
@@ -441,5 +441,5 @@ Migrating from with_X to loop
        All about variables
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/user_guide/playbooks_loops.rst
@@ -442,4 +442,4 @@ Migrating from with_X to loop
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_prompts.rst
+++ b/docs/docsite/rst/user_guide/playbooks_prompts.rst
@@ -113,4 +113,4 @@ Some special characters, such as ``{`` and ``%`` can create templating errors. I
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_prompts.rst
+++ b/docs/docsite/rst/user_guide/playbooks_prompts.rst
@@ -112,5 +112,5 @@ Some special characters, such as ``{`` and ``%`` can create templating errors. I
        All about variables
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_strategies.rst
+++ b/docs/docsite/rst/user_guide/playbooks_strategies.rst
@@ -218,5 +218,5 @@ As always with :ref:`delegation <playbooks_delegation>`, the action will be exec
        Playbook organization by roles
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_strategies.rst
+++ b/docs/docsite/rst/user_guide/playbooks_strategies.rst
@@ -219,4 +219,4 @@ As always with :ref:`delegation <playbooks_delegation>`, the action will be exec
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tags.rst
@@ -430,4 +430,4 @@ If you run or skip certain tags by default, you can use the :ref:`TAGS_RUN` and 
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tags.rst
@@ -429,5 +429,5 @@ If you run or skip certain tags by default, you can use the :ref:`TAGS_RUN` and 
        Playbook organization by roles
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_templating.rst
+++ b/docs/docsite/rst/user_guide/playbooks_templating.rst
@@ -53,5 +53,5 @@ fmt
       Jinja2 documentation, includes the syntax and semantics of the templates
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_templating.rst
+++ b/docs/docsite/rst/user_guide/playbooks_templating.rst
@@ -54,4 +54,4 @@ fmt
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tests.rst
@@ -399,5 +399,5 @@ The following tasks are illustrative of the tests meant to check the status of t
        Tips and tricks for playbooks
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tests.rst
@@ -400,4 +400,4 @@ The following tasks are illustrative of the tests meant to check the status of t
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/user_guide/playbooks_variables.rst
@@ -462,5 +462,5 @@ For information about advanced YAML syntax used to declare variables and have mo
        List of special variables
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/user_guide/playbooks_variables.rst
@@ -463,4 +463,4 @@ For information about advanced YAML syntax used to declare variables and have mo
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/windows_dsc.rst
+++ b/docs/docsite/rst/user_guide/windows_dsc.rst
@@ -501,5 +501,5 @@ Setup IIS Website
        Windows specific module list, all implemented in PowerShell
    `User Mailing List <https://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/windows_dsc.rst
+++ b/docs/docsite/rst/user_guide/windows_dsc.rst
@@ -502,4 +502,4 @@ Setup IIS Website
    `User Mailing List <https://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/windows_faq.rst
+++ b/docs/docsite/rst/user_guide/windows_faq.rst
@@ -248,4 +248,4 @@ host.
    `User Mailing List <https://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/windows_faq.rst
+++ b/docs/docsite/rst/user_guide/windows_faq.rst
@@ -247,5 +247,5 @@ host.
        Tips and tricks for playbooks
    `User Mailing List <https://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/windows_setup.rst
+++ b/docs/docsite/rst/user_guide/windows_setup.rst
@@ -579,5 +579,5 @@ Here are the known ones:
        Windows specific module list, all implemented in PowerShell
    `User Mailing List <https://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/windows_setup.rst
+++ b/docs/docsite/rst/user_guide/windows_setup.rst
@@ -580,4 +580,4 @@ Here are the known ones:
    `User Mailing List <https://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/windows_usage.rst
+++ b/docs/docsite/rst/user_guide/windows_usage.rst
@@ -509,5 +509,5 @@ guides for Windows modules differ substantially from those for standard standard
        Windows specific module list, all implemented in PowerShell
    `User Mailing List <https://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/windows_usage.rst
+++ b/docs/docsite/rst/user_guide/windows_usage.rst
@@ -510,4 +510,4 @@ guides for Windows modules differ substantially from those for standard standard
    `User Mailing List <https://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels

--- a/docs/docsite/rst/user_guide/windows_winrm.rst
+++ b/docs/docsite/rst/user_guide/windows_winrm.rst
@@ -910,5 +910,5 @@ Some of these limitations can be mitigated by doing one of the following:
        Windows specific module list, all implemented in PowerShell
    `User Mailing List <https://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!
-   `irc.libera.chat <https://libera.chat/>`_
-       #ansible IRC chat channel
+   :ref:`communication_irc`
+       How to join ansible chat channels

--- a/docs/docsite/rst/user_guide/windows_winrm.rst
+++ b/docs/docsite/rst/user_guide/windows_winrm.rst
@@ -911,4 +911,4 @@ Some of these limitations can be mitigated by doing one of the following:
    `User Mailing List <https://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!
    :ref:`communication_irc`
-       How to join ansible chat channels
+       How to join Ansible chat channels


### PR DESCRIPTION
##### SUMMARY
In today's [Community meeting](https://meetbot.fedoraproject.org/ansible-community/2021-08-04/ansible_community_meeting.2021-08-04-18.00.html) we voted to accept Matrix as an official chat platform (alongside IRC), and to update our docs, etc, to promote Matrix as the first choice for new community members joining our chat channels. 

This PR changes the docs references in the ansible/ansible repo. We also need to change references elsewhere (see, for example, the list of [Working Groups](https://github.com/ansible/community/wiki#working-groups) - many of these pages mention IRC).

Related to https://github.com/ansible-community/community-topics/issues/36. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
