### PR TITLE
Add support for merging lists to 'combine' filter

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -392,12 +392,12 @@ You can use the transformed data with ``loop`` to iterate over the same subeleme
 
 .. _combine_filter:
 
-Combining hashes/dictionaries
------------------------------
+Combining hashes/dictionaries/lists
+-----------------------------------
 
 .. versionadded:: 2.0
 
-The ``combine`` filter allows hashes to be merged. For example, the following would override keys in one hash::
+The ``combine`` filter allows hashes and lists to be merged. For example, the following would override keys in one hash::
 
     {{ {'a':1, 'b':2} | combine({'b':3}) }}
 
@@ -411,6 +411,17 @@ The filter can also take multiple arguments to merge::
     {{ [a, b, c, d] | combine }}
 
 In this case, keys in ``d`` would override those in ``c``, which would override those in ``b``, and so on.
+
+Next to merging dictionaries, the filter also accepts merging lists:
+
+    {{ [['item1'], ['item2']] | combine(['item3']) }}
+
+The resulting list would be:
+
+    ['item1', 'item2', 'item3']
+
+Merging lists can normally be done with ``['item1'] + ['item2']`` as well, but in some cases (e.g. where the variables
+are not known upfront) the combine filter provides this option as well.
 
 The filter also accepts two optional parameters: ``recursive`` and ``list_merge``.
 

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -177,6 +177,13 @@
       z: z
       key: z
 
+    l1:
+      - item1
+    l2:
+      - item2
+    l3:
+      - item3
+
     # Most complicated combine dicts from the documentation
     default:
       a:
@@ -234,6 +241,10 @@
       - "(x | combine(y, z)) == {'x': 'x', 'y': 'y', 'z': 'z', 'key': 'z'}"
       - "([x, y, z] | combine) == {'x': 'x', 'y': 'y', 'z': 'z', 'key': 'z'}"
       - "([x, y] | combine(z)) == {'x': 'x', 'y': 'y', 'z': 'z', 'key': 'z'}"
+      - "([l1, l2, l3] | combine) == ['item1', 'item2', 'item3']"
+      - "([l1, l2] | combine([l3])) == ['item1', 'item2', 'item3']"
+      - "([l1] | combine([l2, l3])) == ['item1', 'item2', 'item3']"
+      - "([l1] | combine([l2], [l3])) == ['item1', 'item2', 'item3']"
       - "None|combine == {}"
       # more advanced dict combination tests are done in the "merge_hash" function unit tests
       # but even though it's redundant with those unit tests, we do at least the most complicated example of the documentation here
@@ -246,7 +257,7 @@
   ignore_errors: yes
   register: result
 
-- name: Ensure combining objects which aren't dictionaries throws an error
+- name: Ensure combining mixed objects throws an error
   assert:
     that:
       - "result.msg.startswith(\"failed to combine variables, expected dicts but got\")"


### PR DESCRIPTION
##### SUMMARY
This adds support for merging lists to the combine filter. Normally lists can be merged by just using `['item1'] + ['item2']`. This `combine` filter change ensures that unknown variables can be merged together.

Potential usage is merging variables matching a given regular expression:

```yml
merged_list: "{{ lookup('vars', *query('varnames', '^.+__merge_list')) | combine([], recursive=True, list_merge='append') }}"
merged_dict: "{{ lookup('vars', *query('varnames', '^.+__merge_dict')) | combine({}, recursive=True, list_merge='append') }}"
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
combine filter

##### ADDITIONAL INFORMATION
PR created in favor of #75434