### PR TITLE
[stable-2.12] Fix unarchive ignore handling

### DIFF
--- a/changelogs/fragments/76069-fix-unarchive-file-listing-in-zip.yaml
+++ b/changelogs/fragments/76069-fix-unarchive-file-listing-in-zip.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- unarchive - Fix zip archive file listing that caused issues with content
+  postprocessing (https://github.com/ansible/ansible/issues/76067).

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -386,7 +386,7 @@ class ZipArchive(object):
                         exclude_flag = False
                         if self.excludes:
                             for exclude in self.excludes:
-                                if not fnmatch.fnmatch(member, exclude):
+                                if fnmatch.fnmatch(member, exclude):
                                     exclude_flag = True
                                     break
                         if not exclude_flag:

--- a/test/integration/targets/unarchive/tasks/test_exclude.yml
+++ b/test/integration/targets/unarchive/tasks/test_exclude.yml
@@ -11,12 +11,27 @@
     src: "{{ remote_tmp_dir }}/unarchive-00.{{item}}"
     dest: "{{ remote_tmp_dir }}/exclude-{{item}}"
     remote_src: yes
+    list_files: yes
     exclude:
       - "exclude/exclude-*.txt"
       - "other/exclude-1.ext"
+  register: result_of_unarchive
   with_items:
     - zip
     - tar
+
+- name: Make sure unarchive module reported back extracted files
+  assert:
+    that:
+      - "'include/include-1.txt' in item.files"
+      - "'include/include-2.txt' in item.files"
+      - "'include/include-3.txt' in item.files"
+      - "'other/include-1.ext' in item.files"
+      - "'other/include-2.ext' in item.files"
+      - "'other/exclude-2.ext' in item.files"
+      - "'other/other-1.ext' in item.files"
+      - "'other/other-2.ext' in item.files"
+  loop: "{{ result_of_unarchive.results }}"
 
 - name: verify that the file was unarchived
   shell: find {{ remote_tmp_dir }}/exclude-{{item}} chdir={{ remote_tmp_dir }}


### PR DESCRIPTION
When we introduced an include parameter to the unarchive module, we
inadvertently flipped the exclusion logic. This flip meant that the
unarchive module started rejecting files that should be extracted.

This commit flips the bad logic and adds some tests that will make
sure things do not go bad again.

Backport of https://github.com/ansible/ansible/pull/76069

(cherry picked from commit f92830d16e2fcca394a69b13e1017350e07152a3)