### PR TITLE
Ensure we set perms on htpasswd file to avoid permissions errors

### DIFF
--- a/test/integration/targets/subversion/roles/subversion/tasks/setup.yml
+++ b/test/integration/targets/subversion/roles/subversion/tasks/setup.yml
@@ -44,19 +44,19 @@
     chdir: '{{ subversion_server_dir }}'
     creates: '{{ subversion_server_dir }}/{{ subversion_repo_name }}'
 
-- name: apply ownership for all SVN directories
-  file:
-    path: '{{ subversion_server_dir }}'
-    owner: '{{ apache_user }}'
-    group: '{{ apache_group }}'
-    recurse: True
-
 - name: add test user to htpasswd for Subversion site
   htpasswd:
     path: '{{ subversion_server_dir }}/svn-auth-users'
     name: '{{ subversion_username }}'
     password: '{{ subversion_password }}'
     state: present
+
+- name: apply ownership for all SVN directories
+  file:
+    path: '{{ subversion_server_dir }}'
+    owner: '{{ apache_user }}'
+    group: '{{ apache_group }}'
+    recurse: True
 
 - name: start test Apache SVN site - non Red Hat
   command: apachectl -k start -f {{ subversion_server_dir }}/subversion.conf


### PR DESCRIPTION
##### SUMMARY
Ensure we set perms on htpasswd file to avoid permissions errors

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/subversion/roles/subversion/tasks/setup.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
