### PR TITLE
2.12: Fix AttributeError when providing file via --conn-password-file (#76534)

### DIFF
--- a/changelogs/fragments/76530-connection-password-file-tb-fix.yml
+++ b/changelogs/fragments/76530-connection-password-file-tb-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix ``AttributeError`` when providing password file via ``--connection-password-file`` (https://github.com/ansible/ansible/issues/76530)

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -21,6 +21,7 @@ from ansible.errors import AnsibleError
 from ansible.inventory.manager import InventoryManager
 from ansible.module_utils.six import with_metaclass, string_types, PY3
 from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.file import is_executable
 from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.vault import PromptVaultSecret, get_file_vault_secret
 from ansible.plugins.loader import add_all_plugin_dirs
@@ -513,7 +514,7 @@ class CLI(with_metaclass(ABCMeta, object)):
         elif not os.path.exists(b_pwd_file):
             raise AnsibleError("The password file %s was not found" % pwd_file)
 
-        elif os.path.is_executable(b_pwd_file):
+        elif is_executable(b_pwd_file):
             display.vvvv(u'The password file %s is a script.' % to_text(pwd_file))
             cmd = [b_pwd_file]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #76534 

(cherry picked from commit ac2bdd68346634dbc19c9b22ed744fdb01edc249)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/cli/__init__.py`