### PR TITLE
Use the new Codecov Uploader.

### DIFF
--- a/.azure-pipelines/scripts/publish-codecov.sh
+++ b/.azure-pipelines/scripts/publish-codecov.sh
@@ -7,7 +7,8 @@ set -o pipefail -eu
 
 output_path="$1"
 
-curl --silent --show-error https://ansible-ci-files.s3.us-east-1.amazonaws.com/codecov/codecov.sh > codecov.sh
+curl --silent --show-error https://ansible-ci-files.s3.us-east-1.amazonaws.com/codecov/linux/codecov > codecov
+chmod +x codecov
 
 for file in "${output_path}"/reports/coverage*.xml; do
     name="${file}"
@@ -15,7 +16,7 @@ for file in "${output_path}"/reports/coverage*.xml; do
     name="${name##coverage=}"  # remove 'coverage=' prefix if present
     name="${name%.xml}"  # remove '.xml' suffix
 
-    bash codecov.sh \
+    ./codecov \
         -f "${file}" \
         -n "${name}" \
         -X coveragepy \


### PR DESCRIPTION
##### SUMMARY

Use the new Codecov Uploader.

The [Bash Uploader is deprecated](https://about.codecov.io/blog/introducing-codecovs-new-uploader/) and will start seeing service outages beginning September 1st.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

.azure-pipelines/scripts/publish-codecov.sh