### PR TITLE
Do not require SystemdStrategy subclasses for every distro

### DIFF
--- a/changelogs/fragments/76792-hostname-all-systemd.yml
+++ b/changelogs/fragments/76792-hostname-all-systemd.yml
@@ -1,3 +1,3 @@
 bugfixes:
-- hostname - Do not require SystemStrategy subclasses for every distro
+- hostname - Do not require SystemdStrategy subclasses for every distro
   (https://github.com/ansible/ansible/issues/76792)

--- a/changelogs/fragments/76792-hostname-all-systemd.yml
+++ b/changelogs/fragments/76792-hostname-all-systemd.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- hostname - Do not require SystemStrategy subclasses for every distro
+  (https://github.com/ansible/ansible/issues/76792)

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -160,7 +160,8 @@ class Hostname(object):
         if self.use is not None:
             strat = globals()['%sStrategy' % STRATS[self.use]]
             self.strategy = strat(module)
-        elif self.platform == 'Linux' and ServiceMgrFactCollector.is_systemd_managed(module):
+        elif platform.system() == 'Linux' and ServiceMgrFactCollector.is_systemd_managed(module):
+            # This is Linux and systemd is active
             self.strategy = SystemdStrategy(module)
         else:
             self.strategy = self.strategy_class(module)
@@ -643,12 +644,6 @@ class DarwinStrategy(BaseStrategy):
             self.changed = True
 
 
-class FedoraHostname(Hostname):
-    platform = 'Linux'
-    distribution = 'Fedora'
-    strategy_class = SystemdStrategy
-
-
 class SLESHostname(Hostname):
     platform = 'Linux'
     distribution = 'Sles'
@@ -661,60 +656,6 @@ class SLESHostname(Hostname):
             raise ValueError()
     except ValueError:
         strategy_class = UnimplementedStrategy
-
-
-class OpenSUSEHostname(Hostname):
-    platform = 'Linux'
-    distribution = 'Opensuse'
-    strategy_class = SystemdStrategy
-
-
-class OpenSUSELeapHostname(Hostname):
-    platform = 'Linux'
-    distribution = 'Opensuse-leap'
-    strategy_class = SystemdStrategy
-
-
-class OpenSUSETumbleweedHostname(Hostname):
-    platform = 'Linux'
-    distribution = 'Opensuse-tumbleweed'
-    strategy_class = SystemdStrategy
-
-
-class AsteraHostname(Hostname):
-    platform = 'Linux'
-    distribution = '"astralinuxce"'
-    strategy_class = SystemdStrategy
-
-
-class ArchHostname(Hostname):
-    platform = 'Linux'
-    distribution = 'Arch'
-    strategy_class = SystemdStrategy
-
-
-class ArchARMHostname(Hostname):
-    platform = 'Linux'
-    distribution = 'Archarm'
-    strategy_class = SystemdStrategy
-
-
-class AlmaLinuxHostname(Hostname):
-    platform = 'Linux'
-    distribution = 'Almalinux'
-    strategy_class = SystemdStrategy
-
-
-class ManjaroHostname(Hostname):
-    platform = 'Linux'
-    distribution = 'Manjaro'
-    strategy_class = SystemdStrategy
-
-
-class ManjaroARMHostname(Hostname):
-    platform = 'Linux'
-    distribution = 'Manjaro-arm'
-    strategy_class = SystemdStrategy
 
 
 class RHELHostname(Hostname):
@@ -735,12 +676,6 @@ class AnolisOSHostname(Hostname):
     strategy_class = RedHatStrategy
 
 
-class ClearLinuxHostname(Hostname):
-    platform = 'Linux'
-    distribution = 'Clear-linux-os'
-    strategy_class = SystemdStrategy
-
-
 class CloudlinuxserverHostname(Hostname):
     platform = 'Linux'
     distribution = 'Cloudlinuxserver'
@@ -757,18 +692,6 @@ class AlinuxHostname(Hostname):
     platform = 'Linux'
     distribution = 'Alinux'
     strategy_class = RedHatStrategy
-
-
-class CoreosHostname(Hostname):
-    platform = 'Linux'
-    distribution = 'Coreos'
-    strategy_class = SystemdStrategy
-
-
-class FlatcarHostname(Hostname):
-    platform = 'Linux'
-    distribution = 'Flatcar'
-    strategy_class = SystemdStrategy
 
 
 class ScientificHostname(Hostname):
@@ -909,18 +832,6 @@ class DarwinHostname(Hostname):
     strategy_class = DarwinStrategy
 
 
-class OsmcHostname(Hostname):
-    platform = 'Linux'
-    distribution = 'Osmc'
-    strategy_class = SystemdStrategy
-
-
-class PardusHostname(Hostname):
-    platform = 'Linux'
-    distribution = 'Pardus'
-    strategy_class = SystemdStrategy
-
-
 class VoidLinuxHostname(Hostname):
     platform = 'Linux'
     distribution = 'Void'
@@ -933,28 +844,10 @@ class PopHostname(Hostname):
     strategy_class = FileStrategy
 
 
-class RockyHostname(Hostname):
-    platform = 'Linux'
-    distribution = 'Rocky'
-    strategy_class = SystemdStrategy
-
-
-class RedosHostname(Hostname):
-    platform = 'Linux'
-    distribution = 'Redos'
-    strategy_class = SystemdStrategy
-
-
 class EurolinuxHostname(Hostname):
     platform = 'Linux'
     distribution = 'Eurolinux'
     strategy_class = RedHatStrategy
-
-
-class OpenEulerHostname(Hostname):
-    platform = 'Linux'
-    distribution = 'Openeuler'
-    strategy_class = SystemdStrategy
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY
Do not require SystemStrategy subclasses for every distro. Fixes #76792

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/hostname.py

##### ADDITIONAL INFORMATION
No new tests should be required, existing tests cover the change
