### PR TITLE
url_argument_spec: remove deprecated thirsty alias

### DIFF
--- a/changelogs/fragments/75825-75826-get_url-uri-remove-deprecated-thirsty-alias.yml
+++ b/changelogs/fragments/75825-75826-get_url-uri-remove-deprecated-thirsty-alias.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - url_argument_spec - remove deprecated ``thirsty`` alias for ``get_url`` and ``uri`` modules (https://github.com/ansible/ansible/issues/75825, https://github.com/ansible/ansible/issues/75826)

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1673,8 +1673,7 @@ def url_argument_spec():
     '''
     return dict(
         url=dict(type='str'),
-        force=dict(type='bool', default=False, aliases=['thirsty'],
-                   deprecated_aliases=[dict(name='thirsty', version='2.13', collection_name='ansible.builtin')]),
+        force=dict(type='bool', default=False),
         http_agent=dict(type='str', default='ansible-httpget'),
         use_proxy=dict(type='bool', default=True),
         validate_certs=dict(type='bool', default=True),

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -57,10 +57,8 @@ options:
         will only be downloaded if the destination does not exist. Generally
         should be C(yes) only for small local files.
       - Prior to 0.6, this module behaved as if C(yes) was the default.
-      - Alias C(thirsty) has been deprecated and will be removed in 2.13.
     type: bool
     default: no
-    aliases: [ thirsty ]
     version_added: '0.7'
   backup:
     description:
@@ -478,10 +476,6 @@ def main():
         supports_check_mode=True,
         mutually_exclusive=[['checksum', 'sha256sum']],
     )
-
-    if module.params.get('thirsty'):
-        module.deprecate('The alias "thirsty" has been deprecated and will be removed, use "force" instead',
-                         version='2.13', collection_name='ansible.builtin')
 
     if module.params.get('sha256sum'):
         module.deprecate('The parameter "sha256sum" has been deprecated and will be removed, use "checksum" instead',

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -162,10 +162,8 @@ options:
   force:
     description:
       - If C(yes) do not get a cached copy.
-      - Alias C(thirsty) has been deprecated and will be removed in 2.13.
     type: bool
     default: no
-    aliases: [ thirsty ]
   use_proxy:
     description:
       - If C(no), it will not use a proxy, even if one is defined in an environment variable on the target hosts.
@@ -668,10 +666,6 @@ def main():
         add_file_common_args=True,
         mutually_exclusive=[['body', 'src']],
     )
-
-    if module.params.get('thirsty'):
-        module.deprecate('The alias "thirsty" has been deprecated and will be removed, use "force" instead',
-                         version='2.13', collection_name='ansible.builtin')
 
     url = module.params['url']
     body = module.params['body']

--- a/lib/ansible/plugins/doc_fragments/url.py
+++ b/lib/ansible/plugins/doc_fragments/url.py
@@ -18,10 +18,8 @@ options:
   force:
     description:
       - If C(yes) do not get a cached copy.
-      - Alias C(thirsty) has been deprecated and will be removed in 2.13.
     type: bool
     default: no
-    aliases: [ thirsty ]
   http_agent:
     description:
       - Header to identify as, generally appears in web server logs.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #75825
Fixes #75826
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/module_utils/urls.py`
`lib/ansible/modules/get_url.py`
`lib/ansible/modules/uri.py`
`lib/ansible/plugins/doc_fragments/url.py`