### PR TITLE
Update Python Destination FreeBSD 

### DIFF
--- a/docs/docsite/rst/user_guide/intro_bsd.rst
+++ b/docs/docsite/rst/user_guide/intro_bsd.rst
@@ -54,7 +54,7 @@ To support a variety of Unix-like operating systems and distributions, Ansible c
 .. code-block:: text
 
     [freebsd:vars]
-    ansible_python_interpreter=/usr/local/bin/python
+    ansible_python_interpreter=/usr/local/bin/python3.8
     [openbsd:vars]
     ansible_python_interpreter=/usr/local/bin/python3.8
 


### PR DESCRIPTION
Update the Python Destination for FreeBSD. The previous destination "/usr/local/bin/python" does not work for the newer versions of FreeBSD.

