### PR TITLE
subverion , fix validate_certs

### DIFF
--- a/changelogs/fragments/75556-subversion-validate_certs-fix.yml
+++ b/changelogs/fragments/75556-subversion-validate_certs-fix.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - subversion - Now ``validate_certs`` option append ``--trust-server-cert-failures=unknown-ca,cn-mismatch,other`` instead of ``--trust-server-cert``
+  - subversion - Now ``validate_certs`` option append ``--trust-server-cert-failures=unknown-ca,cn-mismatch,other`` for svn 1.9 or later, use ``--trust-server-cert`` for older versions.

--- a/changelogs/fragments/75556-subversion-validate_certs-fix.yml
+++ b/changelogs/fragments/75556-subversion-validate_certs-fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - subversion - Now ``validate_certs`` option append ``--trust-server-cert-failures=unknown-ca,cn-mismatch,other`` instead of ``--trust-server-cert``

--- a/lib/ansible/modules/subversion.py
+++ b/lib/ansible/modules/subversion.py
@@ -93,7 +93,7 @@ options:
     type: bool
   validate_certs:
     description:
-      - If C(no), passes the C(--trust-server-cert) flag to svn.
+      - If C(no), passes the C(--trust-server-cert-failures=unknown-ca,cn-mismatch,other) flag to svn.
       - If C(yes), does not pass the flag.
     default: "no"
     version_added: "2.11"
@@ -163,7 +163,7 @@ class Subversion(object):
             '--no-auth-cache',
         ]
         if not self.validate_certs:
-            bits.append('--trust-server-cert')
+            bits.append('--trust-server-cert-failures=unknown-ca,cn-mismatch,other')
         stdin_data = None
         if self.username:
             bits.extend(["--username", self.username])

--- a/lib/ansible/modules/subversion.py
+++ b/lib/ansible/modules/subversion.py
@@ -93,7 +93,8 @@ options:
     type: bool
   validate_certs:
     description:
-      - If C(no), passes the C(--trust-server-cert-failures=unknown-ca,cn-mismatch,othert) flag for svn 1.9 and later, for older version pass C(--trust-server-cert) flag.
+      - If C(no), passes the C(--trust-server-cert-failures=unknown-ca,cn-mismatch,othert) flag for svn 1.9 and later, 
+        for older version pass C(--trust-server-cert) flag.
       - If C(yes), does not pass the flag.
     default: "no"
     version_added: "2.11"

--- a/lib/ansible/modules/subversion.py
+++ b/lib/ansible/modules/subversion.py
@@ -93,7 +93,7 @@ options:
     type: bool
   validate_certs:
     description:
-      - If C(no), passes the C(--trust-server-cert-failures=unknown-ca,cn-mismatch,othert) flag for svn 1.9 and later, 
+      - If C(no), passes the C(--trust-server-cert-failures=unknown-ca,cn-mismatch,othert) flag for svn 1.9 and later,
         for older version pass C(--trust-server-cert) flag.
       - If C(yes), does not pass the flag.
     default: "no"


### PR DESCRIPTION
##### SUMMARY
From subversion 1.9.0 `--trust-server-cert-failures` doesn't work for al certificate error type. Using `--trust-server-cert-failures=unknown-ca,cn-mismatch,other` solve the problem. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module builtin subversion
