### PR TITLE
Docs: Note groups default behavior in user module

### DIFF
--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -53,7 +53,9 @@ options:
         type: str
     groups:
         description:
-            - List of groups user will be added to. When set to an empty string C(''),
+            - List of groups user will be added to.
+            - By default, the user is removed from all other groups. Configure C(append) to modify this.
+            - When set to an empty string C(''),
               the user is removed from all groups except the primary group.
             - Before Ansible 2.3, the only input format allowed was a comma separated string.
         type: list


### PR DESCRIPTION
##### SUMMARY
When you use the `groups` parameter in the Ansible builtin `user` module to add users to a list of groups, 
the users are removed from all other groups by default. You can modify this behaviour by using `append`.

The current documentation doesn't mention the default removal of the users from all other groups.

Fixes https://github.com/ansible/ansible/issues/75889

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/user.py

##### ADDITIONAL INFORMATION

Definition of `groups` parameter in `user` module

- Before:
```
List of groups user will be added to. 
```

- After:
```
List of groups user will be added to.
By default, the user is removed from all other groups. Configure append to modify this.
```