### PR TITLE
Clarify include parameter in unarchive

### DIFF
--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -72,7 +72,7 @@ options:
   include:
     description:
       - List of directory and file entries that you would like to extract from the archive. If C(include) 
-        is not empty (default), only files listed here will be extracted.
+        is not empty, only files listed here will be extracted.
       - Mutually exclusive with C(exclude).
     type: list
     default: []

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -71,8 +71,8 @@ options:
     version_added: "2.1"
   include:
     description:
-      - List of directory and file entries that you would like to extract from the archive. Only
-        files listed here will be extracted.
+      - List of directory and file entries that you would like to extract from the archive. If C(include) 
+        is not empty (default), only files listed here will be extracted.
       - Mutually exclusive with C(exclude).
     type: list
     default: []

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -71,7 +71,7 @@ options:
     version_added: "2.1"
   include:
     description:
-      - List of directory and file entries that you would like to extract from the archive. If C(include) 
+      - List of directory and file entries that you would like to extract from the archive. If C(include)
         is not empty, only files listed here will be extracted.
       - Mutually exclusive with C(exclude).
     type: list


### PR DESCRIPTION
##### SUMMARY
While debugging https://github.com/ansible/ansible/pull/76542, I noticed that the documentation of the include parameter was incorrect. This MR clarifies this.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
unarchive

##### ADDITIONAL INFORMATION
See examples, leaving the include parameter empty unarchives everything.