### PR TITLE
Fix ansible-doc -l ansible.builtin

### DIFF
--- a/changelogs/fragments/76235-fix-ansible-doc-builtin-legacy.yml
+++ b/changelogs/fragments/76235-fix-ansible-doc-builtin-legacy.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-doc - Fix ansible-doc -l ansible.builtin / ansible.legacy not returning anything

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -595,7 +595,7 @@ class DocCLI(CLI, RoleMixin):
         if len(context.CLIARGS['args']) == 1:
             coll_filter = context.CLIARGS['args'][0]
 
-        if coll_filter in ('', None):
+        if coll_filter in ('ansible.builtin', 'ansible.legacy', '', None):
             paths = loader._get_paths_with_context()
             for path_context in paths:
                 self.plugin_list.update(DocCLI.find_plugins(path_context.path, path_context.internal, plugin_type))

--- a/test/units/cli/test_doc.py
+++ b/test/units/cli/test_doc.py
@@ -5,6 +5,7 @@ __metaclass__ = type
 import pytest
 
 from ansible.cli.doc import DocCLI, RoleMixin
+from ansible.plugins.loader import module_loader
 
 
 TTY_IFY_DATA = {
@@ -111,3 +112,19 @@ def test_rolemixin__build_doc_no_filter_match():
     fqcn, doc = obj._build_doc(role_name, path, collection_name, argspec, entrypoint_filter)
     assert fqcn == '.'.join([collection_name, role_name])
     assert doc is None
+
+
+def test_builtin_modules_list():
+    args = ['ansible-doc', '-l', 'ansible.builtin', '-t', 'module']
+    obj = DocCLI(args=args)
+    obj.parse()
+    result = obj._list_plugins('module', module_loader)
+    assert len(result) > 0
+
+
+def test_legacy_modules_list():
+    args = ['ansible-doc', '-l', 'ansible.legacy', '-t', 'module']
+    obj = DocCLI(args=args)
+    obj.parse()
+    result = obj._list_plugins('module', module_loader)
+    assert len(result) > 0


### PR DESCRIPTION
##### SUMMARY
`ansible-doc -l ansible.builtin` does not return anything but `ansible-doc ansible.builtin.copy` does work. This is very confusing. This patch fixes that.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-doc

##### ADDITIONAL INFORMATION
Before change:
```
# ansible-doc -l ansible.builtin
#
```

After change:
```
# ansible-doc -l ansible.builtin
add_host               Add a host (and alternatively a group) to the ansible-playbook in-memory inventory                   
apt                    Manages apt-packages                                                                                 
apt_key                Add or remove an apt key                                                                             
apt_repository         Add and remove APT repositories                                                                      
assemble               Assemble configuration files from fragments  
[snip]
```