### PR TITLE
Remove centos8 from CI matrix.

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -117,8 +117,6 @@ stages:
               test: alpine3
             - name: CentOS 7
               test: centos7
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 33
               test: fedora33
             - name: Fedora 34
@@ -189,8 +187,6 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 33
               test: fedora33
             - name: Fedora 34


### PR DESCRIPTION
##### SUMMARY

Remove centos8 from CI matrix.

See: https://github.com/ansible-collections/overview/issues/45#issuecomment-944657318

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

.azure-pipelines/azure-pipelines.yml
