### PR TITLE
Revert "ansible-test - Fix import test when vendoring."

### DIFF
--- a/changelogs/fragments/ansible-test-sanity-vendoring.yml
+++ b/changelogs/fragments/ansible-test-sanity-vendoring.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - ansible-test - Fix the ``import`` sanity test to work properly when Ansible's built-in vendoring support is in use.

--- a/lib/ansible/_vendor/__init__.py
+++ b/lib/ansible/_vendor/__init__.py
@@ -39,7 +39,6 @@ def _ensure_vendored_path_entry():
         already_loaded_vendored_modules = set(sys.modules.keys()).intersection(vendored_module_names)
 
         if already_loaded_vendored_modules:
-            # NOTE: If this message is changed, the matching warning filter in ansible-test must also be updated in `importer.py` for the import sanity test.
             warnings.warn('One or more Python packages bundled by this ansible-core distribution were already '
                           'loaded ({0}). This may result in undefined behavior.'.format(', '.join(sorted(already_loaded_vendored_modules))))
 

--- a/test/lib/ansible_test/_util/target/sanity/import/importer.py
+++ b/test/lib/ansible_test/_util/target/sanity/import/importer.py
@@ -475,12 +475,6 @@ def main():
         with warnings.catch_warnings():
             warnings.simplefilter('error')
 
-            # If vendoring is in use (lib/ansible/_vendor/), then vendored modules may already be loaded after the first file is tested.
-            # To avoid test failures, the warning about this condition must be ignored.
-            warnings.filterwarnings(
-                "ignore",
-                "One or more Python packages bundled by this ansible-core distribution were already loaded ")
-
             if sys.version_info[0] == 2:
                 warnings.filterwarnings(
                     "ignore",


### PR DESCRIPTION
##### SUMMARY

This reverts the changes from https://github.com/ansible/ansible/pull/76478, which ended up being incorrect. A follow-up PR will provide a better fix.

This reverts commit 33a8d063327f8e3053799c001eaa21b660cb428e.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
