### PR TITLE
Update attributes of files that are links without specifying link target

### DIFF
--- a/changelogs/fragments/76167-update-attributes-of-files-that-are-links.yml
+++ b/changelogs/fragments/76167-update-attributes-of-files-that-are-links.yml
@@ -1,0 +1,2 @@
+bugfixes: 
+  - file - setting attributes of symbolic links or files that are hard linked no longer fails when the link target is unspecified (https://github.com/ansible/ansible/issues/76142).

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -43,8 +43,8 @@ options:
     - If C(touch) (new in 1.4), an empty file will be created if the file does not
       exist, while an existing file or directory will receive updated file access and
       modification times (similar to the way C(touch) works from the command line).
+    - Default is the current state of the file if it exists, C(directory) if C(recurse=yes), or C(file) otherwise.
     type: str
-    default: file
     choices: [ absent, directory, file, hard, link, touch ]
   src:
     description:

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -285,7 +285,7 @@
       - "hlink_result.changed == False"
 
 - name: Change mode on a hard link
-  file: src={{output_file}} dest={{remote_tmp_dir_test}}/hard.txt mode=0701
+  file: dest={{remote_tmp_dir_test}}/hard.txt mode=0701
   register: file6_mode_change
 
 - name: verify that the hard link was touched

--- a/test/integration/targets/file/tasks/state_link.yml
+++ b/test/integration/targets/file/tasks/state_link.yml
@@ -375,7 +375,6 @@
 - name: attempt to modify the permissions of the link itself
   file:
     path: '{{remote_tmp_dir_test}}/test_follow_link'
-    src: './test_follow'
     state: 'link'
     mode: 0600
     follow: False
@@ -444,6 +443,19 @@
     that:
       - src_state is failed
       - "'src option requires state to be' in src_state.msg"
+
+- name: Create without src
+  file:
+    state: link
+    dest: "{{ output_dir }}/link.txt"
+  ignore_errors: yes
+  register: create_without_src
+
+- name: Ensure create without src failed
+  assert:
+    that:
+      - create_without_src is failed
+      - "'src is required' in create_without_src.msg"
 
 # Test creating a symlink when the destination exists and is a file
 - name: create a test file

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -66,7 +66,6 @@ lib/ansible/modules/copy.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/copy.py validate-modules:undocumented-parameter
 lib/ansible/modules/dnf.py validate-modules:doc-required-mismatch
 lib/ansible/modules/dnf.py validate-modules:parameter-invalid
-lib/ansible/modules/file.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/file.py validate-modules:undocumented-parameter
 lib/ansible/modules/find.py use-argspec-type-path # fix needed
 lib/ansible/modules/git.py pylint:disallowed-name


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When the `file` module is used to modify the permissions or modification time of a file without specifying the `state` parameter, Ansible autodetects the current state of the file and uses that as the desired state. However, if the current state of the file is detected to be "link" or "hard", then Ansible will want `src` to have been specified so it can ensure the correct link target.

This is particularly annoying when dealing with hard links, because essentially all normal files are hard links and the distinction used by Ansible is whether there is more than one link to the backing inode. That means if somebody else hard links to your file, then Ansible will start detecting that your file (the original file) is a hard link, and attempting to modify attributes of the file without specifying the path to the other file in the `src` parameter will fail. Even if you are expecting this, due to the nature of hard links, it's non-trivial (and sometimes impossible) to determine an appropriate value for `src` without creating a new, temporary hard link.

As a workaround, the playbook author can specify `state: file`, which will update the link without treating it as a link.

There were already tests for updating permissions of an existing symlink or hard link, but they specified the target of the link in `src` even though they weren't expecting to change `src`. I've removed `src` from those tests to give coverage to this code path. Tests that verify the link is not changed when specifying the same target should continue to provide coverage for the other code path.

Additionally, I added a check for if the user tries to create a new symlink but does not specify `src`. Previously, a file not found exception would be raised because Ansible would attempt to read the target of the link even if the link did not already exist. In the case where the link does not already exist, Ansible now continues as if `follow: no` was specified, and raises a more appropriate error about requiring `src`.

Fixes #76142

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

file