### PR TITLE
WIP: bypass ansible-connection for existing connections

### DIFF
--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -306,27 +306,31 @@ def main(args=None):
                     result.update(data)
 
             else:
-                messages.append(('vvvv', 'found existing local domain socket, using it!'))
-                conn = Connection(socket_path)
-                try:
-                    conn.set_options(var_options=variables)
-                except ConnectionError as exc:
-                    messages.append(('debug', to_text(exc)))
-                    raise ConnectionError('Unable to decode JSON from response set_options. See the debug log for more information.')
-                pc_data = to_text(init_data)
-                try:
-                    conn.update_play_context(pc_data)
-                    conn.set_check_prompt(task_uuid)
-                except Exception as exc:
-                    # Only network_cli has update_play context and set_check_prompt, so missing this is
-                    # not fatal e.g. netconf
-                    if isinstance(exc, ConnectionError) and getattr(exc, 'code', None) == -32601:
-                        pass
-                    else:
-                        result.update({
-                            'error': to_text(exc),
-                            'exception': traceback.format_exc()
-                        })
+                sys.stderr.write("bang, shouldn't call to create when it already exists")
+                sys.exit(1)
+
+            # else:
+            #     messages.append(('vvvv', 'found existing local domain socket, using it!'))
+            #     conn = Connection(socket_path)
+            #     try:
+            #         conn.set_options(var_options=variables)
+            #     except ConnectionError as exc:
+            #         messages.append(('debug', to_text(exc)))
+            #         raise ConnectionError('Unable to decode JSON from response set_options. See the debug log for more information.')
+            #     pc_data = to_text(init_data)
+            #     try:
+            #         conn.update_play_context(pc_data)
+            #         conn.set_check_prompt(task_uuid)
+            #     except Exception as exc:
+            #         # Only network_cli has update_play context and set_check_prompt, so missing this is
+            #         # not fatal e.g. netconf
+            #         if isinstance(exc, ConnectionError) and getattr(exc, 'code', None) == -32601:
+            #             pass
+            #         else:
+            #             result.update({
+            #                 'error': to_text(exc),
+            #                 'exception': traceback.format_exc()
+            #             })
 
     if os.path.exists(socket_path):
         messages.extend(Connection(socket_path).pop_messages())

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -957,13 +957,11 @@ class TaskExecutor:
 
         if any(((connection.supports_persistence and C.USE_PERSISTENT_CONNECTIONS), connection.force_persistence)):
             self._play_context.timeout = connection.get_option('persistent_command_timeout')
-            display.vvvv('attempting to start connection', host=self._play_context.remote_addr)
-            display.vvvv('using connection plugin %s' % connection.transport, host=self._play_context.remote_addr)
-
             options = self._get_persistent_connection_options(connection, cvars, templar)
-            socket_path = start_connection(self._play_context, options, self._task._uuid)
-            display.vvvv('local domain socket path is %s' % socket_path, host=self._play_context.remote_addr)
-            setattr(connection, '_socket_path', socket_path)
+            # HACK: need a better way to make these necessary bits accessible for the deferred connection startup
+            connection._smuggled_options = options
+            connection._startconn = start_connection
+            connection._task_uuid = self._task._uuid
 
         return connection
 


### PR DESCRIPTION
##### SUMMARY
fixes #75813

Creating new ansible-connection processes to use existing persisted connections is extremely wasteful and slow, since the newly-created ansible-connection effectively exits immediately in that case. This PR significantly reduces connection overhead for all networking connection plugins, but especially speeds up local actions under host contexts where a persistent connection is in use (since TE was blindly running ansible-connection in cases where no connection was used).

* skip creation of (expensive!) new process once a persistent connection is going
* move persistent connection detection logic into main worker
* defer persistent connection creation/update until the connection is used
* clean up special cases in TE, speed up dispatch of local-only actions under persistent connection hosts

KNOWN ISSUES:
* Deferred PlayContext updates have incorrect values (just commented that out for now)- maybe a race where we need to snapshot the playcontext immediately? eg, explicit inventory `ansible_user` is wrong on playcontext `remote_user` on subsequent connection round-trips- seems to default to current UNIX user instead. Not sure how much longer we'll need to serialize playcontext anyway, since we're already sending over all the connection vars.
* Breaks networking's experimental direct module execution without a small patch to the base networking action direct exec case to ensure the connection is activated (since TE used to do this preemptively even when it wasn't necessary):
```
            if hasattr(self._connection, '_ensure_socket_path'):
                self._connection._ensure_socket_path()
```
This could be done in the base persistent connection's `_connect` method , except that it's defined as abstractmethod, so none of the subclasses are currently calling `super()._connect()`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-connection (et al)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
cc @cidrblock @Qalthos