### PR TITLE
allow override of PYTHON variable

### DIFF
--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -45,7 +45,7 @@ endif
 
 DOC_PLUGINS ?= become cache callback cliconf connection httpapi inventory lookup netconf shell strategy vars
 
-PYTHON=python
+PYTHON ?= python
 # fetch version from project release.py as single source-of-truth
 VERSION := $(shell $(PYTHON) ../../packaging/release/versionhelper/version_helper.py --raw || echo error)
 ifeq ($(findstring error,$(VERSION)), error)


### PR DESCRIPTION
##### SUMMARY
allow override to explicitly specify which python to use

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- docs/docsite/Makefile

##### ADDITIONAL INFORMATION
This should operate just as before unless the user has the `PYTHON` environment variable set, in which case, it will use that instead of `python`. This is also how the root level [Makefile](https://github.com/ansible/ansible/blob/devel/Makefile#L37) specifies `PYTHON`.