### PR TITLE
Docs: Link to valid data types for role parameters

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
@@ -320,7 +320,7 @@ role ``meta/argument_specs.yml`` file. All fields are lower-case.
 
         :type:
 
-           * The data type of the option. Default is ``str``.
+           * The data type of the option. See :ref:`Argument spec <argument_spec>` for allowed values for ``type``. Default is ``str``.
            * If an option is of type ``list``, ``elements`` should be specified.
 
         :required:


### PR DESCRIPTION
##### SUMMARY
Link to a [list of valid values for `type`](https://docs.ansible.com/ansible/latest/dev_guide/developing_program_flow_modules.html#argument-spec) in the [role argument specification format table](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#specification-format). 

Fixes #76180

##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME
docs/docsite/rst/user_guide/playbooks_reuse_roles.html

##### ADDITIONAL INFORMATION

