### PR TITLE
Fix rackspace cloud guide docs

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_rax.rst
+++ b/docs/docsite/rst/scenario_guides/guide_rax.rst
@@ -6,7 +6,7 @@ Rackspace Cloud Guide
 Introduction
 ````````````
 
-.. note:: Rackspace functionality in Ansible is not maintained and users should consider the `OpenStack collection <https://galaxy.ansible.com/openstack/cloud>` instead_.
+.. note:: Rackspace functionality in Ansible is not maintained and users should consider the `OpenStack collection <https://galaxy.ansible.com/openstack/cloud>`_ instead.
 
 Ansible contains a number of core modules for interacting with Rackspace Cloud.  
 

--- a/docs/docsite/rst/scenario_guides/guide_rax.rst
+++ b/docs/docsite/rst/scenario_guides/guide_rax.rst
@@ -6,7 +6,7 @@ Rackspace Cloud Guide
 Introduction
 ````````````
 
-.. note:: This section of the documentation is under construction. We are in the process of adding more examples about the Rackspace modules and how they work together.  Once complete, there will also be examples for Rackspace Cloud in `ansible-examples <https://github.com/ansible/ansible-examples/>`_.
+.. note:: Rackspace functionality in Ansible is not maintained and users should consider the `OpenStack collection <https://galaxy.ansible.com/openstack/cloud>` instead_.
 
 Ansible contains a number of core modules for interacting with Rackspace Cloud.  
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #35305 by changing the note at top of https://docs.ansible.com/ansible/2.9/scenario_guides/guide_rax.html#introduction to say - Rackspace functionality in Ansible is not maintained and users should consider the OpenStack collection instead - https://galaxy.ansible.com/openstack/cloud
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Rackspace cloud guide

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
