### PR TITLE
allow vars_files to use dwim (vars/) and vaults

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -411,7 +411,7 @@ class DataLoader:
         Removes all temporary files that DataLoader has created
         NOTE: not thread safe, forks also need special handling see __init__ for details.
         """
-        for f in self._tempfiles:
+        for f in list(self._tempfiles):
             try:
                 self.cleanup_tmp_file(f)
             except Exception as e:

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -7,6 +7,7 @@ __metaclass__ = type
 
 import itertools
 import operator
+import os
 
 from copy import copy as shallowcopy
 from functools import partial
@@ -378,7 +379,6 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
                     validated_defaults_dict[defaults_entry] = defaults
 
                 else:
-                    action_names = []
                     if len(defaults_entry.split('.')) < 3:
                         defaults_entry = 'ansible.legacy.' + defaults_entry
 
@@ -900,4 +900,3 @@ class Base(FieldAttributeBase):
             path_stack.append(task_dir)
 
         return path_stack
-

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -870,17 +870,10 @@ class Base(FieldAttributeBase):
 
     def get_dep_chain(self):
 
-        ret = None
-        try:
-            if self._dep_chain is None:
-                if self._parent:
-                    ret = self._parent.get_dep_chain()
-            else:
-                ret = self._dep_chain[:]
-        except AttributeError:
-            pass
-
-        return ret
+        if hasattr(self, '_parent') and self._parent:
+            return self._parent.get_dep_chain()
+        else:
+            return None
 
     def get_search_path(self):
         '''

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -856,24 +856,31 @@ class Base(FieldAttributeBase):
     DEPRECATED_ATTRIBUTES = []
 
     def get_path(self):
-        ''' return the absolute path of the task with its line number '''
+        ''' return the absolute path of the playbook object and it's line number '''
 
         path = ""
-        if hasattr(self, '_ds') and hasattr(self._ds, '_data_source') and hasattr(self._ds, '_line_number'):
+        try:
             path = "%s:%s" % (self._ds._data_source, self._ds._line_number)
-        elif hasattr(self, '_parent') and \
-             hasattr(self._parent, '_play') and \
-             hasattr(self._parent._play, '_ds') and \
-             hasattr(self._parent._play._ds, '_data_source') and \
-             hasattr(self._parent._play._ds, '_line_number'):
-            path = "%s:%s" % (self._parent._play._ds._data_source, self._parent._play._ds._line_number)
+        except AttributeError:
+            try:
+                path = "%s:%s" % (self._parent._play._ds._data_source, self._parent._play._ds._line_number)
+            except AttributeError:
+                pass
         return path
 
     def get_dep_chain(self):
-        if hasattr(self, '_parent') and self._parent:
-            return self._parent.get_dep_chain()
-        else:
-            return None
+
+        ret = None
+        try:
+            if self._dep_chain is None:
+                if self._parent:
+                    ret = self._parent.get_dep_chain()
+            else:
+                ret = self._dep_chain[:]
+        except AttributeError:
+            pass
+
+        return ret
 
     def get_search_path(self):
         '''

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -859,13 +859,13 @@ class Base(FieldAttributeBase):
         ''' return the absolute path of the task with its line number '''
 
         path = ""
-        if all([hasattr(self, '_ds'), hasattr(self._ds, '_data_source'), hasattr(self._ds, '_line_number')]):
+        if hasattr(self, '_ds') and hasattr(self._ds, '_data_source') and hasattr(self._ds, '_line_number'):
             path = "%s:%s" % (self._ds._data_source, self._ds._line_number)
-        elif all([hasattr(self, '_parent'),
-                  hasattr(self._parent, '_play'),
-                  hasattr(self._parent._play, '_ds'),
-                  hasattr(self._parent._play._ds, '_data_source'),
-                  hasattr(self._parent._play._ds, '_line_number')]):
+        elif hasattr(self, '_parent') and \
+             hasattr(self._parent, '_play') and \
+             hasattr(self._parent._play, '_ds') and \
+             hasattr(self._parent._play._ds, '_data_source') and \
+             hasattr(self._parent._play._ds, '_line_number'):
             path = "%s:%s" % (self._parent._play._ds._data_source, self._parent._play._ds._line_number)
         return path
 

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -856,7 +856,7 @@ class Base(FieldAttributeBase):
     DEPRECATED_ATTRIBUTES = []
 
     def get_path(self):
-        ''' return the absolute path of the playbook object and it's line number '''
+        ''' return the absolute path of the playbook object and its line number '''
 
         path = ""
         try:

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -103,16 +103,6 @@ class Task(Base, Conditional, Taggable, CollectionSearch):
 
         super(Task, self).__init__()
 
-    def get_path(self):
-        ''' return the absolute path of the task with its line number '''
-
-        path = ""
-        if hasattr(self, '_ds') and hasattr(self._ds, '_data_source') and hasattr(self._ds, '_line_number'):
-            path = "%s:%s" % (self._ds._data_source, self._ds._line_number)
-        elif hasattr(self._parent._play, '_ds') and hasattr(self._parent._play._ds, '_data_source') and hasattr(self._parent._play._ds, '_line_number'):
-            path = "%s:%s" % (self._parent._play._ds._data_source, self._parent._play._ds._line_number)
-        return path
-
     def get_name(self, include_role_fqcn=True):
         ''' return the name of the task '''
 
@@ -492,31 +482,6 @@ class Task(Base, Conditional, Taggable, CollectionSearch):
             pass
 
         return value
-
-    def get_dep_chain(self):
-        if self._parent:
-            return self._parent.get_dep_chain()
-        else:
-            return None
-
-    def get_search_path(self):
-        '''
-        Return the list of paths you should search for files, in order.
-        This follows role/playbook dependency chain.
-        '''
-        path_stack = []
-
-        dep_chain = self.get_dep_chain()
-        # inside role: add the dependency chain from current to dependent
-        if dep_chain:
-            path_stack.extend(reversed([x._role_path for x in dep_chain]))
-
-        # add path of task itself, unless it is already in the list
-        task_dir = os.path.dirname(self.get_path())
-        if task_dir not in path_stack:
-            path_stack.append(task_dir)
-
-        return path_stack
 
     def all_parents_static(self):
         if self._parent:

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -352,7 +352,10 @@ class VariableManager:
                                     "a list of string types after template expansion" % vars_file
                                 )
                             try:
-                                data = preprocess_vars(self._loader.load_from_file(vars_file, unsafe=True))
+                                play_search_stack = play.get_search_path()
+                                found_file = real_file = self._loader.path_dwim_relative_stack(play_search_stack, 'vars', vars_file)
+                                decrypted_file = self._loader.get_real_file(found_file)
+                                data = preprocess_vars(self._loader.load_from_file(decrypted_file, unsafe=True))
                                 if data is not None:
                                     for item in data:
                                         all_vars = _combine_and_track(all_vars, item, "play vars_files from '%s'" % vars_file)

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -477,6 +477,8 @@ class VariableManager:
             variables['role_names'] = variables['ansible_play_role_names']
 
             variables['ansible_play_name'] = play.get_name()
+            # get path returns path:line
+            variables['ansible_play_path'] = play.get_path.split(':')[0]
 
         if task:
             if task._role:

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -478,7 +478,7 @@ class VariableManager:
 
             variables['ansible_play_name'] = play.get_name()
             # get path returns path:line
-            variables['ansible_play_path'] = play.get_path.split(':')[0]
+            variables['ansible_play_path'] = play.get_path().split(':')[0]
 
         if task:
             if task._role:

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -477,8 +477,6 @@ class VariableManager:
             variables['role_names'] = variables['ansible_play_role_names']
 
             variables['ansible_play_name'] = play.get_name()
-            # get path returns path:line
-            variables['ansible_play_path'] = play.get_path().split(':')[0]
 
         if task:
             if task._role:


### PR DESCRIPTION
vars_files should always have had dwim (vars/  in context of play) and vault

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vars manager/plays