### PR TITLE
Fix copy/fetch/file test interactions by cleaning up users with `remove` and `force`

### DIFF
--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -115,6 +115,7 @@
         name: '{{ remote_unprivileged_user }}'
         state: absent
         remove: yes
+        force: yes
 
     - name: Remove sudoers.d file
       file:

--- a/test/integration/targets/file/handlers/main.yml
+++ b/test/integration/targets/file/handlers/main.yml
@@ -3,6 +3,7 @@
     name: "{{ item }}"
     state: absent
     remove: yes
+    force: yes
   loop:
     - test1
     - test_uid

--- a/test/integration/targets/file/tasks/state_link.yml
+++ b/test/integration/targets/file/tasks/state_link.yml
@@ -181,6 +181,8 @@
       user:
         name: '{{ remote_unprivileged_user }}'
         state: absent
+        force: yes
+        remove: yes
 
     - name: Delete unprivileged user home and tempdir
       file:


### PR DESCRIPTION
##### SUMMARY
Fixes CI failures like https://dev.azure.com/ansible/ansible/_build/results?buildId=24305&view=logs&jobId=b9b8ace2-f39a-5d8c-c436-cd04784bdaa3&j=b9b8ace2-f39a-5d8c-c436-cd04784bdaa3&t=b4ad4a56-76c9-57e9-775f-902e838c0e81

Fix test interactions by cleaning up users with the same uid by using 'force: yes' and 'remove: yes'

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Tests Pull Request
