### PR TITLE
Return correct url for relative paths in messages

### DIFF
--- a/changelogs/fragments/fix_relative_msg_urls.yml
+++ b/changelogs/fragments/fix_relative_msg_urls.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Since ansible/2.11 doc site was removed, the current relative messages point to a 404 url, this fixes it by chainging the target to ansible-core/2.11

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1302,7 +1302,7 @@ DISPLAY_SKIPPED_HOSTS:
   type: boolean
 DOCSITE_ROOT_URL:
   name: Root docsite URL
-  default: https://docs.ansible.com/ansible/
+  default: https://docs.ansible.com/ansible-core/
   description: Root docsite URL used to generate docs URLs in warning/error text;
                must be an absolute URL with valid scheme and trailing slash.
   ini:


### PR DESCRIPTION
Messages like warning about interpreter discovery internally use relative path, but since removal of ansible/2.11 site they now result in 404 (https://docs.ansible.com/ansible/2.11/reference_appendices/interpreter_discovery.html), the change points to the new location of the site https://docs.ansible.com/ansible-core/2.11/reference_appendices/interpreter_discovery.html

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
display