### PR TITLE
Adding modularity tag to task modularity.yml

### DIFF
--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -56,6 +56,8 @@
 - include_tasks: modularity.yml
   when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('29', '>=')) or
         (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
+  tags:
+    - dnf_modularity
 
 - include_tasks: logging.yml
   when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('31', '>=')) or


### PR DESCRIPTION
##### SUMMARY
Add tag to modularity dnf test to be able to disable it through --skip-tags option

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
dnf integration tests

##### ADDITIONAL INFORMATION
Some distributions can be shipped without modules and user then should be able to skip modularity testing, e.g. using --skip-tags option.