### PR TITLE
[stable-2.9] Disable aws_lamdba test

### DIFF
--- a/test/integration/targets/aws_lambda/aliases
+++ b/test/integration/targets/aws_lambda/aliases
@@ -2,3 +2,4 @@ cloud/aws
 shippable/aws/group2
 execute_lambda
 lambda
+disabled  # Due to change in AWS behavior, this test will no longer pass


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The AWS lamdba API has changed and the modules in 2.9 are effectively broken.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/aws_lambda/aliases`