### PR TITLE
Upgrade `resolvelib>=0.8.1,<0.9.0`

### DIFF
--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -168,9 +168,11 @@ class CollectionDependencyProvider(AbstractProvider):
 
     def get_preference(
             self,  # type: CollectionDependencyProvider
-            resolution,  # type: t.Optional[Candidate]
-            candidates,  # type: list[Candidate]
-            information,  # type: list[t.NamedTuple]
+            identifier,  # type: str
+            resolutions,  # type: t.Mapping[str, Candidate]
+            candidates,  # type: t.Mapping[str, t.Iterator[Candidate]]
+            information,  # type: t.Mapping[str, t.Iterable[t.NamedTuple]]
+            backtrack_causes,  # type: t.Sequence
     ):  # type: (...) -> t.Union[float, int]
         """Return sort key function return value for given requirement.
 
@@ -215,6 +217,7 @@ class CollectionDependencyProvider(AbstractProvider):
         the value is, the more preferred this requirement is (i.e. the
         sorting function is called with ``reverse=False``).
         """
+        candidates = list(candidates[identifier])
         if any(
                 candidate in self._preferred_candidates
                 for candidate in candidates
@@ -224,8 +227,12 @@ class CollectionDependencyProvider(AbstractProvider):
             return float('-inf')
         return len(candidates)
 
-    def find_matches(self, requirements):
-        # type: (list[Requirement]) -> list[Candidate]
+    def find_matches(
+            self,  # type: CollectionDependencyProvider
+            identifier,  # type: str
+            requirements,  # type: t.Mapping[str, t.Iterator[Requirement]]
+            incompatibilities  # type: t.Mapping[str, t.Iterator[Candidate]]
+    ):  # type: (...) -> t.List[Candidate]
         r"""Find all possible candidates satisfying given requirements.
 
         This tries to get candidates based on the requirements' types.
@@ -250,6 +257,7 @@ class CollectionDependencyProvider(AbstractProvider):
         # FIXME: its cloned tmp dir. Using only the first one creates
         # FIXME: loops that prevent any further dependency exploration.
         # FIXME: We need to figure out how to prevent this.
+        requirements = list(requirements[identifier])
         first_req = requirements[0]
         fqcn = first_req.fqcn
         # The fqcn is guaranteed to be the same

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ packaging
 # NOTE: resolvelib 0.x version bumps should be considered major/breaking
 # NOTE: and we should update the upper cap with care, at least until 1.0
 # NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69
-resolvelib >= 0.5.3, < 0.6.0  # dependency resolver used by ansible-galaxy
+resolvelib >= 0.8.1, < 0.9.0  # dependency resolver used by ansible-galaxy

--- a/test/lib/ansible_test/_data/requirements/ansible.txt
+++ b/test/lib/ansible_test/_data/requirements/ansible.txt
@@ -10,4 +10,4 @@ packaging
 # NOTE: resolvelib 0.x version bumps should be considered major/breaking
 # NOTE: and we should update the upper cap with care, at least until 1.0
 # NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69
-resolvelib >= 0.5.3, < 0.6.0  # dependency resolver used by ansible-galaxy
+resolvelib >= 0.8.1, < 0.9.0  # dependency resolver used by ansible-galaxy

--- a/test/sanity/code-smell/docs-build.requirements.in
+++ b/test/sanity/code-smell/docs-build.requirements.in
@@ -1,6 +1,6 @@
 jinja2
 pyyaml
-resolvelib < 0.6.0
+resolvelib >= 0.8.1, < 0.9.0
 sphinx == 4.2.0
 sphinx-notfound-page
 sphinx-ansible-theme

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -27,7 +27,7 @@ pyparsing==2.4.7
 pytz==2021.3
 PyYAML==6.0
 requests==2.26.0
-resolvelib==0.5.4
+resolvelib==0.8.1
 rstcheck==3.3.1
 semantic-version==2.8.5
 sh==1.14.2

--- a/test/sanity/code-smell/package-data.requirements.in
+++ b/test/sanity/code-smell/package-data.requirements.in
@@ -1,7 +1,7 @@
 docutils < 0.18  # match version required by sphinx in the docs-build sanity test
 jinja2
 pyyaml  # ansible-core requirement
-resolvelib < 0.6.0
+resolvelib >= 0.8.1, < 0.9.0
 rstcheck
 straight.plugin
 antsibull-changelog

--- a/test/sanity/code-smell/package-data.requirements.txt
+++ b/test/sanity/code-smell/package-data.requirements.txt
@@ -6,7 +6,7 @@ MarkupSafe==2.0.1
 packaging==21.2
 pyparsing==2.4.7
 PyYAML==6.0
-resolvelib==0.5.4
+resolvelib==0.8.1
 rstcheck==3.3.1
 semantic-version==2.8.5
 straight.plugin==1.5.0


### PR DESCRIPTION
##### SUMMARY

Since 2021-09-27 `resolvelib` author comment with "issue resolved now" (see https://github.com/sarugaku/resolvelib/issues/69#issuecomment-927333533).

Replace `resolvelib` version upper cap with `resolvelib>=0.8.1,<0.9.0` with corresponding `find_matches()` and `get_preference()` interface change should now be good enough.

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Ref: https://github.com/ansible/ansible/issues/74569

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request



