### PR TITLE
[stable-2.12] Fix Windows CI scripts.

### DIFF
--- a/test/utils/shippable/incidental/windows.sh
+++ b/test/utils/shippable/incidental/windows.sh
@@ -23,7 +23,7 @@ python_default="$(PYTHONPATH="${PWD}/test/lib" python -c 'from ansible_test._int
 single_version=2012-R2
 
 # shellcheck disable=SC2086
-ansible-test windows-integration --explain ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} > /tmp/explain.txt 2>&1 || { cat /tmp/explain.txt && false; }
+ansible-test windows-integration --list-targets -v ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} > /tmp/explain.txt 2>&1 || { cat /tmp/explain.txt && false; }
 { grep ' windows-integration: .* (targeted)$' /tmp/explain.txt || true; } > /tmp/windows.txt
 
 if [ -s /tmp/windows.txt ] || [ "${CHANGED:+$CHANGED}" == "" ]; then

--- a/test/utils/shippable/windows.sh
+++ b/test/utils/shippable/windows.sh
@@ -24,7 +24,7 @@ python_default="$(PYTHONPATH="${PWD}/test/lib" python -c 'from ansible_test._int
 single_version=2012-R2
 
 # shellcheck disable=SC2086
-ansible-test windows-integration --explain ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} > /tmp/explain.txt 2>&1 || { cat /tmp/explain.txt && false; }
+ansible-test windows-integration --list-targets -v ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} > /tmp/explain.txt 2>&1 || { cat /tmp/explain.txt && false; }
 { grep ' windows-integration: .* (targeted)$' /tmp/explain.txt || true; } > /tmp/windows.txt
 
 if [ -s /tmp/windows.txt ] || [ "${CHANGED:+$CHANGED}" == "" ]; then


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/76148

The scripts now use `--list-targets -v` instead of `--explain` to evaluate changes.

This is faster and does not trigger parsing of a non-existent inventory file.

(cherry picked from commit 97f729c3d64032ff63e1c940f5c8d3f961cfab29)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

CI scripts
