### PR TITLE
Improve documentation on requirements.yml

### DIFF
--- a/docs/docsite/rst/galaxy/user_guide.rst
+++ b/docs/docsite/rst/galaxy/user_guide.rst
@@ -325,12 +325,12 @@ You can install roles and collections from the same requirements files
     roles:
       # Install a role from Ansible Galaxy.
       - name: geerlingguy.java
-        version: 1.9.6
+        version: ">=1.9.6"
 
     collections:
       # Install a collection from Ansible Galaxy.
       - name: geerlingguy.php_roles
-        version: 0.9.3
+        version: ">=0.9.3"
         source: https://galaxy.ansible.com
 
 Installing multiple roles from multiple files

--- a/docs/docsite/rst/galaxy/user_guide.rst
+++ b/docs/docsite/rst/galaxy/user_guide.rst
@@ -325,7 +325,7 @@ You can install roles and collections from the same requirements files
     roles:
       # Install a role from Ansible Galaxy.
       - name: geerlingguy.java
-        version: ">=1.9.6"
+        version: "1.9.6" # note that ranges are not supported for roles
 
     collections:
       # Install a collection from Ansible Galaxy.

--- a/docs/docsite/rst/shared_snippets/installing_multiple_collections.txt
+++ b/docs/docsite/rst/shared_snippets/installing_multiple_collections.txt
@@ -41,7 +41,8 @@ You can also add roles to a ``requirements.yml`` file, under the ``roles`` key. 
     roles:
       # Install a role from Ansible Galaxy.
       - name: geerlingguy.java
-        version: ">=1.9.6"
+        version: "1.9.6" # note that ranges are not supported for roles
+
 
     collections:
       # Install a collection from Ansible Galaxy.

--- a/docs/docsite/rst/shared_snippets/installing_multiple_collections.txt
+++ b/docs/docsite/rst/shared_snippets/installing_multiple_collections.txt
@@ -10,8 +10,8 @@ You can set up a ``requirements.yml`` file to install multiple collections in on
 
    # With the collection name, version, and source options
    - name: my_namespace.my_other_collection
-     version: 'version range identifiers (default: ``*``)'
-     source: 'The Galaxy URL to pull the collection from (default: ``--api-server`` from cmdline)'
+     version: >=1.2.0 # Version range identifiers (default: ``*``)'
+     source: ... # The Galaxy URL to pull the collection from (default: ``--api-server`` from cmdline)'
 
 You can specify four keys for each collection entry:
 
@@ -41,12 +41,12 @@ You can also add roles to a ``requirements.yml`` file, under the ``roles`` key. 
     roles:
       # Install a role from Ansible Galaxy.
       - name: geerlingguy.java
-        version: 1.9.6
+        version: ">=1.9.6"
 
     collections:
       # Install a collection from Ansible Galaxy.
       - name: geerlingguy.php_roles
-        version: 0.9.3
+        version: ">=0.9.3"
         source: https://galaxy.ansible.com
 
 To install both roles and collections at the same time with one command, run the following:

--- a/docs/docsite/rst/shared_snippets/installing_multiple_collections.txt
+++ b/docs/docsite/rst/shared_snippets/installing_multiple_collections.txt
@@ -10,8 +10,8 @@ You can set up a ``requirements.yml`` file to install multiple collections in on
 
    # With the collection name, version, and source options
    - name: my_namespace.my_other_collection
-     version: >=1.2.0 # Version range identifiers (default: ``*``)'
-     source: ... # The Galaxy URL to pull the collection from (default: ``--api-server`` from cmdline)'
+     version: ">=1.2.0" # Version range identifiers (default: ``*``)
+     source: ... # The Galaxy URL to pull the collection from (default: ``--api-server`` from cmdline)
 
 You can specify four keys for each collection entry:
 


### PR DESCRIPTION
Makes it clear that user can use range identifiers with collection
versions inside requirements.yml files.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
docs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
