### PR TITLE
facts: Add uptime fact for NetBSD

### DIFF
--- a/changelogs/fragments/75431-Add-uptime-fact-for-NetBSD.yml
+++ b/changelogs/fragments/75431-Add-uptime-fact-for-NetBSD.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- NetBSD - Add uptime_seconds fact


### PR DESCRIPTION
##### SUMMARY
This is copied from the current OpenBSD facts code.

Tested on the GCC compile farm: https://cfarm.tetaneutral.net/

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
hardware