### PR TITLE
Code-block wrapping for playbooks_startnstep.rst #75934

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_startnstep.rst
+++ b/docs/docsite/rst/user_guide/playbooks_startnstep.rst
@@ -11,7 +11,9 @@ When you are testing new plays or debugging playbooks, you may need to run the s
 start-at-task
 -------------
 
-To start executing your playbook at a particular task (usually the task that failed on the previous run), use the ``--start-at-task`` option::
+To start executing your playbook at a particular task (usually the task that failed on the previous run), use the ``--start-at-task`` option.
+
+.. code-block::
 
     ansible-playbook playbook.yml --start-at-task="install packages"
 
@@ -22,11 +24,15 @@ In this example, Ansible starts executing your playbook at a task named "install
 Step mode
 ---------
 
-To execute a playbook interactively, use ``--step``::
+To execute a playbook interactively, use ``--step``.
+
+.. code-block::
 
     ansible-playbook playbook.yml --step
 
-With this option, Ansible stops on each task, and asks if it should execute that task. For example, if you have a task called "configure ssh", the playbook run will stop and ask::
+With this option, Ansible stops on each task, and asks if it should execute that task. For example, if you have a task called "configure ssh", the playbook run will stop and ask.
+
+.. code-block::
 
     Perform task: configure ssh (y/n/c):
 

--- a/docs/docsite/rst/user_guide/playbooks_startnstep.rst
+++ b/docs/docsite/rst/user_guide/playbooks_startnstep.rst
@@ -13,7 +13,7 @@ start-at-task
 
 To start executing your playbook at a particular task (usually the task that failed on the previous run), use the ``--start-at-task`` option.
 
-.. code-block::
+.. code-block:: shell
 
     ansible-playbook playbook.yml --start-at-task="install packages"
 

--- a/docs/docsite/rst/user_guide/playbooks_startnstep.rst
+++ b/docs/docsite/rst/user_guide/playbooks_startnstep.rst
@@ -26,7 +26,7 @@ Step mode
 
 To execute a playbook interactively, use ``--step``.
 
-.. code-block::
+.. code-block:: shell
 
     ansible-playbook playbook.yml --step
 

--- a/docs/docsite/rst/user_guide/playbooks_startnstep.rst
+++ b/docs/docsite/rst/user_guide/playbooks_startnstep.rst
@@ -32,7 +32,7 @@ To execute a playbook interactively, use ``--step``.
 
 With this option, Ansible stops on each task, and asks if it should execute that task. For example, if you have a task called "configure ssh", the playbook run will stop and ask.
 
-.. code-block::
+.. code-block:: shell
 
     Perform task: configure ssh (y/n/c):
 


### PR DESCRIPTION
##### SUMMARY

Fixes #75934.

Wraps code examples in code-block sections.

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

- *Note:*
I initially set the `code-block` to `console`, which I thought is the most apropiate for commands and interactive shell sessions.
However, that resulted in plain, no-colours syntax highlighting in the HTML.
To keep the current colouring (blue for the commands, green for the output from Ansible), I didn't pass in the lexer explicitly, which keeps the current syntax highlighting of `yaml+jinja`. Not sure if `yaml+jinja` is the default or is guessed, but I thought it is better to preserve the old syntax highlighting. But somehow it doesn't seem correct to set the lexer explicitly to `yaml+jinja` for `console` examples. I'm happy to change it as required.
- All instances of code examples changed:
```console
$grep -c "^[[:blank:]]*[^[:blank:]\.\.].*::$" ./playbooks_startnstep.rst
0
```
- Manual testing: generated the docs manually as described in the Contributor guide and had a look at the generated HTML.