### PR TITLE
ansible-test - Hide ansible._vendor in import test

### DIFF
--- a/changelogs/fragments/ansible-test-sanity-vendoring.yml
+++ b/changelogs/fragments/ansible-test-sanity-vendoring.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Fix the ``import`` sanity test to work properly when Ansible's built-in vendoring support is in use.

--- a/test/integration/targets/ansible-test/aliases
+++ b/test/integration/targets/ansible-test/aliases
@@ -1,3 +1,4 @@
 shippable/posix/group1  # runs in the distro test containers
 shippable/generic/group1  # runs in the default test container
 context/controller
+destructive  # adds and then removes packages into lib/ansible/_vendor/

--- a/test/integration/targets/ansible-test/ansible_collections/ns/col/plugins/lookup/vendor1.py
+++ b/test/integration/targets/ansible-test/ansible_collections/ns/col/plugins/lookup/vendor1.py
@@ -1,0 +1,31 @@
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+name: vendor2
+short_description: lookup
+description: Lookup.
+author:
+  - Ansible Core Team
+'''
+
+EXAMPLES = '''#'''
+RETURN = '''#'''
+
+from ansible.plugins.lookup import LookupBase
+
+try:
+    import demo
+except ImportError:
+    pass
+else:
+    raise Exception('demo import found when it should not be')
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables, **kwargs):
+        self.set_options(var_options=variables, direct=kwargs)
+
+        return terms

--- a/test/integration/targets/ansible-test/ansible_collections/ns/col/plugins/lookup/vendor1.py
+++ b/test/integration/targets/ansible-test/ansible_collections/ns/col/plugins/lookup/vendor1.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 DOCUMENTATION = '''
-name: vendor2
+name: vendor1
 short_description: lookup
 description: Lookup.
 author:

--- a/test/integration/targets/ansible-test/ansible_collections/ns/col/plugins/lookup/vendor2.py
+++ b/test/integration/targets/ansible-test/ansible_collections/ns/col/plugins/lookup/vendor2.py
@@ -1,0 +1,31 @@
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+name: vendor2
+short_description: lookup
+description: Lookup.
+author:
+  - Ansible Core Team
+'''
+
+EXAMPLES = '''#'''
+RETURN = '''#'''
+
+from ansible.plugins.lookup import LookupBase
+
+try:
+    import demo
+except ImportError:
+    pass
+else:
+    raise Exception('demo import found when it should not be')
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables, **kwargs):
+        self.set_options(var_options=variables, direct=kwargs)
+
+        return terms

--- a/test/integration/targets/ansible-test/collection-tests/sanity-vendor.sh
+++ b/test/integration/targets/ansible-test/collection-tests/sanity-vendor.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+
+cp -a "${TEST_DIR}/ansible_collections" "${WORK_DIR}"
+cd "${WORK_DIR}/ansible_collections/ns/col"
+
+"${TEST_DIR}/collection-tests/update-ignore.py"
+
+vendor_dir="$(python -c 'import pathlib, ansible._vendor; print(pathlib.Path(ansible._vendor.__file__).parent)')"
+
+cleanup() {
+    rm -rf "${vendor_dir}/demo/"
+}
+
+trap cleanup EXIT
+
+# Verify that packages installed in the vendor directory are not available to the import test.
+# If they are, the vendor logic will generate a warning which will be turned into an error.
+# Testing this requires at least two plugins (not modules) to be run through the import test.
+
+mkdir "${vendor_dir}/demo/"
+touch "${vendor_dir}/demo/__init__.py"
+
+ansible-test sanity --test import --color --truncate 0 plugins/lookup/vendor1.py plugins/lookup/vendor2.py "${@}"


### PR DESCRIPTION
##### SUMMARY

ansible-test - Hide ansible._vendor in import test

Fixes https://github.com/ansible/ansible/issues/76473

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
