### PR TITLE
Fix "kubernetes.core" typo in docs

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1806,7 +1806,7 @@ Getting Kubernetes resource names
 Use the "k8s_config_resource_name" filter to obtain the name of a Kubernetes ConfigMap or Secret,
 including its hash::
 
-    {{ configmap_resource_definition | kuberernetes.core.k8s_config_resource_name }}
+    {{ configmap_resource_definition | kubernetes.core.k8s_config_resource_name }}
 
 This can then be used to reference hashes in Pod specifications::
 
@@ -1823,7 +1823,7 @@ This can then be used to reference hashes in Pod specifications::
             containers:
             - envFrom:
                 - secretRef:
-                    name: {{ my_secret | kuberernetes.core.k8s_config_resource_name }}
+                    name: {{ my_secret | kubernetes.core.k8s_config_resource_name }}
 
 .. versionadded:: 2.8
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Replace "kuberernetes.core" with "kubernetes.core" in filter examples.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

