### PR TITLE
ansible-test - Add `--prime-containers` option.

### DIFF
--- a/changelogs/fragments/ansible-test-prime-containers.yml
+++ b/changelogs/fragments/ansible-test-prime-containers.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Added a ``--prime-containers`` option to support downloading containers without running tests.

--- a/test/lib/ansible_test/_internal/__init__.py
+++ b/test/lib/ansible_test/_internal/__init__.py
@@ -42,6 +42,10 @@ from .cli import (
     parse_args,
 )
 
+from .provisioning import (
+    PrimeContainers,
+)
+
 
 def main():
     """Main program function."""
@@ -64,6 +68,8 @@ def main():
 
         try:
             args.func(config)
+        except PrimeContainers:
+            pass
         except ListTargets as ex:
             # save target_names for use once we exit the exception handler
             target_names = ex.target_names

--- a/test/lib/ansible_test/_internal/cli/environments.py
+++ b/test/lib/ansible_test/_internal/cli/environments.py
@@ -385,6 +385,7 @@ def add_global_docker(
             docker_no_pull=False,
             docker_network=None,
             docker_terminate=None,
+            prime_containers=False,
         )
 
         return
@@ -408,6 +409,12 @@ def add_global_docker(
         type=TerminateMode,
         action=EnumAction,
         help='terminate the container: %(choices)s (default: %(default)s)',
+    )
+
+    parser.add_argument(
+        '--prime-containers',
+        action='store_true',
+        help='download containers without running tests',
     )
 
 

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/__init__.py
@@ -151,7 +151,10 @@ def cloud_init(args, targets):  # type: (IntegrationConfig, t.Tuple[IntegrationT
 
     results = {}
 
-    for provider in get_cloud_providers(args, targets):
+    for provider in get_cloud_providers(args, targets):  # type: CloudProvider
+        if args.prime_containers and not provider.uses_docker:
+            continue
+
         args.metadata.cloud_config[provider.platform] = {}
 
         start_time = time.time()

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/cs.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/cs.py
@@ -91,7 +91,7 @@ class CsCloudProvider(CloudProvider):
             self.port,
         ]
 
-        run_support_container(
+        descriptor = run_support_container(
             self.args,
             self.platform,
             self.image,
@@ -100,6 +100,9 @@ class CsCloudProvider(CloudProvider):
             allow_existing=True,
             cleanup=CleanupMode.YES,
         )
+
+        if not descriptor:
+            return
 
         # apply work-around for OverlayFS issue
         # https://github.com/docker/for-linux/issues/72#issuecomment-319904698

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/galaxy.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/galaxy.py
@@ -115,6 +115,9 @@ class GalaxyProvider(CloudProvider):
             allow_existing=True,
         )
 
+        if not descriptor:
+            return
+
         if not descriptor.running:
             pulp_id = descriptor.container_id
 

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/httptester.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/httptester.py
@@ -68,6 +68,9 @@ class HttptesterProvider(CloudProvider):
             },
         )
 
+        if not descriptor:
+            return
+
         # Read the password from the container environment.
         # This allows the tests to work when re-using an existing container.
         # The password is marked as sensitive, since it may differ from the one we generated.

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/openshift.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/openshift.py
@@ -69,7 +69,7 @@ class OpenShiftCloudProvider(CloudProvider):
 
         cmd = ['start', 'master', '--listen', 'https://0.0.0.0:%d' % port]
 
-        run_support_container(
+        descriptor = run_support_container(
             self.args,
             self.platform,
             self.image,
@@ -79,6 +79,9 @@ class OpenShiftCloudProvider(CloudProvider):
             cleanup=CleanupMode.YES,
             cmd=cmd,
         )
+
+        if not descriptor:
+            return
 
         if self.args.explain:
             config = '# Unknown'

--- a/test/lib/ansible_test/_internal/config.py
+++ b/test/lib/ansible_test/_internal/config.py
@@ -106,6 +106,8 @@ class EnvironmentConfig(CommonConfig):
         self.remote_stage = args.remote_stage  # type: t.Optional[str]
         self.remote_terminate = args.remote_terminate  # type: t.Optional[TerminateMode]
 
+        self.prime_containers = args.prime_containers  # type: bool
+
         self.requirements = args.requirements  # type: bool
 
         self.delegate_args = []  # type: t.List[str]

--- a/test/lib/ansible_test/_internal/containers.py
+++ b/test/lib/ansible_test/_internal/containers.py
@@ -113,11 +113,15 @@ def run_support_container(
         env=None,  # type: t.Optional[t.Dict[str, str]]
         options=None,  # type: t.Optional[t.List[str]]
         publish_ports=True,  # type: bool
-):  # type: (...) -> ContainerDescriptor
+):  # type: (...) -> t.Optional[ContainerDescriptor]
     """
     Start a container used to support tests, but not run them.
     Containers created this way will be accessible from tests.
     """
+    if args.prime_containers:
+        docker_pull(args, image)
+        return None
+
     # SSH is required for publishing ports, as well as modifying the hosts file.
     # Initializing the SSH key here makes sure it is available for use after delegation.
     SshKey(args)

--- a/test/lib/ansible_test/_internal/host_profiles.py
+++ b/test/lib/ansible_test/_internal/host_profiles.py
@@ -349,6 +349,9 @@ class DockerProfile(ControllerHostProfile[DockerConfig], SshTargetHostProfile[Do
             cleanup=CleanupMode.NO,
         )
 
+        if not container:
+            return
+
         self.container_name = container.name
 
     def setup(self):  # type: () -> None


### PR DESCRIPTION
##### SUMMARY

Resolves https://github.com/ansible/ansible/issues/75320

The option `--prime-containers` was chosen over `--docker-pull-only` to match the recently added `--prime-venvs` option for sanity tests.

It would also fit well with a future `--prime-requirements` option for pre-installing requirements for unit and integration tests.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
