### PR TITLE
First draft at trying to preserve raw stdio on win script

### DIFF
--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -244,7 +244,15 @@ class ShellModule(ShellBase):
         return self._encode_script(script, preserve_rc=False)
 
     def wrap_for_exec(self, cmd):
-        return '& %s; exit $LASTEXITCODE' % cmd
+        return '''$ErrorActionPreference = 'Continue'
+
+$stdout = $null
+$stderr = . { & %s | Set-Variable stdout } 2>&1 | ForEach-Object ToString
+
+if ($stdout) { [System.Console]::Out.WriteLine($stdout) }
+if ($stderr) { [System.Console]::Error.WriteLine($stderr) }
+exit $LASTEXITCODE
+''' % cmd
 
     def _unquote(self, value):
         '''Remove any matching quotes that wrap the given value.'''


### PR DESCRIPTION
##### SUMMARY
When PowerShell runs a native executable the raw stderr is converted to an error record which the exec wrapper is outputting to `stderr` in the PowerShell format. This is a first attempt at trying to preserve the raw stderr but it will require extra work to:

* Keep the existing `ps1` script behaviour working
* Better handle spaces in the path or temp dir path where the script is located

An alternative option I've been toying with is changing the behaviour of `module_script_wrapper.ps1` to just run the native executable instead of using the PowerShell wrapper. This is mostly likely going to be the better method going forward but it complicates the script action plugin just a bit more.

Fixes https://github.com/ansible/ansible/issues/76237

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
script