### PR TITLE
Update `edgeos_config` module docs for 2.9

### DIFF
--- a/lib/ansible/modules/network/edgeos/edgeos_config.py
+++ b/lib/ansible/modules/network/edgeos/edgeos_config.py
@@ -40,6 +40,7 @@ options:
         compared with the existing configuration on the remote
         device.
     type: list
+    elements: str
   src:
     description:
       - The C(src) argument specifies the path to the source config

--- a/lib/ansible/modules/network/edgeos/edgeos_config.py
+++ b/lib/ansible/modules/network/edgeos/edgeos_config.py
@@ -39,6 +39,7 @@ options:
       - The ordered set of configuration lines to be managed and
         compared with the existing configuration on the remote
         device.
+    type: list
   src:
     description:
       - The C(src) argument specifies the path to the source config

--- a/lib/ansible/modules/network/edgeos/edgeos_config.py
+++ b/lib/ansible/modules/network/edgeos/edgeos_config.py
@@ -280,7 +280,7 @@ def main():
     )
     spec = dict(
         src=dict(type='path'),
-        lines=dict(type='list'),
+        lines=dict(type='list', elements='str'),
 
         match=dict(default='line', choices=['line', 'none']),
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updates docs to reflect correct `lines` argument `type` of `list` instead of default `string`.  Verified by [the module itself](https://github.com/ansible/ansible/blob/stable-2.9/lib/ansible/modules/network/edgeos/edgeos_config.py#L281)


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`edgeos_config` module
##### ADDITIONAL INFORMATION
Causes issues with [SchemaStore](https://github.com/SchemaStore/schemastore/) that gets its ansible schema automatically generated from this repo. SchemaStore is used by the [RedHat VScode-yaml plug-in](https://github.com/redhat-developer/vscode-yaml) which, in turn, is used by the [Ansible VScode module](https://github.com/ansible/vscode-ansible).

First time contributor, so if I'm pointing this in the wrong direction, let me know.  Thanks!
