### PR TITLE
apt.py: fix environment on non-english locales

### DIFF
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1139,7 +1139,7 @@ def main():
         DEBIAN_FRONTEND='noninteractive',
         DEBIAN_PRIORITY='critical',
         LANG=locale,
-        LANGUGE=locale,
+        LANGUAGE=locale,
         LC_ALL=locale,
         LC_MESSAGES=locale,
         LC_CTYPE=locale,

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1139,6 +1139,7 @@ def main():
         DEBIAN_FRONTEND='noninteractive',
         DEBIAN_PRIORITY='critical',
         LANG=locale,
+        LANGUGE=locale,
         LC_ALL=locale,
         LC_MESSAGES=locale,
         LC_CTYPE=locale,


### PR DESCRIPTION
##### SUMMARY
Same issue as https://github.com/ansible/ansible/pull/76542, but in this case the error is not a false-negative "change", but a false positive (idempotence violated). This MR fixes this.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
apt

##### ADDITIONAL INFORMATION
See https://github.com/ansible/ansible/pull/76542
