### PR TITLE
add missing space to `--playbook-dir` help string

### DIFF
--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -224,7 +224,7 @@ def add_async_options(parser):
 def add_basedir_options(parser):
     """Add options for commands which can set a playbook basedir"""
     parser.add_argument('--playbook-dir', default=C.config.get_config_value('PLAYBOOK_DIR'), dest='basedir', action='store',
-                        help="Since this tool does not use playbooks, use this as a substitute playbook directory."
+                        help="Since this tool does not use playbooks, use this as a substitute playbook directory. "
                              "This sets the relative path for many features including roles/ group_vars/ etc.",
                         type=unfrack_path())
 


### PR DESCRIPTION
##### SUMMARY
fixes missing space in optional argument help string
```
  --playbook-dir BASEDIR
                        Since this tool does not use playbooks, use this as a substitute playbook directory.This
                        sets the relative path for many features including roles/ group_vars/ etc.
```


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cli