### PR TITLE
Feat/add mising code block elements to playbooks strategies.rst

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_startnstep.rst
+++ b/docs/docsite/rst/user_guide/playbooks_startnstep.rst
@@ -11,7 +11,9 @@ When you are testing new plays or debugging playbooks, you may need to run the s
 start-at-task
 -------------
 
-To start executing your playbook at a particular task (usually the task that failed on the previous run), use the ``--start-at-task`` option::
+To start executing your playbook at a particular task (usually the task that failed on the previous run), use the ``--start-at-task`` option:
+
+ .. code-block:: bash
 
     ansible-playbook playbook.yml --start-at-task="install packages"
 
@@ -22,11 +24,15 @@ In this example, Ansible starts executing your playbook at a task named "install
 Step mode
 ---------
 
-To execute a playbook interactively, use ``--step``::
+To execute a playbook interactively, use ``--step``:
+
+ .. code-block:: bash
 
     ansible-playbook playbook.yml --step
 
-With this option, Ansible stops on each task, and asks if it should execute that task. For example, if you have a task called "configure ssh", the playbook run will stop and ask::
+With this option, Ansible stops on each task, and asks if it should execute that task. For example, if you have a task called "configure ssh", the playbook run will stop and ask:
+
+ .. code-block:: text
 
     Perform task: configure ssh (y/n/c):
 

--- a/docs/docsite/rst/user_guide/playbooks_startnstep.rst
+++ b/docs/docsite/rst/user_guide/playbooks_startnstep.rst
@@ -11,9 +11,7 @@ When you are testing new plays or debugging playbooks, you may need to run the s
 start-at-task
 -------------
 
-To start executing your playbook at a particular task (usually the task that failed on the previous run), use the ``--start-at-task`` option:
-
- .. code-block:: bash
+To start executing your playbook at a particular task (usually the task that failed on the previous run), use the ``--start-at-task`` option::
 
     ansible-playbook playbook.yml --start-at-task="install packages"
 
@@ -24,15 +22,11 @@ In this example, Ansible starts executing your playbook at a task named "install
 Step mode
 ---------
 
-To execute a playbook interactively, use ``--step``:
-
- .. code-block:: bash
+To execute a playbook interactively, use ``--step``::
 
     ansible-playbook playbook.yml --step
 
-With this option, Ansible stops on each task, and asks if it should execute that task. For example, if you have a task called "configure ssh", the playbook run will stop and ask:
-
- .. code-block:: text
+With this option, Ansible stops on each task, and asks if it should execute that task. For example, if you have a task called "configure ssh", the playbook run will stop and ask::
 
     Perform task: configure ssh (y/n/c):
 

--- a/docs/docsite/rst/user_guide/playbooks_strategies.rst
+++ b/docs/docsite/rst/user_guide/playbooks_strategies.rst
@@ -10,14 +10,18 @@ By default, Ansible runs each task on all hosts affected by a play before starti
 
 Selecting a strategy
 --------------------
-The default behavior described above is the :ref:`linear strategy<linear_strategy>`. Ansible offers other strategies, including the :ref:`debug strategy<debug_strategy>` (see also  :ref:`playbook_debugger`) and the :ref:`free strategy<free_strategy>`, which allows each host to run until the end of the play as fast as it can::
+The default behavior described above is the :ref:`linear strategy<linear_strategy>`. Ansible offers other strategies, including the :ref:`debug strategy<debug_strategy>` (see also  :ref:`playbook_debugger`) and the :ref:`free strategy<free_strategy>`, which allows each host to run until the end of the play as fast as it can:
+
+ .. code-block:: yaml
 
     - hosts: all
       strategy: free
       tasks:
-      ...
+      # ...
 
-You can select a different strategy for each play as shown above, or set your preferred strategy globally in ``ansible.cfg``, under the ``defaults`` stanza::
+You can select a different strategy for each play as shown above, or set your preferred strategy globally in ``ansible.cfg``, under the ``defaults`` stanza:
+
+ .. code-block:: cfg
 
     [defaults]
     strategy = free
@@ -26,7 +30,9 @@ All strategies are implemented as :ref:`strategy plugins<strategy_plugins>`. Ple
 
 Setting the number of forks
 ---------------------------
-If you have the processing power available and want to use more forks, you can set the number in ``ansible.cfg``::
+If you have the processing power available and want to use more forks, you can set the number in ``ansible.cfg``:
+
+ .. code-block:: cfg
 
     [defaults]
     forks = 30
@@ -45,7 +51,9 @@ Other keywords that affect play execution include ``ignore_errors``, ``ignore_un
 Setting the batch size with ``serial``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-By default, Ansible runs in parallel against all the hosts in the :ref:`pattern <intro_patterns>` you set in the ``hosts:`` field of each play. If you want to manage only a few machines at a time, for example during a rolling update, you can define how many hosts Ansible should manage at a single time using the ``serial`` keyword::
+By default, Ansible runs in parallel against all the hosts in the :ref:`pattern <intro_patterns>` you set in the ``hosts:`` field of each play. If you want to manage only a few machines at a time, for example during a rolling update, you can define how many hosts Ansible should manage at a single time using the ``serial`` keyword:
+
+ .. code-block:: yaml
 
     ---
     - name: test play
@@ -59,8 +67,9 @@ By default, Ansible runs in parallel against all the hosts in the :ref:`pattern 
         - name: second task
           command: hostname
 
-In the above example, if we had 6 hosts in the group 'webservers', Ansible would execute the play completely (both tasks) on 3 of the hosts before moving on to the next 3 hosts::
+In the above example, if we had 6 hosts in the group 'webservers', Ansible would execute the play completely (both tasks) on 3 of the hosts before moving on to the next 3 hosts:
 
+ .. code-block:: text
 
     PLAY [webservers] ****************************************
 
@@ -95,7 +104,9 @@ In the above example, if we had 6 hosts in the group 'webservers', Ansible would
     web6      : ok=2    changed=2    unreachable=0    failed=0
 
 
-You can also specify a percentage with the ``serial`` keyword. Ansible applies the percentage to the total number of hosts in a play to determine the number of hosts per pass::
+You can also specify a percentage with the ``serial`` keyword. Ansible applies the percentage to the total number of hosts in a play to determine the number of hosts per pass:
+
+ .. code-block:: yaml
 
     ---
     - name: test play
@@ -104,7 +115,9 @@ You can also specify a percentage with the ``serial`` keyword. Ansible applies t
 
 If the number of hosts does not divide equally into the number of passes, the final pass contains the remainder. In this example, if you had 20 hosts in the webservers group, the first batch would contain 6 hosts, the second batch would contain 6 hosts, the third batch would contain 6 hosts, and the last batch would contain 2 hosts.
 
-You can also specify batch sizes as a list. For example::
+You can also specify batch sizes as a list. For example:
+
+ .. code-block:: yaml
 
     ---
     - name: test play
@@ -116,7 +129,9 @@ You can also specify batch sizes as a list. For example::
 
 In the above example, the first batch would contain a single host, the next would contain 5 hosts, and (if there are any hosts left), every following batch would contain either 10 hosts or all the remaining hosts, if fewer than 10 hosts remained.
 
-You can list multiple batch sizes as percentages::
+You can list multiple batch sizes as percentages:
+
+ .. code-block:: yaml
 
     ---
     - name: test play
@@ -126,7 +141,10 @@ You can list multiple batch sizes as percentages::
         - "20%"
         - "100%"
 
-You can also mix and match the values::
+
+You can also mix and match the values:
+
+ .. code-block:: yaml
 
     ---
     - name: test play
@@ -142,7 +160,9 @@ You can also mix and match the values::
 Restricting execution with ``throttle``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``throttle`` keyword limits the number of workers for a particular task. It can be set at the block and task level. Use ``throttle`` to restrict tasks that may be CPU-intensive or interact with a rate-limiting API::
+The ``throttle`` keyword limits the number of workers for a particular task. It can be set at the block and task level. Use ``throttle`` to restrict tasks that may be CPU-intensive or interact with a rate-limiting API:
+
+ .. code-block:: yaml
 
     tasks:
     - command: /path/to/cpu_intensive_command
@@ -174,7 +194,9 @@ shuffle:
 Running on a single machine with ``run_once``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you want a task to run only on the first host in your batch of hosts, set ``run_once`` to true on that task::
+If you want a task to run only on the first host in your batch of hosts, set ``run_once`` to true on that task:
+
+ .. code-block:: yaml
 
     ---
     # ...
@@ -188,16 +210,22 @@ If you want a task to run only on the first host in your batch of hosts, set ``r
 
         # ...
 
-Ansible executes this task on the first host in the current batch and applies all results and facts to all the hosts in the same batch. This approach is similar to applying a conditional to a task such as::
+
+Ansible executes this task on the first host in the current batch and applies all results and facts to all the hosts in the same batch. This approach is similar to applying a conditional to a task such as:
+
+     .. code-block:: yaml
 
         - command: /opt/application/upgrade_db.py
           when: inventory_hostname == webservers[0]
 
-However, with ``run_once``, the results are applied to all the hosts. To run the task on a specific host, instead of the first host in the batch, delegate the task::
 
-        - command: /opt/application/upgrade_db.py
-          run_once: true
-          delegate_to: web01.example.org
+However, with ``run_once``, the results are applied to all the hosts. To run the task on a specific host, instead of the first host in the batch, delegate the task:
+
+ .. code-block:: yaml
+
+   - command: /opt/application/upgrade_db.py
+       run_once: true
+       delegate_to: web01.example.org
 
 As always with :ref:`delegation <playbooks_delegation>`, the action will be executed on the delegated host, but the information is still that of the original host in the task.
 


### PR DESCRIPTION
##### SUMMARY
    feat: (docs): Add missing code-block elements on playbooks_strategies.rst
    
    ** add code-block elements on user guide/playbooks_strategies.rst file
    so that translation processes keep code as is
    
    - hacktoberfest 2021
    
    Fixes: #75911

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
user guide/ playbooks_strategies.rst

##### ADDITIONAL INFORMATION
```
There is no need of additional information
```
