### PR TITLE
Clarify that "requires_ansible" means Ansible Core

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections_structure.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_structure.rst
@@ -203,7 +203,7 @@ A collection can store some additional metadata in a ``runtime.yml`` file in the
 
 - *requires_ansible*:
 
-  The version of Ansible required to use the collection. Multiple versions can be separated with a comma.
+  The version of Ansible Core (ansible-core) required to use the collection. Multiple versions can be separated with a comma.
 
   .. code:: yaml
 


### PR DESCRIPTION
##### SUMMARY
Clarify that the `requires_ansible` field in meta/runtime.yml refers to the version of Ansible Core (ansible-core), not any package called "ansible" e.g. https://pypi.org/project/ansible/


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
It isn't clear that the `requires_ansible` field refers only to ansible-core

##### ISSUE TYPE


- Docs Pull Request


##### COMPONENT NAME


##### ADDITIONAL INFORMATION

