### PR TITLE
Use verbose regex for PowerShell import detection

### DIFF
--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_csbasic_only.ps1
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_csbasic_only.ps1
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -CSharpUtil Ansible.Missing -ShouldNotFireDueToUnknownOption
 
 $spec = @{
     options = @{

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_uses_coll_psmu.ps1
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/modules/win_uses_coll_psmu.ps1
@@ -5,6 +5,7 @@
 #AnsibleRequires -CSharpUtil Ansible.Basic
 #AnsibleRequires -Powershell ansible_collections.testns.testcoll.plugins.module_utils.MyPSMU
 #AnsibleRequires -PowerShell ansible_collections.testns.testcoll.plugins.module_utils.subpkg.subps
+#AnsibleRequires -CSharpUtil ansible_collections.testns.testcoll.plugins.module_utils.MyMissingPSU -ShouldNotFireDueToUnknownOption
 
 $spec = @{
     options = @{


### PR DESCRIPTION
##### SUMMARY
The regex used to detect PowerShell and C# util imports was getting quite hairy. This PR uses a verbose regex pattern with comments explaining some of the parts and tries to make it easier to add more parameters/options to the import lines for the future.

The aim is to backport the code present to older versions to unify the logic and fix some outstanding bugs but remove any of the new options (like `-Optional`) in versions before this was introduced.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
powershell
