### PR TITLE
Replace "Encrypt" with "Hash" for prompt documentation

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_prompts.rst
+++ b/docs/docsite/rst/user_guide/playbooks_prompts.rst
@@ -45,10 +45,10 @@ If you have a variable that changes infrequently, you can provide a default valu
        prompt: Product release version
        default: "1.0"
 
-Encrypting values supplied by ``vars_prompt``
+Hash values supplied by ``vars_prompt``
 ---------------------------------------------
 
-You can encrypt the entered value so you can use it, for instance, with the user module to define a password:
+You can hash the entered value so you can use it, for instance, with the user module to define a password:
 
 .. code-block:: yaml
 

--- a/docs/docsite/rst/user_guide/playbooks_prompts.rst
+++ b/docs/docsite/rst/user_guide/playbooks_prompts.rst
@@ -46,7 +46,7 @@ If you have a variable that changes infrequently, you can provide a default valu
        default: "1.0"
 
 Hashing values supplied by ``vars_prompt``
----------------------------------------------
+------------------------------------------
 
 You can hash the entered value so you can use it, for instance, with the user module to define a password:
 

--- a/docs/docsite/rst/user_guide/playbooks_prompts.rst
+++ b/docs/docsite/rst/user_guide/playbooks_prompts.rst
@@ -45,7 +45,7 @@ If you have a variable that changes infrequently, you can provide a default valu
        prompt: Product release version
        default: "1.0"
 
-Hash values supplied by ``vars_prompt``
+Hashing values supplied by ``vars_prompt``
 ---------------------------------------------
 
 You can hash the entered value so you can use it, for instance, with the user module to define a password:


### PR DESCRIPTION
##### SUMMARY
This document talks about the possibility to "encrypt" prompted input, though it actually creates a hash that can be used for /etc/passwd and similar. Therefore I would like to have the wording correct. Further _passlib_ and _crypt_ describe themselves as hashing libraries and not as encryption library (hashing is irreversible, while encryption is not), . 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Interactive Inputs: Prompts

##### ADDITIONAL INFORMATION
This is a documentation change to prevent confusion of readers as they might think the "encrypted" values can be reverted into  cleartext values later on which is not possible due to the way how hashing works.
