### PR TITLE
[stable-2.12] ansible-test - Hide ansible._vendor in import test

### DIFF
--- a/changelogs/fragments/ansible-test-sanity-vendoring.yml
+++ b/changelogs/fragments/ansible-test-sanity-vendoring.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Fix the ``import`` sanity test to work properly when Ansible's built-in vendoring support is in use.

--- a/test/integration/targets/ansible-test/aliases
+++ b/test/integration/targets/ansible-test/aliases
@@ -1,3 +1,4 @@
 shippable/posix/group1  # runs in the distro test containers
 shippable/generic/group1  # runs in the default test container
 context/controller
+destructive  # adds and then removes packages into lib/ansible/_vendor/

--- a/test/integration/targets/ansible-test/ansible_collections/ns/col/plugins/lookup/vendor1.py
+++ b/test/integration/targets/ansible-test/ansible_collections/ns/col/plugins/lookup/vendor1.py
@@ -1,0 +1,31 @@
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+name: vendor1
+short_description: lookup
+description: Lookup.
+author:
+  - Ansible Core Team
+'''
+
+EXAMPLES = '''#'''
+RETURN = '''#'''
+
+from ansible.plugins.lookup import LookupBase
+
+try:
+    import demo
+except ImportError:
+    pass
+else:
+    raise Exception('demo import found when it should not be')
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables, **kwargs):
+        self.set_options(var_options=variables, direct=kwargs)
+
+        return terms

--- a/test/integration/targets/ansible-test/ansible_collections/ns/col/plugins/lookup/vendor2.py
+++ b/test/integration/targets/ansible-test/ansible_collections/ns/col/plugins/lookup/vendor2.py
@@ -1,0 +1,31 @@
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+name: vendor2
+short_description: lookup
+description: Lookup.
+author:
+  - Ansible Core Team
+'''
+
+EXAMPLES = '''#'''
+RETURN = '''#'''
+
+from ansible.plugins.lookup import LookupBase
+
+try:
+    import demo
+except ImportError:
+    pass
+else:
+    raise Exception('demo import found when it should not be')
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables, **kwargs):
+        self.set_options(var_options=variables, direct=kwargs)
+
+        return terms

--- a/test/integration/targets/ansible-test/collection-tests/sanity-vendor.sh
+++ b/test/integration/targets/ansible-test/collection-tests/sanity-vendor.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+
+cp -a "${TEST_DIR}/ansible_collections" "${WORK_DIR}"
+cd "${WORK_DIR}/ansible_collections/ns/col"
+
+"${TEST_DIR}/collection-tests/update-ignore.py"
+
+vendor_dir="$(python -c 'import pathlib, ansible._vendor; print(pathlib.Path(ansible._vendor.__file__).parent)')"
+
+cleanup() {
+    rm -rf "${vendor_dir}/demo/"
+}
+
+trap cleanup EXIT
+
+# Verify that packages installed in the vendor directory are not available to the import test.
+# If they are, the vendor logic will generate a warning which will be turned into an error.
+# Testing this requires at least two plugins (not modules) to be run through the import test.
+
+mkdir "${vendor_dir}/demo/"
+touch "${vendor_dir}/demo/__init__.py"
+
+ansible-test sanity --test import --color --truncate 0 plugins/lookup/vendor1.py plugins/lookup/vendor2.py "${@}"

--- a/test/lib/ansible_test/_util/target/sanity/import/importer.py
+++ b/test/lib/ansible_test/_util/target/sanity/import/importer.py
@@ -8,17 +8,28 @@ def main():
     Main program function used to isolate globals from imported code.
     Changes to globals in imported modules on Python 2.x will overwrite our own globals.
     """
+    import os
+    import sys
+    import types
+
+    # preload an empty ansible._vendor module to prevent use of any embedded modules during the import test
+    vendor_module_name = 'ansible._vendor'
+
+    vendor_module = types.ModuleType(vendor_module_name)
+    vendor_module.__file__ = os.path.join(os.path.sep.join(os.path.abspath(__file__).split(os.path.sep)[:-8]), 'lib/ansible/_vendor/__init__.py')
+    vendor_module.__path__ = []
+    vendor_module.__package__ = vendor_module_name
+
+    sys.modules[vendor_module_name] = vendor_module
+
     import ansible
     import contextlib
     import datetime
     import json
-    import os
     import re
     import runpy
     import subprocess
-    import sys
     import traceback
-    import types
     import warnings
 
     ansible_path = os.path.dirname(os.path.dirname(ansible.__file__))
@@ -110,8 +121,8 @@ def main():
         # do not support collection loading when not testing a collection
         collection_loader = None
 
-    # remove all modules under the ansible package
-    list(map(sys.modules.pop, [m for m in sys.modules if m.partition('.')[0] == ansible.__name__]))
+    # remove all modules under the ansible package, except the preloaded vendor module
+    list(map(sys.modules.pop, [m for m in sys.modules if m.partition('.')[0] == ansible.__name__ and m != vendor_module_name]))
 
     if import_type == 'module':
         # pre-load an empty ansible package to prevent unwanted code in __init__.py from loading


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/76503

(cherry picked from commit 82f59d4843358768be98fbade9847c65970d48d5)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
