### PR TITLE
Bump antsibull version from 0.40.1 to 0.41.0 and ansible sphinx theme version to fix HTML generation in return value tables

### DIFF
--- a/docs/docsite/.templates/breadcrumbs.html
+++ b/docs/docsite/.templates/breadcrumbs.html
@@ -13,7 +13,7 @@
                 '_connection', '_inventory', '_lookup',
                 '_shell', '_strategy', '_vars',
                )) %}
-            <!--  <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode or "blob" }}/{{ github_module_version }}{{ meta.get('source', '') }}?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr" class="fa fa-github"> {{ _('Edit on GitHub') }}</a> -->
+            {#  <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode or "blob" }}/{{ github_module_version }}{{ meta.get('source', '') }}?description=%23%23%23%23%23%20SUMMARY%0A%3C!---%20Your%20description%20here%20--%3E%0A%0A%0A%23%23%23%23%23%20ISSUE%20TYPE%0A-%20Docs%20Pull%20Request%0A%0A%2Blabel:%20docsite_pr" class="fa fa-github"> {{ _('Edit on GitHub') }}</a> #}
               <br>
             <!-- Remove main index page as it is no longer editable -->
             {% elif pagename == 'index' %}

--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -4,7 +4,7 @@
 #    test/sanity/code-smell/docs-build.requirements.txt
 #    test/sanity/code-smell/rstcheck.requirements.txt
 
-antsibull == 0.40.1
+antsibull == 0.40.2
 # sphinx 4.2.0 requires docutils < 0.18
 docutils == 0.17.1
 jinja2 == 3.0.3

--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -4,7 +4,7 @@
 #    test/sanity/code-smell/docs-build.requirements.txt
 #    test/sanity/code-smell/rstcheck.requirements.txt
 
-antsibull == 0.40.2
+antsibull == 0.41.0
 # sphinx 4.2.0 requires docutils < 0.18
 docutils == 0.17.1
 jinja2 == 3.0.3

--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -15,5 +15,5 @@ rstcheck == 3.3.1
 sphinx == 4.2.0
 sphinx-notfound-page == 0.8 # must be >= 0.6
 sphinx-intl == 2.0.1
-sphinx-ansible-theme === 0.9.0
+sphinx-ansible-theme === 0.9.1
 straight.plugin == 1.5.0 # Needed for hacking/build-ansible.py which is the backend build script

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -3,7 +3,7 @@
 # if you want known good versions of these dependencies
 # use known_good_reqs.txt instead
 
-antsibull >= 0.40.1
+antsibull >= 0.40.2
 docutils
 jinja2
 pygments >= 2.10.0

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -12,6 +12,6 @@ rstcheck
 sphinx
 sphinx-notfound-page >= 0.6
 sphinx-intl
-sphinx-ansible-theme >= 0.9.0
+sphinx-ansible-theme >= 0.9.1
 resolvelib
 straight.plugin # Needed for hacking/build-ansible.py which is the backend build script

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -3,7 +3,7 @@
 # if you want known good versions of these dependencies
 # use known_good_reqs.txt instead
 
-antsibull >= 0.40.2
+antsibull >= 0.41.0
 docutils
 jinja2
 pygments >= 2.10.0

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -4,7 +4,7 @@ aiohttp==3.8.0
 aiosignal==1.2.0
 alabaster==0.7.12
 ansible-pygments==0.1.0
-antsibull==0.40.1
+antsibull==0.40.2
 antsibull-changelog==0.12.0
 async-timeout==4.0.1
 asyncio-pool==0.5.2

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -34,7 +34,7 @@ sh==1.14.2
 six==1.16.0
 snowballstemmer==2.1.0
 Sphinx==4.2.0
-sphinx-ansible-theme==0.9.0
+sphinx-ansible-theme==0.9.1
 sphinx-notfound-page==0.8
 sphinx-rtd-theme==1.0.0
 sphinxcontrib-applehelp==1.0.2

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -4,7 +4,7 @@ aiohttp==3.8.0
 aiosignal==1.2.0
 alabaster==0.7.12
 ansible-pygments==0.1.0
-antsibull==0.40.2
+antsibull==0.41.0
 antsibull-changelog==0.12.0
 async-timeout==4.0.1
 asyncio-pool==0.5.2


### PR DESCRIPTION
##### SUMMARY
Follow-up PR to #76675. Most important change in antsibull 0.40.2 is https://github.com/ansible-community/antsibull/pull/387 which fixes broken HTML in return value tables. While most browsers simply ignored it and rendered the result fine, lynx wouldn't render the result.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs build
