### PR TITLE
Mention ansible-core 2.11 RPM package in Ansible Core Installation Guide

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -98,8 +98,6 @@ You can choose any of the following ways to install ``ansible-core``:
 
 	Red Hat Ansible Automation Platform 2.0 repository only provides ``ansible-core`` 2.11 RPM package for RHEL 8 x86_64. You need to enable the Red Hat Ansible Automation Platform 2.0 repository for RHEL 8 x86_64 before installing the package with ``sudo subscription-manager repos --enable ansible-automation-platform-2.0-early-access-for-rhel-8-x86_64-rpms``. After enabling the repository, install the package with ``sudo dnf install ansible-core``.
 
-
-
 Ansible generally creates new releases twice a year. See :ref:`release_and_maintenance` for information on release timing and maintenance of older releases.
 
 .. _from_pip:

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -77,6 +77,8 @@ You can choose any of the following ways to install the Ansible community packag
 * Install the latest release with your OS package manager (for Red Hat Enterprise Linux (TM), CentOS, Fedora, Debian, or Ubuntu).
 * Install with ``pip`` (the Python package manager).
 
+.. _install_core:
+
 Installing `ansible-core`
 -------------------------
 
@@ -85,11 +87,18 @@ Ansible also distributes a minimalist object called ``ansible-core`` (or ``ansib
 You can choose any of the following ways to install ``ansible-core``:
 
 * Install ``ansible-core`` (version 2.11 and greater) or ``ansible-base`` (version 2.10) with ``pip``.
+* Install ``ansible-core`` (version 2.11 and greater) RPM package with ``dnf``.
 * Install ``ansible-core`` from source from the ansible/ansible GitHub repository to access the development (``devel``) version to develop or test the latest features.
 
 .. note::
 
 	You should only run ``ansible-core`` from ``devel`` if you are modifying ``ansible-core``, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
+
+.. note::
+
+	Red Hat Ansible Automation Platform 2.0 repository only provides ``ansible-core`` 2.11 RPM package for RHEL 8 x86_64. You need to enable the Red Hat Ansible Automation Platform 2.0 repository for RHEL 8 x86_64 before installing the package with ``sudo subscription-manager repos --enable ansible-automation-platform-2.0-early-access-for-rhel-8-x86_64-rpms``. After enabling the repository, install the package with ``sudo dnf install ansible-core``.
+
+
 
 Ansible generally creates new releases twice a year. See :ref:`release_and_maintenance` for information on release timing and maintenance of older releases.
 
@@ -243,7 +252,7 @@ RPMs for currently supported versions of RHEL and CentOS are also available from
 
 .. note::
 
-	Since Ansible 2.10 for RHEL is not available at this time,  continue to use Ansible 2.9.
+	Red Hat Ansible Automation Platform will not ship RPM package for Ansible 2.10+. Going forward, Red Hat Ansible Automation Platform will ship the ansible-core package as a standalone RPM and within execution environments, see :ref:`install_core`.
 
 Ansible can manage older operating systems that contain Python 2.6 or higher.
 

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -94,9 +94,7 @@ You can choose any of the following ways to install ``ansible-core``:
 
 	You should only run ``ansible-core`` from ``devel`` if you are modifying ``ansible-core``, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
 
-.. note::
 
-	Red Hat Ansible Automation Platform 2.0 repository only provides ``ansible-core`` 2.11 RPM package for RHEL 8 x86_64. You need to enable the Red Hat Ansible Automation Platform 2.0 repository for RHEL 8 x86_64 before installing the package with ``sudo subscription-manager repos --enable ansible-automation-platform-2.0-early-access-for-rhel-8-x86_64-rpms``. After enabling the repository, install the package with ``sudo dnf install ansible-core``.
 
 Ansible generally creates new releases twice a year. See :ref:`release_and_maintenance` for information on release timing and maintenance of older releases.
 
@@ -250,7 +248,6 @@ RPMs for currently supported versions of RHEL and CentOS are also available from
 
 .. note::
 
-	Red Hat Ansible Automation Platform will not ship RPM package for Ansible 2.10+. Going forward, Red Hat Ansible Automation Platform will ship the ansible-core package as a standalone RPM and within execution environments, see :ref:`install_core`.
 
 Ansible can manage older operating systems that contain Python 2.6 or higher.
 

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -94,8 +94,6 @@ You can choose any of the following ways to install ``ansible-core``:
 
 	You should only run ``ansible-core`` from ``devel`` if you are modifying ``ansible-core``, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
 
-
-
 Ansible generally creates new releases twice a year. See :ref:`release_and_maintenance` for information on release timing and maintenance of older releases.
 
 .. _from_pip:
@@ -245,9 +243,6 @@ On CentOS:
     $ sudo yum install ansible
 
 RPMs for currently supported versions of RHEL and CentOS are also available from `EPEL <https://fedoraproject.org/wiki/EPEL>`_.
-
-.. note::
-
 
 Ansible can manage older operating systems that contain Python 2.6 or higher.
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Red Hat Ansible Automation Platform 2 released the ansible-core RPM package a few months ago and kept that updated. So we should mention this in the installation guide of Ansible Core from 2.11 to the latest.
Also Red Hat no longer release the ansible RPM package since Ansible 2.10. Leave a note to make it more explicit.

Some of the contents are cited from the FAQ provided by Red Hat: https://access.redhat.com/articles/6192881#ansible-core

Hope this change can clarify some questions like this: https://stackoverflow.com/questions/70517173/system-does-not-update-ansible-on-centos-8
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
intro_installation.rst

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Some Red Hat Errata with ansible-core shipped:
https://access.redhat.com/errata/RHBA-2021:2703
https://access.redhat.com/errata/RHBA-2021:3672
https://access.redhat.com/errata/RHSA-2021:3874

<!--- Paste verbatim command output below, e.g. before and after your change -->

