### PR TITLE
add AH supported tags to collection structure docs

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections_structure.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_structure.rst
@@ -51,6 +51,20 @@ galaxy.yml
 
 A collection must have a ``galaxy.yml`` file that contains the necessary information to build a collection artifact. See :ref:`collections_galaxy_meta` for details.
 
+You can include one or more of the following tags in your collection to help users filter by tag in Red Hat Automation Hub:
+
+* cloud
+* linux
+* networking
+* storage
+* security
+* windows
+* infrastructure
+* monitoring
+* tools
+* database
+* application
+
 .. _collections_doc_dir:
 
 docs directory
@@ -70,7 +84,7 @@ For community collections included in the Ansible PyPI package, docs.ansible.com
      toctree:
        - scenario_guide
 
-The index page of the documentation for your collection displays the title you define in ``docs/docsite/extra-docs.yml`` with a link to your extra documentation. For an example, see the `community.docker collection repo <https://github.com/ansible-collections/community.docker/tree/main/docs/docsite>`_ and the `community.docker collection documentation <https://docs.ansible.com/ansible/latest/collections/community/docker/index.html>`_. 
+The index page of the documentation for your collection displays the title you define in ``docs/docsite/extra-docs.yml`` with a link to your extra documentation. For an example, see the `community.docker collection repo <https://github.com/ansible-collections/community.docker/tree/main/docs/docsite>`_ and the `community.docker collection documentation <https://docs.ansible.com/ansible/latest/collections/community/docker/index.html>`_.
 
 Plugin and module documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/lib/ansible/galaxy/data/collections_galaxy_meta.yml
+++ b/lib/ansible/galaxy/data/collections_galaxy_meta.yml
@@ -65,7 +65,7 @@
 - key: tags
   description:
   - A list of tags you want to associate with the collection for indexing/searching.
-  - A tag name has the same character requirements as C(namespace) and C(name).
+  - A tag name has the same character requirements as C(namespace) and C(name). See L(here,https://docs.ansible.com/ansible/devel/dev_guide/developing_collections_structure.html) for details.
   type: list
 
 - key: dependencies

--- a/lib/ansible/galaxy/data/collections_galaxy_meta.yml
+++ b/lib/ansible/galaxy/data/collections_galaxy_meta.yml
@@ -65,7 +65,8 @@
 - key: tags
   description:
   - A list of tags you want to associate with the collection for indexing/searching.
-  - A tag name has the same character requirements as C(namespace) and C(name). See L(here,https://docs.ansible.com/ansible/devel/dev_guide/developing_collections_structure.html) for details.
+  - A tag name has the same character requirements as C(namespace) and C(name). See
+  - L(here,https://docs.ansible.com/ansible/devel/dev_guide/developing_collections_structure.html) for details.
   type: list
 
 - key: dependencies


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Automation Hub supports filtering on a fixed subset of tags within a collection's galaxy.yml file.

Seems like it's a good idea to mention this list in the docs so developers preparing for a certified collection have a heads up on the supported tags. Also, helps if/when galaxy-ng becomes a community platform as one could guess the same initial set of tags will be available for filtering collections in search.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/galaxy/data/collections_galaxy_meta.yml
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
