### PR TITLE
Fix wrong ssh_connection group

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -367,7 +367,7 @@
 # Paramiko automatically add host keys.
 #host_key_auto_add = True
 
-[ssh_connection]
+[connection]
 
 # ssh arguments to use
 # Leaving off ControlPersist will result in poor performance, so use


### PR DESCRIPTION
Proper naming is [connection] - pipelining for example was never used while I enabled it in there

##### SUMMARY
Fixes #15083 (seems to be reintroduced?)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Config