### PR TITLE
documentation strings for set theory functions

### DIFF
--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -84,6 +84,14 @@ def unique(environment, a, case_sensitive=None, attribute=None):
 
 @pass_environment
 def intersect(environment, a, b):
+    """
+    Calculate the intersection of a and b; values present in both a and b.
+
+    If possible compute using native Python set operations.
+    This is deemed possible if a and b are both ``Hashable``.
+
+    No duplicates are returned.
+    """
     if isinstance(a, Hashable) and isinstance(b, Hashable):
         c = set(a) & set(b)
     else:
@@ -93,6 +101,14 @@ def intersect(environment, a, b):
 
 @pass_environment
 def difference(environment, a, b):
+    """
+    Calculate the difference of a and b; values present in a, but not in b.
+
+    If possible compute using native Python set operations.
+    This is deemed possible if a and b are both ``Hashable``.
+
+    No duplicates are returned.
+    """
     if isinstance(a, Hashable) and isinstance(b, Hashable):
         c = set(a) - set(b)
     else:
@@ -102,6 +118,14 @@ def difference(environment, a, b):
 
 @pass_environment
 def symmetric_difference(environment, a, b):
+    """
+    Calculate the symmetric difference of a and b; values present in either a or b, but not in both.
+
+    If possible compute using native Python set operations.
+    This is deemed possible if a and b are both ``Hashable``.
+
+    No duplicates are returned.
+    """
     if isinstance(a, Hashable) and isinstance(b, Hashable):
         c = set(a) ^ set(b)
     else:
@@ -112,6 +136,14 @@ def symmetric_difference(environment, a, b):
 
 @pass_environment
 def union(environment, a, b):
+    """
+    Calculate the union of a and b; values present in either a or b.
+
+    If possible compute using native Python set operations.
+    This is deemed possible if a and b are both ``Hashable``.
+
+    No duplicates are returned.
+    """
     if isinstance(a, Hashable) and isinstance(b, Hashable):
         c = set(a) | set(b)
     else:


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The set theory functions are not self-explanatory unless one has taken a course of mathematics or two, hence some documentation is warranted.
Rationale being that I was reading a [StackOverflow Answer](https://stackoverflow.com/questions/47167736/jinja2-compare-items-in-one-list-to-items-in-another-list/47168108#47168108) pertaining to those exact functions and those did link to the code which, without further description is kind of hard to grasp for people not too acquainted with set theory.
For instance the [Rust documentation on set functions](https://doc.rust-lang.org/std/collections/struct.BTreeSet.html#method.difference) provides a short description as well as examples, the latter being used as unit tests, which directly conveys to the user what behavior to expect from the invocation.

Documentation was added for:

- intersect
- difference
- symmetric_difference
- union

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
filter/mathstuff
