### PR TITLE
Docs: Fix text for contributing to collection link

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules.rst
@@ -36,7 +36,7 @@ If your use case isn't covered by an existing module, an action plugin, or a rol
 * I want to :ref:`write a Windows module <developing_modules_general_windows>`.
 * I want :ref:`an overview of Ansible's architecture <developing_program_flow_modules>`.
 * I want to :ref:`document my module <developing_modules_documenting>`.
-* I want to :ref:`contribute my module back to Ansible Core <developing_modules_checklist>`.
+* I want to :ref:`contribute my module to an existing Ansible collection <developing_modules_checklist>`.
 * I want to :ref:`add unit and integration tests to my module <developing_testing>`.
 * I want to :ref:`add Python 3 support to my module <developing_python_3>`.
 * I want to :ref:`write multiple modules <developing_modules_in_groups>`.


### PR DESCRIPTION
##### SUMMARY
Fix link text:

A link in https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/dev_guide/developing_modules.rst points to "Contributing your module to an existing Ansible collection".
The link text is wrong: "I want to contribute my module back to Ansible Core."

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/dev_guide/developing_modules.rst

##### ADDITIONAL INFORMATION

