### PR TITLE
ssh connection, handle 'fun' control paths (#76424)

### DIFF
--- a/changelogs/fragments/ssh_quote_cp.yml
+++ b/changelogs/fragments/ssh_quote_cp.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ssh connection - properly quote controlpersist path given by user to avoid issues with spaces and other characters

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -356,7 +356,6 @@ import subprocess
 import time
 
 from functools import wraps
-from ansible import constants as C
 from ansible.errors import (
     AnsibleAuthenticationFailure,
     AnsibleConnectionFailure,
@@ -771,7 +770,7 @@ class Connection(ConnectionBase):
                         self.port,
                         self.user
                     )
-                b_args = (b"-o", b"ControlPath=" + to_bytes(self.control_path % dict(directory=cpdir), errors='surrogate_or_strict'))
+                b_args = (b"-o", b'ControlPath="%s"' % to_bytes(self.control_path % dict(directory=cpdir), errors='surrogate_or_strict'))
                 self._add_args(b_command, b_args, u"found only ControlPersist; added ControlPath")
 
         # Finally, we add any caller-supplied extras.

--- a/test/integration/targets/connection_ssh/runme.sh
+++ b/test/integration/targets/connection_ssh/runme.sh
@@ -71,3 +71,7 @@ ansible-playbook check_ssh_defaults.yml "$@" -i test_connection.inventory
 
 # ensure we can load from ini cfg
 ANSIBLE_CONFIG=./test_ssh_defaults.cfg ansible-playbook verify_config.yml "$@"
+
+# ensure we handle cp with spaces correctly, otherwise would fail with
+# `"Failed to connect to the host via ssh: command-line line 0: keyword controlpath extra arguments at end of line"`
+ANSIBLE_SSH_CONTROL_PATH='/tmp/ssh cp with spaces' ansible -m ping all -e ansible_connection=ssh -i test_connection.inventory "$@"


### PR DESCRIPTION
* handle 'fun' control paths by quoting the option when passed to ssh cli

Co-authored-by: Matt Clay <matt@mystile.com>
(cherry picked from commit aa022dba2d141cbd3b862767400ba4f714a9edd1)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
connection/ssh