### PR TITLE
Clarify unroll in _finalize

### DIFF
--- a/changelogs/fragments/clarify-unroll.yml
+++ b/changelogs/fragments/clarify-unroll.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Clarify in a comment that unrolling an iterator in ``Templar._finalize`` is actually necessary. Also switch to using the ``_unroll_iterator`` decorator directly to deduplicate code in ``Templar._finalize``. (https://github.com/ansible/ansible/pull/76436)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Clarifies that unrolling in _finalize is actually necessary. Also using
decorator directly.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/template/__init__.py`
