### PR TITLE
sample layout: put playbooks in single repository

### DIFF
--- a/docs/docsite/rst/user_guide/sample_setup.rst
+++ b/docs/docsite/rst/user_guide/sample_setup.rst
@@ -30,9 +30,11 @@ This layout organizes most tasks in roles, with a single inventory file for each
     module_utils/             # if any custom module_utils to support modules, put them here (optional)
     filter_plugins/           # if any custom filter plugins, put them here (optional)
 
-    site.yml                  # main playbook
-    webservers.yml            # playbook for webserver tier
-    dbservers.yml             # playbook for dbserver tier
+    playbooks/
+        site.yml                  # main playbook
+        webservers.yml            # playbook for webserver tier
+        dbservers.yml             # playbook for dbserver tier
+        
     tasks/                    # task files included from playbooks
         webservers-extra.yml  # <-- avoids confusing playbook with task files
 
@@ -91,9 +93,10 @@ Alternatively you can put each inventory file with its ``group_vars``/``host_var
     module_utils/
     filter_plugins/
 
-    site.yml
-    webservers.yml
-    dbservers.yml
+    playbooks/
+         site.yml
+         webservers.yml
+         dbservers.yml
 
     roles/
         common/


### PR DESCRIPTION
##### SUMMARY
<!--- Your description here -->

Considering the amount of playbooks an ansible repo can have, the sample layout should put all playbooks in a dedicated folder.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
