### PR TITLE
Fixes#67642 - Update win_audit_rule.ps1

### DIFF
--- a/lib/ansible/modules/windows/win_audit_rule.ps1
+++ b/lib/ansible/modules/windows/win_audit_rule.ps1
@@ -66,7 +66,7 @@ Catch {
 }
 
 #get the path type
-$ItemType = (Get-Item $path).GetType()
+$ItemType = (Get-Item $path -Force).GetType()
 switch ($ItemType)
 {
     ([Microsoft.Win32.RegistryKey]) {$registry = $true;  $result.path_type = 'registry'}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added "Force" parameter to permit access at hidden items, like protected OS file.

Microsoft documentation:
https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-item?view=powershell-5.1
Indicates that this cmdlet gets items that can't otherwise be accessed, such as hidden items. Implementation varies from provider to provider. For more information, see about_Providers. Even using the Force parameter, the cmdlet can't override security restrictions.

bugfixes:
- win_audit_rule - Fix exception when trying to change a rule on a hidden or protected system file
- https://github.com/ansible-collections/community.windows/issues/17
- https://github.com/ansible/ansible/issues/67642

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module win_audit_rule

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This is a backport fix. Already Fixed in: Ansible Collection:  community.windows
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
PS C:\Windows\System32> $path = "C:\bootmgr"
PS C:\Windows\System32> $ItemType = (Get-Item $path).GetType()
Get-Item : Could not find item C:\bootmgr.
At line:1 char:14
+ $ItemType = (Get-Item $path).GetType()
+              ~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (C:\bootmgr:String) [Get-Item], IOException
    + FullyQualifiedErrorId : ItemNotFound,Microsoft.PowerShell.Commands.GetItemCommand

You cannot call a method on a null-valued expression.
At line:1 char:1
+ $ItemType = (Get-Item $path).GetType()
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], RuntimeException
    + FullyQualifiedErrorId : InvokeMethodOnNull

PS C:\Windows\System32> $ItemType = (Get-Item $path -Force).GetType()
PS C:\Windows\System32> $ItemType

IsPublic IsSerial Name                                     BaseType
-------- -------- ----                                     --------
True     True     FileInfo                                 System.IO.FileSystemInfo
```
