### PR TITLE
Change "fatal" to "error" in config docs to match actual behaviour

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -225,7 +225,7 @@ COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH:
   description:
   - When a collection is loaded that does not support the running Ansible version (via the collection metadata key
     `requires_ansible`), the default behavior is to issue a warning and continue anyway. Setting this value to `ignore`
-    skips the warning entirely, while setting it to `fatal` will immediately halt Ansible execution.
+    skips the warning entirely, while setting it to `error` will immediately halt Ansible execution.
   env: [{name: ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH}]
   ini: [{key: collections_on_ansible_version_mismatch, section: defaults}]
   choices: [error, warning, ignore]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Documentation for the `COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH` config option states that
setting it to `fatal` will stop ansible execution. But the right setting for that is `error`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
config

