### PR TITLE
Handle HTTPError being partially initialized due to the error

### DIFF
--- a/changelogs/fragments/76386-httperror-no-fp.yml
+++ b/changelogs/fragments/76386-httperror-no-fp.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- urls/uri - Address case where ``HTTPError`` isn't fully initialized due to
+  the error, and is missing certain methods and attributes
+  (https://github.com/ansible/ansible/issues/76386)

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1839,6 +1839,11 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     except urllib_error.HTTPError as e:
         r = e
         try:
+            if e.fp is None:
+                # Certain HTTPError objects may not have the ability to call ``.read()`` on Python 3
+                # This is not handled gracefully in Python 3, and instead an exception is raised from
+                # tempfile, due to ``urllib.response.addinfourl`` not being initialized
+                raise AttributeError
             body = e.read()
         except AttributeError:
             body = ''

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -697,7 +697,9 @@ def main():
         filename = get_response_filename(r) or 'index.html'
         dest = os.path.join(dest, filename)
 
-    if r:
+    if r and r.fp is not None:
+        # r may be None for some errors
+        # r.fp may be None depending on the error, which means there are no headers either
         content_type, main_type, sub_type, content_encoding = parse_content_type(r)
     else:
         content_type = 'application/octet-stream'
@@ -710,7 +712,7 @@ def main():
 
     if maybe_output:
         try:
-            if PY3 and r.closed:
+            if PY3 and (r.fp is None or r.closed):
                 raise TypeError
             content = r.read()
         except (AttributeError, TypeError):

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -247,6 +247,16 @@
     headers:
       Cookie: "fake=fake_value"
 
+- name: test digest auth failure
+  uri:
+    url: 'https://{{ httpbin_host }}/digest-auth/auth/user/passwd'
+    user: user
+    password: wrong
+    headers:
+      Cookie: "fake=fake_value"
+  register: result
+  failed_when: result.status != 401
+
 - name: test unredirected_headers
   uri:
     url: 'https://{{ httpbin_host }}/redirect-to?status_code=301&url=/basic-auth/user/passwd'


### PR DESCRIPTION
##### SUMMARY
Handle HTTPError being partially initialized due to the error. Fixes #76386

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/urls.py
lib/ansible/modules/uri.py

##### ADDITIONAL INFORMATION
https://github.com/python/cpython/blob/55fe1ae9708d81b902b6fe8f6590e2a24b1bd4b0/Lib/urllib/error.py#L45-L50
