### PR TITLE
Extract useful code out of `fetch_url`

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1304,6 +1304,9 @@ def rfc2822_date_string(timetuple, zone='-0000'):
 
 
 def normalize_headers(response):
+    """Normalizes headers between Python2 and Python3
+    to behave more like Python2
+    """
     if PY2:
         headers = httplib.HTTPMessage(cStringIO())
     else:
@@ -1328,6 +1331,11 @@ def normalize_headers(response):
 
 
 def process_cookies(cookies):
+    """Processes a CookieJar instance, and returns a tuple
+    of a dict representation of the cookies, and a string
+    that can be used directly for a Cookie header in subsequent
+    requests
+    """
     # parse the cookies into a nice dictionary
     cookie_list = []
     cookie_dict = {}
@@ -1343,6 +1351,10 @@ def process_cookies(cookies):
 
 
 def catch_request_errors(func, *args, **kwargs):
+    """Call ``func`` and catch some typical exceptions,
+    returning a tuple of the HTTPResponse and a dict
+    containing headers and additional info from the request
+    """
     info = {}
     r = None
     try:

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1344,6 +1344,11 @@ def catch_request_errors(func, *args, **kwargs):
     except urllib_error.HTTPError as e:
         r = e
         try:
+            if e.fp is None:
+                # Certain HTTPError objects may not have the ability to call ``.read()`` on Python 3
+                # This is not handled gracefully in Python 3, and instead an exception is raised from
+                # tempfile, due to ``urllib.response.addinfourl`` not being initialized
+                raise AttributeError
             body = e.read()
         except AttributeError:
             body = ''

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1848,11 +1848,11 @@ def process_cookies(cookies):
     return cookie_dict, cookies_string
 
 
-def catch_request_errors(url, *args, **kwargs):
+def catch_request_errors(func, *args, **kwargs):
     info = {}
     r = None
     try:
-        r = open_url(url, *args, **kwargs)
+        r = func(*args, **kwargs)
     except urllib_error.HTTPError as e:
         r = e
         try:
@@ -1956,7 +1956,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     info = {'url': url, 'status': -1}
     try:
         r, tmp_info = catch_request_errors(
-            url, data=data, headers=headers, method=method,
+            open_url, url, data=data, headers=headers, method=method,
             use_proxy=use_proxy, force=force, last_mod_time=last_mod_time, timeout=timeout,
             validate_certs=validate_certs, url_username=username,
             url_password=password, http_agent=http_agent, force_basic_auth=force_basic_auth,

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1825,8 +1825,6 @@ def normalize_headers(response):
         return headers
 
     for name, value in response.headers.items():
-        # The same as above, lower case keys to match py2 behavior, and create more consistent results
-        name = name.lower()
         if name in headers:
             headers[name] = ', '.join((headers[name], value))
         else:

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1980,12 +1980,12 @@ def fetch_url(module, url, data=None, headers=None, method=None,
                     exception=traceback.format_exc())
     else:
         info.update(tmp_info)
-        info['cookies'], info['cookies_string'] = process_cookies(cookies)
     finally:
         tempfile.tempdir = old_tempdir
 
     # Lowercase keys, to conform to py2 behavior, so that py3 and py2 are predictable
     info.update(dict((k.lower(), v) for k, v in normalize_headers(r).items()))
+    info['cookies'], info['cookies_string'] = process_cookies(cookies)
 
     return r, info
 

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1861,16 +1861,33 @@ def catch_request_errors(func, *args, **kwargs):
             body = ''
         else:
             e.close()
-        info.update({'msg': to_native(e), 'body': body, 'status': e.code})
+        info.update({
+            'msg': to_native(e),
+            'body': body,
+            'status': e.code,
+        })
     except urllib_error.URLError as e:
         code = int(getattr(e, 'code', -1))
-        info.update(dict(msg="Request failed: %s" % to_native(e), status=code))
+        info.update({
+            'msg': 'Request failed: %s' % to_native(e),
+            'status': code,
+        })
     except socket.error as e:
-        info.update(dict(msg="Connection failure: %s" % to_native(e), status=-1))
+        info.update({
+            'msg': 'Connection failure: %s' % to_native(e),
+            'status': -1,
+        })
     except httplib.BadStatusLine as e:
-        info.update(dict(msg="Connection failure: connection was closed before a valid response was received: %s" % to_native(e.line), status=-1))
+        info.update({
+            'msg': 'Connection failure: connection was closed before a valid response was received: %s' % to_native(e.line),
+            'status': -1,
+        })
     else:
-        info.update(dict(msg="OK (%s bytes)" % r.headers.get('Content-Length', 'unknown'), url=r.geturl(), status=r.code))
+        info.update({
+            'msg': 'OK (%s bytes)' % r.headers.get('Content-Length', 'unknown'),
+            'url': r.geturl(),
+            'status': r.code,
+        })
 
     return r, info
 
@@ -1976,8 +1993,11 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     except MissingModuleError as e:
         module.fail_json(msg=to_text(e), exception=e.import_traceback)
     except Exception as e:
-        info.update(dict(msg="An unknown error occurred: %s" % to_native(e), status=-1),
-                    exception=traceback.format_exc())
+        info.update({
+            'msg': 'An unknown error occurred: %s' % to_native(e),
+            'status': -1,
+            'exception': traceback.format_exc()
+        })
     else:
         info.update(tmp_info)
     finally:

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1973,7 +1973,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     info = {'url': url, 'status': -1}
     try:
         r, tmp_info = catch_request_errors(
-            Request().open, url, data=data, headers=headers, method=method,
+            Request().open, method, url, data=data, headers=headers,
             use_proxy=use_proxy, force=force, last_mod_time=last_mod_time, timeout=timeout,
             validate_certs=validate_certs, url_username=username,
             url_password=password, http_agent=http_agent, force_basic_auth=force_basic_auth,

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1312,7 +1312,13 @@ def normalize_headers(response):
     if response is None:
         return headers
 
-    for name, value in response.headers.items():
+    try:
+        response_headers = response.headers
+    except AttributeError:
+        # Python2 and HTTPError
+        response_headers = response.hdrs
+
+    for name, value in response_headers.items():
         if name in headers:
             headers[name] = ', '.join((headers[name], value))
         else:

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1973,7 +1973,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     info = {'url': url, 'status': -1}
     try:
         r, tmp_info = catch_request_errors(
-            Request().open, method, url, data=data, headers=headers,
+            open_url, url, data=data, headers=headers, method=method,
             use_proxy=use_proxy, force=force, last_mod_time=last_mod_time, timeout=timeout,
             validate_certs=validate_certs, url_username=username,
             url_password=password, http_agent=http_agent, force_basic_auth=force_basic_auth,

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1815,6 +1815,68 @@ def url_argument_spec():
     )
 
 
+def normalize_headers(response):
+    if PY2:
+        headers = httplib.HTTPMessage(cStringIO())
+    else:
+        headers = httplib.HTTPMessage()
+
+    if response is None:
+        return headers
+
+    for name, value in response.headers.items():
+        # The same as above, lower case keys to match py2 behavior, and create more consistent results
+        name = name.lower()
+        if name in headers:
+            headers[name] = ', '.join((headers[name], value))
+        else:
+            headers[name] = value
+
+    return headers
+
+
+def process_cookies(cookies):
+    # parse the cookies into a nice dictionary
+    cookie_list = []
+    cookie_dict = {}
+    # Python sorts cookies in order of most specific (ie. longest) path first. See ``CookieJar._cookie_attrs``
+    # Cookies with the same path are reversed from response order.
+    # This code makes no assumptions about that, and accepts the order given by python
+    for cookie in cookies:
+        cookie_dict[cookie.name] = cookie.value
+        cookie_list.append((cookie.name, cookie.value))
+    cookies_string = '; '.join('%s=%s' % c for c in cookie_list)
+
+    return cookie_dict, cookies_string
+
+
+def catch_request_errors(url, *args, **kwargs):
+    info = {}
+    r = None
+    try:
+        r = open_url(url, *args, **kwargs)
+    except urllib_error.HTTPError as e:
+        r = e
+        try:
+            body = e.read()
+        except AttributeError:
+            body = ''
+        else:
+            e.close()
+        info.update({'msg': to_native(e), 'body': body, 'status': e.code})
+    except urllib_error.URLError as e:
+        code = int(getattr(e, 'code', -1))
+        info.update(dict(msg="Request failed: %s" % to_native(e), status=code))
+    except socket.error as e:
+        info.update(dict(msg="Connection failure: %s" % to_native(e), status=-1))
+    except httplib.BadStatusLine as e:
+        info.update(dict(msg="Connection failure: connection was closed before a valid response was received: %s" % to_native(e.line), status=-1))
+    else:
+        info.update(dict(msg="OK (%s bytes)" % r.headers.get('Content-Length', 'unknown'), url=r.geturl(), status=r.code))
+
+    return r, info
+
+
 def fetch_url(module, url, data=None, headers=None, method=None,
               use_proxy=None, force=False, last_mod_time=None, timeout=10,
               use_gssapi=False, unix_socket=None, ca_path=None, cookies=None, unredirected_headers=None,
@@ -1893,46 +1955,18 @@ def fetch_url(module, url, data=None, headers=None, method=None,
         cookies = cookiejar.LWPCookieJar()
 
     r = None
-    info = dict(url=url, status=-1)
+    info = {'url': url, 'status': -1}
     try:
-        r = open_url(url, data=data, headers=headers, method=method,
-                     use_proxy=use_proxy, force=force, last_mod_time=last_mod_time, timeout=timeout,
-                     validate_certs=validate_certs, url_username=username,
-                     url_password=password, http_agent=http_agent, force_basic_auth=force_basic_auth,
-                     follow_redirects=follow_redirects, client_cert=client_cert,
-                     client_key=client_key, cookies=cookies, use_gssapi=use_gssapi,
-                     unix_socket=unix_socket, ca_path=ca_path, unredirected_headers=unredirected_headers,
-                     decompress=decompress, ciphers=ciphers)
-        # Lowercase keys, to conform to py2 behavior, so that py3 and py2 are predictable
-        info.update(dict((k.lower(), v) for k, v in r.info().items()))
-
-        # Don't be lossy, append header values for duplicate headers
-        # In Py2 there is nothing that needs done, py2 does this for us
-        if PY3:
-            temp_headers = {}
-            for name, value in r.headers.items():
-                # The same as above, lower case keys to match py2 behavior, and create more consistent results
-                name = name.lower()
-                if name in temp_headers:
-                    temp_headers[name] = ', '.join((temp_headers[name], value))
-                else:
-                    temp_headers[name] = value
-            info.update(temp_headers)
-
-        # parse the cookies into a nice dictionary
-        cookie_list = []
-        cookie_dict = dict()
-        # Python sorts cookies in order of most specific (ie. longest) path first. See ``CookieJar._cookie_attrs``
-        # Cookies with the same path are reversed from response order.
-        # This code makes no assumptions about that, and accepts the order given by python
-        for cookie in cookies:
-            cookie_dict[cookie.name] = cookie.value
-            cookie_list.append((cookie.name, cookie.value))
-        info['cookies_string'] = '; '.join('%s=%s' % c for c in cookie_list)
-
-        info['cookies'] = cookie_dict
-        # finally update the result with a message about the fetch
-        info.update(dict(msg="OK (%s bytes)" % r.headers.get('Content-Length', 'unknown'), url=r.geturl(), status=r.code))
+        r, tmp_info = catch_request_errors(
+            url, data=data, headers=headers, method=method,
+            use_proxy=use_proxy, force=force, last_mod_time=last_mod_time, timeout=timeout,
+            validate_certs=validate_certs, url_username=username,
+            url_password=password, http_agent=http_agent, force_basic_auth=force_basic_auth,
+            follow_redirects=follow_redirects, client_cert=client_cert,
+            client_key=client_key, cookies=cookies, use_gssapi=use_gssapi,
+            unix_socket=unix_socket, ca_path=ca_path, unredirected_headers=unredirected_headers,
+            decompress=decompress, ciphers=ciphers,
+        )
     except NoSSLError as e:
         distribution = get_distribution()
         if distribution is not None and distribution.lower() == 'redhat':
@@ -1943,41 +1977,17 @@ def fetch_url(module, url, data=None, headers=None, method=None,
         module.fail_json(msg=to_native(e), **info)
     except MissingModuleError as e:
         module.fail_json(msg=to_text(e), exception=e.import_traceback)
-    except urllib_error.HTTPError as e:
-        r = e
-        try:
-            if e.fp is None:
-                # Certain HTTPError objects may not have the ability to call ``.read()`` on Python 3
-                # This is not handled gracefully in Python 3, and instead an exception is raised from
-                # tempfile, due to ``urllib.response.addinfourl`` not being initialized
-                raise AttributeError
-            body = e.read()
-        except AttributeError:
-            body = ''
-        else:
-            e.close()
-
-        # Try to add exception info to the output but don't fail if we can't
-        try:
-            # Lowercase keys, to conform to py2 behavior, so that py3 and py2 are predictable
-            info.update(dict((k.lower(), v) for k, v in e.info().items()))
-        except Exception:
-            pass
-
-        info.update({'msg': to_native(e), 'body': body, 'status': e.code})
-
-    except urllib_error.URLError as e:
-        code = int(getattr(e, 'code', -1))
-        info.update(dict(msg="Request failed: %s" % to_native(e), status=code))
-    except socket.error as e:
-        info.update(dict(msg="Connection failure: %s" % to_native(e), status=-1))
-    except httplib.BadStatusLine as e:
-        info.update(dict(msg="Connection failure: connection was closed before a valid response was received: %s" % to_native(e.line), status=-1))
     except Exception as e:
         info.update(dict(msg="An unknown error occurred: %s" % to_native(e), status=-1),
                     exception=traceback.format_exc())
+    else:
+        info.update(tmp_info)
+        info['cookies'], info['cookies_string'] = process_cookies(cookies)
     finally:
         tempfile.tempdir = old_tempdir
+
+    # Lowercase keys, to conform to py2 behavior, so that py3 and py2 are predictable
+    info.update(dict((k.lower(), v) for k, v in normalize_headers(r).items()))
 
     return r, info
 

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -305,7 +305,7 @@
   environment:
     https_proxy: 'https://localhost:3456'
   uri:
-    url: 'https://httpbin.org/get'
+    url: 'https://{{ httpbin_host }}/get'
   register: result
   ignore_errors: true
 
@@ -318,7 +318,7 @@
   environment:
     https_proxy: 'https://localhost:3456'
   uri:
-    url: 'https://httpbin.org/get'
+    url: 'https://{{ httpbin_host }}/get'
     use_proxy: no
 
 # Ubuntu12.04 doesn't have python-urllib3, this makes handling required dependencies a pain across all variations

--- a/test/units/module_utils/urls/test_fetch_url.py
+++ b/test/units/module_utils/urls/test_fetch_url.py
@@ -201,30 +201,35 @@ def test_fetch_url_httperror(open_url_mock, fake_ansible_module):
     r, info = fetch_url(fake_ansible_module, 'http://ansible.com/')
 
     assert info == {'msg': 'HTTP Error 500: Internal Server Error', 'body': 'TESTS',
-                    'status': 500, 'url': 'http://ansible.com/', 'content-type': 'application/json'}
+                    'status': 500, 'url': 'http://ansible.com/', 'content-type': 'application/json',
+                    'cookies_string': '', 'cookies': {}}
 
 
 def test_fetch_url_urlerror(open_url_mock, fake_ansible_module):
     open_url_mock.side_effect = urllib_error.URLError('TESTS')
     r, info = fetch_url(fake_ansible_module, 'http://ansible.com/')
-    assert info == {'msg': 'Request failed: <urlopen error TESTS>', 'status': -1, 'url': 'http://ansible.com/'}
+    assert info == {'msg': 'Request failed: <urlopen error TESTS>', 'status': -1, 'url': 'http://ansible.com/',
+                    'cookies_string': '', 'cookies': {}}
 
 
 def test_fetch_url_socketerror(open_url_mock, fake_ansible_module):
     open_url_mock.side_effect = socket.error('TESTS')
     r, info = fetch_url(fake_ansible_module, 'http://ansible.com/')
-    assert info == {'msg': 'Connection failure: TESTS', 'status': -1, 'url': 'http://ansible.com/'}
+    assert info == {'msg': 'Connection failure: TESTS', 'status': -1, 'url': 'http://ansible.com/',
+                    'cookies_string': '', 'cookies': {}}
 
 
 def test_fetch_url_exception(open_url_mock, fake_ansible_module):
     open_url_mock.side_effect = Exception('TESTS')
     r, info = fetch_url(fake_ansible_module, 'http://ansible.com/')
     exception = info.pop('exception')
-    assert info == {'msg': 'An unknown error occurred: TESTS', 'status': -1, 'url': 'http://ansible.com/'}
+    assert info == {'msg': 'An unknown error occurred: TESTS', 'status': -1, 'url': 'http://ansible.com/',
+                    'cookies_string': '', 'cookies': {}}
     assert "Exception: TESTS" in exception
 
 
 def test_fetch_url_badstatusline(open_url_mock, fake_ansible_module):
     open_url_mock.side_effect = httplib.BadStatusLine('TESTS')
     r, info = fetch_url(fake_ansible_module, 'http://ansible.com/')
-    assert info == {'msg': 'Connection failure: connection was closed before a valid response was received: TESTS', 'status': -1, 'url': 'http://ansible.com/'}
+    assert info == {'msg': 'Connection failure: connection was closed before a valid response was received: TESTS', 'status': -1, 'url': 'http://ansible.com/',
+                    'cookies_string': '', 'cookies': {}}


### PR DESCRIPTION
##### SUMMARY
Extract useful code out of `fetch_url`

This can potentially ease the over reliance on `fetch_url`, moving more plugin authors to `Request`, but offering some added functionality to perform similar processing to what `fetch_url` was solely responsible for:

* normalizing headers
* processing cookies
* handling common exceptions

Fixes #54721 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/urls.py

##### ADDITIONAL INFORMATION
Required:
* docs
* tests
