### PR TITLE
code-block wrapping for playbooks_debugger.rst

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_debugger.rst
+++ b/docs/docsite/rst/user_guide/playbooks_debugger.rst
@@ -120,7 +120,7 @@ If you are running legacy playbooks or roles, you may see the debugger enabled a
 
 Or in ansible.cfg:
 
-.. code-block:: yaml
+.. code-block:: ini
 
     [defaults]
     strategy = debug

--- a/docs/docsite/rst/user_guide/playbooks_debugger.rst
+++ b/docs/docsite/rst/user_guide/playbooks_debugger.rst
@@ -100,7 +100,7 @@ To enable the task debugger from ansible.cfg, add this setting to the defaults s
 
 To enable the task debugger with an environment variable, pass the variable when you run your playbook:
 
-.. code-block::
+.. code-block:: shell
 
     ANSIBLE_ENABLE_TASK_DEBUGGER=True ansible-playbook -i hosts site.yml
 

--- a/docs/docsite/rst/user_guide/playbooks_debugger.rst
+++ b/docs/docsite/rst/user_guide/playbooks_debugger.rst
@@ -74,7 +74,6 @@ Example of setting the ``debugger`` keyword at multiple levels:
 
 .. code-block:: yaml
 
-
     - name: Play
       hosts: all
       debugger: never
@@ -92,12 +91,16 @@ Enabling the debugger in configuration or an environment variable
 
 You can enable the task debugger globally with a setting in ansible.cfg or with an environment variable. The only options are ``True`` or ``False``. If you set the configuration option or environment variable to ``True``, Ansible runs the debugger on failed tasks by default.
 
-To enable the task debugger from ansible.cfg, add this setting to the defaults section::
+To enable the task debugger from ansible.cfg, add this setting to the defaults section:
+
+.. code-block:: yaml
 
     [defaults]
     enable_task_debugger = True
 
-To enable the task debugger with an environment variable, pass the variable when you run your playbook::
+To enable the task debugger with an environment variable, pass the variable when you run your playbook:
+
+.. code-block::
 
     ANSIBLE_ENABLE_TASK_DEBUGGER=True ansible-playbook -i hosts site.yml
 
@@ -115,7 +118,9 @@ If you are running legacy playbooks or roles, you may see the debugger enabled a
      tasks:
      ...
 
-Or in ansible.cfg::
+Or in ansible.cfg:
+
+.. code-block:: yaml
 
     [defaults]
     strategy = debug
@@ -142,7 +147,7 @@ After Ansible invokes the debugger, you can use the seven :ref:`debugger command
 
 If you run this playbook, Ansible invokes the debugger when the task fails. From the debug prompt, you can change the module arguments or the variables and run the task again.
 
-.. code-block:: none
+.. code-block:: ansible-output
 
     PLAY ***************************************************************************
 
@@ -213,7 +218,9 @@ For more details, see the individual descriptions and examples below.
 Print command
 -------------
 
-``print *task/task.args/task_vars/host/result*`` prints information about the task::
+``print *task/task.args/task_vars/host/result*`` prints information about the task.
+
+.. code-block:: ansible-output
 
     [192.0.2.10] TASK: install package (debug)> p task
     TASK: install package
@@ -240,7 +247,9 @@ Print command
 Update args command
 -------------------
 
-``task.args[*key*] = *value*`` updates a module argument. This sample playbook has an invalid package name::
+``task.args[*key*] = *value*`` updates a module argument. This sample playbook has an invalid package name.
+
+.. code-block:: yaml
 
     - hosts: test
       strategy: debug
@@ -251,7 +260,9 @@ Update args command
         - name: Install a package
           ansible.builtin.apt: name={{ pkg_name }}
 
-When you run the playbook, the invalid package name triggers an error, and Ansible invokes the debugger. You can fix the package name by viewing, then updating the module argument::
+When you run the playbook, the invalid package name triggers an error, and Ansible invokes the debugger. You can fix the package name by viewing, then updating the module argument.
+
+.. code-block:: ansible-output
 
     [192.0.2.10] TASK: install package (debug)> p task.args
     {u'name': u'{{ pkg_name }}'}
@@ -267,7 +278,9 @@ After you update the module argument, use ``redo`` to run the task again with th
 Update vars command
 -------------------
 
-``task_vars[*key*] = *value*`` updates the ``task_vars``. You could fix the playbook above by viewing, then updating the task variables instead of the module args::
+``task_vars[*key*] = *value*`` updates the ``task_vars``. You could fix the playbook above by viewing, then updating the task variables instead of the module args.
+
+.. code-block:: ansible-output
 
     [192.0.2.10] TASK: install package (debug)> p task_vars['pkg_name']
     u'not_exist'


### PR DESCRIPTION
##### SUMMARY

Fixes #75919.

Wraps code examples in code-block sections.

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

- made some existing `code-blocks` `ansible-output`, which results in more colouring than what we had before 
- All instances of code examples changed:
```console
$grep -c "^[[:blank:]]*[^[:blank:]\.\.].*::$" ./playbooks_debugger.rst
0
```
- Manual testing: generated the docs manually as described in the Contributor guide and had a look at the generated HTML.
