### PR TITLE
code-block wrapping for playbooks_advanced_syntax.rst

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_advanced_syntax.rst
+++ b/docs/docsite/rst/user_guide/playbooks_advanced_syntax.rst
@@ -23,7 +23,8 @@ You can use the same ``unsafe`` data type in variables you define, to prevent te
     ---
     mypassword: !unsafe 234%234{435lkj{{lkjsdf
 
-In a playbook::
+In a playbook:
+.. code-block:: yaml
 
     ---
     hosts: all
@@ -32,7 +33,8 @@ In a playbook::
     tasks:
         ...
 
-For complex variables such as hashes or arrays, use ``!unsafe`` on the individual elements::
+For complex variables such as hashes or arrays, use ``!unsafe`` on the individual elements:
+.. code-block:: yaml
 
     ---
     my_unsafe_array:
@@ -48,7 +50,8 @@ YAML anchors and aliases: sharing variable values
 =================================================
 
 `YAML anchors and aliases <https://yaml.org/spec/1.2/spec.html#id2765878>`_ help you define, maintain, and use shared variable values in a flexible way.
-You define an anchor with ``&``, then refer to it using an alias, denoted with ``*``. Here's an example that sets three values with an anchor, uses two of those values with an alias, and overrides the third value::
+You define an anchor with ``&``, then refer to it using an alias, denoted with ``*``. Here's an example that sets three values with an anchor, uses two of those values with an alias, and overrides the third value:
+.. code-block:: yaml
 
     ---
     ...
@@ -67,13 +70,15 @@ You define an anchor with ``&``, then refer to it using an alias, denoted with `
 Here, ``app1`` and ``app2`` share the values for ``opts`` and ``port`` using the anchor ``&jvm_opts`` and the alias ``*jvm_opts``.
 The value for ``path`` is merged by ``<<`` or `merge operator <https://yaml.org/type/merge.html>`_.
 
-Anchors and aliases also let you share complex sets of variable values, including nested variables. If you have one variable value that includes another variable value, you can define them separately::
+Anchors and aliases also let you share complex sets of variable values, including nested variables. If you have one variable value that includes another variable value, you can define them separately:
+.. code-block:: yaml
 
       vars:
         webapp_version: 1.0
         webapp_custom_name: ToDo_App-1.0
 
-This is inefficient and, at scale, means more maintenance. To incorporate the version value in the name, you can use an anchor in ``app_version`` and an alias in ``custom_name``::
+This is inefficient and, at scale, means more maintenance. To incorporate the version value in the name, you can use an anchor in ``app_version`` and an alias in ``custom_name``:
+.. code-block:: yaml
 
       vars:
         webapp:
@@ -82,7 +87,8 @@ This is inefficient and, at scale, means more maintenance. To incorporate the ve
                 - "ToDo_App"
                 - *my_version
 
-Now, you can re-use the value of ``app_version`` within the value of  ``custom_name`` and use the output in a template::
+Now, you can re-use the value of ``app_version`` within the value of  ``custom_name`` and use the output in a template:
+.. code-block:: yaml
 
     ---
     - name: Using values nested inside dictionary

--- a/docs/docsite/rst/user_guide/playbooks_advanced_syntax.rst
+++ b/docs/docsite/rst/user_guide/playbooks_advanced_syntax.rst
@@ -24,6 +24,7 @@ You can use the same ``unsafe`` data type in variables you define, to prevent te
     mypassword: !unsafe 234%234{435lkj{{lkjsdf
 
 In a playbook:
+
 .. code-block:: yaml
 
     ---
@@ -34,6 +35,7 @@ In a playbook:
         ...
 
 For complex variables such as hashes or arrays, use ``!unsafe`` on the individual elements:
+
 .. code-block:: yaml
 
     ---
@@ -51,6 +53,7 @@ YAML anchors and aliases: sharing variable values
 
 `YAML anchors and aliases <https://yaml.org/spec/1.2/spec.html#id2765878>`_ help you define, maintain, and use shared variable values in a flexible way.
 You define an anchor with ``&``, then refer to it using an alias, denoted with ``*``. Here's an example that sets three values with an anchor, uses two of those values with an alias, and overrides the third value:
+
 .. code-block:: yaml
 
     ---
@@ -71,6 +74,7 @@ Here, ``app1`` and ``app2`` share the values for ``opts`` and ``port`` using the
 The value for ``path`` is merged by ``<<`` or `merge operator <https://yaml.org/type/merge.html>`_.
 
 Anchors and aliases also let you share complex sets of variable values, including nested variables. If you have one variable value that includes another variable value, you can define them separately:
+
 .. code-block:: yaml
 
       vars:
@@ -78,6 +82,7 @@ Anchors and aliases also let you share complex sets of variable values, includin
         webapp_custom_name: ToDo_App-1.0
 
 This is inefficient and, at scale, means more maintenance. To incorporate the version value in the name, you can use an anchor in ``app_version`` and an alias in ``custom_name``:
+
 .. code-block:: yaml
 
       vars:
@@ -88,6 +93,7 @@ This is inefficient and, at scale, means more maintenance. To incorporate the ve
                 - *my_version
 
 Now, you can re-use the value of ``app_version`` within the value of  ``custom_name`` and use the output in a template:
+
 .. code-block:: yaml
 
     ---


### PR DESCRIPTION
##### SUMMARY
Fixes #75923.

##### ISSUE TYPE
- Docs Pull Request


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
- All code-blocks wrapped:
```paste below
$grep -c "^[[:blank:]]*[^[:blank:]\.\.].*::$" ./playbooks_advanced_syntax.rst
0
```
