### PR TITLE
Don't show params when there is an issue with `set_option(s)`

### DIFF
--- a/changelogs/fragments/avoid-set_options-leak.yaml
+++ b/changelogs/fragments/avoid-set_options-leak.yaml
@@ -1,4 +1,5 @@
 ---
-bugfixes:
-  - Do not include params in exception when a call to set_options fails.
+security_fixes:
+  - Do not include params in exception when a call to ``set_options`` fails.
     Additionally, block the exception that is returned from being displayed to stdout.
+    (CVE-2021-3620)

--- a/changelogs/fragments/avoid-set_options-leak.yaml
+++ b/changelogs/fragments/avoid-set_options-leak.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Do not include params in exception when a call to set_options fails.
+    Additionally, block the exception that is returned from being displayed to stdout.

--- a/lib/ansible/module_utils/connection.py
+++ b/lib/ansible/module_utils/connection.py
@@ -163,6 +163,11 @@ class Connection(object):
         try:
             response = json.loads(out)
         except ValueError:
+            # set_option(s) has sensitive info, and the details are unlikely to matter anyway
+            if name.startswith("set_option"):
+                raise ConnectionError(
+                    "Unable to decode JSON from response to {0}. Received '{1}'.".format(name, out)
+                )
             params = [repr(arg) for arg in args] + ['{0}={1!r}'.format(k, v) for k, v in iteritems(kwargs)]
             params = ', '.join(params)
             raise ConnectionError(

--- a/test/units/module_utils/test_connection.py
+++ b/test/units/module_utils/test_connection.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2021, Matt Martz <matt@sivel.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils import connection
+
+import pytest
+
+
+def test_set_options_credential_exposure():
+    def send(data):
+        return '{'
+
+    c = connection.Connection(connection.__file__)
+    c.send = send
+    with pytest.raises(connection.ConnectionError) as excinfo:
+        c._exec_jsonrpc('set_options', become_pass='password')
+
+    assert 'password' not in str(excinfo.value)


### PR DESCRIPTION
##### SUMMARY
Don't show params when there is an issue with `set_option(s)`

CVE-2021-3620

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/connection.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
