### PR TITLE
Integration test and sanity index generation fixes.

### DIFF
--- a/docs/bin/testing_formatter.sh
+++ b/docs/bin/testing_formatter.sh
@@ -23,10 +23,10 @@ EOF
 # By default use sha1sum which exists on Linux, if not present select the correct binary
 # based on platform defaults
 SHA_CMD="sha1sum"
-if ! which ${SHA_CMD} > /dev/null 2>&1; then
-    if which sha1 > /dev/null 2>&1; then
+if ! command -v ${SHA_CMD} > /dev/null 2>&1; then
+    if command -v sha1 > /dev/null 2>&1; then
         SHA_CMD="sha1"
-    elif which shasum > /dev/null 2>&1; then
+    elif command -v shasum > /dev/null 2>&1; then
         SHA_CMD="shasum"
     else
         # exit early with an error if no hashing binary can be found since it is required later

--- a/docs/bin/testing_formatter.sh
+++ b/docs/bin/testing_formatter.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -eux
+
 FILENAME=../docsite/rst/dev_guide/testing/sanity/index.rst
 
 cat <<- EOF >$FILENAME.new
@@ -35,6 +37,6 @@ if ! command -v ${SHA_CMD} > /dev/null 2>&1; then
 fi
 
 # Put file into place if it has changed
-if [ "$(${SHA_CMD} <$FILENAME)" != "$(${SHA_CMD} <$FILENAME.new)" ]; then
+if [ ! -f "${FILENAME}" ] || [ "$(${SHA_CMD} <$FILENAME)" != "$(${SHA_CMD} <$FILENAME.new)" ]; then
     mv -f $FILENAME.new $FILENAME
 fi

--- a/test/integration/targets/connection_delegation/runme.sh
+++ b/test/integration/targets/connection_delegation/runme.sh
@@ -3,7 +3,7 @@
 set -ux
 
 echo "Checking if sshpass is present"
-which sshpass 2>&1 || exit 0
+command -v sshpass 2>&1 || exit 0
 echo "sshpass is present, continuing with test"
 
 sshpass -p my_password ansible-playbook -i inventory.ini test.yml -k "$@"

--- a/test/integration/targets/infra/runme.sh
+++ b/test/integration/targets/infra/runme.sh
@@ -30,10 +30,10 @@ PING_MODULE_PATH="../../../../lib/ansible/modules/ping.py"
 ../../../../hacking/test-module.py -m "$PING_MODULE_PATH"
 
 # ensure test-module.py script works well
-../../../../hacking/test-module.py -m "$PING_MODULE_PATH" -I ansible_python_interpreter="$(which python)"
+../../../../hacking/test-module.py -m "$PING_MODULE_PATH" -I ansible_python_interpreter="${ANSIBLE_TEST_PYTHON_INTERPRETER}"
 
 # ensure module.ansible_version is defined when using test-module.py
-../../../../hacking/test-module.py -m library/test.py -I ansible_python_interpreter="$(which python)" <<< '{"ANSIBLE_MODULE_ARGS": {}}'
+../../../../hacking/test-module.py -m library/test.py -I ansible_python_interpreter="${ANSIBLE_TEST_PYTHON_INTERPRETER}" <<< '{"ANSIBLE_MODULE_ARGS": {}}'
 
 # ensure exercising module code locally works
 python -m ansible.modules.file  <<< '{"ANSIBLE_MODULE_ARGS": {"path": "/path/to/file", "state": "absent"}}'


### PR DESCRIPTION
##### SUMMARY

Use the correct Python interpreter in integration tests instead of searching for it with `which python`.
Use `command -v` in favor of `which` in scripts.
Stop on errors in `testing_formatter.sh` and do not require the sanity index to already exist.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

integration tests
docs/bin/testing_formatter.sh
