### PR TITLE
Resolves #76449 Misplaced added version info

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tests.rst
@@ -252,10 +252,10 @@ The ``contains`` test is designed to work with the ``select``, ``reject``, ``sel
       - debug:
           msg: "{{ (lacp_groups|selectattr('interfaces', 'contains', 'em1')|first).master }}"
 
-.. versionadded:: 2.4
-
 Testing if a list value is True
 ===============================
+
+.. versionadded:: 2.4
 
 You can use `any` and `all` to check if any or all elements in a list are true or not
 


### PR DESCRIPTION
`.. versionadded::` are coming right after the section tittle, and was misplaced here

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #76449 Misplaced added version info
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Documentation docs/docsite/rst/user_guide/playbooks_tests.rst

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Issue is happening between sections:
* https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html#testing-if-a-list-contains-a-value
* https://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html#testing-if-a-list-value-is-true

Where the first seems to have two added version.

It looks like the issue was introduced with the addition of the section, as confirmed by the same doc page under version 2.9: https://docs.ansible.com/ansible/2.9/user_guide/playbooks_tests.html#test-if-a-list-contains-a-value
