### PR TITLE
Add `v2_runner_item_on_start` callback to callback plugins.

### DIFF
--- a/changelogs/fragments/75874-add-v2_runner_item_on_start-callback.yml
+++ b/changelogs/fragments/75874-add-v2_runner_item_on_start-callback.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Adds the ``v2_runner_item_on_start`` callback to callback plugins. (https://github.com/ansible/ansible/issues/75874)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -302,7 +302,6 @@ class TaskExecutor:
         no_log = False
         items_len = len(items)
         for item_index, item in enumerate(items):
-            self._final_q.send_callback('v2_runner_item_on_start', self._task, item) 
             task_vars['ansible_loop_var'] = loop_var
 
             task_vars[loop_var] = item
@@ -340,6 +339,8 @@ class TaskExecutor:
             else:
                 ran_once = True
 
+            self._final_q.send_callback('v2_runner_item_on_start', self._task, item)
+            
             try:
                 tmp_task = self._task.copy(exclude_parent=True, exclude_tasks=True)
                 tmp_task._parent = self._task._parent

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -302,6 +302,7 @@ class TaskExecutor:
         no_log = False
         items_len = len(items)
         for item_index, item in enumerate(items):
+            self._final_q.send_callback('v2_runner_item_on_start', self._task, item) 
             task_vars['ansible_loop_var'] = loop_var
 
             task_vars[loop_var] = item

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -340,7 +340,7 @@ class TaskExecutor:
                 ran_once = True
 
             self._final_q.send_callback('v2_runner_item_on_start', self._task, item)
-            
+
             try:
                 tmp_task = self._task.copy(exclude_parent=True, exclude_tasks=True)
                 tmp_task._parent = self._task._parent

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -426,6 +426,9 @@ class CallbackBase(AnsiblePlugin):
     def v2_playbook_on_include(self, included_file):
         pass  # no v1 correspondence
 
+    def v2_runner_item_on_start(self, task, item):
+        pass
+
     def v2_runner_item_on_ok(self, result):
         pass
 

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -39,7 +39,8 @@ COMPAT_OPTIONS = (('display_skipped_hosts', C.DISPLAY_SKIPPED_HOSTS),
                   ('show_custom_stats', C.SHOW_CUSTOM_STATS),
                   ('display_failed_stderr', False),
                   ('check_mode_markers', False),
-                  ('show_per_host_start', False))
+                  ('show_per_host_start', False),
+                  ('show_per_item_start', False))
 
 
 class CallbackModule(CallbackBase):
@@ -259,6 +260,10 @@ class CallbackModule(CallbackBase):
                 if self._last_task_banner != result._task._uuid:
                     self._print_task_banner(result._task)
                 self._display.display(diff)
+
+    def v2_runner_item_on_start(self, task, item):
+        if self.get_option('show_per_item_start'):
+            self._display.display(" [started item \"%s\" in %s]" % (item, task), color=C.COLOR_OK)
 
     def v2_runner_item_on_ok(self, result):
 

--- a/lib/ansible/plugins/doc_fragments/default_callback.py
+++ b/lib/ansible/plugins/doc_fragments/default_callback.py
@@ -95,4 +95,15 @@ class ModuleDocFragment(object):
           - key: show_task_path_on_failure
             section: defaults
         version_added: '2.11'
+      show_per_item_start:
+        name: Show per item in task start
+        description: 'This adds output that shows when an item is started to execute in a task'
+        type: bool
+        default: no
+        env:
+          - name: ANSIBLE_SHOW_PER_ITEM_START
+        ini:
+          - key: show_per_item_start
+            section: defaults
+        version_added: '2.13'
 '''


### PR DESCRIPTION
##### SUMMARY

This PR adds the `v2_runner_item_on_start` callback that will execute on an item starting execution. I have also added default behaviour for this callback, including a new option `show_per_item_start` which is inspired by the `v2_runner_on_start` callback and its adjacent option `show_per_host_start`.

Implements #75874

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
callback

##### ADDITIONAL INFORMATION
Here's how the change looks:
```
$ cat test.yml
---
  - name: Test
    hosts: localhost
    tasks:
      - name: Test task
        command: "{{ item }}"
        with_items:
          - echo "hello"
          - echo "world"
          
$ ANSIBLE_SHOW_PER_ITEM_START=0 ansible-playbook test.yml

PLAY [Test] *******************************************************************************************************************

TASK [Gathering Facts] ********************************************************************************************************
ok: [localhost]

TASK [Test task] **************************************************************************************************************
changed: [localhost] => (item=echo "hello")
changed: [localhost] => (item=echo "world")

PLAY RECAP ********************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

$ ANSIBLE_SHOW_PER_ITEM_START=1 ansible-playbook test.yml

PLAY [Test] *******************************************************************************************************************

TASK [Gathering Facts] ********************************************************************************************************
ok: [localhost]

TASK [Test task] **************************************************************************************************************
 [started item "echo "hello"" in TASK: Test task]
changed: [localhost] => (item=echo "hello")
 [started item "echo "world"" in TASK: Test task]
changed: [localhost] => (item=echo "world")

PLAY RECAP ********************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

$
```
