### PR TITLE
harden service_facts states and add new output variable load_states

### DIFF
--- a/lib/ansible/modules/service_facts.py
+++ b/lib/ansible/modules/service_facts.py
@@ -244,44 +244,27 @@ class SystemctlScanService(BaseService):
             return None
 
         # list units as systemd sees them
-        rc, stdout, stderr = self.module.run_command("%s list-units --no-pager --type service --all" % systemctl_path, use_unsafe_shell=True)
-        for line in [svc_line for svc_line in stdout.split('\n') if '.service' in svc_line]:
-
-            state_val = "stopped"
-            status_val = "unknown"
-            fields = line.split()
-            for bad in BAD_STATES:
-                if bad in fields:  # dot is 0
-                    status_val = bad
-                    fields = fields[1:]
-                    break
-            else:
-                # active/inactive
-                status_val = fields[2]
-
-            # array is normalize so predictable now
-            service_name = fields[0]
-            if fields[3] == "running":
-                state_val = "running"
-
+        rc, stdout, stderr = self.module.run_command("%s list-units --no-pager --type service --all --plain --no-legend" % systemctl_path, use_unsafe_shell=True)
+        for line in [svc_line.split() for svc_line in stdout.split('\n') if '.service' in svc_line]:
+            service_name = line[0]
+            status_val = line[2]
+            state_val = line[3]
             services[service_name] = {"name": service_name, "state": state_val, "status": status_val, "source": "systemd"}
 
         # now try unit files for complete picture and final 'status'
-        rc, stdout, stderr = self.module.run_command("%s list-unit-files --no-pager --type service --all" % systemctl_path, use_unsafe_shell=True)
-        for line in [svc_line for svc_line in stdout.split('\n') if '.service' in svc_line]:
-            # there is one more column (VENDOR PRESET) from `systemctl list-unit-files` for systemd >= 245
-            try:
-                service_name, status_val = line.split()[:2]
-            except IndexError:
-                self.module.fail_json(msg="Malformed output discovered from systemd list-unit-files: {0}".format(line))
+        rc, stdout, stderr = self.module.run_command("%s list-unit-files --no-pager --type service --all --plain --no-legend" % systemctl_path, use_unsafe_shell=True)
+        for line in [svc_line.split() for svc_line in stdout.split('\n') if '.service' in svc_line]:
+            service_name = line[0]
+            status_val = line[1]
             if service_name not in services:
-                rc, stdout, stderr = self.module.run_command("%s show %s --property=ActiveState" % (systemctl_path, service_name), use_unsafe_shell=True)
+                rc, show_service_stdout, stderr = self.module.run_command("%s show %s -p ActiveState,SubState" % (systemctl_path, service_name), use_unsafe_shell=True)
                 state = 'unknown'
                 if not rc and stdout != '':
-                    state = stdout.replace('ActiveState=', '').rstrip()
+                    #state = stdout.replace('ActiveState=', '').rstrip()
+                    show_service_stdout = [i.partition("=")[2] for i in show_service_stdout.split()]
+                    status_val = show_service_stdout[0]
+                    state = show_service_stdout[1]
                 services[service_name] = {"name": service_name, "state": state, "status": status_val, "source": "systemd"}
-            elif services[service_name]["status"] not in BAD_STATES:
-                services[service_name]["status"] = status_val
 
         return services
 

--- a/lib/ansible/modules/service_facts.py
+++ b/lib/ansible/modules/service_facts.py
@@ -70,7 +70,7 @@ ansible_facts:
         state:
           description:
           - State of the service.
-          - 'This commonly includes (but is not limited to) the following: C(running), C(failed), C(dead), C(exited), C(running), C(stopped) or C(unknown).'
+          - 'This commonly includes (but is not limited to) the following: C(running), C(failed), C(dead), C(exited), C(stopped) or C(unknown).'
           - Depending on the used init system additional states might be returned.
           returned: always
           type: str

--- a/lib/ansible/modules/service_facts.py
+++ b/lib/ansible/modules/service_facts.py
@@ -70,7 +70,7 @@ ansible_facts:
         state:
           description:
           - State of the service.
-                - 'This commonly includes (but is not limited to) the following: C(running), C(failed), C(dead), C(exited), C(running), C(stopped) or C(unknown).'
+          - 'This commonly includes (but is not limited to) the following: C(running), C(failed), C(dead), C(exited), C(running), C(stopped) or C(unknown).'
           - Depending on the used init system additional states might be returned.
           returned: always
           type: str
@@ -78,7 +78,7 @@ ansible_facts:
         status:
           description:
           - State of the service.
-          - Either C(loaded), C(active), C(inactive), C(failed), C(disabled), C(static), C(indirect) or C(unknown).
+          - Either C(enabled), C(disabled), C(static), C(indirect) or C(unknown).
           - Depending on the systemd version additional status' may be returned.
           returned: systemd systems or RedHat/SUSE flavored sysvinit/upstart or OpenBSD
           type: str
@@ -251,7 +251,8 @@ class SystemctlScanService(BaseService):
             return None
 
         # list units as systemd sees them
-        rc, stdout, stderr = self.module.run_command("%s list-units --no-pager --type service --all --plain --no-legend" % systemctl_path, use_unsafe_shell=True)
+        cmd = [systemctl_path, "list-units", "--no-pager", "--type", "service", "--all", "--plain", "--no-legend"]
+        rc, stdout, stderr = self.module.run_command(cmd, use_unsafe_shell=True)
         for line in [svc_line.split() for svc_line in stdout.split('\n') if '.service' in svc_line]:
             service_name = line[0]
             load_state = line[1]
@@ -260,35 +261,17 @@ class SystemctlScanService(BaseService):
             services[service_name] = {"name": service_name, "state": state_val, "status": status_val, "load_state": load_state, "source": "systemd"}
 
         # now try unit files for complete picture and final 'status'
-
-        # TODO REMOVE COMMENT:
-        # The "STATE" value returned by systemctl list-unit-files is actually the "LoadState"
-
-        rc, stdout, stderr = self.module.run_command("%s list-unit-files --no-pager --type service --all --plain --no-legend" % systemctl_path, use_unsafe_shell=True)
+        cmd = [systemctl_path, "list-unit-files", "--no-pager", "--type", "service", "--all", "--plain", "--no-legend"]
+        rc, stdout, stderr = self.module.run_command(cmd, use_unsafe_shell=True)
         for line in [svc_line.split() for svc_line in stdout.split('\n') if '.service' in svc_line]:
             service_name = line[0]
             load_state = line[1]
             if service_name not in services:
-
-                # TODO REMOVE COMMENT:
-                # To conform to how systemctl list-units uses "ActiveState" for status key and "SubState" for state key in services dict
-                # we should also grab these values from systemctl show and add to dict.
-
-                rc, show_service_stdout, stderr = self.module.run_command("%s show %s -p ActiveState,LoadState,SubState" % (systemctl_path, service_name), use_unsafe_shell=True)
-
-                #TODO REMOVE COMMENT:
-                # Setting state and status values to unknown handles cases of "Template" unit files where systemctl will fail
-                # ex:
-                # systemctl show user@.service
-                # Failed to get properties: Unit name user@.service is neither a valid invocation ID nor unit name.
-
+                cmd = [systemctl_path, "show", service_name, "-p", "ActiveState,LoadState,SubState"]
+                rc, show_service_stdout, stderr = self.module.run_command(cmd, use_unsafe_shell=True)
                 state = 'unknown'
                 status_val = 'unknown'
                 if not rc and stdout != '':
-
-                    #TODO REMOVE COMMENT:
-                    # Every rc=0 output of systemctl show should always have the 3 properties we queried ActiveState,LoadState,SubState
-
                     show_service_stdout = [i.partition("=")[2] for i in show_service_stdout.split()]
                     status_val = show_service_stdout[0]
                     load_state = show_service_stdout[1]

--- a/lib/ansible/modules/service_facts.py
+++ b/lib/ansible/modules/service_facts.py
@@ -70,7 +70,7 @@ ansible_facts:
         state:
           description:
           - State of the service.
-          - 'This commonly includes (but is not limited to) the following: C(running), C(failed), C(dead), C(exited), C(stopped) or C(unknown).'
+          - 'This commonly includes (but is not limited to) the following: C(failed), C(running), C(stopped) or C(unknown).'
           - Depending on the used init system additional states might be returned.
           returned: always
           type: str
@@ -90,6 +90,7 @@ ansible_facts:
           returned: systemd systems
           type: str
           sample: loaded
+          version_added: "2.13"
         name:
           description: Name of the service.
           returned: always

--- a/test/integration/targets/service_facts/files/failed-test.service
+++ b/test/integration/targets/service_facts/files/failed-test.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=failed service test
+
+[Service]
+ExecStart=/usr/fakecmd
+
+[Install]
+WantedBy=multi-user.target

--- a/test/integration/targets/service_facts/tasks/systemd_setup.yml
+++ b/test/integration/targets/service_facts/tasks/systemd_setup.yml
@@ -18,9 +18,25 @@
     mode: '0644'
   register: install_systemd_result
 
+- name: Create fake failed systemd service
+  copy:
+    src: failed-test.service
+    dest:  /etc/systemd/system/failed-test.service
+    mode: '0644'
+  register: failed_service_result
+
+- name: start fake failed service
+  service:
+    name: failed-test.service
+    state: started
+  register: fake_service_started_result
+
 - name: assert that the systemd unit file was installed
   assert:
     that:
     - "install_systemd_result.dest == '/etc/systemd/system/ansible_test.service'"
     - "install_systemd_result.state == 'file'"
     - "install_systemd_result.mode == '0644'"
+    - "failed_service_result is changed"
+    - "fake_service_started_result is changed"
+

--- a/test/integration/targets/service_facts/tasks/systemd_setup.yml
+++ b/test/integration/targets/service_facts/tasks/systemd_setup.yml
@@ -39,4 +39,3 @@
     - "install_systemd_result.mode == '0644'"
     - "failed_service_result is changed"
     - "fake_service_started_result is changed"
-

--- a/test/integration/targets/service_facts/tasks/tests.yml
+++ b/test/integration/targets/service_facts/tasks/tests.yml
@@ -31,6 +31,12 @@
   debug:
     var: services['ansible_test.service'].state
 
-- name: ansible_test service's running state should be \"inactive\"
+- name: ansible_test service's running state should be \"dead\"
   assert:
-    that: "services['ansible_test.service'].state == 'inactive'"
+    that: "services['ansible_test.service'].state == 'dead'"
+
+- name: failed-test service running state should be \"failed\"
+  assert:
+    that: "services['failed-test.service'].state == 'failed'"
+
+

--- a/test/integration/targets/service_facts/tasks/tests.yml
+++ b/test/integration/targets/service_facts/tasks/tests.yml
@@ -39,4 +39,13 @@
   assert:
     that: "services['failed-test.service'].state == 'failed'"
 
+- name: Get states as systemd sees them
+  command: systemctl list-units --no-pager --type service --all --plain --no-legend
+  register: systemctl_list_units_out
 
+- name:  Check on each systemd service with each item from service_facts
+  assert:
+    that:
+      - "services[item.split()[0]].state == item.split()[3]"
+      - "services[item.split()[0]].status == item.split()[2]"
+  loop: "{{systemctl_list_units_out.stdout.split('\n') | list}}"


### PR DESCRIPTION
##### SUMMARY
#76629 

- Better handling of the correct states across systemd
- Added a load_state field as this is easily accessible in the calls so shouldn't require much overhead. This allows user to see if unit is not-found, static, loaded, etc.
- Added integration tests including failed service test.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
service_facts

