### PR TITLE
Add new merge_variables lookup plugin

### DIFF
--- a/lib/ansible/plugins/lookup/merge_variables.py
+++ b/lib/ansible/plugins/lookup/merge_variables.py
@@ -1,0 +1,161 @@
+# (c) 2020 Thales Netherlands
+# (c) 2021 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    name: merge_variables
+    author:
+      - Roy Lenferink (@rlenferink) <lenferinkroy@gmail.com>
+      - Mark Ettema (@m-a-r-k-e) <dev@markettema.nl>
+    version_added: "2.12"
+    short_description: merge variables with a certain suffix
+    description:
+        - This lookup returns the merged result of all variables in scope that matches the given suffix optionally
+          starting with an initial value.
+    options:
+      _terms:
+        description:
+          - The suffix of the variable name (all available variables will be checked with endswith(suffix))
+        required: true
+      initial_value:
+        description:
+          - An initial value to start with
+        required: false
+      override_warning:
+        description:
+          - Print a warning when a key will be overwritten
+        default: false
+      override_error:
+        description:
+          - Return error when a key will be overwritten
+        default: false
+"""
+
+EXAMPLES = """
+# Some example variables, they can be defined anywhere as long as they are in scope
+test_init_list:
+  - "list init item 1"
+  - "list init item 2"
+
+testa__test_list:
+  - "test a item 1"
+
+testb__test_list:
+  - "test b item 1"
+
+testa__test_dict:
+  ports:
+    - 1
+
+testb__test_dict:
+  ports:
+    - 3
+
+
+# Merging variables that ends with '__test_dict' and store the result in a variable 'example_a'
+example_a: "{{ lookup('merge_variables', '__test_dict') }}"
+
+# The variable example_a now contains:
+# ports:
+#   - 1
+#   - 3
+
+
+# Merging variables that ends with '__test_list', starting with an initial value and store the result
+# in a variable 'example_b'
+example_b: "{{ lookup('merge_variables', '__test_list', initial_value=test_init_list) }}"
+
+# The variable example_b now contains:
+#   - "list init item 1"
+#   - "list init item 2"
+#   - "test a item 1"
+#   - "test b item 1"
+"""
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.parsing.convert_bool import boolean
+from ansible.utils.display import Display
+
+display = Display()
+
+
+def _verify_and_get_type(variable):
+    if isinstance(variable, list):
+        return "list"
+    elif isinstance(variable, dict):
+        return "dict"
+    else:
+        raise AnsibleError("Not supported type detected, variable must be a list or a dict")
+
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables=None, **kwargs):
+        self.set_options(direct=kwargs)
+        initial_value = self.get_option("initial_value", None)
+        self._override_warning = boolean(self.get_option('override_warning', False))
+        self._override_error = boolean(self.get_option('override_error', False))
+
+        ret = []
+        for term in terms:
+            ret.append(self._merge_vars(term, initial_value, variables))
+
+        return ret
+
+    def _merge_vars(self, search_suffix, initial_value, variables):
+        display.v("Merge variables with suffix: {0}".format(search_suffix))
+        var_merge_names = sorted([key for key in variables.keys() if key.endswith(search_suffix)])
+        display.v("The following variables will be merged: {0}".format(var_merge_names))
+
+        prev_var_type = None
+        result = None
+
+        if initial_value is not None:
+            display.v("Start merge with initial value: {0}".format(initial_value))
+            prev_var_type = _verify_and_get_type(initial_value)
+            result = initial_value
+
+        for var_name in var_merge_names:
+            var_value = self._templar.template(variables[var_name])  # Render jinja2 templates
+            var_type = _verify_and_get_type(var_value)
+
+            if prev_var_type is None:
+                prev_var_type = var_type
+            elif prev_var_type != var_type:
+                raise AnsibleError("Unable to merge, not all variables are of the same type")
+
+            if result is None:
+                result = var_value
+                continue
+
+            if var_type == "dict":
+                result = self._merge_dict(var_value, result, [var_name])
+            else:  # var_type == "list"
+                result += var_value
+
+        return result
+
+    def _merge_dict(self, src, dest, path):
+        for key, value in src.items():
+            if isinstance(value, dict):
+                node = dest.setdefault(key, {})
+                self._merge_dict(value, node, path + [key])
+            elif isinstance(value, list) and key in dest:
+                dest[key] += value
+            else:
+                if (key in dest) and dest[key] != value:
+                    msg = "The key '{0}' with value '{1}' will be overwritten with value '{2}' from '{3}.{0}'".format(
+                        key, dest[key], value, ".".join(path))
+
+                    if self._override_error:
+                        raise AnsibleError(msg)
+                    if self._override_warning:
+                        display.warning(msg)
+
+                dest[key] = value
+
+        return dest

--- a/test/integration/targets/lookup_merge_variables/aliases
+++ b/test/integration/targets/lookup_merge_variables/aliases
@@ -1,0 +1,3 @@
+shippable/posix/group1
+skip/aix
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/test/integration/targets/lookup_merge_variables/ansible.cfg
+++ b/test/integration/targets/lookup_merge_variables/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+log_path=/tmp/ansible-test-merge-variables

--- a/test/integration/targets/lookup_merge_variables/test_merge_lookup.yml
+++ b/test/integration/targets/lookup_merge_variables/test_merge_lookup.yml
@@ -1,0 +1,145 @@
+---
+# (c) 2020 Thales Netherlands
+# (c) 2021 Ansible Project
+
+- name: Test merge_variables lookup plugin
+  hosts: localhost
+  vars:
+    testlist_initial_value: "{{ testlist2 }}"
+    testlist1__merge_list:
+      - item1
+    testlist2:
+      - item2
+    testlist3__merge_list:
+      - item3
+
+    testdict1__merge_dict:
+      item1: test
+      list_item:
+        - test1
+    testdict2__merge_dict:
+      item2: test
+      list_item:
+        - test2
+
+    override_warning_init:
+      key_to_override: Initial value
+    override__override_warning:
+      key_to_override: Override value
+
+    override_error_init:
+      key_to_override: Initial value
+    override__override_error:
+      key_to_override: Override value
+
+    logging_output_file: /tmp/ansible-test-merge-variables  # The Ansible log output is available in this file
+  tasks:
+    - name: Test merge list
+      block:
+        - name: Print the merged list
+          debug:
+            msg: "{{ merged_list }}"
+
+        - name: Validate that the list is complete
+          assert:
+            that:
+              - "(merged_list | length) == 2"
+              - "'item1' in merged_list"
+              - "'item3' in merged_list"
+      vars:
+        merged_list: "{{ lookup('merge_variables', '__merge_list') }}"
+
+    - name: Test merge dict
+      block:
+        - name: Print the merged list
+          debug:
+            msg: "{{ merged_dict }}"
+
+        - name: Validate that dict is complete
+          assert:
+            that:
+              - "'item1' in merged_dict"
+              - "'item2' in merged_dict"
+              - "'list_item' in merged_dict"
+              - "(merged_dict.list_item | length) == 2"
+              - "'test1' in (merged_dict.list_item)"
+              - "'test2' in (merged_dict.list_item)"
+      vars:
+        merged_dict: "{{ lookup('merge_variables', '__merge_dict') }}"
+
+    - name: Test merge without results
+      block:
+        - debug:
+            msg: "{{ not_found }}"
+        - name: Validate that the variable defaults to an empty list
+          vars:
+          assert:
+            that:
+              - "(not_found | default('default-used', True)) == 'default-used'"
+      vars:
+        not_found: "{{ lookup('merge_variables', '__merge_not_found') }}"
+
+    - name: Test merge without results but with initial value
+      block:
+        - name: Print the merged list
+          debug:
+            msg: "{{ not_found_initial_value }}"
+
+        - name: Validate that the variable only contains the initial value
+          vars:
+          assert:
+            that:
+              - "(not_found_initial_value | count) == 1"
+              - "(not_found_initial_value | first) == 'item2'"
+      vars:
+        not_found_initial_value: "{{ lookup('merge_variables', '__merge_not_found', initial_value=testlist_initial_value) }}"
+
+    - name: Test merge start with an initial value
+      block:
+        - name: Print the merged list
+          debug:
+            msg: "{{ merged_list_with_initial_value }}"
+
+        - name: Validate that the list is complete
+          assert:
+            that:
+              - "(merged_list_with_initial_value | length) == 3"
+              - "'item1' in merged_list_with_initial_value"
+              - "'item2' in merged_list_with_initial_value"
+              - "'item3' in merged_list_with_initial_value"
+      vars:
+        merged_list_with_initial_value: "{{ lookup('merge_variables', '__merge_list', initial_value=testlist_initial_value) }}"
+
+    - name: Test that an override prints a warning
+      block:
+        - name: Print the merged list
+          debug:
+            msg: "{{ merged_with_override_warning }}"
+
+        - name: Validate that the dict is complete and the warning is printed
+          assert:
+            that:
+              - "'key_to_override' in merged_with_override_warning"
+              - "merged_with_override_warning.key_to_override == 'Override value'"
+              - "'key_to_override' in lookup('file', logging_output_file)"  # Check if a message is given
+              - "'[WARNING]' in lookup('file', logging_output_file)"        # and verify that the message is a WARNING
+      vars:
+        merged_with_override_warning: "{{ lookup('merge_variables', '__override_warning', initial_value=override_warning_init, override_warning=True) }}"
+
+    - name: Test that an override result in an error
+      block:
+        - name: Validate that an override result in an error
+          debug:
+            msg: "{{ lookup('merge_variables', '__override_error', initial_value=override_error_init, override_error=True) }}"
+          ignore_errors: true  # Do not stop the playbook
+          register: _override_error_result
+
+        - name: Print the output
+          debug:
+            msg: "{{ _override_error_result }}"
+
+        - name: Validate that the error is reported
+          assert:
+            that:
+              - "_override_error_result.failed"
+              - "'key_to_override' in _override_error_result.msg"

--- a/test/units/plugins/lookup/test_merge_variables.py
+++ b/test/units/plugins/lookup/test_merge_variables.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2020 Thales Netherlands
+# Copyright: (c) 2021 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from units.compat import unittest
+from units.compat.mock import patch
+from units.mock.loader import DictDataLoader
+
+from ansible.plugins import AnsiblePlugin
+from ansible.plugins.lookup import merge_variables
+from ansible.template import Templar
+from ansible.errors import AnsibleError
+from ansible.utils.display import Display
+
+
+class TestMergeVariablesLookup(unittest.TestCase):
+    def setUp(self):
+        self.loader = DictDataLoader({})
+        self.templar = Templar(loader=self.loader, variables={})
+        self.merge_vars_lookup = merge_variables.LookupModule(loader=self.loader, templar=self.templar)
+
+    @patch.object(AnsiblePlugin, 'set_options')
+    @patch.object(AnsiblePlugin, 'get_option', side_effect=[None, False, False])
+    @patch.object(Templar, 'template', side_effect=[['item1'], ['item3']])
+    def test_merge_list(self, mock_set_options, mock_get_option, mock_template):
+        results = self.merge_vars_lookup.run(['__merge_list'], {
+            'testlist1__merge_list': ['item1'],
+            'testlist2': ['item2'],
+            'testlist3__merge_list': ['item3']
+        })
+
+        self.assertEqual(results, [['item1', 'item3']])
+
+    @patch.object(AnsiblePlugin, 'set_options')
+    @patch.object(AnsiblePlugin, 'get_option', side_effect=[['initial_item'], False, False])
+    @patch.object(Templar, 'template', side_effect=[['item1'], ['item3']])
+    def test_merge_list_with_initial_value(self, mock_set_options, mock_get_option, mock_template):
+        results = self.merge_vars_lookup.run(['__merge_list'], {
+            'testlist1__merge_list': ['item1'],
+            'testlist2': ['item2'],
+            'testlist3__merge_list': ['item3']
+        })
+
+        self.assertEqual(results, [['initial_item', 'item1', 'item3']])
+
+    @patch.object(AnsiblePlugin, 'set_options')
+    @patch.object(AnsiblePlugin, 'get_option', side_effect=[None, False, False])
+    @patch.object(Templar, 'template', side_effect=[{'item1': 'test', 'list_item': ['test1']},
+                                                    {'item2': 'test', 'list_item': ['test2']}])
+    def test_merge_dict(self, mock_set_options, mock_get_option, mock_template):
+        results = self.merge_vars_lookup.run(['__merge_dict'], {
+            'testdict1__merge_dict': {
+                'item1': 'test',
+                'list_item': ['test1']
+            },
+            'testdict2__merge_dict': {
+                'item2': 'test',
+                'list_item': ['test2']
+            }
+        })
+
+        self.assertEqual(results, [
+            {
+                'item1': 'test',
+                'item2': 'test',
+                'list_item': ['test1', 'test2']
+            }
+        ])
+
+    @patch.object(AnsiblePlugin, 'set_options')
+    @patch.object(AnsiblePlugin, 'get_option', side_effect=[{'initial_item': 'random value', 'list_item': ['test0']},
+                                                            False, False])
+    @patch.object(Templar, 'template', side_effect=[{'item1': 'test', 'list_item': ['test1']},
+                                                    {'item2': 'test', 'list_item': ['test2']}])
+    def test_merge_dict_with_initial_value(self, mock_set_options, mock_get_option, mock_template):
+        results = self.merge_vars_lookup.run(['__merge_dict'], {
+            'testdict1__merge_dict': {
+                'item1': 'test',
+                'list_item': ['test1']
+            },
+            'testdict2__merge_dict': {
+                'item2': 'test',
+                'list_item': ['test2']
+            }
+        })
+
+        self.assertEqual(results, [
+            {
+                'initial_item': 'random value',
+                'item1': 'test',
+                'item2': 'test',
+                'list_item': ['test0', 'test1', 'test2']
+            }
+        ])
+
+    @patch.object(AnsiblePlugin, 'set_options')
+    @patch.object(AnsiblePlugin, 'get_option', side_effect=[None, True, False])  # override_warning enabled
+    @patch.object(Templar, 'template', side_effect=[{'item': 'value1'}, {'item': 'value2'}])
+    @patch.object(Display, 'warning')
+    def test_merge_dict_non_unique_warning(self, mock_set_options, mock_get_option, mock_template, mock_display):
+        results = self.merge_vars_lookup.run(['__merge_non_unique'], {
+            'testdict1__merge_non_unique': {'item': 'value1'},
+            'testdict2__merge_non_unique': {'item': 'value2'}
+        })
+
+        self.assertTrue(mock_display.called)
+        self.assertEqual(results, [{'item': 'value2'}])
+
+    @patch.object(AnsiblePlugin, 'set_options')
+    @patch.object(AnsiblePlugin, 'get_option', side_effect=[None, False, True])  # override_error enabled
+    @patch.object(Templar, 'template', side_effect=[{'item': 'value1'}, {'item': 'value2'}])
+    def test_merge_dict_non_unique_error(self, mock_set_options, mock_get_option, mock_template):
+        with self.assertRaises(AnsibleError):
+            self.merge_vars_lookup.run(['__merge_non_unique'], {
+                'testdict1__merge_non_unique': {'item': 'value1'},
+                'testdict2__merge_non_unique': {'item': 'value2'}
+            })
+
+    @patch.object(AnsiblePlugin, 'set_options')
+    @patch.object(AnsiblePlugin, 'get_option', side_effect=[None, False, False])
+    @patch.object(Templar, 'template', side_effect=[{'item1': 'test', 'list_item': ['test1']},
+                                                    ['item2', 'item3']])
+    def test_merge_list_and_dict(self, mock_set_options, mock_get_option, mock_template):
+        with self.assertRaises(AnsibleError):
+            self.merge_vars_lookup.run(['__merge_var'], {
+                'testlist__merge_var': {
+                    'item1': 'test',
+                    'list_item': ['test1']
+                },
+                'testdict__merge_var': ['item2', 'item3']
+            })


### PR DESCRIPTION
##### SUMMARY
This adds a new lookup plugin which can be used to merge lists or dicts. This to be able to merge variables that are specified in  both the group_vars and the host_vars for usage in tasks. This is only for chosen variables so that the [DEFAULT_HASH_BEHAVIOR](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-hash-behaviour) can be kept the default (`replace`).

For example in the group_vars a list of packages to install can be specified where on some nodes you want to extend this list with some additional packages. Normally if a variable is specified in the host_vars it overrides the group_vars, but the idea behind this lookup plugin is that it is possible to retain both the group_vars as the host_vars (only for the specified variable).

Example:
```yml
# group_vars/node_collection/packages.yml
---
nodes__packages:
- package1
- package2
- package3

# host_vars/node2/packages.yml
node2__packages:
- extra_package1
```

In the role using this variable (e.g. `_packages_definition: "{{ lookup('merge_variables', '__packages')"`, the lookup plugin is used to merge the variables together and execute the tasks (in this example installing a package).

In the above scenario all nodes part of the `node_collection` group will have `package[1,2,3]` installed, where `node2` has `package[1,2,3]` and `extra_package1` installed.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
merge_variables lookup plugin

##### ADDITIONAL INFORMATION

