### PR TITLE
Use antsibull 0.40.1 for docsite build

### DIFF
--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -4,7 +4,7 @@
 #    test/sanity/code-smell/docs-build.requirements.txt
 #    test/sanity/code-smell/rstcheck.requirements.txt
 
-antsibull == 0.40.0
+antsibull == 0.40.1
 # sphinx 4.2.0 requires docutils < 0.18
 docutils == 0.17.1
 jinja2 == 3.0.3

--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -4,7 +4,7 @@
 #    test/sanity/code-smell/docs-build.requirements.txt
 #    test/sanity/code-smell/rstcheck.requirements.txt
 
-antsibull == 0.39.2
+antsibull == 0.40.0
 # sphinx 4.2.0 requires docutils < 0.18
 docutils == 0.17.1
 jinja2 == 3.0.3

--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -15,5 +15,5 @@ rstcheck == 3.3.1
 sphinx == 4.2.0
 sphinx-notfound-page == 0.8 # must be >= 0.6
 sphinx-intl == 2.0.1
-sphinx-ansible-theme === 0.8.0
+sphinx-ansible-theme === 0.9.0
 straight.plugin == 1.5.0 # Needed for hacking/build-ansible.py which is the backend build script

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -3,7 +3,7 @@
 # if you want known good versions of these dependencies
 # use known_good_reqs.txt instead
 
-antsibull >= 0.40.0
+antsibull >= 0.40.1
 docutils
 jinja2
 pygments >= 2.10.0

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -3,7 +3,7 @@
 # if you want known good versions of these dependencies
 # use known_good_reqs.txt instead
 
-antsibull >= 0.39.2
+antsibull >= 0.40.0
 docutils
 jinja2
 pygments >= 2.10.0

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -12,6 +12,6 @@ rstcheck
 sphinx
 sphinx-notfound-page >= 0.6
 sphinx-intl
-sphinx-ansible-theme >= 0.7.0
+sphinx-ansible-theme >= 0.9.0
 resolvelib
 straight.plugin # Needed for hacking/build-ansible.py which is the backend build script

--- a/hacking/build_library/build_ansible/command_plugins/docs_build.py
+++ b/hacking/build_library/build_ansible/command_plugins/docs_build.py
@@ -119,7 +119,7 @@ def generate_base_docs(args):
 
         # Generate the plugin rst
         return antsibull_docs.run(['antsibull-docs', 'stable', '--deps-file', modified_deps_file,
-                                   '--ansible-core-source', str(args.top_dir),
+                                   '--ansible-base-source', str(args.top_dir),
                                    '--dest-dir', args.output_dir])
 
         # If we make this more than just a driver for antsibull:

--- a/hacking/build_library/build_ansible/command_plugins/docs_build.py
+++ b/hacking/build_library/build_ansible/command_plugins/docs_build.py
@@ -119,7 +119,7 @@ def generate_base_docs(args):
 
         # Generate the plugin rst
         return antsibull_docs.run(['antsibull-docs', 'stable', '--deps-file', modified_deps_file,
-                                   '--ansible-base-source', str(args.top_dir),
+                                   '--ansible-core-source', str(args.top_dir),
                                    '--dest-dir', args.output_dir])
 
         # If we make this more than just a driver for antsibull:

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -4,7 +4,7 @@ aiohttp==3.8.0
 aiosignal==1.2.0
 alabaster==0.7.12
 ansible-pygments==0.1.0
-antsibull==0.39.2
+antsibull==0.40.1
 antsibull-changelog==0.12.0
 async-timeout==4.0.1
 asyncio-pool==0.5.2
@@ -34,7 +34,7 @@ sh==1.14.2
 six==1.16.0
 snowballstemmer==2.1.0
 Sphinx==4.2.0
-sphinx-ansible-theme==0.8.0
+sphinx-ansible-theme==0.9.0
 sphinx-notfound-page==0.8
 sphinx-rtd-theme==1.0.0
 sphinxcontrib-applehelp==1.0.2


### PR DESCRIPTION
##### SUMMARY
Use the [latest release](https://github.com/ansible-community/antsibull/releases/tag/0.40.0) of antsibull to build the docsite. It uses RST tables instead of HTML blobs for option and return value tables, and these tables are responsive.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docsite
