### PR TITLE
Ensure `heuristic_log_sanitize` returns correct data if no password found

### DIFF
--- a/changelogs/fragments/heuristic_log_sanitize--missing-pass.yml
+++ b/changelogs/fragments/heuristic_log_sanitize--missing-pass.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- >
+  ``heuristic_log_sanitize`` - Return the full string if there is no password (https://github.com/ansible/ansible/issues/75542)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -349,9 +349,8 @@ def heuristic_log_sanitize(data, no_log_values=None):
                 # No separator; choices:
                 if begin == 0:
                     # Searched the whole string so there's no password
-                    # here.  Return the remaining data
-                    output.insert(0, data[0:begin])
-                    break
+                    # here.  Return the data
+                    return data
                 # Search for a different beginning of the password field.
                 sep_search_end = begin
                 continue

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -349,8 +349,9 @@ def heuristic_log_sanitize(data, no_log_values=None):
                 # No separator; choices:
                 if begin == 0:
                     # Searched the whole string so there's no password
-                    # here.  Return the data
-                    return data
+                    # here.  Return the remaining data
+                    output.insert(0, data[0:prev_begin])
+                    break
                 # Search for a different beginning of the password field.
                 sep_search_end = begin
                 continue

--- a/test/units/module_utils/basic/test_heuristic_log_sanitize.py
+++ b/test/units/module_utils/basic/test_heuristic_log_sanitize.py
@@ -87,3 +87,6 @@ class TestHeuristicLogSanitize(unittest.TestCase):
     def test_hides_parameter_secrets(self):
         output = heuristic_log_sanitize('token="secret", user="person", token_entry="test=secret"', frozenset(['secret']))
         self.assertNotIn('secret', output)
+
+    def test_no_password(self):
+        self.assertEqual(heuristic_log_sanitize('foo@bar'), 'foo@bar')


### PR DESCRIPTION
##### SUMMARY
Ensure heuristic_log_sanitize returns correct data if no password found. See #75542

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
