### PR TITLE
[bp-2.11]: hostname: update example with 'use'

### DIFF
--- a/changelogs/fragments/fix_hostname_example.yml
+++ b/changelogs/fragments/fix_hostname_example.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hostname, fix module example using `strategy` instead of `use`.

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -52,7 +52,7 @@ EXAMPLES = '''
 - name: Set a hostname specifying strategy
   ansible.builtin.hostname:
     name: web01
-    strategy: systemd
+    use: systemd
 '''
 
 import os


### PR DESCRIPTION
##### SUMMARY

Example for module hostname provides an invalid use of strategy that should be use now.
The doc is correct on stable-2.12, and devel and seems only incorrect in stable-2.11.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
hostname
