### PR TITLE
Handle reboot in a chroot environment

### DIFF
--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -346,6 +346,13 @@ class ActionModule(ActionBase):
                 stderr=to_native(reboot_result['stderr'].strip()))
             return result
 
+        if (reboot_result['rc'] == 0) and ('Running in chroot, ignoring request' in reboot_result['stderr']):
+            result['changed'] = False
+            result['failed'] = True
+            result['rebooted'] = False
+            result['msg'] = 'Cannot reboot chroot environment'
+            return result
+
         result['failed'] = False
         return result
 


### PR DESCRIPTION
Signed-off-by: Stephan Austermühle <au@hcsd.de>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When the `reboot` action is issued to a chroot environment, the `reboot` command returns exit code zero but issues `Running in chroot, ignoring request` to stderr (tested on Ubuntu 18.04.6 LTS). The `reboot` plugin then runs into the reboot validation and finally times out. This PR explictly checks for rejected reboots in chroot environment. Since I’m not really sure about reboot handling in LXC, OpenVZ, and other lightweight container solutions, handling chroot similar to `local` connections is not an option.

Note that I was able to test with Ansible 2.9 only.

Feedback is welcome. Not sure if this is more a bugfix or a feature.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
reboot

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
None.