### PR TITLE
Properly set finalize for the new environment

### DIFF
--- a/changelogs/fragments/76379-set-finalize-on-new-env.yml
+++ b/changelogs/fragments/76379-set-finalize-on-new-env.yml
@@ -1,0 +1,2 @@
+- bugfixes:
+  - "``Templar.copy_with_new_env`` - set the ``finalize`` method of the new ``Templar`` object for the new environment (https://github.com/ansible/ansible/issues/76379)"

--- a/changelogs/fragments/76379-set-finalize-on-new-env.yml
+++ b/changelogs/fragments/76379-set-finalize-on-new-env.yml
@@ -1,2 +1,2 @@
-- bugfixes:
+bugfixes:
   - "``Templar.copy_with_new_env`` - set the ``finalize`` method of the new ``Templar`` object for the new environment (https://github.com/ansible/ansible/issues/76379)"

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -698,6 +698,7 @@ class Templar:
         new_templar = object.__new__(Templar)
         new_templar.__dict__.update(self.__dict__)
         new_templar.environment = new_env
+        new_templar.environment.finalize = new_templar._finalize
 
         new_templar.jinja2_native = environment_class is AnsibleNativeEnvironment
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #76379

This needs to be backported to `2.12`, only then the issue will be fixed as `Templar.copy_with_new_env` is not currently used in devel, for now. Also `2.11` but I am not sure it qualifies.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/template/__init__.py`
