### PR TITLE
fix shell/command/script tasks skipping in check mode

### DIFF
--- a/changelogs/fragments/76353-fix-check-mode-skipping.yaml
+++ b/changelogs/fragments/76353-fix-check-mode-skipping.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - shell/command - only skip in check mode if the options `creates` and `removes` are both None.
+  - script - skip in check mode since the plugin cannot determine if a change will occur.

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -373,7 +373,8 @@ def main():
         # this is partial check_mode support, since we end up skipping if we get here
         r['rc'] = 0
         r['msg'] = "Command would have run if not in check mode"
-        r['skipped'] = True
+        if creates is None and removes is None:
+            r['skipped'] = True
 
     r['changed'] = True
 

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -119,7 +119,9 @@ class ActionModule(ActionBase):
                     script_cmd = ' '.join([env_string, target_command])
 
             if self._play_context.check_mode:
-                raise _AnsibleActionDone()
+                # If the script doesn't return changed in the result, it defaults to True,
+                # but since the script may override 'changed', just skip instead of guessing.
+                raise AnsibleActionSkip('Check mode is not supported for this task.')
 
             script_cmd = self._connection._shell.wrap_for_exec(script_cmd)
 


### PR DESCRIPTION
##### SUMMARY
Fix shell/command to only report `skipped` during check mode if changed is unknown (i.e. `removes` and `creates` are None) which matches the documented behavior: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/command_module.html#notes

Also fix the script module to skip in check mode, since the script can return 'changed' in the result so it's unknown if changed will be True.

Related: #76147

##### ISSUE TYPE
- Bugfix Pull Request
