### PR TITLE
Fix documentation around the password parameter of `ansible.builtin.user`

### DIFF
--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -88,8 +88,8 @@ options:
         description:
             - Optionally set the user's password to this crypted value.
             - On macOS systems, this value has to be cleartext. Beware of security issues.
-            - To create a disabled account on Linux systems, set this to C('!') or C('*').
-            - To create a disabled account on OpenBSD, set this to C('*************').
+            - To create a an account with a locked/disabled password on Linux systems, set this to C('!') or C('*').
+            - To create a an account with a locked/disabled password on OpenBSD, set this to C('*************').
             - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
               for details on various ways to generate these password values.
         type: str


### PR DESCRIPTION
# SUMMARY

The documentation talks about that setting the password to '!' or '\*' on Linux or '\*\*\*\*\*\*\*\*\*\*\*\*\*' on OpenBSD creates a disabled account, which I think is incorrect.
Rather a locked/disabled account get created.

In the additional information, I'll give some background information on the wording as well as examples.

# ISSUE TYPE

- Docs Pull Request

# COMPONENT NAME

`builtin.ansible.user`

# ADDITIONAL INFORMATION

## Background Information Linux

I think it's useful to clarify the difference between "disabled account" and "account with a locked/disabled password".
Here's my attempt at defining what each of them means:

### "Account with locked/disabled Password"

An "account with a locked/disabled password", is an account, which you can still use, but you can't login to using a password.
However other login methods are available.
Such an account can be created by having a "!" or "*" in the password field of the relevant account in `/etc/passwd`.

#### Sources

from <https://man.archlinux.org/man/passwd.1>:

```
-l, --lock
Lock the password of the named account. This option disables a password by changing it to a value which matches no possible encrypted value (it adds a ´!´ at the beginning of the password).

Note that this does not disable the account. The user may still be able to login using another authentication token (e.g. an SSH key). To disable the account, administrators should use usermod --expiredate 1 (this set the account's expire date to Jan 2, 1970).

Users with a locked password are not allowed to change their password.
```

from <https://man.archlinux.org/man/passwd.5>:

```
If the password field contains some string that is not a valid result of crypt(3), for instance ! or *, the user will not be able to use a unix password to log in (but the user may log in the system by other means).
```

from <https://man.archlinux.org/man/usermod.8>:

```
-L, --lock
Lock a user's password. This puts a '!' in front of the encrypted password, effectively disabling the password. You can't use this option with -p or -U.

Note: if you wish to lock the account (not only access with a password), you should also set the EXPIRE_DATE to 1.
```

### "Disabled account"

A "disabled account" on the other side is an account, which simply can't be used anymore.

#### Sources

from <https://man.archlinux.org/man/usermod.8>:

```
-L, --lock
Lock a user's password. This puts a '!' in front of the encrypted password, effectively disabling the password. You can't use this option with -p or -U.

Note: if you wish to lock the account (not only access with a password), you should also set the EXPIRE_DATE to 1.
```

from <https://man.archlinux.org/man/passwd.1>:

```
-l, --lock
Lock the password of the named account. This option disables a password by changing it to a value which matches no possible encrypted value (it adds a ´!´ at the beginning of the password).

Note that this does not disable the account. The user may still be able to login using another authentication token (e.g. an SSH key). To disable the account, administrators should use usermod --expiredate 1 (this set the account's expire date to Jan 2, 1970).

Users with a locked password are not allowed to change their password.
```

## Background Information OpenBSD

Similar to Linux I would define an account, which you can still use, but you can't login to using a password (but using other means), as an "account with a locked/disabled password".
And according to the source below, such an account can be achieved by having "13 asterisks in the password field."

### Sources

from <https://man.openbsd.org/passwd.5>:

```
Note that there is nothing special about ‘*’, it is just one of many characters that cannot occur in a valid encrypted password (see crypt(3)). Similarly, login accounts not allowing password authentication but allowing other authentication methods, for example public key authentication, conventionally have 13 asterisks in the password field.
```

## Examples

Each example was on a fresh target, such that the `test-user` account got created each time.

### Ansible - Creating user account with password set to '!'

- Ansible Host: `Arch`
- Ansible Version: `core 2.12.1`
- Target Host: `Debian 11`
- Ansible Task:
  ```
  - ansible.builtin.user:
      name: test-user
      state: present
      password: '!'
    become: yes
  ```

The following was the result:

- `/etc/passwd` relevant line: `test-user:x:1001:1001::/home/test-user:/bin/sh`
- `/etc/shadow` encrypted password field: `!`
- Able to login to the user using `sudo su test-user`: yes
- Able to login to the user using `su test-user` and password `!`: no

### Ansible - Creating user account with password set to '*'

- Ansible Host: `Arch`
- Ansible Version: `core 2.12.1`
- Target Host: `Debian 11`
- Ansible Task:
  ```
  - ansible.builtin.user:
      name: test-user
      state: present
      password: '*'
    become: yes
  ```

The following was the result:

- `/etc/passwd` relevant line: `test-user:x:1001:1001::/home/test-user:/bin/sh`
- `/etc/shadow` encrypted password field: `*`
- Able to login to the user using `sudo su test-user`: yes
- Able to login to the user using `su test-user` and password `*`: no

### Ansible - Creating user account with password lock

- Ansible Host: `Arch`
- Ansible Version: `core 2.12.1`
- Target Host: `Debian 11`
- Ansible Task:
  ```
  - ansible.builtin.user:
      name: test-user
      state: present
      password_lock: yes
    become: yes
  ```

The following was the result:

- `/etc/passwd` relevant line: `test-user:x:1001:1001::/home/test-user:/bin/sh`
- `/etc/shadow` encrypted password field: `!`
- Able to login to the user using `sudo su test-user`: yes

### No Ansible - `adduser --disabled-login`

- Target Host: `Debian 11`
- Command: `sudo adduser --disabled-login test-user` (and ENTER for default on prompts)

The following was the result:

- `/etc/passwd` relevant line: `test-user:x:1001:1001:,,,:/home/test-user:/bin/bash`
- `/etc/shadow` encrypted password field: `!`
- Able to login to the user using `sudo su test-user`: yes

### No Ansible - `adduser --disabled-password`

- Target Host: `Debian 11`
- Command: `sudo adduser --disabled-password test-user` (and ENTER for default on prompts)

The following was the result:

- `/etc/passwd` relevant line: `test-user:x:1001:1001:,,,:/home/test-user:/bin/bash`
- `/etc/shadow` encrypted password field: `*`
- Able to login to the user using `sudo su test-user`: yes

### No Ansible - Creating account and then using `usermod --expiredate 1`

#### First creating the account

- Target Host: `Debian 11`
- Command: `sudo adduser test-user` (and ENTER for default on prompts and using password `1234`)

The following was the result:

- `/etc/passwd` relevant line: `test-user:x:1001:1001:,,,:/home/test-user:/bin/bash`
- Able to login to the user using `sudo su test-user`: yes
- Able to login to the user using `su test-user` and password `1234`: yes

#### Then disabling the account using `usermod --expiredate 1`

- Target Host: `Debian 11`
- Command: `sudo usermod --expiredate 1 test-user`

The following was the result:

- `/etc/passwd` relevant line: `test-user:x:1001:1001:,,,:/home/test-user:/bin/bash`
- Able to login to the user using `sudo su test-user`: no
  (returned:
  ```
  Your account has expired; please contact your system administrator.
  su: Authentication failure
  ```
  )
- Able to login to the user using `su test-user` and password `1234`: no
  (returned:
  ```
  Your account has expired; please contact your system administrator.
  su: Authentication failure
  ```
  )
