### PR TITLE
ansible-test: fix typo in validate-modules

### DIFF
--- a/changelogs/fragments/ansible-test-fix-typo-validate-modules.yaml
+++ b/changelogs/fragments/ansible-test-fix-typo-validate-modules.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - fix a typo in validate-modules.

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/module_args.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/module_args.py
@@ -117,7 +117,7 @@ def get_ps_argument_spec(filename, collection):
     ps_dep_finder._add_module(name=b"Ansible.ModuleUtils.AddType", ext=".psm1", fqn=None, optional=False, wrapper=False)
 
     util_manifest = json.dumps({
-        'module_path': to_text(module_path, errors='surrogiate_or_strict'),
+        'module_path': to_text(module_path, errors='surrogate_or_strict'),
         'ansible_basic': ps_dep_finder.cs_utils_module["Ansible.Basic"]['path'],
         'ps_utils': {name: info['path'] for name, info in ps_dep_finder.ps_modules.items()}
     })


### PR DESCRIPTION
##### SUMMARY
The correct error strategy for the to_text method is `surrogate_or_strict`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test validate-modules
