### PR TITLE
bug fix: using non-FQDN in plugin choices fails plugin name verification

### DIFF
--- a/docs/docsite/rst/plugins/inventory.rst
+++ b/docs/docsite/rst/plugins/inventory.rst
@@ -30,6 +30,7 @@ If the plugin is in a collection, use the fully qualified name:
    [inventory]
    enable_plugins = namespace.collection_name.inventory_plugin_name
 
+If you use a plugin that supports a YAML configuration source, make sure that the name matches the name provided in the ``plugin`` entry of the inventory source file.
 
 .. _using_inventory:
 

--- a/lib/ansible/plugins/inventory/constructed.py
+++ b/lib/ansible/plugins/inventory/constructed.py
@@ -18,7 +18,7 @@ DOCUMENTATION = '''
         plugin:
             description: token that ensures this is a source file for the 'constructed' plugin.
             required: True
-            choices: ['ansible.builtin.constructed']
+            choices: ['ansible.builtin.constructed', 'constructed']
         use_vars_plugins:
             description:
                 - Normally, for performance reasons, vars plugins get executed after the inventory sources complete the base inventory,

--- a/lib/ansible/plugins/inventory/constructed.py
+++ b/lib/ansible/plugins/inventory/constructed.py
@@ -18,7 +18,7 @@ DOCUMENTATION = '''
         plugin:
             description: token that ensures this is a source file for the 'constructed' plugin.
             required: True
-            choices: ['constructed']
+            choices: ['constructed', 'ansible.builtin.constructed']
         use_vars_plugins:
             description:
                 - Normally, for performance reasons, vars plugins get executed after the inventory sources complete the base inventory,
@@ -36,7 +36,7 @@ DOCUMENTATION = '''
 
 EXAMPLES = r'''
     # inventory.config file in YAML format
-    plugin: constructed
+    plugin: ansible.builtin.constructed
     strict: False
     compose:
         var_sum: var1 + var2

--- a/lib/ansible/plugins/inventory/constructed.py
+++ b/lib/ansible/plugins/inventory/constructed.py
@@ -18,7 +18,7 @@ DOCUMENTATION = '''
         plugin:
             description: token that ensures this is a source file for the 'constructed' plugin.
             required: True
-            choices: ['constructed', 'ansible.builtin.constructed']
+            choices: ['ansible.builtin.constructed']
         use_vars_plugins:
             description:
                 - Normally, for performance reasons, vars plugins get executed after the inventory sources complete the base inventory,

--- a/lib/ansible/plugins/inventory/generator.py
+++ b/lib/ansible/plugins/inventory/generator.py
@@ -17,7 +17,7 @@ DOCUMENTATION = '''
       plugin:
          description: token that ensures this is a source file for the 'generator' plugin.
          required: True
-         choices: ['generator']
+         choices: ['generator', 'ansible.builtin.generator']
       hosts:
         description:
           - The C(name) key is a template used to generate
@@ -39,7 +39,7 @@ EXAMPLES = '''
     # inventory.config file in YAML format
     # remember to enable this inventory plugin in the ansible.cfg before using
     # View the output using `ansible-inventory -i inventory.config --list`
-    plugin: generator
+    plugin: ansible.builtin.generator
     hosts:
         name: "{{ operation }}_{{ application }}_{{ environment }}_runner"
         parents:

--- a/lib/ansible/plugins/inventory/generator.py
+++ b/lib/ansible/plugins/inventory/generator.py
@@ -17,7 +17,7 @@ DOCUMENTATION = '''
       plugin:
          description: token that ensures this is a source file for the 'generator' plugin.
          required: True
-         choices: ['ansible.builtin.generator']
+         choices: ['ansible.builtin.generator', 'generator']
       hosts:
         description:
           - The C(name) key is a template used to generate

--- a/lib/ansible/plugins/inventory/generator.py
+++ b/lib/ansible/plugins/inventory/generator.py
@@ -17,7 +17,7 @@ DOCUMENTATION = '''
       plugin:
          description: token that ensures this is a source file for the 'generator' plugin.
          required: True
-         choices: ['generator', 'ansible.builtin.generator']
+         choices: ['ansible.builtin.generator']
       hosts:
         description:
           - The C(name) key is a template used to generate

--- a/test/integration/targets/inventory/1/2/inventory.yml
+++ b/test/integration/targets/inventory/1/2/inventory.yml
@@ -1,3 +1,3 @@
-plugin: constructed
+plugin: ansible.builtin.constructed
 groups:
   webservers: inventory_hostname.startswith('web')

--- a/test/integration/targets/inventory/extra_vars_constructed.yml
+++ b/test/integration/targets/inventory/extra_vars_constructed.yml
@@ -1,4 +1,4 @@
-plugin: constructed
+plugin: ansible.builtin.constructed
 strict: true
 use_extra_vars: True
 compose:

--- a/test/integration/targets/inventory_constructed/constructed.yml
+++ b/test/integration/targets/inventory_constructed/constructed.yml
@@ -1,4 +1,4 @@
-plugin: constructed
+plugin: ansible.builtin.constructed
 keyed_groups:
   - key: hostvar0
   - key: hostvar1

--- a/test/integration/targets/inventory_constructed/invs/2/constructed.yml
+++ b/test/integration/targets/inventory_constructed/invs/2/constructed.yml
@@ -1,4 +1,4 @@
-plugin: constructed
+plugin: ansible.builtin.constructed
 use_vars_plugins: true
 keyed_groups:
   - key: iamdefined

--- a/test/integration/targets/inventory_constructed/keyed_group_default_value.yml
+++ b/test/integration/targets/inventory_constructed/keyed_group_default_value.yml
@@ -1,4 +1,4 @@
-plugin: constructed
+plugin: ansible.builtin.constructed
 keyed_groups:
   - key: tags
     prefix: tag

--- a/test/integration/targets/inventory_constructed/keyed_group_list_default_value.yml
+++ b/test/integration/targets/inventory_constructed/keyed_group_list_default_value.yml
@@ -1,4 +1,4 @@
-plugin: constructed
+plugin: ansible.builtin.constructed
 keyed_groups:
   - key: roles
     default_value: storage

--- a/test/integration/targets/inventory_constructed/keyed_group_str_default_value.yml
+++ b/test/integration/targets/inventory_constructed/keyed_group_str_default_value.yml
@@ -1,4 +1,4 @@
-plugin: constructed
+plugin: ansible.builtin.constructed
 keyed_groups:
   - key: os
     default_value: "fedora"

--- a/test/integration/targets/inventory_constructed/keyed_group_trailing_separator.yml
+++ b/test/integration/targets/inventory_constructed/keyed_group_trailing_separator.yml
@@ -1,4 +1,4 @@
-plugin: constructed
+plugin: ansible.builtin.constructed
 keyed_groups:
   - key: tags
     prefix: tag

--- a/test/integration/targets/inventory_constructed/no_leading_separator_constructed.yml
+++ b/test/integration/targets/inventory_constructed/no_leading_separator_constructed.yml
@@ -1,4 +1,4 @@
-plugin: constructed
+plugin: ansible.builtin.constructed
 keyed_groups:
   - key: hostvar0
   - key: hostvar1


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `generator` and `constructed` inventory plugins require the `plugin` option to be set. For both, the available choices are limited to the non-FQDN names (`'generator'` and `'constructed'`).
Using these values, however, leads to [an exception when reading the config data](https://github.com/j-i-l/ansible/blob/3aaf0e3462ead147d99a39cb2be44cc0442a2e1c/lib/ansible/plugins/inventory/__init__.py#L232-L234) as the valid plugin names are FQDN.

On the other hand, providing the FQDN name for the `plugin` option fails the `'choices'` validation and [also raises an exception](https://github.com/j-i-l/ansible/blob/3aaf0e3462ead147d99a39cb2be44cc0442a2e1c/lib/ansible/config/manager.py#L551-L552).

##### Proposed Fix

Update the choices for the `plugin` option to a list holding the FQDN of the plugin only.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- `ansible.builtin.generator`
- `ansible.builtin.constructed`
