### PR TITLE
update pycodestyle requirement for pep8 sanity tests

### DIFF
--- a/test/lib/ansible_test/_data/requirements/sanity.pep8.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.pep8.txt
@@ -1,1 +1,1 @@
-pycodestyle == 2.6.0
+pycodestyle == 2.8.0


### PR DESCRIPTION
##### SUMMARY

This PR bumps the requirement of `pycodestyle` for the `pep8` sanity test from version `2.6.0` to version `2.8.0`. The reason for this is that flake8 now requires at least version `2.8.0` and is conflicting with `ansible-test`.

looking at the [changelog](https://github.com/PyCQA/pycodestyle/blob/main/CHANGES.txt) from pycodestyle, the impact should be minimal. And we had no issues testing our collections with this change.

##### ISSUE TYPE

- Feature Pull Request (not really a bugfix, not really a feature)

##### COMPONENT NAME
ansible-test sanity (pep8)
