### PR TITLE
Add support for lists as input arguments to the vars lookup plugin

### DIFF
--- a/test/integration/targets/lookup_vars/tasks/main.yml
+++ b/test/integration/targets/lookup_vars/tasks/main.yml
@@ -6,14 +6,25 @@
     that:
       - 'var_host == ansible_host'
 
-- name: Test that we can give a list of values to var and receive a list of values back
-  set_fact:
-    var_host_info: '{{ query("vars", "ansible_host", "ansible_connection") }}'
+- name: Test that we can give multiple values to var and receive a list of values back
+  block:
+    - set_fact:
+        var_host_info: '{{ query("vars", "ansible_host", "ansible_connection") }}'
 
-- assert:
-    that:
-      - 'var_host_info[0] == ansible_host'
-      - 'var_host_info[1] == ansible_connection'
+    - assert:
+        that:
+          - 'var_host_info[0] == ansible_host'
+          - 'var_host_info[1] == ansible_connection'
+
+- name: Test that we can give a list of values to var and receive a list of values back
+  block:
+    - set_fact:
+        var_host_info: '{{ query("vars", ["ansible_host", "ansible_connection"]) }}'
+
+    - assert:
+        that:
+          - 'var_host_info[0] == ansible_host'
+          - 'var_host_info[1] == ansible_connection'
 
 - block:
   - name: EXPECTED FAILURE - test invalid var


### PR DESCRIPTION
##### SUMMARY
This adds support to specify lists as arguments to the `vars` lookup plugin. This allows for dynamic specification of variables.

Potential usage:

```yml
vars_values: "{{ lookup('vars', query('varnames', '^.+__merge_list')) }}"
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vars lookup plugin

##### ADDITIONAL INFORMATION
PR created in favor of #75434

Related to #75689