### PR TITLE
[bp-2.11] Update examples/scripts/uptime.py

### DIFF
--- a/examples/scripts/uptime.py
+++ b/examples/scripts/uptime.py
@@ -54,7 +54,7 @@ def main():
     host_list = ['localhost', 'www.example.com', 'www.google.com']
     # since the API is constructed for CLI it expects certain options to always be set in the context object
     context.CLIARGS = ImmutableDict(connection='smart', module_path=['/to/mymodules', '/usr/share/ansible'], forks=10, become=None,
-                                    become_method=None, become_user=None, check=False, diff=False)
+                                    become_method=None, become_user=None, check=False, diff=False, verbosity=0)
     # required for
     # https://github.com/ansible/ansible/blob/devel/lib/ansible/inventory/manager.py#L204
     sources = ','.join(host_list)


### PR DESCRIPTION
##### SUMMARY

Fixes missing parameter 'verbosity'

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit 39a49963b5a6652a3d4eaed146dfafe869346457)


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
examples/scripts/uptime.py
