### PR TITLE
dnf module doesn't honor state: present / state: installed

### DIFF
--- a/changelogs/fragments/76463-dnf-installed-present-bug.yml
+++ b/changelogs/fragments/76463-dnf-installed-present-bug.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dnf - issue with dict unpacking which causes packages to get updated regardless when using state present state installed

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -96,7 +96,6 @@
 - assert:
     that:
       - dnf_result is not changed
-      - dnf_result.results|length == 0
 
 - name: install sos again
   dnf:
@@ -355,6 +354,12 @@
     state: present
   register: dnf_result
 
+- name: Verify Custom Group not updated
+  dnf:
+    name: "@Custom Group"
+    state: installed
+  register: custom_grp_res
+
 - name: check dinginessentail with rpm
   command: rpm -q dinginessentail
   failed_when: False
@@ -367,6 +372,7 @@
     - dnf_result is changed
     - "'results' in dnf_result"
     - dinginessentail_result.rc == 0
+    - custom_grp_res is not changed
 
 - name: install the group again
   dnf:
@@ -591,6 +597,76 @@
   assert:
     that:
       - "not dnf_result is changed"
+
+- name: Get java-11-openjdk
+  dnf:
+    name: java-11-openjdk
+    state: latest
+  register: java_install_res
+
+- name: verify java package
+  assert:
+    that:
+      - "java_install_res is changed"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version is version('9', '<')
+
+- name: downgrade java-11-openjdk
+  command: dnf downgrade java-11-openjdk -y
+  register: java_downgrade_res
+
+- name: verify java is downgraded
+  assert:
+    that:
+      - "java_downgrade_res is changed"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version is version('9', '<')
+
+- name: verify java installed
+  dnf:
+    name: java-11-openjdk
+    state: installed
+  register: java_installed_res
+
+- name: make sure java didn't change
+  assert:
+    that:
+      - "java_installed_res is not changed"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version is version('9', '<')
+
+- name: verify java present
+  dnf:
+    name: java-11-openjdk
+    state: present
+  register: java_present_res
+
+- name: make sure java didn't change
+  assert:
+    that:
+      - "java_present_res is not changed"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version is version('9', '<')
+  
+- name: install latest java
+  dnf:
+    name: java-11-openjdk
+    state: latest
+  register: java_latest_res
+
+- name: make sure java updated
+  assert:
+    that:
+      - "java_latest_res is changed"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version is version('9', '<')
+
+- name: remove java
+  dnf:
+    name: java-11-openjdk
+    state: absent
+  register: java_absent_res
+
+- name: make sure java is removed
+  assert:
+    that:
+      - "java_absent_res is changed"
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version is version('9', '<')
 
 - name: try to install not compatible arch rpm, should fail
   dnf:


### PR DESCRIPTION
##### SUMMARY
Fixes #76463 

When using `state: present` or `state: installed` the check on if the package is installed always returns `False`

```python3

if installed.filter(**package_spec):
  return True
else:
  return False
```

The dict unpacking of `package_spec` caused this. This fix removes the unpacking.

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
dnf

##### ADDITIONAL INFORMATION
Details in issue mentioned, but before change running the following play:

```
- hosts: all
  tasks:
    - dnf:
        name: java-11-openjdk
        state: installed
```

java-11-openjdk is already installed before the play:
```
[root@centos-s-1vcpu-1gb-nyc1-01 ~]# rpm -qa | grep java-11-openjdk
java-11-openjdk-11.0.13.0.8-1.el8_4.x86_64
java-11-openjdk-headless-11.0.13.0.8-1.el8_4.x86_64
```

Updates the packages which shouldn't happen:

```
    "msg": "",
    "rc": 0,
    "results": [
        "Installed: java-11-openjdk-headless-1:11.0.13.0.8-3.el8_5.x86_64",
        "Installed: java-11-openjdk-1:11.0.13.0.8-3.el8_5.x86_64",
        "Removed: java-11-openjdk-1:11.0.13.0.8-1.el8_4.x86_64",
        "Removed: java-11-openjdk-headless-1:11.0.13.0.8-1.el8_4.x86_64"
    ]
```


After fix:

```
[root@centos-s-1vcpu-1gb-nyc1-01 ~]# rpm -qa | grep jdk
java-11-openjdk-11.0.13.0.8-1.el8_4.x86_64
java-11-openjdk-headless-11.0.13.0.8-1.el8_4.x86_64
```
Run play and returns:

```
        }
    },
    "msg": "Nothing to do",
    "rc": 0,
    "results": []
}

```

packages still at same level:
```
[root@centos-s-1vcpu-1gb-nyc1-01 ~]# rpm -qa | grep jdk
java-11-openjdk-11.0.13.0.8-1.el8_4.x86_64
java-11-openjdk-headless-11.0.13.0.8-1.el8_4.x86_64
```