### PR TITLE
ansible-test: validate-modules fails is no callable

### DIFF
--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
@@ -606,7 +606,8 @@ class ModuleValidator(Validator):
             if isinstance(child, (ast.FunctionDef, ast.ClassDef)):
                 linenos.append(child.lineno)
 
-        return min(linenos)
+        if linenos:
+            return min(linenos)
 
     def _find_has_import(self):
         for child in self.ast.body:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Avoid a failure/backtrace if there is no callable in the module.


```
/root/ansible/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate-modules --format json --arg-spec plugins/modules/deepsec_anti_malware.py plugins/modules/deepsec_apikey.py plugins/modules/deepsec_firewallrules.py plugins/modules/deepsec_hosts_info.py plugins/modules/deepsec_integrity_monitoringrules.py plugins/modules/deepsec_intrusion_prevention_rules.py plugins/modules/deepsec_log_inspectionrules.py plugins/modules/deepsec_syslog.py plugins/modules/deepsec_system_settings.py --collection ansible_collections/trendmicro/deepsec --collection-version 1.1.1-dev4" returned exit status 1.
2021-12-06 08:29:45.928961 | fedora-34 | >>> Standard Error
2021-12-06 08:29:45.929006 | fedora-34 | Traceback (most recent call last):
2021-12-06 08:29:45.929036 | fedora-34 |   File "/root/ansible/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate-modules", line 7, in <module>
2021-12-06 08:29:45.929059 | fedora-34 |     main()
2021-12-06 08:29:45.929084 | fedora-34 |   File "/root/ansible/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py", line 2423, in main
2021-12-06 08:29:45.929108 | fedora-34 |     run()
2021-12-06 08:29:45.929132 | fedora-34 |   File "/root/ansible/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py", line 2320, in run
2021-12-06 08:29:45.929298 | fedora-34 |     mv1.validate()
2021-12-06 08:29:45.929331 | fedora-34 |   File "/root/ansible/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py", line 2182, in validate
2021-12-06 08:29:45.929356 | fedora-34 |     first_callable = self._get_first_callable()
2021-12-06 08:29:45.929379 | fedora-34 |   File "/root/ansible/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py", line 609, in _get_first_callable
2021-12-06 08:29:45.929402 | fedora-34 |     return min(linenos)
2021-12-06 08:29:45.929425 | fedora-34 | ValueError: min() arg is an empty sequence[0m
```
See: https://0250ce007697a6794885-1ae15b486461a680e2e98b6d71574b13.ssl.cf5.rackcdn.com/25/21a50dd56e7e8336321f495bfb107a0d66e4027f/check/ansible-test-sanity-docker-milestone/ba93a48/job-output.txt

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME

ansibl-test
<!--- Write the short name of the module, plugin, task or feature below -->