### PR TITLE
PowerShell - Ignore LIB env var when building C# code (#75698) - 2.11

### DIFF
--- a/changelogs/fragments/powershell-addtype-env-vars.yml
+++ b/changelogs/fragments/powershell-addtype-env-vars.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- PowerShell - Ignore the ``LIB`` environment variable when compiling C# Ansible code

--- a/test/integration/targets/module_utils_Ansible.ModuleUtils.AddType/library/add_type_test.ps1
+++ b/test/integration/targets/module_utils_Ansible.ModuleUtils.AddType/library/add_type_test.ps1
@@ -295,5 +295,28 @@ namespace Namespace11
 Add-CSharpType -Reference $arch_class
 Assert-Equals -actual ([Namespace11.Class11]::GetIntPtrSize()) -expected ([System.IntPtr]::Size)
 
+$lib_set = @'
+using System;
+
+namespace Namespace12
+{
+    public class Class12
+    {
+        public static string GetString()
+        {
+            return "b";
+        }
+    }
+}
+'@
+$env:LIB = "C:\fake\folder\path"
+try {
+    Add-CSharpType -Reference $lib_set
+}
+finally {
+    Remove-Item -LiteralPath env:\LIB
+}
+Assert-Equals -actual ([Namespace12.Class12]::GetString()) -expected "b"
+
 $result.res = "success"
 Exit-Json -obj $result


### PR DESCRIPTION
(cherry picked from commit 097bc07b6663932705dc2a4baaa5765112fc270e)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/75698

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Ansible.ModuleUtils.AddType.psm1