### PR TITLE
Add basic support for "apt-get clean" operation to apt module

### DIFF
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1233,6 +1233,8 @@ def main():
             clean_diff = {}
         if clean_rc:
             module.fail_json(msg="apt-get clean failed", stdout=clean_out, rc=clean_rc)
+        if clean_err:
+            module.fail_json(msg="apt-get clean failed: %s" % clean_err, stdout=clean_out, rc=clean_rc)
         module.exit_json(changed=True, msg=clean_out, stdout=clean_out, stderr=clean_err, diff=clean_diff)
 
     if p['upgrade'] == 'no':

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -975,16 +975,16 @@ def cleanup(m, purge=False, force=False, operation=None,
     m.exit_json(changed=changed, stdout=out, stderr=err, diff=diff)
 
 def aptclean(m):
-    clean_rc, clean_out, clean_err = module.run_command(['apt-get', 'clean'])
-    if module._diff:
+    clean_rc, clean_out, clean_err = m.run_command(['apt-get', 'clean'])
+    if m._diff:
         clean_diff = parse_diff(clean_out)
     else:
         clean_diff = {}
     if clean_rc:
-        module.fail_json(msg="apt-get clean failed", stdout=clean_out, rc=clean_rc)
+        m.fail_json(msg="apt-get clean failed", stdout=clean_out, rc=clean_rc)
     if clean_err:
-        module.fail_json(msg="apt-get clean failed: %s" % clean_err, stdout=clean_out, rc=clean_rc)
-    module.exit_json(changed=True, msg=clean_out, stdout=clean_out, stderr=clean_err, diff=clean_diff)
+        m.fail_json(msg="apt-get clean failed: %s" % clean_err, stdout=clean_out, rc=clean_rc)
+    m.exit_json(changed=True, msg=clean_out, stdout=clean_out, stderr=clean_err, diff=clean_diff)
 
 def upgrade(m, mode="yes", force=False, default_release=None,
             use_apt_get=False,

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -84,7 +84,7 @@ options:
     default: 'no'
   clean:
     description:
-      - Run the equivalent of C(apt-get clean) to clear out the local repository of retrieved package files. It removes everything but 
+      - Run the equivalent of C(apt-get clean) to clear out the local repository of retrieved package files. It removes everything but
         the lock file from /var/cache/apt/archives/ and /var/cache/apt/archives/partial/.
       - Recommended to run this as a stand-alone operation.
     type: bool

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -974,6 +974,7 @@ def cleanup(m, purge=False, force=False, operation=None,
 
     m.exit_json(changed=changed, stdout=out, stderr=err, diff=diff)
 
+
 def aptclean(m):
     clean_rc, clean_out, clean_err = m.run_command(['apt-get', 'clean'])
     if m._diff:
@@ -985,6 +986,7 @@ def aptclean(m):
     if clean_err:
         m.fail_json(msg="apt-get clean failed: %s" % clean_err, stdout=clean_out, rc=clean_rc)
     m.exit_json(changed=True, msg=clean_out, stdout=clean_out, stderr=clean_err, diff=clean_diff)
+
 
 def upgrade(m, mode="yes", force=False, default_release=None,
             use_apt_get=False,

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -974,6 +974,17 @@ def cleanup(m, purge=False, force=False, operation=None,
 
     m.exit_json(changed=changed, stdout=out, stderr=err, diff=diff)
 
+def aptclean(m):
+    clean_rc, clean_out, clean_err = module.run_command(['apt-get', 'clean'])
+    if module._diff:
+        clean_diff = parse_diff(clean_out)
+    else:
+        clean_diff = {}
+    if clean_rc:
+        module.fail_json(msg="apt-get clean failed", stdout=clean_out, rc=clean_rc)
+    if clean_err:
+        module.fail_json(msg="apt-get clean failed: %s" % clean_err, stdout=clean_out, rc=clean_rc)
+    module.exit_json(changed=True, msg=clean_out, stdout=clean_out, stderr=clean_err, diff=clean_diff)
 
 def upgrade(m, mode="yes", force=False, default_release=None,
             use_apt_get=False,
@@ -1225,17 +1236,7 @@ def main():
     p = module.params
 
     if p['clean'] is True:
-        clean_rc, clean_out, clean_err = module.run_command(['apt-get', 'clean'])
-
-        if module._diff:
-            clean_diff = parse_diff(clean_out)
-        else:
-            clean_diff = {}
-        if clean_rc:
-            module.fail_json(msg="apt-get clean failed", stdout=clean_out, rc=clean_rc)
-        if clean_err:
-            module.fail_json(msg="apt-get clean failed: %s" % clean_err, stdout=clean_out, rc=clean_rc)
-        module.exit_json(changed=True, msg=clean_out, stdout=clean_out, stderr=clean_err, diff=clean_diff)
+        aptclean(module)
 
     if p['upgrade'] == 'no':
         p['upgrade'] = None

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -82,6 +82,13 @@ options:
          Please also see C(man apt-get) for more information.'
     type: bool
     default: 'no'
+  clean:
+    description:
+      - Run the equivalent of C(apt-get clean) to clear out the local repository of retrieved package files. It removes everything but 
+        the lock file from /var/cache/apt/archives/ and /var/cache/apt/archives/partial/.
+      - Recommended to run this as a stand-alone operation.
+    type: bool
+    default: 'no'
   allow_unauthenticated:
     description:
       - Ignore if packages cannot be authenticated. This is useful for bootstrapping environments that manage their own apt-key setup.
@@ -303,6 +310,10 @@ EXAMPLES = '''
 - name: Remove dependencies that are no longer required
   apt:
     autoremove: yes
+
+- name: Run the equivalent of "apt-get clean" as a separate step
+  apt:
+    clean: yes
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1125,6 +1125,7 @@ def main():
             policy_rc_d=dict(type='int', default=None),
             only_upgrade=dict(type='bool', default=False),
             force_apt_get=dict(type='bool', default=False),
+            clean=dict(type='bool', default=False),
             allow_unauthenticated=dict(type='bool', default=False, aliases=['allow-unauthenticated']),
             allow_downgrade=dict(type='bool', default=False, aliases=['allow-downgrade', 'allow_downgrades', 'allow-downgrades']),
             allow_change_held_packages=dict(type='bool', default=False),
@@ -1211,6 +1212,17 @@ def main():
     APT_GET_CMD = module.get_bin_path("apt-get")
 
     p = module.params
+
+    if p['clean'] == True:
+        clean_rc, clean_out, clean_err = module.run_command(['apt-get', 'clean'])
+
+        if module._diff:
+            clean_diff = parse_diff(clean_out)
+        else:
+            clean_diff = {}
+        if clean_rc:
+            module.fail_json(msg="apt-get clean failed", stdout=clean_out, rc=clean_rc)
+        module.exit_json(changed=True, msg=clean_out, stdout=clean_out, stderr=clean_err, diff=clean_diff)
 
     if p['upgrade'] == 'no':
         p['upgrade'] = None

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1224,7 +1224,7 @@ def main():
 
     p = module.params
 
-    if p['clean'] == True:
+    if p['clean'] is True:
         clean_rc, clean_out, clean_err = module.run_command(['apt-get', 'clean'])
 
         if module._diff:

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -89,6 +89,7 @@ options:
       - Recommended to run this as a stand-alone operation.
     type: bool
     default: 'no'
+    version_added: "2.13"
   allow_unauthenticated:
     description:
       - Ignore if packages cannot be authenticated. This is useful for bootstrapping environments that manage their own apt-key setup.

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -86,7 +86,7 @@ options:
     description:
       - Run the equivalent of C(apt-get clean) to clear out the local repository of retrieved package files. It removes everything but
         the lock file from /var/cache/apt/archives/ and /var/cache/apt/archives/partial/.
-      - Recommended to run this as a stand-alone operation.
+      - Can be run as part of the package installation (clean runs before install) or as a separate step.
     type: bool
     default: 'no'
     version_added: "2.13"
@@ -986,7 +986,6 @@ def aptclean(m):
         m.fail_json(msg="apt-get clean failed", stdout=clean_out, rc=clean_rc)
     if clean_err:
         m.fail_json(msg="apt-get clean failed: %s" % clean_err, stdout=clean_out, rc=clean_rc)
-    m.exit_json(changed=True, msg=clean_out, stdout=clean_out, stderr=clean_err, diff=clean_diff)
 
 
 def upgrade(m, mode="yes", force=False, default_release=None,


### PR DESCRIPTION
##### SUMMARY

Adds basic support for "apt-get clean" operation to the apt module. Fixes #38920

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- New function aptclean() that adds logic to perform "apt-get clean" operation.
- Adds 'clean' element to module parameter list and calls aptclean() if 'clean' is True (defaults to False).

##### ADDITIONAL INFORMATION

It is sometimes necessary to run "apt-get clean" both to save space and to conduct routine repository maintenance. Since Ansible did not previously have native support for this, the only way to perform the operation was by using the command module which is less than ideal. 

The changes in this PR add basic support for "apt-get clean" along with corresponding example usage and documentation. Using the proposed functionality is fairly straight-forward and can be seen with the below example playbook:

```
- hosts: test-group
  become: yes
  tasks:
    - name: Run the equivalent of "apt-get clean" as a separate step
      apt:
        clean: yes
```

When the above runs, the module element 'clean' will evaluate as True and run the module command "apt-get clean." If "apt-get clean" is unable to run successfully, it will fail and return the stderr for troubleshooting. Upon successful run, everything but the lock file from `/var/cache/apt/archives/` and `/var/cache/apt/archives/partial/` will be cleared out. 

##### NOTES

This is my first contribution to Ansible directly, so please let me know if I missed or overlooked anything. Thank you!