### PR TITLE
Revert "Revert AnsibleCollectionConfig Py3 only change (#76104)"

### DIFF
--- a/lib/ansible/utils/collection_loader/_collection_config.py
+++ b/lib/ansible/utils/collection_loader/_collection_config.py
@@ -13,7 +13,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.module_utils.common.text.converters import to_text
-from ansible.module_utils.six import with_metaclass
 
 
 class _EventSource:
@@ -103,5 +102,5 @@ class _AnsibleCollectionConfig(type):
 
 
 # concrete class of our metaclass type that defines the class properties we want
-class AnsibleCollectionConfig(with_metaclass(_AnsibleCollectionConfig)):
+class AnsibleCollectionConfig(metaclass=_AnsibleCollectionConfig):
     pass


### PR DESCRIPTION
##### SUMMARY

Revert https://github.com/ansible/ansible/pull/76104 now that the underlying issue has been fixed by https://github.com/ansible/ansible/pull/76137

This reverts commit 04e30d900210fc58e20fa9425a33d03dd27f13c3.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/utils/collection_loader/_collection_config.py
