### PR TITLE
Add rocky to INTERPRETER_PYTHON_DISTRO_MAP

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1489,6 +1489,7 @@ INTERPRETER_PYTHON_DISTRO_MAP:
     oracle: *rhelish
     redhat: *rhelish
     rhel: *rhelish
+    rocky: *rhelish
     ubuntu:
       '14': /usr/bin/python
       '16': /usr/bin/python3


### PR DESCRIPTION
##### SUMMARY
Currently the interpreter discovery on Rocky Linux is not working correctly and does not use the correct interpreter, but is utilizing the fallback list.

As it is also a RHEL derivate, we can use the same `*rhelish` as for e.g. `oracle`

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
config

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before
```paste below
TASK [Gathering Facts] ********************************************************************************************************
[WARNING]: Platform linux on host vm is using the discovered Python interpreter at /usr/bin/python3.8, but future
installation of another Python interpreter could change the meaning of that path. See https://docs.ansible.com/ansible-
core/2.12/reference_appendices/interpreter_discovery.html for more information.
ok: [vm]

```
After:
```
TASK [Gathering Facts] ********************************************************************************************************
ok: [vm]
```