### PR TITLE
Skip recursive suboption validation if sub_parameters is not a dict

### DIFF
--- a/changelogs/fragments/75635-fix-role-argspec-suboption-validation.yml
+++ b/changelogs/fragments/75635-fix-role-argspec-suboption-validation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - validate_argument_spec - Skip suboption validation if the top level option is an invalid type (https://github.com/ansible/ansible/issues/75612).

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -731,7 +731,7 @@ def _validate_sub_spec(argument_spec, parameters, prefix='', options_context=Non
 
             for idx, sub_parameters in enumerate(elements):
                 if not isinstance(sub_parameters, dict):
-                    errors.append(SubParameterTypeError("value of '%s' is a sub-parameter and must be of type dict or list of dicts" % param))
+                    errors.append(SubParameterTypeError("value of '%s' must be of type dict or list of dicts" % param))
                     continue
 
                 # Set prefix for warning messages

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -730,6 +730,8 @@ def _validate_sub_spec(argument_spec, parameters, prefix='', options_context=Non
                 elements = parameters[param]
 
             for idx, sub_parameters in enumerate(elements):
+                no_log_values.update(set_fallbacks(sub_spec, sub_parameters))
+
                 if not isinstance(sub_parameters, dict):
                     errors.append(SubParameterTypeError("value of '%s' must be of type dict or list of dicts" % param))
                     continue
@@ -739,8 +741,6 @@ def _validate_sub_spec(argument_spec, parameters, prefix='', options_context=Non
                 if wanted == 'list':
                     new_prefix += '[%d]' % idx
                 new_prefix += '.'
-
-                no_log_values.update(set_fallbacks(sub_spec, sub_parameters))
 
                 alias_warnings = []
                 alias_deprecations = []

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -724,7 +724,7 @@ def _validate_sub_spec(argument_spec, parameters, prefix='', options_context=Non
             options_context.append(param)
 
             # Make sure we can iterate over the elements
-            if not isinstance(parameters[param], list):
+            if not isinstance(parameters[param], Sequence) or isinstance(parameters[param], string_types):
                 elements = [parameters[param]]
             else:
                 elements = parameters[param]

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -724,14 +724,15 @@ def _validate_sub_spec(argument_spec, parameters, prefix='', options_context=Non
             options_context.append(param)
 
             # Make sure we can iterate over the elements
-            if isinstance(parameters[param], dict):
+            if not isinstance(parameters[param], list):
                 elements = [parameters[param]]
             else:
                 elements = parameters[param]
 
             for idx, sub_parameters in enumerate(elements):
                 if not isinstance(sub_parameters, dict):
-                    errors.append(SubParameterTypeError("value of '%s' must be of type dict or list of dicts" % param))
+                    errors.append(SubParameterTypeError("value of '%s' is a sub-parameter and must be of type dict or list of dicts" % param))
+                    continue
 
                 # Set prefix for warning messages
                 new_prefix = prefix + param

--- a/test/integration/targets/roles_arg_spec/roles/test1/meta/argument_specs.yml
+++ b/test/integration/targets/roles_arg_spec/roles/test1/meta/argument_specs.yml
@@ -73,6 +73,11 @@ argument_specs:
          some_second_level:
            type: "bool"
            default: true
+     some_more_dict_options:
+       type: "dict"
+       options:
+         some_second_level:
+           type: "str"
      some_str_removed_in:
        type: "str"
        removed_in: 2.10

--- a/test/integration/targets/roles_arg_spec/test_complex_role_fails.yml
+++ b/test/integration/targets/roles_arg_spec/test_complex_role_fails.yml
@@ -34,7 +34,10 @@
                   "value of test1_choices must be one of: this paddle game, the astray, this remote control, the chair, got: My dog",
                   "value of some_choices must be one of: choice1, choice2, got: choice4",
                   "argument 'some_second_level' is of type <class 'ansible.parsing.yaml.objects.AnsibleUnicode'> found in 'some_dict_options'. and we were unable to convert to bool: The value 'not-a-bool' is not a valid boolean.  ",
-                  "argument 'third_level' is of type <class 'ansible.parsing.yaml.objects.AnsibleUnicode'> found in 'multi_level_option -> second_level'. and we were unable to convert to int: <class 'ansible.parsing.yaml.objects.AnsibleUnicode'> cannot be converted to an int"
+                  "argument 'third_level' is of type <class 'ansible.parsing.yaml.objects.AnsibleUnicode'> found in 'multi_level_option -> second_level'. and we were unable to convert to int: <class 'ansible.parsing.yaml.objects.AnsibleUnicode'> cannot be converted to an int",
+                  "argument 'some_more_dict_options' is of type <class 'ansible.parsing.yaml.objects.AnsibleUnicode'> and we were unable to convert to dict: dictionary requested, could not parse JSON or key=value",
+                  "value of 'some_more_dict_options' is a sub-parameter and must be of type dict or list of dicts",
+                  "dictionary requested, could not parse JSON or key=value",
                   ]
 
   tasks:
@@ -86,6 +89,7 @@
                 some_str_removed_in: "foo"
                 some_dict_options:
                   some_second_level: "not-a-bool"
+                some_more_dict_options: "not-a-dict"
                 multi_level_option:
                   second_level:
                     third_level: "should_be_int"

--- a/test/integration/targets/roles_arg_spec/test_complex_role_fails.yml
+++ b/test/integration/targets/roles_arg_spec/test_complex_role_fails.yml
@@ -36,7 +36,7 @@
                   "argument 'some_second_level' is of type <class 'ansible.parsing.yaml.objects.AnsibleUnicode'> found in 'some_dict_options'. and we were unable to convert to bool: The value 'not-a-bool' is not a valid boolean.  ",
                   "argument 'third_level' is of type <class 'ansible.parsing.yaml.objects.AnsibleUnicode'> found in 'multi_level_option -> second_level'. and we were unable to convert to int: <class 'ansible.parsing.yaml.objects.AnsibleUnicode'> cannot be converted to an int",
                   "argument 'some_more_dict_options' is of type <class 'ansible.parsing.yaml.objects.AnsibleUnicode'> and we were unable to convert to dict: dictionary requested, could not parse JSON or key=value",
-                  "value of 'some_more_dict_options' is a sub-parameter and must be of type dict or list of dicts",
+                  "value of 'some_more_dict_options' must be of type dict or list of dicts",
                   "dictionary requested, could not parse JSON or key=value",
                   ]
 


### PR DESCRIPTION
##### SUMMARY
Fixes #75612

I tested the same argspec + invalid option with modules and the traceback doesn't occur - this is specific to the role argspec validator.

* Skips recursive suboption validation if the sub_parameter is not a dictionary

* Ensure sub parameter elements is a list to prevent iterating over string and causing duplicate error messages (due to iterating over each char)

* Add a test

##### ISSUE TYPE
- Bugfix Pull Request
