### PR TITLE
ansible-test pslint - fix warning with nested objects (#75792) - 2.11

### DIFF
--- a/changelogs/fragments/pslint-sanity-warning.yml
+++ b/changelogs/fragments/pslint-sanity-warning.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-test pslint - Fix error when encountering validation results that are highly nested - https://github.com/ansible/ansible/issues/74151

--- a/test/lib/ansible_test/_data/sanity/pslint/pslint.ps1
+++ b/test/lib/ansible_test/_data/sanity/pslint/pslint.ps1
@@ -2,7 +2,6 @@
 #Requires -Version 6
 #Requires -Modules PSScriptAnalyzer, PSSA-PSCustomUseLiteralPath
 
-Set-StrictMode -Version 2.0
 $ErrorActionPreference = "Stop"
 $WarningPreference = "Stop"
 
@@ -21,14 +20,12 @@ $PSSAParams = @{
     Setting = (Join-Path -Path $PSScriptRoot -ChildPath "settings.psd1")
 }
 
-$Results = @()
-
-ForEach ($Path in $Args) {
+$Results = @(ForEach ($Path in $Args) {
     $Retries = 3
 
     Do {
         Try {
-            $Results += Invoke-ScriptAnalyzer -Path $Path @PSSAParams 3> $null
+            Invoke-ScriptAnalyzer -Path $Path @PSSAParams 3> $null
             $Retries = 0
         }
         Catch {
@@ -38,6 +35,8 @@ ForEach ($Path in $Args) {
         }
     }
     Until ($Retries -le 0)
-}
+})
 
-ConvertTo-Json -InputObject $Results
+# Since pwsh 7.1 results that exceed depth will produce a warning which fails the process.
+# Ignore warnings only for this step.
+ConvertTo-Json -InputObject $Results -Depth 1 -WarningAction SilentlyContinue


### PR DESCRIPTION
(cherry picked from commit 7e19957afa02245f9ff791c7b6ad17700db4385b)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/75792

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pslint