### PR TITLE
add tencentos fact distro

### DIFF
--- a/changelogs/fragments/76343-tencentos-dnf.yml
+++ b/changelogs/fragments/76343-tencentos-dnf.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- distribution - detect tencentos and gather correct fact on distro 

--- a/changelogs/fragments/76343-tencentos-dnf.yml
+++ b/changelogs/fragments/76343-tencentos-dnf.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- distribution - detect tencentos and gather correct fact on distro 
+- distribution - detect tencentos and gather correct facts on the distro.

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -484,7 +484,7 @@ class Distribution(object):
     OS_FAMILY_MAP = {'RedHat': ['RedHat', 'Fedora', 'CentOS', 'Scientific', 'SLC',
                                 'Ascendos', 'CloudLinux', 'PSBM', 'OracleLinux', 'OVS',
                                 'OEL', 'Amazon', 'Virtuozzo', 'XenServer', 'Alibaba',
-                                'EulerOS', 'openEuler', 'AlmaLinux', 'Rocky'],
+                                'EulerOS', 'openEuler', 'AlmaLinux', 'Rocky', 'TencentOS'],
                      'Debian': ['Debian', 'Ubuntu', 'Raspbian', 'Neon', 'KDE neon',
                                 'Linux Mint', 'SteamOS', 'Devuan', 'Kali', 'Cumulus Linux',
                                 'Pop!_OS', 'Parrot', 'Pardus GNU/Linux'],

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -464,6 +464,10 @@ class DistributionFiles:
             centos_facts['distribution_release'] = 'Stream'
             return True, centos_facts
 
+        if "TencentOS Server" in data:
+            centos_facts['distribution'] = 'TencentOS'
+            return True, centos_facts
+
         return False, centos_facts
 
 

--- a/test/units/module_utils/facts/system/distribution/fixtures/tencentos_3_1.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/tencentos_3_1.json
@@ -1,0 +1,50 @@
+{
+    "name": "TencentOS 3.1",
+    "distro": {
+        "codename": "Final",
+        "id": "tencentos",
+        "name": "TencentOS Server",
+        "version": "3.1",
+        "version_best": "3.1",
+        "lsb_release_info": {},
+        "os_release_info": {
+            "name": "TencentOS Server",
+            "version": "3.1 (Final)",
+            "id": "tencentos",
+            "id_like": "rhel fedora centos",
+            "version_id": "3.1",
+            "platform_id": "platform:el8",
+            "pretty_name": "TencentOS Server 3.1 (Final)",
+            "ansi_color": "0;31",
+            "cpe_name": "cpe:/o:tencentos:tencentos:3",
+            "home_url": "https://tlinux.qq.com/",
+            "bug_report_url": "https://tlinux.qq.com/",
+            "centos_mantisbt_project": "CentOS-8",
+            "centos_mantisbt_project_version": "8",
+            "redhat_support_product": "centos",
+            "redhat_support_product_version": "8",
+            "name_orig": "CentOS Linux",
+            "codename": "Final"
+        }
+    },
+    "input": {
+        "/etc/centos-release": "NAME=\"TencentOS Server\"\nVERSION=\"3.1 (Final)\"\nID=\"tencentos\"\nID_LIKE=\"rhel fedora centos\"\nVERSION_ID=\"3.1\"\nPLATFORM_ID=\"platform:el8\"\nPRETTY_NAME=\"TencentOS Server 3.1 (Final)\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:tencentos:tencentos:3\"\nHOME_URL=\"https://tlinux.qq.com/\"\nBUG_REPORT_URL=\"https://tlinux.qq.com/\"\n\nCENTOS_MANTISBT_PROJECT=\"CentOS-8\"\nCENTOS_MANTISBT_PROJECT_VERSION=\"8\"\nREDHAT_SUPPORT_PRODUCT=\"centos\"\nREDHAT_SUPPORT_PRODUCT_VERSION=\"8\"\nNAME_ORIG=\"CentOS Linux\"\n",
+        "/etc/redhat-release": "CentOS Linux release 8.4.2105 (Core)\n",
+        "/etc/system-release": "NAME=\"TencentOS Server\"\nVERSION=\"3.1 (Final)\"\nID=\"tencentos\"\nID_LIKE=\"rhel fedora centos\"\nVERSION_ID=\"3.1\"\nPLATFORM_ID=\"platform:el8\"\nPRETTY_NAME=\"TencentOS Server 3.1 (Final)\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:tencentos:tencentos:3\"\nHOME_URL=\"https://tlinux.qq.com/\"\nBUG_REPORT_URL=\"https://tlinux.qq.com/\"\n\nCENTOS_MANTISBT_PROJECT=\"CentOS-8\"\nCENTOS_MANTISBT_PROJECT_VERSION=\"8\"\nREDHAT_SUPPORT_PRODUCT=\"centos\"\nREDHAT_SUPPORT_PRODUCT_VERSION=\"8\"\nNAME_ORIG=\"CentOS Linux\"\n",
+        "/etc/os-release": "NAME=\"TencentOS Server\"\nVERSION=\"3.1 (Final)\"\nID=\"tencentos\"\nID_LIKE=\"rhel fedora centos\"\nVERSION_ID=\"3.1\"\nPLATFORM_ID=\"platform:el8\"\nPRETTY_NAME=\"TencentOS Server 3.1 (Final)\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:tencentos:tencentos:3\"\nHOME_URL=\"https://tlinux.qq.com/\"\nBUG_REPORT_URL=\"https://tlinux.qq.com/\"\n\nCENTOS_MANTISBT_PROJECT=\"CentOS-8\"\nCENTOS_MANTISBT_PROJECT_VERSION=\"8\"\nREDHAT_SUPPORT_PRODUCT=\"centos\"\nREDHAT_SUPPORT_PRODUCT_VERSION=\"8\"\nNAME_ORIG=\"CentOS Linux\"\n",
+        "/usr/lib/os-release": "NAME=\"CentOS Linux\"\nVERSION=\"8\"\nID=\"centos\"\nID_LIKE=\"rhel fedora\"\nVERSION_ID=\"8\"\nPLATFORM_ID=\"platform:el8\"\nPRETTY_NAME=\"CentOS Linux 8\"\nANSI_COLOR=\"0;31\"\nCPE_NAME=\"cpe:/o:centos:centos:8\"\nHOME_URL=\"https://centos.org/\"\nBUG_REPORT_URL=\"https://bugs.centos.org/\"\nCENTOS_MANTISBT_PROJECT=\"CentOS-8\"\nCENTOS_MANTISBT_PROJECT_VERSION=\"8\"\n"
+    },
+    "platform.dist": [
+        "tencentos",
+        "3.1",
+        "Final"
+    ],
+    "result": {
+        "distribution": "TencentOS",
+        "distribution_version": "3.1",
+        "distribution_release": "Final",
+        "distribution_major_version": "3",
+        "os_family": "RedHat"
+    },
+    "platform.release": "5.4.32-19-0001"
+}


### PR DESCRIPTION
##### SUMMARY
takes care of #76343 

Correct the distribution fact if node is running TencentOS

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
`distribution` fact gethering

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Before this fix:

```
10.1.1.2 | SUCCESS => {
    "ansible_facts": {
        "ansible_distribution": "CentOS", <------
        "ansible_distribution_file_parsed": true,
        "ansible_distribution_file_path": "/etc/redhat-release",
        "ansible_distribution_file_variety": "RedHat",
        "ansible_distribution_major_version": "3",
        "ansible_distribution_release": "Final",
        "ansible_distribution_version": "3.1",
        "discovered_interpreter_python": "/usr/bin/python3.6"
    },
    "changed": false
}

```

test.yml:
```
- name: install socat & conntrack
    package:
      name:
        - socat
        - conntrack
      state: present
    become: true
```

Failed with:
```
fatal: [10.1.1.2]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "allow_downgrade": false,
            "autoremove": false,
            "bugfix": false,
            "cacheonly": false,
            "conf_file": null,
            "disable_excludes": null,
            "disable_gpg_check": false,
            "disable_plugin": [],
            "disablerepo": [],
            "download_dir": null,
            "download_only": false,
            "enable_plugin": [],
            "enablerepo": [],
            "exclude": [],
            "install_repoquery": true,
            "install_weak_deps": true,
            "installroot": "/",
            "list": null,
            "lock_timeout": 30,
            "name": [
                "socat",
                "conntrack"
            ],
            "releasever": null,
            "security": false,
            "skip_broken": false,
            "state": "present",
            "update_cache": false,
            "update_only": false,
            "use_backend": "auto",
            "validate_certs": true
        }
    },
    "msg": "The Python 2 yum module is needed for this module. If you require Python 3 support use the `dnf` Ansible module instead."
}
```

After fix:

```
10.1.1.2 | SUCCESS => {
    "ansible_facts": {
        "ansible_distribution": "TencentOS",
        "ansible_distribution_file_parsed": true,
        "ansible_distribution_file_path": "/etc/centos-release",
        "ansible_distribution_file_variety": "CentOS",
        "ansible_distribution_major_version": "3",
        "ansible_distribution_release": "Final",
        "ansible_distribution_version": "3.1",
        "discovered_interpreter_python": "/usr/bin/python3.6"
    },
    "changed": false
}
```

installs via dnf and succeeds:
```
changed: [10.1.1.2] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "allow_downgrade": false,
            "allowerasing": false,
            "autoremove": false,
            "bugfix": false,
            "cacheonly": false,
            "conf_file": null,
            "disable_excludes": null,
            "disable_gpg_check": false,
            "disable_plugin": [],
            "disablerepo": [],
            "download_dir": null,
            "download_only": false,
            "enable_plugin": [],
            "enablerepo": [],
            "exclude": [],
            "install_repoquery": true,
            "install_weak_deps": true,
            "installroot": "/",
            "list": null,
            "lock_timeout": 30,
            "name": [
                "socat",
                "conntrack"
            ],
            "nobest": false,
            "releasever": null,
            "security": false,
            "skip_broken": false,
            "state": "present",
            "update_cache": false,
            "update_only": false,
            "validate_certs": true
        }
    },
    "msg": "",
    "rc": 0,
    "results": [
        "Installed: libnetfilter_conntrack-1.0.6-5.tl3.x86_64",
        "Installed: libnetfilter_cthelper-1.0.0-15.tl3.x86_64",
        "Installed: conntrack-tools-1.4.4-10.tl3.x86_64",
        "Installed: libnetfilter_cttimeout-1.0.0-11.tl3.x86_64",
        "Installed: libnetfilter_queue-1.0.4-3.el8.x86_64",
        "Installed: libnfnetlink-1.0.1-13.tl3.x86_64",
        "Installed: socat-1.7.4.1-1.el8.x86_64"
    ]
}
```
