### PR TITLE
Make distro.id() report newer versions of OpenSuSE (at least >=15) also report as opensuse

### DIFF
--- a/changelogs/fragments/opensuse_disto_id.yml
+++ b/changelogs/fragments/opensuse_disto_id.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - >-
+     module_utils - Make distro.id() report newer versions of OpenSuSE
+     (at least >=15) also report as ``opensuse``. They report themselves as
+     ``opensuse-leap``.

--- a/lib/ansible/module_utils/distro/_distro.py
+++ b/lib/ansible/module_utils/distro/_distro.py
@@ -54,6 +54,7 @@ _OS_RELEASE_BASENAME = "os-release"
 #: * Value: Normalized value.
 NORMALIZED_OS_ID = {
     "ol": "oracle",  # Oracle Linux
+    "opensuse-leap": "opensuse",  # Newer versions of OpenSuSE report as opensuse-leap
 }
 
 #: Translation table for normalizing the "Distributor ID" attribute returned by

--- a/test/units/module_utils/test_distro.py
+++ b/test/units/module_utils/test_distro.py
@@ -31,3 +31,9 @@ class TestDistro():
     def test_id(self):
         id = distro.id()
         assert isinstance(id, string_types), 'distro.id() returned %s (%s) which is not a string' % (id, type(id))
+
+    def test_opensuse_leap_id(self):
+        name = distro.name()
+        if name == 'openSUSE Leap':
+            id = distro.id()
+            assert id == 'opensuse', "OpenSUSE Leap did not return 'opensuse' as id"


### PR DESCRIPTION
##### SUMMARY
Make distro.id() report newer versions of OpenSuSE (at least >=15) also report
as opensuse. They report themselves as opensuse-leap.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
module_utils/distro

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
