### PR TITLE
Allow lookup vars plugin to search for list vars

### DIFF
--- a/lib/ansible/plugins/lookup/vars.py
+++ b/lib/ansible/plugins/lookup/vars.py
@@ -57,6 +57,15 @@ EXAMPLES = """
     - hosts
     - batch
     - hosts_all
+
+- name: lookup vars from a list
+  debug: msg="{{ lookup('vars', _varlist, wantedlist=True) }}"
+  vars:
+    myvar: 123
+    enabled: true
+    _varlist:
+      - myvar
+      - enabled
 """
 
 RETURN = """
@@ -83,6 +92,7 @@ class LookupModule(LookupBase):
         default = self.get_option('default')
 
         ret = []
+        terms = self._flatten(terms)
         for term in terms:
             if not isinstance(term, string_types):
                 raise AnsibleError('Invalid setting identifier, "%s" is not a string, its a %s' % (term, type(term)))


### PR DESCRIPTION
##### SUMMARY

The vars lookup plugin can get values from a single var, or several vars separated by a ',' but not a list.

For ie, `lookup("vars", _types, wantlist=True)` will fail with `Invalid setting identifier` if `_types` is a list.
The plugin expects strings

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lookup vars plugin

##### ADDITIONAL INFORMATION

```yaml

#
---
- hosts: 'localhost'
  gather_facts: false
  tasks:
  - name: lookup vars from a list
    debug:
      msg: "{{ lookup('vars', _varlist, wantedlist=True) }}"
    vars:
      myvar: 123
      enabled: true
      _varlist:
        - myvar
        - enabled
```
will output :

```
TASK [test lookup] *************************************************************************************************************************************************************************************************************************
Monday 29 November 2021  16:22:54 +0100 (0:00:00.124)       0:00:00.124 *******
fatal: [localhost]: FAILED! => {}

MSG:

An unhandled exception occurred while templating '{{ lookup("vars", _l, wantlist=true) }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: An unhandled exception occurred while running the lookup plugin 'vars'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Invalid setting identifier, "['abcd', 'efgh']" is not a string, its a <class 'list'>

PLAY RECAP *********************************************************************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```

With the modification provided in this PR, output will be :

```
TASK [lookup vars from a list msg={{ lookup('listvars', _varlist, wantedlist=True) }}] *****************************************************************************************************************************************************
ok: [localhost] => {}

MSG:

[123, True]

PLAY RECAP *********************************************************************************************************************************************************************************************************************************
localhost   
```

This allows complex data manipulation without the `set_fact / loop` bad pattern.