### PR TITLE
ansible-test - Fix plugin loading.

### DIFF
--- a/changelogs/fragments/ansible-test-plugin-loading.yml
+++ b/changelogs/fragments/ansible-test-plugin-loading.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Fix plugin loading.

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -770,10 +770,9 @@ def load_module(path, name):  # type: (str, str) -> None
 
     spec = importlib.util.spec_from_file_location(name, path)
     module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
     # noinspection PyUnresolvedReferences
     spec.loader.exec_module(module)
-
-    sys.modules[name] = module
 
 
 def sanitize_host_name(name):


### PR DESCRIPTION
##### SUMMARY

This fixes a traceback when loading plugins that use dataclasses.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
