### PR TITLE
template lookup: jinja2_native has no effect if global is off

### DIFF
--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -103,7 +103,7 @@ class LookupModule(LookupBase):
         # capture options
         convert_data_p = self.get_option('convert_data')
         lookup_template_vars = self.get_option('template_vars')
-        jinja2_native = self.get_option('jinja2_native')
+        jinja2_native = self.get_option('jinja2_native') and C.DEFAULT_JINJA2_NATIVE
         variable_start_string = self.get_option('variable_start_string')
         variable_end_string = self.get_option('variable_end_string')
         comment_start_string = self.get_option('comment_start_string')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* This is [documented behavior](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/template_lookup.html#parameter-jinja2_native) that was unintentionally changed in #75587.
* Changelog is not needed.
* Discovered when investigating https://github.com/ansible/ansible/issues/76379
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
template lookup