### PR TITLE
makes Fest link from docs trackable

### DIFF
--- a/docs/docsite/.templates/banner.html
+++ b/docs/docsite/.templates/banner.html
@@ -23,7 +23,7 @@
       '<p>' +
         'Explore ways to automate, innovate, and accelerate with our free virtual event September 29-30. ' +
       '<pr>' +
-        '<a href="https://reg.ansiblefest.redhat.com/flow/redhat/ansible21/regGenAttendee/login">Register now!</a> ' +
+        '<a href="https://reg.ansiblefest.redhat.com/flow/redhat/ansible21/regGenAttendee/login?sc_cid=7013a000002pemAAAQ">Register now!</a> ' +
       '</p>' +
       '<br>' +
       '</div>';


### PR DESCRIPTION
##### SUMMARY
We put a link up on the docsite to the AnsibleFest registration page, but the docs haven't been getting credit for those clicks.

This PR adds tracking.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com banner
