### PR TITLE
Update module documentation about ref links

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -227,8 +227,8 @@ All fields in the ``DOCUMENTATION`` block are lower-case. All fields are require
           link: https://developer.cisco.com/docs/apic-mim-ref/
 
 
-  * Using ``ref:`` with a reference that is not published to the public docsite may require the use of a title to work correctly.
-  * Non-module plugins can be linked to with ``ref:`` using the rST anchor, for example ``ref: The documentation for namespace.collection.plugin_name lookup <ansible_collections.namespace.collection.plugin_name_lookup>``.
+  * If you use ``ref:`` to link to a page that does not exist on docs.ansible.com (for example, documentation for a module you are adding on your branch), you might need to add a title to make the link work correctly.
+  * You can link to non-module plugins with ``ref:`` using the rST anchor, for example ``ref: The documentation for namespace.collection.plugin_name lookup <ansible_collections.namespace.collection.plugin_name_lookup>``.
 
 
 :notes:

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -217,10 +217,19 @@ All fields in the ``DOCUMENTATION`` block are lower-case. All fields are require
         - ref: aci_guide
           description: Detailed information on how to manage your ACI infrastructure using Ansible.
 
+        # Reference by rST documentation anchor (with custom title)
+        - ref: The official Ansible ACI guide <aci_guide>
+          description: Detailed information on how to manage your ACI infrastructure using Ansible.
+
         # Reference by Internet resource
         - name: APIC Management Information Model reference
           description: Complete reference of the APIC object model.
           link: https://developer.cisco.com/docs/apic-mim-ref/
+
+
+  * Using ``ref:`` with a reference that is not published to the public docsite may require the use of a title to work correctly.
+  * Non-module plugins can be linked to with ``ref:`` using the rST anchor, for example ``ref: The documentation for namespace.collection.plugin_name lookup <ansible_collections.namespace.collection.plugin_name_lookup>``.
+
 
 :notes:
 

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -227,8 +227,8 @@ All fields in the ``DOCUMENTATION`` block are lower-case. All fields are require
           link: https://developer.cisco.com/docs/apic-mim-ref/
 
 
-  * If you use ``ref:`` to link to an anchor that isn't associated with a title, you must add a title to the ref for the link to work correctly.
-  * You can link to non-module plugins with ``ref:`` using the rST anchor, but note that plugin and module anchors are never associated with a title, so a title must always be supplied. For example ``ref: namespace.collection.plugin_name lookup plugin  <ansible_collections.namespace.collection.plugin_name_lookup>``.
+  * If you use ``ref:`` to link to an anchor that is not associated with a title, you must add a title to the ref for the link to work correctly.
+  * You can link to non-module plugins with ``ref:`` using the rST anchor, but plugin and module anchors are never associated with a title, so you must supply a title when you link to them. For example ``ref: namespace.collection.plugin_name lookup plugin  <ansible_collections.namespace.collection.plugin_name_lookup>``.
 
 
 :notes:

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -227,8 +227,8 @@ All fields in the ``DOCUMENTATION`` block are lower-case. All fields are require
           link: https://developer.cisco.com/docs/apic-mim-ref/
 
 
-  * If you use ``ref:`` to link to a page that does not exist on docs.ansible.com (for example, documentation for a module you are adding on your branch), you might need to add a title to make the link work correctly.
-  * You can link to non-module plugins with ``ref:`` using the rST anchor, for example ``ref: The documentation for namespace.collection.plugin_name lookup <ansible_collections.namespace.collection.plugin_name_lookup>``.
+  * If you use ``ref:`` to link to an anchor that isn't associated with a title, you must add a title to the ref for the link to work correctly.
+  * You can link to non-module plugins with ``ref:`` using the rST anchor, but note that plugin and module anchors are never associated with a title, so a title must always be supplied. For example ``ref: The documentation for namespace.collection.plugin_name lookup <ansible_collections.namespace.collection.plugin_name_lookup>``.
 
 
 :notes:

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -228,7 +228,7 @@ All fields in the ``DOCUMENTATION`` block are lower-case. All fields are require
 
 
   * If you use ``ref:`` to link to an anchor that isn't associated with a title, you must add a title to the ref for the link to work correctly.
-  * You can link to non-module plugins with ``ref:`` using the rST anchor, but note that plugin and module anchors are never associated with a title, so a title must always be supplied. For example ``ref: The documentation for namespace.collection.plugin_name lookup <ansible_collections.namespace.collection.plugin_name_lookup>``.
+  * You can link to non-module plugins with ``ref:`` using the rST anchor, but note that plugin and module anchors are never associated with a title, so a title must always be supplied. For example ``ref: namespace.collection.plugin_name lookup plugin  <ansible_collections.namespace.collection.plugin_name_lookup>``.
 
 
 :notes:


### PR DESCRIPTION
##### SUMMARY
* add example of a `seealso:` `ref:` link that includes a title.
* explain how to link to a non-module plugin using `ref:` links


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
