### PR TITLE
validate-modules: fix choices for return values

### DIFF
--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
@@ -423,6 +423,7 @@ def return_schema(for_collection):
                         Required('type'): Any('bool', 'complex', 'dict', 'float', 'int', 'list', 'str'),
                         'version_added': version(for_collection),
                         'version_added_collection': collection_name,
+                        'choices': Any([object], (object,)),
                         'sample': json_value,
                         'example': json_value,
                         'contains': Any(None, *list_dict_return_contains_schema),


### PR DESCRIPTION
##### SUMMARY
In #76009 it looks like I only added `choices` for subvalues of return values, not for top-level return values themselves.

This fixes #76009 to also work for top-level return values.

(I didn't include a changelog fragment since #76009 isn't part of a release yet.)

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
validate-modules
