### PR TITLE
Fix wait_for integration test.

### DIFF
--- a/test/integration/targets/wait_for/tasks/main.yml
+++ b/test/integration/targets/wait_for/tasks/main.yml
@@ -150,7 +150,7 @@
 
 - name: install psutil using pip (non-Linux only)
   pip:
-    name: psutil
+    name: psutil==5.8.0
   when: ansible_system != 'Linux'
 
 - name: Copy zombie.py


### PR DESCRIPTION
##### SUMMARY

Pin the `psutil` package to 5.8.0 since 5.9.0 is broken on macOS.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

wait_for integration test
