### PR TITLE
reset defaults for json filters

### DIFF
--- a/changelogs/fragments/json_filter_fix.yml
+++ b/changelogs/fragments/json_filter_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - to_json/to_nice_json filters defaults back to unvaulting/no unsafe packing.

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -65,6 +65,13 @@ def to_nice_yaml(a, indent=4, *args, **kw):
 
 def to_json(a, *args, **kw):
     ''' Convert the value to JSON '''
+
+    # defualts for filters
+    if 'vault_to_text' not in kw:
+        kw['vault_to_text'] = True
+    if 'preprocess_unsafe' not in kw:
+        kw['preprocess_unsafe'] = False
+
     return json.dumps(a, cls=AnsibleJSONEncoder, *args, **kw)
 
 


### PR DESCRIPTION
  these had change on unification of json parsing/dumping
  now they behave like before, but are still controlable by user.

  fixes #76334

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
filters/to_json