### PR TITLE
adding validate_certs option

### DIFF
--- a/changelogs/fragments/76260-adding-validate_certs option.yml
+++ b/changelogs/fragments/76260-adding-validate_certs option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "apt - adding validate_certs option to apt module (https://github.com/ansible/ansible/pull/76260)"

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -177,12 +177,12 @@ options:
     version_added: "2.12"
   validate_certs:
     description:
-      - This only applies if using a https url as the source of the rpm. e.g. for localinstall. If set to C(no), the SSL certificates will not be validated.
+      - This only applies if using a https url as the source of the deb. e.g. for localinstall. If set to C(no), the SSL certificates will not be validated.
       - This should only set to C(no) used on personally controlled sites using self-signed certificates as it avoids verifying the source site.
       - Prior to 2.1 the code worked as if this was set to C(yes).
     type: bool
     default: "yes"
-    version_added: "2.1"
+    version_added: "2.13"
 requirements:
    - python-apt (python 2)
    - python3-apt (python 3)
@@ -1127,7 +1127,7 @@ def main():
             allow_unauthenticated=dict(type='bool', default=False, aliases=['allow-unauthenticated']),
             allow_downgrade=dict(type='bool', default=False, aliases=['allow-downgrade', 'allow_downgrades', 'allow-downgrades']),
             lock_timeout=dict(type='int', default=60),
-            validate_certs=dict(type='bool', default=False),
+            validate_certs=dict(type='bool', default=True),
         ),
         mutually_exclusive=[['deb', 'package', 'upgrade']],
         required_one_of=[['autoremove', 'deb', 'package', 'update_cache', 'upgrade']],

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -175,6 +175,14 @@ options:
     type: int
     default: 60
     version_added: "2.12"
+  validate_certs:
+    description:
+      - This only applies if using a https url as the source of the rpm. e.g. for localinstall. If set to C(no), the SSL certificates will not be validated.
+      - This should only set to C(no) used on personally controlled sites using self-signed certificates as it avoids verifying the source site.
+      - Prior to 2.1 the code worked as if this was set to C(yes).
+    type: bool
+    default: "yes"
+    version_added: "2.1"
 requirements:
    - python-apt (python 2)
    - python3-apt (python 3)
@@ -1119,6 +1127,7 @@ def main():
             allow_unauthenticated=dict(type='bool', default=False, aliases=['allow-unauthenticated']),
             allow_downgrade=dict(type='bool', default=False, aliases=['allow-downgrade', 'allow_downgrades', 'allow-downgrades']),
             lock_timeout=dict(type='int', default=60),
+            validate_certs=dict(type='bool', default=False),
         ),
         mutually_exclusive=[['deb', 'package', 'upgrade']],
         required_one_of=[['autoremove', 'deb', 'package', 'update_cache', 'upgrade']],

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -270,6 +270,20 @@
 - name: uninstall hello with apt
   apt: pkg=hello state=absent purge=yes
 
+- name: install deb file from URL with validate_certs off
+  apt:
+    name: deb="{{ distro_mirror }}/pool/main/h/hello/hello_{{ hello_version.stdout }}_{{ hello_architecture.stdout }}.deb"
+    validate_certs: no
+  register: apt_url
+
+- name: verify installation of hello
+  assert:
+    that:
+        - "apt_url.changed"
+
+- name: uninstall hello with apt
+  apt: pkg=hello state=absent purge=yes
+
 - name: force install of deb
   apt: deb="/var/cache/apt/archives/hello_{{ hello_version.stdout }}_{{ hello_architecture.stdout }}.deb" force=true
   register: dpkg_force

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -272,7 +272,7 @@
 
 - name: install deb file from URL with validate_certs off
   apt:
-    name: deb="{{ distro_mirror }}/pool/main/h/hello/hello_{{ hello_version.stdout }}_{{ hello_architecture.stdout }}.deb"
+    deb: "{{ distro_mirror }}/pool/main/h/hello/hello_{{ hello_version.stdout }}_{{ hello_architecture.stdout }}.deb"
     validate_certs: no
   register: apt_url
 


### PR DESCRIPTION
##### SUMMARY
Adding in the validate_certs option for the apt module
Already supported in fetch_file

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
apt

##### ADDITIONAL INFORMATION
From my testing I was able to download RPM files with option to bypass cert validation but was not able to do the same thing with DEB files.
This is to get parity between those two.
