### PR TITLE
set host_key_checking check to False, rather than if not (which captures False and None) (#75168)

### DIFF
--- a/changelogs/fragments/set-ssh-host_key_checking-defaults.yaml
+++ b/changelogs/fragments/set-ssh-host_key_checking-defaults.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - set ssh host_key_checking defaults to True, restoring original behaviour (https://github.com/ansible/ansible/issues/75168)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -33,6 +33,7 @@ DOCUMENTATION = '''
                - name: delegated_vars['ansible_ssh_host']
       host_key_checking:
           description: Determines if ssh should check host keys
+          default: True
           type: boolean
           ini:
               - section: defaults
@@ -666,7 +667,7 @@ class Connection(ConnectionBase):
             self._add_args(b_command, b_args, u"ansible.cfg set ssh_args")
 
         # Now we add various arguments that have their own specific settings defined in docs above.
-        if not self.get_option('host_key_checking'):
+        if self.get_option('host_key_checking') is False:
             b_args = (b"-o", b"StrictHostKeyChecking=no")
             self._add_args(b_command, b_args, u"ANSIBLE_HOST_KEY_CHECKING/host_key_checking disabled")
 


### PR DESCRIPTION
Backport #75168 (fix for #75167) to 2.11.

* set host_key_checking check to False, rather than if not (which captures False and None)
* add host_key_checking default to ssh.py / update documentation

(cherry picked from commit d527be8a524ff0f6bd23dfc48c6b511b9d14ddf8)

##### SUMMARY
Backport #75168 to 2.11.

Fixes #75167

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ssh

##### ADDITIONAL INFORMATION
Backport of #75168

Tested on 2.11.6.
