### PR TITLE
apt: Add config option to allow cache to be updated with unsigned repository

### DIFF
--- a/changelogs/fragments/76630-apt-allow-unsigned-cache-update.yml
+++ b/changelogs/fragments/76630-apt-allow-unsigned-cache-update.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  apt - Add update_cache_insecure to allow updating cache when unsigned repo is present. (https://github.com/ansible/ansible/pull/76632)

--- a/changelogs/fragments/76630-apt-allow-unsigned-cache-update.yml
+++ b/changelogs/fragments/76630-apt-allow-unsigned-cache-update.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  apt - Add update_cache_insecure to allow updating cache when unsigned repo is present. (https://github.com/ansible/ansible/pull/76632)
+  - apt - Add update_cache_insecure to allow updating cache when unsigned repo is present. (https://github.com/ansible/ansible/pull/76632)

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -39,6 +39,11 @@ options:
       - Default is not to update the cache.
     aliases: [ update-cache ]
     type: bool
+  update_cache_insecure:
+    description:
+      - Allows for updating the cache when a repository may be unsigned. Equivalent of C(apt-get update --allow-insecure-repositories).
+    type: bool
+    default: false
   update_cache_retries:
     description:
       - Amount of retries if the cache update fails. Also see I(update_cache_retry_max_delay).
@@ -1103,6 +1108,7 @@ def main():
         argument_spec=dict(
             state=dict(type='str', default='present', choices=['absent', 'build-dep', 'fixed', 'latest', 'present']),
             update_cache=dict(type='bool', aliases=['update-cache']),
+            update_cache_insecure=dict(type='bool', default=False),
             update_cache_retries=dict(type='int', default=5),
             update_cache_retry_max_delay=dict(type='int', default=12),
             cache_valid_time=dict(type='int', default=0),
@@ -1249,6 +1255,12 @@ def main():
             #  needed and `update_cache` was set to true
             updated_cache = False
             if p['update_cache'] or p['cache_valid_time']:
+                if p['update_cache_insecure']:
+                    try:
+                        apt_pkg.config['Acquire::AllowInsecureRepositories'] = "true"
+                    except AttributeError:
+                        apt_pkg.Config['Acquire::AllowInsecureRepositories'] = "true"
+
                 now = datetime.datetime.now()
                 tdelta = datetime.timedelta(seconds=p['cache_valid_time'])
                 if not mtimestamp + tdelta >= now:

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -507,3 +507,41 @@
     that:
       - "allow_change_held_packages_no_update is not changed"
       - "allow_change_held_packages_hello_version.stdout == allow_change_held_packages_hello_version_again.stdout"
+
+- name: Get repository that is not signed
+  get_url: 
+    url: https://master.dl.sourceforge.net/project/d-apt/files/d-apt.list
+    dest: /etc/apt/sources.list.d/d-apt.list
+
+- name: Update cache with update_cache_insecure = false
+  apt:
+    update_cache: yes
+  register: update_cache_insecure_false
+  ignore_errors: yes
+
+- name: Verify cache update failed
+  assert:
+    that:
+      - "update_cache_insecure_false is failed"
+
+- name: Update cache with update_cache_insecure = true
+  apt:
+    update_cache: yes
+    update_cache_insecure: true
+  register: update_cache_insecure_true
+
+- name: Verify cache was updated
+  assert:
+    that:
+      - "update_cache_insecure_true is changed"
+
+- name: Remove unsigned repository
+  apt_repository:
+    repo: deb https://master.dl.sourceforge.net/project/d-apt/ d-apt main
+    state: absent
+  register: insecure_repo_removed
+
+- name: Verify unsigned repository removed
+  assert:
+    that: 
+      - "insecure_repo_removed is changed"

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -509,11 +509,11 @@
       - "allow_change_held_packages_hello_version.stdout == allow_change_held_packages_hello_version_again.stdout"
 
 - name: Get repository that is not signed
-  get_url: 
+  get_url:
     url: https://master.dl.sourceforge.net/project/d-apt/files/d-apt.list
     dest: /etc/apt/sources.list.d/d-apt.list
 
-- name: Update cache with update_cache_insecure = false
+- name: Update cache with update_cache_insecure = false (default)
   apt:
     update_cache: yes
   register: update_cache_insecure_false
@@ -527,7 +527,7 @@
 - name: Update cache with update_cache_insecure = true
   apt:
     update_cache: yes
-    update_cache_insecure: true
+    apt_options: Acquire::AllowInsecureRepositories=True
   register: update_cache_insecure_true
 
 - name: Verify cache was updated
@@ -543,5 +543,5 @@
 
 - name: Verify unsigned repository removed
   assert:
-    that: 
+    that:
       - "insecure_repo_removed is changed"


### PR DESCRIPTION
##### SUMMARY
Fixes #76630 
- Updated code to allow for this option as with current code there is no way to use such an option (e.g., using`dpkg_options`)
- Added Integration tests

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
apt

##### ADDITIONAL INFORMATION
With this pr a user can specify new option `update_cache_insecure: true` to allow apt cache to update with unsigned repository. The default of course is false.

With out this pr:

```
 "msg": "Failed to update apt cache: W:Updating from such a repository can't be done securely, and is therefore disabled by default., W:See apt-secure(8) manpage for repository creation and user configuration details., W:GPG error: https://iweb.dl.sourceforge.net/project/d-apt d-apt Release: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY EDC4FB09C3AEEDD0, E:The repository 'https://master.dl.sourceforge.net/project/d-apt d-apt Release' is not signed."
}

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************************************************************************************
143.198.160.191            : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

with pr:

```
changed: [143.198.160.191] => {"cache_update_time": 1640972556, "cache_updated": true, "changed": true}
PLAY RECAP ***********************************************************************************************************************************************************************************************************************************************************************************************************
143.198.160.191            : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```
