### PR TITLE
Update dnf tests to reflect new behavior.

### DIFF
--- a/test/integration/targets/dnf/tasks/cacheonly.yml
+++ b/test/integration/targets/dnf/tasks/cacheonly.yml
@@ -8,8 +8,9 @@
     state: latest
     cacheonly: true
   register: dnf_result
+  ignore_errors: true
 
-- name: Verify dnf has not changed
+- name: Verify dnf failure
   assert:
     that:
-      - "not dnf_result is changed"
+      - "dnf_result is failed"

--- a/test/integration/targets/dnf/tasks/cacheonly.yml
+++ b/test/integration/targets/dnf/tasks/cacheonly.yml
@@ -10,7 +10,7 @@
   register: dnf_result
   ignore_errors: true
 
-- name: Verify dnf failure
+- name: Verify dnf failed or has not changed
   assert:
     that:
-      - "dnf_result is failed"
+      - "dnf_result is failed or not dnf_result is changed"


### PR DESCRIPTION
##### SUMMARY

Previously dnf would report there was nothing to do when trying to install a package from the cache when it was not present.

A recent update to dnf has changed this behavior to match yum, resulting in a failure instead.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

dnf integration tests
