### PR TITLE
set VERSION to 5 for realz

### DIFF
--- a/docs/docsite/sphinx_conf/ansible_conf.py
+++ b/docs/docsite/sphinx_conf/ansible_conf.py
@@ -32,7 +32,7 @@ sys.path.insert(0, os.path.join('ansible', 'lib'))
 # the repository version needs to be the one that is loaded:
 sys.path.insert(0, os.path.abspath(os.path.join('..', '..', '..', 'lib')))
 
-VERSION = 'devel'
+VERSION = '5'
 AUTHOR = 'Ansible, Inc'
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The actual fix that was supposed to be in https://github.com/ansible/ansible/pull/76405. That other PR is fine, just repeats a patch from a different backport.

This PR is the actual fix to change the VERSION to 5.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
part of #75884
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs/docsite/sphinx_conf/ansible_conf.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
