### PR TITLE
[stable-2.12] Update dnf tests to reflect new behavior. (#76743)

### DIFF
--- a/test/integration/targets/dnf/tasks/cacheonly.yml
+++ b/test/integration/targets/dnf/tasks/cacheonly.yml
@@ -8,8 +8,9 @@
     state: latest
     cacheonly: true
   register: dnf_result
+  ignore_errors: true
 
-- name: Verify dnf has not changed
+- name: Verify dnf failed or has not changed
   assert:
     that:
-      - "not dnf_result is changed"
+      - "dnf_result is failed or not dnf_result is changed"


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/76743

* Update dnf tests to reflect new behavior.

Previously dnf would report there was nothing to do when trying to install a package from the cache when it was not present.

A recent update to dnf has changed this behavior to match yum, resulting in a failure instead.

* Allow dnf to fail or report no changes.

(cherry picked from commit c1df36e3ae999a32131442d124fd00dd0d649e35)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

dnf integration tests
