### PR TITLE
No longer needed to fall back to sha

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -28,13 +28,10 @@ import re
 import time
 
 from contextlib import contextmanager
+from hashlib import sha1
 from numbers import Number
 from traceback import format_exc
 
-try:
-    from hashlib import sha1
-except ImportError:
-    from sha import sha as sha1
 
 from jinja2.exceptions import TemplateSyntaxError, UndefinedError
 from jinja2.loaders import FileSystemLoader

--- a/lib/ansible/utils/hashing.py
+++ b/lib/ansible/utils/hashing.py
@@ -21,8 +21,6 @@ __metaclass__ = type
 
 import os
 
-# Note, sha1 is the only hash algorithm compatible with python2.4 and with
-# FIPS-140 mode (as of 11-2014)
 from hashlib import sha1
 
 # Backwards compat only

--- a/lib/ansible/utils/hashing.py
+++ b/lib/ansible/utils/hashing.py
@@ -23,10 +23,7 @@ import os
 
 # Note, sha1 is the only hash algorithm compatible with python2.4 and with
 # FIPS-140 mode (as of 11-2014)
-try:
-    from hashlib import sha1
-except ImportError:
-    from sha import sha as sha1
+from hashlib import sha1
 
 # Backwards compat only
 try:

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -23,11 +23,7 @@ import os
 import sys
 
 from collections import defaultdict
-
-try:
-    from hashlib import sha1
-except ImportError:
-    from sha import sha as sha1
+from hashlib import sha1
 
 from jinja2.exceptions import UndefinedError
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It is long gone from Python stdlib.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/template/__init__.py`
`lib/ansible/utils/hashing.py`
`lib/ansible/vars/manager.py`
