### PR TITLE
ansible-test - Add RHEL 9 support.

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -96,6 +96,8 @@ stages:
               test: rhel/8.4@3.6
             - name: RHEL 8.4 py38
               test: rhel/8.4@3.8
+            - name: RHEL 9.0b
+              test: rhel/9.0b
             - name: FreeBSD 12.2
               test: freebsd/12.2
             - name: FreeBSD 13.0
@@ -173,6 +175,8 @@ stages:
               test: rhel/8.4@3.6
             - name: RHEL 8.4 py38
               test: rhel/8.4@3.8
+            - name: RHEL 9.0b
+              test: rhel/9.0b
             - name: FreeBSD 12.2
               test: freebsd/12.2
             - name: FreeBSD 13.0

--- a/changelogs/fragments/ansible-test-rhel9.yaml
+++ b/changelogs/fragments/ansible-test-rhel9.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Add support for RHEL 9.

--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -66,10 +66,12 @@
 #
 # This fails due to conflicts on Fedora 34, but we can nuke this entirely once
 # #74224 lands, because it covers nobest cases.
+# Skipped in RHEL9 by changing the version test to == instead of >=
+#   due to missing RHEL9 docker-ce packages currently
 - include_tasks: nobest.yml
   when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('24', '>=') and
           ansible_distribution_major_version is version('34', '!=')) or
-        (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
+        (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '=='))
 
 
 - include_tasks: cacheonly.yml

--- a/test/integration/targets/dnf/vars/RedHat-9.yml
+++ b/test/integration/targets/dnf/vars/RedHat-9.yml
@@ -1,0 +1,2 @@
+astream_name: '@container-tools:latest/common'
+astream_name_no_stream: '@container-tools/common'

--- a/test/integration/targets/incidental_inventory_docker_swarm/aliases
+++ b/test/integration/targets/incidental_inventory_docker_swarm/aliases
@@ -3,6 +3,7 @@ context/controller
 skip/osx
 skip/macos
 skip/freebsd
+skip/rhel/9.0b  # there are no docker-ce packages for CentOS/RHEL 9
 destructive
 skip/docker  # The tests sometimes make docker daemon unstable; hence,
              # we skip all docker-based CI runs to avoid disrupting

--- a/test/integration/targets/interpreter_discovery_python/tasks/main.yml
+++ b/test/integration/targets/interpreter_discovery_python/tasks/main.yml
@@ -157,8 +157,10 @@
       that:
       # rhel 6/7
       - (auto_out.ansible_facts.discovered_interpreter_python == '/usr/bin/python' and distro_version is version('8','<')) or distro_version is version('8','>=')
-      # rhel 8+
-      - (auto_out.ansible_facts.discovered_interpreter_python == '/usr/libexec/platform-python' and distro_version is version('8','>=')) or distro_version is version('8','<')
+      # rhel 8
+      - (auto_out.ansible_facts.discovered_interpreter_python == '/usr/libexec/platform-python' and distro_version is version('8','==')) or distro_version is version('8','!=')
+      # rhel 9
+      - (auto_out.ansible_facts.discovered_interpreter_python == '/usr/bin/python3' and distro_version is version('9','==')) or distro_version is version('9','!=')
     when: distro == 'redhat'
 
   - name: ubuntu assertions

--- a/test/integration/targets/prepare_http_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_http_tests/tasks/main.yml
@@ -16,6 +16,7 @@
     - include_tasks: "{{ lookup('first_found', files)}}"
       vars:
         files:
+          - "{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version }}.yml"
           - "{{ ansible_os_family | lower }}.yml"
           - "default.yml"
   when:

--- a/test/integration/targets/prepare_http_tests/vars/RedHat-9.yml
+++ b/test/integration/targets/prepare_http_tests/vars/RedHat-9.yml
@@ -1,0 +1,4 @@
+krb5_packages:
+- krb5-devel
+- krb5-workstation
+- redhat-rpm-config  # needed for gssapi install

--- a/test/integration/targets/setup_paramiko/install-RedHat-9-python-3.yml
+++ b/test/integration/targets/setup_paramiko/install-RedHat-9-python-3.yml
@@ -1,0 +1,9 @@
+- name: Setup remote constraints
+  include_tasks: setup-remote-constraints.yml
+- name: Install Paramiko for Python 3 on RHEL 9
+  pip: # no python3-paramiko package exists for RHEL 9
+    name: paramiko
+    extra_args: "-c {{ remote_constraints }}"
+
+- name: Drop the crypto-policy to LEGACY for these tests
+  command: update-crypto-policies --set LEGACY

--- a/test/integration/targets/setup_paramiko/uninstall-RedHat-9-python-3.yml
+++ b/test/integration/targets/setup_paramiko/uninstall-RedHat-9-python-3.yml
@@ -1,0 +1,7 @@
+- name: Uninstall Paramiko for Python 3 on RHEL 9
+  pip: # no python3-paramiko package exists for RHEL 9
+    name: paramiko
+    state: absent
+
+- name: Revert the crypto-policy back to DEFAULT
+  command: update-crypto-policies --set DEFAULT

--- a/test/integration/targets/setup_rpm_repo/tasks/main.yml
+++ b/test/integration/targets/setup_rpm_repo/tasks/main.yml
@@ -24,6 +24,11 @@
     args:
       name: "{{ rpm_repo_packages }}"
 
+  - name: Install rpmfluff via pip
+    pip:
+      name: rpmfluff
+    when: ansible_facts.os_family == 'RedHat' and ansible_distribution_major_version is version('9', '==')
+
   - set_fact:
       repos:
         - "fake-{{ ansible_architecture }}"

--- a/test/integration/targets/setup_rpm_repo/vars/RedHat-9.yml
+++ b/test/integration/targets/setup_rpm_repo/vars/RedHat-9.yml
@@ -1,0 +1,4 @@
+rpm_repo_packages:
+  - rpm-build
+  - createrepo_c
+  - createrepo

--- a/test/integration/targets/subversion/aliases
+++ b/test/integration/targets/subversion/aliases
@@ -3,5 +3,6 @@ shippable/posix/group2
 skip/aix
 skip/osx
 skip/macos
+skip/rhel/9.0b  # svn checkout hangs
 destructive
 needs/root

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -5,6 +5,7 @@ macos/11.1 python=3.9 python_dir=/usr/local/bin provider=parallels
 macos python_dir=/usr/local/bin provider=parallels
 rhel/7.9 python=2.7 provider=aws
 rhel/8.4 python=3.6,3.8 provider=aws
+rhel/9.0b python=3.9 provider=aws
 rhel provider=aws
 aix/7.2 python=2.7,3.7 python_dir=/opt/freeware/bin provider=ibmps
 aix python_dir=/opt/freeware/bin provider=ibmps

--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -221,6 +221,8 @@ bootstrap_remote_rhel_7()
     done
 
     install_pip
+
+    bootstrap_remote_rhel_pinned_pip_packages
 }
 
 bootstrap_remote_rhel_8()
@@ -253,6 +255,8 @@ bootstrap_remote_rhel_8()
         echo "Failed to install packages. Sleeping before trying again..."
         sleep 10
     done
+
+    bootstrap_remote_rhel_pinned_pip_packages
 }
 
 bootstrap_remote_rhel()
@@ -261,7 +265,10 @@ bootstrap_remote_rhel()
         7.*) bootstrap_remote_rhel_7 ;;
         8.*) bootstrap_remote_rhel_8 ;;
     esac
+}
 
+bootstrap_remote_rhel_pinned_pip_packages()
+{
     # pin packaging and pyparsing to match the downstream vendored versions
     pip_packages="
         packaging==20.4

--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -259,11 +259,42 @@ bootstrap_remote_rhel_8()
     bootstrap_remote_rhel_pinned_pip_packages
 }
 
+bootstrap_remote_rhel_9()
+{
+    py_pkg_prefix="python3"
+
+    packages="
+        gcc
+        ${py_pkg_prefix}-devel
+        "
+
+    # Jinja2 is not installed with an OS package since the provided version is too old.
+    # Instead, ansible-test will install it using pip.
+    if [ "${controller}" ]; then
+        packages="
+            ${packages}
+            ${py_pkg_prefix}-cryptography
+            ${py_pkg_prefix}-packaging
+            ${py_pkg_prefix}-pyyaml
+            ${py_pkg_prefix}-resolvelib
+            "
+    fi
+
+    while true; do
+        # shellcheck disable=SC2086
+        dnf install -q -y ${packages} \
+        && break
+        echo "Failed to install packages. Sleeping before trying again..."
+        sleep 10
+    done
+}
+
 bootstrap_remote_rhel()
 {
     case "${platform_version}" in
         7.*) bootstrap_remote_rhel_7 ;;
         8.*) bootstrap_remote_rhel_8 ;;
+        9.*) bootstrap_remote_rhel_9 ;;
     esac
 }
 


### PR DESCRIPTION
##### SUMMARY

Add RHEL 9 support to ansible-test and CI.

Currently configured for RHEL 9.0 Beta. Once RHEL 9 GA is available it will replace the Beta.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
