### PR TITLE
[2.12] ansible-galaxy - fix the --ignore-certs flag for the implicit galaxy server

### DIFF
--- a/changelogs/fragments/76735-ansible-galaxy-fix-ignore-certs.yaml
+++ b/changelogs/fragments/76735-ansible-galaxy-fix-ignore-certs.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - Fix using the '--ignore-certs' option when there is no server-specific configuration for the Galaxy server.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -551,6 +551,7 @@ class GalaxyCLI(CLI):
                 self.api_servers.append(GalaxyAPI(
                     self.galaxy, 'cmd_arg', cmd_server, token=cmd_token,
                     priority=len(config_servers) + 1,
+                    validate_certs=validate_certs_fallback,
                     **galaxy_options
                 ))
         else:
@@ -561,6 +562,7 @@ class GalaxyCLI(CLI):
             self.api_servers.append(GalaxyAPI(
                 self.galaxy, 'default', C.GALAXY_SERVER, token=cmd_token,
                 priority=0,
+                validate_certs=validate_certs_fallback,
                 **galaxy_options
             ))
 

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -218,7 +218,49 @@ def server_config(monkeypatch):
 
 
 @pytest.mark.parametrize('global_ignore_certs', [True, False])
-def test_validate_certs(global_ignore_certs, server_config, monkeypatch):
+def test_validate_certs(global_ignore_certs, monkeypatch):
+    cli_args = [
+        'ansible-galaxy',
+        'collection',
+        'install',
+        'namespace.collection:1.0.0',
+    ]
+    if global_ignore_certs:
+        cli_args.append('--ignore-certs')
+
+    galaxy_cli = GalaxyCLI(args=cli_args)
+    mock_execute_install = MagicMock()
+    monkeypatch.setattr(galaxy_cli, '_execute_install_collection', mock_execute_install)
+    galaxy_cli.run()
+
+    assert len(galaxy_cli.api_servers) == 1
+    assert galaxy_cli.api_servers[0].validate_certs is not global_ignore_certs
+
+
+@pytest.mark.parametrize('global_ignore_certs', [True, False])
+def test_validate_certs_with_server_url(global_ignore_certs, monkeypatch):
+    cli_args = [
+        'ansible-galaxy',
+        'collection',
+        'install',
+        'namespace.collection:1.0.0',
+        '-s',
+        'https://galaxy.ansible.com'
+    ]
+    if global_ignore_certs:
+        cli_args.append('--ignore-certs')
+
+    galaxy_cli = GalaxyCLI(args=cli_args)
+    mock_execute_install = MagicMock()
+    monkeypatch.setattr(galaxy_cli, '_execute_install_collection', mock_execute_install)
+    galaxy_cli.run()
+
+    assert len(galaxy_cli.api_servers) == 1
+    assert galaxy_cli.api_servers[0].validate_certs is not global_ignore_certs
+
+
+@pytest.mark.parametrize('global_ignore_certs', [True, False])
+def test_validate_certs_with_server_config(global_ignore_certs, server_config, monkeypatch):
     get_plugin_options = MagicMock(side_effect=server_config)
     monkeypatch.setattr(C.config, 'get_plugin_options', get_plugin_options)
 


### PR DESCRIPTION
##### SUMMARY
Backport of #76735

This was broken in https://github.com/ansible/ansible/commit/72ba2bdc82944f904245a044a9c917a3bfad4c78 so it only needs to be backported to 2.12.

* ansible-galaxy - fix the --ignore-certs flag for the implicit galaxy server

* changelog

* Add a test without the server config

* Fix respecting --ignore-certs for individual --server URLs also

* Update changelogs/fragments/76735-ansible-galaxy-fix-ignore-certs.yaml

(cherry picked from commit 76220c4a7bf90c97113fe104ea33957a9881b8a9)

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request
