### PR TITLE
Enable ansible-galaxy to specify client id override with Keycloak Token

### DIFF
--- a/changelogs/fragments/75593-ansible-galaxy-keycloak-clientid.yml
+++ b/changelogs/fragments/75593-ansible-galaxy-keycloak-clientid.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Allow specification of client_id override value for Keycloak Token interaction with ansible-galaxy

--- a/changelogs/fragments/75593-ansible-galaxy-keycloak-clientid.yml
+++ b/changelogs/fragments/75593-ansible-galaxy-keycloak-clientid.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Allow specification of client_id override value for Keycloak Token interaction with ansible-galaxy
+  - ansible-galaxy - Allow specification of client_id override value for Keycloak Token (https://github.com/ansible/ansible/issues/75593).

--- a/docs/docsite/rst/shared_snippets/galaxy_server_list.txt
+++ b/docs/docsite/rst/shared_snippets/galaxy_server_list.txt
@@ -28,7 +28,7 @@ The following example shows how to configure multiple servers:
 .. code-block:: ini
 
     [galaxy]
-    server_list = automation_hub, my_org_hub, release_galaxy, test_galaxy
+    server_list = automation_hub, my_org_hub, release_galaxy, test_galaxy, my_galaxy_ng
 
     [galaxy_server.automation_hub]
     url=https://cloud.redhat.com/api/automation-hub/
@@ -47,6 +47,12 @@ The following example shows how to configure multiple servers:
     [galaxy_server.test_galaxy]
     url=https://galaxy-dev.ansible.com/
     token=my_test_token
+
+    [galaxy_server.my_galaxy_ng]
+    url=http://my_galaxy_ng:8000/api/automation-hub/
+    auth_url=http://my_keycloak:8080/auth/realms/myco/protocol/openid-connect/token
+    client_id=galaxy-ng
+    token=my_keycloak_access_token
 
 .. note::
     You can use the ``--server`` command line argument to select an explicit Galaxy server in the ``server_list`` and
@@ -67,6 +73,7 @@ define the following keys:
 * ``password``: The password to use, in conjunction with ``username``, for basic authentication.
 * ``auth_url``: The URL of a Keycloak server 'token_endpoint' if using SSO authentication (for example, Automation Hub). Mutually exclusive with ``username``. Requires ``token``.
 * ``validate_certs``: Whether or not to verify TLS certificates for the Galaxy server. This defaults to True unless the ``--ignore-certs`` option is provided or ``GALAXY_IGNORE_CERTS`` is configured to True.
+* ``client_id``: The Keycloak token's client_id to use for authentication. Requires ``auth_url`` and ``token``. The default ``client_id`` is cloud-services to work with Red Hat SSO.
 
 As well as defining these server options in the ``ansible.cfg`` file, you can also define them as environment variables.
 The environment variable is in the form ``ANSIBLE_GALAXY_SERVER_{{ id }}_{{ key }}`` where ``{{ id }}`` is the upper

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -62,7 +62,8 @@ SERVER_DEF = [
     ('token', False),
     ('auth_url', False),
     ('v3', False),
-    ('validate_certs', False)
+    ('validate_certs', False),
+    ('client_id', False),
 ]
 
 
@@ -498,6 +499,7 @@ class GalaxyCLI(CLI):
             # auth_url is used to create the token, but not directly by GalaxyAPI, so
             # it doesn't need to be passed as kwarg to GalaxyApi
             auth_url = server_options.pop('auth_url', None)
+            client_id = server_options.pop('client_id', None)
             token_val = server_options['token'] or NoTokenSentinel
             username = server_options['username']
             available_api_versions = None
@@ -524,7 +526,8 @@ class GalaxyCLI(CLI):
                     if auth_url:
                         server_options['token'] = KeycloakToken(access_token=token_val,
                                                                 auth_url=auth_url,
-                                                                validate_certs=validate_certs)
+                                                                validate_certs=validate_certs,
+                                                                client_id=client_id)
                     else:
                         # The galaxy v1 / github / django / 'Token'
                         server_options['token'] = GalaxyToken(token=token_val)

--- a/lib/ansible/galaxy/token.py
+++ b/lib/ansible/galaxy/token.py
@@ -50,14 +50,18 @@ class KeycloakToken(object):
 
     token_type = 'Bearer'
 
-    def __init__(self, access_token=None, auth_url=None, validate_certs=True):
+    def __init__(self, access_token=None, auth_url=None, validate_certs=True, client_id=None):
         self.access_token = access_token
         self.auth_url = auth_url
         self._token = None
         self.validate_certs = validate_certs
+        self.client_id = client_id
+        if self.client_id is None:
+            self.client_id = 'cloud-services'
 
     def _form_payload(self):
-        return 'grant_type=refresh_token&client_id=cloud-services&refresh_token=%s' % self.access_token
+        return 'grant_type=refresh_token&client_id=%s&refresh_token=%s' % (self.client_id,
+                                                                           self.access_token)
 
     def get(self):
         if self._token:


### PR DESCRIPTION
* Specify ability to provide override of client_id

##### SUMMARY
GalaxyNG just added the capability to use Keycloak for user integration/authentication, instead of using DRF tokens it would be great to be able to use Keycloak tokens with ansible-galaxy CLI. ansible-galaxy CLI has the ability to use Keycloak tokens today in order to work with Public Automation Hub on console.redhat.com. However, it won't work with GalaxyNG + Keycloak because the client ID in the code for refreshing tokens is hardcoded to cloud-services to work with the Red Hat SSO.

It would be great to be able to supply an override configuration variable for the client ID.

Fixes #75593

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/galaxy

##### ADDITIONAL INFORMATION
As described in the galaxy [download a collection section](https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#downloading-a-collection-from-automation-hub)

Instead of supplying:
```
[galaxy]
server_list = automation_hub

[galaxy_server.automation_hub]
url=https://cloud.redhat.com/api/automation-hub/
auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
token=my_ah_token
```

You could supply the following:
```
[galaxy]
server_list = my_galaxy_ng

[galaxy_server.my_galaxy_ng]
url=http://my_galaxy_ng:8000/api/automation-hub/
auth_url=http://my_keycloak:8080/auth/realms/myco/protocol/openid-connect/token
client_id=galaxy-ng
token=my_keycloak_access_token
```
