### PR TITLE
Revert "[stable-2.9] Add additional constraint for `setuptools` (#756…

### DIFF
--- a/changelogs/fragments/setuptools-constraint.yml
+++ b/changelogs/fragments/setuptools-constraint.yml
@@ -1,5 +1,0 @@
-bugfixes:
-  - >-
-    ansible_test - add additional constraint for ``setuptools`` on Python >= 3.5 due to a bug
-    in the recently released version of ``setuptools`` related to the 'use_2to3' feature
-    (https://github.com/ansible/ansible/pull/75651)

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -42,7 +42,6 @@ pyone == 1.1.9 # newer versions do not pass current integration tests
 MarkupSafe < 2.0.0 ; python_version < '3.6' # MarkupSafe >= 2.0.0. requires Python >= 3.6
 botocore >= 1.10.0 # adds support for the following AWS services: secretsmanager, fms, and acm-pca
 setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require python 3.5 or later
-setuptools < 58.0.2 ; python_version >= '3.5' # setuptools 58.0.2 breaks installation of packages, such as coverage, that reference the 'use_2to3' feature
 cffi != 1.14.4 # Fails on systems with older gcc. Should be fixed in the next release. https://foss.heptapod.net/pypy/cffi/-/issues/480
 websocket-client < 1 ; python_version < '3'  # version 1.0.0 drops support for python 2
 


### PR DESCRIPTION
##### SUMMARY

Revert https://github.com/ansible/ansible/pull/75651 now that `setuptools` 58.0.3 has been released with a fix.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
