### PR TITLE
2.11: paramiko_ssh - mark connection as connected when successful (#74459)

### DIFF
--- a/changelogs/fragments/74081-paramiko-mark-connected.yml
+++ b/changelogs/fragments/74081-paramiko-mark-connected.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - paramiko_ssh - mark connection as connected when ``_connect()`` is called (https://github.com/ansible/ansible/issues/74081)

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -241,6 +241,8 @@ class Connection(ConnectionBase):
             self.ssh = SSH_CONNECTION_CACHE[cache_key]
         else:
             self.ssh = SSH_CONNECTION_CACHE[cache_key] = self._connect_uncached()
+
+        self._connected = True
         return self
 
     def _set_log_channel(self, name):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #74459

(cherry picked from commit 74b2add460f25b83ae728b06e50d06321a2a9b79)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/connection/paramiko_ssh.py`