### PR TITLE
LinkUtil - ignore LIB env var (#76184) - 2.12

### DIFF
--- a/changelogs/fragments/win_LinkUtil-ignore-LIB.yml
+++ b/changelogs/fragments/win_LinkUtil-ignore-LIB.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Ansible.ModuleUtils.LinkUtil - Ignore the ``LIB`` environment variable when loading the ``LinkUtil`` code

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.LinkUtil.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.LinkUtil.psm1
@@ -394,6 +394,7 @@ namespace Ansible
 
     # FUTURE: find a better way to get the _ansible_remote_tmp variable
     $original_tmp = $env:TMP
+    $original_lib = $env:LIB
 
     $remote_tmp = $original_tmp
     $module_params = Get-Variable -Name complex_args -ErrorAction SilentlyContinue
@@ -405,8 +406,10 @@ namespace Ansible
     }
 
     $env:TMP = $remote_tmp
+    $env:LIB = $null
     Add-Type -TypeDefinition $link_util
     $env:TMP = $original_tmp
+    $env:LIB = $original_lib
 
     # enable the SeBackupPrivilege if it is disabled
     $state = Get-AnsiblePrivilege -Name SeBackupPrivilege


### PR DESCRIPTION
(cherry picked from commit db2aee558bd58269b380c6643fb87bee2c00ee47)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/76184

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Ansible.WIndows.LinkUtil