### PR TITLE
uri: add documentation for return value path

### DIFF
--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -407,6 +407,11 @@ msg:
   returned: always
   type: str
   sample: OK (unknown bytes)
+path:
+  description: destination file/path
+  returned: dest is defined
+  type: str
+  sample: /path/to/file.txt
 redirected:
   description: Whether the request was redirected.
   returned: on success


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR adds documentation for the already existing return value `path`.

The uri module has - like the related `get_url` module - the parameter `dest` for saving the content as a download but unlike `get_url` it does not return the path value where the file was downloaded to. The information is already present within `path` but it's just not documented. Making this visible was the easiest solution.

But for consistency sake it might make more sense to add `dest` as a separate return value and document it. Because `path` is internally used for another purpose, for details see here: https://github.com/ansible/ansible/blob/872fda881540172ef94a9e81150b37ec021a6f8e/lib/ansible/modules/uri.py#L742-L744

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

uri

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
