### PR TITLE
[WIP] Fix [ssh_connection] pipelining and timeout options

### DIFF
--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -250,7 +250,7 @@ def add_connect_options(parser):
                                help='connect as this user (default=%s)' % C.DEFAULT_REMOTE_USER)
     connect_group.add_argument('-c', '--connection', dest='connection', default=C.DEFAULT_TRANSPORT,
                                help="connection type to use (default=%s)" % C.DEFAULT_TRANSPORT)
-    connect_group.add_argument('-T', '--timeout', default=C.DEFAULT_TIMEOUT, type=int, dest='timeout',
+    connect_group.add_argument('-T', '--timeout', type=int, dest='timeout',
                                help="override the connection timeout in seconds (default=%s)" % C.DEFAULT_TIMEOUT)
 
     # ssh only

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -322,6 +322,9 @@ class PlayContext(Base):
             try:
                 if 'become' in prop:
                     continue
+                if prop in ['pipelining', 'timeout']:
+                    # HACK: exclude FAs with non-None defaults to allow SSH connection plugin specific configuration
+                    continue
 
                 var_val = getattr(self, prop)
                 for var_opt in var_list:

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -334,8 +334,6 @@ DOCUMENTATION = '''
         vars:
           - name: ansible_ssh_timeout
             version_added: '2.11'
-        cli:
-          - name: timeout
         type: integer
       pkcs11_provider:
         version_added: '2.12'

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -334,6 +334,8 @@ DOCUMENTATION = '''
         vars:
           - name: ansible_ssh_timeout
             version_added: '2.11'
+        cli:
+          - name: timeout
         type: integer
       pkcs11_provider:
         version_added: '2.12'

--- a/test/integration/targets/connection_ssh/test_ssh_defaults.cfg
+++ b/test/integration/targets/connection_ssh/test_ssh_defaults.cfg
@@ -1,4 +1,6 @@
 [ssh_connection]
+pipelining=True
+timeout=1
 ssh_common_args=fromconfig
 ssh_extra_args=fromconfig
 scp_extra_args=fromconfig

--- a/test/integration/targets/connection_ssh/verify_config.yml
+++ b/test/integration/targets/connection_ssh/verify_config.yml
@@ -1,21 +1,39 @@
 - hosts: localhost
   gather_facts: false
   vars:
-    ssh_configs:
+    str_ssh_configs:
       - ssh_common_args
       - ssh_extra_args
       - sftp_extra_args
       - scp_extra_args
+    bool_ssh_configs:
+      - pipelining
+    int_ssh_configs:
+      - timeout
   tasks:
     - debug:
         msg: '{{item ~ ": " ~ lookup("config", item, plugin_type="connection", plugin_name="ssh")}}'
         verbosity: 3
-      loop: '{{ssh_configs}}'
+      loop: '{{str_ssh_configs + bool_ssh_configs + int_ssh_configs}}'
       tags: [ configfile ]
 
-    - name: check config from file
+    - name: check str config from file
       assert:
         that:
           - 'lookup("config", item, plugin_type="connection", plugin_name="ssh") == "fromconfig"'
-      loop: '{{ssh_configs}}'
+      loop: '{{str_ssh_configs}}'
+      tags: [ configfile ]
+
+    - name: check bool config from file
+      assert:
+        that:
+          - 'lookup("config", item, plugin_type="connection", plugin_name="ssh") == True'
+      loop: '{{bool_ssh_configs}}'
+      tags: [ configfile ]
+
+    - name: check int config from file
+      assert:
+        that:
+          - 'lookup("config", item, plugin_type="connection", plugin_name="ssh") == 1'
+      loop: '{{int_ssh_configs}}'
       tags: [ configfile ]


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/ansible/issues/76572#issuecomment-997077865.

The `pipelining` and `timeout` options are ignored when set in the [ssh_connection] section. This happens because the default values for those PlayContext FieldAttributes are not None, so when they're included in the variables to configure pipelining/timeout, it looks like they're being configured via vars. `timeout` was doubly un-configurable because it included the cli option `timeout`, the default of which is not None.

##### ISSUE TYPE
- Bugfix Pull Request
