### PR TITLE
Fix local facts unreadable

### DIFF
--- a/changelogs/fragments/local_fact_unreadable.yml
+++ b/changelogs/fragments/local_fact_unreadable.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - >-
+     local facts - if a local fact in the facts directory cannot be stated,
+     store an error message as the fact value and emit a warning just as if
+     just as if the facts execution has failed. The stat can fail e.g. on
+     dangling symlinks.

--- a/changelogs/fragments/local_fact_unreadable.yml
+++ b/changelogs/fragments/local_fact_unreadable.yml
@@ -4,5 +4,3 @@ bugfixes:
      store an error message as the fact value and emit a warning just as if
      just as if the facts execution has failed. The stat can fail e.g. on
      dangling symlinks.
-     Furthermore also ignore errors while opening a static fact file not only
-     when reading it.

--- a/changelogs/fragments/local_fact_unreadable.yml
+++ b/changelogs/fragments/local_fact_unreadable.yml
@@ -4,3 +4,5 @@ bugfixes:
      store an error message as the fact value and emit a warning just as if
      just as if the facts execution has failed. The stat can fail e.g. on
      dangling symlinks.
+     Furthermore also ignore errors while opening a static fact file not only
+     when reading it.

--- a/lib/ansible/module_utils/facts/system/local.py
+++ b/lib/ansible/module_utils/facts/system/local.py
@@ -50,8 +50,15 @@ class LocalFactCollector(BaseFactCollector):
         for fn in sorted(glob.glob(fact_path + '/*.fact')):
             # use filename for key where it will sit under local facts
             fact_base = os.path.basename(fn).replace('.fact', '')
-            if stat.S_IXUSR & os.stat(fn)[stat.ST_MODE]:
-                failed = None
+            failed = None
+            try:
+                executable_fact = stat.S_IXUSR & os.stat(fn)[stat.ST_MODE]
+            except Exception as e:
+                failed = 'Could not stat fact (%s): %s' % (fn, to_text(e))
+                local[fact_base] = failed
+                module.warn(failed)
+                continue
+            if executable_fact:
                 try:
                     # run it
                     rc, out, err = module.run_command(fn)

--- a/lib/ansible/module_utils/facts/system/local.py
+++ b/lib/ansible/module_utils/facts/system/local.py
@@ -53,7 +53,7 @@ class LocalFactCollector(BaseFactCollector):
             failed = None
             try:
                 executable_fact = stat.S_IXUSR & os.stat(fn)[stat.ST_MODE]
-            except Exception as e:
+            except OSError as e:
                 failed = 'Could not stat fact (%s): %s' % (fn, to_text(e))
                 local[fact_base] = failed
                 module.warn(failed)

--- a/test/integration/targets/facts_d/tasks/main.yml
+++ b/test/integration/targets/facts_d/tasks/main.yml
@@ -24,6 +24,7 @@
       file:
         path: "{{ fact_dir }}/dead_symlink.fact"
         src: /tmp/dead_symlink
+        force: yes
         state: link
 
 - name: force fact gather to get ansible_local

--- a/test/integration/targets/facts_d/tasks/main.yml
+++ b/test/integration/targets/facts_d/tasks/main.yml
@@ -20,6 +20,12 @@
         - name: unreadable
           mode: '0000'
 
+    - name: Create dangling symlink
+      file:
+        path: "{{ fact_dir }}/dead_symlink.fact"
+        src: /tmp/dead_symlink
+        state: link
+
 - name: force fact gather to get ansible_local
   setup:
     fact_path: "{{ fact_dir | expanduser }}"
@@ -43,3 +49,4 @@
         - setup_result['ansible_facts']['ansible_local']['goodscript']['script_ran']|bool
         - setup_result['ansible_facts']['ansible_local']['basdscript'].startswith("Failure executing fact script")
         - setup_result['ansible_facts']['ansible_local']['unreadable'].startswith('error loading facts')
+        - setup_result['ansible_facts']['ansible_local']['dead_symlink'].startswith('Could not stat fact')


### PR DESCRIPTION
##### SUMMARY
If a local fact in the facts directory cannot be stated, store an error message as the fact value and emit a warning just as if
the facts execution has failed. The stat can fail e.g. on dangling symlinks.

Furthermore also ignore errors while opening a static fact file not only when reading it.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
local facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
