### PR TITLE
pkg_mgr: prohibit pkg5 usage on Altlinux

### DIFF
--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -113,12 +113,22 @@ class PkgMgrFactCollector(BaseFactCollector):
                     pkg_mgr_name = 'apt'
         return pkg_mgr_name
 
+    def pkg_mgrs(self, collected_facts):
+        # Filter out the /usr/bin/pkg because on Altlinux it is actually the
+        # perl-Package (not Solaris package manager).
+        # Since the pkg5 takes precedence over apt, this workaround
+        # is required to select the suitable package manager on Altlinux.
+        if collected_facts['ansible_os_family'] == 'Altlinux':
+            return filter(lambda pkg: pkg['path'] != '/usr/bin/pkg', PKG_MGRS)
+        else:
+            return PKG_MGRS
+
     def collect(self, module=None, collected_facts=None):
         facts_dict = {}
         collected_facts = collected_facts or {}
 
         pkg_mgr_name = 'unknown'
-        for pkg in PKG_MGRS:
+        for pkg in self.pkg_mgrs(collected_facts):
             if os.path.exists(pkg['path']):
                 pkg_mgr_name = pkg['name']
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The current implementation expects ```/usr/bin/pkg``` as ```pkg5``` package manager, but this is not suitable for Altlinux. There is an ```perl-Package``` rpm package that has an executable with the same path as ```pkg5``` (```/usr/bin/pkg```).
Since the ```pkg5``` takes precedence over ```apt```, this patch is required to select an appropriate package manager on Altlinux.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pkg_mgr
