### PR TITLE
Fix markdown links that were errantly formatted as rst

### DIFF
--- a/docs/docsite/README.md
+++ b/docs/docsite/README.md
@@ -11,7 +11,7 @@ Contributions to the documentation are welcome.
 
 The Ansible community produces guidance on contributions, building documentation, and submitting pull requests, which you can find in [Contributing to the Ansible Documentation](https://docs.ansible.com/ansible/latest/community/documentation_contributions.html).
 
-You can also join the [Docs Working Group](https://github.com/ansible/community/wiki/Docs) and/or the ``#ansible-docs`` IRC channel on `irc.libera.chat <https://libera.chat/>`_
+You can also join the [Docs Working Group](https://github.com/ansible/community/wiki/Docs) and/or the ``#ansible-docs`` IRC channel on [irc.libera.chat](https://libera.chat/)
 
 Ansible style guide
 ===================

--- a/hacking/ticket_stubs/bug_is_really_a_question.md
+++ b/hacking/ticket_stubs/bug_is_really_a_question.md
@@ -7,7 +7,7 @@ Thanks very much for your interest in Ansible.  It sincerely means a lot to us.
 
 This appears to be a user question, and we'd like to direct these kinds of things to either the mailing list or the IRC channel.
 
-   * IRC: #ansible on `irc.libera.chat <https://libera.chat/>`_
+   * IRC: #ansible on [irc.libera.chat](https://libera.chat/)
    * mailing list: https://groups.google.com/forum/#!forum/ansible-project
 
 If you can stop by there, we'd appreciate it.  This allows us to keep the issue tracker for bugs, pull requests, RFEs and the like.

--- a/hacking/ticket_stubs/collections.md
+++ b/hacking/ticket_stubs/collections.md
@@ -10,5 +10,5 @@ Thank you once again for this and your interest in Ansible!
 
 If you have further questions please stop by IRC or the mailing list:
 
-   * IRC: #ansible on `irc.libera.chat <https://libera.chat/>`_
+   * IRC: #ansible on [irc.libera.chat](https://libera.chat/)
    * mailing list: https://groups.google.com/forum/#!forum/ansible-project

--- a/hacking/ticket_stubs/proposal.md
+++ b/hacking/ticket_stubs/proposal.md
@@ -9,7 +9,7 @@ https://github.com/ansible/proposals/blob/master/proposals_process_proposal.md
 
 If you have any further questions, please let us know by stopping by our devel mailing list, or our devel IRC channel:
 
-   * #ansible-devel on `irc.libera.chat <https://libera.chat/>`_
+   * #ansible-devel on [irc.libera.chat](https://libera.chat/)
    * https://groups.google.com/forum/#!forum/ansible-devel
 
 Thank you!


### PR DESCRIPTION
##### SUMMARY
Fix markdown links that were errantly formatted as rst

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
many

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
