### PR TITLE
docs: clarify skip_broken option in dnf/yum

### DIFF
--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -109,7 +109,8 @@ options:
     elements: str
   skip_broken:
     description:
-      - Skip packages with broken dependencies(devsolve) and are causing problems.
+      - Skip all unavailable packages or packages with broken dependencies
+        without raising an error. Equivalent to passing the --skip-broken option.
     type: bool
     default: "no"
     version_added: "2.7"

--- a/lib/ansible/modules/yum.py
+++ b/lib/ansible/modules/yum.py
@@ -98,7 +98,8 @@ options:
     version_added: "1.2"
   skip_broken:
     description:
-      - Skip packages with broken dependencies(devsolve) and are causing problems.
+      - Skip all unavailable packages or packages with broken dependencies
+        without raising an error. Equivalent to passing the --skip-broken option.
     type: bool
     default: "no"
     version_added: "2.3"


### PR DESCRIPTION
##### SUMMARY
Clarify documentation around the `skip_broken` option in dnf & yum modules

Fixes #76036

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
DNF / YUM

##### ADDITIONAL INFORMATION
Went with the DNF ReadTheDocs description:
>> Skip all unavailable packages or packages with broken dependencies without raising an error. Equivalent to passing the --skip-broken option.

For interest, the previous description (with the devsolve reference) probably came from here: https://man7.org/linux/man-pages/man8/yum.8.html
