### PR TITLE
[stable-2.9] Add additional constraint for `setuptools`

### DIFF
--- a/changelogs/fragments/setuptools-constraint.yml
+++ b/changelogs/fragments/setuptools-constraint.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    ansible_test - add additional constraint for ``setuptools`` due to a bug
+    in the recently released version of ``setuptools`` (https://github.com/ansible/ansible/pull/75651)

--- a/changelogs/fragments/setuptools-constraint.yml
+++ b/changelogs/fragments/setuptools-constraint.yml
@@ -1,4 +1,5 @@
 bugfixes:
   - >-
-    ansible_test - add additional constraint for ``setuptools`` due to a bug
-    in the recently released version of ``setuptools`` (https://github.com/ansible/ansible/pull/75651)
+    ansible_test - add additional constraint for ``setuptools`` on Python >= 3.5 due to a bug
+    in the recently released version of ``setuptools`` related to the 'use_2to3' feature
+    (https://github.com/ansible/ansible/pull/75651)

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -42,6 +42,7 @@ pyone == 1.1.9 # newer versions do not pass current integration tests
 MarkupSafe < 2.0.0 ; python_version < '3.6' # MarkupSafe >= 2.0.0. requires Python >= 3.6
 botocore >= 1.10.0 # adds support for the following AWS services: secretsmanager, fms, and acm-pca
 setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require python 3.5 or later
+setuptools < 58.0.2 ; python_version >= '3.5' # setuptools 58.0.2 breaks installation of packages, such as coverage, that reference the 'use_2to3' feature
 cffi != 1.14.4 # Fails on systems with older gcc. Should be fixed in the next release. https://foss.heptapod.net/pypy/cffi/-/issues/480
 websocket-client < 1 ; python_version < '3'  # version 1.0.0 drops support for python 2
 


### PR DESCRIPTION
##### SUMMARY
The [recent release of setuptools 58.0.2](https://setuptools.readthedocs.io/en/latest/history.html#v58-0-2) breaks installation of coverage since it references the 'use_2to3' feature. This is a bug in `setuptools` (https://github.com/pypa/setuptools/issues/2775).

Adding a constraint only in this branch as a temporary fix.

The constraint will need to be updated in the future since restricting the upper `setuptools` version can cause issues with systems where the version of `setuptools` provided with the OS is newer than the constraint.

Fixes #75651.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/lib/ansible_test/_data/requirements/constraints.txt`

##### ADDITIONAL INFORMATION
The reason this only showed up in `stable-2.9` is because the default test container image version (1.10.1 currently) has a broken `venv` installation. If `venv` does not work, `ansible-test` falls back to using `virtualenv`. When a new virtual environment is created with `virtualenv` it updates `setuptools` to the latest version. Then 💥.

The issue only occurs on Python 3.8, which installs `coverage` from a tarball. Python 3.7 and earlier install using a wheel, which does not trigger the `setuptools` issue.