### PR TITLE
Clarify get_bin_path error message

### DIFF
--- a/changelogs/fragments/clarify_missing_exe.yml
+++ b/changelogs/fragments/clarify_missing_exe.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - get_bin_path, clarify with quotes what the missing required executable is.

--- a/lib/ansible/module_utils/common/process.py
+++ b/lib/ansible/module_utils/common/process.py
@@ -39,6 +39,6 @@ def get_bin_path(arg, opt_dirs=None, required=None):
             bin_path = path
             break
     if bin_path is None:
-        raise ValueError('Failed to find required executable %s in paths: %s' % (arg, os.pathsep.join(paths)))
+        raise ValueError('Failed to find required executable "%s" in paths: %s' % (arg, os.pathsep.join(paths)))
 
     return bin_path

--- a/test/units/module_utils/common/process/test_get_bin_path.py
+++ b/test/units/module_utils/common/process/test_get_bin_path.py
@@ -35,5 +35,5 @@ def test_get_path_path_raise_valueerror(mocker):
     mocker.patch('os.path.isdir', return_value=False)
     mocker.patch('ansible.module_utils.common.process.is_executable', return_value=True)
 
-    with pytest.raises(ValueError, match='Failed to find required executable notacommand'):
+    with pytest.raises(ValueError, match='Failed to find required executable "notacommand"'):
         get_bin_path('notacommand')


### PR DESCRIPTION
Without anything else to guide you the current message can be misread as sometimes the executable is a common word, i.e 'at'.

```Failed to find required executable at in paths: ...```

vs

```Failed to find required executable "at" in paths:```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/common./process