### PR TITLE
Cleanup write_file method in uri

### DIFF
--- a/changelogs/fragments/write_file_uri_cleanup.yml
+++ b/changelogs/fragments/write_file_uri_cleanup.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - cleanup write_file method, remove overkill safety checks and report any exception, change shutilcopyfile to use module.atomic_move
+  - uri - cleanup write_file method, remove overkill safety checks and report any exception, change shutilcopyfile to use module.atomic_move

--- a/changelogs/fragments/write_file_uri_cleanup.yml
+++ b/changelogs/fragments/write_file_uri_cleanup.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cleanup write_file method, remove overkill safety checks and report any exception, change shutilcopyfile to use module.atomic_move

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -469,7 +469,8 @@ def write_file(module, dest, content, resp):
             else:
                 shutil.copyfileobj(content, f)
     except Exception as e:
-        os.remove(tmpsrc)
+        if os.path.exists(tmpsrc):
+            os.remove(tmpsrc)
         msg = format_message("Failed to create temporary content file: %s" % to_native(e), resp)
         module.fail_json(msg=msg, **resp)
 
@@ -483,11 +484,13 @@ def write_file(module, dest, content, resp):
         try:
             module.atomic_move(tmpsrc, dest)
         except Exception as e:
-            os.remove(tmpsrc)
-            msg = format_message("failed to copy %s to %s: %s" % (tmpsrc, dest, to_native(e)), resp)
+            if os.path.exists(tmpsrc):
+                os.remove(tmpsrc)
+            msg = format_message("failed to copy %s to %s: %s" % (tmpsrc, dest, to_native(e)))
             module.fail_json(msg=msg, **resp)
 
-    os.remove(tmpsrc)
+    if os.path.exists(tmpsrc):
+        os.remove(tmpsrc)
 
 
 def absolute_location(url, location):

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -480,14 +480,15 @@ def write_file(module, dest, content, resp):
     checksum_dest = module.sha1(dest)
 
     if checksum_src != checksum_dest:
-      try:
-          module.atomic_move(tmpsrc, dest)
-      except Exception as e:
-          os.remove(tmpsrc)
-          msg = format_message("failed to copy %s to %s: %s" % (tmpsrc, dest, to_native(e)), resp)
-          module.fail_json(msg=msg, **resp)
+        try:
+            module.atomic_move(tmpsrc, dest)
+        except Exception as e:
+            os.remove(tmpsrc)
+            msg = format_message("failed to copy %s to %s: %s" % (tmpsrc, dest, to_native(e)), resp)
+            module.fail_json(msg=msg, **resp)
 
-    os.remove(tmpsrc)  
+    os.remove(tmpsrc)
+
 
 def absolute_location(url, location):
     """Attempts to create an absolute URL based on initial URL, and

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -474,7 +474,7 @@ def write_file(module, dest, content, resp):
         module.fail_json(msg=msg, **resp)
 
     checksum_src = None
-    checksum_dst = None
+    checksum_dest = None
 
     checksum_src = module.sha1(tmpsrc)
     checksum_dest = module.sha1(dest)
@@ -486,7 +486,7 @@ def write_file(module, dest, content, resp):
           os.remove(tmpsrc)
           msg = format_message("failed to copy %s to %s: %s" % (tmpsrc, dest, to_native(e)), resp)
           module.fail_json(msg=msg, **resp)
-          
+
     os.remove(tmpsrc)  
 
 def absolute_location(url, location):

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -486,7 +486,7 @@ def write_file(module, dest, content, resp):
         except Exception as e:
             if os.path.exists(tmpsrc):
                 os.remove(tmpsrc)
-            msg = format_message("failed to copy %s to %s: %s" % (tmpsrc, dest, to_native(e)))
+            msg = format_message("failed to copy %s to %s: %s" % (tmpsrc, dest, to_native(e)), resp)
             module.fail_json(msg=msg, **resp)
 
     if os.path.exists(tmpsrc):

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -460,59 +460,19 @@ def format_message(err, resp):
 def write_file(module, dest, content, resp):
     # create a tempfile with some test content
     fd, tmpsrc = tempfile.mkstemp(dir=module.tmpdir)
-    f = os.fdopen(fd, 'wb')
     try:
-        if isinstance(content, binary_type):
-            f.write(content)
-        else:
-            shutil.copyfileobj(content, f)
+        with os.fdopen(fd, 'wb') as f:
+            if isinstance(content, binary_type):
+                f.write(content)
+            else:
+                module.atomic_move(content, f)
     except Exception as e:
         os.remove(tmpsrc)
         msg = format_message("Failed to create temporary content file: %s" % to_native(e), resp)
         module.fail_json(msg=msg, **resp)
-    f.close()
-
-    checksum_src = None
-    checksum_dest = None
-
-    # raise an error if there is no tmpsrc file
-    if not os.path.exists(tmpsrc):
+    finally:
+        f.close()
         os.remove(tmpsrc)
-        msg = format_message("Source '%s' does not exist" % tmpsrc, resp)
-        module.fail_json(msg=msg, **resp)
-    if not os.access(tmpsrc, os.R_OK):
-        os.remove(tmpsrc)
-        msg = format_message("Source '%s' not readable" % tmpsrc, resp)
-        module.fail_json(msg=msg, **resp)
-    checksum_src = module.sha1(tmpsrc)
-
-    # check if there is no dest file
-    if os.path.exists(dest):
-        # raise an error if copy has no permission on dest
-        if not os.access(dest, os.W_OK):
-            os.remove(tmpsrc)
-            msg = format_message("Destination '%s' not writable" % dest, resp)
-            module.fail_json(msg=msg, **resp)
-        if not os.access(dest, os.R_OK):
-            os.remove(tmpsrc)
-            msg = format_message("Destination '%s' not readable" % dest, resp)
-            module.fail_json(msg=msg, **resp)
-        checksum_dest = module.sha1(dest)
-    else:
-        if not os.access(os.path.dirname(dest), os.W_OK):
-            os.remove(tmpsrc)
-            msg = format_message("Destination dir '%s' not writable" % os.path.dirname(dest), resp)
-            module.fail_json(msg=msg, **resp)
-
-    if checksum_src != checksum_dest:
-        try:
-            shutil.copyfile(tmpsrc, dest)
-        except Exception as e:
-            os.remove(tmpsrc)
-            msg = format_message("failed to copy %s to %s: %s" % (tmpsrc, dest, to_native(e)), resp)
-            module.fail_json(msg=msg, **resp)
-
-    os.remove(tmpsrc)
 
 
 def absolute_location(url, location):

--- a/test/integration/targets/uri/tasks/unexpected-failures.yml
+++ b/test/integration/targets/uri/tasks/unexpected-failures.yml
@@ -23,5 +23,4 @@
     that:
       - ret is failed
       - "not ret.msg.startswith('MODULE FAILURE')"
-      - '"Destination dir ''" ~ remote_dir_expanded ~ "/non/existent'' not writable" in ret.msg'
-      - ret.status == 200
+      - '"Could not replace file" in ret.msg'


### PR DESCRIPTION
##### SUMMARY
Takes care of #76302
- Cleans up `write_file` method in `uri` by removing excessive error checking and instead guarding with try/except that will handle the similar error conditions accordingly.
-  change `shutil.copyfileobj` to `module.atomic_move` as best practice for updating a file in place for avoiding data corruption.


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
uri

##### ADDITIONAL INFORMATION
This is my first pr and have read all the contributing guidelines, I hope I didn't miss anything :-) 

