### PR TITLE
Update `argcomplete` install via apt command

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -612,7 +612,7 @@ Installing ``argcomplete`` with ``apt``
 
 .. code-block:: bash
 
-    $ sudo apt install python-argcomplete
+    $ sudo apt install python3-argcomplete
 
 
 Installing ``argcomplete`` with ``pip``


### PR DESCRIPTION
##### SUMMARY
To install `argcomplete` on Ubuntu 21.10 we need to update the install line to use Python3.

##### ISSUE TYPE
- Docs Pull Request


##### ADDITIONAL INFORMATION
Installing `argcomplete` on Ubuntu 21.10 needs to be updated to use `python3`:
```
$ sudo apt install python3-argcomplete

```

##### More info

```
➜  ~ sudo apt install python-argcomplete
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package python-argcomplete is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  python3-argcomplete
E: Package 'python-argcomplete' has no installation candidate
```

Using python3:
```
➜  ~ sudo apt install python3-argcomplete
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  python3-argcomplete
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 27,2 kB of archives.
After this operation, 126 kB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu impish/universe amd64 python3-argcomplete all 1.8.1-1.5 [27,2 kB]
Fetched 27,2 kB in 0s (140 kB/s)              
Selecting previously unselected package python3-argcomplete.
(Reading database ... 305446 files and directories currently installed.)
Preparing to unpack .../python3-argcomplete_1.8.1-1.5_all.deb ...
Unpacking python3-argcomplete (1.8.1-1.5) ...
Setting up python3-argcomplete (1.8.1-1.5) ...
Processing triggers for man-db (2.9.4-2) ...
```
