### PR TITLE
ansible-test - remove obsolete power/centos remote

### DIFF
--- a/changelogs/fragments/ansible-test-power-cleanup.yml
+++ b/changelogs/fragments/ansible-test-power-cleanup.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Remove obsolete ``--remote`` entry ``power/centos/7``

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -9,4 +9,3 @@ rhel/7.9 python=2.7
 rhel/8.1 python=3.6
 rhel/8.2 python=3.6
 aix/7.2 python=2.7 httptester=disabled temp-unicode=disabled pip-check=disabled
-power/centos/7 python=2.7


### PR DESCRIPTION
##### SUMMARY

Remove obsolete `power/centos/7` remote entry.

This change was originally made for 2.11 in https://github.com/ansible/ansible/pull/73757 but was overlooked for 2.10.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
