### PR TITLE
ansible-test - Remove obsolete junos entries.

### DIFF
--- a/changelogs/fragments/ansible-test-junos-obsolete.yml
+++ b/changelogs/fragments/ansible-test-junos-obsolete.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Remove obsolete ``junos`` entries for the ``--remote`` option.

--- a/test/lib/ansible_test/_data/completion/network.txt
+++ b/test/lib/ansible_test/_data/completion/network.txt
@@ -1,4 +1,2 @@
 ios/csr1000v
-junos/vmx
-junos/vsrx
 vyos/1.1.8


### PR DESCRIPTION
##### SUMMARY

Remove obsolete `junos` entries.

This was previously fixed for 2.10 in https://github.com/ansible/ansible/pull/67666 but was overlooked for 2.9.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
