### PR TITLE
ansible-test: Set max number of open files in containers to 10240

### DIFF
--- a/changelogs/fragments/ansible-test-docker-ulimit.yml
+++ b/changelogs/fragments/ansible-test-docker-ulimit.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ansible-test - Automatically increase the maximum number of open files in a test container from ``1024`` to ``2048``.
+  - ansible-test - Change the maximum number of open files in a test container from the default to ``2048``.

--- a/changelogs/fragments/ansible-test-docker-ulimit.yml
+++ b/changelogs/fragments/ansible-test-docker-ulimit.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ansible-test - Change the maximum number of open files in a test container from the default to ``2048``.
+  - ansible-test - Change the maximum number of open files in a test container from the default to ``10240``.

--- a/changelogs/fragments/ansible-test-docker-ulimit.yml
+++ b/changelogs/fragments/ansible-test-docker-ulimit.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Automatically increase the maximum number of open files in a test container from ``1024`` to ``2048``.

--- a/test/lib/ansible_test/_internal/docker_util.py
+++ b/test/lib/ansible_test/_internal/docker_util.py
@@ -280,7 +280,7 @@ def docker_run(args, image, options, cmd=None, create_only=False):
         # Only when the network is not the default bridge network.
         options.extend(['--network', network])
 
-    options.extend(['--ulimit', 'nofile=%s:%s' % (MAX_NUM_OPEN_FILES, MAX_NUM_OPEN_FILES)])
+    options.extend(['--ulimit', 'nofile=%s' % MAX_NUM_OPEN_FILES])
 
     for _iteration in range(1, 3):
         try:

--- a/test/lib/ansible_test/_internal/docker_util.py
+++ b/test/lib/ansible_test/_internal/docker_util.py
@@ -45,7 +45,7 @@ DOCKER_COMMANDS = [
 
 # Max number of open files in a docker container.
 # Passed with --ulimit option to the docker run command.
-MAX_NUM_OPEN_FILES = 2048
+MAX_NUM_OPEN_FILES = 10240
 
 
 class DockerCommand:

--- a/test/lib/ansible_test/_internal/docker_util.py
+++ b/test/lib/ansible_test/_internal/docker_util.py
@@ -43,6 +43,10 @@ DOCKER_COMMANDS = [
     'podman',
 ]
 
+# Max number of open files in a docker container.
+# Passed with --ulimit option to the docker run command.
+MAX_NUM_OPEN_FILES = 2048
+
 
 class DockerCommand:
     """Details about the available docker command."""
@@ -275,6 +279,8 @@ def docker_run(args, image, options, cmd=None, create_only=False):
     if is_docker_user_defined_network(network):
         # Only when the network is not the default bridge network.
         options.extend(['--network', network])
+
+    options.extend(['--ulimit', 'nofile=%s:%s' % (MAX_NUM_OPEN_FILES, MAX_NUM_OPEN_FILES)])
 
     for _iteration in range(1, 3):
         try:


### PR DESCRIPTION
##### SUMMARY


I'm developing a collection for one service from scratch.

I wrote integration tests.

When trying to run the service with `ansible-test` with `--docker`, I got the following error from the service I want to test against:
```
ERROR: failed to start server: failed to create engines: hard open file descriptor limit of 1024 is under the 
minimum required 1956
```
I tried to run `ulimit -n 9000` inside the container with and without `--docker-privileged` -> in both the cases i got "error setting limit (Operation not permitted)". 

With this patch, the following command works now and the service starts successfully:
```
ansible-test integration test_service_query --docker ubuntu2004 --docker-ulimit "nofile=90000:90000" -vvv > ~/test.log
```

I'm also OK with if ulimits will be increased in docker files for the tests containers
However, this solution gives more flexibility and covers more possible cases

**UPDATE**
During discussion we decided to hardcode 10240 as max number of open files to not provide the additional option.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test