### PR TITLE
Add a 'rtl_sorted' inventory sort-order

### DIFF
--- a/changelogs/fragments/rtl_sorted.yml
+++ b/changelogs/fragments/rtl_sorted.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - inventory/manager.py add 'rtl_sorted' sorting order for get_host, returnes hosts sorted looking from the end of the string.

--- a/docs/docsite/rst/user_guide/playbooks_strategies.rst
+++ b/docs/docsite/rst/user_guide/playbooks_strategies.rst
@@ -183,6 +183,8 @@ sorted:
     Sorted alphabetically sorted by name
 reverse_sorted:
     Sorted by name in reverse alphabetical order
+rtl_sorted:
+    Sorted by name reading right to left (from the end of string to the beginning)
 shuffle:
     Randomly ordered on each run
 

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -415,7 +415,7 @@ class InventoryManager(object):
                 if order == 'shuffle':
                     shuffle(hosts)
                 elif order == 'last_segment':
-                    hosts = sorted(hosts, key=lambda x: getattr(x, 'name').rsplit("-",1)[-1])
+                    hosts = sorted(hosts, key=lambda x: getattr(x, 'name').split("-")[::-1])
                 elif order not in [None, 'inventory']:
                     raise AnsibleOptionsError("Invalid 'order' specified for inventory hosts: %s" % order)
 

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -410,6 +410,8 @@ class InventoryManager(object):
                 hosts = sorted(self._hosts_patterns_cache[pattern_hash][:], key=attrgetter('name'), reverse=(order == 'reverse_sorted'))
             elif order == 'reverse_inventory':
                 hosts = self._hosts_patterns_cache[pattern_hash][::-1]
+            elif order == 'order_last_dash':
+                hosts = sorted(self._hosts_patterns_cache[pattern_hash][:], key=lambda x: getattr(x, 'name').rsplit("-",1)[-1])
             else:
                 hosts = self._hosts_patterns_cache[pattern_hash][:]
                 if order == 'shuffle':

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -414,8 +414,8 @@ class InventoryManager(object):
                 hosts = self._hosts_patterns_cache[pattern_hash][:]
                 if order == 'shuffle':
                     shuffle(hosts)
-                elif order == 'last_segment':
-                    hosts = sorted(hosts, key=lambda x: getattr(x, 'name').split("-")[::-1])
+                elif order == 'rtl_sorted':
+                    hosts = sorted(hosts, key=lambda x: getattr(x, 'name')[::-1])
                 elif order not in [None, 'inventory']:
                     raise AnsibleOptionsError("Invalid 'order' specified for inventory hosts: %s" % order)
 

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -410,12 +410,12 @@ class InventoryManager(object):
                 hosts = sorted(self._hosts_patterns_cache[pattern_hash][:], key=attrgetter('name'), reverse=(order == 'reverse_sorted'))
             elif order == 'reverse_inventory':
                 hosts = self._hosts_patterns_cache[pattern_hash][::-1]
-            elif order == 'order_last_dash':
-                hosts = sorted(self._hosts_patterns_cache[pattern_hash][:], key=lambda x: getattr(x, 'name').rsplit("-",1)[-1])
             else:
                 hosts = self._hosts_patterns_cache[pattern_hash][:]
                 if order == 'shuffle':
                     shuffle(hosts)
+                elif order == 'order_last_dash':
+                    hosts = sorted(hosts, key=lambda x: getattr(x, 'name').rsplit("-",1)[-1])
                 elif order not in [None, 'inventory']:
                     raise AnsibleOptionsError("Invalid 'order' specified for inventory hosts: %s" % order)
 

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -414,7 +414,7 @@ class InventoryManager(object):
                 hosts = self._hosts_patterns_cache[pattern_hash][:]
                 if order == 'shuffle':
                     shuffle(hosts)
-                elif order == 'order_last_dash':
+                elif order == 'last_segment':
                     hosts = sorted(hosts, key=lambda x: getattr(x, 'name').rsplit("-",1)[-1])
                 elif order not in [None, 'inventory']:
                     raise AnsibleOptionsError("Invalid 'order' specified for inventory hosts: %s" % order)

--- a/test/integration/targets/order/runme.sh
+++ b/test/integration/targets/order/runme.sh
@@ -14,6 +14,7 @@ cleanup () {
 for EXTRA in '{"inputlist": ["hostB", "hostA", "hostD", "hostC"]}' \
              '{"myorder": "inventory", "inputlist": ["hostB", "hostA", "hostD", "hostC"]}' \
              '{"myorder": "sorted", "inputlist": ["hostA", "hostB", "hostC", "hostD"]}'  \
+             '{"myorder": "rtl_sorted", "inputlist": ["hostA", "hostB", "hostC", "hostD"]}'  \
              '{"myorder": "reverse_sorted", "inputlist": ["hostD", "hostC", "hostB", "hostA"]}' \
              '{"myorder": "reverse_inventory", "inputlist": ["hostC", "hostD", "hostA", "hostB"]}' \
              '{"myorder": "shuffle", "inputlist": ["hostC", "hostD", "hostA", "hostB"]}'


### PR DESCRIPTION
##### SUMMARY

This will allow hosts to be sorted but looking from the end of the hostname, for example if using hostname in a setup like below, this will not return all 'name' hostnames directly affter eachother, but nicely spread out, and ordered on the number (in this case).

name-1
name-2
name-3
name-4
other-1
other-2
other-3
other-4

will then be sorted like
name-1
other-1
name-2
other-2
name-3
other-3
...

So you can have multiple hosts with the same function / in the same cluster/ha-setup not be running at the same time (if serial is set accordingly)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Inventory/manager.py get_host
