### PR TITLE
Fix group name lusermod tmp

### DIFF
--- a/changelogs/fragments/fix_group_name_lusermod.yml
+++ b/changelogs/fragments/fix_group_name_lusermod.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - >-
+     user - on Linux use the gid of the new primary group of the user for the
+     ``-g`` parameter of (l)usermod as lusermod's ``-g`` only accepts an id.
+     usermod accepts names and ids for the ``-g`` parameter.

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -821,7 +821,7 @@ class User(object):
             ginfo = self.group_info(self.group)
             if info[3] != ginfo[2]:
                 cmd.append('-g')
-                cmd.append(self.group)
+                cmd.append(ginfo[2])
 
         if self.groups is not None:
             # get a list of all groups for the user, including the primary

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -3175,6 +3175,21 @@ def main():
         if info is False:
             result['msg'] = "failed to look up user name: %s" % user.name
             result['failed'] = True
+        # If we changed something with local commands a possible nss cache
+        # might not have been updated. Reread from nss at maximum for
+        # 1 second every 0.1 second.
+        if user.local and result['changed']:
+            spin = 10
+            old_info = info
+            while spin > 0:
+                spin -= 1
+                time.sleep(0.1)
+                old_info = info
+                info = user.user_info()
+                # Something has changed in the cache. Hopefully this is now
+                # reality. Hence leave the loop.
+                if not (old_info == info):
+                    break
         result['uid'] = info[2]
         result['group'] = info[3]
         result['comment'] = info[4]

--- a/test/integration/targets/user/tasks/test_local.yml
+++ b/test/integration/targets/user/tasks/test_local.yml
@@ -143,6 +143,14 @@
   tags:
     - user_test_local_mode
 
+- name: Remove local_ansibulluser group
+  group:
+    name: local_ansibulluser
+    state: absent
+    local: yes
+  tags:
+    - user_test_local_mode
+
 - name: Remove test groups
   group:
     name: "{{ item }}"

--- a/test/integration/targets/user/tasks/test_local.yml
+++ b/test/integration/targets/user/tasks/test_local.yml
@@ -85,6 +85,8 @@
     - testgroup2
     - testgroup3
     - testgroup4
+    - testgroup5
+  register: local_user_test_groups
   tags:
     - user_test_local_mode
 
@@ -121,6 +123,17 @@
   tags:
     - user_test_local_mode
 
+- name: Change primary group for local_ansibulluser
+  user:
+    name: local_ansibulluser
+    state: present
+    local: yes
+    group: testgroup5
+  register: local_user_test_6
+  ignore_errors: yes
+  tags:
+    - user_test_local_mode
+
 - name: Remove local_ansibulluser again
   user:
     name: local_ansibulluser
@@ -139,6 +152,7 @@
     - testgroup2
     - testgroup3
     - testgroup4
+    - testgroup5
   tags:
     - user_test_local_mode
 
@@ -164,6 +178,10 @@
   when: ansible_facts.system in ['Linux']
   tags:
     - user_test_local_mode
+
+- name: Check that primary group was changed
+  assert:
+    that: local_user_test_6['group'] == local_user_test_groups.results|selectattr('name', 'testgroup5')|map(attribute='gid')|first
 
 - name: Test expires for local users
   import_tasks: test_local_expires.yml

--- a/test/integration/targets/user/tasks/test_local.yml
+++ b/test/integration/targets/user/tasks/test_local.yml
@@ -181,7 +181,7 @@
 
 - name: Check that primary group was changed
   assert:
-    that: local_user_test_6['group'] == local_user_test_groups.results|selectattr('name', 'testgroup5')|map(attribute='gid')|first
+    that: local_user_test_6['group'] == local_user_test_groups.results|selectattr('name', 'equalto', 'testgroup5')|map(attribute='gid')|first
 
 - name: Test expires for local users
   import_tasks: test_local_expires.yml


### PR DESCRIPTION
##### SUMMARY

When changing the primary group of a user with `local` set to `yes`, the user module failed because it added the name of the new group to the `-g` option of `lusermod`. While `usermod` accepts a groups name and a groups id as parameter to `-g` `lusermod` only accepts the groups id.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Error message without patch:
```paste below
Invalid group ID testgroup5\nUsage: lusermod 
```
