### PR TITLE
[stable-2.11] Fix subversion test.

### DIFF
--- a/test/integration/targets/subversion/roles/subversion/defaults/main.yml
+++ b/test/integration/targets/subversion/roles/subversion/defaults/main.yml
@@ -8,4 +8,4 @@ subversion_repo_url: http://127.0.0.1:{{ apache_port }}/svn/{{ subversion_repo_n
 subversion_repo_auth_url: http://127.0.0.1:{{ apache_port }}/svnauth/{{ subversion_repo_name }}
 subversion_username: subsvn_user'''
 subversion_password: Password123!
-subversion_external_repo_url: https://github.com/ansible/ansible-base-test-container  # GitHub serves SVN
+subversion_external_repo_url: https://github.com/ansible/ansible.github.com  # GitHub serves SVN


### PR DESCRIPTION
##### SUMMARY

Switch to a different repo that isn't giving 503 errors since GitHub hasn't fixed the issue yet.

Backport of https://github.com/ansible/ansible/pull/76041

(cherry picked from commit 319b50f04c93c2247088dadcb9568d5a9ef65d59)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

subversion integration test
