### PR TITLE
added ansible-galaxy to ansible-pull

### DIFF
--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -125,7 +125,7 @@ class PullCLI(CLI):
                                  help="when changing (small) files and templates, show the differences in those files; works great with --check")
         self.parser.add_argument("-r", "--galaxy-role-file", dest='role_file', default=None,
                                  help='requirements file to install before running the playbook')
-        self.parser.add_argument("--galaxy-force-with-deps", default=False, dest='force_with_deps', action='store_true'
+        self.parser.add_argument("--galaxy-force-with-deps", default=False, dest='force_with_deps', action='store_true',
                                  help='adds --force-with-deps to the ansible-galaxy call')
 
     def post_process_args(self, options):

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -123,7 +123,10 @@ class PullCLI(CLI):
                                  help="don't make any changes; instead, try to predict some of the changes that may occur")
         self.parser.add_argument("--diff", default=C.DIFF_ALWAYS, dest='diff', action='store_true',
                                  help="when changing (small) files and templates, show the differences in those files; works great with --check")
-        self.parser.add_argument("-r", "--role-file", dest='role_file', default=None, help='requirements file to install before running the playbook')
+        self.parser.add_argument("-r", "--galaxy-role-file", dest='role_file', default=None,
+                                 help='requirements file to install before running the playbook')
+        self.parser.add_argument("--galaxy-force-with-deps", default=False, dest='force_with_deps', action='store_true'
+                                 help='adds --force-with-deps to the ansible-galaxy call')
 
     def post_process_args(self, options):
         options = super(PullCLI, self).post_process_args(options)
@@ -259,7 +262,11 @@ class PullCLI(CLI):
         # Install Galaxy Requirements
         requirements = self.select_requirements(context.CLIARGS['dest'])
         if requirements is not None:
-            cmd = '%s/ansible-galaxy install --force --force-with-deps --role-file %s' % (bin_path, requirements)
+            cmd = '%s/ansible-galaxy install --role-file %s' % (bin_path, requirements)
+            if context.CLIARGS['force']:
+                cmd += ' --force'
+            if context.CLIARGS['force_with_deps']:
+                cmd += ' --force-with-deps'
             display.vvvv('running %s' % cmd)
             os.chdir(context.CLIARGS['dest'])
             rc, b_out, b_err = run_cmd(cmd, live=True)

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -123,10 +123,6 @@ class PullCLI(CLI):
                                  help="don't make any changes; instead, try to predict some of the changes that may occur")
         self.parser.add_argument("--diff", default=C.DIFF_ALWAYS, dest='diff', action='store_true',
                                  help="when changing (small) files and templates, show the differences in those files; works great with --check")
-        self.parser.add_argument("-r", "--galaxy-role-file", dest='role_file', default=None,
-                                 help='requirements file to install before running the playbook')
-        self.parser.add_argument("--galaxy-force-with-deps", default=False, dest='force_with_deps', action='store_true',
-                                 help='adds --force-with-deps to the ansible-galaxy call')
 
     def post_process_args(self, options):
         options = super(PullCLI, self).post_process_args(options)
@@ -263,10 +259,6 @@ class PullCLI(CLI):
         requirements = self.select_requirements(context.CLIARGS['dest'])
         if requirements is not None:
             cmd = '%s/ansible-galaxy install --role-file %s' % (bin_path, requirements)
-            if context.CLIARGS['force']:
-                cmd += ' --force'
-            if context.CLIARGS['force_with_deps']:
-                cmd += ' --force-with-deps'
             display.vvvv('running %s' % cmd)
             os.chdir(context.CLIARGS['dest'])
             rc, b_out, b_err = run_cmd(cmd, live=True)
@@ -337,13 +329,7 @@ class PullCLI(CLI):
     def select_requirements(path):
         requirements = None
         errors = []
-        files = []
-        if context.CLIARGS['role_file'] is not None:
-            files.append(context.CLIARGS['role_file'])
-        files.append('requirements.yml')
-        files.append('requirements.yaml')
-        files.append('roles/requirements.yml')
-        files.append('roles/requirements.yaml')
+        files = ['roles/requirements.yml', 'roles/requirements.yaml']
         for req in files:
             req_path = os.path.join(path, req)
             rc = PullCLI.try_file(req_path)

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -259,7 +259,7 @@ class PullCLI(CLI):
         # Install Galaxy Requirements
         requirements = self.select_requirements(context.CLIARGS['dest'])
         if requirements is not None:
-            cmd = '%s/ansible-galaxy install --force --role-file %s' % (bin_path, requirements)
+            cmd = '%s/ansible-galaxy install --force --force-with-deps --role-file %s' % (bin_path, requirements)
             display.vvvv('running %s' % cmd)
             os.chdir(context.CLIARGS['dest'])
             rc, b_out, b_err = run_cmd(cmd, live=True)


### PR DESCRIPTION
##### SUMMARY

Change the `ansible-pull` process to include a call to `ansible-galaxy install`
this fixes #76535

order:
* scm checkout ...
* ansible-galaxy install ...
* ansible-playbook ...

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-pull

##### ADDITIONAL INFORMATION

**After change**
```
Starting Ansible Pull at 2021-12-13 13:36:49
/usr/bin/ansible-pull -KU <redacted>.git
BECOME password: 
[WARNING]: Could not match supplied host pattern, ignoring: ...
localhost | SUCCESS => {
    "after": "79b9226c7e976b9ef73da1d929aed5a0c1300ace",
    "before": "79b9226c7e976b9ef73da1d929aed5a0c1300ace",
    "changed": false,
    "remote_url_changed": false
}
Starting galaxy role install process
- changing role service-prometheus from  to unspecified
- extracting service-prometheus to /home/bastiaan/.ansible/pull/localhost/roles/service-prometheus
- service-prometheus was installed successfully
- dependency pilab-role-common is already installed, skipping.
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'
[WARNING]: Could not match supplied host pattern, ignoring: basberry

PLAY [localhost] ***************************************************************
```

**Before change**
```
Starting Ansible Pull at 2021-12-13 13:36:49
/usr/bin/ansible-pull -KU <redacted>.git
BECOME password: 
[WARNING]: Could not match supplied host pattern, ignoring: ...
localhost | SUCCESS => {
    "after": "79b9226c7e976b9ef73da1d929aed5a0c1300ace",
    "before": "79b9226c7e976b9ef73da1d929aed5a0c1300ace",
    "changed": false,
    "remote_url_changed": false
}
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'
[WARNING]: Could not match supplied host pattern, ignoring: basberry

PLAY [localhost] ***************************************************************
```
