### PR TITLE
remove core docs build warnings from playbooks_keywords

### DIFF
--- a/docs/docsite/rst/dev_guide/index.rst
+++ b/docs/docsite/rst/dev_guide/index.rst
@@ -95,5 +95,4 @@ If you prefer to read the entire guide, here's a list of the pages in order.
    developing_collections
    migrating_roles
    collections_galaxy_meta
-   migrating_roles
    overview_architecture

--- a/docs/templates/playbooks_keywords.rst.j2
+++ b/docs/templates/playbooks_keywords.rst.j2
@@ -23,7 +23,7 @@ These are the keywords available on common playbook objects. Keywords are one of
 
 {{ name }}
 {{ '-' * name|length }}
-.. glossary::
+{#.. glossary::#}
 
 {% for attribute in pb_keywords[name]|sort %}
     {{ attribute }}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
These went from annoying to causing problems with a CI test so fixing the `make coredocs` build warnings...

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs/docsite/rst/dev_guide/index.rst
docs/templates/playbooks_keywords.rst.j2
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
