### PR TITLE
Allow to keep search path in import_playbook

### DIFF
--- a/lib/ansible/modules/import_playbook.py
+++ b/lib/ansible/modules/import_playbook.py
@@ -22,6 +22,11 @@ options:
   free-form:
     description:
       - The name of the imported playbook is specified directly without any other option.
+  keep_search_path:
+    description:
+      - Whether to keep or not the search path from the current playbook.
+    type: bool
+    default: "no"
 extends_documentation_fragment:
 - action_common_attributes
 attributes:

--- a/lib/ansible/playbook/playbook_include.py
+++ b/lib/ansible/playbook/playbook_include.py
@@ -43,6 +43,7 @@ class PlaybookInclude(Base, Conditional, Taggable):
 
     _import_playbook = FieldAttribute(isa='string')
     _vars = FieldAttribute(isa='dict', default=dict)
+    _keep_search_path = FieldAttribute(isa='bool', default=False)
 
     @staticmethod
     def load(data, basedir, variable_manager=None, loader=None):
@@ -113,7 +114,7 @@ class PlaybookInclude(Base, Conditional, Taggable):
             entry.vars = temp_vars
             entry.tags = list(set(entry.tags).union(new_obj.tags))
             if entry._included_path is None:
-                entry._included_path = os.path.dirname(playbook)
+                entry._included_path = basedir if new_obj.keep_search_path else os.path.dirname(playbook)
 
             # Check to see if we need to forward the conditionals on to the included
             # plays. If so, we can take a shortcut here and simply prepend them to


### PR DESCRIPTION
The core module import_playbook now supports a new boolean option that allows
to decide whether to keep or not the search path from the current playbook

Fixes #75448

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

import_playbook