### PR TITLE
Use rpm_ostree_pkg module on OSTree Red Hat systems

### DIFF
--- a/changelogs/fragments/use-rpm-ostree-pkg-packages-module-on-ostree-systems.yaml
+++ b/changelogs/fragments/use-rpm-ostree-pkg-packages-module-on-ostree-systems.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+- Use `rpm_ostree_pkg` module for package installation on OSTree
+  systems instead of `atomic_container`, which is no longer under
+  development.

--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -498,12 +498,6 @@ plugin_routing:
       redirect: community.general.ali_instance
     ali_instance_info:
       redirect: community.general.ali_instance_info
-    atomic_container:
-      redirect: community.general.atomic_container
-    atomic_host:
-      redirect: community.general.atomic_host
-    atomic_image:
-      redirect: community.general.atomic_image
     clc_aa_policy:
       redirect: community.general.clc_aa_policy
     clc_alert_policy:
@@ -1182,6 +1176,8 @@ plugin_routing:
       redirect: community.general.rax_scaling_group
     rax_scaling_policy:
       redirect: community.general.rax_scaling_policy
+    rpm_ostree_pkg:
+      redirect: community.general.rpm_ostree_pkg
     scaleway_image_facts:
       redirect: community.general.scaleway_image_facts
     scaleway_ip_facts:

--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -15,7 +15,7 @@ from ansible.module_utils.facts.collector import BaseFactCollector
 # A list of dicts.  If there is a platform with more than one
 # package manager, put the preferred one last.  If there is an
 # ansible module, use that as the value for the 'name' key.
-PKG_MGRS = [{'path': '/usr/bin/rpm-ostree', 'name': 'atomic_container'},
+PKG_MGRS = [{'path': '/usr/bin/rpm-ostree', 'name': 'rpm_ostree_pkg'},
             {'path': '/usr/bin/yum', 'name': 'yum'},
             {'path': '/usr/bin/dnf', 'name': 'dnf'},
             {'path': '/usr/bin/apt-get', 'name': 'apt'},
@@ -70,7 +70,7 @@ class PkgMgrFactCollector(BaseFactCollector):
 
     def _check_rh_versions(self, pkg_mgr_name, collected_facts):
         if os.path.exists('/run/ostree-booted'):
-            return "atomic_container"
+            return "rpm_ostree_pkg"
 
         if collected_facts['ansible_distribution'] == 'Fedora':
             try:

--- a/test/units/module_utils/facts/test_ansible_collector.py
+++ b/test/units/module_utils/facts/test_ansible_collector.py
@@ -493,7 +493,7 @@ class TestPkgMgrOSTreeFacts(TestPkgMgrFacts):
         # Recollect facts
         self.setUp()
         self.assertIn('pkg_mgr', self.facts)
-        self.assertEqual(self.facts['pkg_mgr'], 'atomic_container')
+        self.assertEqual(self.facts['pkg_mgr'], 'rpm_ostree_pkg')
 
     def test_is_rhel_edge_ostree(self):
         self._recollect_facts('RedHat', 8)


### PR DESCRIPTION

##### SUMMARY
The Atomic Container efforts are no longer under development and the
proper way to install "packages" (software that isn't containers) on
OSTree based Fedora/RHEL systems is using `rpm-ostree install`. That is
facilitated by the `community.general.rpm_ostree_pkg` module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Support for `rpm_ostree_pkg` as a backend for the `packages` module.
