### PR TITLE
Revert "Compile role with parents in the task's dependency chain

### DIFF
--- a/changelogs/fragments/75165-fix-role-dep-chain.yaml
+++ b/changelogs/fragments/75165-fix-role-dep-chain.yaml
@@ -1,4 +1,0 @@
-bugfixes:
-  - include_role - Only inherit from role parents in the current task dependency chain (https://github.com/ansible/ansible/issues/39543).
-  - include_role - Inherit from role parents beyond a depth of 3 (https://github.com/ansible/ansible/issues/47023).
-  - include_role - Inherit from role parents in the order of the task dependency chain.

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -100,7 +100,11 @@ class IncludeRole(TaskInclude):
 
         # compile role with parent roles as dependencies to ensure they inherit
         # variables
-        dep_chain = self.get_dep_chain() or []
+        if not self._parent_role:
+            dep_chain = []
+        else:
+            dep_chain = list(self._parent_role._parents)
+            dep_chain.append(self._parent_role)
 
         p_block = self.build_parent_block()
 

--- a/test/integration/targets/roles/39543.yml
+++ b/test/integration/targets/roles/39543.yml
@@ -1,7 +1,0 @@
----
-- hosts: all
-  gather_facts: no
-  roles:
-    - 39543_role1
-    - role: 39543_role3
-      when: false

--- a/test/integration/targets/roles/47023.yml
+++ b/test/integration/targets/roles/47023.yml
@@ -1,5 +1,0 @@
----
-- hosts: all
-  gather_facts: no
-  tasks:
-    - include_role: name=47023_role1

--- a/test/integration/targets/roles/roles/39543_role1/tasks/main.yml
+++ b/test/integration/targets/roles/roles/39543_role1/tasks/main.yml
@@ -1,5 +1,0 @@
-- debug:
-    msg: 'role1'
-
-- include_role:
-    name: 39543_role2

--- a/test/integration/targets/roles/roles/39543_role2/tasks/main.yml
+++ b/test/integration/targets/roles/roles/39543_role2/tasks/main.yml
@@ -1,2 +1,0 @@
-- debug:
-    msg: 'role2'

--- a/test/integration/targets/roles/roles/39543_role3/meta/main.yml
+++ b/test/integration/targets/roles/roles/39543_role3/meta/main.yml
@@ -1,2 +1,0 @@
-dependencies:
-  - 39543_role1

--- a/test/integration/targets/roles/roles/39543_role3/tasks/main.yml
+++ b/test/integration/targets/roles/roles/39543_role3/tasks/main.yml
@@ -1,2 +1,0 @@
-- debug:
-    msg: 'role3'

--- a/test/integration/targets/roles/roles/47023_role1/defaults/main.yml
+++ b/test/integration/targets/roles/roles/47023_role1/defaults/main.yml
@@ -1,1 +1,0 @@
-my_default: defined

--- a/test/integration/targets/roles/roles/47023_role1/tasks/main.yml
+++ b/test/integration/targets/roles/roles/47023_role1/tasks/main.yml
@@ -1,1 +1,0 @@
-- include_role: name=47023_role2

--- a/test/integration/targets/roles/roles/47023_role1/vars/main.yml
+++ b/test/integration/targets/roles/roles/47023_role1/vars/main.yml
@@ -1,1 +1,0 @@
-my_var: defined

--- a/test/integration/targets/roles/roles/47023_role2/tasks/main.yml
+++ b/test/integration/targets/roles/roles/47023_role2/tasks/main.yml
@@ -1,1 +1,0 @@
-- include_role: name=47023_role3

--- a/test/integration/targets/roles/roles/47023_role3/tasks/main.yml
+++ b/test/integration/targets/roles/roles/47023_role3/tasks/main.yml
@@ -1,1 +1,0 @@
-- include_role: name=47023_role4

--- a/test/integration/targets/roles/roles/47023_role4/tasks/main.yml
+++ b/test/integration/targets/roles/roles/47023_role4/tasks/main.yml
@@ -1,5 +1,0 @@
-- debug:
-    msg: "Var is {{ my_var | default('undefined') }}"
-
-- debug:
-    msg: "Default is {{ my_default | default('undefined') }}"

--- a/test/integration/targets/roles/runme.sh
+++ b/test/integration/targets/roles/runme.sh
@@ -17,14 +17,3 @@ set -eux
 
 # ensure role data is merged correctly
 ansible-playbook data_integrity.yml -i ../../inventory "$@"
-
-
-# ensure role vars are inherited correctly
-ANSIBLE_PRIVATE_ROLE_VARS=True ansible-playbook 39543.yml -i ../../inventory "$@" | tee out.txt
-test "$(grep '"msg": "role1"' -c out.txt)" = "1"
-test "$(grep '"msg": "role2"' -c out.txt)" = "1"
-test "$(grep '"msg": "role3"' -c out.txt)" = "0"
-
-
-# test nested includes get parent roles greater than a depth of 3
-[ "$(ansible-playbook 47023.yml -i ../../inventory "$@" | grep '\<\(Default\|Var\)\>' | grep -c 'is defined')" = "2" ]


### PR DESCRIPTION
##### SUMMARY
This reverts commit 440cf15aeb134e7df3969d4481dbe027358d74db.

It looks like it broke playbooks in https://github.com/ansible/automation-platform-collection. It's probably safer to re-evaluate and try to get it in early next cycle for lots of testing.

##### ISSUE TYPE
- Bugfix Pull Request
