### PR TITLE
Add Python 3.8 and Python 3.9 To The Fallback List

### DIFF
--- a/changelogs/fragments/py38-py39-fallback.yml
+++ b/changelogs/fragments/py38-py39-fallback.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Interpreter Discovery - Add Python 3.8 and Python 3.9 to the fallback list

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1462,6 +1462,8 @@ INTERPRETER_PYTHON_FALLBACK:
   name: Ordered list of Python interpreters to check for in discovery
   default:
   - /usr/bin/python
+  - python3.9
+  - python3.8
   - python3.7
   - python3.6
   - python3.5


### PR DESCRIPTION
(cherry picked from commit 7d57c233357277fd1db2c44db603bb1732c0f62d)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In Fedora > 31 installing Python 2.7 from the repositories will break the `ansible.builtin.dnf` module. This is because the fallback interpreter discovery only looks for Python 3.7 => 3.6 => 3.5 => 2.7. There is no `python2-dnf` package and the `python3-dnf` package is built against and for the same version of Python installed via `python3`. Even though `python3.7`, `python3.6` and `python3.5` are available in the repo's they do not get a DNF compatible module.

This can be worked around via the normal methods (ansible.cfg, etc) but it is non-obvious to users that this is why (and the back-story).

Ansible 2.9 is the current version found in Tower as of this PR so it's more likely to be seen via that route. I can cherry-pick into 2.10 as well if that's preferred. Not sure if I should make sure to get it into 2.9.23 because of Tower or if it's just as good to get it onto stable-2.9.

Last bit - Fedora 34 still installs Ansible 2.9.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Ansible interpreter discovery and ansible.builtin.dnf

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

On Fedora 34 this is an easy way to reproduce it (may need `--privileged` and the RO systemd mounts on other platforms).

<!--- Paste verbatim command output below, e.g. before and after your change -->
```bash
cd `mktemp -d`

cat > Dockerfile <<LIGHTWEIGHT
FROM registry.fedoraproject.org/fedora:34
RUN dnf install --assumeyes systemd
CMD ["/usr/sbin/init"]
LIGHTWEIGHT

cat > issue.yml <<ISSUE
---
- hosts: all

  tasks:
    - ansible.builtin.dnf:
        name:
          - httpd
ISSUE

podman build --tag fedora:34-init --file .
export CONTAINER_ID=`podman run --rm --detach localhost/fedora:34-init`
podman exec $CONTAINER_ID dnf install --assumeyes python2.7 python3

ansible-playbook issue.yml --connection podman --inventory "$CONTAINER_ID," -vvv
podman stop $CONTAINER_ID
sleep 30 ; podman rmi localhost/fedora:34-init
```

@sivel borrowed this commit from you just backporting. Not sure if the changelog should be kept w/the cherry-pick or not.