### PR TITLE
new antsibull supports breadcrumbs toggle

### DIFF
--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -1,7 +1,7 @@
 # pip packages required to build docsite
 # tested June 9 2021
 
-antsibull==0.34.0
+antsibull==0.36.0
 docutils==0.16
 # check unordered lists when testing more recent docutils versions
 # see https://github.com/readthedocs/sphinx_rtd_theme/issues/1115

--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -1,7 +1,8 @@
 # pip packages required to build docsite
 # tested June 9 2021
 
-antsibull==0.36.0
+antsibull
+# version floats free, since we control features and releases
 docutils==0.16
 # check unordered lists when testing more recent docutils versions
 # see https://github.com/readthedocs/sphinx_rtd_theme/issues/1115


### PR DESCRIPTION
##### SUMMARY

We need to be able toggle breadcrumbs off if the build uses more memory resources than are available.

Updating to antsibull 38 to get that functionality.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
