### PR TITLE
Disable the _distutils_hack in newer setuptools

### DIFF
--- a/test/integration/targets/entry_points/runme.sh
+++ b/test/integration/targets/entry_points/runme.sh
@@ -4,7 +4,7 @@ set -eu
 source virtualenv.sh
 set +x
 unset PYTHONPATH
-export SETUPTOOLS_USE_DISTUTILS=nope
+export SETUPTOOLS_USE_DISTUTILS=stdlib
 
 base_dir="$(dirname "$(dirname "$(dirname "$(dirname "${OUTPUT_DIR}")")")")"
 bin_dir="$(dirname "$(command -v pip)")"

--- a/test/integration/targets/entry_points/runme.sh
+++ b/test/integration/targets/entry_points/runme.sh
@@ -4,6 +4,7 @@ set -eu
 source virtualenv.sh
 set +x
 unset PYTHONPATH
+export SETUPTOOLS_USE_DISTUTILS=nope
 
 base_dir="$(dirname "$(dirname "$(dirname "$(dirname "${OUTPUT_DIR}")")")")"
 bin_dir="$(dirname "$(command -v pip)")"

--- a/test/integration/targets/setup_paramiko/install-FreeBSD-python-3.yml
+++ b/test/integration/targets/setup_paramiko/install-FreeBSD-python-3.yml
@@ -5,4 +5,4 @@
     name: paramiko
     extra_args: "-c {{ remote_constraints }}"
   environment:
-    SETUPTOOLS_USE_DISTUTILS: nope
+    SETUPTOOLS_USE_DISTUTILS: stdlib

--- a/test/integration/targets/setup_paramiko/install-FreeBSD-python-3.yml
+++ b/test/integration/targets/setup_paramiko/install-FreeBSD-python-3.yml
@@ -4,3 +4,5 @@
   pip: # no package in pkg, just use pip
     name: paramiko
     extra_args: "-c {{ remote_constraints }}"
+  environment:
+    SETUPTOOLS_USE_DISTUTILS: nope

--- a/test/integration/targets/setup_paramiko/install-RedHat-8-python-3.yml
+++ b/test/integration/targets/setup_paramiko/install-RedHat-8-python-3.yml
@@ -4,3 +4,5 @@
   pip: # no python3-paramiko package exists for RHEL 8
     name: paramiko
     extra_args: "-c {{ remote_constraints }}"
+  environment:
+    SETUPTOOLS_USE_DISTUTILS: stdlib


### PR DESCRIPTION
##### SUMMARY
Disable the _distutils_hack in newer setuptools. 
Doesn't fix the underlying issue of the venv finding the _distutils_hack of a setuptools that is not its own.

ci_complete

##### ISSUE TYPE
- Test Pull Request

