### PR TITLE
Revert "Fix wrong ssh_connection group"

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -367,7 +367,7 @@
 # Paramiko automatically add host keys.
 #host_key_auto_add = True
 
-[connection]
+[ssh_connection]
 
 # ssh arguments to use
 # Leaving off ControlPersist will result in poor performance, so use


### PR DESCRIPTION
Reverts ansible/ansible#75888

Just changing the section name from 'ssh_connection' to 'connection' in ansible.cfg example made all other ssh_connection specific configuration unset. Instead a
new section can be added for 'connection' with pipelining option.

Looking at the stable-2.9 code seems pipelining can be configured in default, connection or ssh_connection section.