### PR TITLE
Resolve perf issue with async callback events

### DIFF
--- a/changelogs/fragments/76729-async-callback-perf.yml
+++ b/changelogs/fragments/76729-async-callback-perf.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- async - Improve performance of sending async callback events by never sending the full task through the queue
+  (https://github.com/ansible/ansible/issues/76729)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -797,7 +797,7 @@ class TaskExecutor:
         # that (with a sleep for "poll" seconds between each retry) until the
         # async time limit is exceeded.
 
-        async_task = Task().load(dict(action='async_status jid=%s' % async_jid, environment=self._task.environment))
+        async_task = Task().load(dict(action='async_status', args={'jid': async_jid}, environment=self._task.environment))
 
         # FIXME: this is no longer the case, normal takes care of all, see if this can just be generalized
         # Because this is an async task, the action handler is async. However,

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -851,7 +851,7 @@ class TaskExecutor:
                         self._host.name,
                         async_task._uuid,
                         async_result,
-                        task_fields=self._task.dump_attrs(),
+                        task_fields=async_task.dump_attrs(),
                     ),
                 )
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -621,14 +621,14 @@ class TaskExecutor:
                         self._final_q.send_callback(
                             'v2_runner_on_async_failed',
                             TaskResult(self._host.name,
-                                       self._task,    # We send the full task here, because the controller knows nothing about it, the TE created it
+                                       self._task._uuid,
                                        result,
                                        task_fields=self._task.dump_attrs()))
                     else:
                         self._final_q.send_callback(
                             'v2_runner_on_async_ok',
                             TaskResult(self._host.name,
-                                       self._task,    # We send the full task here, because the controller knows nothing about it, the TE created it
+                                       self._task._uuid,
                                        result,
                                        task_fields=self._task.dump_attrs()))
 
@@ -849,7 +849,7 @@ class TaskExecutor:
                     'v2_runner_on_async_poll',
                     TaskResult(
                         self._host.name,
-                        async_task,  # We send the full task here, because the controller knows nothing about it, the TE created it
+                        async_task._uuid,
                         async_result,
                         task_fields=self._task.dump_attrs(),
                     ),

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -797,7 +797,7 @@ class TaskExecutor:
         # that (with a sleep for "poll" seconds between each retry) until the
         # async time limit is exceeded.
 
-        async_task = Task().load(dict(action='async_status', args={'jid': async_jid}, environment=self._task.environment))
+        async_task = Task.load(dict(action='async_status', args={'jid': async_jid}, environment=self._task.environment))
 
         # FIXME: this is no longer the case, normal takes care of all, see if this can just be generalized
         # Because this is an async task, the action handler is async. However,
@@ -863,7 +863,7 @@ class TaskExecutor:
         else:
             # If the async task finished, automatically cleanup the temporary
             # status file left behind.
-            cleanup_task = Task().load(
+            cleanup_task = Task.load(
                 {
                     'async_status': {
                         'jid': async_jid,


### PR DESCRIPTION
##### SUMMARY
Resolve perf issue with async callback events

To achieve this, we ensure we don't send the full task in the callback event through the queue

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/task_executor.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
