### PR TITLE
[stable-2.10] ansible-test - pin antsibull to prevent failures

### DIFF
--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -47,12 +47,6 @@ setuptools < 37 ; python_version == '2.6' # setuptools 37 and later require pyth
 setuptools < 45 ; python_version == '2.7' # setuptools 45 and later require python 3.5 or later
 MarkupSafe < 2.0.0 ; python_version < '3.6' # MarkupSafe >= 2.0.0. requires Python >= 3.6
 
-# freeze antsibull-changelog for consistent test results
-antsibull-changelog == 0.9.0
-
-# Make sure we have a new enough antsibull for the CLI args we use
-antsibull >= 0.21.0
-
 # freeze pylint and its requirements for consistent test results
 astroid == 2.3.3
 isort == 4.3.15

--- a/test/lib/ansible_test/_data/requirements/sanity.changelog.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.changelog.txt
@@ -1,2 +1,2 @@
 # changelog build requires python 3.6+
-antsibull-changelog ; python_version >= '3.6'
+antsibull-changelog == 0.9.0 ; python_version >= '3.6'

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -3,4 +3,4 @@ pyyaml
 sphinx
 sphinx-notfound-page
 straight.plugin
-antsibull
+antsibull == 0.26.0

--- a/test/sanity/code-smell/package-data.requirements.txt
+++ b/test/sanity/code-smell/package-data.requirements.txt
@@ -7,4 +7,4 @@ setuptools > 39.2
 straight.plugin
 
 # changelog build requires python 3.6+
-antsibull-changelog ; python_version >= '3.6'
+antsibull-changelog == 0.9.0 ; python_version >= '3.6'

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -321,6 +321,7 @@ test/integration/targets/win_script/files/test_script_with_splatting.ps1 pslint:
 test/integration/targets/windows-minimal/library/win_ping_syntax_error.ps1 pslint!skip
 test/lib/ansible_test/_data/requirements/constraints.txt test-constraints
 test/lib/ansible_test/_data/requirements/integration.cloud.azure.txt test-constraints
+test/lib/ansible_test/_data/requirements/sanity.changelog.txt test-constraints
 test/lib/ansible_test/_data/requirements/sanity.ps1 pslint:PSCustomUseLiteralPath # Uses wildcards on purpose
 test/lib/ansible_test/_data/sanity/pylint/plugins/string_format.py use-compat-six
 test/lib/ansible_test/_data/setup/ConfigureRemotingForAnsible.ps1 pslint:PSCustomUseLiteralPath


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A recent release of `antsibull` is causing docs-build sanity tests to fail and it was not properly pinned in the `stable-2.10` branch.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/lib/ansible_test/_data/requirements/constraints.txt`
`test/lib/ansible_test/_data/requirements/sanity.changelog.txt`
`test/sanity/code-smell/docs-build.requirements.txt`
`test/sanity/code-smell/package-data.requirements.txt`

