### PR TITLE
[2.12] Disable the _distutils_hack in newer setuptools (#76600)

### DIFF
--- a/test/integration/targets/setup_paramiko/install-FreeBSD-python-3.yml
+++ b/test/integration/targets/setup_paramiko/install-FreeBSD-python-3.yml
@@ -4,3 +4,5 @@
   pip: # no package in pkg, just use pip
     name: paramiko
     extra_args: "-c {{ remote_constraints }}"
+  environment:
+    SETUPTOOLS_USE_DISTUTILS: stdlib

--- a/test/integration/targets/setup_paramiko/install-RedHat-8-python-3.yml
+++ b/test/integration/targets/setup_paramiko/install-RedHat-8-python-3.yml
@@ -4,3 +4,5 @@
   pip: # no python3-paramiko package exists for RHEL 8
     name: paramiko
     extra_args: "-c {{ remote_constraints }}"
+  environment:
+    SETUPTOOLS_USE_DISTUTILS: stdlib


### PR DESCRIPTION
##### SUMMARY
Backport of #76600

* Disable the _distutils_hack in newer setuptools. Doesn't fix the underlying issue of the venv finding the _distutils_hack of a setuptools that is not its own.

ci_complete

* re-throw blanket

(cherry picked from commit fa617fcd7b146b110c7f932c224f838116f43a60)

##### ISSUE TYPE
- Test Pull Request
