### PR TITLE
ansible-config avoid _terms and _input in --only-changed (#76597)

### DIFF
--- a/changelogs/fragments/config_fix_terms.yml
+++ b/changelogs/fragments/config_fix_terms.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-config avoid showing _terms and _input when --only-changed.

--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -365,18 +365,23 @@ class ConfigCLI(CLI):
 
         text = []
         for setting in sorted(config):
+            changed = False
             if isinstance(config[setting], Setting):
+                # proceed normally
                 if config[setting].origin == 'default':
                     color = 'green'
                 elif config[setting].origin == 'REQUIRED':
+                    # should include '_terms', '_input', etc
                     color = 'red'
                 else:
                     color = 'yellow'
+                    changed = True
                 msg = "%s(%s) = %s" % (setting, config[setting].origin, config[setting].value)
             else:
                 color = 'green'
                 msg = "%s(%s) = %s" % (setting, 'default', config[setting].get('default'))
-            if not context.CLIARGS['only_changed'] or color == 'yellow':
+
+            if not context.CLIARGS['only_changed'] or changed:
                 text.append(stringc(msg, color))
 
         return text
@@ -440,6 +445,11 @@ class ConfigCLI(CLI):
                         o = 'REQUIRED'
                     else:
                         raise e
+
+                if v is None and o is None:
+                    # not all cases will be error
+                    o = 'REQUIRED'
+
                 config_entries[finalname][setting] = Setting(setting, v, o, None)
 
             # pretty please!


### PR DESCRIPTION
 dont display _terms or _intput on only changed
 those always change and it expected for the plugins that support them

Co-authored-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit 2246ed96786c600e5c5d9c120c77de1968282d85)


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-config