### PR TITLE
Fix example in password lookup

### DIFF
--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -110,7 +110,7 @@ EXAMPLES = """
 
 - name: create random but idempotent password
   set_fact:
-    password: "{{ lookup('password', '/dev/null', seed=inventory_hostname) }}"
+    password: "{{ lookup('password', '/dev/null seed=' + inventory_hostname) }}"
 """
 
 RETURN = """


### PR DESCRIPTION
##### SUMMARY
The correct syntax is 

    lookup('password', '/dev/null seed=myseed')

To use a different seed, you need to concatenate strings

    lookup('password', '/dev/null seed=' + seed_var)

With the old syntax, the module does run without error, but the settings are not applied. This can be check by running the module multiple time: with a fixed seed, a fixed password is expected

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
password lookup

##### ADDITIONAL INFORMATION

