### PR TITLE
added Gentoo to 'INTERPRETER_PYTHON_DISTRO_MAP'

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1486,6 +1486,8 @@ INTERPRETER_PYTHON_DISTRO_MAP:
       '10': /usr/bin/python3
     fedora:
       '23': /usr/bin/python3
+    gentoo:
+      '2': /usr/bin/python
     oracle: *rhelish
     redhat: *rhelish
     rhel: *rhelish


### PR DESCRIPTION
##### SUMMARY
Added Gentoo to INTERPRETER_PYTHON_DISTRO_MAP. The '2' is discovered by Ansible based on the BaseLayout, see the [official ebuild](https://packages.gentoo.org/packages/sys-apps/baselayout)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Python Interpreter discovery

##### ADDITIONAL INFORMATION
When using auto discovery, it picks the wrong python interpreter currently 3.10 which should be python 3.9.
