### PR TITLE
Update Windows host requirements

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_general_windows.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general_windows.rst
@@ -84,13 +84,11 @@ created Windows VM:
 The OS that is created is based on the image set. The following
 images can be used:
 
-- `jborean93/WindowsServer2008-x86 <https://app.vagrantup.com/jborean93/boxes/WindowsServer2008-x86>`_
-- `jborean93/WindowsServer2008-x64 <https://app.vagrantup.com/jborean93/boxes/WindowsServer2008-x64>`_
-- `jborean93/WindowsServer2008R2 <https://app.vagrantup.com/jborean93/boxes/WindowsServer2008R2>`_
 - `jborean93/WindowsServer2012 <https://app.vagrantup.com/jborean93/boxes/WindowsServer2012>`_
 - `jborean93/WindowsServer2012R2 <https://app.vagrantup.com/jborean93/boxes/WindowsServer2012R2>`_
 - `jborean93/WindowsServer2016 <https://app.vagrantup.com/jborean93/boxes/WindowsServer2016>`_
 - `jborean93/WindowsServer2019 <https://app.vagrantup.com/jborean93/boxes/WindowsServer2019>`_
+- `jborean93/WindowsServer2022 <https://app.vagrantup.com/jborean93/boxes/WindowsServer2022>`_
 
 When the host is online, it can accessible by RDP on ``127.0.0.1:3389`` but the
 port may differ depending if there was a conflict. To get rid of the host, run
@@ -157,10 +155,6 @@ controller started with ``00`` and is incremented from there. For example, in
 the default ``inventory.yml`` file, WinRM over HTTPS for ``SERVER2012R2`` is
 forwarded over port ``29804`` as it's the fourth entry in ``domain_children``.
 
-.. note:: While an SSH server is available on all Windows hosts but Server
-    2008 (non R2), it is not a support connection for Ansible managing Windows
-    hosts and should not be used with Ansible.
-
 Windows new module development
 ==============================
 
@@ -177,7 +171,7 @@ When creating a new module there are a few things to keep in mind:
 - Look for common functions in ``./lib/ansible/module_utils/powershell/`` and use the code there instead of duplicating work. These can be imported by adding the line ``#Requires -Module *`` where * is the filename to import, and will be automatically included with the module code sent to the Windows target when run via Ansible
 - As well as PowerShell module utils, C# module utils are stored in ``./lib/ansible/module_utils/csharp/`` and are automatically imported in a module execution if the line ``#AnsibleRequires -CSharpUtil *`` is present
 - C# and PowerShell module utils achieve the same goal but C# allows a developer to implement low level tasks, such as calling the Win32 API, and can be faster in some cases
-- Ensure the code runs under Powershell v3 and higher on Windows Server 2008 and higher; if higher minimum Powershell or OS versions are required, ensure the documentation reflects this clearly
+- Ensure the code runs under Powershell v3 and higher on Windows Server 2012 and higher; if higher minimum Powershell or OS versions are required, ensure the documentation reflects this clearly
 - Ansible runs modules under strictmode version 2.0. Be sure to test with that enabled by putting ``Set-StrictMode -Version 2.0`` at the top of your dev script
 - Favor native Powershell cmdlets over executable calls if possible
 - Use the full cmdlet name instead of aliases, for example ``Remove-Item`` over ``rm``

--- a/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
@@ -74,7 +74,7 @@ Platform versions, as specified using the ``--remote`` option with ``/`` removed
 
 Windows versions, as specified using the ``--windows`` option can also be skipped:
 
-- ``skip/windows/2008`` - Skip tests on Windows Server 2008.
+- ``skip/windows/2012`` - Skip tests on Windows Server 2012.
 - ``skip/windows/2012-R2`` - Skip tests on Windows Server 2012 R2.
 
 Aliases can be used to skip Python major versions using one of the following:

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -116,8 +116,8 @@ Windows Tests
 =============
 
 These tests exercise the ``winrm`` connection plugin and Windows modules.  You'll
-need to define an inventory with a remote Windows 2008 or 2012 Server to use
-for testing, and enable PowerShell Remoting to continue.
+need to define an inventory with a remote Windows Server to use for testing,
+and enable PowerShell Remoting to continue.
 
 Running these tests may result in changes to your Windows host, so don't run
 them against a production/critical Windows environment.

--- a/docs/docsite/rst/user_guide/windows_dsc.rst
+++ b/docs/docsite/rst/user_guide/windows_dsc.rst
@@ -17,8 +17,7 @@ More details on DSC can be viewed at `DSC Overview <https://docs.microsoft.com/e
 Host Requirements
 `````````````````
 To use the ``win_dsc`` module, a Windows host must have PowerShell v5.0 or
-newer installed. All supported hosts, except for Windows Server 2008 (non R2) can be
-upgraded to PowerShell v5.
+newer installed. All supported hosts can be upgraded to PowerShell v5.
 
 Once the PowerShell requirements have been met, using DSC is as simple as
 creating a task with the ``win_dsc`` module.

--- a/docs/docsite/rst/user_guide/windows_setup.rst
+++ b/docs/docsite/rst/user_guide/windows_setup.rst
@@ -14,8 +14,8 @@ Windows host must meet these requirements:
 
 * Ansible can generally manage Windows versions under current
   and extended support from Microsoft. Ansible can manage desktop OSs including
-  Windows 7, 8.1, and 10, and server OSs including Windows Server 2008,
-  2008 R2, 2012, 2012 R2, 2016, and 2019.
+  Windows 8.1, and 10, and server OSs including Windows Server 2012, 2012 R2,
+  2016, 2019, and 2022.
 
 * Ansible requires PowerShell 3.0 or newer and at least .NET 4.0 to be
   installed on the Windows host.


### PR DESCRIPTION
##### SUMMARY
Add references to Server 2022 which is tested in CI and is supported in Ansible. Please note this does not mean supported from Red Hat support, this statement would need to be done by Red Hat Support BU and their documentation updated to mention this.

This also removes Server 2008 (R2) from most of the docs as we've dropped support in Ansible for these hosts since 2.10.

Fixes https://github.com/ansible-collections/ansible.windows/issues/322

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Windows docs