### PR TITLE
unarchive: Keep stderr when pick_handler fails

### DIFF
--- a/changelogs/fragments/76365-unarchive-include-stderr-in-error-message.yml
+++ b/changelogs/fragments/76365-unarchive-include-stderr-in-error-message.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - unarchive - include the original error when a handler cannot manage the archive (https://github.com/ansible/ansible/issues/28977).

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -739,7 +739,7 @@ class ZipArchive(object):
         rc, out, err = self.module.run_command(cmd)
         if rc == 0:
             return True, None
-        return False, 'Command "%s" could not handle archive.' % self.cmd_path
+        return False, 'Command "%s" could not handle archive: %s' % (self.cmd_path, err)
 
 
 class TgzArchive(object):
@@ -788,7 +788,7 @@ class TgzArchive(object):
         locale = get_best_parsable_locale(self.module)
         rc, out, err = self.module.run_command(cmd, cwd=self.b_dest, environ_update=dict(LANG=locale, LC_ALL=locale, LC_MESSAGES=locale, LANGUAGE=locale))
         if rc != 0:
-            raise UnarchiveError('Unable to list files in the archive')
+            raise UnarchiveError(err)
 
         for filename in out.splitlines():
             # Compensate for locale-related problems in gtar output (octal unicode representation) #11348
@@ -907,8 +907,8 @@ class TgzArchive(object):
         try:
             if self.files_in_archive:
                 return True, None
-        except UnarchiveError:
-            return False, 'Command "%s" could not handle archive.' % self.cmd_path
+        except UnarchiveError as e:
+            return False, 'Command "%s" could not handle archive: %s' % (self.cmd_path, e)
         # Errors and no files in archive assume that we weren't able to
         # properly unarchive it
         return False, 'Command "%s" found no files in archive. Empty archive files are not supported.' % self.cmd_path
@@ -952,15 +952,15 @@ class TarZstdArchive(TgzArchive):
 # try handlers in order and return the one that works or bail if none work
 def pick_handler(src, dest, file_args, module):
     handlers = [ZipArchive, TgzArchive, TarArchive, TarBzipArchive, TarXzArchive, TarZstdArchive]
-    reasons = set()
+    reasons = []
     for handler in handlers:
         obj = handler(src, dest, file_args, module)
         (can_handle, reason) = obj.can_handle_archive()
         if can_handle:
             return obj
-        reasons.add(reason)
-    reason_msg = ' '.join(reasons)
-    module.fail_json(msg='Failed to find handler for "%s". Make sure the required command to extract the file is installed. %s' % (src, reason_msg))
+        reasons.append("%s: %s" % (handler.__name__, reason))
+    reason_msg = '\n'.join(reasons)
+    module.fail_json(msg='Failed to find handler for "%s". Make sure the required command to extract the file is installed.\n%s' % (src, reason_msg))
 
 
 def main():

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -788,7 +788,7 @@ class TgzArchive(object):
         locale = get_best_parsable_locale(self.module)
         rc, out, err = self.module.run_command(cmd, cwd=self.b_dest, environ_update=dict(LANG=locale, LC_ALL=locale, LC_MESSAGES=locale, LANGUAGE=locale))
         if rc != 0:
-            raise UnarchiveError(err)
+            raise UnarchiveError('Unable to list files in the archive: %s' % err)
 
         for filename in out.splitlines():
             # Compensate for locale-related problems in gtar output (octal unicode representation) #11348
@@ -908,7 +908,7 @@ class TgzArchive(object):
             if self.files_in_archive:
                 return True, None
         except UnarchiveError as e:
-            return False, 'Command "%s" could not handle archive: %s' % (self.cmd_path, e)
+            return False, 'Command "%s" could not handle archive: %s' % (self.cmd_path, to_native(e))
         # Errors and no files in archive assume that we weren't able to
         # properly unarchive it
         return False, 'Command "%s" found no files in archive. Empty archive files are not supported.' % self.cmd_path

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -391,9 +391,9 @@ class ZipArchive(object):
                                     break
                         if not exclude_flag:
                             self._files_in_archive.append(to_native(member))
-            except Exception:
+            except Exception as e:
                 archive.close()
-                raise UnarchiveError('Unable to list files in the archive')
+                raise UnarchiveError('Unable to list files in the archive: %s' % to_native(e))
 
             archive.close()
         return self._files_in_archive

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -952,13 +952,13 @@ class TarZstdArchive(TgzArchive):
 # try handlers in order and return the one that works or bail if none work
 def pick_handler(src, dest, file_args, module):
     handlers = [ZipArchive, TgzArchive, TarArchive, TarBzipArchive, TarXzArchive, TarZstdArchive]
-    reasons = []
+    reasons = set()
     for handler in handlers:
         obj = handler(src, dest, file_args, module)
         (can_handle, reason) = obj.can_handle_archive()
         if can_handle:
             return obj
-        reasons.append("%s: %s" % (handler.__name__, reason))
+        reasons.add(reason)
     reason_msg = '\n'.join(reasons)
     module.fail_json(msg='Failed to find handler for "%s". Make sure the required command to extract the file is installed.\n%s' % (src, reason_msg))
 

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -18,3 +18,4 @@
 - import_tasks: test_download.yml
 - import_tasks: test_unprivileged_user.yml
 - import_tasks: test_different_language_var.yml
+- import_tasks: test_invalid_options.yml

--- a/test/integration/targets/unarchive/tasks/test_invalid_options.yml
+++ b/test/integration/targets/unarchive/tasks/test_invalid_options.yml
@@ -1,0 +1,27 @@
+- name: create our tar unarchive destination
+  file:
+    path: '{{remote_tmp_dir}}/test-unarchive-tar'
+    state: directory
+
+- name: unarchive a tar file with an invalid option
+  unarchive:
+    src: '{{remote_tmp_dir}}/test-unarchive.tar'
+    dest: '{{remote_tmp_dir}}/test-unarchive-tar'
+    remote_src: yes
+    extra_opts:
+      - "--invalid-éxtra-optら"
+  ignore_errors: yes
+  register: unarchive
+
+- name: verify that the invalid option is in the error message
+  assert:
+    that:
+      - "unarchive is failed"
+      - "unarchive['msg'] is search(msg)"
+  vars:
+    msg: "Unable to list files in the archive: /.*/(tar|gtar): unrecognized option '--invalid-éxtra-optら'"
+
+- name: remove our tar unarchive destination
+  file:
+    path: '{{remote_tmp_dir}}/test-unarchive-tar'
+    state: absent


### PR DESCRIPTION
##### SUMMARY
This is a quick stab at trying to fix #28977

As outlined in the issue above, if there's an error in the `include` or `extra_opts` parameters of the unarchive module (and quite possibly other parameters), the error message reported to the user is not very helpful:

```
localhost | FAILED! => {"changed": false,"msg": "Failed to find handler for \"/home/jean/.ansible/tmp/ansible-tmp-1637803546.8787358-363459-92461935259214/source\". Make sure the required command to extract the file is installed. Command \"/bin/unzip\" could not handle archive. Command \"/bin/tar\" could not handle archive."}   
```
With this change, the error message becomes a lot more verbose, which is clearly not optimal, but at least the actual error is shown and the user can figure out what is going on by reading it.  (in this case, the task is trying to `include` a file that doesn't exist in the archive)

```localhost | FAILED! => {
    "changed": false,
    "msg": "Failed to find handler for \"/home/jean/.ansible/tmp/ansible-tmp-1637805599.1465375-364358-227471331157378/source\". Make sure the required command to extract the file is installed.\nZipArchive: Command \"/bin/unzip\" could not handle archive:   End-of-central-directory signature not found.  Either this file is not\n  a zipfile, or it constitutes one disk of a multi-part archive.  In the\n  latter case the central directory and zipfile comment will be found on\n  the last disk(s) of this archive.\nnote:  /home/jean/.ansible/tmp/ansible-tmp-1637805599.1465375-364358-227471331157378/source may be a plain executable, not an archive\nunzip:  cannot find zipfile directory in one of /home/jean/.ansible/tmp/ansible-tmp-1637805599.1465375-364358-227471331157378/source or\n        /home/jean/.ansible/tmp/ansible-tmp-1637805599.1465375-364358-227471331157378/source.zip, and cannot find /home/jean/.ansible/tmp/ansible-tmp-1637805599.1465375-364358-227471331157378/source.ZIP, period.\n\nTgzArchive: Command \"/bin/tar\" could not handle archive: /bin/tar: b: Not found in archive\n/bin/tar: Exiting with failure status due to previous errors\n\nTarArchive: Command \"/bin/tar\" could not handle archive: /bin/tar: b: Not found in archive\n/bin/tar: Exiting with failure status due to previous errors\n\nTarBzipArchive: Command \"/bin/tar\" could not handle archive: bzip2: (stdin) is not a bzip2 file.\n/bin/tar: Child returned status 2\n/bin/tar: Error is not recoverable: exiting now\n\nTarXzArchive: Command \"/bin/tar\" could not handle archive: xz: (stdin): File format not recognized\n/bin/tar: Child returned status 1\n/bin/tar: Error is not recoverable: exiting now\n\nTarZstdArchive: Command \"/bin/tar\" could not handle archive: /bin/tar: b: Not found in archive\n/bin/tar: Exiting with failure status due to previous errors\n"
}
```

(with actual newlines...)
```
localhost | FAILED! => {                                                                                                                                                                                                                                                                   
    "changed": false,                                                                                                                                                                                                                                                                      
    "msg": "Failed to find handler for \"/home/jean/.ansible/tmp/ansible-tmp-1637805671.1341913-364481-176437873597887/source\". Make sure the required command to extract the file is installed.                                                                                          ZipArchive: Command \"/bin/unzip\" could not handle archive:   End-of-central-directory signature not found.  Either this file is not                                                                                                                                                        a zipfile, or it constitutes one disk of a multi-part archive.  In the                                                                                                                                                                                                                     latter case the central directory and zipfile comment will be found on                                                                                                                                                                                                                     the last disk(s) of this archive.                                                                                                                                                                                                                                                        note:  /home/jean/.ansible/tmp/ansible-tmp-1637805671.1341913-364481-176437873597887/source may be a plain executable, not an archive                                                                                                                                                      unzip:  cannot find zipfile directory in one of /home/jean/.ansible/tmp/ansible-tmp-1637805671.1341913-364481-176437873597887/source or                                                                                                                                                    
        /home/jean/.ansible/tmp/ansible-tmp-1637805671.1341913-364481-176437873597887/source.zip, and cannot find /home/jean/.ansible/tmp/ansible-tmp-1637805671.1341913-364481-176437873597887/source.ZIP, period.                                                                        
                                                                                                                                                                                                                                                                                           
TgzArchive: Command \"/bin/tar\" could not handle archive: /bin/tar: b: Not found in archive                                                                                                                                                                                               
/bin/tar: Exiting with failure status due to previous errors                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                           
TarArchive: Command \"/bin/tar\" could not handle archive: /bin/tar: b: Not found in archive                                                                                                                                                                                               
/bin/tar: Exiting with failure status due to previous errors                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                           
TarBzipArchive: Command \"/bin/tar\" could not handle archive: bzip2: (stdin) is not a bzip2 file.                                                                                                                                                                                         
/bin/tar: Child returned status 2                                                                                                                                                                                                                                                          
/bin/tar: Error is not recoverable: exiting now                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                           
TarXzArchive: Command \"/bin/tar\" could not handle archive: xz: (stdin): File format not recognized                                                                                                                                                                                       
/bin/tar: Child returned status 1                                                                                                                                                                                                                                                          
/bin/tar: Error is not recoverable: exiting now                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                           
TarZstdArchive: Command \"/bin/tar\" could not handle archive: /bin/tar: b: Not found in archive                                                                                                                                                                                           
/bin/tar: Exiting with failure status due to previous errors                                                                                                                                                                                                                               
"                                                                                                                                                                                                                                                                                          
}   
```
Of course, this feels verbose and clunky, but one could argue that it is much better than swallowing the error.

Would there be a better way to provide this information to the user?


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
unarchive