### PR TITLE
documenting_modules_network.rst: Add missing space

### DIFF
--- a/docs/docsite/rst/network/dev_guide/documenting_modules_network.rst
+++ b/docs/docsite/rst/network/dev_guide/documenting_modules_network.rst
@@ -8,7 +8,7 @@ Documenting new network platforms
 .. contents::
   :local:
 
-When you create network modules for a new platform, or modify the connections provided by an existing network platform(such as ``network_cli`` and ``httpapi``), you also need to update  the :ref:`settings_by_platform` table and add or modify the Platform Options file for your platform.
+When you create network modules for a new platform, or modify the connections provided by an existing network platform (such as ``network_cli`` and ``httpapi``), you also need to update  the :ref:`settings_by_platform` table and add or modify the Platform Options file for your platform.
 
 You should already have documented each module as described in :ref:`developing_modules_documenting`.
 


### PR DESCRIPTION
##### SUMMARY
A space was missing before an opening parent, in the prose of `docs/docsite/rst/network/dev_guide/documenting_modules_network.rst`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Docsite.

