### PR TITLE
Fix typo for ssh control path

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1715,7 +1715,7 @@ PARAMIKO_LOOK_FOR_KEYS:
   type: boolean
 PERSISTENT_CONTROL_PATH_DIR:
   name: Persistence socket path
-  default: ~/.ansible/pc
+  default: ~/.ansible/cp
   description: Path to socket to be used by the connection persistence system.
   env: [{name: ANSIBLE_PERSISTENT_CONTROL_PATH_DIR}]
   ini:


### PR DESCRIPTION
##### SUMMARY
Fix a tiny but confusing typo in the documentation regarding SSH control path

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
config/base.yml

##### ADDITIONAL INFORMATION
A very minor issue with the documentation.
