### PR TITLE
Fix an exception when passlib library is used with a wrapped algo

### DIFF
--- a/changelogs/fragments/75527_password_lookup_handle_wrapped_algo.yml
+++ b/changelogs/fragments/75527_password_lookup_handle_wrapped_algo.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - password - Handle passlib wrapped algos bsd_nthash, django_argon2, django_bcrypt, ldap_bcrypt, ldap_bsdi_crypt,
+    ldap_des_crypt, ldap_hex_md5, ldap_hex_sha1, ldap_md5_crypt, ldap_pbkdf2_sha1, ldap_pbkdf2_sha256,
+    ldap_pbkdf2_sha512, ldap_sha1_crypt, ldap_sha256_crypt, ldap_sha512_crypt, roundup_plaintext
+    (https://github.com/ansible/ansible/pull/75527).

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -23,7 +23,7 @@ HAS_CRYPT = PASSLIB_AVAILABLE = False
 try:
     import passlib
     import passlib.hash
-    from passlib.utils.handlers import HasRawSalt
+    from passlib.utils.handlers import HasRawSalt, PrefixWrapper
     try:
         from passlib.utils.binary import bcrypt64
     except ImportError:
@@ -194,7 +194,7 @@ class PasslibHash(BaseHash):
     def _clean_salt(self, salt):
         if not salt:
             return None
-        elif issubclass(self.crypt_algo, HasRawSalt):
+        elif issubclass(self.crypt_algo.wrapped if isinstance(self.crypt_algo, PrefixWrapper) else self.crypt_algo, HasRawSalt):
             ret = to_bytes(salt, encoding='ascii', errors='strict')
         else:
             ret = to_text(salt, encoding='ascii', errors='strict')


### PR DESCRIPTION
##### SUMMARY
Fix error when passlib library is used with a wrapped algo.

The exception was:

     An unhandled exception occurred while running the lookup plugin 'password'.
     Error was a <class 'TypeError'>, original message: issubclass() arg 1 must be a class

and can be reproduced using the following command:

    ansible localhost -i localhost, -mdebug -amsg="{{ lookup('password', '/dev/null encrypt=ldap_sha512_crypt') }}"

The concerned algos are:
- `bsd_nthash`
- `django_argon2`
- `django_bcrypt`
- `ldap_bcrypt`
- `ldap_bsdi_crypt`
- `ldap_des_crypt`
- `ldap_hex_md5`
- `ldap_hex_sha1`
- `ldap_md5_crypt`
- `ldap_pbkdf2_sha1`
- `ldap_pbkdf2_sha256`
- `ldap_pbkdf2_sha512`
- `ldap_sha1_crypt`
- `ldap_sha256_crypt`
- `ldap_sha512_crypt`
- `roundup_plaintext`

First commit provides an unit test (in order to check the tests), then the bugfix will be committed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
password

##### ADDITIONAL INFORMATION
None