### PR TITLE
Update docs build requirements to most recent versions of dependencies

### DIFF
--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -3,7 +3,7 @@
 # NOTE - this file must align with CI test for docs-build at
 #    test/sanity/code-smell/docs-build.requirements.txt
 
-antsibull==0.39.1
+antsibull==0.39.2
 # check what sphinx requires testing more recent docutils versions
 docutils==0.17.1
 jinja2==3.0.1

--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -7,9 +7,9 @@
 antsibull == 0.39.2
 # sphinx 4.2.0 requires docutils < 0.18
 docutils == 0.17.1
-jinja2 == 3.0.1
-Pygments == 2.9.0
-PyYAML == 5.4.1
+jinja2 == 3.0.3
+Pygments == 2.10.0
+PyYAML == 6.0
 resolvelib == 0.5.4
 rstcheck == 3.3.1
 sphinx == 4.2.0

--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -1,18 +1,18 @@
 # pip packages required to build docsite
-# tested June 9 2021
+# tested Nov 11 2021
+# NOTE - this file must align with CI test for docs-build at
+#    test/sanity/code-smell/docs-build.requirements.txt
 
-antsibull
-# version floats free, since we control features and releases
-docutils==0.16
-# check unordered lists when testing more recent docutils versions
-# see https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
+antsibull==0.39.1
+# check what sphinx requires testing more recent docutils versions
+docutils==0.17.1
 jinja2==3.0.1
 Pygments==2.9.0
 PyYAML==5.4.1
 resolvelib==0.5.4
 rstcheck==3.3.1
-sphinx==4.0.2
-sphinx-notfound-page==0.7.1 # must be >= 0.6
+sphinx==4.2.0
+sphinx-notfound-page==0.8 # must be >= 0.6
 sphinx-intl==2.0.1
-sphinx-ansible-theme===0.7.0
+sphinx-ansible-theme===0.8.0
 straight.plugin==1.5.0 # Needed for hacking/build-ansible.py which is the backend build script

--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -2,17 +2,18 @@
 # tested Nov 11 2021
 # NOTE - this file must align with CI test for docs-build at
 #    test/sanity/code-smell/docs-build.requirements.txt
+#    test/sanity/code-smell/rstcheck.requirements.txt
 
-antsibull==0.39.2
-# check what sphinx requires testing more recent docutils versions
-docutils==0.17.1
-jinja2==3.0.1
-Pygments==2.9.0
-PyYAML==5.4.1
-resolvelib==0.5.4
-rstcheck==3.3.1
-sphinx==4.2.0
-sphinx-notfound-page==0.8 # must be >= 0.6
-sphinx-intl==2.0.1
-sphinx-ansible-theme===0.8.0
-straight.plugin==1.5.0 # Needed for hacking/build-ansible.py which is the backend build script
+antsibull == 0.39.2
+# sphinx 4.2.0 requires docutils < 0.18
+docutils == 0.17.1
+jinja2 == 3.0.1
+Pygments == 2.9.0
+PyYAML == 5.4.1
+resolvelib == 0.5.4
+rstcheck == 3.3.1
+sphinx == 4.2.0
+sphinx-notfound-page == 0.8 # must be >= 0.6
+sphinx-intl == 2.0.1
+sphinx-ansible-theme === 0.8.0
+straight.plugin == 1.5.0 # Needed for hacking/build-ansible.py which is the backend build script

--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -8,8 +8,8 @@ antsibull == 0.39.2
 # sphinx 4.2.0 requires docutils < 0.18
 docutils == 0.17.1
 jinja2 == 3.0.3
-Pygments == 2.10.0
-PyYAML == 6.0
+pygments == 2.10.0
+pyyaml == 6.0
 resolvelib == 0.5.4
 rstcheck == 3.3.1
 sphinx == 4.2.0

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -3,7 +3,7 @@
 # if you want known good versions of these dependencies
 # use known_good_reqs.txt instead
 
-antsibull >= 0.39.1
+antsibull >= 0.39.2
 docutils
 jinja2
 Pygments >= 2.4.0

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -6,8 +6,8 @@
 antsibull >= 0.39.2
 docutils
 jinja2
-Pygments >= 2.10.0
-PyYAML
+pygments >= 2.10.0
+pyyaml
 rstcheck
 sphinx
 sphinx-notfound-page >= 0.6

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -6,7 +6,7 @@
 antsibull >= 0.39.2
 docutils
 jinja2
-Pygments >= 2.4.0
+Pygments >= 2.10.0
 PyYAML
 rstcheck
 sphinx

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -1,11 +1,10 @@
 # pip packages required to build docsite
 # these requirements are as loosely defined as possible
 # if you want known good versions of these dependencies
-# use known_good_reqs.txt instead 
+# use known_good_reqs.txt instead
 
-antsibull >= 0.38.2
-docutils == 0.16 # pin for now until the problem with unordered lists is fixed
-# see https://github.com/readthedocs/sphinx_rtd_theme/issues/1115jinja2==3.0.1
+antsibull >= 0.39.1
+docutils
 jinja2
 Pygments >= 2.4.0
 PyYAML


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This updates to Sphinx 4.2, antsibull 0.39.2 and docutils 0.17.1 (highest that sphinx supports).
It also aligns docs CI tests with docs builds as they'd gottten out of sync
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs/docsite/known_good_reqs.txt
docs/docsite/requirements.txt
test/sanity/code-smell/docs-build.requirements.txt
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
