### PR TITLE
ansible-test pslint - fix warning with nested objects

### DIFF
--- a/changelogs/fragments/pslint-sanity-warning.yml
+++ b/changelogs/fragments/pslint-sanity-warning.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-test pslint - Fix error when encountering validation results that are highly nested - https://github.com/ansible/ansible/issues/74151

--- a/test/lib/ansible_test/_util/controller/sanity/pslint/pslint.ps1
+++ b/test/lib/ansible_test/_util/controller/sanity/pslint/pslint.ps1
@@ -38,4 +38,4 @@ $Results = @(ForEach ($Path in $Args) {
 
 # Since pwsh 7.1 results that exceed depth will produce a warning which fails the process.
 # Ignore warnings only for this step.
-ConvertTo-Json -InputObject $Results -Depth 2 -WarningAction SilentlyContinue
+ConvertTo-Json -InputObject $Results -Depth 1 -WarningAction SilentlyContinue

--- a/test/lib/ansible_test/_util/controller/sanity/pslint/pslint.ps1
+++ b/test/lib/ansible_test/_util/controller/sanity/pslint/pslint.ps1
@@ -4,81 +4,6 @@
 $ErrorActionPreference = "Stop"
 $WarningPreference = "Stop"
 
-Function Convert-OutputObject {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
-        [AllowNull()]
-        [object]
-        $InputObject,
-
-        [Parameter(Mandatory=$true)]
-        [int]
-        $Depth
-    )
-
-    begin {
-        $childDepth = $Depth - 1
-    }
-
-    process {
-        if ($null -eq $InputObject) {
-            $null
-        }
-        elseif ($InputObject -is [DateTime] -or $InputObject -is [DateTimeOffset]) {
-            # Behaviour of ConvertTo-Json with date types differs across versions, just use ISO 8601
-            $InputObject.ToString('o')
-        }
-        elseif ($InputObject -is [Type]) {
-            # Type contains lots of properties, some with circular references
-            $InputObject.FullName
-        }
-        elseif ($InputObject -is [switch]) {
-            $InputObject.IsPresent
-        }
-        elseif ($InputObject -is [string]) {
-            # A string is not a ValueType but should be handled as one
-            $InputObject
-        }
-        elseif ($InputObject.GetType().IsValueType) {
-            # We want to display just this value and not any properties it has (if any).
-            $InputObject
-        }
-        elseif ($Depth -lt 0) {
-            # This must occur after the above to ensure ints and other ValueTypes are preserved as is.
-            [string]$InputObject
-        }
-        elseif ($InputObject -is [Collections.IList]) {
-            ,@(foreach ($obj in $InputObject) {
-                Convert-OutputObject -InputObject $obj -Depth $childDepth
-            })
-        }
-        elseif ($InputObject -is [Collections.IDictionary]) {
-            $newObj = @{}
-
-            # Replicate ConvertTo-Json, props are replaced by keys if they share the same name. We only want ETS
-            # properties as well.
-            foreach ($prop in $InputObject.PSObject.Properties) {
-                if ($prop.MemberType -notin @('AliasProperty', 'ScriptProperty', 'NoteProperty')) {
-                    continue
-                }
-                $newObj[$prop.Name] = Convert-OutputObject -InputObject $prop.Value -Depth $childDepth
-            }
-            foreach ($kvp in $InputObject.GetEnumerator()) {
-                $newObj[$kvp.Key] = Convert-OutputObject -InputObject $kvp.Value -Depth $childDepth
-            }
-            $newObj
-        }
-        else {
-            $newObj = @{}
-            foreach ($prop in $InputObject.PSObject.Properties) {
-                $newObj[$prop.Name] = Convert-OutputObject -InputObject $prop.Value -Depth $childDepth
-            }
-            $newObj
-        }
-    }
-}
-
 # Until https://github.com/PowerShell/PSScriptAnalyzer/issues/1217 is fixed we need to import Pester if it's
 # available.
 if (Get-Module -Name Pester -ListAvailable -ErrorAction SilentlyContinue) {
@@ -111,4 +36,6 @@ $Results = @(ForEach ($Path in $Args) {
     Until ($Retries -le 0)
 })
 
-ConvertTo-Json -InputObject (Convert-OutputObject -InputObject $Results -Depth 2) -Depth 2
+# Since pwsh 7.1 results that exceed depth will produce a warning which fails the process.
+# Ignore warnings only for this step.
+ConvertTo-Json -InputObject $Results -Depth 2 -WarningAction SilentlyContinue

--- a/test/lib/ansible_test/_util/controller/sanity/pslint/pslint.ps1
+++ b/test/lib/ansible_test/_util/controller/sanity/pslint/pslint.ps1
@@ -1,9 +1,83 @@
 #Requires -Version 6
 #Requires -Modules PSScriptAnalyzer, PSSA-PSCustomUseLiteralPath
 
-Set-StrictMode -Version 2.0
 $ErrorActionPreference = "Stop"
 $WarningPreference = "Stop"
+
+Function Convert-OutputObject {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [AllowNull()]
+        [object]
+        $InputObject,
+
+        [Parameter(Mandatory=$true)]
+        [int]
+        $Depth
+    )
+
+    begin {
+        $childDepth = $Depth - 1
+    }
+
+    process {
+        if ($null -eq $InputObject) {
+            $null
+        }
+        elseif ($InputObject -is [DateTime] -or $InputObject -is [DateTimeOffset]) {
+            # Behaviour of ConvertTo-Json with date types differs across versions, just use ISO 8601
+            $InputObject.ToString('o')
+        }
+        elseif ($InputObject -is [Type]) {
+            # Type contains lots of properties, some with circular references
+            $InputObject.FullName
+        }
+        elseif ($InputObject -is [switch]) {
+            $InputObject.IsPresent
+        }
+        elseif ($InputObject -is [string]) {
+            # A string is not a ValueType but should be handled as one
+            $InputObject
+        }
+        elseif ($InputObject.GetType().IsValueType) {
+            # We want to display just this value and not any properties it has (if any).
+            $InputObject
+        }
+        elseif ($Depth -lt 0) {
+            # This must occur after the above to ensure ints and other ValueTypes are preserved as is.
+            [string]$InputObject
+        }
+        elseif ($InputObject -is [Collections.IList]) {
+            ,@(foreach ($obj in $InputObject) {
+                Convert-OutputObject -InputObject $obj -Depth $childDepth
+            })
+        }
+        elseif ($InputObject -is [Collections.IDictionary]) {
+            $newObj = @{}
+
+            # Replicate ConvertTo-Json, props are replaced by keys if they share the same name. We only want ETS
+            # properties as well.
+            foreach ($prop in $InputObject.PSObject.Properties) {
+                if ($prop.MemberType -notin @('AliasProperty', 'ScriptProperty', 'NoteProperty')) {
+                    continue
+                }
+                $newObj[$prop.Name] = Convert-OutputObject -InputObject $prop.Value -Depth $childDepth
+            }
+            foreach ($kvp in $InputObject.GetEnumerator()) {
+                $newObj[$kvp.Key] = Convert-OutputObject -InputObject $kvp.Value -Depth $childDepth
+            }
+            $newObj
+        }
+        else {
+            $newObj = @{}
+            foreach ($prop in $InputObject.PSObject.Properties) {
+                $newObj[$prop.Name] = Convert-OutputObject -InputObject $prop.Value -Depth $childDepth
+            }
+            $newObj
+        }
+    }
+}
 
 # Until https://github.com/PowerShell/PSScriptAnalyzer/issues/1217 is fixed we need to import Pester if it's
 # available.
@@ -20,14 +94,12 @@ $PSSAParams = @{
     Setting = (Join-Path -Path $PSScriptRoot -ChildPath "settings.psd1")
 }
 
-$Results = @()
-
-ForEach ($Path in $Args) {
+$Results = @(ForEach ($Path in $Args) {
     $Retries = 3
 
     Do {
         Try {
-            $Results += Invoke-ScriptAnalyzer -Path $Path @PSSAParams 3> $null
+            Invoke-ScriptAnalyzer -Path $Path @PSSAParams 3> $null
             $Retries = 0
         }
         Catch {
@@ -37,6 +109,6 @@ ForEach ($Path in $Args) {
         }
     }
     Until ($Retries -le 0)
-}
+})
 
-ConvertTo-Json -InputObject $Results
+ConvertTo-Json -InputObject (Convert-OutputObject -InputObject $Results -Depth 2) -Depth 2


### PR DESCRIPTION
##### SUMMARY
Some rules seem to output objects with a depth greater than 2. On some PowerShell versions `ConvertTo-Json` will emit a warning which stops the pipeline causing a failure rather than the validation error message. This PR will use a custom function to ensure the depth is not exceeded and to also add an explicit depth value just in case it does happen again.

Fixes https://github.com/ansible/ansible/issues/74151

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test