### PR TITLE
gather_facts fails silently, when /proc/1/environ can't be read

### DIFF
--- a/changelogs/fragments/76751-facts-check-datafile-before-close.yml
+++ b/changelogs/fragments/76751-facts-check-datafile-before-close.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - gather_facts - Fact gathering now continues even if it fails to read a file

--- a/lib/ansible/module_utils/facts/utils.py
+++ b/lib/ansible/module_utils/facts/utils.py
@@ -32,6 +32,7 @@ def get_file_content(path, default=None, strip=True):
     '''
     data = default
     if os.path.exists(path) and os.access(path, os.R_OK):
+        datafile = None
         try:
             datafile = open(path)
             try:
@@ -55,7 +56,8 @@ def get_file_content(path, default=None, strip=True):
             # ignore errors as some jails/containers might have readable permissions but not allow reads
             pass
         finally:
-            datafile.close()
+            if datafile is not None:
+                datafile.close()
 
     return data
 


### PR DESCRIPTION


##### SUMMARY
Starting with ansible v4.0.0 we noticed that ansible_facts started missing host facts (p.e. ansible_virtualization_type when testing in docker containers)

The root cause seems to be that on gathering facts the following exception is encountered and not handled well.

```
Traceback (most recent call last):
  File "/tmp/ansible_setup_payload_vzlgl6bf/ansible_setup_payload.zip/ansible/module_utils/facts/ansible_collector.py", line 78, in collect
    collected_facts=collected_facts)
  File "/tmp/ansible_setup_payload_vzlgl6bf/ansible_setup_payload.zip/ansible/module_utils/facts/collector.py", line 101, in collect_with_namespace
    facts_dict = self.collect(module=module, collected_facts=collected_facts)
  File "/tmp/ansible_setup_payload_vzlgl6bf/ansible_setup_payload.zip/ansible/module_utils/facts/virtual/base.py", line 76, in collect
    facts_dict = facts_obj.populate(collected_facts=collected_facts)
  File "/tmp/ansible_setup_payload_vzlgl6bf/ansible_setup_payload.zip/ansible/module_utils/facts/virtual/base.py", line 44, in populate
    virtual_facts = self.get_virtual_facts()
  File "/tmp/ansible_setup_payload_vzlgl6bf/ansible_setup_payload.zip/ansible/module_utils/facts/virtual/linux.py", line 73, in get_virtual_facts
    for line in get_file_lines('/proc/1/environ', line_sep='\x00'):
  File "/tmp/ansible_setup_payload_vzlgl6bf/ansible_setup_payload.zip/ansible/module_utils/facts/utils.py", line 65, in get_file_lines
    data = get_file_content(path, strip=strip)
  File "/tmp/ansible_setup_payload_vzlgl6bf/ansible_setup_payload.zip/ansible/module_utils/facts/utils.py", line 58, in get_file_content
    datafile.close()
UnboundLocalError: local variable 'datafile' referenced before assignment

```

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

facts


##### ADDITIONAL INFORMATION

The change first checks if datafile was openend correctly and only performs a .close() in that case. This prevents " "UnboundLocalError: local variable 'datafile' referenced before assignment" from happening.
