### PR TITLE
lookup find_first.py supports spaces in paths and filenames (#76651)

### DIFF
--- a/lib/ansible/plugins/lookup/first_found.py
+++ b/lib/ansible/plugins/lookup/first_found.py
@@ -145,12 +145,12 @@ from ansible.plugins.lookup import LookupBase
 
 def _split_on(terms, spliters=','):
 
-    # TODO: fix as it does not allow spaces in names
     termlist = []
+    splitSym = spliters[0]
     if isinstance(terms, string_types):
         for spliter in spliters:
-            terms = terms.replace(spliter, ' ')
-        termlist = terms.split(' ')
+            terms = terms.replace(spliter, splitSym)
+        termlist = terms.split(splitSym)
     else:
         # added since options will already listify
         for t in terms:


### PR DESCRIPTION
##### SUMMARY
lookup first_find.py does not support spaces in paths and filenames.

Fixes #76651 76651

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
first_found lookup plugin

##### ADDITIONAL INFORMATION
The code uses the first character from the passed sequence as a split character instead of space.

Before
```
PLAY [all] *********************************************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] *********************************************************************************************************************************************************************************************************************************************************
[WARNING]: Platform darwin on host localhost is using the discovered Python interpreter at /usr/local/bin/python3.9, but future installation of another Python interpreter could change the meaning of that path. See https://docs.ansible.com/ansible-
core/2.12/reference_appendices/interpreter_discovery.html for more information.
ok: [localhost]

TASK [test : include_vars] *****************************************************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "No file was found when using first_found."}

PLAY RECAP *********************************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   

```

after
```
PLAY [all] *********************************************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] *********************************************************************************************************************************************************************************************************************************************************
[WARNING]: Platform darwin on host localhost is using the discovered Python interpreter at /usr/local/bin/python3.9, but future installation of another Python interpreter could change the meaning of that path. See https://docs.ansible.com/ansible-
core/2.12/reference_appendices/interpreter_discovery.html for more information.
ok: [localhost]

TASK [test : include_vars] *****************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

PLAY RECAP *********************************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```
