### PR TITLE
PowerShell - Ignore LIB env var when building C# code

### DIFF
--- a/changelogs/fragments/powershell-addtype-env-vars.yml
+++ b/changelogs/fragments/powershell-addtype-env-vars.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- PowerShell - Ignore environment variables when compiling C# Ansible code

--- a/changelogs/fragments/powershell-addtype-env-vars.yml
+++ b/changelogs/fragments/powershell-addtype-env-vars.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- PowerShell - Ignore environment variables when compiling C# Ansible code
+- PowerShell - Ignore the ``LIB`` environment variable when compiling C# Ansible code

--- a/test/integration/targets/module_utils_Ansible.ModuleUtils.AddType/library/add_type_test.ps1
+++ b/test/integration/targets/module_utils_Ansible.ModuleUtils.AddType/library/add_type_test.ps1
@@ -314,7 +314,7 @@ try {
     Add-CSharpType -Reference $lib_set
 }
 finally {
-    Remove-Item env:\LIB
+    Remove-Item -LiteralPath env:\LIB
 }
 Assert-Equals -actual ([Namespace12.Class12]::GetString()) -expected "b"
 

--- a/test/integration/targets/module_utils_Ansible.ModuleUtils.AddType/library/add_type_test.ps1
+++ b/test/integration/targets/module_utils_Ansible.ModuleUtils.AddType/library/add_type_test.ps1
@@ -295,5 +295,28 @@ namespace Namespace11
 Add-CSharpType -Reference $arch_class
 Assert-Equals -actual ([Namespace11.Class11]::GetIntPtrSize()) -expected ([System.IntPtr]::Size)
 
+$lib_set = @'
+using System;
+
+namespace Namespace12
+{
+    public class Class12
+    {
+        public static string GetString()
+        {
+            return "b";
+        }
+    }
+}
+'@
+$env:LIB = "C:\fake\folder\path"
+try {
+    Add-CSharpType -Reference $lib_set
+}
+finally {
+    Remove-Item env:\LIB
+}
+Assert-Equals -actual ([Namespace12.Class12]::GetString()) -expected "b"
+
 $result.res = "success"
 Exit-Json -obj $result


### PR DESCRIPTION
##### SUMMARY
The C# CodeDom calls `csc.exe` to compile the code which can read compiler options from environment variables. If an env var is set with an invalid configuration it can break the whole compiling process making Ansible on Windows unusable. Instead the code will temporarily unset known problematic env vars to avoid this problem.

The Roslyn code is unaffected by this problem, it does not seem to read any env vars so this only applies to the .NET Framework side.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Ansible.ModuleUtils.AddType