### PR TITLE
Bump antsibull version to get support for attributes and CLI options

### DIFF
--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -3,7 +3,7 @@
 # if you want known good versions of these dependencies
 # use known_good_reqs.txt instead 
 
-antsibull >= 0.38.1
+antsibull >= 0.38.2
 docutils == 0.16 # pin for now until the problem with unordered lists is fixed
 # see https://github.com/readthedocs/sphinx_rtd_theme/issues/1115jinja2==3.0.1
 jinja2

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -3,7 +3,7 @@
 # if you want known good versions of these dependencies
 # use known_good_reqs.txt instead 
 
-antsibull >= 0.34.0
+antsibull >= 0.38.0
 docutils == 0.16 # pin for now until the problem with unordered lists is fixed
 # see https://github.com/readthedocs/sphinx_rtd_theme/issues/1115jinja2==3.0.1
 jinja2

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -3,7 +3,7 @@
 # if you want known good versions of these dependencies
 # use known_good_reqs.txt instead 
 
-antsibull >= 0.38.0
+antsibull >= 0.38.1
 docutils == 0.16 # pin for now until the problem with unordered lists is fixed
 # see https://github.com/readthedocs/sphinx_rtd_theme/issues/1115jinja2==3.0.1
 jinja2


### PR DESCRIPTION
##### SUMMARY
Bumps the minimum antsibull version to [0.38.0](https://github.com/ansible-community/antsibull/releases/tag/0.38.0), which supports plugin/module attributes and plugin CLI options.

Fixes #75164 (attributes), fixes #74838 (SSH connection plugin).

This might not be strictly necessary (since 0.38.0 >= 0.34.0), but that depends on how exactly the docs pipeline works (we'll find out tomorrow on https://docs.ansible.com/ansible/devel/collections/ansible/builtin/); this PR should ensure that the necessary version of antsibull is always used.

CC @samccann

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugin/module HTML docs
