### PR TITLE
Docs Backport: fixes typo in changelog entry

### DIFF
--- a/changelogs/fragments/70319-reduce-ignored-module-sanity-tests.yml
+++ b/changelogs/fragments/70319-reduce-ignored-module-sanity-tests.yml
@@ -1,4 +1,4 @@
 bugfixes:
   - apt_repository - fixes ``mode`` doc to remove ineffective default (https://github.com/ansible/ansible/pull/70319).
 deprecated_features:
-  - apt_key - the paramater ``key`` does not have any effect, has been deprecated and will be removed in ansible-core version 2.14 (https://github.com/ansible/ansible/pull/70319).
+  - apt_key - the parameter ``key`` does not have any effect, has been deprecated and will be removed in ansible-core version 2.14 (https://github.com/ansible/ansible/pull/70319).


### PR DESCRIPTION
##### SUMMARY

There is a typo in a changelog fragment for ansible-core 2.11, which gets picked up in the Ansible 4 changelog as well. Fixing this at the source.

Related to #75442, which fixed in the Ansible 4 changelog.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
changelogs
