### PR TITLE
validate_modules: allow 'choices' for return values

### DIFF
--- a/changelogs/fragments/76008-validate-modules-choices-return-value.yml
+++ b/changelogs/fragments/76008-validate-modules-choices-return-value.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - "ansible-test validate_modules - allow ``choices`` for return values (https://github.com/ansible/ansible/pull/76008)."

--- a/changelogs/fragments/76008-validate-modules-choices-return-value.yml
+++ b/changelogs/fragments/76008-validate-modules-choices-return-value.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "ansible-test validate_modules - allow ``choices`` for return values (https://github.com/ansible/ansible/pull/76008)."

--- a/changelogs/fragments/76009-validate-modules-choices-return-value.yml
+++ b/changelogs/fragments/76009-validate-modules-choices-return-value.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "ansible-test validate_modules - allow ``choices`` for return values (https://github.com/ansible/ansible/pull/76009)."

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
@@ -395,6 +395,7 @@ def return_schema(for_collection):
                     Required('type'): Any('bool', 'complex', 'dict', 'float', 'int', 'list', 'str'),
                     'version_added': version(for_collection),
                     'version_added_collection': collection_name,
+                    'choices': Any([object], (object,)),
                     'sample': json_value,
                     'example': json_value,
                     'contains': Any(None, *list({str_type: Self} for str_type in string_types)),


### PR DESCRIPTION
##### SUMMARY
Right now choices can be used for argument documentation, but not for return value documentation. For return values which are basically an enumeration, one has to describe the possible values in `description:` instead of simply listing the possible values in `choices`. This PR allows them to be specified in return values without having to ignore a return value syntax error in ignore.txt.

Please note that both ansible-doc and antsibull already handle `choices:` in return values: ansible-doc formats them correctly:
```
        - status
            The account's status.
            (Choices: valid, deactivated, revoked)
            returned: always
            sample: valid
            type: str
```
while antsibull accepts them in its schema, but won't show them. (Something I will work on next...)

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
ansible-test validate_modules
