### PR TITLE
Docs cheatsheet - skeleton and ansible-playbook

### DIFF
--- a/docs/docsite/rst/user_guide/cheatsheet.rst
+++ b/docs/docsite/rst/user_guide/cheatsheet.rst
@@ -4,8 +4,27 @@
 Ansible CLI cheatsheet
 **********************
 
-This page shows one or more examples of each Ansible command line utility with some common flags added and a link to the full documentation for the command. This page offers a quick reminder of some common use cases only. For canonical documentation, follow the links to the CLI pages.
+This page shows one or more examples of each Ansible command line utility with some common flags added and a link to the full documentation for the command. This page offers a quick reminder of some common use cases only - it may be out of date or incomplete or both. For canonical documentation, follow the links to the CLI pages.
 
 .. contents::
    :local:
+
+ansible-playbook
+================
+
+.. code-block:: bash
+
+   ansible-playbook -i /path/to/my_inventory_file -u my_connection_user -k /path/to/my_ssh_key -f 3 -T 30 -t my_tag -m /path/to/my_modules -b -K my_playbook.yml
+
+Loads ``my_playbook.yml`` from the current working directory and:
+  - uses ``my_inventory_file`` in the path provided for inventory
+  - connects over SSH as ``my_connection_user`` using ``my_ssh_key`` in the path provided
+  - allocates 3 forks
+  - sets a 30-second timeout
+  - runs only tasks marked with ``my_tag``
+  - loads local modules from ``/path/to/my/modules``
+  - executes with elevated privileges (become)
+  - prompts the user for the become password
+
+See :ref:`ansible-playbook` for detailed documentation.
 

--- a/docs/docsite/rst/user_guide/cheatsheet.rst
+++ b/docs/docsite/rst/user_guide/cheatsheet.rst
@@ -1,0 +1,11 @@
+.. _cheatsheet:
+
+**********************
+Ansible CLI cheatsheet
+**********************
+
+This page shows one or more examples of each Ansible command line utility with some common flags added and a link to the full documentation for the command. This page offers a quick reminder of some common use cases only. For canonical documentation, follow the links to the CLI pages.
+
+.. contents::
+   :local:
+

--- a/docs/docsite/rst/user_guide/cheatsheet.rst
+++ b/docs/docsite/rst/user_guide/cheatsheet.rst
@@ -17,14 +17,14 @@ ansible-playbook
    ansible-playbook -i /path/to/my_inventory_file -u my_connection_user -k /path/to/my_ssh_key -f 3 -T 30 -t my_tag -m /path/to/my_modules -b -K my_playbook.yml
 
 Loads ``my_playbook.yml`` from the current working directory and:
-  - ``-i`` - uses ``my_inventory_file`` in the path provided for inventory.
-  - ``-u`` - connects over SSH as ``my_connection_user``.
-  - ``-k`` - uses ``my_ssh_key`` in the path provided for authentication.
-  - ``-f`` - allocates 3 forks.
+  - ``-i`` - uses ``my_inventory_file`` in the path provided for :ref:`inventory <intro_inventory>` to match the :ref:`pattern <intro_patterns>`.
+  - ``-u`` - connects :ref:`over SSH <connections>` as ``my_connection_user``.
+  - ``-k`` - uses ``my_ssh_key`` in the path provided for SSH authentication.
+  - ``-f`` - allocates 3 :ref:`forks <playbooks_strategies>`.
   - ``-T`` - sets a 30-second timeout.
-  - ``-t`` - runs only tasks marked with ``my_tag``.
-  - ``-m`` - loads local modules from ``/path/to/my/modules``.
-  - ``-b`` - executes with elevated privileges (uses become).
+  - ``-t`` - runs only tasks marked with the :ref:`tag <tags>` ``my_tag``.
+  - ``-m`` - loads :ref:`local modules <developing_locally>` from ``/path/to/my/modules``.
+  - ``-b`` - executes with elevated privileges (uses :ref:`become <become>`).
   - ``-K`` - prompts the user for the become password.
 
 See :ref:`ansible-playbook` for detailed documentation.

--- a/docs/docsite/rst/user_guide/cheatsheet.rst
+++ b/docs/docsite/rst/user_guide/cheatsheet.rst
@@ -17,7 +17,7 @@ ansible-playbook
    ansible-playbook -i /path/to/my_inventory_file -u my_connection_user -k /path/to/my_ssh_key -f 3 -T 30 -t my_tag -m /path/to/my_modules -b -K my_playbook.yml
 
 Loads ``my_playbook.yml`` from the current working directory and:
-  - uses ``my_inventory_file`` in the path provided for inventory
+  - ``-i`` - uses ``my_inventory_file`` in the path provided for inventory.
   - connects over SSH as ``my_connection_user`` using ``my_ssh_key`` in the path provided
   - allocates 3 forks
   - sets a 30-second timeout

--- a/docs/docsite/rst/user_guide/cheatsheet.rst
+++ b/docs/docsite/rst/user_guide/cheatsheet.rst
@@ -18,13 +18,14 @@ ansible-playbook
 
 Loads ``my_playbook.yml`` from the current working directory and:
   - ``-i`` - uses ``my_inventory_file`` in the path provided for inventory.
-  - connects over SSH as ``my_connection_user`` using ``my_ssh_key`` in the path provided
-  - allocates 3 forks
-  - sets a 30-second timeout
-  - runs only tasks marked with ``my_tag``
-  - loads local modules from ``/path/to/my/modules``
-  - executes with elevated privileges (become)
-  - prompts the user for the become password
+  - ``-u`` - connects over SSH as ``my_connection_user``.
+  - ``-k`` - uses ``my_ssh_key`` in the path provided for authentication.
+  - ``-f`` - allocates 3 forks.
+  - ``-T`` - sets a 30-second timeout.
+  - ``-t`` - runs only tasks marked with ``my_tag``.
+  - ``-m`` - loads local modules from ``/path/to/my/modules``.
+  - ``-b`` - executes with elevated privileges (uses become).
+  - ``-K`` - prompts the user for the become password.
 
 See :ref:`ansible-playbook` for detailed documentation.
 

--- a/docs/docsite/rst/user_guide/index.rst
+++ b/docs/docsite/rst/user_guide/index.rst
@@ -22,6 +22,7 @@ Getting started
 
 * I'm ready to learn about Ansible. What :ref:`basic_concepts` do I need to learn?
 * I want to use Ansible without writing a playbook. How do I use :ref:`ad hoc commands <intro_adhoc>`?
+* I'm running an Ansible command and forgot which flags to use. Do you have a :ref:`cheatsheet`?
 
 Writing tasks, plays, and playbooks
 ===================================
@@ -91,6 +92,7 @@ If you prefer to read the entire User Guide, here's a list of the pages in order
    :maxdepth: 2
 
    quickstart
+   cheatsheet
    basic_concepts
    intro_getting_started
    intro_adhoc


### PR DESCRIPTION
##### SUMMARY

Starts to address ansible/ansible-documentation#48.

Starting with a skeleton page - a header and a first example. I'll add a list of CLI commands to the issue so the community can help create this content. We should certainly cover the most commonly-used CLI commands.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com

##### ADDITIONAL INFORMATION
N/A
