### PR TITLE
include_vars initialize failed (#76754)

### DIFF
--- a/changelogs/fragments/include_vars_failed.yml
+++ b/changelogs/fragments/include_vars_failed.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - include_vars, properly initialize variable as there is corner case in which it can end up referenced and not defined

--- a/lib/ansible/plugins/action/include_vars.py
+++ b/lib/ansible/plugins/action/include_vars.py
@@ -100,6 +100,7 @@ class ActionModule(ActionBase):
         self._set_args()
 
         results = dict()
+        failed = False
         if self.source_dir:
             self._set_dir_defaults()
             self._set_root_dir()
@@ -172,13 +173,16 @@ class ActionModule(ActionBase):
                 )
                 self.source_dir = path.join(current_dir, self.source_dir)
 
+    def _log_walk(self, error):
+        self._display.vvv('Issue with walking through "%s": %s' % (to_native(error.filename), to_native(error)))
+
     def _traverse_dir_depth(self):
         """ Recursively iterate over a directory and sort the files in
             alphabetical order. Do not iterate pass the set depth.
             The default depth is unlimited.
         """
         current_depth = 0
-        sorted_walk = list(walk(self.source_dir))
+        sorted_walk = list(walk(self.source_dir, onerror=self._log_walk))
         sorted_walk.sort(key=lambda x: x[0])
         for current_root, current_dir, current_files in sorted_walk:
             current_depth += 1


### PR DESCRIPTION
* include_vars initialize failed

  if source dir is given, but not present and traversal is empty you
  can end up trying to access failed w/o it ever being defined.

  also future proof for more corner cases in decision tree

(cherry picked from commit 89c884e2a2bd124b49bf9419f053f659a7d1c554)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
action/include_vars