### PR TITLE
Move the 'elif' case for checking 'os.path.exists' higher

### DIFF
--- a/lib/ansible/module_utils/facts/system/service_mgr.py
+++ b/lib/ansible/module_utils/facts/system/service_mgr.py
@@ -137,10 +137,10 @@ class ServiceMgrFactCollector(BaseFactCollector):
                 service_mgr_name = 'upstart'
             elif os.path.exists('/sbin/openrc'):
                 service_mgr_name = 'openrc'
+            elif os.path.exists('/etc/init.d/'):
+                service_mgr_name = 'sysvinit
             elif self.is_systemd_managed_offline(module=module):
                 service_mgr_name = 'systemd'
-            elif os.path.exists('/etc/init.d/'):
-                service_mgr_name = 'sysvinit'
 
         if not service_mgr_name:
             # if we cannot detect, fallback to generic 'service'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The change is required so that sysv init will be correctly identified and set as service manager.

This necessary because in WSL Ubuntu (20.04.4 LTS), the elif check using method 'is_systemd_managed_offline' will lead ansible to set 'systemd' as service manager, while the true service manager is SysV Init, as shown by running command (on my local machine running WSL Ubuntu 20.04.3 LTS) show as follows:
```
$ ps -p 1 -o comm=
init

```
while by running 'll /sbin/init' do returns this:
```
$ ll /sbin/init
/sbin/init -> /lib/systemd/systemd*
```
Currently, without making this change, the user of Ansible on Windows WSL Linux (i.e. Ubuntu) like me have to use another argument 'use' when using module 'service' to start or stop a service.

which mislead ansible to think the service manager is 'systemd' while it is actually SysV Init.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Currently, running the next command on Windows WSL Ubuntu 20.04.3 LTS (Windows 11) get this:
```
$ ansible mylaptop -i hosts -m service -a "name=apache2 state=started" --ask-become-pass
localhost | FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python3"
    },
    "changed": false,
    "msg": "Service is in unknown state",
    "status": {}
}
```
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The issue is also reported here by me on StackOverFlow: 
https://stackoverflow.com/questions/70200273/failed-to-start-apache2-using-ansible-module-service-on-localhost-in-wsl-ubuntu
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
