### PR TITLE
unarchive: fix non-english locales

### DIFF
--- a/changelogs/fragments/76542-fix-unarchive-on-nenglish-locales.yml
+++ b/changelogs/fragments/76542-fix-unarchive-on-nenglish-locales.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- unarchive - Make extraction work when the LANGUAGE environment variable is set to a non-English locale.

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -786,7 +786,7 @@ class TgzArchive(object):
             cmd.extend(self.include_files)
 
         locale = get_best_parsable_locale(self.module)
-        rc, out, err = self.module.run_command(cmd, cwd=self.b_dest, environ_update=dict(LANG=locale, LC_ALL=locale, LC_MESSAGES=locale))
+        rc, out, err = self.module.run_command(cmd, cwd=self.b_dest, environ_update=dict(LANG=locale, LC_ALL=locale, LC_MESSAGES=locale, LANGUAGE=locale))
         if rc != 0:
             raise UnarchiveError('Unable to list files in the archive')
 
@@ -831,7 +831,7 @@ class TgzArchive(object):
         if self.include_files:
             cmd.extend(self.include_files)
         locale = get_best_parsable_locale(self.module)
-        rc, out, err = self.module.run_command(cmd, cwd=self.b_dest, environ_update=dict(LANG=locale, LC_ALL=locale, LC_MESSAGES=locale))
+        rc, out, err = self.module.run_command(cmd, cwd=self.b_dest, environ_update=dict(LANG=locale, LC_ALL=locale, LC_MESSAGES=locale, LANGUAGE=locale))
 
         # Check whether the differences are in something that we're
         # setting anyway
@@ -885,7 +885,7 @@ class TgzArchive(object):
         if self.include_files:
             cmd.extend(self.include_files)
         locale = get_best_parsable_locale(self.module)
-        rc, out, err = self.module.run_command(cmd, cwd=self.b_dest, environ_update=dict(LANG=locale, LC_ALL=locale, LC_MESSAGES=locale))
+        rc, out, err = self.module.run_command(cmd, cwd=self.b_dest, environ_update=dict(LANG=locale, LC_ALL=locale, LC_MESSAGES=locale, LANGUAGE=locale))
         return dict(cmd=cmd, rc=rc, out=out, err=err)
 
     def can_handle_archive(self):

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -17,3 +17,4 @@
 - import_tasks: test_symlink.yml
 - import_tasks: test_download.yml
 - import_tasks: test_unprivileged_user.yml
+- import_tasks: test_different_language_var.yml

--- a/test/integration/targets/unarchive/tasks/test_different_language_var.yml
+++ b/test/integration/targets/unarchive/tasks/test_different_language_var.yml
@@ -1,4 +1,5 @@
 - name: test non-ascii with different LANGUAGE
+  when: ansible_os_family == 'Debian'
   block:
     - name: install de language pack
       apt: 

--- a/test/integration/targets/unarchive/tasks/test_different_language_var.yml
+++ b/test/integration/targets/unarchive/tasks/test_different_language_var.yml
@@ -4,14 +4,14 @@
       apt: 
         name: language-pack-de 
         state: present
-    - name: Ensure de_DE.UTF-8 exists
-      community.general.locale_gen:
-        name: de_DE.UTF-8
-        state: present
-    - name: Ensure de_DE exists
-      community.general.locale_gen:
-        name: de_DE
-        state: present
+    #- name: Ensure de_DE.UTF-8 exists
+    #  community.general.locale_gen:
+    #    name: de_DE.UTF-8
+    #    state: present
+    #- name: Ensure de_DE exists
+    #  community.general.locale_gen:
+    #    name: de_DE
+    #    state: present
       
     - name: create our unarchive destination
       file:

--- a/test/integration/targets/unarchive/tasks/test_different_language_var.yml
+++ b/test/integration/targets/unarchive/tasks/test_different_language_var.yml
@@ -4,14 +4,6 @@
       apt: 
         name: language-pack-de 
         state: present
-    #- name: Ensure de_DE.UTF-8 exists
-    #  community.general.locale_gen:
-    #    name: de_DE.UTF-8
-    #    state: present
-    #- name: Ensure de_DE exists
-    #  community.general.locale_gen:
-    #    name: de_DE
-    #    state: present
       
     - name: create our unarchive destination
       file:

--- a/test/integration/targets/unarchive/tasks/test_different_languave_var.yml
+++ b/test/integration/targets/unarchive/tasks/test_different_languave_var.yml
@@ -1,0 +1,35 @@
+- name: test non-ascii with different LANGUAGE
+  block:
+    - name: create our unarchive destination
+      file:
+        path: "{{ remote_tmp_dir }}/test-unarchive-nonascii-くらとみ-tar-gz"
+        state: directory
+
+    - name: test that unarchive works with an archive that contains non-ascii filenames
+      unarchive:
+        # Both the filename of the tarball and the filename inside the tarball have
+        # nonascii chars
+        src: "test-unarchive-nonascii-くらとみ.tar.gz"
+        dest: "{{ remote_tmp_dir }}/test-unarchive-nonascii-くらとみ-tar-gz"
+        mode: "u+rwX,go+rX"
+        remote_src: no
+      register: nonascii_result0
+
+    - name: Check that file is really there
+      stat:
+        path: "{{ remote_tmp_dir }}/test-unarchive-nonascii-くらとみ-tar-gz/storage/àâæçéèïîôœ(copy)!@#$%^&-().jpg"
+      register: nonascii_stat0
+
+    - name: Assert that nonascii tests succeeded
+      assert:
+        that:
+          - "nonascii_result0.changed == true"
+          - "nonascii_stat0.stat.exists == true"
+
+    - name: remove nonascii test
+      file:
+        path: "{{ remote_tmp_dir }}/test-unarchive-nonascii-くらとみ-tar-gz"
+        state: absent
+
+  environment:
+    LANGUAGE: de_DE:en

--- a/test/integration/targets/unarchive/tasks/test_different_languave_var.yml
+++ b/test/integration/targets/unarchive/tasks/test_different_languave_var.yml
@@ -1,5 +1,18 @@
 - name: test non-ascii with different LANGUAGE
   block:
+    - name: install de language pack
+      apt: 
+        name: language-pack-de 
+        state: present
+    - name: Ensure de_DE.UTF-8 exists
+      community.general.locale_gen:
+        name: de_DE.UTF-8
+        state: present
+    - name: Ensure de_DE exists
+      community.general.locale_gen:
+        name: de_DE
+        state: present
+      
     - name: create our unarchive destination
       file:
         path: "{{ remote_tmp_dir }}/test-unarchive-nonascii-くらとみ-tar-gz"


### PR DESCRIPTION
##### SUMMARY
For GNU Gettext, the LANGUAGE environment variable takes precedence over LANG or LC_ALL (http://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/The-LANGUAGE-variable.html#The-LANGUAGE-variable). On systems where LANGUAGE was set to a non-english locale, the output of the tar command was in that language, so the module didn't understand it. This lead to the module failing silently ("changed": false, but the archive was not extracted).

The issue is simply fixed by adding the LANGUAGE environment variable as well.

Tested with:
```
ansible [core 2.12.1]
  config file = /md1/config/ansible/ansible.cfg
  configured module search path = ['/user/hi202/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/ansible/lib/python3.8/site-packages/ansible
  ansible collection location = /user/hi202/.ansible/collections:/usr/share/ansible/collections
  executable location = /opt/ansible/bin/ansible
  python version = 3.8.0 (default, Feb 25 2021, 22:10:10) [GCC 8.4.0]
  jinja version = 3.0.3
  libyaml = True
```
on Ubuntu 20.04, German system, i.e.
```
LANG=de_DE.UTF-8
LANGUAGE=de_DE:en
LC_MESSAGES="de_DE.UTF-8"
```
If you are affected by this issue, add 
```
environment:
        LANGUAGE: en_US.utf8
```
to your play.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
unarchive

##### ADDITIONAL INFORMATION
Step by step reproduction:

1. Change locale as above
2. Try to unarchive a tar archive using one of the example plays in the documentation
3. Nothing is unarchived, the module shows "changed: false"