### PR TITLE
Drop python2.6 support in module execution

### DIFF
--- a/changelogs/fragments/drop-target-2.6-support.yml
+++ b/changelogs/fragments/drop-target-2.6-support.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- Module Python Dependency - Drop support for Python 2.6 in module execution.

--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.13.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.13.rst
@@ -1,9 +1,9 @@
 
 .. _porting_2.13_guide_core:
 
-**************************
+*******************************
 Ansible-core 2.13 Porting Guide
-**************************
+*******************************
 
 This section discusses the behavioral changes between ``ansible-core`` 2.12 and ``ansible-core`` 2.13.
 

--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.13.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.13.rst
@@ -1,15 +1,15 @@
 
-.. _porting_2.13_guide:
+.. _porting_2.13_guide_core:
 
 **************************
-Ansible 2.13 Porting Guide
+Ansible-core 2.13 Porting Guide
 **************************
 
-This section discusses the behavioral changes between Ansible 2.12 and Ansible 2.13.
+This section discusses the behavioral changes between ``ansible-core`` 2.12 and ``ansible-core`` 2.13.
 
 It is intended to assist in updating your playbooks, plugins and other parts of your Ansible infrastructure so they will work with this version of Ansible.
 
-We suggest you read this page along with `Ansible Changelog for 2.13 <https://github.com/ansible/ansible/blob/devel/changelogs/CHANGELOG-v2.13.rst>`_ to understand what updates you may need to make.
+We suggest you read this page along with `ansible-core Changelog for 2.13 <https://github.com/ansible/ansible/blob/devel/changelogs/CHANGELOG-v2.13.rst>`_ to understand what updates you may need to make.
 
 This document is part of a collection on porting. The complete list of porting guides can be found at :ref:`porting guides <porting_guides>`.
 
@@ -37,7 +37,7 @@ No notable changes
 Modules
 =======
 
-No notable changes
+* Python 2.7 is a hard requirement for module execution in this release. Any code utilizing ``ansible.module_utils.basic`` will not function with a lower Python version.
 
 
 Modules removed

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -248,24 +248,15 @@ PERMS_RE = re.compile(r'[^rwxXstugo]')
 
 # Used for determining if the system is running a new enough python version
 # and should only restrict on our documented minimum versions
-_PY3_MIN = sys.version_info[:2] >= (3, 5)
-_PY2_MIN = (2, 6) <= sys.version_info[:2] < (3,)
-_PY26 = (2, 6) == sys.version_info[:2]
+_PY3_MIN = sys.version_info >= (3, 5)
+_PY2_MIN = (2, 7) <= sys.version_info < (3,)
 _PY_MIN = _PY3_MIN or _PY2_MIN
 if not _PY_MIN:
     print(
         '\n{"failed": true, '
-        '"msg": "ansible-core requires a minimum of Python2 version 2.6 or Python3 version 3.5. Current version: %s"}' % ''.join(sys.version.splitlines())
+        '"msg": "ansible-core requires a minimum of Python2 version 2.7 or Python3 version 3.5. Current version: %s"}' % ''.join(sys.version.splitlines())
     )
     sys.exit(1)
-
-if _PY26:
-    deprecate(
-        'ansible-core 2.13 will require Python 2.7 or newer on the target. '
-        'Current version: %s' % ''.join(sys.version.splitlines()),
-        version='2.13',
-    )
-
 
 #
 # Deprecated functions

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -258,6 +258,7 @@ if not _PY_MIN:
     )
     sys.exit(1)
 
+
 #
 # Deprecated functions
 #


### PR DESCRIPTION
##### SUMMARY
Drop python2.6 support in module execution

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
