### PR TITLE
Add an `undef` global Jinja function

### DIFF
--- a/changelogs/fragments/75435-creating-Undefined.yml
+++ b/changelogs/fragments/75435-creating-Undefined.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - adds the ``Undef`` keyword to the templating environment. This allows for directly creating Undefined values in templates. It is most useful for providing a hint for variables which must be overridden.

--- a/changelogs/fragments/75435-creating-Undefined.yml
+++ b/changelogs/fragments/75435-creating-Undefined.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - adds the ``Undef`` keyword to the templating environment. This allows for directly creating Undefined values in templates. It is most useful for providing a hint for variables which must be overridden.
+  - adds the ``undef`` keyword to the templating environment. This allows for directly creating Undefined values in templates. It is most useful for providing a hint for variables which must be overridden.

--- a/changelogs/fragments/75435-fail-filter.yml
+++ b/changelogs/fragments/75435-fail-filter.yml
@@ -1,0 +1,3 @@
+add plugin.filter:
+  - name: fail
+    description: Fails if invoked. Useful for requiring a variable to be overridden

--- a/changelogs/fragments/75435-fail-filter.yml
+++ b/changelogs/fragments/75435-fail-filter.yml
@@ -1,3 +1,0 @@
-add plugin.filter:
-  - name: fail
-    description: Fails if invoked. Useful for requiring a variable to be overridden

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -68,7 +68,9 @@ If you configure Ansible to ignore undefined variables, you may want to define s
 
 The variable value will be used as is, but the template evaluation will raise an error if it is undefined.
 
-A convenient way of requiring a variable to be overridden is to give it an undefined value using the ``Undef`` keyword. This can be useful in a role's defaults::
+A convenient way of requiring a variable to be overridden is to give it an undefined value using the ``Undef`` keyword. This can be useful in a role's defaults.
+
+.. code-block:: yaml+jinja
 
     galaxy_url: "https://galaxy.ansible.com"
     galaxy_api_key: {{ Undef(hint="You must specify your Galaxy API key") }}

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -68,6 +68,11 @@ If you configure Ansible to ignore undefined variables, you may want to define s
 
 The variable value will be used as is, but the template evaluation will raise an error if it is undefined.
 
+A convenient way of requiring a variable to be overridden is to use the ``fail`` filter. This is useful in a role's defaults::
+
+    galaxy_url: "https://galaxy.ansible.com"
+    galaxy_api_key: {{ "You must specify your Galaxy API key" | fail }}
+
 Defining different values for true/false/null (ternary)
 =======================================================
 

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -68,10 +68,10 @@ If you configure Ansible to ignore undefined variables, you may want to define s
 
 The variable value will be used as is, but the template evaluation will raise an error if it is undefined.
 
-A convenient way of requiring a variable to be overridden is to use the ``fail`` filter. This is useful in a role's defaults::
+A convenient way of requiring a variable to be overridden is to give it an undefined value using the ``Undef`` keyword. This can be useful in a role's defaults::
 
     galaxy_url: "https://galaxy.ansible.com"
-    galaxy_api_key: {{ "You must specify your Galaxy API key" | fail }}
+    galaxy_api_key: {{ Undef(hint="You must specify your Galaxy API key") }}
 
 Defining different values for true/false/null (ternary)
 =======================================================

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -68,12 +68,12 @@ If you configure Ansible to ignore undefined variables, you may want to define s
 
 The variable value will be used as is, but the template evaluation will raise an error if it is undefined.
 
-A convenient way of requiring a variable to be overridden is to give it an undefined value using the ``Undef`` keyword. This can be useful in a role's defaults.
+A convenient way of requiring a variable to be overridden is to give it an undefined value using the ``undef`` keyword. This can be useful in a role's defaults.
 
 .. code-block:: yaml+jinja
 
     galaxy_url: "https://galaxy.ansible.com"
-    galaxy_api_key: {{ Undef(hint="You must specify your Galaxy API key") }}
+    galaxy_api_key: {{ undef(hint="You must specify your Galaxy API key") }}
 
 Defining different values for true/false/null (ternary)
 =======================================================

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -32,7 +32,7 @@ from ansible.module_utils.common._collections_compat import Mapping
 from ansible.module_utils.common.yaml import yaml_load, yaml_load_all
 from ansible.parsing.ajson import AnsibleJSONEncoder
 from ansible.parsing.yaml.dumper import AnsibleDumper
-from ansible.template import recursive_check_defined
+from ansible.template import AnsibleUndefined, recursive_check_defined
 from ansible.utils.display import Display
 from ansible.utils.encrypt import passlib_or_crypt
 from ansible.utils.hashing import md5s, checksum_s
@@ -297,6 +297,12 @@ def mandatory(a, msg=None):
             raise AnsibleFilterError("Mandatory variable %s not defined." % name)
 
     return a
+
+
+def fail(msg=None):
+    if msg is None:
+        msg = "Mandatory variable has not been overridden"
+    return AnsibleUndefined(msg)
 
 
 def combine(*terms, **kwargs):
@@ -638,6 +644,7 @@ class FilterModule(object):
 
             # undefined
             'mandatory': mandatory,
+            'fail': fail,
 
             # comment-style decoration
             'comment': comment,

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -299,14 +299,6 @@ def mandatory(a, msg=None):
     return a
 
 
-def fail(msg=None):
-    from jinja2.runtime import Undefined
-
-    if msg is None or isinstance(msg, Undefined) or msg == '':
-        msg = "Mandatory variable has not been overridden"
-    return AnsibleUndefined(msg)
-
-
 def combine(*terms, **kwargs):
     recursive = kwargs.pop('recursive', False)
     list_merge = kwargs.pop('list_merge', 'replace')
@@ -646,7 +638,6 @@ class FilterModule(object):
 
             # undefined
             'mandatory': mandatory,
-            'fail': fail,
 
             # comment-style decoration
             'comment': comment,

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -300,7 +300,9 @@ def mandatory(a, msg=None):
 
 
 def fail(msg=None):
-    if msg is None:
+    from jinja2.runtime import Undefined
+
+    if msg is None or isinstance(msg, Undefined) or msg == '':
         msg = "Mandatory variable has not been overridden"
     return AnsibleUndefined(msg)
 

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -1069,12 +1069,12 @@ class Templar:
 
         return ran
 
-    def _make_undefined(self, msg=None):
+    def _make_undefined(self, hint=None):
         from jinja2.runtime import Undefined
 
-        if msg is None or isinstance(msg, Undefined) or msg == '':
-            msg = "Mandatory variable has not been overridden"
-        return AnsibleUndefined(msg)
+        if hint is None or isinstance(hint, Undefined) or hint == '':
+            hint = "Mandatory variable has not been overridden"
+        return AnsibleUndefined(hint)
 
     def do_template(self, data, preserve_trailing_newlines=True, escape_backslashes=True, fail_on_undefined=None, overrides=None, disable_lookups=False):
         if self.jinja2_native and not isinstance(data, string_types):

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -693,7 +693,7 @@ class Templar:
         self.environment.globals['query'] = self.environment.globals['q'] = self._query_lookup
         self.environment.globals['now'] = self._now_datetime
         self.environment.globals['finalize'] = self._finalize
-        self.environment.globals['Undef'] = self._make_undefined
+        self.environment.globals['undef'] = self._make_undefined
 
         # the current rendering context under which the templar class is working
         self.cur_context = None

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -693,6 +693,7 @@ class Templar:
         self.environment.globals['query'] = self.environment.globals['q'] = self._query_lookup
         self.environment.globals['now'] = self._now_datetime
         self.environment.globals['finalize'] = self._finalize
+        self.environment.globals['Undef'] = self._make_undefined
 
         # the current rendering context under which the templar class is working
         self.cur_context = None
@@ -1067,6 +1068,13 @@ class Templar:
                     ran = wrap_var(ran)
 
         return ran
+
+    def _make_undefined(self, msg=None):
+        from jinja2.runtime import Undefined
+
+        if msg is None or isinstance(msg, Undefined) or msg == '':
+            msg = "Mandatory variable has not been overridden"
+        return AnsibleUndefined(msg)
 
     def do_template(self, data, preserve_trailing_newlines=True, escape_backslashes=True, fail_on_undefined=None, overrides=None, disable_lookups=False):
         if self.jinja2_native and not isinstance(data, string_types):

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -494,33 +494,33 @@
       - mandatory_2 is failed
       - "mandatory_2.msg == 'You did not give me a variable. I am a sad wolf.'"
 
-- name: Verify Undef throws if resolved
+- name: Verify undef throws if resolved
   set_fact:
     foo: '{{ fail_foo }}'
   vars:
-    fail_foo: '{{ Undef("Expected failure") }}'
+    fail_foo: '{{ undef("Expected failure") }}'
   ignore_errors: yes
   register: fail_1
 
 - name: Setup fail_foo for overriding in test
   block:
-    - name: Verify Undef not executed if overridden
+    - name: Verify undef not executed if overridden
       set_fact:
         foo: '{{ fail_foo }}'
       vars:
         fail_foo: 'overridden value'
       register: fail_2
   vars:
-    fail_foo: '{{ Undef(hint="Expected failure") }}'
+    fail_foo: '{{ undef(hint="Expected failure") }}'
 
-- name: Verify Undef is inspectable
+- name: Verify undef is inspectable
   debug:
     var: fail_foo
   vars:
-    fail_foo: '{{ Undef("Expected failure") }}'
+    fail_foo: '{{ undef("Expected failure") }}'
   register: fail_3
 
-- name: Verify Undef
+- name: Verify undef
   assert:
     that:
       - fail_1 is failed

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -494,6 +494,39 @@
       - mandatory_2 is failed
       - "mandatory_2.msg == 'You did not give me a variable. I am a sad wolf.'"
 
+- name: Verify fail throws if executed
+  set_fact:
+    foo: '{{ fail_foo }}'
+  vars:
+    fail_foo: '{{ "Expected failure" | fail }}'
+  ignore_errors: yes
+  register: fail_1
+
+- name: Setup fail_foo for overriding in test
+  block:
+    - name: Verify fail not executed if overridden
+      set_fact:
+        foo: '{{ fail_foo }}'
+      vars:
+        fail_foo: 'overridden value'
+      register: fail_2
+  vars:
+    fail_foo: '{{ "Expected failure" | fail }}'
+
+- name: Verify fail is inspectable
+  debug:
+    var: fail_foo
+  vars:
+    fail_foo: '{{ "Expected failure" | fail }}'
+  register: fail_3
+
+- name: Verify fail
+  assert:
+    that:
+      - fail_1 is failed
+      - not (fail_2 is failed)
+      - not (fail_3 is failed)
+
 - name: Verify comment
   assert:
     that:

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -494,33 +494,33 @@
       - mandatory_2 is failed
       - "mandatory_2.msg == 'You did not give me a variable. I am a sad wolf.'"
 
-- name: Verify fail throws if executed
+- name: Verify Undef throws if resolved
   set_fact:
     foo: '{{ fail_foo }}'
   vars:
-    fail_foo: '{{ "Expected failure" | fail }}'
+    fail_foo: '{{ Undef("Expected failure") }}'
   ignore_errors: yes
   register: fail_1
 
 - name: Setup fail_foo for overriding in test
   block:
-    - name: Verify fail not executed if overridden
+    - name: Verify Undef not executed if overridden
       set_fact:
         foo: '{{ fail_foo }}'
       vars:
         fail_foo: 'overridden value'
       register: fail_2
   vars:
-    fail_foo: '{{ "Expected failure" | fail }}'
+    fail_foo: '{{ Undef(hint="Expected failure") }}'
 
-- name: Verify fail is inspectable
+- name: Verify Undef is inspectable
   debug:
     var: fail_foo
   vars:
-    fail_foo: '{{ "Expected failure" | fail }}'
+    fail_foo: '{{ Undef("Expected failure") }}'
   register: fail_3
 
-- name: Verify fail
+- name: Verify Undef
   assert:
     that:
       - fail_1 is failed

--- a/test/integration/targets/template/runme.sh
+++ b/test/integration/targets/template/runme.sh
@@ -4,8 +4,8 @@ set -eux
 
 ANSIBLE_ROLES_PATH=../ ansible-playbook template.yml -i ../../inventory -v "$@"
 
-# Test for #35571
-ansible testhost -i testhost, -m debug -a 'msg={{ hostvars["localhost"] }}' -e "vars1={{ undef }}" -e "vars2={{ vars1 }}"
+# Test for https://github.com/ansible/ansible/pull/35571
+ansible testhost -i testhost, -m debug -a 'msg={{ hostvars["localhost"] }}' -e "vars1={{ undef() }}" -e "vars2={{ vars1 }}"
 
 # Test for https://github.com/ansible/ansible/issues/27262
 ansible-playbook ansible_managed.yml -c  ansible_managed.cfg -i ../../inventory -v "$@"

--- a/test/integration/targets/undefined/tasks/main.yml
+++ b/test/integration/targets/undefined/tasks/main.yml
@@ -11,7 +11,7 @@
 
     - assert:
         that:
-          - '"%r"|format(undef) == "AnsibleUndefined"'
+          - '"%r"|format(undef()) == "AnsibleUndefined"'
           # The existence of AnsibleUndefined in a templating result
           # prevents safe_eval from turning the value into a python object
           - names is string

--- a/test/integration/targets/undefined/tasks/main.yml
+++ b/test/integration/targets/undefined/tasks/main.yml
@@ -11,6 +11,7 @@
 
     - assert:
         that:
+          - '"%r"|format(an_undefined_var) == "AnsibleUndefined"'
           - '"%r"|format(undef()) == "AnsibleUndefined"'
           # The existence of AnsibleUndefined in a templating result
           # prevents safe_eval from turning the value into a python object

--- a/test/units/plugins/filter/test_core.py
+++ b/test/units/plugins/filter/test_core.py
@@ -3,12 +3,14 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+from jinja2.runtime import Undefined
+from jinja2.exceptions import UndefinedError
 __metaclass__ = type
 
 import pytest
 
 from ansible.module_utils._text import to_native
-from ansible.plugins.filter.core import to_uuid
+from ansible.plugins.filter.core import fail, to_uuid
 from ansible.errors import AnsibleFilterError
 
 
@@ -39,3 +41,12 @@ def test_to_uuid_invalid_namespace():
     with pytest.raises(AnsibleFilterError) as e:
         to_uuid('example.com', namespace='11111111-2222-3333-4444-555555555')
     assert 'Invalid value' in to_native(e.value)
+
+
+@pytest.mark.parametrize('msg, expected', (("Expected failure", "Expected failure"), (None, "Mandatory variable has not been overridden")))
+def test_fail_returns_undefined_with_expected_message(msg, expected):
+    ret = fail(msg)
+    assert isinstance(ret, Undefined)
+    with pytest.raises(UndefinedError) as e:
+        str(ret)
+    assert expected in to_native(e.value)

--- a/test/units/plugins/filter/test_core.py
+++ b/test/units/plugins/filter/test_core.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 import pytest
 
 from ansible.module_utils._text import to_native
-from ansible.plugins.filter.core import fail, to_uuid
+from ansible.plugins.filter.core import to_uuid
 from ansible.errors import AnsibleFilterError
 
 
@@ -41,12 +41,3 @@ def test_to_uuid_invalid_namespace():
     with pytest.raises(AnsibleFilterError) as e:
         to_uuid('example.com', namespace='11111111-2222-3333-4444-555555555')
     assert 'Invalid value' in to_native(e.value)
-
-
-@pytest.mark.parametrize('msg, expected', (("Expected failure", "Expected failure"), (None, "Mandatory variable has not been overridden")))
-def test_fail_returns_undefined_with_expected_message(msg, expected):
-    ret = fail(msg)
-    assert isinstance(ret, Undefined)
-    with pytest.raises(UndefinedError) as e:
-        str(ret)
-    assert expected in to_native(e.value)


### PR DESCRIPTION
##### SUMMARY
Factors in the feedback on the previous attempt #75407 ; I couldn't reopen the PR. This PR originally made a filter, but we felt that wasn't really appropriate given the semantics (it doesn't actually filter anything). I think explicitly calling it Undefined also clarifies its semantics; the fail filter would just return `Undefined` so it didn't explode things, but people might have expected it to behave almost like the `fail` module.

Fixes #69255

Enables the creation of `Undefined` values. This is useful for specifying variables that must be overridden. These variables don't require an intermediate filtering and local variable For example, in a role's defaults file:
```yaml
global_mysql_root_user: "sqladmin"
global_mysql_root_password: "{{ undef(hint='required, generate with pwgen -s 20') }}"
```
instead of the suggested workaround
```yaml
global_mysql_root_user: "sqladmin"
# global_mysql_root_password: 
_global_mysql_root_password: "{{ global_mysql_root_password | mandatory('required, generate with pwgen -s 20') }}"
```
This makes it easier to search a codebase for where a variable is used, as it doesn't require also looking for all the local variants of that variable.

###### Alternatives

One suggestion was to extend the "mandatory" filter to treat `null` values as undefined. But there are valid use cases for requiring a user to specify a value but where `null` is a valid value.

Another suggestion was to use `validate_argument_spec`. I like this suggestion, argspec looks cool. It currently lacks documentation. As well, there are things like vars_files where the `fail` filter is much simpler than an argspec.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible.template.Templar

##### ADDITIONAL INFORMATION
###### Basic Usage
If not overridden:
```bash
ansible localhost -m debug -a msg="{{ foo }}" -e foo="{{ undef('xfail') }}"
localhost | FAILED! => {
    "msg": "The task includes an option with an undefined variable. The error was: {{ undef('xfail') }}: xfail. {{ undef('xfail') }}: xfail"
}

ansible localhost -m debug -a msg="{{ foo }}" -e foo="{{ undef('xfail') }}" -e foo="hi"
localhost | SUCCESS => {
    "msg": "hi"
}
```
###### Other Usage:

```yaml
- name: demo
  hosts: localhost
  connection: local
  gather_facts: false

  tasks:
    - name: print mandatory
      debug:
        var: v0
      ignore_errors: true

    - name: "print fail"
      debug:
        var: v1

    - name: "print fail with default"
      debug:
        var: v2
      ignore_errors: true

    - name: "print fail in ternary"
      debug:
        var: v3
      loop: [True, False]
      ignore_errors: true

    - name: "print msg undef"
      debug:
        msg: "{{ v4 }}"
      ignore_errors: true
    - name: "inspect undef"
      debug:
        var: undefined
      ignore_errors: true

    - name: "undef is undefined"
      assert:
        that: undef() is undefined

  vars:
    v0: "{{ undef() | mandatory('xfail') }}"
    v1: "{{ undef(hint='xfail') }}"
    v2: "{{ undef('xfail') | default('xx') }}"
    v3: "{{ item | ternary(0, undef('xfail')) }}"
    v4: "{{ undef() }}"

```

yields:
```bash
ansible-playbook demo.yml -vvv

PLAYBOOK: demo.yml **************************************************************************************************************************
1 plays in demo.yml

PLAY [demo] *********************************************************************************************************************************
META: ran handlers

TASK [print mandatory] **********************************************************************************************************************
task path: /home/lilatomic/GIT/ansible/demo.yml:7
fatal: [localhost]: FAILED! => {
    "msg": "An unhandled exception occurred while templating '{{ undef() | mandatory('xfail') }}'. Error was a <class 'ansible.errors.AnsibleFilterError'>, original message: xfail"
}
...ignoring

TASK [print fail] ***************************************************************************************************************************
task path: /home/lilatomic/GIT/ansible/demo.yml:12
ok: [localhost] => {
    "v1": "VARIABLE IS NOT DEFINED!: {{ undef(hint='xfail') }}: xfail"
}

TASK [print fail with default] **************************************************************************************************************
task path: /home/lilatomic/GIT/ansible/demo.yml:16
ok: [localhost] => {
    "v2": "xx"
}

TASK [print fail in ternary] ****************************************************************************************************************
task path: /home/lilatomic/GIT/ansible/demo.yml:21
ok: [localhost] => (item=True) => {
    "ansible_loop_var": "item",
    "item": true,
    "v3": "0"
}
ok: [localhost] => (item=False) => {
    "ansible_loop_var": "item",
    "item": false,
    "v3": "VARIABLE IS NOT DEFINED!: {{ item | ternary(0, undef('xfail')) }}: xfail"
}

TASK [print msg undef] **********************************************************************************************************************
task path: /home/lilatomic/GIT/ansible/demo.yml:27
fatal: [localhost]: FAILED! => {
    "msg": "The task includes an option with an undefined variable. The error was: {{ undef() }}: Mandatory variable has not been overridden\n\nThe error appears to be in '/home/lilatomic/GIT/ansible/demo.yml': line 27, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: \"print msg undef\"\n      ^ here\n"
}
...ignoring

TASK [inspect undef] ************************************************************************************************************************
task path: /home/lilatomic/GIT/ansible/demo.yml:31
ok: [localhost] => {
    "undefined": "VARIABLE IS NOT DEFINED!: 'undefined' is undefined"
}

TASK [undef is undefined] *******************************************************************************************************************
task path: /home/lilatomic/GIT/ansible/demo.yml:36
ok: [localhost] => {
    "changed": false,
    "msg": "All assertions passed"
}
META: ran handlers
META: ran handlers

PLAY RECAP **********************************************************************************************************************************
localhost                  : ok=7    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=2   

```