### PR TITLE
Update special_variables.rst

### DIFF
--- a/docs/docsite/rst/reference_appendices/special_variables.rst
+++ b/docs/docsite/rst/reference_appendices/special_variables.rst
@@ -119,7 +119,7 @@ ansible_play_name
     The name of the currently executed play. Added in ``2.8``. (`name` attribute of the play, not file name of the playbook.)
 
 playbook_dir
-    The path to the directory of the playbook that was passed to the ``ansible-playbook`` command line.
+    The path to the directory of the current playbook being executed.  NOTE: This might be different than directory of the playbook passed to the ``ansible-playbook`` command line when a playbook contains a ``import_playbook`` statement. 
 
 role_name
     The name of the role currently being executed.


### PR DESCRIPTION
##### SUMMARY
The value of this variable changes when an `import_playbook` statement is encountered.  If I have a local playbook, that then includes a playbook from a collection, the `playbook_dir` variable is set to a directory in the collection, not to the local playbook passed to `ansible-playbook`.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
