### PR TITLE
Feature: add extra_args to builtin.git module

### DIFF
--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -217,7 +217,8 @@ options:
            - For availible options, see `man git clone`
         type: list
         elements: str
-        default: None
+        aliases: [clone_extra_arg]
+        default: []
         version_added: "2.13"
 
 requirements:
@@ -567,7 +568,7 @@ def clone(git_path, module, repo, dest, remote, depth, version, bare,
     if reference:
         cmd.extend(['--reference', str(reference)])
 
-    if clone_extra_args is not None:
+    if clone_extra_args is not None and iter(clone_extra_args) and len(clone_extra_args) > 0:
         cmd.extend(clone_extra_args)
 
     if single_branch:
@@ -1171,7 +1172,7 @@ def main():
             archive=dict(type='path'),
             archive_prefix=dict(),
             separate_git_dir=dict(type='path'),
-            clone_extra_args=dict(type='list', default=None, aliases=['clone_extra_arg'], elements='str'),
+            clone_extra_args=dict(type='list', default=[], aliases=['clone_extra_arg'], elements='str'),
         ),
         mutually_exclusive=[('separate_git_dir', 'bare'), ('accept_hostkey', 'accept_newhostkey')],
         required_by={'archive_prefix': ['archive']},

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -213,8 +213,8 @@ options:
 
     clone_extra_args:
         description:
-           - A list of extra arguments, to pass to git clone
-           - For availible options, see `man git`
+           - A list of additional arguments, to pass to git clone
+           - For availible options, see `man git clone`
         type: list
         elements: str
         default: None


### PR DESCRIPTION
##### SUMMARY

As proposed in #19125 i've added an `clone_extra_args` option to `builtin.git` to be able to pass additional arguments to `git clone`.

Possible usecases are described in #54181 and #55707 as well as in #19125 itself.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`builtin.git`

##### Usage example
```yaml
- name: Example clone with extra_args
  ansible.builtin.git:
    repo: https://github.com/ansible/ansible-examples.git
    dest: /src/ansible-examples
    clone_extra_args: "--no-checkout"
```
