### PR TITLE
add support for NFLOG iptables extension

### DIFF
--- a/changelogs/fragments/add-iptables-nflog-support.yaml
+++ b/changelogs/fragments/add-iptables-nflog-support.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- iptables - Add support for NFLOG target and options

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -169,14 +169,14 @@ options:
       - The netlink group (0 - 2^16-1) to which packets are (only applicable for nfnetlink_log).
         The default value is 0. Only make sense with a NFLOG jump.
     type: str
-    version_added: "2.11.4"
+    version_added: "2.12"
   nflog_prefix:
     description:
       - A prefix string to include in the log message,
         up to 64 characters long, useful for distinguishing
         messages in the logs. Only make sense with a NFLOG jump.
     type: str
-    version_added: "2.11.4"
+    version_added: "2.12"
   nflog_size:
     description:
       - The number of bytes to be copied to userspace
@@ -184,7 +184,7 @@ options:
         instances may specify their own range, this option overrides it.
         Only make sense with a NFLOG jump.
     type: str
-    version_added: "2.11.4"
+    version_added: "2.12"
   nflog_threshold:
     description:
       - Number of packets to queue inside the kernel before
@@ -192,7 +192,7 @@ options:
         Higher values result in less overhead per packet, but increase
         delay until the packets reach userspace. The default value is 1.
     type: str
-    version_added: "2.11.4"
+    version_added: "2.12"
   goto:
     description:
       - This specifies that the processing should continue in a user specified chain.

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -168,7 +168,7 @@ options:
     description:
       - The netlink group (0 - 2^16-1) to which packets are (only applicable for nfnetlink_log). 
         The default value is 0. Only make sense with a NFLOG jump.
-    type: int
+    type: str
     version_added: "2.11.4"
   nflog_prefix:
     description:
@@ -183,7 +183,7 @@ options:
         (only applicable for nfnetlink_log). nfnetlink_log 
         instances may specify their own range, this option overrides it.
         Only make sense with a NFLOG jump.
-    type: int
+    type: str
     version_added: "2.11.4"
   nflog_threshold:
     description:
@@ -191,7 +191,7 @@ options:
         sending them to userspace (only applicable for nfnetlink_log). 
         Higher values result in less overhead per packet, but increase 
         delay until the packets reach userspace. The default value is 1.
-    type: int
+    type: str
     version_added: "2.11.4"
   goto:
     description:

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -166,30 +166,30 @@ options:
     choices: [ '0', '1', '2', '3', '4', '5', '6', '7', 'emerg', 'alert', 'crit', 'error', 'warning', 'notice', 'info', 'debug' ]
   nflog_group:
     description:
-      - The netlink group (0 - 2^16-1) to which packets are (only applicable for nfnetlink_log). 
+      - The netlink group (0 - 2^16-1) to which packets are (only applicable for nfnetlink_log).
         The default value is 0. Only make sense with a NFLOG jump.
     type: str
     version_added: "2.11.4"
   nflog_prefix:
     description:
-      - A prefix string to include in the log message, 
-        up to 64 characters long, useful for distinguishing 
+      - A prefix string to include in the log message,
+        up to 64 characters long, useful for distinguishing
         messages in the logs. Only make sense with a NFLOG jump.
     type: str
     version_added: "2.11.4"
   nflog_size:
     description:
-      - The number of bytes to be copied to userspace 
-        (only applicable for nfnetlink_log). nfnetlink_log 
+      - The number of bytes to be copied to userspace
+        (only applicable for nfnetlink_log). nfnetlink_log
         instances may specify their own range, this option overrides it.
         Only make sense with a NFLOG jump.
     type: str
     version_added: "2.11.4"
   nflog_threshold:
     description:
-      - Number of packets to queue inside the kernel before 
-        sending them to userspace (only applicable for nfnetlink_log). 
-        Higher values result in less overhead per packet, but increase 
+      - Number of packets to queue inside the kernel before
+        sending them to userspace (only applicable for nfnetlink_log).
+        Higher values result in less overhead per packet, but increase
         delay until the packets reach userspace. The default value is 1.
     type: str
     version_added: "2.11.4"

--- a/test/units/modules/test_iptables.py
+++ b/test/units/modules/test_iptables.py
@@ -764,6 +764,29 @@ class TestIptables(ModuleTestCase):
                 '--nflog-threshold', '2',
             ])
 
+        set_module_args({
+            'chain': 'INPUT',
+            'nflog_group': '1',
+        })
+        commands_results = [
+            (0, '', ''),
+        ]
+
+        with patch.object(basic.AnsibleModule, 'run_command') as run_command:
+            run_command.side_effect = commands_results
+            with self.assertRaises(AnsibleExitJson) as result:
+                iptables.main()
+                self.assertTrue(result.exception.args[0]['changed'])
+
+            self.assertEqual(run_command.call_count, 1)
+            self.assertEqual(run_command.call_args_list[0][0][0], [
+                '/sbin/iptables',
+                '-t', 'filter',
+                '-C', 'INPUT',
+                '-j', 'NFLOG',
+                '--nflog-group', '1',
+            ])
+
     def test_iprange(self):
         """ Test iprange module with its flags src_range and dst_range """
         set_module_args({

--- a/test/units/modules/test_iptables.py
+++ b/test/units/modules/test_iptables.py
@@ -730,6 +730,40 @@ class TestIptables(ModuleTestCase):
                     '--log-level', log_lvl
                 ])
 
+    def test_nflog_flags(self):
+        """ Test various ways of nflog target flags """
+
+        set_module_args({
+            'chain': 'INPUT',
+            'action': 'append',
+            'jump': 'NFLOG',
+            'nflog_group': '1',
+            'nflog_prefix': '**accepted input**',
+            'nflog_size': '20000',
+            'nflog_threshold': '2',
+        })
+        commands_results = [
+            (0, '', ''),
+        ]
+
+        with patch.object(basic.AnsibleModule, 'run_command') as run_command:
+            run_command.side_effect = commands_results
+            with self.assertRaises(AnsibleExitJson) as result:
+                iptables.main()
+                self.assertTrue(result.exception.args[0]['changed'])
+
+            self.assertEqual(run_command.call_count, 1)
+            self.assertEqual(run_command.call_args_list[0][0][0], [
+                '/sbin/iptables',
+                '-t', 'filter',
+                '-C', 'INPUT',
+                '-j', 'NFLOG',
+                '--nflog-group', '1',
+                '--nflog-prefix', '**accepted input**',
+                '--nflog-size', '20000',
+                '--nflog-threshold', '2',
+            ])
+
     def test_iprange(self):
         """ Test iprange module with its flags src_range and dst_range """
         set_module_args({


### PR DESCRIPTION
##### SUMMARY

Added support for iptables  [NFLOG](https://ipset.netfilter.org/iptables-extensions.man.html#lbDG) target and its options. 


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
iptables

##### ADDITIONAL INFORMATION

Allows to pass additional target options for NFLOG target like `--nflog-group` below:

```
$ iptables -A INPUT -j NFLOG --nflog-group 2
```
