### PR TITLE
Modified yum-repository modules to have params only if redhat version less than 8 (#75364)

### DIFF
--- a/lib/ansible/modules/yum_repository.py
+++ b/lib/ansible/modules/yum_repository.py
@@ -6,8 +6,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-
-from ansible.module_utils.facts.system import distribution
 __metaclass__ = type
 
 
@@ -431,10 +429,13 @@ state:
 
 import os
 
+from ansible.module_utils.facts.system import distribution
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves import configparser
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import get_distribution_version
+
+
 class YumRepo(object):
     # Class global variables
     module = None

--- a/lib/ansible/modules/yum_repository.py
+++ b/lib/ansible/modules/yum_repository.py
@@ -6,6 +6,8 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+
+from ansible.module_utils.facts.system import distribution
 __metaclass__ = type
 
 
@@ -432,9 +434,7 @@ import os
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves import configparser
 from ansible.module_utils._text import to_native
-from ansible.module_utils.common import sys_info
-
-
+from ansible.module_utils.basic import get_distribution_version
 class YumRepo(object):
     # Class global variables
     module = None
@@ -516,6 +516,9 @@ class YumRepo(object):
             self.repofile.read(self.params['dest'])
 
     def add(self):
+
+        # Get distriubtion version
+        distribution_version = get_distribution_version()
         # Remove already existing repo and create a new one
         if self.repofile.has_section(self.section):
             self.repofile.remove_section(self.section)
@@ -543,10 +546,10 @@ class YumRepo(object):
 
             # Set the value only if it was defined (default is None)
             if value is not None and key in self.allowed_params:
-              
-              # Apply async param if the redhat version is less than 8 only
-              # https://github.com/ansible/ansible/issues/75364
-              if key == "async" and sys_info.get_distribution_version < 8:
+                # Apply async param if the redhat version is less than 8 only
+                # https://github.com/ansible/ansible/issues/75364
+                if key == "async" and float(distribution_version) >= 8:
+                    continue
                 self.repofile.set(self.section, key, value)
 
     def save(self):

--- a/lib/ansible/modules/yum_repository.py
+++ b/lib/ansible/modules/yum_repository.py
@@ -432,6 +432,7 @@ import os
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves import configparser
 from ansible.module_utils._text import to_native
+from ansible.module_utils.common import sys_info
 
 
 class YumRepo(object):
@@ -542,7 +543,10 @@ class YumRepo(object):
 
             # Set the value only if it was defined (default is None)
             if value is not None and key in self.allowed_params:
-              if key == "async" and self.basic.platform.version < 8:
+              
+              # Apply async param if the redhat version is less than 8 only
+              # https://github.com/ansible/ansible/issues/75364
+              if key == "async" and sys_info.get_distribution_version < 8:
                 self.repofile.set(self.section, key, value)
 
     def save(self):

--- a/lib/ansible/modules/yum_repository.py
+++ b/lib/ansible/modules/yum_repository.py
@@ -542,6 +542,7 @@ class YumRepo(object):
 
             # Set the value only if it was defined (default is None)
             if value is not None and key in self.allowed_params:
+              if key == "async" and self.basic.platform.version < 8:
                 self.repofile.set(self.section, key, value)
 
     def save(self):

--- a/test/integration/targets/yum_repository/tasks/main.yml
+++ b/test/integration/targets/yum_repository/tasks/main.yml
@@ -122,6 +122,23 @@
           - "'module_hotfixes = 0' in repo_file_contents"
       vars:
         repo_file_contents: "{{ slurp.content | b64decode }}"
+      when:
+        - "ansible_os_family == 'RedHat'"
+        - ansible_distribution_major_version is version('7', '<=')
+    
+    - name: check that options are correctly getting written to the repo file for RedHat > 8
+      assert:
+        that:
+          - "'name = New description' in repo_file_contents"
+          - "'enablegroups = 0' in repo_file_contents"
+          - "'ip_resolve = 4' in repo_file_contents"
+          - "'keepalive = 0' in repo_file_contents"
+          - "'module_hotfixes = 0' in repo_file_contents"
+      vars:
+        repo_file_contents: "{{ slurp.content | b64decode }}"
+      when:
+        - "ansible_os_family == 'RedHat'"
+        - ansible_distribution_major_version is version('8', '>=')
 
     - name: check new config doesn't change (Idempotant)
       yum_repository:


### PR DESCRIPTION
This is a bug. For RedHat version >= 8 has an issue with the param `async` that is no longer supported.
https://github.com/ansible/ansible/issues/75364

##### SUMMARY

Modified yum_repository.py to only include the param if RedHat version is less than 8. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
yum_repository 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
