### PR TITLE
Update porting guide Python 2.7+ wording.

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.13.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.13.rst
@@ -49,7 +49,7 @@ No notable changes
 Modules
 =======
 
-* Python 2.7 is a hard requirement for module execution in this release. Any code utilizing ``ansible.module_utils.basic`` will not function with a lower Python version.
+* To use ansible-core 2.13 for module execution, you must use Python 2 version 2.7 or Python 3 version 3.5 or newer. Any code utilizing ``ansible.module_utils.basic`` will not function with lower Python versions.
 
 
 Modules removed


### PR DESCRIPTION
##### SUMMARY

fixes:  #76242

I was reading the porting docs about modules now requiring Python >= 2.7.

```
Python 2.7 is a hard requirement for module execution in this release.
```

While with the context I'm aware that this should be Python (2) >= 2.7 , as written it's slightly ambiguous and could be read as Python == 2.7, with no support for Python 3.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

docs/docsite/rst/porting_guides/porting_guide_core_2.13.rst

##### ADDITIONAL INFORMATION
