### PR TITLE
Add support for distinct collection skeleton configuration

### DIFF
--- a/changelogs/fragments/75845-ansible-galaxy-support-collection-skeleton.yml
+++ b/changelogs/fragments/75845-ansible-galaxy-support-collection-skeleton.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - Add galaxy_collection_skeleton/galaxy_collection_skeleton_ignore configuration options

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -274,7 +274,7 @@ class GalaxyCLI(CLI):
                                  help='The path in which the skeleton {0} will be created. The default is the '
                                       'current working directory.'.format(galaxy_type))
         init_parser.add_argument('--{0}-skeleton'.format(galaxy_type), dest='{0}_skeleton'.format(galaxy_type),
-                                 default=C.GALAXY_ROLE_SKELETON,
+                                 default=C.GALAXY_COLLECTION_SKELETON if galaxy_type == 'collection' else C.GALAXY_ROLE_SKELETON,
                                  help='The path to a {0} skeleton that the new {0} should be based '
                                       'upon.'.format(galaxy_type))
 
@@ -934,6 +934,7 @@ class GalaxyCLI(CLI):
                 dependencies=[],
             ))
 
+            skeleton_ignore_expressions = C.GALAXY_ROLE_SKELETON_IGNORE
             obj_path = os.path.join(init_path, obj_name)
         elif galaxy_type == 'collection':
             namespace, collection_name = obj_name.split('.', 1)
@@ -952,6 +953,7 @@ class GalaxyCLI(CLI):
                 build_ignore=[],
             ))
 
+            skeleton_ignore_expressions = C.GALAXY_COLLECTION_SKELETON_IGNORE
             obj_path = os.path.join(init_path, namespace, collection_name)
 
         b_obj_path = to_bytes(obj_path, errors='surrogate_or_strict')
@@ -967,7 +969,6 @@ class GalaxyCLI(CLI):
 
         if obj_skeleton is not None:
             own_skeleton = False
-            skeleton_ignore_expressions = C.GALAXY_ROLE_SKELETON_IGNORE
         else:
             own_skeleton = True
             obj_skeleton = self.galaxy.default_role_skeleton_path

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1352,19 +1352,34 @@ GALAXY_IGNORE_CERTS:
   - {key: ignore_certs, section: galaxy}
   type: boolean
 GALAXY_ROLE_SKELETON:
-  name: Galaxy role or collection skeleton directory
-  description: Role or collection skeleton directory to use as a template for the ``init`` action in ``ansible-galaxy``, same as ``--role-skeleton``.
+  name: Galaxy role skeleton directory
+  description: Role skeleton directory to use as a template for the ``init`` action in ``ansible-galaxy``/``ansible-galaxy role``, same as ``--role-skeleton``.
   env: [{name: ANSIBLE_GALAXY_ROLE_SKELETON}]
   ini:
   - {key: role_skeleton, section: galaxy}
   type: path
 GALAXY_ROLE_SKELETON_IGNORE:
-  name: Galaxy skeleton ignore
+  name: Galaxy role skeleton ignore
   default: ["^.git$", "^.*/.git_keep$"]
   description: patterns of files to ignore inside a Galaxy role or collection skeleton directory
   env: [{name: ANSIBLE_GALAXY_ROLE_SKELETON_IGNORE}]
   ini:
   - {key: role_skeleton_ignore, section: galaxy}
+  type: list
+GALAXY_COLLECTION_SKELETON:
+  name: Galaxy collection skeleton directory
+  description: Collection skeleton directory to use as a template for the ``init`` action in ``ansible-galaxy collection``, same as ``--collection-skeleton``.
+  env: [{name: ANSIBLE_GALAXY_COLLECTION_SKELETON}]
+  ini:
+  - {key: collection_skeleton, section: galaxy}
+  type: path
+GALAXY_COLLECTION_SKELETON_IGNORE:
+  name: Galaxy collection skeleton ignore
+  default: ["^.git$", "^.*/.git_keep$"]
+  description: patterns of files to ignore inside a Galaxy collection skeleton directory
+  env: [{name: ANSIBLE_GALAXY_COLLECTION_SKELETON_IGNORE}]
+  ini:
+  - {key: collection_skeleton_ignore, section: galaxy}
   type: list
 # TODO: unused?
 #GALAXY_SCMS:


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/ansible/issues/68920

This adds support for `GALAXY_COLLECTION_SKELETON` and `GALAXY_COLLECTION_SKELETON_IGNORE` variables. Currently, collections and roles both key off of the `GALAXY_ROLE_SKELETON` variable for where to source skeletons, and that means you can't feasibly have a default location for both types defined at once.

If anyone is relying on the current behavior where `GALAXY_ROLE_SKELETON` defines the location of their collection skeleton, this is a breaking change. That said, it's clearly preferable to have separate configuration options for these.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-galaxy CLI

