### PR TITLE
Add default value for lvm_facts when lvm or lvm2 is not installed or …

### DIFF
--- a/changelogs/fragments/17393-fix_silently_failing_lvm_facts.yaml
+++ b/changelogs/fragments/17393-fix_silently_failing_lvm_facts.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - setup - Adds a default value to ``lvm_facts`` when lvm or lvm2 is not installed on linux (https://github.com/ansible/ansible/issues/17393)

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -818,7 +818,7 @@ class LinuxHardware(Hardware):
     def get_lvm_facts(self):
         """ Get LVM Facts if running as root and lvm utils are available """
 
-        lvm_facts = {}
+        lvm_facts = {'lvm': 'N/A'}
 
         if os.getuid() == 0 and self.module.get_bin_path('vgs'):
             lvm_util_options = '--noheadings --nosuffix --units g --separator ,'


### PR DESCRIPTION
…there are no lvm facts

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Adds a default value to `lvm_facts` as suggested [here](https://github.com/ansible/ansible/issues/17393#issuecomment-834570561)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes: #17393
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- setup module for linux
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
N/A
```
