### PR TITLE
Remove install of setuptools in venv for pip test.

### DIFF
--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -90,13 +90,6 @@
     state: absent
     name: "{{ remote_tmp_dir }}/pipenv"
 
-- name: install a working version of setuptools in the virtualenv
-  pip:
-    name: setuptools
-    virtualenv: "{{ remote_tmp_dir }}/pipenv"
-    state: present
-    version: 33.1.1
-
 - name: create a requirement file with an vcs url
   copy:
     dest: "{{ remote_tmp_dir }}/pipreq.txt"


### PR DESCRIPTION
##### SUMMARY

Remove install of setuptools in venv for pip test.

This task was previously added in https://github.com/ansible/ansible/pull/25243 as a work-around for a setuptools bug.

The pinned version does not work with Python 3.10, and the task should no longer be needed.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

pip integration test
