### PR TITLE
Explicitly require iptables for incidental_setup_docker on RHEL8

### DIFF
--- a/test/integration/targets/incidental_setup_docker/vars/RedHat-8.yml
+++ b/test/integration/targets/incidental_setup_docker/vars/RedHat-8.yml
@@ -3,6 +3,7 @@ docker_prereq_packages:
   - device-mapper-persistent-data
   - lvm2
   - libseccomp
+  - iptables
 
 docker_packages:
   - docker-ce-19.03.13


### PR DESCRIPTION
##### SUMMARY
Explicitly require iptables for incidental_setup_docker on RHEL8

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/integration/targets/incidental_setup_docker/vars/RedHat-8.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
