### PR TITLE
[stable-2.11] pin mongodb libraries in test

### DIFF
--- a/test/integration/targets/incidental_setup_mongodb/defaults/main.yml
+++ b/test/integration/targets/incidental_setup_mongodb/defaults/main.yml
@@ -42,5 +42,5 @@ redhat_packages_py3:
 # Do not install requests[security] via pip. It will cause test failures.
 # See https://github.com/ansible/ansible/pull/66319
 pip_packages:
-  - psutil
-  - pymongo
+  - psutil==5.8.0
+  - pymongo==3.12.2


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A recent release of PyMongo 4.0 caused tests to fail
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`test/integration/targets/incidental_setup_mongodb`