### PR TITLE
Do not format the choice as a definition list for non-mapping values

### DIFF
--- a/docs/templates/config.rst.j2
+++ b/docs/templates/config.rst.j2
@@ -122,7 +122,7 @@ you can use the command line utility mentioned above (`ansible-config`) to brows
 {%         endfor %}
 {%       else %}
 {%         for key in config['choices'] %}
-    - :{{key}}:
+    - {{key}}
 {%         endfor %}
 {%       endif %}
 {%     endif %}


### PR DESCRIPTION
##### SUMMARY
Do not format the choice as a definition list for non-mapping values

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/templates/config.rst.j2

##### ADDITIONAL INFORMATION
Currently it looks like this, which is misleading:

<img width="535" alt="Screen Shot 2021-12-15 at 10 53 53 AM" src="https://user-images.githubusercontent.com/39340/146229861-5315975b-0846-4b34-b905-9a3b094d6a35.png">

