### PR TITLE
galaxy build - ignore existing MANIFEST and FILES

### DIFF
--- a/changelogs/fragments/galaxy-build-files-ignore.yml
+++ b/changelogs/fragments/galaxy-build-files-ignore.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- >-
+  ansible-galaxy collection build - Ignore any existing ``MANIFEST.json`` and ``FILES.json`` in the root directory
+  when building a collection.

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -791,6 +791,8 @@ def _build_files_manifest(b_collection_path, namespace, name, ignore_patterns):
     # We always ignore .pyc and .retry files as well as some well known version control directories. The ignore
     # patterns can be extended by the build_ignore key in galaxy.yml
     b_ignore_patterns = [
+        b'MANIFEST.json',
+        b'FILES.json',
         b'galaxy.yml',
         b'galaxy.yaml',
         b'.git',

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -289,6 +289,45 @@ def test_build_existing_output_with_force(collection_input):
     assert tarfile.is_tarfile(existing_output)
 
 
+def test_build_with_existing_files_and_manifest(collection_input):
+    input_dir, output_dir = collection_input
+
+    with open(os.path.join(input_dir, 'MANIFEST.json'), "wb") as fd:
+        fd.write(b'{"collection_info": {"version": "6.6.6"}, "version": 1}')
+
+    with open(os.path.join(input_dir, 'FILES.json'), "wb") as fd:
+        fd.write(b'{"files": [], "format": 1}')
+
+    with open(os.path.join(input_dir, "plugins", "MANIFEST.json"), "wb") as fd:
+        fd.write(b"test data that should be in build")
+
+    collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'), to_text(output_dir, errors='surrogate_or_strict'), False)
+
+    output_artifact = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
+    assert tarfile.is_tarfile(output_artifact)
+
+    with tarfile.open(output_artifact, mode='r') as actual:
+        members = actual.getmembers()
+
+        manifest_file = next(m for m in members if m.path == "MANIFEST.json")
+        manifest_file_obj = actual.extractfile(manifest_file.name)
+        manifest_file_text = manifest_file_obj.read()
+        manifest_file_obj.close()
+        assert manifest_file_text != b'{"collection_info": {"version": "6.6.6"}, "version": 1}'
+
+        json_file = next(m for m in members if m.path == "MANIFEST.json")
+        json_file_obj = actual.extractfile(json_file.name)
+        json_file_text = json_file_obj.read()
+        json_file_obj.close()
+        assert json_file_text != b'{"files": [], "format": 1}'
+
+        sub_manifest_file = next(m for m in members if m.path == "plugins/MANIFEST.json")
+        sub_manifest_file_obj = actual.extractfile(sub_manifest_file.name)
+        sub_manifest_file_text = sub_manifest_file_obj.read()
+        sub_manifest_file_obj.close()
+        assert sub_manifest_file_text == b"test data that should be in build"
+
+
 @pytest.mark.parametrize('galaxy_yml_dir', [b'namespace: value: broken'], indirect=True)
 def test_invalid_yaml_galaxy_file(galaxy_yml_dir):
     galaxy_file = os.path.join(galaxy_yml_dir, b'galaxy.yml')


### PR DESCRIPTION
##### SUMMARY
When running a build on a directory that contains an existing `MANIFEST.json` and `FILES.json` the build artifact will contain 2 entries for each file, the existing file and the one generated for that build step. There should only be 1 file in the built artifact favouring our generated one for the build.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy collection build