### PR TITLE
[stable-2.12] ansible-test - Update base and default containers.

### DIFF
--- a/changelogs/fragments/ansible-test-default-base-containers-python-3.10.yaml
+++ b/changelogs/fragments/ansible-test-default-base-containers-python-3.10.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Update the ``base`` and ``default`` containers from Python 3.10.0rc2 to 3.10.0.

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,6 +1,6 @@
-base image=quay.io/ansible/base-test-container:1.0.0 python=3.9,2.6,2.7,3.5,3.6,3.7,3.8,3.10 seccomp=unconfined
-default image=quay.io/ansible/default-test-container:4.0.1 python=3.9,2.6,2.7,3.5,3.6,3.7,3.8,3.10 seccomp=unconfined context=collection
-default image=quay.io/ansible/ansible-core-test-container:4.0.1 python=3.9,2.6,2.7,3.5,3.6,3.7,3.8,3.10 seccomp=unconfined context=ansible-core
+base image=quay.io/ansible/base-test-container:1.1.0 python=3.9,2.6,2.7,3.5,3.6,3.7,3.8,3.10 seccomp=unconfined
+default image=quay.io/ansible/default-test-container:4.1.0 python=3.9,2.6,2.7,3.5,3.6,3.7,3.8,3.10 seccomp=unconfined context=collection
+default image=quay.io/ansible/ansible-core-test-container:4.1.0 python=3.9,2.6,2.7,3.5,3.6,3.7,3.8,3.10 seccomp=unconfined context=ansible-core
 alpine3 image=quay.io/ansible/alpine3-test-container:3.1.0 python=3.9
 centos6 image=quay.io/ansible/centos6-test-container:3.1.0 python=2.6 seccomp=unconfined
 centos7 image=quay.io/ansible/centos7-test-container:3.1.0 python=2.7 seccomp=unconfined


### PR DESCRIPTION
##### SUMMARY

The containers now include Python 3.10.0 instead of Python 3.10.0rc2.

Backport of https://github.com/ansible/ansible/pull/75913

(cherry picked from commit 2f531d73dd50f7524bd5636d4f68c780ec823e7a)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
