### PR TITLE
attributes: keep default value around

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -333,8 +333,8 @@ def augment_attributes(attributes):
     for attribute, data in attributes.items():
         default_value = data.pop('default_support_value')
         support = data.get('support')
-        if support == default_value:
-            data['support'] = '%s (default)' % support
+        if support == default_value or support is None:
+            data['support'] = '%s (default)' % default_value
     return attributes
 
 

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -329,6 +329,15 @@ class RoleMixin(object):
         return result
 
 
+def augment_attributes(attributes):
+    for attribute, data in attributes.items():
+        default_value = data.pop('default_support_value')
+        support = data.get('support')
+        if support == default_value:
+            data['support'] = '%s (default)' % support
+    return attributes
+
+
 class DocCLI(CLI, RoleMixin):
     ''' displays information on modules installed in Ansible libraries.
         It displays a terse listing of plugins and their short descriptions,
@@ -1152,7 +1161,7 @@ class DocCLI(CLI, RoleMixin):
 
             if doc.get('attributes'):
                 text.append("ATTRIBUTES:\n")
-                text.append(DocCLI._dump_yaml(doc.pop('attributes'), opt_indent))
+                text.append(DocCLI._dump_yaml(augment_attributes(doc.pop('attributes')), opt_indent))
                 text.append('')
 
             # generic elements we will handle identically
@@ -1226,7 +1235,7 @@ class DocCLI(CLI, RoleMixin):
 
         if doc.get('attributes', False):
             text.append("ATTRIBUTES:\n")
-            text.append(DocCLI._dump_yaml(doc.pop('attributes'), opt_indent))
+            text.append(DocCLI._dump_yaml(augment_attributes(doc.pop('attributes')), opt_indent))
             text.append('')
 
         if doc.get('notes', False):

--- a/lib/ansible/plugins/doc_fragments/action_common_attributes.py
+++ b/lib/ansible/plugins/doc_fragments/action_common_attributes.py
@@ -14,81 +14,106 @@ attributes:
     action:
       description: Indicates this has a corresponding action plugin so some parts of the options can be executed on the controller
       support: none
+      default_support_value: none
     action_group:
       description: Action is part of action_group(s), for convenient setting of module_defaults.
       support: none
+      default_support_value: none
       membership: []
     api:
       description: Instead of executing code on a target, this action interacts with an API on behalf of the target.
       support: none
+      default_support_value: none
     async:
       description: Supports being used with the ``async`` keyword
       support: full
+      default_support_value: full
     become:
       description: Is usable alongside become keywords
       support: full
+      default_support_value: full
     bypass_host_loop:
       description: Forces a 'global' task that does not execute per host, this bypasses per host templating and serial,
                    throttle and other loop considerations.  Also, this action cannot be used in non lockstep strategies
       support: none
+      default_support_value: none
     check_mode:
       description: Can run in check_mode and return changed status prediction withought modifying target
       support: none
+      default_support_value: none
     connection:
       description: Uses the target's configured connection information to execute code on it
       support: full
+      default_support_value: full
     conditional:
       description: Will respect the `when` keyword  per item loop or task (when no loop is present)
       support: full
+      default_support_value: full
     delegation:
       description: Can be used in conjunction with delegate_to and related keywords
       support: full
+      default_support_value: full
     diff_mode:
       description: Will return details on what has changed (or possibly needs changing in check_mode), when in diff mode
       support: none
+      default_support_value: none
     facts:
       description: Action returns an ``ansible_facts`` dictionary that will update existing host facts
       support: none
+      default_support_value: none
     forced_local:
       description: The connection itself is passed to the action while the code is still executed on the controller
       support: none
+      default_support_value: none
     forced_action_plugin:
       description: This action uses a specific action plugin instead of 'normal' or matching by name
       support: none
+      default_support_value: none
       action_plugin: none
     info:
       description: This returns general info (not facts) that you might want to register into a variable for later use
       support: none
+      default_support_value: none
     loops:
       description: both ``loop`` and ``with_`` looping keywords will be honored
       support: full
+      default_support_value: full
     proprietary:
       description: Designed to only be run against specific proprietary OS(s), normally a network appliance or similar
       support: none
+      default_support_value: none
       platforms: []
     posix:
       description: Can be run against most POSIX (and GNU/Linux) OS targets
       support: full
+      default_support_value: full
     safe_file_operations:
       description: Uses Ansbile's strict file operation functions to ensure proper permissions and avoid data corruption
       support: none
+      default_support_value: none
     tags:
       description: Tags will be evaluated to determine if this task considered for execution
       support: full
+      default_support_value: full
     tty:
       description: requires direct access to a TTY
       support: none
+      default_support_value: none
     turbo:
       description: Uses an Ansible supplied caching mechanism (Turbo!) on the remote for authentication and
                    3rd party libraries to speed up recurrent execution
       support: none
+      default_support_value: none
     until:
       description: Usable with until/retry loops
       support: full
+      default_support_value: full
     vault:
       description: Can automatically decrypt Ansible vaulted files
       support: none
+      default_support_value: none
     windows:
       description: Can be run against Windows OS targets
       support: none
+      default_support_value: none
 '''

--- a/lib/ansible/plugins/doc_fragments/action_common_attributes.py
+++ b/lib/ansible/plugins/doc_fragments/action_common_attributes.py
@@ -13,107 +13,82 @@ class ModuleDocFragment(object):
 attributes:
     action:
       description: Indicates this has a corresponding action plugin so some parts of the options can be executed on the controller
-      support: none
       default_support_value: none
     action_group:
       description: Action is part of action_group(s), for convenient setting of module_defaults.
-      support: none
       default_support_value: none
       membership: []
     api:
       description: Instead of executing code on a target, this action interacts with an API on behalf of the target.
-      support: none
       default_support_value: none
     async:
       description: Supports being used with the ``async`` keyword
-      support: full
       default_support_value: full
     become:
       description: Is usable alongside become keywords
-      support: full
       default_support_value: full
     bypass_host_loop:
       description: Forces a 'global' task that does not execute per host, this bypasses per host templating and serial,
                    throttle and other loop considerations.  Also, this action cannot be used in non lockstep strategies
-      support: none
       default_support_value: none
     check_mode:
       description: Can run in check_mode and return changed status prediction withought modifying target
-      support: none
       default_support_value: none
     connection:
       description: Uses the target's configured connection information to execute code on it
-      support: full
       default_support_value: full
     conditional:
       description: Will respect the `when` keyword  per item loop or task (when no loop is present)
-      support: full
       default_support_value: full
     delegation:
       description: Can be used in conjunction with delegate_to and related keywords
-      support: full
       default_support_value: full
     diff_mode:
       description: Will return details on what has changed (or possibly needs changing in check_mode), when in diff mode
-      support: none
       default_support_value: none
     facts:
       description: Action returns an ``ansible_facts`` dictionary that will update existing host facts
-      support: none
       default_support_value: none
     forced_local:
       description: The connection itself is passed to the action while the code is still executed on the controller
-      support: none
       default_support_value: none
     forced_action_plugin:
       description: This action uses a specific action plugin instead of 'normal' or matching by name
-      support: none
       default_support_value: none
       action_plugin: none
     info:
       description: This returns general info (not facts) that you might want to register into a variable for later use
-      support: none
       default_support_value: none
     loops:
       description: both ``loop`` and ``with_`` looping keywords will be honored
-      support: full
       default_support_value: full
     proprietary:
       description: Designed to only be run against specific proprietary OS(s), normally a network appliance or similar
-      support: none
       default_support_value: none
       platforms: []
     posix:
       description: Can be run against most POSIX (and GNU/Linux) OS targets
-      support: full
       default_support_value: full
     safe_file_operations:
       description: Uses Ansbile's strict file operation functions to ensure proper permissions and avoid data corruption
-      support: none
       default_support_value: none
     tags:
       description: Tags will be evaluated to determine if this task considered for execution
-      support: full
       default_support_value: full
     tty:
       description: requires direct access to a TTY
-      support: none
       default_support_value: none
     turbo:
       description: Uses an Ansible supplied caching mechanism (Turbo!) on the remote for authentication and
                    3rd party libraries to speed up recurrent execution
-      support: none
       default_support_value: none
     until:
       description: Usable with until/retry loops
-      support: full
       default_support_value: full
     vault:
       description: Can automatically decrypt Ansible vaulted files
-      support: none
       default_support_value: none
     windows:
       description: Can be run against Windows OS targets
-      support: none
       default_support_value: none
 '''

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
@@ -543,7 +543,7 @@ def doc_schema(module_name, for_collection=False, deprecated_module=False):
                 any_string_types: {
                     Required('description'): any_string_types,
                     'support': Any('full', 'partial', 'none', 'unknown'),
-                    Required('default_support_value'): Any('full', 'partial', 'none'),
+                    Required('default_support_value'): Any('full', 'partial', 'none', 'unknown'),
                     'version_added_collection': collection_name,
                     'version_added': version(for_collection=for_collection),
                 },

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
@@ -542,7 +542,7 @@ def doc_schema(module_name, for_collection=False, deprecated_module=False):
             Schema({
                 any_string_types: {
                     Required('description'): any_string_types,
-                    Required('support'): Any('full', 'partial', 'none', 'unknown'),
+                    'support': Any('full', 'partial', 'none', 'unknown'),
                     Required('default_support_value'): Any('full', 'partial', 'none'),
                     'version_added_collection': collection_name,
                     'version_added': version(for_collection=for_collection),

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
@@ -529,6 +529,7 @@ def doc_schema(module_name, for_collection=False, deprecated_module=False):
         schema = {
             'description': any_string_types,
             'support': any_string_types,
+            'default_support_value': any_string_types,
             'version_added_collection': any_string_types,
             'version_added': any_string_types,
         }
@@ -541,7 +542,8 @@ def doc_schema(module_name, for_collection=False, deprecated_module=False):
             Schema({
                 any_string_types: {
                     Required('description'): any_string_types,
-                    Required('support'): Any('full', 'partial', 'none'),
+                    Required('support'): Any('full', 'partial', 'none', 'unknown'),
+                    Required('default_support_value'): Any('full', 'partial', 'none'),
                     'version_added_collection': collection_name,
                     'version_added': version(for_collection=for_collection),
                 },


### PR DESCRIPTION
##### SUMMARY
This is an approach to solve the current problems the docs working group sees with the new attributes feature.

1. The default list of attributes is rather long, and when shown on a webpage it's hard for users to see which attribute values are default and which ones are different for this specific module/action. While this could be solved by a hard-coded list of attributes with their default values, this will not work for attributes defined in collections.
2. When new attributes are added later, one (usually) cannot assume that all actions which include the `action_common_attributes` fragment will use this default value for `support`. The default for new attributes should thus be (something like) `unknown`, not one of `full`/`partial`/`none`. Which right now is not possible.

Simplify displaying all attributes results in a table like this: [![attributes table mockup screenshot](https://user-images.githubusercontent.com/30267855/132581892-e27959da-085f-42df-996e-01933be09816.png)](https://user-images.githubusercontent.com/30267855/132581892-e27959da-085f-42df-996e-01933be09816.png)
(The entries "default" in column "Version added" cannot be automatically produced with the current implementation.)

The docs WG really would like to either show a reduced table (featuring only the attributes that have different values from the default, with a link to the full table), or a full table where the values which differ from default are highlighted in a way. But this really requires being able to know which values are different from default.

This PR adds a mechanism to indicate the default value, and modifies the ansible-doc text output to include that information in a nice way: the output is almost as it is now, except that support values equal to the default get `(default)` added.

(Log from today's docs meeting, which discusses the attributes feature and its problems in detail: https://meetbot.fedoraproject.org/ansible-docs/2021-09-14/documentation_working_group_aka_dawgs.2021-09-14-15.01.log.html)

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
attributes feature
