### PR TITLE
Address urllib behavior assumption in tests

### DIFF
--- a/test/units/module_utils/urls/test_RedirectHandlerFactory.py
+++ b/test/units/module_utils/urls/test_RedirectHandlerFactory.py
@@ -130,9 +130,11 @@ def test_redir_validate_certs(urllib_req, request_body, mocker):
     assert opener_mock.add_handler.call_count == int(not HAS_SSLCONTEXT)
 
 
-def test_redir_http_error_308_urllib2(urllib_req, request_body):
+def test_redir_http_error_308_urllib2(urllib_req, request_body, mocker):
+    redir_mock = mocker.patch.object(urllib_request.HTTPRedirectHandler, 'redirect_request')
     handler = RedirectHandlerFactory('urllib2', False)
     inst = handler()
 
-    with pytest.raises(urllib_error.HTTPError):
-        inst.redirect_request(urllib_req, request_body, 308, '308 Permanent Redirect', {}, 'https://docs.ansible.com/')
+    inst.redirect_request(urllib_req, request_body, 308, '308 Permanent Redirect', {}, 'https://docs.ansible.com/')
+
+    assert redir_mock.call_count == 1


### PR DESCRIPTION
##### SUMMARY
Don't assert stdlib behavior, just assert that urllib was called

Py3.11 added HTTP redirect 308 support in https://github.com/python/cpython/commit/c379bc5ec9012cf66424ef3d80612cf13ec51006.  The previous test was asserting that stdlib python didn't understand 308.

Just assert that urllib was utilized.  This test could have also just easily been deleted.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/units/module_utils/urls/test_RedirectHandlerFactory.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
