### PR TITLE
Added support for iptables IPVS. original pr is #58329

### DIFF
--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -376,6 +376,16 @@ options:
         the program from running concurrently.
     type: str
     version_added: "2.10"
+  vaddr:
+    description:
+      - The LVS Virtual IP address to match
+    type: str
+    version_added: "2.9"
+  vport:
+    description:
+      - The LVS port to match
+    type: str
+    version_added: "2.9"
 '''
 
 EXAMPLES = r'''
@@ -514,6 +524,16 @@ EXAMPLES = r'''
       - "443"
       - "8081:8083"
     jump: ACCEPT
+- name: "Setup SNAT for LVS"
+  iptables:
+    table: nat
+    chain: POSTROUTING
+    match: ipvs
+    vaddr: '192.168.1.11/24'
+    vport: 80
+    jump: SNAT
+    to_source: '192.168.1.21'
+    comment: "SNAT the VIP"
 '''
 
 import re
@@ -655,6 +675,8 @@ def construct_rule(params):
         False)
     append_match(rule, params['comment'], 'comment')
     append_param(rule, params['comment'], '--comment', False)
+    append_param(rule, params['vaddr'], '--vaddr', False)
+    append_param(rule, params['vport'], '--vport', False)
     return rule
 
 
@@ -774,6 +796,8 @@ def main():
             syn=dict(type='str', default='ignore', choices=['ignore', 'match', 'negate']),
             flush=dict(type='bool', default=False),
             policy=dict(type='str', choices=['ACCEPT', 'DROP', 'QUEUE', 'RETURN']),
+            vaddr=dict(type='str'),
+            vport=dict(type='str')
         ),
         mutually_exclusive=(
             ['set_dscp_mark', 'set_dscp_mark_class'],

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -380,12 +380,12 @@ options:
     description:
       - The LVS Virtual IP address to match
     type: str
-    version_added: "2.9"
+    version_added: "2.13"
   vport:
     description:
       - The LVS port to match
     type: str
-    version_added: "2.9"
+    version_added: "2.13"
 '''
 
 EXAMPLES = r'''

--- a/test/units/modules/test_iptables.py
+++ b/test/units/modules/test_iptables.py
@@ -1006,3 +1006,39 @@ class TestIptables(ModuleTestCase):
             '-m', 'set',
             '--match-set', 'banned_hosts', 'src,dst'
         ])
+
+    def test_match_ipvs(self):
+        """ Test match_ipvs together with vaddr and vport """
+        set_module_args({
+            'table': 'nat',
+            'chain': 'POSTROUTING',
+            'match': 'ipvs',
+            'vaddr': '192.168.1.11/24',
+            'vport': '80',
+            'jump': 'SNAT',
+            'to_source': '192.168.1.21',
+            'comment': 'SNAT the VIP',
+        })
+        commands_results = [
+            (0, '', ''),
+        ]
+
+        with patch.object(basic.AnsibleModule, 'run_command') as run_command:
+            run_command.side_effect = commands_results
+            with self.assertRaises(AnsibleExitJson) as result:
+                iptables.main()
+                self.assertTrue(result.exception.args[0]['changed'])
+
+        self.assertEqual(run_command.call_count, 1)
+        self.assertEqual(run_command.call_args_list[0][0][0], [
+            '/sbin/iptables',
+            '-t', 'nat',
+            '-C', 'POSTROUTING',
+            '-m', 'ipvs',
+            '-j', 'SNAT',
+            '--to-source', '192.168.1.21',
+            '-m', 'comment',
+            '--comment', 'SNAT the VIP',
+            '--vaddr', '192.168.1.11/24',
+            '--vport', '80',
+        ])


### PR DESCRIPTION
##### SUMMARY
Fix Conflict this PR[#58329](https://github.com/ansible/ansible/pull/58329) and add unit test.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- iptables 
##### ADDITIONAL INFORMATION
Below is quoted from original Pull Rquest.

> Setting up Source NAT for, e.g. one-armed IPVS-based loadbalancers lacked support for the VIP address and VPort > arguments. This PR implements these arguments and allows issueing
```yaml
- name: "Setup SNAT for LVS"
  iptables:
    table: nat
    chain: POSTROUTING
    match: ipvs
    vaddr: '192.168.1.11/24'
    vport: 443
    jump: SNAT
    to_source: '192.168.1.21'
    comment: "SNAT the VIP"
```

> which is the equivalent of

```
iptables -t nat -A POSTROUTING -m ipvs --vaddr 192.168.1.11 --vport 443 -j SNAT --to-source 192.168.1.21
```
> Like other matches it requires a kernel module to be loaded first (xt_ipvs in this case).
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

---

######  added unit test
file: `test/units/modules/test_iptables.py`

Test if check command suceeds when run with this module args 
```
set_module_args({
  'table': 'nat',
  'chain': 'POSTROUTING',
   'match': 'ipvs',
   'vaddr': '192.168.1.11/24',
   'vport': '80',
   'jump': 'SNAT',
   'to_source': '192.168.1.21',
   'comment': 'SNAT the VIP',
})
```

check command
```
/sbin/iptables -t nat -C POSTROUTING -m ipvs -j SNAT --to-source 192.168.1.21 -m comment --comment 'SNAT the VIP' --vaddr 192.168.1.11/24 --vport 80
```


