### PR TITLE
add systemd alias check

### DIFF
--- a/changelogs/fragments/75538-systemd-alias-check
+++ b/changelogs/fragments/75538-systemd-alias-check
@@ -1,0 +1,2 @@
+bugfixes:
+- systemd - check if service is alias so it gets enabled (https://github.com/ansible/ansible/issues/75538).

--- a/changelogs/fragments/75538-systemd-alias-check
+++ b/changelogs/fragments/75538-systemd-alias-check
@@ -1,2 +1,0 @@
-bugfixes:
-- systemd - check if service is alias so it gets enabled (https://github.com/ansible/ansible/issues/75538).

--- a/changelogs/fragments/75538-systemd-alias-check.yml
+++ b/changelogs/fragments/75538-systemd-alias-check.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- systemd - check if service is alias so it gets enabled (https://github.com/ansible/ansible/issues/75538).

--- a/lib/ansible/modules/systemd.py
+++ b/lib/ansible/modules/systemd.py
@@ -502,7 +502,7 @@ def main():
             # check systemctl result or if it is a init script
             if rc == 0:
                 enabled = True
-                # Check if service is indirect or alias and if out contains exactly 1 line of string 'indirect'/ 'alias' it's disabled
+                # Check if the service is indirect or alias and if out contains exactly 1 line of string 'indirect'/ 'alias' it's disabled
                 if out.splitlines() == ["indirect"] or out.splitlines() == ["alias"]:
                     enabled = False
 

--- a/lib/ansible/modules/systemd.py
+++ b/lib/ansible/modules/systemd.py
@@ -502,8 +502,8 @@ def main():
             # check systemctl result or if it is a init script
             if rc == 0:
                 enabled = True
-                # Check if service is indirect and if out contains exactly 1 line of string 'indirect' it's disabled
-                if out.splitlines() == ["indirect"]:
+                # Check if service is indirect or alias and if out contains exactly 1 line of string 'indirect'/ 'alias' it's disabled
+                if out.splitlines() == ["indirect"] or out.splitlines() == ["alias"]:
                     enabled = False
 
             elif rc == 1:


### PR DESCRIPTION
##### SUMMARY
Just like my last fix for [76462](https://github.com/ansible/ansible/pull/76462)
This takes care of checking for 'alias' status on systemd output using same method as checking for 'indirect`

This fixes #75538


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
systemd

##### ADDITIONAL INFORMATION

