### PR TITLE
Docs: fedora32 is no longer supported (for integration tests)

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -70,15 +70,15 @@ Non-destructive Tests
 These tests will modify files in subdirectories, but will not do things that install or remove packages or things
 outside of those test subdirectories.  They will also not reconfigure or bounce system services.
 
-.. note:: Running integration tests within Docker
+.. note:: Running integration tests within containers
 
-   To protect your system from any potential changes caused by integration tests, and to ensure a sensible set of dependencies are available we recommend that you always run integration tests with the ``--docker`` option, for example ``--docker centos8``. See the `list of supported docker images <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt>`_ for options (the ``default`` image is used for sanity and unit tests, as well as for platform independent integration tests such as those for cloud modules).
+   To protect your system from any potential changes caused by integration tests, and to ensure a sensible set of dependencies are available we recommend that you always run integration tests with the ``--docker`` option, for example ``--docker centos8``. See the `list of supported container images <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt>`_ for options (the ``default`` image is used for sanity and unit tests, as well as for platform independent integration tests such as those for cloud modules).
 
-.. note:: Avoiding pulling new Docker images
+.. note:: Avoiding pulling new container images
 
    Use the ``--docker-no-pull`` option to avoid pulling the latest container image. This is required when using custom local images that are not available for download.
 
-Run as follows for all POSIX platform tests executed by our CI system in a Fedora 34 Docker container:
+Run as follows for all POSIX platform tests executed by our CI system in a Fedora 34 container:
 
 .. code-block:: shell-session
 
@@ -145,11 +145,16 @@ Run the Windows tests executed by our CI system:
 
     ansible-test windows-integration -v shippable/
 
-Tests in Docker containers
+Tests in containers
 ==========================
 
-If you have a Linux system with Docker installed, running integration tests using the same Docker containers used by
+If you have a Linux system with Docker or Podman installed, running integration tests using the same containers used by
 the Ansible continuous integration (CI) system is recommended.
+
+.. note:: Podman
+
+   By default, Podman will only be used if the Docker CLI is not installed. If you have Docker installed but want to use
+   Podman, you can change this behavior by setting the environment variable ``ANSIBLE_TEST_PREFER_PODMAN``.
 
 .. note:: Docker on non-Linux
 

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -78,7 +78,7 @@ outside of those test subdirectories.  They will also not reconfigure or bounce 
 
    Use the ``--docker-no-pull`` option to avoid pulling the latest container image. This is required when using custom local images that are not available for download.
 
-Run as follows for all POSIX platform tests executed by our CI system in a fedora34 docker container:
+Run as follows for all POSIX platform tests executed by our CI system in a Fedora 34 Docker container:
 
 .. code-block:: shell-session
 

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -74,10 +74,6 @@ outside of those test subdirectories.  They will also not reconfigure or bounce 
 
    To protect your system from any potential changes caused by integration tests, and to ensure a sensible set of dependencies are available we recommend that you always run integration tests with the ``--docker`` option, for example ``--docker centos8``. See the `list of supported container images <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt>`_ for options (the ``default`` image is used for sanity and unit tests, as well as for platform independent integration tests such as those for cloud modules).
 
-.. note:: Avoiding pulling new container images
-
-   Use the ``--docker-no-pull`` option to avoid pulling the latest container image. This is required when using custom local images that are not available for download.
-
 Run as follows for all POSIX platform tests executed by our CI system in a Fedora 34 container:
 
 .. code-block:: shell-session

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -78,11 +78,11 @@ outside of those test subdirectories.  They will also not reconfigure or bounce 
 
    Use the ``--docker-no-pull`` option to avoid pulling the latest container image. This is required when using custom local images that are not available for download.
 
-Run as follows for all POSIX platform tests executed by our CI system in a fedora32 docker container:
+Run as follows for all POSIX platform tests executed by our CI system in a fedora34 docker container:
 
 .. code-block:: shell-session
 
-    ansible-test integration shippable/ --docker fedora32
+    ansible-test integration shippable/ --docker fedora34
 
 You can target a specific tests as well, such as for individual modules:
 
@@ -114,7 +114,7 @@ to a virtual environment, such as Docker.  They won't reformat your filesystem:
 
 .. code-block:: shell-session
 
-    ansible-test integration destructive/ --docker fedora32
+    ansible-test integration destructive/ --docker fedora34
 
 Windows Tests
 =============
@@ -176,27 +176,26 @@ For example, to run tests for the ``ping`` module on a Ubuntu 18.04 container:
 Container Images
 ----------------
 
-Python 2
-^^^^^^^^
-
-Most container images are for testing with Python 2:
-
-  - centos6
-  - centos7
-  - opensuse15py2
-
 Python 3
 ^^^^^^^^
 
-To test with Python 3 use the following images:
+Most container images are for testing with Python 3:
 
   - alpine3
   - centos8
-  - fedora32
   - fedora33
+  - fedora34
   - opensuse15
   - ubuntu1804
   - ubuntu2004
+
+Python 2
+^^^^^^^^
+
+To test with Python 2 use the following images:
+
+  - centos7
+  - opensuse15py2
 
 
 Legacy Cloud Tests


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

I tried to run the integration tests and thought I would use a Docker container. I copied the parameter from the documentation and first it told me that I needed to specify which version of Python I wanted to use, which I thought was weird since the documentation didn't say anything about that, and then it told me that I didn't have permission to pull the image. It turns out the Docker image given as an example isn't supported anymore. This PR makes the documentation match the supported images list again.

I also ran into a problem where the test container would immediately exit. Apparently, you must be running systemd for this to work because the container CMD tries to do something involving the cgroups of the host machine's systemd on startup. Should that be documented somewhere? These days, systemd is very common but WSL doesn't normally run it.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

testing_integration.rst

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Error from using fedora32 as suggested:
```paste below
# ansible-test integration file --docker fedora32 --python 3.8 
Starting new "ansible-test-controller-CcVKdZvv" container.
ERROR: Command "docker run --volume /sys/fs/cgroup:/sys/fs/cgroup:ro --privileged=false --volume /var/run/docker.sock:/var/run/docker.sock --name ansible-test-controller-CcVKdZvv -d fedora32" returned exit status 125.
>>> Standard Error
Unable to find image 'fedora32:latest' locally
docker: Error response from daemon: pull access denied for fedora32, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
WARNING: Failed to run docker image "fedora32". Waiting a few seconds before trying again.
```
