### PR TITLE
module_utils: Consolidate set_owner_if_different & set_group_if_different

### DIFF
--- a/changelogs/fragments/75742-chown-if-different.yml
+++ b/changelogs/fragments/75742-chown-if-different.yml
@@ -1,0 +1,6 @@
+minor_changes:
+  - >
+    module_utils - Consolidate the implemenations of
+    `AnsibleModule.set_owner_if_different()` &
+    `AnsibleModule.set_group_if_different()`. Provide wrappers to maintain
+    compatibility.

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -787,10 +787,10 @@ class AnsibleModule(object):
         return changed
 
     def set_owner_if_different(self, path, owner, changed, diff=None, expand=True):
-        return self.set_owner_and_group_if_different(path, owner, None, changed, diff=None, expand=True)
+        return self.set_owner_and_group_if_different(path, owner, None, changed, diff=diff, expand=expand)
 
     def set_group_if_different(self, path, group, changed, diff=None, expand=True):
-        return self.set_owner_and_group_if_different(path, None, group, changed, diff=None, expand=True)
+        return self.set_owner_and_group_if_different(path, None, group, changed, diff=diff, expand=expand)
 
     def set_mode_if_different(self, path, mode, changed, diff=None, expand=True):
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -722,7 +722,7 @@ class AnsibleModule(object):
             changed = True
         return changed
 
-    def _chown_if_different(self, path, owner, group, changed, diff=None, expand=True):
+    def set_owner_and_group_if_different(self, path, owner, group, changed, diff=None, expand=True):
         if owner is None and group is None:
             return changed
 
@@ -787,10 +787,10 @@ class AnsibleModule(object):
         return changed
 
     def set_owner_if_different(self, path, owner, changed, diff=None, expand=True):
-        return self._chown_if_different(path, owner, None, changed, diff=None, expand=True)
+        return self.set_owner_and_group_if_different(path, owner, None, changed, diff=None, expand=True)
 
     def set_group_if_different(self, path, group, changed, diff=None, expand=True):
-        return self._chown_if_different(path, None, group, changed, diff=None, expand=True)
+        return self.set_owner_and_group_if_different(path, None, group, changed, diff=None, expand=True)
 
     def set_mode_if_different(self, path, mode, changed, diff=None, expand=True):
 


### PR DESCRIPTION
##### SUMMARY
This merges implementations of `AnsibleModule.set_owner_if_different()` & `AnsibleModule.set_group_if_different()` into a single method. The benefits are
- reduction in code duplication
- makes possible halving the number of calls to `os.lchown()` when the copy module sets both owner and group.

There should be no outward change in behavior. The two original methods become thin wrappers around the new one.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
This PR is related to #75741. If both are merged, then the second benefit above can be realised - by replacing calls in `copy.chown_recursive()`.