### PR TITLE
Allow make docs to use PYTHON variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ linkcheckdocs:
 .PHONY: generate_rst
 generate_rst: lib/ansible/cli/*.py
 	mkdir -p ./docs/man/man1/ ; \
-	$(GENERATE_CLI) --template-file=docs/templates/man.j2 --output-dir=docs/man/man1/ --output-format man lib/ansible/cli/*.py
+	$(PYTHON) $(GENERATE_CLI) --template-file=docs/templates/man.j2 --output-dir=docs/man/man1/ --output-format man lib/ansible/cli/*.py
 
 
 docs: generate_rst


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allow user to override make docs PYTHON version.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

We noticed this issue in downstream builds where we do not have python in our buildroots.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
+ find hacking/build_library/build_ansible/command_plugins '!' -name generate_man.py -type f -exec rm -f '{}' +
+ PYTHON=python3.8
+ PYTHONPATH=/builddir/build/BUILDROOT/ansible-core-2.12.0~20210824.gitff72908-1.el8ap.x86_64/usr/lib/python3.8/site-packages//ansible/_vendor/:/tmp/_vendor
+ make docs
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
fatal: not a git repository (or any of the parent directories): .git
mkdir -p ./docs/man/man1/ ; \
hacking/build-ansible.py generate-man --template-file=docs/templates/man.j2 --output-dir=docs/man/man1/ --output-format man lib/ansible/cli/*.py
/usr/bin/env: 'python': No such file or directory
make: *** [Makefile:301: generate_rst] Error 127
error: Bad exit status from /var/tmp/rpm-tmp.fJckRd (%install)

```