### PR TITLE
Add turbo mode support

### DIFF
--- a/lib/ansible/module_utils/turbo/common.py
+++ b/lib/ansible/module_utils/turbo/common.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2021 Red Hat
+#
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+import os
+import socket
+import sys
+import time
+import subprocess
+import pickle
+from contextlib import contextmanager
+import json
+
+from .exceptions import (
+    EmbeddedModuleUnexpectedFailure,
+)
+
+
+class AnsibleTurboSocket:
+    def __init__(self, socket_path, ttl=None, plugin="module"):
+        self._socket_path = socket_path
+        self._ttl = ttl
+        self._plugin = plugin
+        self._socket = None
+
+    def bind(self):
+        running = False
+        self._socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        for attempt in range(100, -1, -1):
+            try:
+                self._socket.connect(self._socket_path)
+                return True
+            except (ConnectionRefusedError, FileNotFoundError):
+                if not running:
+                    running = self.start_server()
+                if attempt == 0:
+                    raise
+            time.sleep(0.01)
+
+    def start_server(self):
+        env = os.environ
+        parameters = [
+            "--fork",
+            "--socket-path",
+            self._socket_path,
+        ]
+
+        if self._ttl:
+            parameters += ["--ttl", str(self._ttl)]
+
+        command = [sys.executable]
+        if self._plugin == "module":
+            ansiblez_path = sys.path[0]
+            env.update({"PYTHONPATH": ansiblez_path})
+            command += [
+                "-m",
+                "ansible.module_utils.turbo.server",
+            ]
+        else:
+            parent_dir = os.path.dirname(__file__)
+            server_path = os.path.join(parent_dir, "server.py")
+            command += [server_path]
+        p = subprocess.Popen(
+            command + parameters,
+            env=env,
+            close_fds=True,
+        )
+        p.communicate()
+        return p.pid
+
+    def communicate(self, data, wait_sleep=0.01):
+        encoded_data = pickle.dumps((self._plugin, data))
+        self._socket.sendall(encoded_data)
+        self._socket.shutdown(socket.SHUT_WR)
+        raw_answer = b""
+        while True:
+            b = self._socket.recv((1024 * 1024))
+            if not b:
+                break
+            raw_answer += b
+            time.sleep(wait_sleep)
+        try:
+            result = json.loads(raw_answer.decode())
+            return result
+        except json.decoder.JSONDecodeError:
+            raise EmbeddedModuleUnexpectedFailure(
+                "Cannot decode plugin answer: {0}".format(raw_answer)
+            )
+
+    def close(self):
+        if self._socket:
+            self._socket.close()
+
+
+@contextmanager
+def connect(socket_path, ttl=None, plugin="module"):
+    turbo_socket = AnsibleTurboSocket(socket_path=socket_path, ttl=ttl, plugin=plugin)
+    try:
+        turbo_socket.bind()
+        yield turbo_socket
+    finally:
+        turbo_socket.close()

--- a/lib/ansible/module_utils/turbo/exceptions.py
+++ b/lib/ansible/module_utils/turbo/exceptions.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2021 Red Hat
+#
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+
+class EmbeddedModuleFailure(Exception):
+    def __init__(self, msg, **kwargs):
+        self._message = msg
+        self._kwargs = kwargs
+
+    def get_message(self):
+        return self._message
+
+    @property
+    def kwargs(self):
+        return self._kwargs
+
+    def __repr__(self):
+        return repr(self.get_message())
+
+    def __str__(self):
+        return str(self.get_message())
+
+
+class EmbeddedModuleUnexpectedFailure(Exception):
+    def __init__(self, msg):
+        self._message = msg
+
+    def get_message(self):
+        return self._message
+
+    def __repr__(self):
+        return repr(self.get_message())
+
+    def __str__(self):
+        return str(self.get_message())
+
+
+class EmbeddedModuleSuccess(Exception):
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs

--- a/lib/ansible/module_utils/turbo/module.py
+++ b/lib/ansible/module_utils/turbo/module.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2021 Red Hat
+#
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+import json
+import os
+import os.path
+import sys
+import tempfile
+
+import ansible.module_utils.basic
+from .exceptions import (
+    EmbeddedModuleSuccess,
+    EmbeddedModuleFailure,
+)
+import ansible.module_utils.turbo.common
+
+if False:  # pylint: disable=using-constant-test
+    from .server import please_include_me
+
+    # This is a trick to be sure server.py is embedded in the Ansiblez
+    # zip archive.🥷
+    please_include_me
+
+
+def get_collection_name_from_path():
+    module_path = ansible.module_utils.basic.get_module_path()
+
+    ansiblez = module_path.split("/")[-3]
+    if ansiblez.startswith("ansible_") and ansiblez.endswith(".zip"):
+        return ".".join(ansiblez[8:].split(".")[:2])
+
+
+def expand_argument_specs_aliases(argument_spec):
+    """Returns a dict of accepted argument that includes the aliases"""
+    expanded_argument_specs = {}
+    for k, v in argument_spec.items():
+        for alias in [k] + v.get("aliases", []):
+            expanded_argument_specs[alias] = v
+    return expanded_argument_specs
+
+
+def prepare_args(argument_specs, params):
+    """Take argument_spec and the user params and prepare the final argument structure."""
+
+    def _keep_value(v, argument_specs, key, subkey=None):
+        if v is None:  # cannot be a valide parameter
+            return False
+        if key not in argument_specs:  # should never happen
+            return
+        if not subkey:  # level 1 parameter
+            return v != argument_specs[key].get("default")
+        elif subkey not in argument_specs[key]:  # Freeform
+            return True
+        elif isinstance(argument_specs[key][subkey], dict):
+            return v != argument_specs[key][subkey].get("default")
+        else:  # should never happen
+            return True
+
+    def _is_an_alias(k):
+        aliases = argument_specs[k].get("aliases")
+        return aliases and k in aliases
+
+    new_params = {}
+    for k, v in params.items():
+        if not _keep_value(v, argument_specs, k):
+            continue
+
+        if _is_an_alias(k):
+            continue
+
+        if isinstance(v, dict):
+            new_params[k] = {
+                i: j for i, j in v.items() if _keep_value(j, argument_specs, k, i)
+            }
+        else:
+            new_params[k] = v
+    args = {"ANSIBLE_MODULE_ARGS": new_params}
+    return args
+
+
+class AnsibleTurboModule(ansible.module_utils.basic.AnsibleModule):
+    embedded_in_server = False
+    collection_name = None
+
+    def __init__(self, *args, **kwargs):
+        self.embedded_in_server = sys.argv[0].endswith("/server.py")
+        self.collection_name = (
+            AnsibleTurboModule.collection_name or get_collection_name_from_path()
+        )
+        ansible.module_utils.basic.AnsibleModule.__init__(
+            self, *args, bypass_checks=not self.embedded_in_server, **kwargs
+        )
+        self._running = None
+        if not self.embedded_in_server:
+            self.run_on_daemon()
+
+    def socket_path(self):
+        if self._remote_tmp is None:
+            abs_remote_tmp = tempfile.gettempdir()
+        else:
+            abs_remote_tmp = os.path.expanduser(os.path.expandvars(self._remote_tmp))
+        return os.path.join(abs_remote_tmp, f"turbo_mode.{self.collection_name}.socket")
+
+    def init_args(self):
+        argument_specs = expand_argument_specs_aliases(self.argument_spec)
+        args = prepare_args(argument_specs, self.params)
+        for k in ansible.module_utils.basic.PASS_VARS:
+            attribute = ansible.module_utils.basic.PASS_VARS[k][0]
+            if not hasattr(self, attribute):
+                continue
+            v = getattr(self, attribute)
+            if isinstance(v, int) or isinstance(v, bool) or isinstance(v, str):
+                args["ANSIBLE_MODULE_ARGS"][f"_ansible_{k}"] = v
+        return args
+
+    def run_on_daemon(self):
+        result = dict(changed=False, original_message="", message="")
+        ttl = os.environ.get("ANSIBLE_TURBO_LOOKUP_TTL", None)
+        with ansible.module_utils.turbo.common.connect(
+            socket_path=self.socket_path(), ttl=ttl
+        ) as turbo_socket:
+            ansiblez_path = sys.path[0]
+            args = self.init_args()
+            data = [
+                ansiblez_path,
+                json.dumps(args),
+                dict(os.environ),
+            ]
+            content = json.dumps(data).encode()
+            result = turbo_socket.communicate(content)
+        self.exit_json(**result)
+
+    def exit_json(self, **kwargs):
+        if not self.embedded_in_server:
+            super().exit_json(**kwargs)
+        else:
+            self.do_cleanup_files()
+            raise EmbeddedModuleSuccess(**kwargs)
+
+    def fail_json(self, *args, **kwargs):
+        if not self.embedded_in_server:
+            super().fail_json(**kwargs)
+        else:
+            self.do_cleanup_files()
+            raise EmbeddedModuleFailure(*args, **kwargs)

--- a/lib/ansible/module_utils/turbo/server.py
+++ b/lib/ansible/module_utils/turbo/server.py
@@ -1,0 +1,383 @@
+# Copyright (c) 2021 Red Hat
+#
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+import argparse
+import asyncio
+import importlib
+
+# py38 only, See: https://github.com/PyCQA/pylint/issues/2976
+import inspect  # pylint: disable=syntax-error
+import io
+import json
+
+# py38 only, See: https://github.com/PyCQA/pylint/issues/2976
+import collections  # pylint: disable=syntax-error
+import os
+import signal
+import sys
+import traceback
+import zipfile
+from zipimport import zipimporter
+import pickle
+
+sys_path_lock = None
+env_lock = None
+
+import ansible.module_utils.basic
+
+please_include_me = "bar"
+
+
+def fork_process():
+    """
+    This function performs the double fork process to detach from the
+    parent process and execute.
+    """
+    pid = os.fork()
+
+    if pid == 0:
+        fd = os.open(os.devnull, os.O_RDWR)
+
+        # clone stdin/out/err
+        for num in range(3):
+            if fd != num:
+                os.dup2(fd, num)
+
+        if fd not in range(3):
+            os.close(fd)
+
+        pid = os.fork()
+        if pid > 0:
+            os._exit(0)
+
+        # get new process session and detach
+        sid = os.setsid()
+        if sid == -1:
+            raise Exception("Unable to detach session while daemonizing")
+
+        # avoid possible problems with cwd being removed
+        os.chdir("/")
+
+        pid = os.fork()
+        if pid > 0:
+            sys.exit(0)  # pylint: disable=ansible-bad-function
+    else:
+        sys.exit(0)  # pylint: disable=ansible-bad-function
+    return pid
+
+
+class EmbeddedModule:
+    def __init__(self, ansiblez_path, params):
+        self.ansiblez_path = ansiblez_path
+        self.collection_name, self.module_name = self.find_module_name()
+        self.params = params
+        self.module_class = None
+        self.debug_mode = False
+        self.module_path = (
+            "ansible_collections.{collection_name}." "plugins.modules.{module_name}"
+        ).format(collection_name=self.collection_name, module_name=self.module_name)
+
+    def find_module_name(self):
+        with zipfile.ZipFile(self.ansiblez_path) as zip:
+            for path in zip.namelist():
+                if not path.startswith("ansible_collections"):
+                    continue
+                if not path.endswith(".py"):
+                    continue
+                if path.endswith("__init__.py"):
+                    continue
+                splitted = path.split("/")
+                if len(splitted) != 6:
+                    continue
+                if splitted[-3:-1] != ["plugins", "modules"]:
+                    continue
+                collection = ".".join(splitted[1:3])
+                name = splitted[-1][:-3]
+                return collection, name
+        raise Exception("Cannot find module name")
+
+    async def load(self):
+        async with sys_path_lock:
+            # Add the Ansiblez_path in sys.path
+            sys.path.insert(0, self.ansiblez_path)
+
+            # resettle the loaded modules that were associated
+            # with a different Ansiblez.
+            for path, module in tuple(sys.modules.items()):
+                if path and module and path.startswith("ansible_collections"):
+                    try:
+                        prefix = sys.modules[path].__loader__.prefix
+                    except AttributeError:
+                        # Not from a zipimporter loader, skipping
+                        continue
+                    py_path = self.ansiblez_path + os.sep + prefix
+                    my_loader = zipimporter(py_path)
+                    sys.meta_path.append(my_loader)
+                    if hasattr(sys.modules[path], "__path__"):
+                        sys.modules[path].__path__ = py_path
+
+            # Finally, load the plugin class.
+            self.module_class = importlib.import_module(self.module_path)
+
+    async def unload(self):
+        async with sys_path_lock:
+            sys.path = [i for i in sys.path if i != self.ansiblez_path]
+            sys.meta_path = [
+                i
+                for i in sys.meta_path
+                if not (isinstance(i, zipimporter) and i.archive == self.ansiblez_path)
+            ]
+
+    def create_profiler(self):
+        if self.debug_mode:
+            import cProfile
+
+            pr = cProfile.Profile()
+            pr.enable()
+            return pr
+
+    def print_profiling_info(self, pr):
+        if self.debug_mode:
+            import pstats
+
+            sortby = pstats.SortKey.CUMULATIVE
+            ps = pstats.Stats(pr).sort_stats(sortby)
+            ps.print_stats(20)
+
+    def print_backtrace(self, backtrace):
+        if self.debug_mode:
+            print(backtrace)  # pylint: disable=ansible-bad-function
+
+    async def run(self):
+        class FakeStdin:
+            buffer = None
+
+        from .exceptions import (
+            EmbeddedModuleFailure,
+            EmbeddedModuleUnexpectedFailure,
+            EmbeddedModuleSuccess,
+        )
+
+        # monkeypatching to pass the argument to the module, this is not
+        # really safe, and in the future, this will prevent us to run several
+        # modules in parallel. We can maybe use a scoped monkeypatch instead
+        _fake_stdin = FakeStdin()
+        _fake_stdin.buffer = io.BytesIO(self.params.encode())
+        sys.stdin = _fake_stdin
+        # Trick to be sure ansible.module_utils.basic._load_params() won't
+        # try to build the module parameters from the daemon arguments
+        sys.argv = sys.argv[:1]
+        ansible.module_utils.basic._ANSIBLE_ARGS = None
+        pr = self.create_profiler()
+        if not hasattr(self.module_class, "main"):
+            raise EmbeddedModuleFailure("No main() found!")
+        try:
+            if inspect.iscoroutinefunction(self.module_class.main):
+                await self.module_class.main()
+            elif pr:
+                pr.runcall(self.module_class.main)
+            else:
+                self.module_class.main()
+        except EmbeddedModuleSuccess as e:
+            self.print_profiling_info(pr)
+            return e.kwargs
+        except EmbeddedModuleFailure as e:
+            backtrace = traceback.format_exc()
+            self.print_backtrace(backtrace)
+            raise
+        except Exception as e:
+            backtrace = traceback.format_exc()
+            self.print_backtrace(backtrace)
+            raise EmbeddedModuleUnexpectedFailure(str(backtrace))
+        else:
+            raise EmbeddedModuleUnexpectedFailure(
+                "Likely a bug: exit_json() or fail_json() should be called during the module excution"
+            )
+
+
+async def run_as_lookup_plugin(data):
+    errors = None
+    try:
+        import ansible.plugins.loader as plugin_loader
+        from ansible.parsing.dataloader import DataLoader
+        from ansible.template import Templar
+        from ansible.module_utils._text import to_native
+
+        (
+            lookup_name,
+            terms,
+            variables,
+            kwargs,
+        ) = data
+
+        # load lookup plugin
+        templar = Templar(loader=DataLoader(), variables=None)
+        ansible_collections = "ansible_collections."
+        if lookup_name.startswith(ansible_collections):
+            lookup_name = lookup_name.replace(ansible_collections, "", 1)
+        ansible_plugins_lookup = ".plugins.lookup."
+        if ansible_plugins_lookup in lookup_name:
+            lookup_name = lookup_name.replace(ansible_plugins_lookup, ".", 1)
+
+        instance = plugin_loader.lookup_loader.get(
+            name=lookup_name, loader=templar._loader, templar=templar
+        )
+
+        if not hasattr(instance, "_run"):
+            return [None, "No _run() found"]
+        if inspect.iscoroutinefunction(instance._run):
+            result = await instance._run(terms, variables=variables, **kwargs)
+        else:
+            result = instance._run(terms, variables=variables, **kwargs)
+    except Exception as e:
+        errors = to_native(e)
+    return [result, errors]
+
+
+async def run_as_module(content, debug_mode):
+    from ansible.module_utils.turbo.exceptions import (
+        EmbeddedModuleFailure,
+    )
+
+    try:
+        (
+            ansiblez_path,
+            params,
+            env,
+        ) = json.loads(content)
+        if debug_mode:
+            print(  # pylint: disable=ansible-bad-function
+                f"-----\nrunning {ansiblez_path} with params: ¨{params}¨"
+            )
+
+        embedded_module = EmbeddedModule(ansiblez_path, params)
+        if debug_mode:
+            embedded_module.debug_mode = True
+
+        await embedded_module.load()
+        try:
+            async with env_lock:
+                os.environ.clear()
+                os.environ.update(env)
+                result = await embedded_module.run()
+        except SystemExit:
+            backtrace = traceback.format_exc()
+            result = {"msg": str(backtrace), "failed": True}
+        except EmbeddedModuleFailure as e:
+            result = {"msg": str(e), "failed": True}
+            if e.kwargs:
+                result.update(e.kwargs)
+        except Exception as e:
+            result = {
+                "msg": traceback.format_stack() + [str(e)],
+                "failed": True,
+            }
+        await embedded_module.unload()
+    except Exception as e:
+        result = {"msg": traceback.format_stack() + [str(e)], "failed": True}
+    return result
+
+
+class AnsibleVMwareTurboMode:
+    def __init__(self):
+        self.sessions = collections.defaultdict(dict)
+        self.socket_path = None
+        self.ttl = None
+        self.debug_mode = None
+
+    async def ghost_killer(self):
+        await asyncio.sleep(self.ttl)
+        self.stop()
+
+    async def handle(self, reader, writer):
+        self._watcher.cancel()
+
+        raw_data = await reader.read()
+        if not raw_data:
+            return
+
+        (plugin_type, content) = pickle.loads(raw_data)
+
+        def _terminate(result):
+            writer.write(json.dumps(result).encode())
+            writer.close()
+            self._watcher = self.loop.create_task(self.ghost_killer())
+
+        if plugin_type == "module":
+            result = await run_as_module(content, debug_mode=self.debug_mode)
+        elif plugin_type == "lookup":
+            result = await run_as_lookup_plugin(content)
+        _terminate(result)
+
+    def handle_exception(self, loop, context):
+        e = context.get("exception")
+        traceback.print_exception(type(e), e, e.__traceback__)
+        self.stop()
+
+    def start(self):
+        self.loop = asyncio.get_event_loop()
+        self.loop.add_signal_handler(signal.SIGTERM, self.stop)
+        self.loop.set_exception_handler(self.handle_exception)
+        self._watcher = self.loop.create_task(self.ghost_killer())
+
+        import sys
+
+        if sys.hexversion >= 0x30A00B1:
+            # py3.10 drops the loop argument of create_task.
+            self.loop.create_task(
+                asyncio.start_unix_server(self.handle, path=self.socket_path)
+            )
+        else:
+            self.loop.create_task(
+                asyncio.start_unix_server(
+                    self.handle, path=self.socket_path, loop=self.loop
+                )
+            )
+        self.loop.run_forever()
+
+    def stop(self):
+        os.unlink(self.socket_path)
+        self.loop.stop()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Start a background daemon.")
+    parser.add_argument("--socket-path")
+    parser.add_argument("--ttl", default=15, type=int)
+    parser.add_argument("--fork", action="store_true")
+
+    args = parser.parse_args()
+    if args.fork:
+        fork_process()
+    sys_path_lock = asyncio.Lock()
+    env_lock = asyncio.Lock()
+
+    server = AnsibleVMwareTurboMode()
+    server.socket_path = args.socket_path
+    server.ttl = args.ttl
+    server.debug_mode = not args.fork
+    server.start()

--- a/test/integration/targets/turbo/aliases
+++ b/test/integration/targets/turbo/aliases
@@ -1,0 +1,1 @@
+context/controller

--- a/test/integration/targets/turbo/collections/ansible_collections/ns/col/plugins/modules/turbo_demo.py
+++ b/test/integration/targets/turbo/collections/ansible_collections/ns/col/plugins/modules/turbo_demo.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (C) 2020, Gonéri Le Bouder <goneri@lebouder.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: turbo_demo
+short_description: A demo module for ansible_module.turbo
+version_added: "1.0.0"
+description:
+- "This module is an example of an ansible_module.turbo integration."
+author:
+- Gonéri Le Bouder (@goneri)
+"""
+
+EXAMPLES = r"""
+- name: Run the module
+  ns.col.turbo_demo:
+"""
+
+import os
+
+from ansible.module_utils.turbo.module import (
+    AnsibleTurboModule as AnsibleModule,
+)
+
+
+def counter():
+    counter.i += 1
+    return counter.i
+
+
+# NOTE: workaround to avoid a warning with ansible-doc
+if True:  # pylint: disable=using-constant-test
+    counter.i = 0
+
+
+def get_message():
+    return f"This is me running with PID: {os.getpid()}, called {counter.i} time(s)"
+
+
+def run_module():
+    result = {}
+
+    # the AnsibleModule object will be our abstraction working with Ansible
+    # this includes instantiation, a couple of common attr would be the
+    # args/params passed to the execution, as well as if the module
+    # supports check mode
+    module = AnsibleModule(argument_spec={}, supports_check_mode=True)
+    module.collection_name = "ns.col"
+    previous_value = counter.i
+    if not module.check_mode:
+        counter()
+        result["changed"] = True
+    result["message"] = get_message()
+    result["counter"] = counter.i
+    result["envvar"] = os.environ.get("TURBO_TEST_VAR")
+
+    if module._diff:
+        result["diff"] = {"before": previous_value, "after": counter.i}
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/integration/targets/turbo/collections/ansible_collections/ns/col/plugins/modules/turbo_fail.py
+++ b/test/integration/targets/turbo/collections/ansible_collections/ns/col/plugins/modules/turbo_fail.py
@@ -1,0 +1,57 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (C) 2021, Aubin Bikouo <abikouo>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: turbo_fail
+short_description: A short module which honor additional args when calling fail_json
+version_added: "1.0.0"
+description:
+- "This module aims to test fail_json method on Ansible.turbo module"
+options:
+  params:
+    description:
+      - parameter to display in task output
+    required: false
+    type: dict
+author:
+- Aubin Bikouo (@abikouo)
+"""
+
+EXAMPLES = r"""
+- name: Fail without additional arguments
+  ns.col.turbo_fail:
+
+- name: Fail with additional arguments
+  ns.col.turbo_fail:
+    params:
+        test: "ansible"
+"""
+
+from ansible.module_utils.turbo.module import (
+    AnsibleTurboModule as AnsibleModule,
+)
+
+
+def run_module():
+    module = AnsibleModule(
+        argument_spec=dict(
+            params=dict(type="dict"),
+        )
+    )
+    module.collection_name = "ns.col"
+    msg = "ansible.cloud.fail"
+    if module.params.get("params"):
+        module.fail_json(msg=msg, **module.params.get("params"))
+    module.fail_json(msg=msg)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/integration/targets/turbo/runme.sh
+++ b/test/integration/targets/turbo/runme.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eux
+
+export ANSIBLE_COLLECTIONS_PATH=.
+ansible-playbook test_turbo_mode.yaml -vvv
+ansible-playbook test_turbo_fail.yaml -vvv 

--- a/test/integration/targets/turbo/test_turbo_fail.yaml
+++ b/test/integration/targets/turbo/test_turbo_fail.yaml
@@ -1,0 +1,29 @@
+- hosts: localhost
+  gather_facts: no
+  collections:
+    - ns.col
+  tasks:
+    - name: fail with no additionnal args
+      turbo_fail:
+      register: result
+      failed_when: not result.failed
+
+    - assert:
+        that:
+          - result | list | difference(["failed_when_result"]) | sort == ["changed", "failed", "msg"]
+
+    - name: fail with additionnal args
+      turbo_fail:
+        params:
+          test:
+            phase: integration
+            release: 1.0
+          environment: production
+      register: result
+      failed_when: not result.failed
+
+    - assert:
+        that:
+          - result.environment == "production"
+          - result.test.phase == "integration"
+          - result.test.release == 1.0

--- a/test/integration/targets/turbo/test_turbo_mode.yaml
+++ b/test/integration/targets/turbo/test_turbo_mode.yaml
@@ -1,0 +1,80 @@
+- hosts: localhost
+  gather_facts: no
+  collections:
+    - ns.col
+  tasks:
+    - ns.col.turbo_demo:
+      with_sequence: count=10
+      register: _result
+    - debug: var=_result.results[-1]
+    - assert:
+        that:
+          - _result.results[-1].counter == 10
+    - ns.col.turbo_demo:
+      with_sequence: count=10
+      check_mode: True
+      register: _result
+    - assert:
+        that:
+          - _result.results[-1].counter == 10
+    - ns.col.turbo_demo:
+      with_sequence: count=10
+      become: true
+      register: _result
+    - assert:
+        that:
+          - _result.results[-1].counter == 10
+    - ns.col.turbo_demo:
+      diff: yes
+      register: _result_with_diff
+    - assert:
+        that:
+          - _result_with_diff.diff is defined
+    - ns.col.turbo_demo:
+      diff: no
+      register: _result_no_diff
+    - assert:
+        that:
+          - _result_no_diff.diff is undefined
+
+    - name: Test task environment var
+      ns.col.turbo_demo:
+      environment:
+        TURBO_TEST_VAR: foobar
+      register: _result
+
+    - assert:
+        that:
+          - _result.envvar == "foobar"
+
+    - name: Test task environment var not set
+      ns.col.turbo_demo:
+      register: _result
+
+    - assert:
+        that:
+          - not _result.envvar
+
+
+    - name: Create temporary dir
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: temp
+      register: tempdir_1
+
+    - name: Test with a different remote_tmp, there is no socket yet.
+      ns.col.turbo_demo:
+      vars:
+        ansible_remote_tmp: "{{ tempdir_1.path }}"
+      register: _result
+    - assert:
+        that:
+          - _result.counter == 1
+
+    - name: test using default remote_tmp. socket previously created
+      ns.col.turbo_demo:
+      register: _result
+
+    - assert:
+            that:
+            - _result.counter > 1


### PR DESCRIPTION
##### SUMMARY

The traditional execution flow of an Ansible module includes
the following steps:

- Upload of a ZIP archive with the module and its dependencies
- Execution of the module, which is just a Python script
- Ansible collects the results once the script is finished

These steps happen for each task of a playbook, and on every host.

Most of the time, the execution of a module is fast enough for
the user. However, sometime the module requires an important
amount of time, just to initialize itself. This is a common
situation with the API based modules. A classic initialization
involves the following steps:

- Load a Python library to access the remote resource (via SDK)
- Open a client
    - Load a bunch of Python modules.
    - Request a new TCP connection.
    - Create a session.
    - Authenticate the client.

All these steps are time consuming and the same operations
will be running again and again.

For instance, here:

- `import openstack`: takes 0.569s
- `client = openstack.connect()`: takes 0.065s
- `client.authorize()`: takes 1.360s

These numbers are from test ran against VexxHost public cloud.

In this case, it's a 2s-ish overhead per task. If the playbook
comes with 10 tasks, the execution time cannot go below 20s.

`AnsibleTurboModule` is actually a class that inherites from
the standard `AnsibleModule` class that your modules probably
already use.
The big difference is that when an module starts, it also spawns
a little Python daemon. If a daemon already exists, it will just
reuse it.
All the module logic is run inside this Python daemon. This means:

- Python modules are actually loaded one time
- Ansible module can reuse an existing authenticated session.

If you are a collection maintainer and want to enable `AnsibleTurboModule`, you can
follow these steps.
Your module should inherit from `AnsibleTurboModule`, instead of `AnsibleModule`.

```python

  from ansible.module_utils.turbo.module import AnsibleTurboModule as AnsibleModule

```

You can also use the `functools.lru_cache()` decorator to ask Python to cache
the result of an operation, like a network session creation.

Finally, if some of the dependeded libraries are large, it may be nice
to defer your module imports, and do the loading AFTER the
`AnsibleTurboModule` instance creation.

The Ansible module is slightly different while using AnsibleTurboModule.
Here are some examples with OpenStack and VMware.

These examples use `functools.lru_cache` that is the Python core since 3.3.
`lru_cache()` decorator will managed the cache. It uses the function parameters
as unicity criteria.

- Integration with OpenStack Collection: https://github.com/goneri/ansible-collections-openstack/commit/53ce9860bb84eeab49a46f7a30e3c9588d53e367
- Integration with VMware Collection: https://github.com/goneri/vmware/commit/d1c02b93cbf899fde3a4665e6bcb4d7531f683a3
- Integration with Kubernetes Collection: https://github.com/ansible-collections/kubernetes.core/pull/68

In this demo, we run one playbook that do several `os_keypair`
calls. For the first time, we run the regular Ansible module.
The second time, we run the same playbook, but with the modified
version.

[![asciicast](https://asciinema.org/a/329481.png)](https://asciinema.org/a/329481)

The daemon kills itself after 15s, and communication are done
through an Unix socket.
It runs in one single process and uses `asyncio` internally.
Consequently you can use the `async` keyword in your Ansible module.
This will be handy if you interact with a lot of remote systems
at the same time.

`ansible_module.turbo` open an Unix socket to interact with the background service.
We use this service to open the connection toward the different target systems.

This is similar to what SSH does with the sockets.

Keep in mind that:

- All the modules can access the same cache. Soon an isolation will be done at the collection level (https://github.com/ansible-collections/cloud.common/pull/17)
- A task can loaded a different version of a library and impact the next tasks.
- If the same user runs two `ansible-playbook` at the same time, they will have access to the same cache.

When a module stores a session in a cache, it's a good idea to use a hash of the authentication information to identify the session.

.. note:: You may want to isolate your Ansible environemt in a container, in this case you can consider https://github.com/ansible/ansible-builder

`ansible_module.turbo` uses exception to communicate a result back to the module.

- `EmbeddedModuleFailure` is raised when `json_fail()` is called.
- `EmbeddedModuleSuccess` is raised in case of success and return the result to the origin module processthe origin.

Thse exceptions are defined in `ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions`.
You can raise `EmbeddedModuleFailure` exception yourself, for instance from a module in `module_utils`.

Be careful with the catch all exception (`except Exception:`). Not only they are bad practice, but also may interface with this mechanism.

You may want to manually start the server. This can be done with the following command:

.. code-block:: shell

  PYTHONPATH=$HOME/.ansible/collections python -m ansible.module_utils.turbo.server --socket-path $HOME/.ansible/tmp/turbo_mode.foo.bar.socket

Replace `foo.bar` with the name of the collection.

You can use the `--help` argument to get a list of the optional parameters.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

turbo