### PR TITLE
Add "reload-or-restarted" state for systemd module

### DIFF
--- a/changelogs/fragments/71969-systemd-add-reload-or-restarted-state.yml
+++ b/changelogs/fragments/71969-systemd-add-reload-or-restarted-state.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - systemd - add ``reload-or-restarted`` state (https://github.com/ansible/ansible/issues/71969)

--- a/lib/ansible/modules/systemd.py
+++ b/lib/ansible/modules/systemd.py
@@ -28,8 +28,9 @@ options:
         description:
             - C(started)/C(stopped) are idempotent actions that will not run commands unless necessary.
               C(restarted) will always bounce the unit. C(reloaded) will always reload.
+              C(reload-or-restarted) (available since 2.13) will always reload-or-restart.
         type: str
-        choices: [ reloaded, restarted, started, stopped ]
+        choices: [ reloaded, restarted, reload-or-restarted, started, stopped ]
     enabled:
         description:
             - Whether the unit should start on boot. B(At least one of state and enabled are required.)
@@ -339,7 +340,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             name=dict(type='str', aliases=['service', 'unit']),
-            state=dict(type='str', choices=['reloaded', 'restarted', 'started', 'stopped']),
+            state=dict(type='str', choices=['reloaded', 'restarted', 'reload-or-restarted', 'started', 'stopped']),
             enabled=dict(type='bool'),
             force=dict(type='bool'),
             masked=dict(type='bool'),
@@ -543,7 +544,7 @@ def main():
                     if not is_running_service(result['status']):
                         action = 'start'
                     else:
-                        action = module.params['state'][:-2]  # remove 'ed' from restarted/reloaded
+                        action = module.params['state'][:-2]  # remove 'ed' from restarted/reloaded/reload-or-restarted
                     result['state'] = 'started'
 
                 if action:


### PR DESCRIPTION
##### SUMMARY
This runs `systemctl reload-or-restart <unit>`, in a manner similar to the "reloaded" state (and just as tested :wink:)

Fixes #71969.

`reload-or-restart` is quite useful: it lets you mostly just Do The Right Thing:tm: when configs have been updated for a unit, without needing to know whether the unit actually supports graceful reloads.

The name "reload-or-restarted" was chosen mostly just to piggy-back off of the existing code to translate "reloaded" -> "reload" and "restarted" -> "restart".

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
systemd

##### ADDITIONAL INFORMATION
N/A