### PR TITLE
json normalization

### DIFF
--- a/hacking/test-module.py
+++ b/hacking/test-module.py
@@ -42,7 +42,7 @@ import shutil
 from ansible.release import __version__
 import ansible.utils.vars as utils_vars
 from ansible.parsing.dataloader import DataLoader
-from ansible.parsing.utils.jsonify import jsonify
+from ansible.module_utils.common.text.converters import jsonify
 from ansible.parsing.splitter import parse_kv
 from ansible.executor import module_common
 import ansible.constants as C
@@ -248,7 +248,7 @@ def runtest(modfile, argspath, modname, module_style, interpreters):
 
     print("*" * 35)
     print("PARSED OUTPUT")
-    print(jsonify(results, format=True))
+    print(jsonify(results, indent=4))
 
 
 def rundebug(debugger, modfile, argspath, modname, module_style, interpreters):

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -11,7 +11,6 @@ __metaclass__ = type
 from ansible.cli import CLI
 
 import datetime
-import json
 import pkgutil
 import os
 import os.path
@@ -29,7 +28,7 @@ from ansible.collections.list import list_collection_dirs
 from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.common._collections_compat import Sequence
-from ansible.module_utils.common.json import AnsibleJSONEncoder
+from ansible.module_utils.common.text.converters import jsonify
 from ansible.module_utils.common.yaml import yaml_dump
 from ansible.module_utils.compat import importlib
 from ansible.module_utils.six import string_types
@@ -42,7 +41,6 @@ from ansible.utils.collection_loader._collection_finder import _get_collection_n
 from ansible.utils.display import Display
 from ansible.utils.plugin_docs import (
     REJECTLIST,
-    remove_current_collection_from_versions_and_dates,
     get_docstring,
     get_versioned_doclink,
 )
@@ -58,7 +56,7 @@ SNIPPETS = ['inventory', 'lookup', 'module']
 
 def jdump(text):
     try:
-        display.display(json.dumps(text, cls=AnsibleJSONEncoder, sort_keys=True, indent=4))
+        display.display(jsonify(text, sort_keys=True, indent=4))
     except TypeError as e:
         display.vvv(traceback.format_exc())
         raise AnsibleError('We could not convert all the documentation into JSON as there was a conversion issue: %s' % to_native(e))

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -10,7 +10,6 @@ __metaclass__ = type
 # ansible.cli needs to be imported first, to ensure the source bin/* scripts run that code first
 from ansible.cli import CLI
 
-import json
 import os.path
 import re
 import shutil
@@ -45,6 +44,7 @@ from ansible.galaxy.role import GalaxyRole
 from ansible.galaxy.token import BasicAuthToken, GalaxyToken, KeycloakToken, NoTokenSentinel
 from ansible.module_utils.ansible_release import __version__ as ansible_version
 from ansible.module_utils.common.collections import is_iterable
+from ansible.module_utils.common.text.converters import jsonify
 from ansible.module_utils.common.yaml import yaml_dump, yaml_load
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils import six
@@ -1523,7 +1523,7 @@ class GalaxyCLI(CLI):
             raise AnsibleOptionsError("- None of the provided paths were usable. Please specify a valid path with --{0}s-path".format(context.CLIARGS['type']))
 
         if output_format == 'json':
-            display.display(json.dumps(collections_in_paths))
+            display.display(jsonify(collections_in_paths))
         elif output_format == 'yaml':
             display.display(yaml_dump(collections_in_paths))
 

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -195,12 +195,11 @@ class InventoryCLI(CLI):
                     'change.' % e.args[0]
                 )
         else:
-            import json
-            from ansible.parsing.ajson import AnsibleJSONEncoder
+            from ansible.module_utils.common.text.converters import jsonify
             try:
-                results = json.dumps(stuff, cls=AnsibleJSONEncoder, sort_keys=True, indent=4, preprocess_unsafe=True, ensure_ascii=False)
+                results = jsonify(stuff, sort_keys=True, indent=4, preprocess_unsafe=True, ensure_ascii=False)
             except TypeError as e:
-                results = json.dumps(stuff, cls=AnsibleJSONEncoder, sort_keys=False, indent=4, preprocess_unsafe=True, ensure_ascii=False)
+                results = jsonify(stuff, sort_keys=False, indent=4, preprocess_unsafe=True, ensure_ascii=False)
                 display.warning("Could not sort JSON output due to issues while sorting keys: %s" % to_native(e))
 
         return results

--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -27,7 +27,8 @@ from ansible.cli.arguments.option_helpers import AnsibleVersion
 from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.connection import Connection, ConnectionError, send_data, recv_data
 from ansible.module_utils.service import fork_process
-from ansible.parsing.ajson import AnsibleJSONEncoder, AnsibleJSONDecoder
+from ansible.module_utils.common.text.converters import jsonify
+from ansible.parsing.ajson import AnsibleJSONDecoder
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader
 from ansible.utils.path import unfrackpath, makedirs_safe
@@ -123,7 +124,7 @@ class ConnectionProcess(object):
             result['exception'] = traceback.format_exc()
         finally:
             result['messages'] = messages
-            self.fd.write(json.dumps(result, cls=AnsibleJSONEncoder))
+            self.fd.write(jsonify(result))
             self.fd.close()
 
     def run(self):
@@ -339,10 +340,10 @@ def main(args=None):
     sys.stdout = saved_stdout
     if 'exception' in result:
         rc = 1
-        sys.stderr.write(json.dumps(result, cls=AnsibleJSONEncoder))
+        sys.stderr.write(jsonify(result)
     else:
         rc = 0
-        sys.stdout.write(json.dumps(result, cls=AnsibleJSONEncoder))
+        sys.stdout.write(jsonify(result)
 
     sys.exit(rc)
 

--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -340,10 +340,10 @@ def main(args=None):
     sys.stdout = saved_stdout
     if 'exception' in result:
         rc = 1
-        sys.stderr.write(jsonify(result)
+        sys.stderr.write(jsonify(result))
     else:
         rc = 0
-        sys.stdout.write(jsonify(result)
+        sys.stdout.write(jsonify(result))
 
     sys.exit(rc)
 

--- a/lib/ansible/module_utils/common/text/converters.py
+++ b/lib/ansible/module_utils/common/text/converters.py
@@ -270,12 +270,6 @@ def _json_encode_fallback(obj):
 
 def jsonify(data, **kwargs):
 
-    # for backwards compat with 'other' jsonify
-    if 'format' in kwargs:
-        if kwargs['format']:
-            kwargs['indent'] = 4
-        del kwargs['format']
-
     for encoding in ("utf-8", "latin-1"):
         try:
             return json.dumps(data, cls=AnsibleJSONEncoder, encoding=encoding, default=_json_encode_fallback, **kwargs)

--- a/lib/ansible/module_utils/common/text/converters.py
+++ b/lib/ansible/module_utils/common/text/converters.py
@@ -11,7 +11,6 @@ import datetime
 import json
 
 from ansible.module_utils.common._collections_compat import Set
-from ansible.module_utils.common.json import AnsibleJSONEncoder
 from ansible.module_utils.six import (
     PY3,
     binary_type,
@@ -269,6 +268,8 @@ def _json_encode_fallback(obj):
 
 
 def jsonify(data, **kwargs):
+    # avoid circular
+    from ansible.module_utils.common.json import AnsibleJSONEncoder
 
     for encoding in ("utf-8", "latin-1"):
         try:

--- a/lib/ansible/module_utils/connection.py
+++ b/lib/ansible/module_utils/connection.py
@@ -39,7 +39,7 @@ import uuid
 
 from functools import partial
 from ansible.module_utils._text import to_bytes, to_text
-from ansible.module_utils.common.json import AnsibleJSONEncoder
+from ansible.module_utils.common.text.converters import jsonify
 from ansible.module_utils.six import iteritems
 from ansible.module_utils.six.moves import cPickle
 
@@ -144,7 +144,7 @@ class Connection(object):
             )
 
         try:
-            data = json.dumps(req, cls=AnsibleJSONEncoder)
+            data = jsonify(req)
         except TypeError as exc:
             raise ConnectionError(
                 "Failed to encode some variables as JSON for communication with ansible-connection. "

--- a/lib/ansible/parsing/utils/jsonify.py
+++ b/lib/ansible/parsing/utils/jsonify.py
@@ -21,9 +21,17 @@ __metaclass__ = type
 
 import json
 
+from ansible.utils.display import Display
+
+
+display = Display()
+
 
 def jsonify(result, format=False):
     ''' format JSON output (uncompressed or uncompressed) '''
+
+    display.deprecated("A plugin/module is using an old copy of the 'jsonify' function, it should Use ansible.module_utils.common.text.converters.jsonify instead",
+                        version='2.17')
 
     if result is None:
         return "{}"

--- a/lib/ansible/parsing/utils/jsonify.py
+++ b/lib/ansible/parsing/utils/jsonify.py
@@ -30,8 +30,9 @@ display = Display()
 def jsonify(result, format=False):
     ''' format JSON output (uncompressed or uncompressed) '''
 
-    display.deprecated("A plugin/module is using an old copy of the 'jsonify' function, it should Use ansible.module_utils.common.text.converters.jsonify instead",
-                        version='2.17')
+    display.deprecated("A plugin/module is using an old copy of the 'jsonify' function, "
+                       "it should Use ansible.module_utils.common.text.converters.jsonify instead",
+                       version='2.17')
 
     if result is None:
         return "{}"

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import base64
+import json
 import os
 import random
 import re

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import base64
-import json
 import os
 import random
 import re
@@ -22,10 +21,10 @@ from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleAction
 from ansible.executor.module_common import modify_module
 from ansible.executor.interpreter_discovery import discover_interpreter, InterpreterDiscoveryRequiredError
 from ansible.module_utils.common._collections_compat import Sequence
+from ansible.module_utils.common.text.converters import jsonify
 from ansible.module_utils.json_utils import _filter_non_json_lines
 from ansible.module_utils.six import binary_type, string_types, text_type
 from ansible.module_utils._text import to_bytes, to_native, to_text
-from ansible.parsing.utils.jsonify import jsonify
 from ansible.release import __version__
 from ansible.utils.collection_loader import resource_from_fqcr
 from ansible.utils.display import Display
@@ -1027,7 +1026,7 @@ class ActionBase(ABC):
                     args_data += '%s=%s ' % (k, shlex.quote(text_type(v)))
                 self._transfer_data(args_file_path, args_data)
             elif module_style in ('non_native_want_json', 'binary'):
-                self._transfer_data(args_file_path, json.dumps(module_args))
+                self._transfer_data(args_file_path, jsonify(module_args))
             display.debug("done transferring module to remote")
 
         environment_string = self._compute_environment_string()

--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -45,7 +45,8 @@ DOCUMENTATION = '''
 import codecs
 import json
 
-from ansible.parsing.ajson import AnsibleJSONEncoder, AnsibleJSONDecoder
+from ansible.parsing.ajson import AnsibleJSONDecoder
+from ansible.module_utils.common.text.converters import jsonify
 from ansible.plugins.cache import BaseFileCacheModule
 
 
@@ -61,4 +62,4 @@ class CacheModule(BaseFileCacheModule):
 
     def _dump(self, value, filepath):
         with codecs.open(filepath, 'w', encoding='utf-8') as f:
-            f.write(json.dumps(value, cls=AnsibleJSONEncoder, sort_keys=True, indent=4))
+            f.write(jsonify(value, sort_keys=True, indent=4))

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -20,7 +20,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import difflib
-import json
 import re
 import sys
 import textwrap
@@ -29,9 +28,8 @@ from copy import deepcopy
 
 from ansible import constants as C
 from ansible.module_utils.common._collections_compat import MutableMapping
-from ansible.module_utils.common.text.converters import to_text
+from ansible.module_utils.common.text.converters import to_text, jsonify
 from ansible.module_utils.six import text_type
-from ansible.parsing.ajson import AnsibleJSONEncoder
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.parsing.yaml.objects import AnsibleUnicode
 from ansible.plugins import AnsiblePlugin, get_plugin_class
@@ -247,7 +245,7 @@ class CallbackBase(AnsiblePlugin):
 
         if result_format == 'json':
             try:
-                return json.dumps(abridged_result, cls=AnsibleJSONEncoder, indent=indent, ensure_ascii=False, sort_keys=sort_keys)
+                return jsonify(abridged_result, indent=indent, ensure_ascii=False, sort_keys=sort_keys)
             except TypeError:
                 # Python3 bug: throws an exception when keys are non-homogenous types:
                 # https://bugs.python.org/issue25457
@@ -322,7 +320,7 @@ class CallbackBase(AnsiblePlugin):
             pretty_results = None
 
         if result_format == 'json':
-            return json.dumps(diff, sort_keys=True, indent=4, separators=(u',', u': ')) + u'\n'
+            return jsonify(diff, sort_keys=True, indent=4, separators=(u',', u': ')) + u'\n'
         elif result_format == 'yaml':
             # None is a sentinel in this case that indicates default behavior
             # default behavior for yaml is to prettify results


### PR DESCRIPTION
  use jsonify function whenever possible
  deprecate dupluicate jsonify
  use AnsibleJSONEncoder

  TODO:
    - dejsonify wrapper to handle the de-serialization?
    - double check json.loads left to ensure they are unrelated to most Ansible content
    - move AnsibleJSONDecoder to module_utils?

ci_complete


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
json