### PR TITLE
Docs: Update cross reference tag syntax in User Guide

### DIFF
--- a/docs/docsite/rst/user_guide/complex_data_manipulation.rst
+++ b/docs/docsite/rst/user_guide/complex_data_manipulation.rst
@@ -306,9 +306,9 @@ https://www.reddit.com/r/ansible/comments/gj5a93/trying_to_get_uptime_from_secon
 
 .. seealso::
 
-   :doc:`playbooks_filters`
+   :ref:`playbooks_filters`
        Jinja2 filters included with Ansible
-   :doc:`playbooks_tests`
+   :ref:`playbooks_tests`
        Jinja2 tests included with Ansible
    `Jinja2 Docs <https://jinja.palletsprojects.com/>`_
       Jinja2 documentation, includes lists for core filters and tests

--- a/docs/docsite/rst/user_guide/playbooks_advanced_syntax.rst
+++ b/docs/docsite/rst/user_guide/playbooks_advanced_syntax.rst
@@ -104,7 +104,7 @@ You've anchored the value of ``version`` with the ``&my_version`` anchor, and re
 
    :ref:`playbooks_variables`
        All about variables
-   :doc:`complex_data_manipulation`
+   :ref:`complex_data_manipulation`
        Doing complex data manipulation in Ansible
    `User Mailing List <https://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update User Guide docs to replace old `:doc:` cross reference tags with correct `:ref:` tags.

Fixes #75683

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Docs: User Guide

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Replaced old `:doc:` tag with correct `:ref:` tag.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

