### PR TITLE
Fixed typo in keyword_desc.yml

### DIFF
--- a/lib/ansible/keyword_desc.yml
+++ b/lib/ansible/keyword_desc.yml
@@ -41,7 +41,7 @@ ignore_errors: Boolean that allows you to ignore task failures and continue with
 ignore_unreachable: Boolean that allows you to ignore task failures due to an unreachable host and continue with the play. This does not affect other task errors (see :term:`ignore_errors`) but is useful for groups of volatile/ephemeral hosts.
 loop: "Takes a list for the task to iterate over, saving each list element into the ``item`` variable (configurable via loop_control)"
 loop_control: Several keys here allow you to modify/set loop behaviour in a task. See :ref:`loop_control`.
-max_fail_percentage: can be used to abort the run after a given percentage of hosts in the current batch has failed. This only wokrs on linear or linear derived strategies.
+max_fail_percentage: can be used to abort the run after a given percentage of hosts in the current batch has failed. This only works on linear or linear derived strategies.
 module_defaults: Specifies default parameter values for modules.
 name: "Identifier. Can be used for documentation, or in tasks/handlers."
 no_log: Boolean that controls information disclosure.


### PR DESCRIPTION
The description of 'max_fail_percentage' had a typo.

##### SUMMARY
Fixed a typo in the description.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Ansible Core

##### ADDITIONAL INFORMATION
None.