### PR TITLE
[stable-2.12] Fix wait_for integration test.

### DIFF
--- a/test/integration/targets/wait_for/tasks/main.yml
+++ b/test/integration/targets/wait_for/tasks/main.yml
@@ -150,7 +150,7 @@
 
 - name: install psutil using pip (non-Linux only)
   pip:
-    name: psutil
+    name: psutil==5.8.0
   when: ansible_system != 'Linux'
 
 - name: Copy zombie.py


### PR DESCRIPTION
##### SUMMARY

Pin the `psutil` package to 5.8.0 since 5.9.0 is broken on macOS.

Backport of https://github.com/ansible/ansible/pull/76645

(cherry picked from commit a5f4a25d324d29a04da9505b19da54267e90f778)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

wait_for integration test
