### PR TITLE
Check if skeleton is /dev/null while creating home folder

### DIFF
--- a/changelogs/fragments/75063-allow-dev-nul-as-skeleton-for-new-homedir.yml
+++ b/changelogs/fragments/75063-allow-dev-nul-as-skeleton-for-new-homedir.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - modules/user.py - Add check for valid directory when creating new user homedir (allows /dev/null as skeleton) (https://github.com/ansible/ansible/issues/75063)
+  

--- a/changelogs/fragments/75063-allow-dev-nul-as-skeleton-for-new-homedir.yml
+++ b/changelogs/fragments/75063-allow-dev-nul-as-skeleton-for-new-homedir.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - modules/user.py - Add check for valid directory when creating new user homedir (allows /dev/null as skeleton) (https://github.com/ansible/ansible/issues/75063)

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1247,7 +1247,7 @@ class User(object):
             else:
                 skeleton = '/etc/skel'
 
-            if os.path.exists(skeleton):
+            if os.path.exists(skeleton) and os.path.isdir(skeleton):
                 try:
                     shutil.copytree(skeleton, path, symlinks=True)
                 except OSError as e:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1247,7 +1247,7 @@ class User(object):
             else:
                 skeleton = '/etc/skel'
 
-            if os.path.exists(skeleton) and os.path.isdir(skeleton):
+            if os.path.exists(skeleton) and skeleton != os.devnull:
                 try:
                     shutil.copytree(skeleton, path, symlinks=True)
                 except OSError as e:

--- a/test/integration/targets/user/tasks/test_create_user_home.yml
+++ b/test/integration/targets/user/tasks/test_create_user_home.yml
@@ -134,3 +134,19 @@
     name: randomuser
     state: absent
     remove: yes
+
+# https://github.com/ansible/ansible/issues/75063
+# Create user home directory with /dev/null as skeleton
+- name: "Create user home directory with /dev/null as skeleton"
+  user:
+    name: withskeleton
+    state: present
+    skeleton: "/dev/null"
+    createhome: yes
+  register: create_user_with_skeleton_dev_null
+
+- name: "Remove test user"
+  user:
+    name: withskeleton
+    state: absent
+    remove: yes

--- a/test/integration/targets/user/tasks/test_create_user_home.yml
+++ b/test/integration/targets/user/tasks/test_create_user_home.yml
@@ -136,6 +136,8 @@
     remove: yes
 
 - name: Create user home directory with /dev/null as skeleton, https://github.com/ansible/ansible/issues/75063
+  # create_homedir is mostly used by linux, rest of OSs take care of it themselves via -k option (which fails this task)
+  when: ansible_system == 'Linux'  
   block:
     - name: "Create user home directory with /dev/null as skeleton"
       user:

--- a/test/integration/targets/user/tasks/test_create_user_home.yml
+++ b/test/integration/targets/user/tasks/test_create_user_home.yml
@@ -135,18 +135,18 @@
     state: absent
     remove: yes
 
-# https://github.com/ansible/ansible/issues/75063
-# Create user home directory with /dev/null as skeleton
-- name: "Create user home directory with /dev/null as skeleton"
-  user:
-    name: withskeleton
-    state: present
-    skeleton: "/dev/null"
-    createhome: yes
-  register: create_user_with_skeleton_dev_null
-
-- name: "Remove test user"
-  user:
-    name: withskeleton
-    state: absent
-    remove: yes
+- name: Create user home directory with /dev/null as skeleton, https://github.com/ansible/ansible/issues/75063
+  block:
+    - name: "Create user home directory with /dev/null as skeleton"
+      user:
+        name: withskeleton
+        state: present
+        skeleton: "/dev/null"
+        createhome: yes
+     register: create_user_with_skeleton_dev_null
+  always:
+    - name: "Remove test user"
+      user:
+        name: withskeleton
+        state: absent
+        remove: yes

--- a/test/integration/targets/user/tasks/test_create_user_home.yml
+++ b/test/integration/targets/user/tasks/test_create_user_home.yml
@@ -143,7 +143,7 @@
         state: present
         skeleton: "/dev/null"
         createhome: yes
-     register: create_user_with_skeleton_dev_null
+      register: create_user_with_skeleton_dev_null
   always:
     - name: "Remove test user"
       user:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add additional check for skeleton is a valid directory in addition to the pure existence of the path.

This prevents `shutil.copytree()` to throw an exception and also allows the use of `/dev/null` as a valid skeleton, which results in a empty home-directory to be created.

Fixes #75063

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Fix in User-Module.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
