### PR TITLE
Add openrc support to service_facts

### DIFF
--- a/changelogs/fragments/76373-add-openrc-support-to-service_facts.yaml
+++ b/changelogs/fragments/76373-add-openrc-support-to-service_facts.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - services_facts: Add support for openrc (https://github.com/ansible/ansible/pull/76373).
+  - services_facts - Add support for openrc (https://github.com/ansible/ansible/pull/76373).

--- a/changelogs/fragments/76373-add-openrc-support-to-service_facts.yaml
+++ b/changelogs/fragments/76373-add-openrc-support-to-service_facts.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - services_facts: Add support for openrc (https://github.com/ansible/ansible/pull/76373).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add openrc support to `service_facts` module.

The `service` module supports openrc, but the `service_facts` doesn't, making it unusable on for example alpine linux.

As in openrc, services are configured by runlevels, instead of using status enabled/disabled, I chose to include the configure runlevels, or `None` if there isn't any reported.

Services can be added to multiple runlevels, so this is reported as an array.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
service_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Using the following playbook:
```
---
- hosts: all
  become: false
  tasks:
    - service_facts:
      become: true

    - debug: var=ansible_facts.services

```

Before:
```
PLAY [all] *********************************************************************

TASK [Gathering Facts] *********************************************************
ok: [alpine]

TASK [service_facts] ***********************************************************
skipping: [alpine]

TASK [debug] *******************************************************************
ok: [alpine] => {
    "ansible_facts.services": "VARIABLE IS NOT DEFINED!"
}

PLAY RECAP *********************************************************************
alpine                     : ok=2    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
```

After:
```
PLAY [all] *********************************************************************                                                                                                                                                  [394/15332]

TASK [Gathering Facts] *********************************************************
ok: [alpine]

TASK [service_facts] ***********************************************************
ok: [alpine]

TASK [debug] *******************************************************************
ok: [alpine] => {
    "ansible_facts.services": {
        "acpid": {
            "name": "acpid",
            "runlevels": [
                "default"
            ],
            "source": "openrc",
            "state": "started"
        },
        "agetty": {
            "name": "agetty",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "binfmt": {
            "name": "binfmt",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "bootmisc": {
            "name": "bootmisc",
            "runlevels": [
                "boot"
            ],
            "source": "openrc",
            "state": "started"
        },
        "cgroups": {
            "name": "cgroups",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "consolefont": {                                                                                                                                                                                                          [349/15332]
            "name": "consolefont",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "crond": {
            "name": "crond",
            "runlevels": [
                "default"
            ],
            "source": "openrc",
            "state": "started"
        },
        "devfs": {
            "name": "devfs",
            "runlevels": [
                "sysinit"
            ],
            "source": "openrc",
            "state": "started"
        },
        "dmesg": {
            "name": "dmesg",
            "runlevels": [
                "sysinit"
            ],
            "source": "openrc",
            "state": "started"
        },
        "dnsd": {
            "name": "dnsd",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "firstboot": {
            "name": "firstboot",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "fsck": {
            "name": "fsck",
            "runlevels": null,
            "source": "openrc",
            "state": "started"
        },
        "haveged": {                                                                                                                                                                                                              [301/15332]
            "name": "haveged",
            "runlevels": [
                "default"
            ],
            "source": "openrc",
            "state": "started"
        },
        "hostname": {
            "name": "hostname",
            "runlevels": [
                "boot"
            ],
            "source": "openrc",
            "state": "started"
        },
        "httpd": {
            "name": "httpd",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "hwclock": {
            "name": "hwclock",
            "runlevels": [
                "boot"
            ],
            "source": "openrc",
            "state": "started"
        },
        "hwdrivers": {
            "name": "hwdrivers",
            "runlevels": [
                "sysinit"
            ],
            "source": "openrc",
            "state": "started"
        },
        "inetd": {
            "name": "inetd",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "killprocs": {                                                                                                                                                                                                            [257/15332]
            "name": "killprocs",
            "runlevels": [
                "shutdown"
            ],
            "source": "openrc",
            "state": "stopped"
        },
        "klogd": {
            "name": "klogd",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "kmod-static-nodes": {
            "name": "kmod-static-nodes",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "loadkmap": {
            "name": "loadkmap",
            "runlevels": [
                "boot"
            ],
            "source": "openrc",
            "state": "started"
        },
        "local": {
            "name": "local",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "localmount": {
            "name": "localmount",
            "runlevels": null,
            "source": "openrc",
            "state": "started"
        },
        "loopback": {
            "name": "loopback",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "machine-id": {                                                                                                                                                                                                           [211/15332]
            "name": "machine-id",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "mdev": {
            "name": "mdev",
            "runlevels": [
                "sysinit"
            ],
            "source": "openrc",
            "state": "started"
        },
        "modloop": {
            "name": "modloop",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "modules": {
            "name": "modules",
            "runlevels": [
                "boot"
            ],
            "source": "openrc",
            "state": "started"
        },
        "mount-ro": {
            "name": "mount-ro",
            "runlevels": [
                "shutdown"
            ],
            "source": "openrc",
            "state": "stopped"
        },
        "mtab": {
            "name": "mtab",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "net-online": {                                                                                                                                                                                                           [169/15332]
            "name": "net-online",
            "runlevels": [
                "default"
            ],
            "source": "openrc",
            "state": "started"
        },
        "netmount": {
            "name": "netmount",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "network": {
            "name": "network",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "networking": {
            "name": "networking",
            "runlevels": [
                "boot"
            ],
            "source": "openrc",
            "state": "started"
        },
        "ntpd": {
            "name": "ntpd",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "numlock": {
            "name": "numlock",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "openntpd": {
            "name": "openntpd",
            "runlevels": [
                "default"
            ],
            "source": "openrc",
            "state": "crashed"
        },
        "osclock": {                                                                                                                                                                                                              [121/15332]
            "name": "osclock",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "procfs": {
            "name": "procfs",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "qemu-guest-agent": {
            "name": "qemu-guest-agent",
            "runlevels": [
                "default"
            ],
            "source": "openrc",
            "state": "started"
        },
        "rdate": {
            "name": "rdate",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "root": {
            "name": "root",
            "runlevels": null,
            "source": "openrc",
            "state": "started"
        },
        "runsvdir": {
            "name": "runsvdir",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "s6-svscan": {
            "name": "s6-svscan",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "save-keymaps": {                                                                                                                                                                                                          [77/15332]
            "name": "save-keymaps",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "save-termencoding": {
            "name": "save-termencoding",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "savecache": {
            "name": "savecache",
            "runlevels": [
                "shutdown"
            ],
            "source": "openrc",
            "state": "stopped"
        },
        "sshd": {
            "name": "sshd",
            "runlevels": [
                "default"
            ],
            "source": "openrc",
            "state": "started"
        },
        "staticroute": {
            "name": "staticroute",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "swap": {
            "name": "swap",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "swclock": {
            "name": "swclock",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "sysctl": {                                                                                                                                                                                                                [31/15332]
            "name": "sysctl",
            "runlevels": [
                "boot"
            ],
            "source": "openrc",
            "state": "started"
        },
        "sysfs": {
            "name": "sysfs",
            "runlevels": null,
            "source": "openrc",
            "state": "started"
        },
        "sysfsconf": {
            "name": "sysfsconf",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "syslog": {
            "name": "syslog",
            "runlevels": [
                "boot"
            ],
            "source": "openrc",
            "state": "started"
        },
        "termencoding": {
            "name": "termencoding",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "udhcpd": {
            "name": "udhcpd",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "urandom": {
            "name": "urandom",
            "runlevels": [
                "boot"
            ],
            "source": "openrc",
            "state": "started"
        },
        "utmpd": {
            "name": "utmpd",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "watchdog": {
            "name": "watchdog",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        },
        "wtmpd": {
            "name": "wtmpd",
            "runlevels": null,
            "source": "openrc",
            "state": "stopped"
        }
    }
}

PLAY RECAP *********************************************************************
alpine                     : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
