### PR TITLE
Remove edit on Github from non-editable pages

### DIFF
--- a/docs/docsite/.templates/breadcrumbs.html
+++ b/docs/docsite/.templates/breadcrumbs.html
@@ -18,6 +18,9 @@
             <!-- Remove main index page as it is no longer editable -->
             {% elif pagename == 'index' %}
               <br>
+            <!-- Remove all pages under collections/ as no longer editable -->
+            {% elif pagename.startswith('collections/') %}
+              <br>
 
             {% elif check_meta and pagename.startswith('cli') and meta.get('source', None) %}
               <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode or "blob" }}/{{ github_cli_version }}{{ meta.get('source', '') }}?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>

--- a/docs/docsite/.templates/breadcrumbs.html
+++ b/docs/docsite/.templates/breadcrumbs.html
@@ -15,6 +15,10 @@
                )) %}
             <!--  <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode or "blob" }}/{{ github_module_version }}{{ meta.get('source', '') }}?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr" class="fa fa-github"> {{ _('Edit on GitHub') }}</a> -->
               <br>
+            <!-- Remove main index page as it is no longer editable -->
+            {% elif pagename == 'index' %}
+              <br>
+
             {% elif check_meta and pagename.startswith('cli') and meta.get('source', None) %}
               <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode or "blob" }}/{{ github_cli_version }}{{ meta.get('source', '') }}?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
             {% elif (not 'list_of' in pagename) and (not 'category' in pagename) %}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A number of pages still have Edit on Github were that functionality is no longer supported. Removing them now to stop 404 errors.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #73869
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs/docsite/.templates/breadcrumbs.html
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
