### PR TITLE
ansible-test - Limit paramiko to < 2.9.0

### DIFF
--- a/changelogs/fragments/ansible-test-paramiko-constraint.yaml
+++ b/changelogs/fragments/ansible-test-paramiko-constraint.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-test - Limit ``paramiko`` installation to versions before 2.9.0.
+    This is required to maintain support for systems which do not support RSA SHA-2 algorithms.

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -1,6 +1,7 @@
 # do not add a cryptography or pyopenssl constraint to this file, they require special handling, see get_cryptography_requirements in python_requirements.py
 # do not add a coverage constraint to this file, it is handled internally by ansible-test
 packaging < 21.0 ; python_version < '3.6' # packaging 21.0 requires Python 3.6 or newer
+paramiko < 2.9.0 # paramiko 2.9.0+ requires changes to the paramiko_ssh connection plugin to work with older systems
 pywinrm >= 0.3.0 # message encryption support
 pytest < 5.0.0, >= 4.5.0 ; python_version == '2.7' # pytest 5.0.0 and later will no longer support python 2.7
 pytest >= 4.5.0 ; python_version > '2.7' # pytest 4.5.0 added support for --strict-markers


### PR DESCRIPTION
##### SUMMARY

ansible-test - Limit paramiko to < 2.9.0

See: https://github.com/ansible/ansible/issues/76737

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
