### PR TITLE
Add a YAML representer for NativeJinjaUnsafeText

### DIFF
--- a/changelogs/fragments/nativejinjaunsafetext-yaml-representer.yml
+++ b/changelogs/fragments/nativejinjaunsafetext-yaml-representer.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Add a YAML representer for ``NativeJinjaUnsafeText``

--- a/lib/ansible/parsing/yaml/dumper.py
+++ b/lib/ansible/parsing/yaml/dumper.py
@@ -24,7 +24,7 @@ import yaml
 from ansible.module_utils.six import text_type, binary_type
 from ansible.module_utils.common.yaml import SafeDumper
 from ansible.parsing.yaml.objects import AnsibleUnicode, AnsibleSequence, AnsibleMapping, AnsibleVaultEncryptedUnicode
-from ansible.utils.unsafe_proxy import AnsibleUnsafeText, AnsibleUnsafeBytes
+from ansible.utils.unsafe_proxy import AnsibleUnsafeText, AnsibleUnsafeBytes, NativeJinjaUnsafeText
 from ansible.template import AnsibleUndefined
 from ansible.vars.hostvars import HostVars, HostVarsVars
 from ansible.vars.manager import VarsWithSources
@@ -109,4 +109,9 @@ AnsibleDumper.add_representer(
 AnsibleDumper.add_representer(
     AnsibleUndefined,
     represent_undefined,
+)
+
+AnsibleDumper.add_representer(
+    NativeJinjaUnsafeText,
+    represent_unicode,
 )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
See https://github.com/ansible-collections/community.general/pull/3651 and https://github.com/ansible-collections/community.general/pull/3643.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/parsing/yaml/dumper.py`