### PR TITLE
netconf - handle import error when running in FIPS mode (#73992)

### DIFF
--- a/changelogs/fragments/fips-ncclient-import-error.yaml
+++ b/changelogs/fragments/fips-ncclient-import-error.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - netconf - catch and handle exception to prevent stack trace when running in FIPS mode

--- a/lib/ansible/plugins/netconf/__init__.py
+++ b/lib/ansible/plugins/netconf/__init__.py
@@ -32,7 +32,10 @@ try:
     from ncclient.xml_ import to_xml, to_ele, NCElement
     HAS_NCCLIENT = True
     NCCLIENT_IMP_ERR = None
-except (ImportError, AttributeError) as err:  # paramiko and gssapi are incompatible and raise AttributeError not ImportError
+# paramiko and gssapi are incompatible and raise AttributeError not ImportError
+# When running in FIPS mode, cryptography raises InternalError
+# https://bugzilla.redhat.com/show_bug.cgi?id=1778939
+except Exception as err:
     HAS_NCCLIENT = False
     NCCLIENT_IMP_ERR = err
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
*  While running in FIPS mode importing ncclient result in
   InternalError raised by cryptography
*  Original PR https://github.com/ansible/ansible/pull/73992

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
netconf