### PR TITLE
ansible-test - Add minimum constraints for pytest.

### DIFF
--- a/changelogs/fragments/ansible-test-pytest-constraints.yml
+++ b/changelogs/fragments/ansible-test-pytest-constraints.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - ansible-test - Set minimum version constraints for ``pytest``.
+bugfixes:
+  - ansible-test - Use ``--strict`` for ``pytest`` on Python 2.6 since ``--strict-markers`` is not available.

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -8,8 +8,9 @@ pywinrm >= 0.3.0 # message encryption support
 wheel < 0.30.0 ; python_version < '2.7' # wheel 0.30.0 and later require python 2.7 or later
 idna < 2.6, >= 2.5 # linode requires idna < 2.9, >= 2.5, requests requires idna < 2.6, but cryptography will cause the latest version to be installed instead
 paramiko < 2.4.0 ; python_version < '2.7' # paramiko 2.4.0 drops support for python 2.6
-pytest < 3.3.0 ; python_version < '2.7' # pytest 3.3.0 drops support for python 2.6
-pytest < 5.0.0 ; python_version == '2.7' # pytest 5.0.0 and later will no longer support python 2.7
+pytest < 3.3.0, >= 3.1.0 ; python_version < '2.7' # pytest 3.3.0 drops support for python 2.6
+pytest < 5.0.0, >= 4.5.0 ; python_version == '2.7' # pytest 5.0.0 and later will no longer support python 2.7
+pytest >= 4.5.0 ; python_version > '2.7' # pytest 4.5.0 added support for --strict-markers
 pytest-forked < 1.0.2 ; python_version < '2.7' # pytest-forked 1.0.2 and later require python 2.7 or later
 pytest-forked >= 1.0.2 ; python_version >= '2.7' # pytest-forked before 1.0.2 does not work with pytest 4.2.0+ (which requires python 2.7+)
 ntlm-auth >= 1.3.0 # message encryption support using cryptography

--- a/test/lib/ansible_test/_internal/commands/units/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/units/__init__.py
@@ -252,7 +252,10 @@ def command_units(args):
         if not data_context().content.collection:
             cmd.append('--durations=25')
 
-        if python.version != '2.6':
+        if python.version == '2.6':
+            # same as --strict-markers in older versions of pytest which still support python 2.6
+            cmd.append('--strict')
+        else:
             # added in pytest 4.5.0, which requires python 2.7+
             cmd.append('--strict-markers')
 


### PR DESCRIPTION
##### SUMMARY

ansible-test - Add minimum constraints for pytest.

Use `--strict` for `pytest` on Python 2.6 since `--strict-markers` is not available.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
