### PR TITLE
Don't use output_dir in target tests

### DIFF
--- a/test/integration/targets/blockinfile/meta/main.yml
+++ b/test/integration/targets/blockinfile/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
   - prepare_tests
+  - setup_remote_tmp_dir

--- a/test/integration/targets/blockinfile/tasks/add_block_to_existing_file.yml
+++ b/test/integration/targets/blockinfile/tasks/add_block_to_existing_file.yml
@@ -1,11 +1,11 @@
 - name: copy the sshd_config to the test dir
   copy:
     src: sshd_config
-    dest: "{{ output_dir_test }}"
+    dest: "{{ remote_tmp_dir_test }}"
 
 - name: insert/update "Match User" configuration block in sshd_config
   blockinfile:
-    path: "{{ output_dir_test }}/sshd_config"
+    path: "{{ remote_tmp_dir_test }}/sshd_config"
     block: |
       Match User ansible-agent
       PasswordAuthentication no
@@ -18,7 +18,7 @@
       - "'backup_file' in blockinfile_test0"
 
 - name: check content
-  shell: 'grep -c -e "Match User ansible-agent" -e "PasswordAuthentication no" {{ output_dir_test }}/sshd_config'
+  shell: 'grep -c -e "Match User ansible-agent" -e "PasswordAuthentication no" {{ remote_tmp_dir_test }}/sshd_config'
   register: blockinfile_test0_grep
 
 - debug:
@@ -40,7 +40,7 @@
 
 - name: check idemptotence
   blockinfile:
-    path: "{{ output_dir_test }}/sshd_config"
+    path: "{{ remote_tmp_dir_test }}/sshd_config"
     block: |
       Match User ansible-agent
       PasswordAuthentication no

--- a/test/integration/targets/blockinfile/tasks/block_without_trailing_newline.yml
+++ b/test/integration/targets/blockinfile/tasks/block_without_trailing_newline.yml
@@ -1,6 +1,6 @@
 - name: Add block without trailing line separator
   blockinfile:
-    path: "{{ output_dir_test }}/chomped_block_test.txt"
+    path: "{{ remote_tmp_dir_test }}/chomped_block_test.txt"
     create: yes
     content: |-
       one
@@ -10,7 +10,7 @@
 
 - name: Add block without trailing line separator again
   blockinfile:
-    path: "{{ output_dir_test }}/chomped_block_test.txt"
+    path: "{{ remote_tmp_dir_test }}/chomped_block_test.txt"
     content: |-
       one
       two
@@ -19,7 +19,7 @@
 
 - name: Check output file
   stat:
-    path: "{{ output_dir_test }}/chomped_block_test.txt"
+    path: "{{ remote_tmp_dir_test }}/chomped_block_test.txt"
   register: chomptest_file
 
 - name: Ensure chomptest results are correct

--- a/test/integration/targets/blockinfile/tasks/create_file.yml
+++ b/test/integration/targets/blockinfile/tasks/create_file.yml
@@ -1,6 +1,6 @@
 - name: Create a file with blockinfile
   blockinfile:
-    path: "{{ output_dir_test }}/empty.txt"
+    path: "{{ remote_tmp_dir_test }}/empty.txt"
     block: |
       Hey
       there
@@ -10,7 +10,7 @@
 
 - name: Run a task that results in an empty file
   blockinfile:
-    path: "{{ output_dir_test }}/empty.txt"
+    path: "{{ remote_tmp_dir_test }}/empty.txt"
     block: |
       Hey
       there
@@ -19,7 +19,7 @@
   register: empty_test_2
 
 - stat:
-    path: "{{ output_dir_test }}/empty.txt"
+    path: "{{ remote_tmp_dir_test }}/empty.txt"
   register: empty_test_stat
 
 - name: Ensure empty file was created

--- a/test/integration/targets/blockinfile/tasks/diff.yml
+++ b/test/integration/targets/blockinfile/tasks/diff.yml
@@ -1,11 +1,11 @@
 - name: Create a test file
   copy:
     content: diff test
-    dest: "{{ output_dir_test }}/diff.txt"
+    dest: "{{ remote_tmp_dir_test }}/diff.txt"
 
 - name: Add block to file with diff
   blockinfile:
-    path: "{{ output_dir_test }}/diff.txt"
+    path: "{{ remote_tmp_dir_test }}/diff.txt"
     block: |
       line 1
       line 2

--- a/test/integration/targets/blockinfile/tasks/file_without_trailing_newline.yml
+++ b/test/integration/targets/blockinfile/tasks/file_without_trailing_newline.yml
@@ -1,13 +1,13 @@
 - name: Create file without trailing newline
   copy:
     content: '# File with no newline'
-    dest: "{{ output_dir_test }}/no_newline_at_end.txt"
+    dest: "{{ remote_tmp_dir_test }}/no_newline_at_end.txt"
   register: no_newline
 
 
 - name: Add block to file that does not have a newline at the end
   blockinfile:
-    path: "{{ output_dir_test }}/no_newline_at_end.txt"
+    path: "{{ remote_tmp_dir_test }}/no_newline_at_end.txt"
     content: |
       one
       two
@@ -16,7 +16,7 @@
 
 - name: Add block to file that does not have a newline at the end again
   blockinfile:
-    path: "{{ output_dir_test }}/no_newline_at_end.txt"
+    path: "{{ remote_tmp_dir_test }}/no_newline_at_end.txt"
     content: |
       one
       two
@@ -25,7 +25,7 @@
 
 - name: Stat the file
   stat:
-    path: "{{ output_dir_test }}/no_newline_at_end.txt"
+    path: "{{ remote_tmp_dir_test }}/no_newline_at_end.txt"
   register: no_newline_file
 
 - name: Ensure block was correctly written to file with no newline at end

--- a/test/integration/targets/blockinfile/tasks/insertafter.yml
+++ b/test/integration/targets/blockinfile/tasks/insertafter.yml
@@ -1,6 +1,6 @@
 - name: Create insertafter test file
   copy:
-    dest: "{{ output_dir }}/after.txt"
+    dest: "{{ remote_tmp_dir }}/after.txt"
     content: |
       line1
       line2
@@ -8,7 +8,7 @@
 
 - name: Add block using insertafter
   blockinfile:
-    path: "{{ output_dir }}/after.txt"
+    path: "{{ remote_tmp_dir }}/after.txt"
     insertafter: line2
     block: |
       block1
@@ -17,7 +17,7 @@
 
 - name: Add block using insertafter again
   blockinfile:
-    path: "{{ output_dir }}/after.txt"
+    path: "{{ remote_tmp_dir }}/after.txt"
     insertafter: line2
     block: |
       block1
@@ -26,7 +26,7 @@
 
 - name: Stat the after.txt file
   stat:
-    path: "{{ output_dir }}/after.txt"
+    path: "{{ remote_tmp_dir }}/after.txt"
   register: after_file
 
 - name: Ensure insertafter worked correctly

--- a/test/integration/targets/blockinfile/tasks/insertbefore.yml
+++ b/test/integration/targets/blockinfile/tasks/insertbefore.yml
@@ -1,6 +1,6 @@
 - name: Create insertbefore test file
   copy:
-    dest: "{{ output_dir }}/before.txt"
+    dest: "{{ remote_tmp_dir }}/before.txt"
     content: |
       line1
       line2
@@ -8,7 +8,7 @@
 
 - name: Add block using insertbefore
   blockinfile:
-    path: "{{ output_dir }}/before.txt"
+    path: "{{ remote_tmp_dir }}/before.txt"
     insertbefore: line2
     block: |
       block1
@@ -17,7 +17,7 @@
 
 - name: Add block using insertbefore again
   blockinfile:
-    path: "{{ output_dir }}/before.txt"
+    path: "{{ remote_tmp_dir }}/before.txt"
     insertbefore: line2
     block: |
       block1
@@ -26,10 +26,10 @@
 
 - name: Stat the before.txt file
   stat:
-    path: "{{ output_dir }}/before.txt"
+    path: "{{ remote_tmp_dir }}/before.txt"
   register: after_file
 
-- command: cat {{ output_dir }}/before.txt
+- command: cat {{ remote_tmp_dir }}/before.txt
 
 - name: Ensure insertbefore worked correctly
   assert:

--- a/test/integration/targets/blockinfile/tasks/main.yml
+++ b/test/integration/targets/blockinfile/tasks/main.yml
@@ -17,16 +17,16 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 - set_fact:
-    output_dir_test: "{{ output_dir }}/test_blockinfile"
+    remote_tmp_dir_test: "{{ remote_tmp_dir }}/test_blockinfile"
 
 - name: make sure our testing sub-directory does not exist
   file:
-    path: "{{ output_dir_test }}"
+    path: "{{ remote_tmp_dir_test }}"
     state: absent
 
 - name: create our testing sub-directory
   file:
-    path: "{{ output_dir_test }}"
+    path: "{{ remote_tmp_dir_test }}"
     state: directory
 
 - import_tasks: add_block_to_existing_file.yml

--- a/test/integration/targets/blockinfile/tasks/preserve_line_endings.yml
+++ b/test/integration/targets/blockinfile/tasks/preserve_line_endings.yml
@@ -1,19 +1,19 @@
 - name: create line_endings_test.txt in the test dir
   copy:
-    dest: "{{ output_dir_test }}/line_endings_test.txt"
+    dest: "{{ remote_tmp_dir_test }}/line_endings_test.txt"
     # generating the content like this instead of copying a fixture file
     # prevents sanity checks from warning about mixed line endings
     content: "unix\nunix\nunix\n\ndos\r\ndos\r\ndos\r\n\nunix\nunix\n# BEGIN ANSIBLE MANAGED BLOCK\ndos\r\n# END ANSIBLE MANAGED BLOCK\nunix\nunix\nunix\nunix\n"
 
 - name: insert/update "dos" configuration block in line_endings_test.txt
   blockinfile:
-    path: "{{ output_dir_test }}/line_endings_test.txt"
+    path: "{{ remote_tmp_dir_test }}/line_endings_test.txt"
     block: "dos\r\ndos\r\ndos\r\n"
   register: blockinfile_test2
 
 - name: check content
   # using the more precise `grep -Pc "^dos\\r$" ...` fails on BSD/macOS
-  shell: 'grep -c "^dos.$" {{ output_dir_test }}/line_endings_test.txt'
+  shell: 'grep -c "^dos.$" {{ remote_tmp_dir_test }}/line_endings_test.txt'
   register: blockinfile_test2_grep
 
 - name: validate line_endings_test.txt results

--- a/test/integration/targets/blockinfile/tasks/validate.yml
+++ b/test/integration/targets/blockinfile/tasks/validate.yml
@@ -1,6 +1,6 @@
 - name: EXPECTED FAILURE test improper validate
   blockinfile:
-    path: "{{ output_dir }}/validate.txt"
+    path: "{{ remote_tmp_dir }}/validate.txt"
     block: |
       line1
       line2
@@ -10,7 +10,7 @@
 
 - name: EXPECTED FAILURE test failure to validate
   blockinfile:
-    path: "{{ output_dir }}/validate.txt"
+    path: "{{ remote_tmp_dir }}/validate.txt"
     block: |
       line1
       line2
@@ -20,7 +20,7 @@
 
 - name: Test proper validate
   blockinfile:
-    path: "{{ output_dir }}/validate.txt"
+    path: "{{ remote_tmp_dir }}/validate.txt"
     block: |
       line1
       line2

--- a/test/integration/targets/git/meta/main.yml
+++ b/test/integration/targets/git/meta/main.yml
@@ -1,3 +1,4 @@
 dependencies:
   - prepare_tests
   - setup_gnutar
+  - setup_remote_tmp_dir

--- a/test/integration/targets/git/tasks/missing_hostkey.yml
+++ b/test/integration/targets/git/tasks/missing_hostkey.yml
@@ -2,7 +2,7 @@
   git:
     repo: '{{ repo_format2 }}'
     dest: '{{ checkout_dir }}'
-    ssh_opts: '-o UserKnownHostsFile={{ output_dir }}/known_hosts'
+    ssh_opts: '-o UserKnownHostsFile={{ remote_tmp_dir }}/known_hosts'
   register: git_result
   ignore_errors: true
 
@@ -16,7 +16,7 @@
     dest: '{{ checkout_dir }}'
     accept_hostkey: true
     key_file: '{{ github_ssh_private_key }}'
-    ssh_opts: '-o UserKnownHostsFile={{ output_dir }}/known_hosts'
+    ssh_opts: '-o UserKnownHostsFile={{ remote_tmp_dir }}/known_hosts'
   register: git_result
   when: github_ssh_private_key is defined
 
@@ -38,7 +38,7 @@
     version: 'master'
     accept_hostkey: false # should already have been accepted
     key_file: '{{ github_ssh_private_key }}'
-    ssh_opts: '-o UserKnownHostsFile={{ output_dir }}/known_hosts'
+    ssh_opts: '-o UserKnownHostsFile={{ remote_tmp_dir }}/known_hosts'
   register: git_result
   when: github_ssh_private_key is defined
 
@@ -49,7 +49,7 @@
 
 - name: MISSING-HOSTEKY | Remove github.com hostkey from known_hosts
   lineinfile:
-    dest: '{{ output_dir }}/known_hosts'
+    dest: '{{ remote_tmp_dir }}/known_hosts'
     regexp: "github.com"
     state: absent
   when: github_ssh_private_key is defined

--- a/test/integration/targets/git/tasks/missing_hostkey_acceptnew.yml
+++ b/test/integration/targets/git/tasks/missing_hostkey_acceptnew.yml
@@ -9,7 +9,7 @@
         repo: '{{ repo_format2 }}'
         dest: '{{ checkout_dir }}'
         accept_newhostkey: true
-        ssh_opts: '-o UserKnownHostsFile={{ output_dir }}/known_hosts'
+        ssh_opts: '-o UserKnownHostsFile={{ remote_tmp_dir }}/known_hosts'
       register: git_result
       ignore_errors: true
 
@@ -24,7 +24,7 @@
   git:
     repo: '{{ repo_format2 }}'
     dest: '{{ checkout_dir }}'
-    ssh_opts: '-o UserKnownHostsFile={{ output_dir }}/known_hosts'
+    ssh_opts: '-o UserKnownHostsFile={{ remote_tmp_dir }}/known_hosts'
   register: git_result
   ignore_errors: true
 
@@ -39,7 +39,7 @@
         dest: '{{ checkout_dir }}'
         accept_newhostkey: true
         key_file: '{{ github_ssh_private_key }}'
-        ssh_opts: '-o UserKnownHostsFile={{ output_dir }}/known_hosts'
+        ssh_opts: '-o UserKnownHostsFile={{ remote_tmp_dir }}/known_hosts'
       register: git_result
 
     - assert:
@@ -58,7 +58,7 @@
         version: 'master'
         accept_newhostkey: false # should already have been accepted
         key_file: '{{ github_ssh_private_key }}'
-        ssh_opts: '-o UserKnownHostsFile={{ output_dir }}/known_hosts'
+        ssh_opts: '-o UserKnownHostsFile={{ remote_tmp_dir }}/known_hosts'
       register: git_result
 
     - assert:
@@ -67,7 +67,7 @@
 
     - name: MISSING-HOSTEKY | Remove github.com hostkey from known_hosts
       lineinfile:
-        dest: '{{ output_dir }}/known_hosts'
+        dest: '{{ remote_tmp_dir }}/known_hosts'
         regexp: "github.com"
         state: absent
 

--- a/test/integration/targets/git/tasks/setup.yml
+++ b/test/integration/targets/git/tasks/setup.yml
@@ -1,11 +1,11 @@
-- name: SETUP | clean out the output_dir
+- name: SETUP | clean out the remote_tmp_dir
   file:
-    path: "{{ output_dir }}"
+    path: "{{ remote_tmp_dir }}"
     state: absent
 
-- name: SETUP | create clean output_dir
+- name: SETUP | create clean remote_tmp_dir
   file:
-    path: "{{ output_dir }}"
+    path: "{{ remote_tmp_dir }}"
     state: directory
 
 - name: SETUP | install git

--- a/test/integration/targets/git/vars/main.yml
+++ b/test/integration/targets/git/vars/main.yml
@@ -27,9 +27,9 @@ git_list_commands:
   tgz: tar -tf
   zip: unzip -Z1
 
-checkout_dir: '{{ output_dir }}/git'
-repo_dir: '{{ output_dir }}/local_repos'
-separate_git_dir: '{{ output_dir }}/sep_git_dir'
+checkout_dir: '{{ remote_tmp_dir }}/git'
+repo_dir: '{{ remote_tmp_dir }}/local_repos'
+separate_git_dir: '{{ remote_tmp_dir }}/sep_git_dir'
 repo_format1: 'https://github.com/jimi-c/test_role'
 repo_format2: 'git@github.com:jimi-c/test_role.git'
 repo_format3: 'ssh://git@github.com/jimi-c/test_role.git'

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -19,8 +19,8 @@
 - name: set role facts
   set_fact:
     http_port: 15260
-    files_dir: '{{ output_dir|expanduser }}/files'
-    checkout_dir: '{{ output_dir }}/git'
+    files_dir: '{{ remote_tmp_dir|expanduser }}/files'
+    checkout_dir: '{{ remote_tmp_dir }}/git'
 
 - name: create a directory to serve files from
   file:
@@ -39,10 +39,10 @@
 
 - copy:
     src: "testserver.py"
-    dest: "{{ output_dir }}/testserver.py"
+    dest: "{{ remote_tmp_dir }}/testserver.py"
 
 - name: start SimpleHTTPServer
-  shell: cd {{ files_dir }} && {{ ansible_python.executable }} {{ output_dir}}/testserver.py {{ http_port }}
+  shell: cd {{ files_dir }} && {{ ansible_python.executable }} {{ remote_tmp_dir}}/testserver.py {{ http_port }}
   async: 120 # this test set can take ~1m to run on FreeBSD (via Shippable)
   poll: 0
 
@@ -91,12 +91,12 @@
 - name: test https fetch to a site with mismatched hostname and certificate
   uri:
     url: "https://{{ badssl_host }}/"
-    dest: "{{ output_dir }}/shouldnotexist.html"
+    dest: "{{ remote_tmp_dir }}/shouldnotexist.html"
   ignore_errors: True
   register: result
 
 - stat:
-    path: "{{ output_dir }}/shouldnotexist.html"
+    path: "{{ remote_tmp_dir }}/shouldnotexist.html"
   register: stat_result
 
 - name: Assert that the file was not downloaded
@@ -111,18 +111,18 @@
 
 - name: Clean up any cruft from the results directory
   file:
-    name: "{{ output_dir }}/kreitz.html"
+    name: "{{ remote_tmp_dir }}/kreitz.html"
     state: absent
 
 - name: test https fetch to a site with mismatched hostname and certificate and validate_certs=no
   uri:
     url: "https://{{ badssl_host }}/"
-    dest: "{{ output_dir }}/kreitz.html"
+    dest: "{{ remote_tmp_dir }}/kreitz.html"
     validate_certs: no
   register: result
 
 - stat:
-    path: "{{ output_dir }}/kreitz.html"
+    path: "{{ remote_tmp_dir }}/kreitz.html"
   register: stat_result
 
 - name: Assert that the file was downloaded
@@ -139,13 +139,13 @@
 - name: test https fetch to a site with self signed certificate using ca_path
   uri:
     url: "https://{{ self_signed_host }}:444/"
-    dest: "{{ output_dir }}/self-signed_using_ca_path.html"
+    dest: "{{ remote_tmp_dir }}/self-signed_using_ca_path.html"
     ca_path: "{{ remote_tmp_dir }}/ca2cert.pem"
     validate_certs: yes
   register: result
 
 - stat:
-    path: "{{ output_dir }}/self-signed_using_ca_path.html"
+    path: "{{ remote_tmp_dir }}/self-signed_using_ca_path.html"
   register: stat_result
 
 - name: Assert that the file was downloaded
@@ -157,13 +157,13 @@
 - name: test https fetch to a site with self signed certificate without using ca_path
   uri:
     url: "https://{{ self_signed_host }}:444/"
-    dest: "{{ output_dir }}/self-signed-without_using_ca_path.html"
+    dest: "{{ remote_tmp_dir }}/self-signed-without_using_ca_path.html"
     validate_certs: yes
   register: result
   ignore_errors: true
 
 - stat:
-    path: "{{ output_dir }}/self-signed-without_using_ca_path.html"
+    path: "{{ remote_tmp_dir }}/self-signed-without_using_ca_path.html"
   register: stat_result
 
 - name: Assure that https access to a host with self-signed certificate without providing ca_path fails
@@ -672,16 +672,16 @@
 - name: Create a testing file
   copy:
     content: "content"
-    dest: "{{ output_dir }}/output"
+    dest: "{{ remote_tmp_dir }}/output"
 
 - name: Download a file from non existing location
   uri:
     url: http://does/not/exist
-    dest: "{{ output_dir }}/output"
+    dest: "{{ remote_tmp_dir }}/output"
   ignore_errors: yes
 
 - name: Save testing file's output
-  command: "cat {{ output_dir }}/output"
+  command: "cat {{ remote_tmp_dir }}/output"
   register: file_out
 
 - name: Test the testing file was not overwritten
@@ -691,7 +691,7 @@
 
 - name: Clean up
   file:
-    dest: "{{ output_dir }}/output"
+    dest: "{{ remote_tmp_dir }}/output"
     state: absent
 
 - name: Test follow_redirects=none

--- a/test/integration/targets/uri/tasks/unexpected-failures.yml
+++ b/test/integration/targets/uri/tasks/unexpected-failures.yml
@@ -1,6 +1,6 @@
 ---
 # same as expanduser & expandvars called on managed host
-- command: 'echo {{ output_dir }}'
+- command: 'echo {{ remote_tmp_dir }}'
   register: echo
 
 - set_fact:
@@ -8,13 +8,13 @@
 
 - name: ensure test directory doesn't exist
   file:
-    path: '{{ output_dir }}/non/existent/path'
+    path: '{{ remote_tmp_dir }}/non/existent/path'
     state: absent
 
 - name: destination doesn't exist
   uri:
     url: 'https://{{ httpbin_host }}/get'
-    dest: '{{ output_dir }}/non/existent/path'
+    dest: '{{ remote_tmp_dir }}/non/existent/path'
   ignore_errors: true
   register: ret
 

--- a/test/integration/targets/user/tasks/test_ssh_key_passphrase.yml
+++ b/test/integration/targets/user/tasks/test_ssh_key_passphrase.yml
@@ -10,11 +10,12 @@
     state: present
     generate_ssh_key: yes
     force: yes
-    ssh_key_file: "{{ output_dir }}/test_id_rsa"
+    ssh_key_file: .ssh/test_id_rsa
     ssh_key_passphrase: secret_passphrase
+  register: ansibulluser_create_with_ssh_key
 
 - name: Unlock ssh key
-  command: "ssh-keygen -y -f {{ output_dir }}/test_id_rsa -P secret_passphrase"
+  command: "ssh-keygen -y -f {{ ansibulluser_create_with_ssh_key.ssh_key_file|quote }} -P secret_passphrase"
   register: result
 
 - name: Check that ssh key was unlocked successfully
@@ -24,6 +25,6 @@
 
 - name: Clean ssh key
   file:
-    path: "{{ output_dir }}/test_id_rsa"
+    path: "{{ ansibulluser_create_with_ssh_key.ssh_key_file }}"
     state: absent
   when: ansible_os_family == 'FreeBSD'


### PR DESCRIPTION
##### SUMMARY
Don't use `output_dir` in target tests.  Rely on not needing a temp dir, or depending on `setup_remote_tmp_dir`.

Targets addressed in this PR:

- `user`
- `blockinfile`
- `git`
- `uri`

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/integration/targets/user/tasks/test_ssh_key_passphrase.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
