### PR TITLE
Removing translatable words from codeblock

### DIFF
--- a/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
+++ b/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
@@ -110,7 +110,7 @@ While in the above ``>`` example all newlines are folded into spaces, there are 
     
 same_as::
     
-    "a b\nc d\n  e\nf\n"
+     no_fold_some_newlines: "a b\nc d\n  e\nf\n"
 
 Let's combine what we learned so far in an arbitrary YAML example.
 This really has nothing to do with Ansible, but will give you a feel for the format::

--- a/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
+++ b/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
@@ -110,7 +110,7 @@ While in the above ``>`` example all newlines are folded into spaces, there are 
 
 Alternatively, it can be enforced by including newline ``\n`` characters::
 
-    same_as: "a b\nc d\n  e\nf\n"
+    fold_same_newlines: "a b\nc d\n  e\nf\n"
 
 Let's combine what we learned so far in an arbitrary YAML example.
 This really has nothing to do with Ansible, but will give you a feel for the format::

--- a/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
+++ b/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
@@ -107,10 +107,10 @@ While in the above ``>`` example all newlines are folded into spaces, there are 
         d
           e
         f
-    
-same_as::
-    
-     no_fold_some_newlines: "a b\nc d\n  e\nf\n"
+
+Alternatively, it can be enforced by including newline ``\n`` characters::
+
+    same_as: "a b\nc d\n  e\nf\n"
 
 Let's combine what we learned so far in an arbitrary YAML example.
 This really has nothing to do with Ansible, but will give you a feel for the format::

--- a/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
+++ b/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
@@ -107,7 +107,10 @@ While in the above ``>`` example all newlines are folded into spaces, there are 
         d
           e
         f
-    same_as: "a b\nc d\n  e\nf\n"
+    
+same_as::
+    
+    "a b\nc d\n  e\nf\n"
 
 Let's combine what we learned so far in an arbitrary YAML example.
 This really has nothing to do with Ansible, but will give you a feel for the format::


### PR DESCRIPTION
SUMMARY

Removed translatable words from codeblocks as per #59449
ISSUE TYPE

    Docs Pull Request

+label: docsite_pr