### PR TITLE
new antsibull supports breadcrumbs toggle (#75424)

### DIFF
--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -1,7 +1,8 @@
 # pip packages required to build docsite
 # tested June 9 2021
 
-antsibull==0.34.0
+antsibull
+# version floats free, since we control features and releases
 docutils==0.16
 # check unordered lists when testing more recent docutils versions
 # see https://github.com/readthedocs/sphinx_rtd_theme/issues/1115


### PR DESCRIPTION
* new antsibull supports breadcrumbs toggle

* let antsibull version float free

Co-authored-by: Alicia Cozine <acozine@users.noreply.github.com>
(cherry picked from commit d9d98740f2f59ef6f6f764531e9b94c2a6fae5ae)

##### SUMMARY

Allows the version of antsibull in our known_good_reqs file to float free.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
