### PR TITLE
Run apache via async in subversion tests

### DIFF
--- a/test/integration/targets/subversion/roles/subversion/tasks/setup.yml
+++ b/test/integration/targets/subversion/roles/subversion/tasks/setup.yml
@@ -60,9 +60,13 @@
 
 - name: start test Apache SVN site - non Red Hat
   command: apachectl -k start -f {{ subversion_server_dir }}/subversion.conf
+  async: 3600  # We kill apache manually in the clean up phase
+  poll: 0
   when: ansible_os_family not in ['RedHat', 'Alpine']
 
 # On Red Hat based OS', we can't use apachectl to start up own instance, just use the raw httpd
 - name: start test Apache SVN site - Red Hat
   command: httpd -k start -f {{ subversion_server_dir }}/subversion.conf
+  async: 3600  # We kill apache manually in the clean up phase
+  poll: 0
   when: ansible_os_family in ['RedHat', 'Alpine']


### PR DESCRIPTION
##### SUMMARY
Run apache via async in subversion tests

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/subversion/roles/subversion/tasks/setup.yml

##### ADDITIONAL INFORMATION
With split controller, it appears as though apache was being killed part way through the tests, I am assuming once the control path exited, because we were simply starting apache via `command`.

This should prevent apache from being reaped during the tests.