### PR TITLE
[WIP] Excluded certain `include_role` and `include_tasks` attributes from `post_validate`

### DIFF
--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -636,6 +636,10 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
                 # default, as their values are often inherited by other objects and validated
                 # later, so we don't want them to fail out early
                 continue
+            elif not attribute.always_post_validate and \
+                    self.__class__.__name__ == 'PlayContext' and \
+                    self._action in C._ACTION_ALL_INCLUDE_ROLE_TASKS:
+                continue
 
             try:
                 # Run the post-validator if present. These methods are responsible for

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -631,14 +631,10 @@ class FieldAttributeBase(with_metaclass(BaseMeta, object)):
                     continue
                 else:
                     raise AnsibleParserError("the field '%s' is required but was not set" % name)
-            elif not attribute.always_post_validate and self.__class__.__name__ not in ('Task', 'Handler', 'PlayContext'):
+            elif not attribute.always_post_validate and self.__class__.__name__ not in ('Task', 'Handler'):
                 # Intermediate objects like Play() won't have their fields validated by
                 # default, as their values are often inherited by other objects and validated
                 # later, so we don't want them to fail out early
-                continue
-            elif not attribute.always_post_validate and \
-                    self.__class__.__name__ == 'PlayContext' and \
-                    self._action in C._ACTION_ALL_INCLUDE_ROLE_TASKS:
                 continue
 
             try:

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -832,7 +832,7 @@ class Base(FieldAttributeBase):
 
     # flags and misc. settings
     _environment = FieldAttribute(isa='list', extend=True, prepend=True)
-    _no_log = FieldAttribute(isa='bool')
+    _no_log = FieldAttribute(isa='bool', always_post_validate=True)
     _run_once = FieldAttribute(isa='bool')
     _ignore_errors = FieldAttribute(isa='bool')
     _ignore_unreachable = FieldAttribute(isa='bool')

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -125,9 +125,6 @@ class PlayContext(Base):
     # "PlayContext.force_handlers should not be used, the calling code should be using play itself instead"
     _force_handlers = FieldAttribute(isa='bool', default=False)
 
-    # Holds the class name for the active task in task executor
-    _action = None
-
     def __init__(self, play=None, passwords=None, connection_lockfd=None):
         # Note: play is really not optional.  The only time it could be omitted is when we create
         # a PlayContext just so we can invoke its deserialize method to load it from a serialized

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -84,7 +84,7 @@ class PlayContext(Base):
 
     # base
     _module_compression = FieldAttribute(isa='string', default=C.DEFAULT_MODULE_COMPRESSION)
-    _shell = FieldAttribute(isa='string')
+    _shell = FieldAttribute(isa='string', always_post_validate=True)
     _executable = FieldAttribute(isa='string', default=C.DEFAULT_EXECUTABLE)
 
     # connection fields, some are inherited from Base:

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -199,9 +199,6 @@ class PlayContext(Base):
 
         new_info = self.copy()
 
-        # store current task type
-        new_info._action = task.action
-
         # loop through a subset of attributes on the task object and set
         # connection fields based on their values
         for attr in TASK_ATTRIBUTE_OVERRIDES:

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -125,6 +125,9 @@ class PlayContext(Base):
     # "PlayContext.force_handlers should not be used, the calling code should be using play itself instead"
     _force_handlers = FieldAttribute(isa='bool', default=False)
 
+    # Holds the class name for the active task in task executor
+    _action = None
+
     def __init__(self, play=None, passwords=None, connection_lockfd=None):
         # Note: play is really not optional.  The only time it could be omitted is when we create
         # a PlayContext just so we can invoke its deserialize method to load it from a serialized
@@ -195,6 +198,9 @@ class PlayContext(Base):
         '''
 
         new_info = self.copy()
+
+        # store current task type
+        new_info._action = task.action
 
         # loop through a subset of attributes on the task object and set
         # connection fields based on their values

--- a/test/integration/targets/roles/issue75240.yml
+++ b/test/integration/targets/roles/issue75240.yml
@@ -1,0 +1,15 @@
+- hosts: testhost
+  gather_facts: no
+  vars:
+    ansible_connection: "ssh"
+    ansible_user: "{{ lookup('file', '/etc/some_auth_token') }}"
+  tasks:
+    - name: "Init"
+      block:
+        - name: "Setup"
+          setup:
+            gather_subset: "!All"
+      rescue:
+        - name: "Error handler"
+          include_role:
+            name: "error_handler"

--- a/test/integration/targets/roles/roles/error_handler/tasks/main.yml
+++ b/test/integration/targets/roles/roles/error_handler/tasks/main.yml
@@ -1,0 +1,6 @@
+- assert:
+    that:
+      - ansible_failed_task.name == "Setup"
+      - ansible_failed_task.action == "setup"
+  vars:
+    ansible_connection: local

--- a/test/integration/targets/roles/runme.sh
+++ b/test/integration/targets/roles/runme.sh
@@ -17,3 +17,6 @@ set -eux
 
 # ensure role data is merged correctly
 ansible-playbook data_integrity.yml -i ../../inventory "$@"
+
+# include_role should work in rescue, even if error is from magic variable templating
+ansible-playbook issue75240.yml -i ../../inventory "$@"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #75240.

This PR makes some of `IncludeRole` and `IncludeTasks` attributes to be exempt from `post_validate` based on value of `always_post_validate` property and aims to remove unnecessary template validation at `include_role` or `include_tasks` task level (not their content). E.g.: when using `include_role` with a role which has only one task, and if `remote_user` is templated, then it should not be validated at `include_role` level, but validated on the tasks inside the included role.

I'm not fully sure this is a complete fix though, hence the WIP/Draft status, as I'm looking for feedback.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/base.py
lib/ansible/playbook/play_context.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Example playbook/role: https://github.com/egmar/include_role_example/blob/main/validate.yml

**Before fix:**
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
/Users/egor/Projects/Development/Github.Public/ansible/venv/bin/python /Users/egor/Projects/Development/Github.Public/ansible/bin/ansible-playbook -i inventories/inventory.yaml -l server1 validate.yml
[WARNING]: You are running the development version of Ansible. You should only
run Ansible from "devel" if you are modifying the Ansible engine, or trying out
features under development. This is a rapidly changing source of code and can
become unstable at any point.

PLAY [test] ********************************************************************

TASK [test] ********************************************************************
fatal: [server1]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'url'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Received HTTP error for https://ip-ranges.amazonaws.com/ip-ranges.json2 : HTTP Error 403: Forbidden. Received HTTP error for https://ip-ranges.amazonaws.com/ip-ranges.json2 : HTTP Error 403: Forbidden"}

TASK [1.1. Error handler] ******************************************************
fatal: [server1]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'url'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Received HTTP error for https://ip-ranges.amazonaws.com/ip-ranges.json2 : HTTP Error 403: Forbidden. Received HTTP error for https://ip-ranges.amazonaws.com/ip-ranges.json2 : HTTP Error 403: Forbidden"}

PLAY RECAP *********************************************************************
server1                    : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=1    ignored=0   


Process finished with exit code 2
```

**After fix:**
```
/Users/egor/Projects/Development/Github.Public/ansible/venv/bin/python /Users/egor/Projects/Development/Github.Public/ansible/bin/ansible-playbook -i inventories/inventory.yaml -l server1 validate.yml
[WARNING]: You are running the development version of Ansible. You should only
run Ansible from "devel" if you are modifying the Ansible engine, or trying out
features under development. This is a rapidly changing source of code and can
become unstable at any point.

PLAY [test] ********************************************************************

TASK [test] ********************************************************************
fatal: [server1]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'url'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Received HTTP error for https://ip-ranges.amazonaws.com/ip-ranges.json2 : HTTP Error 403: Forbidden. Received HTTP error for https://ip-ranges.amazonaws.com/ip-ranges.json2 : HTTP Error 403: Forbidden"}

TASK [1.1. Error handler] ******************************************************

TASK [sample_role : 1.1. Error handler] ****************************************
ok: [server1 -> localhost] => {
    "msg": [
        "Task: test",
        "Ansible Action: setup",
        "Error Message: An unhandled exception occurred while running the lookup plugin 'url'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Received HTTP error for https://ip-ranges.amazonaws.com/ip-ranges.json2 : HTTP Error 403: Forbidden. Received HTTP error for https://ip-ranges.amazonaws.com/ip-ranges.json2 : HTTP Error 403: Forbidden"
    ]
}

TASK [sample_role : 1.2. Run a command on remote to prove post_validate still works here] ***
fatal: [server1]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'url'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Received HTTP error for https://ip-ranges.amazonaws.com/ip-ranges.json2 : HTTP Error 403: Forbidden. Received HTTP error for https://ip-ranges.amazonaws.com/ip-ranges.json2 : HTTP Error 403: Forbidden"}

PLAY RECAP *********************************************************************
server1                    : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=1    ignored=0   
```