### PR TITLE
make python interpreter discovery work for almalinux targets

### DIFF
--- a/changelogs/fragments/almalinux_interpreter_discovery.yml
+++ b/changelogs/fragments/almalinux_interpreter_discovery.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - make python interpreter discovery work for almalinux targets

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1488,6 +1488,7 @@ INTERPRETER_PYTHON_DISTRO_MAP:
     oracle: *rhelish
     redhat: *rhelish
     rhel: *rhelish
+    almalinux: *rhelish
     ubuntu:
       '14': /usr/bin/python
       '16': /usr/bin/python3


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change adds python interpreter discovery for [AlmaLinux](https://almalinux.org/) targets.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/config/base.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
If you have an AlmaLinux target system and run a simple ansible command, the following interpreter discovery warning is displayed:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ ansible test_almalinux -m shell -a "cat /etc/redhat-release"
[WARNING]: Platform linux on host test-almalinux is using the discovered Python interpreter at /usr/bin/python3.6,
but future installation of another Python interpreter could change the meaning of that path. See
https://docs.ansible.com/ansible/2.11/reference_appendices/interpreter_discovery.html for more information.
test-almalinux | CHANGED | rc=0 >>
AlmaLinux release 8.4 (Electric Cheetah)
```
Applying the change from this PR makes interpreter discovery working smoothly and the warning disappears:
```
$ ansible test_almalinux -m shell -a "cat /etc/redhat-release"
test-almalinux | CHANGED | rc=0 >>
AlmaLinux release 8.4 (Electric Cheetah)
```
