### PR TITLE
hostname: add support for openEuler distro

### DIFF
--- a/changelogs/fragments/openEuler_hostname.yml
+++ b/changelogs/fragments/openEuler_hostname.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - hostname - add hostname support for openEuler distro (https://github.com/ansible/ansible/pull/76619).

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -951,6 +951,12 @@ class EurolinuxHostname(Hostname):
     strategy_class = RedHatStrategy
 
 
+class OpenEulerHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Openeuler'
+    strategy_class = SystemdStrategy
+
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(


### PR DESCRIPTION
##### SUMMARY
run following command on openEuler:

ansible -m hostname localhost -a  "name=test"

hostname module cannot be used on platform Linux (Openeuler)"

openEuler:
https://www.openeuler.org/
          

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
modules/hostname

##### ADDITIONAL INFORMATION
```
before:
localhost | FAILED! => {
      "changed": false,
      "msg": "hostname module cannot be used on platform Linux (Openeuler)"
  }

after:
localhost | CHANGED => {
    "ansible_facts": {
        "ansible_domain": "",
        "ansible_fqdn": "test",
        "ansible_hostname": "test",
        "ansible_nodename": "test"
    },
    "changed": true,
    "name": "test"
}
```
