### PR TITLE
Use -n instead of -N for Ubuntu luseradd command

### DIFF
--- a/changelogs/fragments/ubuntu_n_switch.yml
+++ b/changelogs/fragments/ubuntu_n_switch.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+     user - Ubuntu starting from version 20 only supports ``-n`` and not ``-N``
+     on the ``luseradd`` command.

--- a/changelogs/fragments/ubuntu_n_switch.yml
+++ b/changelogs/fragments/ubuntu_n_switch.yml
@@ -1,4 +1,4 @@
 bugfixes:
   - >-
-     user - Ubuntu starting from version 20 only supports ``-n`` and not ``-N``
+     user - Ubuntu starting from version 16 only supports ``-n`` and not ``-N``
      on the ``luseradd`` command.

--- a/changelogs/fragments/ubuntu_n_switch.yml
+++ b/changelogs/fragments/ubuntu_n_switch.yml
@@ -1,4 +1,5 @@
 bugfixes:
   - >-
      user - Ubuntu starting from version 16 only supports ``-n`` and not ``-N``
-     on the ``luseradd`` command.
+     on the ``luseradd`` command. The same is true for SuSE at least since
+     version 15.

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -679,7 +679,7 @@ class User(object):
                 if major_release >= 12:
                     cmd.append('-N')
             elif self.local and distro.id() == 'ubuntu' \
-                    and int(distro.major_version()) >= 20:
+                    and int(distro.major_version()) >= 16:
                 cmd.append('-n')
             else:
                 cmd.append('-N')

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -678,6 +678,9 @@ class User(object):
                 major_release = int(dist.split('.')[0])
                 if major_release >= 12:
                     cmd.append('-N')
+            elif self.local and distro.id() == 'ubuntu' \
+                    and int(distro.major_version()) >= 20:
+                cmd.append('-n')
             else:
                 cmd.append('-N')
 

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -673,7 +673,7 @@ class User(object):
                 else:
                     cmd.append('-N')
             elif os.path.exists('/etc/SuSE-release') \
-                    or distro_id == 'opensuse' or distro_id == 'sles':
+                    or distro_id.startswith('opensuse') or distro_id == 'sles':
                 # -N did not exist in useradd before SLE 11 and did not
                 # automatically create a group
                 dist = distro.version()

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -676,7 +676,11 @@ class User(object):
                 # automatically create a group
                 dist = distro.version()
                 major_release = int(dist.split('.')[0])
-                if major_release >= 12:
+                # At least since SLE 15 only -n seems to be supported by
+                # luseradd
+                if self.local and major_release >= 15:
+                    cmd.append('-n')
+                elif major_release >= 12:
                     cmd.append('-N')
             elif self.local and distro.id() == 'ubuntu' \
                     and int(distro.major_version()) >= 16:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -664,6 +664,7 @@ class User(object):
             # exists with the same name as the user to prevent
             # errors from useradd trying to create a group when
             # USERGROUPS_ENAB is set in /etc/login.defs.
+            distro_id = distro.id()
             if os.path.exists('/etc/redhat-release'):
                 dist = distro.version()
                 major_release = int(dist.split('.')[0])
@@ -671,7 +672,8 @@ class User(object):
                     cmd.append('-n')
                 else:
                     cmd.append('-N')
-            elif os.path.exists('/etc/SuSE-release'):
+            elif os.path.exists('/etc/SuSE-release') \
+                    or distro_id == 'opensuse' or distro_id == 'sles':
                 # -N did not exist in useradd before SLE 11 and did not
                 # automatically create a group
                 dist = distro.version()
@@ -682,7 +684,7 @@ class User(object):
                     cmd.append('-n')
                 elif major_release >= 12:
                     cmd.append('-N')
-            elif self.local and distro.id() == 'ubuntu' \
+            elif self.local and distro_id == 'ubuntu' \
                     and int(distro.major_version()) >= 16:
                 cmd.append('-n')
             else:

--- a/test/integration/targets/user/tasks/test_local.yml
+++ b/test/integration/targets/user/tasks/test_local.yml
@@ -130,6 +130,27 @@
   tags:
     - user_test_local_mode
 
+- name: Add local_ansibulluser group
+  group:
+    name: local_ansibulluser
+    state: present
+
+- name: Add user again with local_ansibulluser group present
+  user:
+    name: local_ansibulluser
+    state: present
+  tags:
+    - user_test_local_mode
+
+- name: Remove local_ansibulluser again
+  user:
+    name: local_ansibulluser
+    state: absent
+    remove: yes
+    local: yes
+  tags:
+    - user_test_local_mode
+
 - name: Remove test groups
   group:
     name: "{{ item }}"


### PR DESCRIPTION
##### SUMMARY
Ubuntu starting from version 20 only supports `-n` and not `-N`  on the `luseradd` command.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
