### PR TITLE
Update netbox_interface redirect to netbox_device_interface

### DIFF
--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -5037,7 +5037,7 @@ plugin_routing:
     netbox_ip_address:
       redirect: netbox.netbox.netbox_ip_address
     netbox_interface:
-      redirect: netbox.netbox.netbox_interface
+      redirect: netbox.netbox.netbox_device_interface
     netbox_prefix:
       redirect: netbox.netbox.netbox_prefix
     netbox_site:


### PR DESCRIPTION
##### SUMMARY

netbox_interface was renamed, and is now located at
netbox_device_interface.

Currently the netbox ansible modules maintain a redirect from
netbox_interface to netbox_device_interface, but it would be better to
have only one layer of indirection instead of two layers.

Related issue: netbox-community/ansible_modules#533

##### ISSUE TYPE

- Bugfix Pull Request