### PR TITLE
Add note about `loop_control.extended` memory impact

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/user_guide/playbooks_loops.rst
@@ -410,6 +410,8 @@ Variable                    Description
       loop_control:
         extended: yes
 
+.. note:: When using ``loop_control.extended`` more memory will be utilized on the control node. This is a result of ``ansible_loop.allitems`` containing a reference to the full loop data for every loop. When serializing the results to communicate with the main ansible process, these references will be dereferenced causing memory usage to increase.
+
 Accessing the name of your loop_var
 -----------------------------------
 .. versionadded:: 2.8

--- a/docs/docsite/rst/user_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/user_guide/playbooks_loops.rst
@@ -410,7 +410,7 @@ Variable                    Description
       loop_control:
         extended: yes
 
-.. note:: When using ``loop_control.extended`` more memory will be utilized on the control node. This is a result of ``ansible_loop.allitems`` containing a reference to the full loop data for every loop. When serializing the results to communicate with the main ansible process, these references will be dereferenced causing memory usage to increase.
+.. note:: When using ``loop_control.extended`` more memory will be utilized on the control node. This is a result of ``ansible_loop.allitems`` containing a reference to the full loop data for every loop. When serializing the results for display in callback plugins within the main ansible process, these references may be dereferenced causing memory usage to increase.
 
 Accessing the name of your loop_var
 -----------------------------------


### PR DESCRIPTION
##### SUMMARY
Add note about `loop_control.extended` memory impact

See https://github.com/ansible/ansible/issues/75216

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/user_guide/playbooks_loops.rst

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
