### PR TITLE
ansible-test - Update base and default containers.

### DIFF
--- a/changelogs/fragments/ansible-test-default-base-containers-base-update.yaml
+++ b/changelogs/fragments/ansible-test-default-base-containers-base-update.yaml
@@ -1,0 +1,5 @@
+minor_changes:
+  - ansible-test - Update the ``base`` and ``default`` containers from a Ubuntu 18.04 to Ubuntu 20.04 base image.
+  - ansible-test - Use Python 3.10 as the default Python version for the ``base`` and ``default`` containers.
+  - ansible-test - Shellcheck in the ``base`` and ``default`` containers has been upgraded to version 0.7.0.
+  - ansible-test - PowerShell in the ``base`` and ``default`` containers has been upgraded to version 7.1.4.

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,6 +1,6 @@
-base image=quay.io/ansible/base-test-container:1.1.0 python=3.9,2.7,3.5,3.6,3.7,3.8,3.10 seccomp=unconfined
-default image=quay.io/ansible/default-test-container:4.1.0 python=3.9,2.7,3.5,3.6,3.7,3.8,3.10 seccomp=unconfined context=collection
-default image=quay.io/ansible/ansible-core-test-container:4.1.0 python=3.9,2.7,3.5,3.6,3.7,3.8,3.10 seccomp=unconfined context=ansible-core
+base image=quay.io/ansible/base-test-container:2.0.0 python=3.10,2.7,3.5,3.6,3.7,3.8,3.9 seccomp=unconfined
+default image=quay.io/ansible/default-test-container:5.0.0 python=3.10,2.7,3.5,3.6,3.7,3.8,3.9 seccomp=unconfined context=collection
+default image=quay.io/ansible/ansible-core-test-container:5.0.0 python=3.10,2.7,3.5,3.6,3.7,3.8,3.9 seccomp=unconfined context=ansible-core
 alpine3 image=quay.io/ansible/alpine3-test-container:3.1.0 python=3.9
 centos7 image=quay.io/ansible/centos7-test-container:3.1.0 python=2.7 seccomp=unconfined
 centos8 image=quay.io/ansible/centos8-test-container:3.1.0 python=3.6 seccomp=unconfined


### PR DESCRIPTION
##### SUMMARY

ansible-test - Update base and default containers.

- The containers are now based on Ubuntu 20.04 instead of Ubuntu 18.04.
- The default Python version used for the containers is now Python 3.10.
- The included version of PowerShell was upgraded to version 7.1.4.
- The included version of shellcheck was upgraded to version 0.7.0.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
