### PR TITLE
add skip for filter empty

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -524,7 +524,10 @@ class CLI(ABC):
 
         hosts = inventory.list_hosts(pattern)
         if not hosts and no_hosts is False:
-            raise AnsibleError("Specified hosts and/or --limit does not match any hosts")
+            if C.HOST_FILTER_EMPTY:
+                display.warning("provided hosts list after filter was applied was empty")
+            else:
+                raise AnsibleError("Specified hosts and/or --limit does not match any hosts")
 
         return hosts
 

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -420,6 +420,16 @@ LOCALHOST_WARNING:
   - {key: localhost_warning, section: defaults}
   type: boolean
   version_added: "2.6"
+HOST_FILTER_EMPTY:
+  name: Warning when using limit or filter and no hosts match
+  default: False
+  description:
+    - By default Ansible will error when no hosts match.
+  env: [{name: ANSIBLE_HOST_FILTER_EMPTY}]
+  ini:
+  - {key: host_filter_empty, section: defaults}
+  type: boolean
+  version_added: "2.13"
 DOC_FRAGMENT_PLUGIN_PATH:
   name: documentation fragment plugins path
   default: ~/.ansible/plugins/doc_fragments:/usr/share/ansible/plugins/doc_fragments


### PR DESCRIPTION
##### SUMMARY
This is an attempt to fix issue AWX issue [#2893](https://github.com/ansible/awx/issues/2893)
When running in outside of Controller, most users would not use this, where this primarily be aimed is users using slices in Controller where the job will fail if there are no hosts. 

The general idea is to not change the base behavior of Ansible, but allow user to override the default behavior similar to the localhost warning. 


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ansible config and behavior 

##### ADDITIONAL INFORMATION
I am unsure on how to update 
docs/docsite/rst/locales/ja/LC_MESSAGES/reference_appendices.po
to account for a new config option.
