### PR TITLE
jsonfile / doc: fix misnamed _uri parameters

### DIFF
--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -19,9 +19,9 @@ DOCUMENTATION = '''
         description:
           - Path in which the cache plugin will save the JSON files
         env:
-          - name: ANSIBLE_CACHE_PLUGIN_CONNECTION
+          - name: ANSIBLE_CACHE_PLUGIN_URI
         ini:
-          - key: fact_caching_connection
+          - key: fact_caching_uri
             section: defaults
         type: path
       _prefix:


### PR DESCRIPTION
##### SUMMARY

In the page https://docs.ansible.com/ansible/latest/collections/ansible/builtin/jsonfile_cache.html#ansible-collections-ansible-builtin-jsonfile-cache , the `_uri` parameters are wrongly named:

![image](https://user-images.githubusercontent.com/329467/143669088-b41a1d14-67e9-4663-b01b-80a7b4691f66.png)



##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`ansible.builtin.jsonfile`
