### PR TITLE
dnf: allow handling of modules without a default profile

### DIFF
--- a/test/integration/targets/dnf/tasks/modularity.yml
+++ b/test/integration/targets/dnf/tasks/modularity.yml
@@ -102,3 +102,51 @@
     that:
         - "not dnf_result.failed"
         - "not dnf_result.changed"
+
+- name: enable "{{ astream_name_no_profile }}" module without providing profile
+  dnf:
+    name: "{{ astream_name_no_profile }}"
+    state: enabled
+  register: dnf_result
+
+- name: verify enablement of "{{ astream_name_no_profile }}" module without providing profile
+  assert:
+    that:
+        - "not dnf_result.failed"
+        - "dnf_result.changed"
+
+- name: enable "{{ astream_name_no_profile }}" module again without providing profile
+  dnf:
+    name: "{{ astream_name_no_profile }}"
+    state: enabled
+  register: dnf_result
+
+- name: verify enablement of "{{ astream_name_no_profile }}" module again without providing profile
+  assert:
+    that:
+        - "not dnf_result.failed"
+        - "not dnf_result.changed"
+
+- name: disable "{{ astream_name_no_profile }}" module without providing profile
+  dnf:
+    name: "{{ astream_name_no_profile }}"
+    state: disabled
+  register: dnf_result
+
+- name: verify disablement of "{{ astream_name_no_profile }}" module without providing profile
+  assert:
+    that:
+        - "not dnf_result.failed"
+        - "dnf_result.changed"
+
+- name: disable "{{ astream_name_no_profile }}" module again without providing profile
+  dnf:
+    name: "{{ astream_name_no_profile }}"
+    state: disabled
+  register: dnf_result
+
+- name: verify disablement of "{{ astream_name_no_profile }}" module again without providing profile
+  assert:
+    that:
+        - "not dnf_result.failed"
+        - "not dnf_result.changed"

--- a/test/integration/targets/dnf/vars/CentOS.yml
+++ b/test/integration/targets/dnf/vars/CentOS.yml
@@ -1,2 +1,3 @@
 astream_name: '@php:7.2/minimal'
 astream_name_no_stream: '@php/minimal'
+astream_name_no_profile: '@pki-core:10.6'

--- a/test/integration/targets/dnf/vars/Fedora-33.yml
+++ b/test/integration/targets/dnf/vars/Fedora-33.yml
@@ -1,2 +1,3 @@
 astream_name: '@httpd:2.4/common'
 astream_name_no_stream: '@httpd/common'
+astream_name_no_profile: '@cri-o:nightly'

--- a/test/integration/targets/dnf/vars/Fedora-34.yml
+++ b/test/integration/targets/dnf/vars/Fedora-34.yml
@@ -1,2 +1,3 @@
 astream_name: '@httpd:2.4/common'
 astream_name_no_stream: '@httpd/common'
+astream_name_no_profile: '@cri-o:nightly'

--- a/test/integration/targets/dnf/vars/Fedora-35.yml
+++ b/test/integration/targets/dnf/vars/Fedora-35.yml
@@ -1,2 +1,3 @@
 astream_name: '@varnish:6.0/default'
 astream_name_no_stream: '@varnish/default'
+astream_name_no_profile: '@cri-o:1.19'

--- a/test/integration/targets/dnf/vars/Fedora.yml
+++ b/test/integration/targets/dnf/vars/Fedora.yml
@@ -4,3 +4,4 @@ astream_name: '@hub:pre-release/default'
 # Such packages, that exist on all the versions we test on, are hard to come by.
 # TODO: This would be solved by using our own repo with modularity/streams.
 astream_name_no_stream: '@hub/default'
+astream_name_no_profile: '@cri-o:nightly'

--- a/test/integration/targets/dnf/vars/RedHat-9.yml
+++ b/test/integration/targets/dnf/vars/RedHat-9.yml
@@ -1,2 +1,3 @@
 astream_name: '@container-tools:latest/common'
 astream_name_no_stream: '@container-tools/common'
+astream_name_no_profile: '@container-tools:latest'

--- a/test/integration/targets/dnf/vars/RedHat.yml
+++ b/test/integration/targets/dnf/vars/RedHat.yml
@@ -1,2 +1,3 @@
 astream_name: '@php:7.2/minimal'
 astream_name_no_stream: '@php/minimal'
+astream_name_no_profile: '@pki-core:10.6'


### PR DESCRIPTION
##### SUMMARY

DNF modules can be shipped without a default profile. In this case
calling 'install module:stream' errors out, as DNF doesn't know
what to install (as this is determined by the profile).

One solution is to explicitly call 'install module:stream/profile'.
However, it can be beneficial to only enable a module, without
installing anything from it. This is useful when the module is just
needed for dependencies, and maybe doesn't ship *any* profiles at all.

Examples for such modules are pki-deps and pki-core in EL8.

Fixes: #56504

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

dnf

##### ADDITIONAL INFORMATION

On EL8, the `pki-core` module can't be *installed*, just *enabled*, as it does not have any profiles.

```paste below
# ansible -m dnf -a 'name=@pki-core:10.6' localhost
localhost | FAILED! => {
    "changed": false,
    "failures": [
        "pki-core:10.6 Problems in request:\nbroken groups or modules: pki-core:10.6"
    ],
    "msg": "Failed to install some of the specified packages",
    "rc": 1,
    "results": []
}

# dnf module install pki-core:10.6
Failed to set locale, defaulting to C.UTF-8
Last metadata expiration check: 19:38:41 ago on Wed Nov 10 12:54:13 2021.
No profiles for module pki-core:10.6
Error: Problems in request:
broken groups or modules: pki-core:10.6

# ansible -m dnf -a 'name=@pki-core:10.6 state=enabled' localhost   
localhost | CHANGED => {
    "changed": true,
    "msg": "",
    "rc": 0,
    "results": [
        "Module pki-core:10.6 enabled."
    ]
}
```
