### PR TITLE
Document return values of template module

### DIFF
--- a/lib/ansible/modules/template.py
+++ b/lib/ansible/modules/template.py
@@ -132,7 +132,7 @@ gid:
     returned: success
     type: int
     sample: 1003
-user:
+owner:
     description: User name of owner
     returned: success
     type: str

--- a/lib/ansible/modules/template.py
+++ b/lib/ansible/modules/template.py
@@ -110,3 +110,46 @@ EXAMPLES = r'''
     validate: /usr/sbin/sshd -t -f %s
     backup: yes
 '''
+
+RETURN = r'''
+dest:
+    description: Destination file/path, equal to the value passed to I(dest).
+    returned: success
+    type: str
+    sample: /path/to/file.txt
+checksum:
+    description: SHA1 checksum of the rendered file
+    returned: success
+    type: str
+    sample: 373296322247ab85d26d5d1257772757e7afd172
+uid:
+    description: Numeric id representing the file owner
+    returned: success
+    type: int
+    sample: 1003
+gid:
+    description: Numeric id representing the group of the owner
+    returned: success
+    type: int
+    sample: 1003
+user:
+    description: User name of owner
+    returned: success
+    type: str
+    sample: httpd
+group:
+    description: Group name of owner
+    returned: success
+    type: str
+    sample: www-data
+mode:
+    description: Unix permissions of the file in octal representation as a string
+    returned: success
+    type: str
+    sample: 1755
+size:
+    description: Size of the rendered file in bytes
+    returned: success
+    type: int
+    sample: 42
+'''

--- a/lib/ansible/modules/template.py
+++ b/lib/ansible/modules/template.py
@@ -119,7 +119,7 @@ dest:
     sample: /path/to/file.txt
 checksum:
     description: SHA1 checksum of the rendered file
-    returned: success
+    returned: always
     type: str
     sample: 373296322247ab85d26d5d1257772757e7afd172
 uid:
@@ -142,14 +142,29 @@ group:
     returned: success
     type: str
     sample: www-data
+md5sum:
+    description: MD5 checksum of the rendered file
+    returned: changed
+    type: str
+    sample: d41d8cd98f00b204e9800998ecf8427e
 mode:
     description: Unix permissions of the file in octal representation as a string
     returned: success
     type: str
     sample: 1755
+msg:
+    description: Failure explanation
+    returned: failure
+    type: str
+    sample: Destination directory /some/example/path does not exist
 size:
     description: Size of the rendered file in bytes
     returned: success
     type: int
     sample: 42
+src:
+    description: Source file used for the copy on the target machine.
+    returned: changed
+    type: str
+    sample: /home/httpd/.ansible/tmp/ansible-tmp-1423796390.97-147729857856000/source
 '''

--- a/lib/ansible/modules/template.py
+++ b/lib/ansible/modules/template.py
@@ -152,11 +152,6 @@ mode:
     returned: success
     type: str
     sample: 1755
-msg:
-    description: Failure explanation
-    returned: failure
-    type: str
-    sample: Destination directory /some/example/path does not exist
 size:
     description: Size of the rendered file in bytes
     returned: success


### PR DESCRIPTION
##### SUMMARY

Add documentation for some return values of template module.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

template

##### ADDITIONAL INFORMATION
I've only included values that are returned consistently, there are more
that are only returned under special circumstances - like when
destination is changed - but I'm not entirely sure if that behavior is
entirely intentional or subject to change, so I decided to not include
it in this PR.

I have not tested this extensively, so it's possible that under special
circumstances this might not be entirely accurate, but briefly looking
at the code as far as I can tell they are correct.

Sample code I used to see the returned values:

```
$ ansible -m template -a "dest=/tmp/test src=/tmp/template.j2" localhost
localhost | SUCCESS => {
    "changed": false,
    "checksum": "373296322247ab85d26d5d1257772757e7afd172",
    "dest": "/tmp/test",
    "gid": 1000,
    "group": "mprasil",
    "mode": "0664",
    "owner": "mprasil",
    "path": "/tmp/test",
    "size": 22,
    "state": "file",
    "uid": 1000
}

```

Note that I haven't tested this. Not sure how can I generate the docs
locally to test that my change renders correctly.