### PR TITLE
ansible-test - Fix `pylint` error.

### DIFF
--- a/changelogs/fragments/ansible-test-isort.yml
+++ b/changelogs/fragments/ansible-test-isort.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Update ``isort`` constraint from version 4.3.15 to 4.3.16 to prevent ``pylint`` from failing with warnings reported as errors.

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -55,7 +55,7 @@ antsibull >= 0.21.0
 
 # freeze pylint and its requirements for consistent test results
 astroid == 2.3.3
-isort == 4.3.15
+isort == 4.3.16
 lazy-object-proxy == 1.4.3
 mccabe == 0.6.1
 pylint == 2.3.1


### PR DESCRIPTION
##### SUMMARY

This prevents `pylint` from failing with warnings reported as errors and with no test results given.

Resolves https://github.com/ansible/ansible/issues/75791

The issue does not occur in stable-2.11 and later due to already using a newer version of `isort`.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
