### PR TITLE
Allow specifying specific python via shebang

### DIFF
--- a/changelogs/fragments/restore_python_shebang_adherence.yml
+++ b/changelogs/fragments/restore_python_shebang_adherence.yml
@@ -1,0 +1,2 @@
+bugfixes:
+ - python modules (new type) will now again prefer the specific python stated in the module's shebang instead of hardcoding to /usr/bin/python.

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1349,12 +1349,12 @@ def _extract_interpreter(b_module_data):
         b_shebang = b_lines[0].strip()
 
         # shlex.split on python-2.6 needs bytes.  On python-3.x it needs text
-        n_args = shlex.split(to_native(b_shebang[2:], errors='surrogate_or_strict'))
+        cli_split = shlex.split(to_native(b_shebang[2:], errors='surrogate_or_strict'))
 
         # convert args to text
-        n_args = [to_text(a, errors='surrogate_or_strict') for a in args]
-        interpreter = n_args[0]
-        args = n_args[1:]
+        cli_split = [to_text(a, errors='surrogate_or_strict') for a in cli_split]
+        interpreter = cli_split[0]
+        args = cli_split[1:]
 
     return interpreter, args
 

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1402,19 +1402,17 @@ def modify_module(module_name, module_path, module_args, templar, task_vars=None
         if interpreter is not None:
 
             shebang = _get_shebang(interpreter, task_vars, templar, args, remote_is_local=remote_is_local)[0]
+            if shebang is None:
+                shebang = '#!{0}'.format(interpreter)
 
+            # update shebang
             b_lines = b_module_data.split(b"\n", 1)
-            updated = False
-            if shebang is not None:
-                b_lines[0] = to_bytes(shebang, errors='surrogate_or_strict', nonstring='passthru')
-                updated = True
+            b_lines[0] = to_bytes(shebang, errors='surrogate_or_strict', nonstring='passthru')
 
             if os.path.basename(interpreter).startswith(u'python'):
                 b_lines.insert(1, b_ENCODING_STRING)
-                updated = True
 
-            if updated:
-                b_module_data = b"\n".join(b_lines)
+            b_module_data = b"\n".join(b_lines)
 
     return (b_module_data, module_style, shebang)
 

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1243,7 +1243,7 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
 
         o_interpreter, o_args = _extract_interpreter(b_module_data)
         if o_interpreter is None:
-            o_interpreter= u'/usr/bin/python'
+            o_interpreter = u'/usr/bin/python'
 
         shebang, interpreter = _get_shebang(o_interpreter, task_vars, templar, o_args, remote_is_local=remote_is_local)
         if shebang is None:

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1391,11 +1391,13 @@ def modify_module(module_name, module_path, module_args, templar, task_vars=None
         # No interpreter/shebang, assume a binary module?
         if interpreter is not None:
 
-            shebang = _get_shebang(interpreter, task_vars, templar, args, remote_is_local=remote_is_local)[0]
+            shebang, new_interpreter = _get_shebang(interpreter, task_vars, templar, args, remote_is_local=remote_is_local)
 
             # update shebang
             b_lines = b_module_data.split(b"\n", 1)
-            b_lines[0] = to_bytes(shebang, errors='surrogate_or_strict', nonstring='passthru')
+
+            if interpreter != new_interpreter:
+                b_lines[0] = to_bytes(shebang, errors='surrogate_or_strict', nonstring='passthru')
 
             if os.path.basename(interpreter).startswith(u'python'):
                 b_lines.insert(1, b_ENCODING_STRING)

--- a/test/units/executor/module_common/test_module_common.py
+++ b/test/units/executor/module_common/test_module_common.py
@@ -113,6 +113,9 @@ class TestGetShebang:
         with pytest.raises(InterpreterDiscoveryRequiredError):
             amc._get_shebang(u'/usr/bin/python', {}, templar)
 
+    def test_python_interpreter(self, templar):
+        assert amc._get_shebang(u'/usr/bin/python3.8', {}, templar) == ('#!/usr/bin/python3.8', u'/usr/bin/python3.8')
+
     def test_non_python_interpreter(self, templar):
         assert amc._get_shebang(u'/usr/bin/ruby', {}, templar) == ('#!/usr/bin/ruby', u'/usr/bin/ruby')
 

--- a/test/units/executor/module_common/test_module_common.py
+++ b/test/units/executor/module_common/test_module_common.py
@@ -114,7 +114,7 @@ class TestGetShebang:
             amc._get_shebang(u'/usr/bin/python', {}, templar)
 
     def test_non_python_interpreter(self, templar):
-        assert amc._get_shebang(u'/usr/bin/ruby', {}, templar) == (None, u'/usr/bin/ruby')
+        assert amc._get_shebang(u'/usr/bin/ruby', {}, templar) == ('#!/usr/bin/ruby', u'/usr/bin/ruby')
 
     def test_interpreter_set_in_task_vars(self, templar):
         assert amc._get_shebang(u'/usr/bin/python', {u'ansible_python_interpreter': u'/usr/bin/pypy'}, templar) == \


### PR DESCRIPTION
  modules with python were always normalized to /usr/bin/python,
  while other interpreters could have specific versions.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
core