### PR TITLE
yum_repository: Do not set default value for async

### DIFF
--- a/changelogs/fragments/75364-yum-repository-async.yml
+++ b/changelogs/fragments/75364-yum-repository-async.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- yum_repository - do not give the ``async`` parameter a default value anymore, since this option is deprecated in RHEL 8. This means that ``async = 1`` won't be added to repository files if omitted, but it can still be set explicitly if needed.

--- a/lib/ansible/modules/yum_repository.py
+++ b/lib/ansible/modules/yum_repository.py
@@ -24,7 +24,6 @@ options:
       - If set to C(yes) Yum will download packages and metadata from this
         repo in parallel, if possible.
     type: bool
-    default: 'yes'
   bandwidth:
     description:
       - Maximum available network bandwidth in bytes/second. Used with the
@@ -650,7 +649,7 @@ def main():
         username=dict(),
     )
 
-    argument_spec['async'] = dict(type='bool', default=True)
+    argument_spec['async'] = dict(type='bool')
 
     module = AnsibleModule(
         argument_spec=argument_spec,

--- a/lib/ansible/modules/yum_repository.py
+++ b/lib/ansible/modules/yum_repository.py
@@ -23,6 +23,10 @@ options:
     description:
       - If set to C(yes) Yum will download packages and metadata from this
         repo in parallel, if possible.
+      - In ansible-core 2.11, 2.12, and 2.13 the default value is C(true).
+      - This option has been deprecated in RHEL 8. If you're using one of the
+        versions listed above, you can set this option to None to avoid passing an
+        unknown configuration option.
     type: bool
   bandwidth:
     description:


### PR DESCRIPTION


Signed-off-by: Benoît Knecht <bknecht@protonmail.ch>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The `async` repository option is deprecated in RHEL 8, but Ansible sets

```ini
async = 1
```

even when it's omitted from the module options, which causes `dnf` to complain
about an unknown configuration option.

This commit removes the default value from the `async` parameter, which means
it won't be added to the repository file if omitted from the module parameters.

Fixes #75364
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`yum_repository`