### PR TITLE
Fix parsing of device serial number for RHEL8

### DIFF
--- a/changelogs/fragments/ 75876-fix-parsing-of-device-serial-number-for-rhel-8.yaml
+++ b/changelogs/fragments/ 75876-fix-parsing-of-device-serial-number-for-rhel-8.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible_facts.devices - Fix parsing of device serial number detected via sg_inq for rhel8 (https://github.com/ansible/ansible/issues/75420)

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -649,6 +649,14 @@ class LinuxHardware(Hardware):
                 else:
                     block_dev_dict['holders'].append(folder)
 
+    def _get_sg_inq_serial(self, sg_inq, block):
+        device = "/dev/%s" % (block)
+        rc, drivedata, err = self.module.run_command([sg_inq, device])
+        if rc == 0:
+            serial = re.search(r"(?:Unit serial|Serial) number:\s+(\w+)", drivedata)
+            if serial:
+                return serial.group(1)
+
     def get_device_facts(self):
         device_facts = {}
 
@@ -714,12 +722,9 @@ class LinuxHardware(Hardware):
             serial_path = "/sys/block/%s/device/serial" % (block)
 
             if sg_inq:
-                device = "/dev/%s" % (block)
-                rc, drivedata, err = self.module.run_command([sg_inq, device])
-                if rc == 0:
-                    serial = re.search(r"(?:Unit serial|Serial) number:\s+(\w+)", drivedata)
-                    if serial:
-                        d['serial'] = serial.group(1)
+                serial = self._get_sg_inq_serial(sg_inq, block)
+                if serial:
+                    d['serial'] = serial
             else:
                 serial = get_file_content(serial_path)
                 if serial:

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -717,7 +717,7 @@ class LinuxHardware(Hardware):
                 device = "/dev/%s" % (block)
                 rc, drivedata, err = self.module.run_command([sg_inq, device])
                 if rc == 0:
-                    serial = re.search(r"Unit serial number:\s+(\w+)", drivedata)
+                    serial = re.search(r"(?:Unit serial|Serial) number:\s+(\w+)", drivedata)
                     if serial:
                         d['serial'] = serial.group(1)
             else:

--- a/test/units/module_utils/facts/hardware/linux_data.py
+++ b/test/units/module_utils/facts/hardware/linux_data.py
@@ -583,3 +583,51 @@ CPU_INFO_TEST_SCENARIOS = [
         },
     },
 ]
+
+SG_INQ_OUTPUTS = ["""
+Identify controller for /dev/nvme0n1:
+  Model number: Amazon Elastic Block Store
+  Serial number: vol0123456789
+  Firmware revision: 1.0
+  Version: 0.0
+  No optional admin command support
+  No optional NVM command support
+  PCI vendor ID VID/SSVID: 0x1d0f/0x1d0f
+  IEEE OUI Identifier: 0xa002dc
+  Controller ID: 0x0
+  Number of namespaces: 1
+  Maximum data transfer size: 64 pages
+  Namespace 1 (deduced from device name):
+    Namespace size/capacity: 62914560/62914560 blocks
+    Namespace utilization: 0 blocks
+    Number of LBA formats: 1
+    Index LBA size: 0
+    LBA format 0 support: <-- active
+      Logical block size: 512 bytes
+      Approximate namespace size: 32 GB
+      Metadata size: 0 bytes
+      Relative performance: Best [0x0]
+""", """
+Identify controller for /dev/nvme0n1:
+  Model number: Amazon Elastic Block Store
+  Unit serial number: vol0123456789
+  Firmware revision: 1.0
+  Version: 0.0
+  No optional admin command support
+  No optional NVM command support
+  PCI vendor ID VID/SSVID: 0x1d0f/0x1d0f
+  IEEE OUI Identifier: 0xa002dc
+  Controller ID: 0x0
+  Number of namespaces: 1
+  Maximum data transfer size: 64 pages
+  Namespace 1 (deduced from device name):
+    Namespace size/capacity: 62914560/62914560 blocks
+    Namespace utilization: 0 blocks
+    Number of LBA formats: 1
+    Index LBA size: 0
+    LBA format 0 support: <-- active
+      Logical block size: 512 bytes
+      Approximate namespace size: 32 GB
+      Metadata size: 0 bytes
+      Relative performance: Best [0x0]
+"""]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Simple change of regular expression to parse serial number of device from output of `sg_inq` for RHEL8 and Fedora 34 based on suggestion in the issue.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #75420

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
affected component ansible_facts.devices

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Example output to parse
```paste below
# sg_inq /dev/nvme0n1
Identify controller for /dev/nvme0n1:
  Model number: Amazon Elastic Block Store
  Serial number: vol00030c2ca006fa585
  Firmware revision: 1.0
  Version: 0.0
  No optional admin command support
  No optional NVM command support
  PCI vendor ID VID/SSVID: 0x1d0f/0x1d0f
  IEEE OUI Identifier: 0xa002dc
  Controller ID: 0x0
  Number of namespaces: 1
  Maximum data transfer size: 64 pages
  Namespace 1 (deduced from device name):
    Namespace size/capacity: 62914560/62914560 blocks
    Namespace utilization: 0 blocks
    Number of LBA formats: 1
    Index LBA size: 0
    LBA format 0 support: <-- active
      Logical block size: 512 bytes
      Approximate namespace size: 32 GB
      Metadata size: 0 bytes
      Relative performance: Best [0x0]
```
Non capturing group for parsing used so no change in groups indexation required.
My first contribution attempt.
