### PR TITLE
Fix tests failing on pytest 7

### DIFF
--- a/changelogs/fragments/ansible-test-pytest7.yml
+++ b/changelogs/fragments/ansible-test-pytest7.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- ansible-test - Fix tests that were broken with ``pytest 7`` - https://github.com/ansible/ansible/issues/76577

--- a/changelogs/fragments/ansible-test-pytest7.yml
+++ b/changelogs/fragments/ansible-test-pytest7.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-test - Fix tests that were broken with ``pytest 7`` - https://github.com/ansible/ansible/issues/76577

--- a/test/units/galaxy/test_role_install.py
+++ b/test/units/galaxy/test_role_install.py
@@ -8,6 +8,7 @@ __metaclass__ = type
 
 
 import os
+import functools
 import pytest
 import tempfile
 
@@ -59,9 +60,9 @@ def mock_NamedTemporaryFile(mocker, **args):
     return mock_ntf
 
 
-@pytest.fixture(autouse=True)
-def init_test(monkeypatch):
-    monkeypatch.setattr(tempfile, 'NamedTemporaryFile', mock_NamedTemporaryFile)
+@pytest.fixture
+def init_mock_temp_file(mocker, monkeypatch):
+    monkeypatch.setattr(tempfile, 'NamedTemporaryFile', functools.partial(mock_NamedTemporaryFile, mocker))
 
 
 @pytest.fixture(autouse=True)
@@ -74,7 +75,7 @@ def mock_role_download_api(mocker, monkeypatch):
     return mock_role_api
 
 
-def test_role_download_github(mocker, galaxy_server, mock_role_download_api, monkeypatch):
+def test_role_download_github(init_mock_temp_file, mocker, galaxy_server, mock_role_download_api, monkeypatch):
     mock_api = mocker.MagicMock()
     mock_api.side_effect = [
         StringIO(u'{"available_versions":{"v1":"v1/"}}'),
@@ -89,7 +90,7 @@ def test_role_download_github(mocker, galaxy_server, mock_role_download_api, mon
     assert mock_role_download_api.mock_calls[0][1][0] == 'https://github.com/test_owner/test_role/archive/0.0.1.tar.gz'
 
 
-def test_role_download_github_default_version(mocker, galaxy_server, mock_role_download_api, monkeypatch):
+def test_role_download_github_default_version(init_mock_temp_file, mocker, galaxy_server, mock_role_download_api, monkeypatch):
     mock_api = mocker.MagicMock()
     mock_api.side_effect = [
         StringIO(u'{"available_versions":{"v1":"v1/"}}'),
@@ -104,7 +105,7 @@ def test_role_download_github_default_version(mocker, galaxy_server, mock_role_d
     assert mock_role_download_api.mock_calls[0][1][0] == 'https://github.com/test_owner/test_role/archive/0.0.2.tar.gz'
 
 
-def test_role_download_github_no_download_url_for_version(mocker, galaxy_server, mock_role_download_api, monkeypatch):
+def test_role_download_github_no_download_url_for_version(init_mock_temp_file, mocker, galaxy_server, mock_role_download_api, monkeypatch):
     mock_api = mocker.MagicMock()
     mock_api.side_effect = [
         StringIO(u'{"available_versions":{"v1":"v1/"}}'),
@@ -119,7 +120,7 @@ def test_role_download_github_no_download_url_for_version(mocker, galaxy_server,
     assert mock_role_download_api.mock_calls[0][1][0] == 'https://github.com/test_owner/test_role/archive/0.0.1.tar.gz'
 
 
-def test_role_download_url(mocker, galaxy_server, mock_role_download_api, monkeypatch):
+def test_role_download_url(init_mock_temp_file, mocker, galaxy_server, mock_role_download_api, monkeypatch):
     mock_api = mocker.MagicMock()
     mock_api.side_effect = [
         StringIO(u'{"available_versions":{"v1":"v1/"}}'),
@@ -135,7 +136,7 @@ def test_role_download_url(mocker, galaxy_server, mock_role_download_api, monkey
     assert mock_role_download_api.mock_calls[0][1][0] == 'http://localhost:8080/test_owner/test_role/0.0.1.tar.gz'
 
 
-def test_role_download_url_default_version(mocker, galaxy_server, mock_role_download_api, monkeypatch):
+def test_role_download_url_default_version(init_mock_temp_file, mocker, galaxy_server, mock_role_download_api, monkeypatch):
     mock_api = mocker.MagicMock()
     mock_api.side_effect = [
         StringIO(u'{"available_versions":{"v1":"v1/"}}'),


### PR DESCRIPTION
##### SUMMARY
While this may be a problem just with the rc I'm unsure whether it will be fixed in time for the final release and it's better to just only call this fixture for the tests that need it. In the latest version it was being loaded by all the tests breaking any that used `tempfile.NamedTemporaryFile`.

Fixes https://github.com/ansible/ansible/issues/76577

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test