### PR TITLE
docs - Use code-block to format examples in Network Guide

### DIFF
--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -42,7 +42,9 @@ Ansible includes logging to help diagnose and troubleshoot issues regarding Ansi
 
 Because logging is very verbose, it is disabled by default. It can be enabled with the :envvar:`ANSIBLE_LOG_PATH` and :envvar:`ANSIBLE_DEBUG` options on the ansible-controller, that is the machine running ``ansible-playbook``.
 
-Before running ``ansible-playbook``, run the following commands to enable logging::
+Before running ``ansible-playbook``, run the following commands to enable logging:
+
+.. code:: shell
 
    # Specify the location for the log file
    export ANSIBLE_LOG_PATH=~/ansible.log
@@ -379,7 +381,9 @@ or
 
 You can tell Ansible to automatically accept the keys
 
-Environment variable method::
+Environment variable method:
+
+.. code-block:: shell
 
   export ANSIBLE_PARAMIKO_HOST_KEY_AUTO_ADD=True
   ansible-playbook ...

--- a/docs/docsite/rst/network/user_guide/network_working_with_command_output.rst
+++ b/docs/docsite/rst/network/user_guide/network_working_with_command_output.rst
@@ -26,7 +26,9 @@ executed remotely on the device.  Once the task executes the command
 set, the ``wait_for`` argument can be used to evaluate the results before
 returning control to the Ansible playbook.
 
-For example::
+For example:
+
+.. code-block:: yaml
 
     ---
     - name: wait for interface to be admin enabled
@@ -45,7 +47,9 @@ until either the condition is satisfied or the number of retries has
 expired (by default, this is 10 retries at 1 second intervals).
 
 The commands module can also evaluate more than one set of command
-results in an interface.  For instance::
+results in an interface.  For instance:
+
+.. code-block:: yaml
 
     ---
     - name: wait for interfaces to be admin enabled


### PR DESCRIPTION
##### SUMMARY

This pull request formats all code examples in the Network Guide

Fixes #75676

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

docsite

##### ADDITIONAL INFORMATION

Nothing particular