### PR TITLE
set_Stats: Added list_merge option

### DIFF
--- a/lib/ansible/executor/stats.py
+++ b/lib/ansible/executor/stats.py
@@ -81,7 +81,7 @@ class AggregateStats:
         else:
             self.custom[host][which] = what
 
-    def update_custom_stats(self, which, what, host=None):
+    def update_custom_stats(self, which, what, host=None, list_merge='replace'):
         ''' allow aggregation of a custom stat'''
 
         if host is None:
@@ -94,7 +94,7 @@ class AggregateStats:
             return None
 
         if isinstance(what, MutableMapping):
-            self.custom[host][which] = merge_hash(self.custom[host][which], what)
+            self.custom[host][which] = merge_hash(self.custom[host][which], what, list_merge=list_merge)
         else:
             # let overloaded + take care of other types
             self.custom[host][which] += what

--- a/lib/ansible/modules/set_stats.py
+++ b/lib/ansible/modules/set_stats.py
@@ -31,6 +31,13 @@ options:
         - Whether the provided value is aggregated to the existing stat C(yes) or will replace it C(no).
     type: bool
     default: yes
+  list_merge:
+    description:
+        - Set list merge behaviour on aggregating existing stat.
+        - See L(Combining hashes/dictionaries,https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#combining-hashes-dictionaries).
+    type: str
+    default: replace
+    choices: [ replace, keep, append, prepend, append_rp, prepend_rp ]
 extends_documentation_fragment:
     - action_common_attributes
     - action_common_attributes.conn

--- a/lib/ansible/plugins/action/set_stats.py
+++ b/lib/ansible/plugins/action/set_stats.py
@@ -18,7 +18,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.module_utils.six import string_types
+from ansible.module_utils.six import iteritems, string_types
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.action import ActionBase
 from ansible.utils.vars import isidentifier
@@ -27,7 +27,7 @@ from ansible.utils.vars import isidentifier
 class ActionModule(ActionBase):
 
     TRANSFERS_FILES = False
-    _VALID_ARGS = frozenset(('aggregate', 'data', 'per_host'))
+    _VALID_ARGS = frozenset(('aggregate', 'data', 'per_host', 'list_merge'))
 
     # TODO: document this in non-empty set_stats.py module
     def run(self, tmp=None, task_vars=None):
@@ -37,7 +37,7 @@ class ActionModule(ActionBase):
         result = super(ActionModule, self).run(tmp, task_vars)
         del tmp  # tmp no longer has any effect
 
-        stats = {'data': {}, 'per_host': False, 'aggregate': True}
+        stats = {'data': {}, 'per_host': False, 'aggregate': True, 'list_merge': 'replace'}
 
         if self._task.args:
             data = self._task.args.get('data', {})
@@ -58,6 +58,10 @@ class ActionModule(ActionBase):
                         stats[opt] = boolean(self._templar.template(val), strict=False)
                     else:
                         stats[opt] = val
+            # set list_merge option
+            list_merge = self._task.args.get('list_merge', None)
+            if (val is not None) and isinstance(list_merge, str):
+                stats[opt] = list_merge
 
             for (k, v) in data.items():
 

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -767,7 +767,7 @@ class StrategyBase:
                         for myhost in host_list:
                             for k in data.keys():
                                 if aggregate:
-                                    self._tqm._stats.update_custom_stats(k, data[k], myhost)
+                                    self._tqm._stats.update_custom_stats(k, data[k], myhost, list_merge=result_item['ansible_stats']['list_merge'])
                                 else:
                                     self._tqm._stats.set_custom_stats(k, data[k], myhost)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added the ability to choose list_merge behavior for set_stats action.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
set_stats action plugin.
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
When we use aggregation on set_stats action, if our data hash includes an array, the default behavior for list merge is "replace", with this change, we will have the ability to use different options for list merge behavior.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Setting stats
  set_stats:
    list_merge: append
    data:
      some_hash:
         key1: val1
         key2:
           - val1
           - val2
           - val3
```
