### PR TITLE
ansible-test - Remove support for Python 2.6.

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -62,7 +62,6 @@ stages:
           nameFormat: Python {0}
           testFormat: units/{0}
           targets:
-            - test: 2.6
             - test: 2.7
             - test: 3.5
             - test: 3.6
@@ -116,8 +115,6 @@ stages:
           targets:
             - name: Alpine 3
               test: alpine3
-            - name: CentOS 6
-              test: centos6
             - name: CentOS 7
               test: centos7
             - name: CentOS 8
@@ -190,8 +187,6 @@ stages:
         parameters:
           testFormat: i/linux/{0}
           targets:
-            - name: CentOS 6
-              test: centos6
             - name: CentOS 7
               test: centos7
             - name: CentOS 8

--- a/changelogs/fragments/ansible-test-python-2.6.yaml
+++ b/changelogs/fragments/ansible-test-python-2.6.yaml
@@ -1,0 +1,2 @@
+major_changes:
+  - ansible-test - Remove support for Python 2.6.

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,8 +1,7 @@
-base image=quay.io/ansible/base-test-container:1.0.0 python=3.9,2.6,2.7,3.5,3.6,3.7,3.8,3.10 seccomp=unconfined
-default image=quay.io/ansible/default-test-container:4.0.1 python=3.9,2.6,2.7,3.5,3.6,3.7,3.8,3.10 seccomp=unconfined context=collection
-default image=quay.io/ansible/ansible-core-test-container:4.0.1 python=3.9,2.6,2.7,3.5,3.6,3.7,3.8,3.10 seccomp=unconfined context=ansible-core
+base image=quay.io/ansible/base-test-container:1.0.0 python=3.9,2.7,3.5,3.6,3.7,3.8,3.10 seccomp=unconfined
+default image=quay.io/ansible/default-test-container:4.0.1 python=3.9,2.7,3.5,3.6,3.7,3.8,3.10 seccomp=unconfined context=collection
+default image=quay.io/ansible/ansible-core-test-container:4.0.1 python=3.9,2.7,3.5,3.6,3.7,3.8,3.10 seccomp=unconfined context=ansible-core
 alpine3 image=quay.io/ansible/alpine3-test-container:3.0.0 python=3.9
-centos6 image=quay.io/ansible/centos6-test-container:3.0.0 python=2.6 seccomp=unconfined
 centos7 image=quay.io/ansible/centos7-test-container:3.0.0 python=2.7 seccomp=unconfined
 centos8 image=quay.io/ansible/centos8-test-container:3.0.0 python=3.6 seccomp=unconfined
 fedora33 image=quay.io/ansible/fedora33-test-container:3.0.0 python=3.9

--- a/test/lib/ansible_test/_data/pytest.ini
+++ b/test/lib/ansible_test/_data/pytest.ini
@@ -1,9 +1,4 @@
 [pytest]
 xfail_strict = true
 mock_use_standalone_module = true
-# It was decided to stick with "legacy" (aka "xunit1") for now.
-# Currently used pytest versions all support xunit2 format too.
-# Except the one used under Python 2.6 - it doesn't process this option
-# at all. Ref:
-# https://github.com/ansible/ansible/pull/66445#discussion_r372530176
 junit_family = xunit1

--- a/test/lib/ansible_test/_internal/commands/units/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/units/__init__.py
@@ -245,17 +245,11 @@ def command_units(args):  # type: (UnitsConfig) -> None
             '-p', 'no:cacheprovider',
             '-c', os.path.join(ANSIBLE_TEST_DATA_ROOT, 'pytest.ini'),
             '--junit-xml', os.path.join(ResultType.JUNIT.path, 'python%s-%s-units.xml' % (python.version, test_context)),
+            '--strict-markers',  # added in pytest 4.5.0
         ]
 
         if not data_context().content.collection:
             cmd.append('--durations=25')
-
-        if python.version == '2.6':
-            # same as --strict-markers in older versions of pytest which still support python 2.6
-            cmd.append('--strict')
-        else:
-            # added in pytest 4.5.0, which requires python 2.7+
-            cmd.append('--strict-markers')
 
         plugins = []
 

--- a/test/lib/ansible_test/_internal/pypi_proxy.py
+++ b/test/lib/ansible_test/_internal/pypi_proxy.py
@@ -54,8 +54,9 @@ def run_pypi_proxy(args, targets_use_pypi):  # type: (EnvironmentConfig, bool) -
     if args.pypi_endpoint:
         return  # user has overridden the proxy endpoint, there is nothing to provision
 
+    versions_needing_proxy = tuple()  # preserved for future use, no versions currently require this
     posix_targets = [target for target in args.targets if isinstance(target, PosixConfig)]
-    need_proxy = targets_use_pypi and any(target.python.version == '2.6' for target in posix_targets)
+    need_proxy = targets_use_pypi and any(target.python.version in versions_needing_proxy for target in posix_targets)
     use_proxy = args.pypi_proxy or need_proxy
 
     if not use_proxy:

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -367,9 +367,6 @@ def common_environment():
         # Example configuration for brew on macOS:
         # export LDFLAGS="-L$(brew --prefix openssl)/lib/     -L$(brew --prefix libyaml)/lib/"
         # export  CFLAGS="-I$(brew --prefix openssl)/include/ -I$(brew --prefix libyaml)/include/"
-        # However, this is not adequate for PyYAML 3.13, which is the latest version supported on Python 2.6.
-        # For that version the standard location must be used, or `pip install` must be invoked with additional options:
-        # --global-option=build_ext --global-option=-L{path_to_lib_dir}
         'LDFLAGS',
         'CFLAGS',
     )

--- a/test/lib/ansible_test/_internal/venv.py
+++ b/test/lib/ansible_test/_internal/venv.py
@@ -96,10 +96,6 @@ def create_virtual_environment(args,  # type: EnvironmentConfig
             # virtualenv not available for this Python or we were unable to detect the version
             continue
 
-        if python.version == '2.6' and virtualenv_version >= (16, 0, 0):
-            # virtualenv 16.0.0 dropped python 2.6 support: https://virtualenv.pypa.io/en/latest/changes/#v16-0-0-2018-05-16
-            continue
-
         # try using 'virtualenv' from another Python to setup the desired version
         if run_virtualenv(args, available_python_interpreter, python.path, system_site_packages, pip, path):
             display.info('Created Python %s virtual environment using "virtualenv" on Python %s: %s' % (python.version, available_python_version, path),

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test-target.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test-target.cfg
@@ -1,8 +1,6 @@
 [MESSAGES CONTROL]
 
 disable=
-    consider-using-dict-comprehension,  # requires Python 2.7+, but we still require Python 2.6 support
-    consider-using-set-comprehension,  # requires Python 2.7+, but we still require Python 2.6 support
     cyclic-import,  # consistent results require running with --jobs 1 and testing all files
     duplicate-code,  # consistent results require running with --jobs 1 and testing all files
     import-error,  # inconsistent results which depend on the availability of imports

--- a/test/lib/ansible_test/_util/target/common/constants.py
+++ b/test/lib/ansible_test/_util/target/common/constants.py
@@ -13,7 +13,6 @@ SOFT_RLIMIT_NOFILE = 1024
 TIMEOUT_PATH = '.ansible-test-timeout.json'
 
 REMOTE_ONLY_PYTHON_VERSIONS = (
-    '2.6',
     '2.7',
     '3.5',
     '3.6',

--- a/test/lib/ansible_test/_util/target/setup/quiet_pip.py
+++ b/test/lib/ansible_test/_util/target/setup/quiet_pip.py
@@ -21,23 +21,6 @@ LOGGING_MESSAGE_FILTER = re.compile("^("
 # [1] https://src.fedoraproject.org/rpms/python-pip/blob/master/f/emit-a-warning-when-running-with-root-privileges.patch
 
 WARNING_MESSAGE_FILTERS = (
-    # DEPRECATION: Python 2.6 is no longer supported by the Python core team, please upgrade your Python.
-    # A future version of pip will drop support for Python 2.6
-    'Python 2.6 is no longer supported by the Python core team, ',
-
-    # {path}/python2.6/lib/python2.6/site-packages/pip/_vendor/urllib3/util/ssl_.py:137: InsecurePlatformWarning:
-    # A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail.
-    # You can upgrade to a newer version of Python to solve this.
-    # For more information, see https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
-    'A true SSLContext object is not available. ',
-
-    # {path}/python2.6/lib/python2.6/site-packages/pip/_vendor/urllib3/util/ssl_.py:339: SNIMissingWarning:
-    # An HTTPS request has been made, but the SNI (Subject Name Indication) extension to TLS is not available on this platform.
-    # This may cause the server to present an incorrect TLS certificate, which can cause validation failures.
-    # You can upgrade to a newer version of Python to solve this.
-    # For more information, see https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
-    'An HTTPS request has been made, but the SNI ',
-
     # DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained.
     # pip 21.0 will drop support for Python 2.7 in January 2021.
     # More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
@@ -65,7 +48,6 @@ def main():
 
     for message_filter in WARNING_MESSAGE_FILTERS:
         # Setting filterwarnings in code is necessary because of the following:
-        #   Python 2.6 does not support the PYTHONWARNINGS environment variable. It does support the -W option.
         #   Python 2.7 cannot use the -W option to match warning text after a colon. This makes it impossible to match specific warning messages.
         warnings.filterwarnings('ignore', message_filter)
 

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -83,7 +83,6 @@ lib/ansible/modules/yum_repository.py validate-modules:undocumented-parameter
 lib/ansible/module_utils/compat/_selectors2.py future-import-boilerplate # ignore bundled
 lib/ansible/module_utils/compat/_selectors2.py metaclass-boilerplate # ignore bundled
 lib/ansible/module_utils/compat/_selectors2.py pylint:disallowed-name
-lib/ansible/module_utils/compat/selinux.py import-2.6!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/compat/selinux.py import-2.7!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/compat/selinux.py import-3.5!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/compat/selinux.py import-3.6!skip # pass/fail depends on presence of libselinux.so


### PR DESCRIPTION
##### SUMMARY

Remove support for Python 2.6.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

Deferring removal of obsolete constraints until container updates are required.
