### PR TITLE
[stable-2.9] ansible-test - Fix `pylint` error.

### DIFF
--- a/changelogs/fragments/ansible-test-isort.yml
+++ b/changelogs/fragments/ansible-test-isort.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Update ``isort`` constraint from version 4.3.15 to 4.3.16 to prevent ``pylint`` from failing with warnings reported as errors.

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -47,7 +47,7 @@ websocket-client < 1 ; python_version < '3'  # version 1.0.0 drops support for p
 
 # freeze pylint and its requirements for consistent test results
 astroid == 2.3.3
-isort == 4.3.15
+isort == 4.3.16
 lazy-object-proxy == 1.4.3
 mccabe == 0.6.1
 pylint == 2.3.1


### PR DESCRIPTION
##### SUMMARY

This prevents `pylint` from failing with warnings reported as errors and with no test results given.

Resolves https://github.com/ansible/ansible/issues/75791

Backport of https://github.com/ansible/ansible/pull/75802

(cherry picked from commit a00c61719b825c21c629d25244715c82716548e3)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
