### PR TITLE
_run_loop: Add the task name to warning

### DIFF
--- a/changelogs/fragments/76011-loop-variable-in-use-warning.yml
+++ b/changelogs/fragments/76011-loop-variable-in-use-warning.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- _run_loop - Add the task name to the warning
+  (https://github.com/ansible/ansible/issues/76011)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -293,9 +293,9 @@ class TaskExecutor:
             label = '{{' + loop_var + '}}'
 
         if loop_var in task_vars:
-            display.warning(u"The loop variable '%s' is already in use. "
+            display.warning(u"%s: The loop variable '%s' is already in use. "
                             u"You should set the `loop_var` value in the `loop_control` option for the task"
-                            u" to something else to avoid variable collisions and unexpected behavior." % loop_var)
+                            u" to something else to avoid variable collisions and unexpected behavior." % (self._task, loop_var))
 
         ran_once = False
 


### PR DESCRIPTION
Prepend the task name to the warning "The loop variable 'item' is
already in use", so that you can get some context even if stdout and
stderr go to separate places.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
