### PR TITLE
apt - remove obsolete documentation

### DIFF
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -170,7 +170,7 @@ options:
     version_added: "2.4"
   lock_timeout:
     description:
-      - How many seconds will this action wait to aquire a lock on the apt db.
+      - How many seconds will this action wait to acquire a lock on the apt db.
       - Sometimes there is a transitory lock and this will retry at least until timeout is hit.
     type: int
     default: 60
@@ -298,18 +298,6 @@ EXAMPLES = '''
 - name: Remove dependencies that are no longer required
   apt:
     autoremove: yes
-
-# Sometimes apt tasks fail because apt is locked by an autoupdate or by a race condition on a thread.
-# To check for a lock file before executing, and keep trying until the lock file is released:
-- name: Install packages only when the apt process is not locked
-  apt:
-    name: foo
-    state: present
-  register: apt_action
-  retries: 100
-  until: apt_action is success or ('Failed to lock apt for exclusive operation' not in apt_action.msg and '/var/lib/dpkg/lock' not in apt_action.msg)
-
-
 '''
 
 RETURN = '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `lock_timeout` feature was added in #74095 to the `apt` module making this section in the documentation no longer necessary.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/apt.py`