### PR TITLE
INTERPRETER_PYTHON_DISTRO_MAP: Treat oracle same as rhel/centos (#73498)

### DIFF
--- a/changelogs/fragments/73498-INTERPRETER_PYTHON_DISTRO_MAP-Treat-oracle-same-as-rhel-centos.yml
+++ b/changelogs/fragments/73498-INTERPRETER_PYTHON_DISTRO_MAP-Treat-oracle-same-as-rhel-centos.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- INTERPRETER_PYTHON_DISTRO_MAP - prefer ``/usr/libexec/platform-python`` on ``oraclelinux 8`` when other pythons are present.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1450,6 +1450,7 @@ INTERPRETER_PYTHON_DISTRO_MAP:
       '8': /usr/libexec/platform-python
     fedora:
       '23': /usr/bin/python3
+    oracle: *rhelish
     redhat: *rhelish
     rhel: *rhelish
     ubuntu:


### PR DESCRIPTION
This is a simple backport of #73498 .

There was a discussion about whether or not to backport to 2.9 and 2.10 that suggested against. However:

- Oracle Linux is not new. It may be unfamiliar to the community, but it has existed almost as long as CentOS: https://en.wikipedia.org/wiki/Oracle_Linux . This means it should not be in the same category as the "new" distributions coming out in 2021.
- The prior behaviour is wrong on Oracle Linux 8, just as it was wrong on RHEL 8 and CentOS 8, so the fix should be published in a generally available release. Hard coding the Python interpreter is not desirable for the same reason that it is not desirable in RHEL 8 or CentOS 8.
- The fix was made in 2.11, and 2.11 is not generally available to the affected users. EPEL 7 and EPEL 8 currently only make Ansible 2.9 available, making this fix difficult to access for users. I am asking for this to be pushed to Stable 2.10 to make sure that changes in Stable 2.9 are also in Stable 2.10, but the real requirement here is to make it available on Ansible 2.9 for users of EL 7 and EL 8. The main reason it hasn't caused a bigger issue, is that many people do not install a conflicting Python in /usr/bin/python. RHEL 8, CentOS 8, and Oracle Linux 8, do not come with a /usr/bin/python, although they document that users can create one using alternatives. We have been lucky.
- As a result of CentOS 8 support being dropped by the end of 2021, a large number of people are staying on CentOS 7 which continues to be supported until 2024. Also, many users are switching from CentOS 8 to other distributions, including Oracle Linux 8.

I think the change is very simple, it is important, it is correct, and it deserves to be backport to both 2.10 and 2.9, so I am raising this pull request.

For full context, here is the original comments suggesting against backport:

> The general consensus inside the core team seems to be that backporting changes to the distro map is likely to cause more harm to existing automation than it fixes... If you're using a distro that's currently unsupported, you can always set ansible_python_interpreter in your inventory (and for 2.11+ it's even less an issue with respawn and internal selinux bindings). That change will still apply even if we add distro map support for a given distro in the future, but if we backported this change, someone doing a patch upgrade to Ansible targeting one of those distros could be broken, since their deps are no longer accessible without changing their inventory/config.
>
> This would be less an issue with brand-new distros (eg all the CentOS clones that are coming), but we think it's probably better to just keep the blanket rule in place that we likely won't backport updates to the distro interpreter map to prevent from breaking existing users on patch releases.
>
> So +1 for merge to devel (+ changelog and porting guide entry), but -1 to [backport.](url)
