### PR TITLE
Add a "fail" filter

### DIFF
--- a/changelogs/fragments/75407-fail-filter.yml
+++ b/changelogs/fragments/75407-fail-filter.yml
@@ -1,0 +1,3 @@
+add plugin.filter:
+  - name: fail
+    description: Fails if invoked. Useful for requiring a variable to be overridden

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -68,6 +68,11 @@ If you configure Ansible to ignore undefined variables, you may want to define s
 
 The variable value will be used as is, but the template evaluation will raise an error if it is undefined.
 
+A convenient way of requiring a variable to be overridden is to use the ``fail`` filter. This is useful in a role's defaults::
+
+    galaxy_url: "https://galaxy.ansible.com"
+    galaxy_api_key: {{ "You must specify your Galaxy API key" | fail }}
+
 Defining different values for true/false/null (ternary)
 =======================================================
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -299,6 +299,10 @@ def mandatory(a, msg=None):
     return a
 
 
+def fail(msg="Mandatory variable has not been overridden"):
+    raise AnsibleFilterError(to_native(msg))
+
+
 def combine(*terms, **kwargs):
     recursive = kwargs.pop('recursive', False)
     list_merge = kwargs.pop('list_merge', 'replace')
@@ -638,6 +642,7 @@ class FilterModule(object):
 
             # undefined
             'mandatory': mandatory,
+            'fail': fail,
 
             # comment-style decoration
             'comment': comment,

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -299,7 +299,9 @@ def mandatory(a, msg=None):
     return a
 
 
-def fail(msg="Mandatory variable has not been overridden"):
+def fail(msg=None):
+    if msg is None:
+        msg = "Mandatory variable has not been overridden"
     raise AnsibleFilterError(to_native(msg))
 
 

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -494,6 +494,33 @@
       - mandatory_2 is failed
       - "mandatory_2.msg == 'You did not give me a variable. I am a sad wolf.'"
 
+- name: Verify fail throws if executed
+  set_fact:
+    foo: '{{ fail_foo }}'
+  vars:
+    fail_foo: '{{ "Expected failure" | fail }}'
+  ignore_errors: yes
+  register: fail_1
+
+- name: Setup fail_foo for overriding in test
+  block:
+    - name: Verify fail not executed if overridden
+      set_fact:
+        foo: '{{ fail_foo }}'
+      vars:
+        fail_foo: 'overridden value'
+      register: fail_2
+      
+  vars:
+    fail_foo: '{{ "Expected failure" | fail }}'
+
+- name: Verify fail
+  assert:
+    that:
+      - fail_1 is failed
+      - not (fail_2 is failed)
+
+
 - name: Verify comment
   assert:
     that:

--- a/test/units/plugins/filter/test_core.py
+++ b/test/units/plugins/filter/test_core.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 import pytest
 
 from ansible.module_utils._text import to_native
-from ansible.plugins.filter.core import to_uuid
+from ansible.plugins.filter.core import fail, to_uuid
 from ansible.errors import AnsibleFilterError
 
 
@@ -39,3 +39,10 @@ def test_to_uuid_invalid_namespace():
     with pytest.raises(AnsibleFilterError) as e:
         to_uuid('example.com', namespace='11111111-2222-3333-4444-555555555')
     assert 'Invalid value' in to_native(e.value)
+
+
+def test_fail_throws_if_invoked():
+    msg = "Expected failure"
+    with pytest.raises(AnsibleFilterError) as e:
+        fail(msg)
+    assert msg in to_native(e.value)

--- a/test/units/plugins/filter/test_core.py
+++ b/test/units/plugins/filter/test_core.py
@@ -46,3 +46,10 @@ def test_fail_throws_if_invoked():
     with pytest.raises(AnsibleFilterError) as e:
         fail(msg)
     assert msg in to_native(e.value)
+
+
+def test_fail_falls_back_to_generic_message():
+    msg = "Mandatory variable has not been overridden"
+    with pytest.raises(AnsibleFilterError) as e:
+        fail(None)
+    assert msg in to_native(e.value)


### PR DESCRIPTION
##### SUMMARY
Fixes #69255

Adds a "fail" filter as an analog for the "fail" module, failing if it is invoked. This is useful for specifying variables that must be overridden. These variables don't require an intermediate filtering and local variable For example, in a role's defaults file:
```yaml
global_mysql_root_user: "sqladmin"
global_mysql_root_password: "{{ 'required, generate with pwgen -s 20' | fail }}"
```
instead of the suggested workaround
```yaml
global_mysql_root_user: "sqladmin"
# global_mysql_root_password: 
_global_mysql_root_password: "{{ global_mysql_root_password | mandatory('required, generate with pwgen -s 20') }}"
```
This makes it easier to search a codebase for where a variable is used, as it doesn't require also looking for all the local variants of that variable.

One suggestion was to extend the "mandatory" filter to treat `null` values as undefined. But there are valid use cases for requiring a user to specify a value but where `null` is a valid value.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
filters.core

##### ADDITIONAL INFORMATION
If not overridden:
```bash
ansible localhost -m debug -a msg="{{ foo }}" -e foo="{{ 'xfail' | fail }}"
localhost | FAILED! => {
    "msg": "An unhandled exception occurred while templating '{{ 'xfail' | fail }}'. Error was a <class 'ansible.errors.AnsibleFilterError'>, original message: xfail"
}
```
If overridden:
```bash
ansible localhost -m debug -a msg="{{ foo }}" -e foo="{{ 'xfail' | fail }}" -e  foo="hello"
localhost | SUCCESS => {
    "msg": "hello"
}
```
