### PR TITLE
Docsite/dev_guide: add note about ansible-test utility installation ways

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections_testing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_testing.rst
@@ -13,7 +13,7 @@ Testing your collection ensures that your code works well and integrates well wi
 Testing tools
 =============
 
-The main tool for testing collections is ``ansible-test``, Ansible's testing tool described in :ref:`developing_testing`. You can run several compile and sanity checks, as well as run unit and integration tests for plugins using ``ansible-test``. When you test collections, test against the ansible-core version(s) you are targeting.
+The main tool for testing collections is ``ansible-test``, Ansible's testing tool described in :ref:`testing_running_locally` and :ref:`developing_testing`. You can run several compile and sanity checks, as well as run unit and integration tests for plugins using ``ansible-test``. When you test collections, test against the ansible-core version(s) you are targeting.
 
 You must always execute ``ansible-test`` from the root directory of a collection. You can run ``ansible-test`` in Docker containers without installing any special requirements. The Ansible team uses this approach in Azure Pipelines both in the ansible/ansible GitHub repository and in the large community collections such as `community.general <https://github.com/ansible-collections/community.general/>`_ and `community.network <https://github.com/ansible-collections/community.network/>`_. The examples below demonstrate running tests in Docker containers.
 

--- a/docs/docsite/rst/dev_guide/developing_collections_testing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_testing.rst
@@ -13,7 +13,9 @@ Testing your collection ensures that your code works well and integrates well wi
 Testing tools
 =============
 
-The main tool for testing collections is ``ansible-test``, Ansible's testing tool described in :ref:`testing_running_locally` and :ref:`developing_testing`. You can run several compile and sanity checks, as well as run unit and integration tests for plugins using ``ansible-test``. When you test collections, test against the ansible-core version(s) you are targeting.
+The main tool for testing collections is ``ansible-test``, Ansible's testing tool described in :ref:`developing_testing` and provided by both the ``ansible`` and ``ansible-core`` packages.
+
+You can run several compile and sanity checks, as well as run unit and integration tests for plugins using ``ansible-test``. When you test collections, test against the ansible-core version(s) you are targeting.
 
 You must always execute ``ansible-test`` from the root directory of a collection. You can run ``ansible-test`` in Docker containers without installing any special requirements. The Ansible team uses this approach in Azure Pipelines both in the ansible/ansible GitHub repository and in the large community collections such as `community.general <https://github.com/ansible-collections/community.general/>`_ and `community.network <https://github.com/ansible-collections/community.network/>`_. The examples below demonstrate running tests in Docker containers.
 

--- a/docs/docsite/rst/dev_guide/testing_running_locally.rst
+++ b/docs/docsite/rst/dev_guide/testing_running_locally.rst
@@ -2,25 +2,20 @@
 
 .. _testing_running_locally:
 
-*****************************************
-Testing Ansible locally with ansible-test
-*****************************************
+***************
+Testing Ansible
+***************
+
+This document describes how to:
+
+* Run tests locally using ``ansible-test``
+* Extend
 
 .. contents::
    :local:
 
 Requirements
 ============
-
-The ``ansible-test`` utility is provided by both the ``ansible`` and ``ansible-core`` packages. You do not need to install it separately.
-
-You can also use its development version:
-
-.. code-block:: bash
-
-  git clone https://github.com/ansible/ansible.git
-  cd ansible
-  source hacking/env-setup
 
 There are no special requirements for running ``ansible-test`` on Python 2.7 or later.
 The ``argparse`` package is required for Python 2.6.

--- a/docs/docsite/rst/dev_guide/testing_running_locally.rst
+++ b/docs/docsite/rst/dev_guide/testing_running_locally.rst
@@ -2,14 +2,9 @@
 
 .. _testing_running_locally:
 
-***************
-Testing Ansible
-***************
-
-This document describes how to:
-
-* Run tests locally using ``ansible-test``
-* Extend
+*****************************************
+Testing Ansible locally with ansible-test
+*****************************************
 
 .. contents::
    :local:

--- a/docs/docsite/rst/dev_guide/testing_running_locally.rst
+++ b/docs/docsite/rst/dev_guide/testing_running_locally.rst
@@ -17,6 +17,16 @@ This document describes how to:
 Requirements
 ============
 
+The ``ansible-test`` utility is provided by both the ``ansible`` and ``ansible-core`` packages. You do not need to install it separately.
+
+You can also use its development version:
+
+.. code-block:: bash
+
+  git clone https://github.com/ansible/ansible.git
+  cd ansible
+  source hacking/env-setup
+
 There are no special requirements for running ``ansible-test`` on Python 2.7 or later.
 The ``argparse`` package is required for Python 2.6.
 The requirements for each ``ansible-test`` command are covered later.


### PR DESCRIPTION
##### SUMMARY
As there are questions like "How can I get / install ansible-test" https://github.com/ansible-collections/community.general/pull/3562#issuecomment-945415386 , this needs to be clarified.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/testing_running_locally.rst
docs/docsite/rst/dev_guide/developing_collections_testing.rst (I added the link to `testing_running_locally.rst` because ansible-test is described better there than in `:ref:developing_testing` - where's no explanation, only examples, BTW)