### PR TITLE
Allow `retries` without `until` to retry until task is successful

### DIFF
--- a/changelogs/fragments/76101-retries-without-until.yml
+++ b/changelogs/fragments/76101-retries-without-until.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - using ``retries`` without specifying ``until`` defaults to retrying until the task is successful
+  - using ``retries`` without specifying ``until`` defaults to retrying until the task is successful (https://github.com/ansible/ansible/issues/20802)

--- a/changelogs/fragments/76101-retries-without-until.yml
+++ b/changelogs/fragments/76101-retries-without-until.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - using ``retries`` without specifying ``until`` defaults to retrying until the task is successful

--- a/docs/docsite/rst/playbook_guide/playbooks_loops.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_loops.rst
@@ -270,6 +270,16 @@ When you run a task with ``until`` and register the result as a variable, the re
 
 .. note:: You must set the ``until`` parameter if you want a task to retry. If ``until`` is not defined, the value for the ``retries`` parameter is forced to 1.
 
+.. versionadded:: 2.14
+
+In the common case of retrying a task until it is successful, you can use ``retries`` without ``until``. For example,
+
+.. code-block:: yaml
+
+  - name: Retry a task until successful
+    ansible.builtin.shell: /usr/bin/foo
+    retries: 5
+
 Looping over inventory
 ----------------------
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -13,7 +13,6 @@ import subprocess
 import sys
 import termios
 import traceback
-from typing import List, Tuple, Union
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleParserError, AnsibleUndefinedVariable, AnsibleConnectionFailure, AnsibleActionFail, AnsibleActionSkip
@@ -811,11 +810,11 @@ class TaskExecutor:
         return result
 
     @staticmethod
-    def _retries_requested(_task: Task) -> boolean:
+    def _retries_requested(_task):  # type: (Task) -> boolean
         return (_task.retries is not None) or bool(_task.until)
 
     @staticmethod
-    def process_retry_parameters(retries_requested: bool, _task: Task) -> Tuple[int, int, Union[str, List]]:
+    def process_retry_parameters(retries_requested, _task):  # type: (bool, Task) -> Tuple[int, int, Union[str, List]]
         '''
         Extract the parameters used in retrying the task
         '''

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -831,7 +831,7 @@ class TaskExecutor:
 
         delay = _task.delay
         if delay is None:
-            delay = _task._delay.default
+            delay = Task.delay.default
         if delay is None or delay < 0:
             delay = 1
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -706,7 +706,7 @@ class TaskExecutor:
                     result['failed'] = False
 
             # Make attempts and retries available early to allow their use in changed/failed_when
-            if self._task.until:
+            if retries_requested:
                 result['attempts'] = attempt
 
             # set the changed property if it was missing.
@@ -736,7 +736,7 @@ class TaskExecutor:
                     result['failed'] = True
                     result['%s_when_result' % condname] = to_text(e)
 
-            if retries > 1:
+            if retries_requested:
                 cond = Conditional(loader=self._loader)
                 cond.when = self._task.until
                 if cond.evaluate_conditional(templar, vars_copy):
@@ -759,7 +759,7 @@ class TaskExecutor:
                         time.sleep(delay)
                         self._handler = self._get_action_handler(connection=self._connection, templar=templar)
         else:
-            if retries > 1:
+            if retries_requested:
                 # we ran out of attempts, so mark the result as failed
                 result['attempts'] = retries - 1
                 result['failed'] = True

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -826,11 +826,13 @@ class TaskExecutor:
             else:
                 attempts += 3
 
-        if attempts <= 0: # guard against negative retries
+        if attempts <= 0:  # guard against negative retries
             attempts = 1
 
         delay = _task.delay
-        if delay < 0:
+        if delay is None:
+            delay = _task._delay.default
+        if delay is None or delay < 0:
             delay = 1
 
         return attempts, delay

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -603,7 +603,7 @@ class TaskExecutor:
         if omit_token is not None:
             self._task.args = remove_omit(self._task.args, omit_token)
 
-        retries, delay, until = self.process_retry_parameters(self._task)
+        retries, delay = self.process_retry_parameters(self._task)
 
         display.debug("starting attempt loop")
         result = None
@@ -705,7 +705,7 @@ class TaskExecutor:
                     result['failed'] = False
 
             # Make attempts and retries available early to allow their use in changed/failed_when
-            if until:
+            if self._task.until:
                 result['attempts'] = attempt
 
             # set the changed property if it was missing.
@@ -737,7 +737,7 @@ class TaskExecutor:
 
             if retries > 1:
                 cond = Conditional(loader=self._loader)
-                cond.when = until
+                cond.when = self._task.until
                 if cond.evaluate_conditional(templar, vars_copy):
                     break
                 else:
@@ -824,9 +824,7 @@ class TaskExecutor:
         if delay < 0:
             delay = 1
 
-        until = _task.until
-
-        return attempts, delay, until
+        return attempts, delay
 
     def _poll_async_result(self, result, templar, task_vars=None):
         '''

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -805,6 +805,10 @@ class TaskExecutor:
         return result
 
     @staticmethod
+    def _retries_requested(_task: Task) -> boolean:
+        return bool((_task.retries and _task.retries > 1) or _task.until)
+
+    @staticmethod
     def process_retry_parameters(_task: Task) -> Tuple[int, int, Union[str, List]]:
         '''
         Extract the parameters used in retrying the task

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -809,15 +809,15 @@ class TaskExecutor:
         '''
         Extract the parameters used in retrying the task
         '''
-        if _task.until:
-            retries = _task.retries
-            if retries is None:
-                retries = 3
-            elif retries <= 0:
-                retries = 1
-            else:
-                retries += 1
+        if _task.retries is not None:
+            retries = _task.retries + 1
+        elif _task.until: # implicit request for retries, uses default
+            retries = 3 + 1
         else:
+            # no retries, no implicit retry request from `until`
+            retries = 0 + 1
+
+        if retries <= 0:
             retries = 1
 
         delay = _task.delay

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import termios
 import traceback
+from typing import List, Tuple, Union
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleParserError, AnsibleUndefinedVariable, AnsibleConnectionFailure, AnsibleActionFail, AnsibleActionSkip
@@ -810,11 +811,11 @@ class TaskExecutor:
         return result
 
     @staticmethod
-    def _retries_requested(_task):  # type: (Task) -> boolean
+    def _retries_requested(_task):  # type: (Task) -> bool
         return (_task.retries is not None) or bool(_task.until)
 
     @staticmethod
-    def process_retry_parameters(retries_requested, _task):  # type: (bool, Task) -> Tuple[int, int, Union[str, List]]
+    def process_retry_parameters(retries_requested, _task):  # type: (bool, Task) -> Tuple[int, int]
         '''
         Extract the parameters used in retrying the task
         '''

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -810,15 +810,15 @@ class TaskExecutor:
         Extract the parameters used in retrying the task
         '''
         if _task.retries is not None:
-            retries = _task.retries + 1
+            attempts = 1 + _task.retries
         elif _task.until: # implicit request for retries, uses default
-            retries = 3 + 1
+            attempts = 1 + 3
         else:
             # no retries, no implicit retry request from `until`
-            retries = 0 + 1
+            attempts = 1
 
-        if retries <= 0:
-            retries = 1
+        if attempts <= 0:
+            attempts = 1
 
         delay = _task.delay
         if delay < 0:
@@ -826,7 +826,7 @@ class TaskExecutor:
 
         until = _task.until
 
-        return retries, delay, until
+        return attempts, delay, until
 
     def _poll_async_result(self, result, templar, task_vars=None):
         '''

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -737,9 +737,14 @@ class TaskExecutor:
                     result['%s_when_result' % condname] = to_text(e)
 
             if retries_requested:
-                cond = Conditional(loader=self._loader)
-                cond.when = self._task.until
-                if cond.evaluate_conditional(templar, vars_copy):
+                if self._task.until:
+                    cond = Conditional(loader=self._loader)
+                    cond.when = self._task.until
+                    until_satisfied = cond.evaluate_conditional(templar, vars_copy)
+                else:
+                    until_satisfied = not result['failed']
+
+                if until_satisfied:
                     break
                 else:
                     # no conditional check, or it failed, so sleep for the specified time

--- a/lib/ansible/playbook/attribute.py
+++ b/lib/ansible/playbook/attribute.py
@@ -155,6 +155,8 @@ class FieldAttribute(Attribute):
         self.prepend = prepend
 
     def __get__(self, obj, obj_type=None):
+        if obj is None:
+            return self
         if getattr(obj, '_squashed', False) or getattr(obj, '_finalized', False):
             value = getattr(obj, f'_{self.name}', Sentinel)
         else:

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -80,7 +80,7 @@ class Task(Base, Conditional, Taggable, CollectionSearch):
     notify = FieldAttribute(isa='list')
     poll = FieldAttribute(isa='int', default=C.DEFAULT_POLL_INTERVAL)
     register = FieldAttribute(isa='string', static=True)
-    retries = FieldAttribute(isa='int', default=3)
+    retries = FieldAttribute(isa='int')
     until = FieldAttribute(isa='list', default=list)
 
     # deprecated, used to be loop and loop_args but loop has been repurposed

--- a/test/integration/targets/until/tasks/main.yml
+++ b/test/integration/targets/until/tasks/main.yml
@@ -34,7 +34,7 @@
     state: absent
 
 - name: Test failed_when impacting until
-  shell: 'true'
+  shell: "true"
   register: failed_when_until
   failed_when: True
   until: failed_when_until is successful
@@ -47,7 +47,7 @@
       - failed_when_until.attempts == 3
 
 - name: Test changed_when impacting until
-  shell: 'true'
+  shell: "true"
   register: changed_when_until
   changed_when: False
   until: changed_when_until is changed
@@ -63,7 +63,7 @@
 # and would cause the conditional to fail due to ``'dict object' has no attribute 'attempts'``
 # https://github.com/ansible/ansible/issues/34139
 - name: Test access to attempts in changed_when/failed_when
-  shell: 'true'
+  shell: "true"
   register: changed_when_attempts
   until: 1 == 0
   retries: 5
@@ -82,3 +82,44 @@
   register: counter
   delay: 0.5
   until: counter.rc == 0
+
+- name: test explicit null in `retries`
+  shell: "false"
+  retries: null
+  delay: 0.1
+  register: retries_null
+  until: "false"
+  failed_when: retries_null.attempts != 3
+
+- name: test default in `retries`
+  shell: "false"
+  delay: 0.1
+  register: default_retries
+  until: "false"
+  failed_when: "default_retries.attempts != 4"
+# xfail
+# - name: test explicit null in `delay`
+#   shell: "false"
+#   retries: 2
+#   delay: null
+#   register: delay_null
+#   until: "false"
+#   failed_when: retries_null.attempts != 2
+
+- name: get pre-exec timestamp for test negative `delay`
+  set_fact:
+    negative_delay_preexec: "{{ now() }}"
+
+- name: test negative `delay`
+  shell: "false"
+  delay: -42
+  register: negative_delay
+  retries: 1
+  until: "false"
+  failed_when: "false"
+
+- name: assert negative `delay` defaulted to 1
+  assert:
+    that:
+      - "(now() - ((negative_delay_preexec) | to_datetime(format='%Y-%m-%d %H:%M:%S.%f'))) > (('1' | to_datetime('%S'))-('0' | to_datetime('%S')))" # delays at least 1s per retry
+      - "(now() - ((negative_delay_preexec) | to_datetime(format='%Y-%m-%d %H:%M:%S.%f'))) < (('5' | to_datetime('%S'))-('0' | to_datetime('%S')))" # delay has not been set to the default

--- a/test/integration/targets/until/tasks/main.yml
+++ b/test/integration/targets/until/tasks/main.yml
@@ -97,14 +97,14 @@
   register: default_retries
   until: "false"
   failed_when: "default_retries.attempts != 4"
-# xfail
-# - name: test explicit null in `delay`
-#   shell: "false"
-#   retries: 2
-#   delay: null
-#   register: delay_null
-#   until: "false"
-#   failed_when: retries_null.attempts != 2
+
+- name: test explicit null in `delay`
+  shell: "false"
+  retries: 2
+  delay: null
+  register: delay_null
+  until: "false"
+  failed_when: "retries_null.attempts != 3"
 
 - name: get pre-exec timestamp for test negative `delay`
   set_fact:
@@ -123,6 +123,7 @@
     that:
       - "(now() - ((negative_delay_preexec) | to_datetime(format='%Y-%m-%d %H:%M:%S.%f'))) > (('1' | to_datetime('%S'))-('0' | to_datetime('%S')))" # delays at least 1s per retry
       - "(now() - ((negative_delay_preexec) | to_datetime(format='%Y-%m-%d %H:%M:%S.%f'))) < (('5' | to_datetime('%S'))-('0' | to_datetime('%S')))" # delay has not been set to the default
+
 - name: until defaults to 'succeeded'
   shell: "false"
   failed_when: until_default.attempts <= 2
@@ -135,3 +136,17 @@
     that:
       - until_default is succeeded
       - until_default.attempts == 3
+
+- name: set variables for testing use in retry
+  set_fact:
+    vars_in_retry_retries: 2
+    vars_in_retry_delay: 0
+    vars_in_retry_until: "vars_in_retry is succeeded"
+
+- name: test vars in parameters
+  command: "false"
+  register: vars_in_retry
+  failed_when: vars_in_retry.attempts <= 2
+  retries: "{{ vars_in_retry_retries }}"
+  delay: "{{ vars_in_retry_delay }}"
+  until: "{{ vars_in_retry_until }}"

--- a/test/integration/targets/until/tasks/main.yml
+++ b/test/integration/targets/until/tasks/main.yml
@@ -89,7 +89,7 @@
   delay: 0.1
   register: retries_null
   until: "false"
-  failed_when: retries_null.attempts != 3
+  failed_when: retries_null.attempts != 4
 
 - name: test default in `retries`
   shell: "false"

--- a/test/integration/targets/until/tasks/main.yml
+++ b/test/integration/targets/until/tasks/main.yml
@@ -123,3 +123,15 @@
     that:
       - "(now() - ((negative_delay_preexec) | to_datetime(format='%Y-%m-%d %H:%M:%S.%f'))) > (('1' | to_datetime('%S'))-('0' | to_datetime('%S')))" # delays at least 1s per retry
       - "(now() - ((negative_delay_preexec) | to_datetime(format='%Y-%m-%d %H:%M:%S.%f'))) < (('5' | to_datetime('%S'))-('0' | to_datetime('%S')))" # delay has not been set to the default
+- name: until defaults to 'succeeded'
+  shell: "false"
+  failed_when: until_default.attempts <= 2
+  retries: 3
+  delay: 0.1
+  register: until_default
+
+- name: assert until defaulted to 'succeeded'
+  assert:
+    that:
+      - until_default is succeeded
+      - until_default.attempts == 3

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -520,7 +520,7 @@ class TestTaskExecutorRetries:
     def _do_retry_parameters_test(self, task: Task, expected_retries=None, expected_delay=None):
         retries_requested = TaskExecutor._retries_requested(task)
         retries, delay = TaskExecutor.process_retry_parameters(retries_requested, task)
-        
+
         if expected_retries is not None:
             assert expected_retries == retries
         if expected_delay is not None:
@@ -533,7 +533,7 @@ class TestTaskExecutorRetries:
 
     def test_process_retry_parameters_no_until_follows_retries(self):
         retries = 42
-        expected_retries = retries+1
+        expected_retries = retries + 1
         self._do_retry_parameters_test(self._make_task({"retries": retries}), expected_retries=expected_retries)
 
     def test_process_retry_parameters_with_until_defaults_3(self):
@@ -554,7 +554,7 @@ class TestTaskExecutorRetries:
         retries = 42
         expected_retries = retries + 1
         self._do_retry_parameters_test(self._make_task({"until": valid_until, "retries": retries}), expected_retries=expected_retries)
-    
+
     # delay
 
     def test_process_retry_parameters_no_delay_defaults_to_Task_default(self):

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -505,13 +505,17 @@ class TestTaskExecutorRetries:
 
     valid_until = "taskresult is succeeded"
 
-    def _do_test(self, task: Task, expected_retries=None, expected_delay=None):
-        retries, delay = TaskExecutor.process_retry_parameters(task)
+    def _do_test(self, task: Task, expected_retries=None, expected_delay=None, expected_until=None):
+        retries, delay, until = TaskExecutor.process_retry_parameters(task)
         
         if expected_retries is not None:
             assert expected_retries == retries
         if expected_delay is not None:
             assert expected_delay == delay
+        if expected_until is not None:
+            assert expected_until == until
+
+    # retries
 
     def test_process_retry_parameters_no_until_defaults_1(self):
         self._do_test(self._make_task(), expected_retries=1)
@@ -538,6 +542,8 @@ class TestTaskExecutorRetries:
         expected_retries = retries + 1
         self._do_test(self._make_task({"until": self.valid_until, "retries": retries}), expected_retries=expected_retries)
     
+    # delay
+
     def test_process_retry_parameters_no_delay_defaults_to_Task_default(self):
         expected_delay = Task._delay.default
         self._do_test(self._make_task(), expected_delay=expected_delay)
@@ -560,3 +566,11 @@ class TestTaskExecutorRetries:
     )
     def test_process_retry_parameters_delay_is_followed(self, value):
         self._do_test(self._make_task({"delay": value}), expected_delay=value)
+
+    # until
+
+    def test_process_retry_parameters_until_returns(self):
+        self._do_test(self._make_task({"until": self.valid_until}), expected_until=self.valid_until)
+
+    def test_process_retry_parameters_no_until_returns_emptylist(self):
+        self._do_test(self._make_task(), expected_until=[])

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -520,15 +520,17 @@ class TestTaskExecutorRetries:
     def test_process_retry_parameters_no_until_defaults_1(self):
         self._do_test(self._make_task(), expected_retries=1)
 
-    def test_process_retry_parameters_no_until_overrides_retries(self):
-        self._do_test(self._make_task({"retries": 42}), expected_retries=1)
+    def test_process_retry_parameters_no_until_follows_retries(self):
+        retries = 42
+        expected_retries = retries+1
+        self._do_test(self._make_task({"retries": retries}), expected_retries=expected_retries)
 
     def test_process_retry_parameters_with_until_defaults_3(self):
         expected_retries = 3 + 1
         self._do_test(self._make_task({"until": self.valid_until}), expected_retries=expected_retries)
 
     def test_process_retry_parameters_with_until_and_null_retry_defaults_3(self):
-        expected_retries = 3
+        expected_retries = 3 + 1
         self._do_test(self._make_task({"until": self.valid_until, "retries": None}), expected_retries=expected_retries)
 
     def test_process_retry_parameters_with_negative_retries_returns_1(self):
@@ -572,5 +574,5 @@ class TestTaskExecutorRetries:
     def test_process_retry_parameters_until_returns(self):
         self._do_test(self._make_task({"until": self.valid_until}), expected_until=self.valid_until)
 
-    def test_process_retry_parameters_no_until_returns_emptylist(self):
+    def test_process_retry_parameters_no_until_and_no_retry_returns_emptylist(self):
         self._do_test(self._make_task(), expected_until=[])

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -507,7 +507,14 @@ class TestTaskExecutorRetries:
         params.update(extra or {})
         return Task.load(params)
 
-    valid_until = "taskresult is succeeded"
+    @pytest.mark.parametrize("task_extras,expected", [
+        ({}, False),
+        ({"retries": 42}, True),
+        ({"until": valid_until}, True),
+        ({"retries": 42, "until": valid_until}, True)
+    ])
+    def test_retries_requested(self, task_extras, expected):
+        assert expected == TaskExecutor._retries_requested(self._make_task(task_extras))
 
     def _do_test(self, task: Task, expected_retries=None, expected_delay=None):
         retries, delay = TaskExecutor.process_retry_parameters(task)
@@ -516,7 +523,6 @@ class TestTaskExecutorRetries:
             assert expected_retries == retries
         if expected_delay is not None:
             assert expected_delay == delay
-
 
     # retries
 

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -517,7 +517,7 @@ class TestTaskExecutorRetries:
     def test_retries_requested(self, task_extras, expected):
         assert expected == TaskExecutor._retries_requested(self._make_task(task_extras))
 
-    def _do_test(self, task: Task, expected_retries=None, expected_delay=None):
+    def _do_retry_parameters_test(self, task: Task, expected_retries=None, expected_delay=None):
         retries_requested = TaskExecutor._retries_requested(task)
         retries, delay = TaskExecutor.process_retry_parameters(retries_requested, task)
         
@@ -529,37 +529,37 @@ class TestTaskExecutorRetries:
     # retries
 
     def test_process_retry_parameters_no_until_defaults_1(self):
-        self._do_test(self._make_task(), expected_retries=1)
+        self._do_retry_parameters_test(self._make_task(), expected_retries=1)
 
     def test_process_retry_parameters_no_until_follows_retries(self):
         retries = 42
         expected_retries = retries+1
-        self._do_test(self._make_task({"retries": retries}), expected_retries=expected_retries)
+        self._do_retry_parameters_test(self._make_task({"retries": retries}), expected_retries=expected_retries)
 
     def test_process_retry_parameters_with_until_defaults_3(self):
         expected_retries = 3 + 1
-        self._do_test(self._make_task({"until": valid_until}), expected_retries=expected_retries)
+        self._do_retry_parameters_test(self._make_task({"until": valid_until}), expected_retries=expected_retries)
 
     def test_process_retry_parameters_with_until_and_null_retry_defaults_3(self):
         expected_retries = 3 + 1
-        self._do_test(self._make_task({"until": valid_until, "retries": None}), expected_retries=expected_retries)
+        self._do_retry_parameters_test(self._make_task({"until": valid_until, "retries": None}), expected_retries=expected_retries)
 
     def test_process_retry_parameters_with_negative_retries_returns_1(self):
-        self._do_test(self._make_task({"until": valid_until, "retries": -42}), expected_retries=1)
+        self._do_retry_parameters_test(self._make_task({"until": valid_until, "retries": -42}), expected_retries=1)
 
     def test_process_retry_parameters_with_0_retries_returns_1(self):
-        self._do_test(self._make_task({"until": valid_until, "retries": 0}), expected_retries=1)
+        self._do_retry_parameters_test(self._make_task({"until": valid_until, "retries": 0}), expected_retries=1)
 
     def test_process_retry_parameters_with_until_follows_retries(self):
         retries = 42
         expected_retries = retries + 1
-        self._do_test(self._make_task({"until": valid_until, "retries": retries}), expected_retries=expected_retries)
+        self._do_retry_parameters_test(self._make_task({"until": valid_until, "retries": retries}), expected_retries=expected_retries)
     
     # delay
 
     def test_process_retry_parameters_no_delay_defaults_to_Task_default(self):
         expected_delay = Task._delay.default
-        self._do_test(self._make_task(), expected_delay=expected_delay)
+        self._do_retry_parameters_test(self._make_task(), expected_delay=expected_delay)
 
     @pytest.mark.parametrize(
         "value",
@@ -567,26 +567,15 @@ class TestTaskExecutorRetries:
         [-1]
     )
     def test_process_retry_parameters_delay_defaults(self, value):
-        self._do_test(self._make_task({"delay":value}), expected_delay=1)
+        self._do_retry_parameters_test(self._make_task({"delay":value}), expected_delay=1)
 
     @pytest.mark.xfail(reason="existing behaviour is to error", raises=TypeError)
     def test_process_retry_parameters_null_delay_defaults(self):
-        self._do_test(self._make_task({"delay":None}), expected_delay=1)
+        self._do_retry_parameters_test(self._make_task({"delay":None}), expected_delay=1)
 
     @pytest.mark.parametrize(
         "value",
         [42, 0]
     )
     def test_process_retry_parameters_delay_is_followed(self, value):
-        self._do_test(self._make_task({"delay": value}), expected_delay=value)
-
-    # until
-
-    # def test_process_retry_parameters_until_returns(self):
-    #     self._do_test(self._make_task({"until": valid_until}), expected_until=valid_until)
-
-    # def test_process_retry_parameters_no_until_and_no_retry_returns_emptylist(self):
-    #     self._do_test(self._make_task(), expected_until=[])
-
-    # def test_process_retry_parameters_no_until_with_retry_returns_default(self):
-    #     self._do_test(self._make_task({"retries": 42}), expected_until="")
+        self._do_retry_parameters_test(self._make_task({"delay": value}), expected_delay=value)

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -561,17 +561,12 @@ class TestTaskExecutorRetries:
         expected_delay = Task._delay.default
         self._do_retry_parameters_test(self._make_task(), expected_delay=expected_delay)
 
-    @pytest.mark.parametrize(
-        "value",
-        # [-1, None] # `None` is currently xfail
-        [-1]
-    )
-    def test_process_retry_parameters_delay_defaults(self, value):
-        self._do_retry_parameters_test(self._make_task({"delay":value}), expected_delay=1)
-
-    @pytest.mark.xfail(reason="existing behaviour is to error", raises=TypeError)
     def test_process_retry_parameters_null_delay_defaults(self):
-        self._do_retry_parameters_test(self._make_task({"delay":None}), expected_delay=1)
+        expected_delay = Task._delay.default
+        self._do_retry_parameters_test(self._make_task({"delay": None}), expected_delay=expected_delay)
+
+    def test_process_retry_parameters_negative_delay_results_1(self):
+        self._do_retry_parameters_test(self._make_task({"delay": -42}), expected_delay=1)
 
     @pytest.mark.parametrize(
         "value",

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -511,13 +511,15 @@ class TestTaskExecutorRetries:
         ({}, False),
         ({"retries": 42}, True),
         ({"until": valid_until}, True),
-        ({"retries": 42, "until": valid_until}, True)
+        ({"retries": 42, "until": valid_until}, True),
+        ({"retries": 0, "until": valid_until}, True)
     ])
     def test_retries_requested(self, task_extras, expected):
         assert expected == TaskExecutor._retries_requested(self._make_task(task_extras))
 
     def _do_test(self, task: Task, expected_retries=None, expected_delay=None):
-        retries, delay = TaskExecutor.process_retry_parameters(task)
+        retries_requested = TaskExecutor._retries_requested(task)
+        retries, delay = TaskExecutor.process_retry_parameters(retries_requested, task)
         
         if expected_retries is not None:
             assert expected_retries == retries
@@ -545,7 +547,7 @@ class TestTaskExecutorRetries:
     def test_process_retry_parameters_with_negative_retries_returns_1(self):
         self._do_test(self._make_task({"until": valid_until, "retries": -42}), expected_retries=1)
 
-    def test_process_retry_parameters_with_negative_retries_returns_0(self):
+    def test_process_retry_parameters_with_0_retries_returns_1(self):
         self._do_test(self._make_task({"until": valid_until, "retries": 0}), expected_retries=1)
 
     def test_process_retry_parameters_with_until_follows_retries(self):

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -499,7 +499,7 @@ valid_until = "taskresult is succeeded"
 class TestTaskExecutorRetries:
 
     @staticmethod
-    def _make_task(extra: Dict = None) -> Task:
+    def _make_task(extra=None):  # type: (Dict) -> Task
         params = dict(
             name='Test Task',
             command='echo hi',

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -492,6 +492,10 @@ class TestTaskExecutor(unittest.TestCase):
 
         self.assertEqual(remove_omit(data, omit_token), expected)
 
+
+valid_until = "taskresult is succeeded"
+
+
 class TestTaskExecutorRetries:
 
     @staticmethod
@@ -505,15 +509,14 @@ class TestTaskExecutorRetries:
 
     valid_until = "taskresult is succeeded"
 
-    def _do_test(self, task: Task, expected_retries=None, expected_delay=None, expected_until=None):
-        retries, delay, until = TaskExecutor.process_retry_parameters(task)
+    def _do_test(self, task: Task, expected_retries=None, expected_delay=None):
+        retries, delay = TaskExecutor.process_retry_parameters(task)
         
         if expected_retries is not None:
             assert expected_retries == retries
         if expected_delay is not None:
             assert expected_delay == delay
-        if expected_until is not None:
-            assert expected_until == until
+
 
     # retries
 
@@ -527,22 +530,22 @@ class TestTaskExecutorRetries:
 
     def test_process_retry_parameters_with_until_defaults_3(self):
         expected_retries = 3 + 1
-        self._do_test(self._make_task({"until": self.valid_until}), expected_retries=expected_retries)
+        self._do_test(self._make_task({"until": valid_until}), expected_retries=expected_retries)
 
     def test_process_retry_parameters_with_until_and_null_retry_defaults_3(self):
         expected_retries = 3 + 1
-        self._do_test(self._make_task({"until": self.valid_until, "retries": None}), expected_retries=expected_retries)
+        self._do_test(self._make_task({"until": valid_until, "retries": None}), expected_retries=expected_retries)
 
     def test_process_retry_parameters_with_negative_retries_returns_1(self):
-        self._do_test(self._make_task({"until": self.valid_until, "retries": -42}), expected_retries=1)
+        self._do_test(self._make_task({"until": valid_until, "retries": -42}), expected_retries=1)
 
     def test_process_retry_parameters_with_negative_retries_returns_0(self):
-        self._do_test(self._make_task({"until": self.valid_until, "retries": 0}), expected_retries=1)
+        self._do_test(self._make_task({"until": valid_until, "retries": 0}), expected_retries=1)
 
     def test_process_retry_parameters_with_until_follows_retries(self):
         retries = 42
         expected_retries = retries + 1
-        self._do_test(self._make_task({"until": self.valid_until, "retries": retries}), expected_retries=expected_retries)
+        self._do_test(self._make_task({"until": valid_until, "retries": retries}), expected_retries=expected_retries)
     
     # delay
 
@@ -571,8 +574,11 @@ class TestTaskExecutorRetries:
 
     # until
 
-    def test_process_retry_parameters_until_returns(self):
-        self._do_test(self._make_task({"until": self.valid_until}), expected_until=self.valid_until)
+    # def test_process_retry_parameters_until_returns(self):
+    #     self._do_test(self._make_task({"until": valid_until}), expected_until=valid_until)
 
-    def test_process_retry_parameters_no_until_and_no_retry_returns_emptylist(self):
-        self._do_test(self._make_task(), expected_until=[])
+    # def test_process_retry_parameters_no_until_and_no_retry_returns_emptylist(self):
+    #     self._do_test(self._make_task(), expected_until=[])
+
+    # def test_process_retry_parameters_no_until_with_retry_returns_default(self):
+    #     self._do_test(self._make_task({"retries": 42}), expected_until="")

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -558,11 +558,11 @@ class TestTaskExecutorRetries:
     # delay
 
     def test_process_retry_parameters_no_delay_defaults_to_Task_default(self):
-        expected_delay = Task._delay.default
+        expected_delay = Task.delay.default
         self._do_retry_parameters_test(self._make_task(), expected_delay=expected_delay)
 
     def test_process_retry_parameters_null_delay_defaults(self):
-        expected_delay = Task._delay.default
+        expected_delay = Task.delay.default
         self._do_retry_parameters_test(self._make_task({"delay": None}), expected_delay=expected_delay)
 
     def test_process_retry_parameters_negative_delay_results_1(self):


### PR DESCRIPTION
##### SUMMARY

Specifying `retries` without `until` defaults to using the `{{ task }} is succeeded`. This removes the boilerplate of having to register the output and check it succeeded. It also removes the need for the warning in the docs that simply specifying `retries` will not retry the task on failure.

Original
```yaml
  - name: old way
    get_url:
      url: http://1.2.3.4/zzz
      dest: /tmp/zzz
    retries: 2
    delay: 3
    register: result
    until: result is succeeded
# ---
  - name: new way
    get_url:
      url: http://1.2.3.4/zzz
      dest: /tmp/zzz
    retries: 2
    delay: 3
```
fixes #20802

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
until
TaskExecutor

##### ADDITIONAL INFORMATION
The existing MR #43128 appears to be inactive. One of the main reasons for returning it for rework was a lack of tests, for both the new and (especially) the existing behaviour. This MR  addresses that of those by extracting functions and pinning down the existing behaviour. It then changes the tests necessary for the new behaviour and demonstrates that they are compatible except for the new functionality. That is, it no longer ignores the `retries` parameter if `until` is not specified.
