### PR TITLE
[WIP] Slip ansible 5 release to account for ansible-core slip.

### DIFF
--- a/docs/docsite/rst/roadmap/COLLECTIONS_5.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_5.rst
@@ -4,7 +4,7 @@
 Ansible project 5.0
 ===================
 
-This release schedule includes dates for the `ansible <https://pypi.org/project/ansible/>`_ package, with a few dates for the `ansible-core <https://pypi.org/project/ansible-core/>`_ package as well. All dates are subject to change. See :ref:`base_roadmap_2_12` for the most recent updates on ``ansible-core``.
+This release schedule includes dates for the `ansible <https://pypi.org/project/ansible/>`_ package, with a few dates for the `ansible-core <https://pypi.org/project/ansible-core/>`_ package as well. All dates are subject to change. See :ref:`core_roadmap_2_12` for the most recent updates on ``ansible-core``.
 
 .. contents::
    :local:

--- a/docs/docsite/rst/roadmap/COLLECTIONS_5.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_5.rst
@@ -14,23 +14,24 @@ Release schedule
 =================
 
 :2021-04-14: New Collections can be reviewed for inclusion in Ansible 5. Submit a request to include a new collection in this `GitHub Discussion <https://github.com/ansible-collections/ansible-inclusion/discussions/new>`_.
-:2021-08-30: ansible-core feature freeze.
-:2021-09-13: start of ansible-core 2.12 betas (weekly, as needed).
-:2021-09-21: Ansible-5.0.0 alpha1 (biweekly ``ansible`` alphas timed to coincide with ``ansible-core-2.12`` pre-releases).
-:2021-10-04: first ansible-core release candidate, stable-2.12 branch created.
-:2021-10-05: Ansible-5.0.0 alpha2.
-:2021-10-12: Last day for new collections to be submitted for inclusion in Ansible-5. Collections MUST be reviewed and approved before being included. There is no guarantee that we will review every collection. The earlier your collection is submitted, the more likely it will be that your collection will be reviewed and the necessary feedback can be addressed in time for inclusion.
-:2021-10-13: Community Meeting topic: List any new collection reviews which block release. List any backwards incompatible collection releases that beta1 should try to accommodate.
-:2021-10-19: Ansible-5.0.0 alpha3.
-:2021-10-20: Community Meeting topic: Decide what contingencies to activate for any blockers that do not meet the deadline.
-:2021-10-25: Last day for new collections to be **reviewed and approved** for inclusion in Ansible-5.
-:2021-10-25: Last day for collections to make backwards incompatible releases that will be accepted into Ansible-5.
-:2021-10-26: Create the ansible-build-data directory and files for Ansible-6; new collection approvals will target this.
-:2021-10-26: Ansible-5.0.0 beta1 -- feature freeze [1]_ (weekly beta releases; collection owners and interested users should test for bugs).
-:2021-11-02: Ansible-5.0.0 beta2.
-:2021-11-09: Ansible-5.0.0 rc1 [2]_ [3]_ (weekly release candidates as needed; test and alert us to any blocker bugs).
-:2021-11-16: Ansible-5.0.0 release.
-:2021-12-07: Release of Ansible-5.1.0 (bugfix + compatible features: every three weeks).
+:2021-09-24: ansible-core feature freeze.
+:2021-09-27: Start of ansible-core 2.12 betas (weekly, as needed).
+:2021-10-05: Ansible-5.0.0 alpha1 (roughly biweekly ``ansible`` alphas timed to coincide with ``ansible-core-2.12`` pre-releases).
+:2021-10-18: First ansible-core release candidate, stable-2.12 branch created.
+:2021-10-19: Ansible-5.0.0 alpha2.
+:2021-10-26: Last day for new collections to be submitted for inclusion in Ansible-5. Collections MUST be reviewed and approved before being included. There is no guarantee that we will review every collection. The earlier your collection is submitted, the more likely it will be that your collection will be reviewed and the necessary feedback can be addressed in time for inclusion.
+:2021-10-27: Community Meeting topic: List any new collection reviews which block release. List any backwards incompatible collection releases that beta1 should try to accommodate.
+:2021-11-02: Ansible-5.0.0 alpha3.
+:2021-11-03: Last day for new collections to be **reviewed and approved** for inclusion in Ansible-5.
+:2021-11-03: Community Meeting topic: Decide what contingencies to activate for any blockers that do not meet the deadline.
+:2021-11-08: Ansible-core-2.12 released.
+:2021-11-08: Last day for collections to make backwards incompatible releases that will be accepted into Ansible-5.
+:2021-11-09: Create the ansible-build-data directory and files for Ansible-6; new collection approvals will target this.
+:2021-11-09: Ansible-5.0.0 beta1 -- feature freeze [1]_ (weekly beta releases; collection owners and interested users should test for bugs).
+:2021-11-16: Ansible-5.0.0 beta2.
+:2021-11-23: Ansible-5.0.0 rc1 [2]_ [3]_ (weekly release candidates as needed; test and alert us to any blocker bugs).
+:2021-11-30: Ansible-5.0.0 release.
+:2022-01-04: Release of Ansible-5.1.0 (bugfix + compatible features: every three weeks. Note: this comes 4 week after 5.0.0 due to the winter holiday season).
 
 .. [1] No new modules or major features accepted after this date. In practice, this means we will freeze the semver collection versions to compatible release versions. For example, if the version of community.crypto on this date was community.crypto 2.1.0; Ansible-5.0.0 could ship with community.crypto 2.1.1.  It would not ship with community.crypto 2.2.0.
 


### PR DESCRIPTION
##### SUMMARY
ansible-core-2.12 has slipped (beta1 slips 4 weeks.  final slips 2 weeks).

We need to adjust the ansible-5 schedule to account for that and the winter holidays.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
