### PR TITLE
ansible_concat: return strings only unless eval

### DIFF
--- a/changelogs/fragments/76610-empty-template-none.yml
+++ b/changelogs/fragments/76610-empty-template-none.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Fix for when templating empty template file resulted in file with string 'None' (https://github.com/ansible/ansible/issues/76610)"

--- a/lib/ansible/template/native_helpers.py
+++ b/lib/ansible/template/native_helpers.py
@@ -60,7 +60,7 @@ def ansible_concat(nodes, convert_data, variable_start_string):
     head = list(islice(nodes, 2))
 
     if not head:
-        return None
+        return ''
 
     if len(head) == 1:
         out = _fail_on_undefined(head[0])

--- a/test/integration/targets/template/tasks/main.yml
+++ b/test/integration/targets/template/tasks/main.yml
@@ -756,3 +756,13 @@
 - assert:
     that:
       - out.rc == 0
+
+- template:
+    src: empty_template.j2
+    dest: "{{ output_dir }}/empty_template.templated"
+
+- assert:
+    that:
+      - test
+  vars:
+    test: "{{ lookup('file', '{{ output_dir }}/empty_template.templated')|length == 0 }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Introduced in `devel` (https://github.com/ansible/ansible/pull/75587), changelog should not be needed.

Fixes #76610
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/template/native_helpers.py`