### PR TITLE
cli - remove deprecated setting verbosity before sub command

### DIFF
--- a/changelogs/fragments/75823-cli-remove-deprecated-verbosity-before-sub-cmd.yml
+++ b/changelogs/fragments/75823-cli-remove-deprecated-verbosity-before-sub-cmd.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cli - remove deprecated ability to set verbosity before the sub-command (https://github.com/ansible/ansible/issues/75823)

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -349,16 +349,6 @@ class CLI(with_metaclass(ABCMeta, object)):
             else:
                 options.inventory = C.DEFAULT_HOST_LIST
 
-        # Dup args set on the root parser and sub parsers results in the root parser ignoring the args. e.g. doing
-        # 'ansible-galaxy -vvv init' has no verbosity set but 'ansible-galaxy init -vvv' sets a level of 3. To preserve
-        # back compat with pre-argparse changes we manually scan and set verbosity based on the argv values.
-        if self.parser.prog in ['ansible-galaxy', 'ansible-vault'] and not options.verbosity:
-            verbosity_arg = next(iter([arg for arg in self.args if arg.startswith('-v')]), None)
-            if verbosity_arg:
-                display.deprecated("Setting verbosity before the arg sub command is deprecated, set the verbosity "
-                                   "after the sub command", "2.13", collection_name='ansible.builtin')
-                options.verbosity = verbosity_arg.count('v')
-
         return options
 
     def parse(self):

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -462,13 +462,7 @@ class TestGalaxyInitSkeleton(unittest.TestCase, ValidRoleTests):
 @pytest.mark.parametrize('cli_args, expected', [
     (['ansible-galaxy', 'collection', 'init', 'abc._def'], 0),
     (['ansible-galaxy', 'collection', 'init', 'abc._def', '-vvv'], 3),
-    (['ansible-galaxy', '-vv', 'collection', 'init', 'abc._def'], 2),
-    # Due to our manual parsing we want to verify that -v set in the sub parser takes precedence. This behaviour is
-    # deprecated and tests should be removed when the code that handles it is removed
-    (['ansible-galaxy', '-vv', 'collection', 'init', 'abc._def', '-v'], 1),
-    (['ansible-galaxy', '-vv', 'collection', 'init', 'abc._def', '-vvvv'], 4),
-    (['ansible-galaxy', '-vvv', 'init', 'name'], 3),
-    (['ansible-galaxy', '-vvvvv', 'init', '-v', 'name'], 1),
+    (['ansible-galaxy', 'collection', 'init', 'abc._def', '-vv'], 2),
 ])
 def test_verbosity_arguments(cli_args, expected, monkeypatch):
     # Mock out the functions so we don't actually execute anything

--- a/test/units/cli/test_vault.py
+++ b/test/units/cli/test_vault.py
@@ -209,11 +209,7 @@ class TestVaultCli(unittest.TestCase):
 @pytest.mark.parametrize('cli_args, expected', [
     (['ansible-vault', 'view', 'vault.txt'], 0),
     (['ansible-vault', 'view', 'vault.txt', '-vvv'], 3),
-    (['ansible-vault', '-vv', 'view', 'vault.txt'], 2),
-    # Due to our manual parsing we want to verify that -v set in the sub parser takes precedence. This behaviour is
-    # deprecated and tests should be removed when the code that handles it is removed
-    (['ansible-vault', '-vv', 'view', 'vault.txt', '-v'], 1),
-    (['ansible-vault', '-vv', 'view', 'vault.txt', '-vvvv'], 4),
+    (['ansible-vault', 'view', 'vault.txt', '-vv'], 2),
 ])
 def test_verbosity_arguments(cli_args, expected, tmp_path_factory, monkeypatch):
     # Add a password file so we don't get a prompt in the test


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #75823
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/cli/__init__.py`