### PR TITLE
exhaust list of vault ids before failing

### DIFF
--- a/changelogs/fragments/75540-warn-invalid-configured-vault-secret-files.yaml
+++ b/changelogs/fragments/75540-warn-invalid-configured-vault-secret-files.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vault - Warn instead of fail for missing vault IDs if at least one valid vault secret is found.

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -215,7 +215,7 @@ class CLI(with_metaclass(ABCMeta, object)):
                                                           vault_id=vault_id_name,
                                                           loader=loader)
             except AnsibleError as exc:
-                display.warning('Error getting secret from vault password file (%s): %s' % (vault_id_name, to_text(exc)))
+                display.warning('Error getting vault password file (%s): %s' % (vault_id_name, to_text(exc)))
                 last_exception = exc
                 continue
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -218,15 +218,15 @@ class CLI(with_metaclass(ABCMeta, object)):
                 display.warning('Error getting secret from vault password file (%s): %s' % (vault_id_name, to_text(exc)))
                 last_exception = exc
                 continue
-            found_vault_secret = True
 
-            # an invalid password file will error globally
             try:
                 file_vault_secret.load()
             except AnsibleError as exc:
                 display.warning('Error in vault password file loading (%s): %s' % (vault_id_name, to_text(exc)))
-                raise
+                last_exception = exc
+                continue
 
+            found_vault_secret = True
             if vault_id_name:
                 vault_secrets.append((vault_id_name, file_vault_secret))
             else:
@@ -235,7 +235,8 @@ class CLI(with_metaclass(ABCMeta, object)):
             # update loader with as-yet-known vault secrets
             loader.set_vault_secrets(vault_secrets)
 
-        # No valid vault secrets and at least one error
+        # An invalid or missing password file will error globally
+        # if no valid vault secret was found.
         if last_exception and not found_vault_secret:
             raise last_exception
 

--- a/test/integration/targets/ansible-vault/runme.sh
+++ b/test/integration/targets/ansible-vault/runme.sh
@@ -524,7 +524,26 @@ ansible-playbook -v "$@" --vault-password-file vault-password test_dangling_temp
 ansible-playbook "$@" --vault-password-file vault-password single_vault_as_string.yml
 
 # Test that only one accessible vault password is required
+export ANSIBLE_VAULT_IDENTITY_LIST="id1@./nonexistent, id2@${MYTMPDIR}/unreadable, id3@./vault-password"
+
 touch "${MYTMPDIR}/unreadable"
 sudo chmod 000 "${MYTMPDIR}/unreadable"
-ANSIBLE_VAULT_IDENTITY_LIST="id1@./nonexistent, id2@${MYTMPDIR}/unreadable, id3@./vault-password" ansible-vault encrypt_string content
-[ "$?" -eq 0 ]
+
+ansible-vault encrypt_string content
+ansible-vault encrypt_string content --encrypt-vault-id id3
+
+set +e
+
+# Try to use a missing vault password file
+ansible-vault encrypt_string content --encrypt-vault-id id1 2>&1 | tee out.txt
+test $? -ne 0
+grep out.txt -e '[WARNING]: Error getting vault password file (id1)'
+grep out.txt -e "ERROR! Did not find a match for --encrypt-vault-id=id2 in the known vault-ids ['id3']"
+
+# Try to use an inaccessible vault password file
+ansible-vault encrypt_string content --encrypt-vault-id id2 2>&1 | tee out.txt
+test $? -ne 0
+grep out.txt -e "[WARNING]: Error in vault password file loading (id2)"
+grep out.txt -e "ERROR! Did not find a match for --encrypt-vault-id=id2 in the known vault-ids ['id3']"
+
+set -e

--- a/test/integration/targets/ansible-vault/runme.sh
+++ b/test/integration/targets/ansible-vault/runme.sh
@@ -522,3 +522,9 @@ ansible-playbook -i ../../inventory -v "$@" --vault-password-file vault-password
 ansible-playbook -v "$@" --vault-password-file vault-password test_dangling_temp.yml
 
 ansible-playbook "$@" --vault-password-file vault-password single_vault_as_string.yml
+
+# Test that only one accessible vault password is required
+touch "${MYTMPDIR}/unreadable"
+sudo chmod 000 "${MYTMPDIR}/unreadable"
+ANSIBLE_VAULT_IDENTITY_LIST="id1@./nonexistent, id2@${MYTMPDIR}/unreadable, id3@./vault-password" ansible-vault encrypt_string content
+[ "$?" -eq 0 ]


### PR DESCRIPTION
##### SUMMARY
If a configured vault secret isn't accessible, don't fail until it's used (or if no valid vault secrets are found).

Fixes #58938

##### ISSUE TYPE
- Bugfix Pull Request
