### PR TITLE
Stop using "checksumming" instead of "encrypting" in the docs

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1518,8 +1518,8 @@ This allows for dynamic generation of VLAN lists on a Cisco IOS tagged interface
 
 .. _hash_filters:
 
-Encrypting and checksumming strings and passwords
-=================================================
+Hashing and checksumming strings and passwords
+==============================================
 
 .. versionadded:: 1.9
 

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1518,7 +1518,7 @@ This allows for dynamic generation of VLAN lists on a Cisco IOS tagged interface
 
 .. _hash_filters:
 
-Hashing and checksumming strings and passwords
+Hashing and encrypting strings and passwords
 ==============================================
 
 .. versionadded:: 1.9


### PR DESCRIPTION
All encryption systems have a formal inverse function to decrypt
A hash is a one way function without inverse by definition

##### SUMMARY
Change title in template filter documentation that says encrypting when hashing is described

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Template hashing and checksum filters