### PR TITLE
hacking - account for job names that contain separators

### DIFF
--- a/hacking/azp/download.py
+++ b/hacking/azp/download.py
@@ -214,6 +214,11 @@ def download_run(args):
                 parent_id = parent_of.get(p['id'], None)
 
             path = " ".join(names)
+
+            if os.sep in path:
+                # Some job names have the separator in them.
+                path = path.replace(os.sep, '_')
+
             log_path = os.path.join(output_dir, '%s.log' % path)
             if args.verbose:
                 print(log_path)

--- a/hacking/azp/download.py
+++ b/hacking/azp/download.py
@@ -215,9 +215,8 @@ def download_run(args):
 
             path = " ".join(names)
 
-            if os.sep in path:
-                # Some job names have the separator in them.
-                path = path.replace(os.sep, '_')
+            # Some job names have the separator in them.
+            path = path.replace(os.sep, '_')
 
             log_path = os.path.join(output_dir, '%s.log' % path)
             if args.verbose:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Some Azure Pipelines job names contain `/` which causes the download job to fail.

Replace the `/` with `_` so `open()` does not raise a `FileNotFoundError`.

Example job name: `Post-job: Checkout ansible/ansible@refs/pull/75445/merge to ansible`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`hacking/azp/download.py`