### PR TITLE
Add missing typing import for _distro.py.

### DIFF
--- a/changelogs/fragments/distro-module_utils-typing.yml
+++ b/changelogs/fragments/distro-module_utils-typing.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - module_utils.distro - Add missing ``typing`` import from original code.

--- a/lib/ansible/module_utils/distro/_distro.py
+++ b/lib/ansible/module_utils/distro/_distro.py
@@ -41,6 +41,39 @@ import warnings
 
 __version__ = "1.6.0"
 
+# Use `if False` to avoid an ImportError on Python 2. After dropping Python 2
+# support, can use typing.TYPE_CHECKING instead. See:
+# https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING
+if False:  # pragma: nocover
+    from typing import (
+        Any,
+        Callable,
+        Dict,
+        Iterable,
+        Optional,
+        Sequence,
+        TextIO,
+        Tuple,
+        Type,
+        TypedDict,
+        Union,
+    )
+
+    VersionDict = TypedDict(
+        "VersionDict", {"major": str, "minor": str, "build_number": str}
+    )
+    InfoDict = TypedDict(
+        "InfoDict",
+        {
+            "id": str,
+            "version": str,
+            "version_parts": VersionDict,
+            "like": str,
+            "codename": str,
+        },
+    )
+
+
 _UNIXCONFDIR = os.environ.get("UNIXCONFDIR", "/etc")
 _UNIXUSRLIBDIR = os.environ.get("UNIXUSRLIBDIR", "/usr/lib")
 _OS_RELEASE_BASENAME = "os-release"

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -113,6 +113,7 @@ lib/ansible/module_utils/compat/selinux.py import-3.9!skip # pass/fail depends o
 lib/ansible/module_utils/distro/_distro.py future-import-boilerplate # ignore bundled
 lib/ansible/module_utils/distro/_distro.py metaclass-boilerplate # ignore bundled
 lib/ansible/module_utils/distro/_distro.py no-assert
+lib/ansible/module_utils/distro/_distro.py pylint:using-constant-test # bundled code we don't want to modify
 lib/ansible/module_utils/distro/_distro.py pep8!skip # bundled code we don't want to modify
 lib/ansible/module_utils/distro/__init__.py empty-init # breaks namespacing, bundled, do not override
 lib/ansible/module_utils/facts/__init__.py empty-init # breaks namespacing, deprecate and eventually remove


### PR DESCRIPTION
##### SUMMARY

Add missing typing import for `_distro.py`.

See: https://github.com/python-distro/distro/blob/116cdad222637c8612c4126ff8b3718bdfcb8696/distro.py#L42-L72

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/module_utils/distro/_distro.py