### PR TITLE
Add vim undo files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ deb-build
 # Vim swap files
 *.swp
 *.swo
+[._]*.un~
 credentials.yml
 # test output
 *.retry


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add vim undo files to `.gitignore`.

The vim persistent undo files look like this: `.filename.un~`.

This is for hacktoberfest.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Minor
