### PR TITLE
dnf: allow for download_only to be run without root

### DIFF
--- a/changelogs/fragments/75530-dnf-download_only-non-root.yml
+++ b/changelogs/fragments/75530-dnf-download_only-non-root.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - dnf - allow for ``download_only`` to be run without root privileges (https://github.com/ansible/ansible/issues/75530)

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -1348,7 +1348,7 @@ class DnfModule(YumDnf):
         else:
             # Note: base takes a long time to run so we want to check for failure
             # before running it.
-            if not dnf.util.am_i_root():
+            if not self.download_only and not dnf.util.am_i_root():
                 self.module.fail_json(
                     msg="This command has to be run under the root user.",
                     results=[],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #75530
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`lib/ansible/modules/dnf.py`
