### PR TITLE
Docs: Edit list of locations to search for roles

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
@@ -78,10 +78,12 @@ Roles may also include modules and other plugin types in a directory called ``li
 Storing and finding roles
 =========================
 
-By default, Ansible looks for roles in two locations:
+By default, Ansible looks for roles in the following locations:
 
+- in collections, if you are using them
 - in a directory called ``roles/``, relative to the playbook file
-- in ``/etc/ansible/roles``
+- in the configured roles path. The default search path is ``~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles``.
+- in the directory where the playbook file is located
 
 If you store your roles in a different location, set the :ref:`roles_path <DEFAULT_ROLES_PATH>` configuration option so Ansible can find your roles. Checking shared roles into a single location makes them easier to use in multiple playbooks. See :ref:`intro_configuration` for details about managing settings in ansible.cfg.
 

--- a/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
@@ -82,7 +82,7 @@ By default, Ansible looks for roles in the following locations:
 
 - in collections, if you are using them
 - in a directory called ``roles/``, relative to the playbook file
-- in the configured roles path. The default search path is ``~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles``.
+- in the configured :ref:`roles_path <DEFAULT_ROLES_PATH>`. The default search path is ``~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles``.
 - in the directory where the playbook file is located
 
 If you store your roles in a different location, set the :ref:`roles_path <DEFAULT_ROLES_PATH>` configuration option so Ansible can find your roles. Checking shared roles into a single location makes them easier to use in multiple playbooks. See :ref:`intro_configuration` for details about managing settings in ansible.cfg.


### PR DESCRIPTION
##### SUMMARY
Edited list of locations to search for roles in [Storing and finding Roles](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#storing-and-finding-roles): 
Listed search locations in the same order as the searches in the `_load_role_path` function in [/lib/ansible/playbook/role/definition.py](https://github.com/ansible/ansible/blob/01f0c38aa5cd9f4785fcfcc1215652a2df793739/lib/ansible/playbook/role/definition.py#L157)

###### Changes
- Reordered searches
- Added search in collection
- Added playbook base directory as a search location
- Edited default roles path

Fixes #75120

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
user_guide/playbooks_reuse_roles.rst

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
