### PR TITLE
Fix unarchive tests for split controller

### DIFF
--- a/test/integration/targets/unarchive/tasks/test_owner_group.yml
+++ b/test/integration/targets/unarchive/tasks/test_owner_group.yml
@@ -155,6 +155,8 @@
       user:
         name: testuser
         state: absent
+        remove: yes
+        force: yes
 
     - name: Remove testgroup
       group:

--- a/test/integration/targets/unarchive/tasks/test_tar_gz_owner_group.yml
+++ b/test/integration/targets/unarchive/tasks/test_tar_gz_owner_group.yml
@@ -41,6 +41,8 @@
       user:
         name: testuser
         state: absent
+        remove: yes
+        force: yes
 
     - name: Remove testgroup
       group:

--- a/test/integration/targets/unarchive/tasks/test_unprivileged_user.yml
+++ b/test/integration/targets/unarchive/tasks/test_unprivileged_user.yml
@@ -75,7 +75,8 @@
         name: unarchivetest1
         state: absent
         remove: yes
-      become: no
+      become: yes
+      become_user: root
 
     - name: Remove user home directory on macOS
       file:


### PR DESCRIPTION
##### SUMMARY
Fixes https://dev.azure.com/ansible/ansible/_build/results?buildId=24331&view=logs&jobId=7e75fc89-7473-58d3-71c8-e102f6c98560&j=7e75fc89-7473-58d3-71c8-e102f6c98560&t=95e92a5b-d6ab-588a-b82f-f8d289dff8b1

Become root to clean up test user

Always clean up test users with 'remove' and 'force'

##### ISSUE TYPE
- Test Pull Request