### PR TITLE
feat: (docs): Add missing code-block elements to playbooks_startnstep…

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_startnstep.rst
+++ b/docs/docsite/rst/user_guide/playbooks_startnstep.rst
@@ -11,7 +11,9 @@ When you are testing new plays or debugging playbooks, you may need to run the s
 start-at-task
 -------------
 
-To start executing your playbook at a particular task (usually the task that failed on the previous run), use the ``--start-at-task`` option::
+To start executing your playbook at a particular task (usually the task that failed on the previous run), use the ``--start-at-task`` option:
+
+ .. code-block:: bash
 
     ansible-playbook playbook.yml --start-at-task="install packages"
 
@@ -22,11 +24,15 @@ In this example, Ansible starts executing your playbook at a task named "install
 Step mode
 ---------
 
-To execute a playbook interactively, use ``--step``::
+To execute a playbook interactively, use ``--step``:
+
+ .. code-block:: bash
 
     ansible-playbook playbook.yml --step
 
-With this option, Ansible stops on each task, and asks if it should execute that task. For example, if you have a task called "configure ssh", the playbook run will stop and ask::
+With this option, Ansible stops on each task, and asks if it should execute that task. For example, if you have a task called "configure ssh", the playbook run will stop and ask:
+
+ .. code-block:: text
 
     Perform task: configure ssh (y/n/c):
 


### PR DESCRIPTION
##### SUMMARY
 Add code-block element so that translation processes do not
translate code and/or instruction blocks. They must be kept as is.

Fixes #75934

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

User guide => playbooks_start_and_step

##### ADDITIONAL INFORMATION
```
Documentation does not need additional information
```
