### PR TITLE
[stable-2.12] Explicitly require iptables for incidental_setup_docker on RHEL8 (#76212)

### DIFF
--- a/test/integration/targets/incidental_setup_docker/vars/RedHat-8.yml
+++ b/test/integration/targets/incidental_setup_docker/vars/RedHat-8.yml
@@ -3,6 +3,7 @@ docker_prereq_packages:
   - device-mapper-persistent-data
   - lvm2
   - libseccomp
+  - iptables
 
 docker_packages:
   - docker-ce-19.03.13


### PR DESCRIPTION
(cherry picked from commit 27a5116)


Co-authored-by: Matt Martz <matt@sivel.net>