### PR TITLE
Added Debian 11 to INTERPRETER_PYTHON_DISTRO_MAP

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1483,6 +1483,7 @@ INTERPRETER_PYTHON_DISTRO_MAP:
     debian:
       '8': /usr/bin/python
       '10': /usr/bin/python3
+      '11': /usr/bin/python3
     fedora:
       '23': /usr/bin/python3
     oracle: *rhelish


### PR DESCRIPTION
Hi


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When using ansible on an bare Debian install I get this error

https://github.com/ansible/ansible/issues/69053

I see you closed it back then, but now Debian 11 is released it would be nice if you added it

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
