### PR TITLE
Fix delegating to hosts with null remote address vars

### DIFF
--- a/changelogs/fragments/76599-fix-delegate-to-with-null-remote-addr.yaml
+++ b/changelogs/fragments/76599-fix-delegate-to-with-null-remote-addr.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fall back to DNS resolution if a delegate_to host is defined in inventory with a null remote address (https://github.com/ansible/ansible/issues/76359).

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -219,7 +219,7 @@ class PlayContext(Base):
             # may happen when users put an IP entry into their inventory, or if
             # they rely on DNS for a non-inventory hostname
             for address_var in ('ansible_%s_host' % delegated_transport,) + C.MAGIC_VARIABLE_MAPPING.get('remote_addr'):
-                if address_var in delegated_vars:
+                if address_var in delegated_vars and delegated_vars[address_var] is not None:
                     break
             else:
                 display.debug("no remote address found for delegated host %s\nusing its name, so success depends on DNS resolution" % delegated_host_name)


### PR DESCRIPTION
##### SUMMARY
Fixes #76359

If a delegate_to host has a null remote address defined in inventory, treat it like a non-inventory host and rely on DNS resolution.

##### ISSUE TYPE
- Bugfix Pull Request
