### PR TITLE
[stable-2.12] check /.dockerenv and /.dockerinit to guess a dockercontainer (#74349)

### DIFF
--- a/changelogs/fragments/74349-improve-docker-detection.yml
+++ b/changelogs/fragments/74349-improve-docker-detection.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - setup - detect docker container with check for ./dockerenv or ./dockinit (https://github.com/ansible/ansible/pull/74349).

--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -110,6 +110,16 @@ class LinuxVirtual(Virtual):
                 virtual_facts['virtualization_role'] = 'guest'
                 found_virt = True
 
+        # If docker/containerd has a custom cgroup parent, checking /proc/1/cgroup (above) might fail.
+        # https://docs.docker.com/engine/reference/commandline/dockerd/#default-cgroup-parent
+        # Fallback to more rudimentary checks.
+        if os.path.exists('/.dockerenv') or os.path.exists('/.dockerinit'):
+            guest_tech.add('docker')
+            if not found_virt:
+                virtual_facts['virtualization_type'] = 'docker'
+                virtual_facts['virtualization_role'] = 'guest'
+                found_virt = True
+
         # ensure 'container' guest_tech is appropriately set
         if guest_tech.intersection(set(['docker', 'lxc', 'podman', 'openvz', 'containerd'])) or systemd_container:
             guest_tech.add('container')

--- a/test/units/module_utils/facts/virtual/test_linux.py
+++ b/test/units/module_utils/facts/virtual/test_linux.py
@@ -8,6 +8,30 @@ __metaclass__ = type
 from ansible.module_utils.facts.virtual import linux
 
 
+def mock_os_path_is_file_docker(filename):
+    if filename in ('/.dockerenv', '/.dockerinit'):
+        return True
+    return False
+
+
+def test_get_virtual_facts_docker(mocker):
+    mocker.patch('os.path.exists', mock_os_path_is_file_docker)
+
+    module = mocker.Mock()
+    module.run_command.return_value = (0, '', '')
+    inst = linux.LinuxVirtual(module)
+    facts = inst.get_virtual_facts()
+
+    expected = {
+        'virtualization_role': 'guest',
+        'virtualization_tech_host': set(),
+        'virtualization_type': 'docker',
+        'virtualization_tech_guest': set(['docker', 'container']),
+    }
+
+    assert facts == expected
+
+
 def test_get_virtual_facts_bhyve(mocker):
     mocker.patch('os.path.exists', return_value=False)
     mocker.patch('ansible.module_utils.facts.virtual.linux.get_file_content', return_value='')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #74349 for Ansible 2.12.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/facts/virtual/linux.py`
`test/units/module_utils/facts/virtual/test_linux.py`