### PR TITLE
makes Fest link from docs trackable (#75594)

### DIFF
--- a/docs/docsite/.templates/banner.html
+++ b/docs/docsite/.templates/banner.html
@@ -23,7 +23,7 @@
       '<p>' +
         'Explore ways to automate, innovate, and accelerate with our free virtual event September 29-30. ' +
       '<pr>' +
-        '<a href="https://reg.ansiblefest.redhat.com/flow/redhat/ansible21/regGenAttendee/login">Register now!</a> ' +
+        '<a href="https://reg.ansiblefest.redhat.com/flow/redhat/ansible21/regGenAttendee/login?sc_cid=7013a000002pemAAAQ">Register now!</a> ' +
       '</p>' +
       '<br>' +
       '</div>';


### PR DESCRIPTION
Co-authored-by: Alicia Cozine <acozine@users.noreply.github.com>
(cherry picked from commit e35e8ed2ecfafaba2e4258fcc961d534b572ee5c)

##### SUMMARY
Backports the trackable link that takes users from the docsite to AnsibleFest registration.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
