### PR TITLE
role arg spec - allow file extensions in `tasks_from`

### DIFF
--- a/changelogs/fragments/role-argspec-file-extension-tasks_from.yml
+++ b/changelogs/fragments/role-argspec-file-extension-tasks_from.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    role argument spec validation - find the correct spec when the file specified in ``tasks_from`` field
+    contains a file extension

--- a/lib/ansible/module_utils/splitter.py
+++ b/lib/ansible/module_utils/splitter.py
@@ -29,6 +29,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import os
+
 
 def _get_quote_state(token, quote_char):
     '''
@@ -217,3 +219,13 @@ def unquote(data):
     if is_quoted(data):
         return data[1:-1]
     return data
+
+
+def stem(path):
+    """Return the last element in a path minus its last suffix"""
+    name = os.path.basename(path)
+    i = name.rfind('.')
+    if 0 < i < len(name) - 1:
+        return name[:i]
+    else:
+        return name

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -318,10 +318,9 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
             # This comes from the `tasks_from` value to include_role or import_role.
             entrypoint = self._from_files.get('tasks', 'main')
 
-            # Remove the file extension
-            i = entrypoint.rfind('.')
-            if 0 < i < len(entrypoint) - 1:
-                entrypoint = entrypoint[:i]
+            # This could be a filename with an extension or an absolute path.
+            # Extract the stem in order to look up the proper spec.
+            entrypoint = os.path.splitext(os.path.basename(entrypoint))[0]
 
             entrypoint_arg_spec = argspecs.get(entrypoint)
 

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -26,6 +26,7 @@ from ansible.errors import AnsibleError, AnsibleParserError, AnsibleAssertionErr
 from ansible.module_utils._text import to_text
 from ansible.module_utils.six import iteritems, binary_type, text_type
 from ansible.module_utils.common._collections_compat import Container, Mapping, Set, Sequence
+from ansible.module_utils.splitter import stem
 from ansible.playbook.attribute import FieldAttribute
 from ansible.playbook.base import Base
 from ansible.playbook.collectionsearch import CollectionSearch
@@ -316,16 +317,14 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
         if argspecs:
             # Determine the role entry point so we can retrieve the correct argument spec.
             # This comes from the `tasks_from` value to include_role or import_role.
-            entrypoint = self._from_files.get('tasks', 'main')
-
+            #
             # This could be a filename with an extension or an absolute path.
             # Extract the stem in order to look up the proper spec.
-            entrypoint = os.path.splitext(os.path.basename(entrypoint))[0]
-
-            entrypoint_arg_spec = argspecs.get(entrypoint)
+            entrypoint_name = stem(self._from_files.get('tasks', 'main'))
+            entrypoint_arg_spec = argspecs.get(entrypoint_name)
 
             if entrypoint_arg_spec:
-                validation_task = self._create_validation_task(entrypoint_arg_spec, entrypoint)
+                validation_task = self._create_validation_task(entrypoint_arg_spec, entrypoint_name)
 
                 # Prepend our validate_argument_spec action to happen before any tasks provided by the role.
                 # 'any tasks' can and does include 0 or None tasks, in which cases we create a list of tasks and add our

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -317,6 +317,12 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
             # Determine the role entry point so we can retrieve the correct argument spec.
             # This comes from the `tasks_from` value to include_role or import_role.
             entrypoint = self._from_files.get('tasks', 'main')
+
+            # Remove the file extension
+            i = entrypoint.rfind('.')
+            if 0 < i < len(entrypoint) - 1:
+                entrypoint = entrypoint[:i]
+
             entrypoint_arg_spec = argspecs.get(entrypoint)
 
             if entrypoint_arg_spec:

--- a/test/integration/targets/roles_arg_spec/runme.sh
+++ b/test/integration/targets/roles_arg_spec/runme.sh
@@ -30,3 +30,12 @@ set -e
 # The task is tagged with 'foo' but we use 'bar' in the call below and expect
 # the validation task to run anyway since it is tagged 'always'.
 ansible-playbook test_tags.yml -i ../../inventory "$@" --tags bar | grep "a : Validating arguments against arg spec 'main' - Main entry point for role A."
+
+# Test validation with various values for "tasks_from"
+ansible-playbook test_path_extension.yml -i ../../inventory "$@" 2>&1 | tee out.txt
+count="$(grep -c 'TASK.*Validating arguments against arg spec' out.txt)"
+expected_count="$(grep -c import_role test_path_extension.yml)"
+if [ "$count" -ne "$expected_count" ]; then
+    echo "Failed to find the expected number of argument spec validation tasks"
+    exit 1
+fi

--- a/test/integration/targets/roles_arg_spec/test_path_extension.yml
+++ b/test/integration/targets/roles_arg_spec/test_path_extension.yml
@@ -1,0 +1,32 @@
+- hosts: localhost
+  gather_facts: no
+
+  vars:
+    a_int: 100
+    a_str: "100"
+
+  tasks:
+    - name: Tasks from main
+      import_role:
+          name: a
+          tasks_from: main
+
+    - name: Tasks from main.yml
+      import_role:
+          name: a
+          tasks_from: main
+
+    - name: Tasks from tasks/alternate
+      import_role:
+          name: a
+          tasks_from: taks/alternate
+
+    - name: Tasks from tasks/alternate.yml
+      import_role:
+          name: a
+          tasks_from: tasks/alternate.yml
+
+    - name: Tasks from alternate.yml absolute path
+      import_role:
+          name: a
+          tasks_from: "{{ playbook_dir }}/roles/a/tasks/alternate.yml"

--- a/test/integration/targets/roles_arg_spec/test_path_extension.yml
+++ b/test/integration/targets/roles_arg_spec/test_path_extension.yml
@@ -19,7 +19,7 @@
     - name: Tasks from tasks/alternate
       import_role:
           name: a
-          tasks_from: taks/alternate
+          tasks_from: tasks/alternate
 
     - name: Tasks from tasks/alternate.yml
       import_role:

--- a/test/units/module_utils/splitter/test_stem.py
+++ b/test/units/module_utils/splitter/test_stem.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import pytest
+
+from ansible.module_utils.splitter import stem
+
+
+@pytest.mark.parametrize(
+    'path, expected', (
+        ('main', 'main'),
+        ('main.yml', 'main'),
+        ('/absolute/path/main.yml', 'main'),
+        ('/absolute/path/main.yml.tar.gz', 'main.yml.tar'),
+        ('main.yml.tar.gz', 'main.yml.tar'),
+        ('çafé.yml', 'çafé'),
+    )
+)
+def test_stem(path, expected):
+    assert stem(path) == expected
+
+
+@pytest.mark.parametrize(
+    'path', (
+        ['list'],
+        {'di': 'ct'},
+        set(['me', 'on', 'fire']),
+        1.7897298374,
+        -1,
+    )
+)
+def test_stem_invalid(path):
+    with pytest.raises(TypeError):
+        stem(path)

--- a/test/units/module_utils/splitter/test_stem.py
+++ b/test/units/module_utils/splitter/test_stem.py
@@ -34,5 +34,5 @@ def test_stem(path, expected):
     )
 )
 def test_stem_invalid(path):
-    with pytest.raises(TypeError):
+    with pytest.raises((TypeError, AttributeError)):
         stem(path)


### PR DESCRIPTION
##### SUMMARY
Lookup the spec using the basename of the last part of the path or file specified in `tasks_from`. Since `tasks_form` accepts a file or path both with and without an extension, the argument spec lookup should as well.

Fixes #75456

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/playbook/role/__init__.py`


To do:
- [x] Add tests


