### PR TITLE
package_facts: Add pkg_info support for OpenBSD

### DIFF
--- a/changelogs/fragments/76580-add-pkg_info-support-to-package_facts.yml
+++ b/changelogs/fragments/76580-add-pkg_info-support-to-package_facts.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - package_facts - add pkg_info support for OpenBSD and NetBSD (https://github.com/ansible/ansible/pull/76580)


### PR DESCRIPTION
##### SUMMARY
Add `package_facts` support to OpenBSD via `pkg_info`.

The implementation is mostly copied from the `apk` one.

Tested on  OpenBSD 6.9 and OpenBSD 7.0.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
package_facts
