### PR TITLE
setup module, dont truncate hpux interfaces

### DIFF
--- a/changelogs/fragments/hpux_iface_facts_length.yml
+++ b/changelogs/fragments/hpux_iface_facts_length.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - setup module should now not truncate hpux interface names.

--- a/lib/ansible/module_utils/facts/network/hpux.py
+++ b/lib/ansible/module_utils/facts/network/hpux.py
@@ -47,7 +47,7 @@ class HPUXNetwork(Network):
 
     def get_default_interfaces(self):
         default_interfaces = {}
-        rc, out, err = self.module.run_command("/usr/bin/netstat -nr")
+        rc, out, err = self.module.run_command("/usr/bin/netstat -nrw")
         lines = out.splitlines()
         for line in lines:
             words = line.split()
@@ -60,7 +60,7 @@ class HPUXNetwork(Network):
 
     def get_interfaces_info(self):
         interfaces = {}
-        rc, out, err = self.module.run_command("/usr/bin/netstat -ni")
+        rc, out, err = self.module.run_command("/usr/bin/netstat -niw")
         lines = out.splitlines()
         for line in lines:
             words = line.split()

--- a/lib/ansible/module_utils/facts/network/hpux.py
+++ b/lib/ansible/module_utils/facts/network/hpux.py
@@ -47,7 +47,7 @@ class HPUXNetwork(Network):
 
     def get_default_interfaces(self):
         default_interfaces = {}
-        rc, out, err = self.module.run_command("/usr/bin/netstat -nrw")
+        rc, out, err = self.module.run_command("/usr/bin/netstat -nr")
         lines = out.splitlines()
         for line in lines:
             words = line.split()


### PR DESCRIPTION
  fixes #70533

  note that i dont have hpux so im going off user
  stating `w` is hte missing parameter in our use of `netstat`
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
modules/setup