### PR TITLE
setup module, dont truncate hpux interfaces (#75423)

### DIFF
--- a/changelogs/fragments/hpux_iface_facts_length.yml
+++ b/changelogs/fragments/hpux_iface_facts_length.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - setup module should now not truncate hpux interface names.

--- a/lib/ansible/module_utils/facts/network/hpux.py
+++ b/lib/ansible/module_utils/facts/network/hpux.py
@@ -60,7 +60,7 @@ class HPUXNetwork(Network):
 
     def get_interfaces_info(self):
         interfaces = {}
-        rc, out, err = self.module.run_command("/usr/bin/netstat -ni")
+        rc, out, err = self.module.run_command("/usr/bin/netstat -niw")
         lines = out.splitlines()
         for line in lines:
             words = line.split()


### PR DESCRIPTION
* setup module, dont truncate hpux interfaces

  fixes #70533

 no hpux to test so relying on man page and users that reported successful testing

(cherry picked from commit 03083c3139fa4b4da19ddec143f5f7d9e69dee9a)


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
modules/setup.py