### PR TITLE
Switching to FQDN in the Examples of apt

### DIFF
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -206,102 +206,102 @@ notes:
 
 EXAMPLES = '''
 - name: Install apache httpd  (state=present is optional)
-  apt:
+  ansible.builtin.apt:
     name: apache2
     state: present
 
 - name: Update repositories cache and install "foo" package
-  apt:
+  ansible.builtin.apt:
     name: foo
     update_cache: yes
 
 - name: Remove "foo" package
-  apt:
+  ansible.builtin.apt:
     name: foo
     state: absent
 
 - name: Install the package "foo"
-  apt:
+  ansible.builtin.apt:
     name: foo
 
 - name: Install a list of packages
-  apt:
+  ansible.builtin.apt:
     pkg:
     - foo
     - foo-tools
 
 - name: Install the version '1.00' of package "foo"
-  apt:
+  ansible.builtin.apt:
     name: foo=1.00
 
 - name: Update the repository cache and update package "nginx" to latest version using default release squeeze-backport
-  apt:
+  ansible.builtin.apt:
     name: nginx
     state: latest
     default_release: squeeze-backports
     update_cache: yes
 
 - name: Install the version '1.18.0' of package "nginx" and allow potential downgrades
-  apt:
+  ansible.builtin.apt:
     name: nginx=1.18.0
     state: present
     allow_downgrade: yes
 
 - name: Install zfsutils-linux with ensuring conflicted packages (e.g. zfs-fuse) will not be removed.
-  apt:
+  ansible.builtin.apt:
     name: zfsutils-linux
     state: latest
     fail_on_autoremove: yes
 
 - name: Install latest version of "openjdk-6-jdk" ignoring "install-recommends"
-  apt:
+  ansible.builtin.apt:
     name: openjdk-6-jdk
     state: latest
     install_recommends: no
 
 - name: Update all packages to their latest version
-  apt:
+  ansible.builtin.apt:
     name: "*"
     state: latest
 
 - name: Upgrade the OS (apt-get dist-upgrade)
-  apt:
+  ansible.builtin.apt:
     upgrade: dist
 
 - name: Run the equivalent of "apt-get update" as a separate step
-  apt:
+  ansible.builtin.apt:
     update_cache: yes
 
 - name: Only run "update_cache=yes" if the last one is more than 3600 seconds ago
-  apt:
+  ansible.builtin.apt:
     update_cache: yes
     cache_valid_time: 3600
 
 - name: Pass options to dpkg on run
-  apt:
+  ansible.builtin.apt:
     upgrade: dist
     update_cache: yes
     dpkg_options: 'force-confold,force-confdef'
 
 - name: Install a .deb package
-  apt:
+  ansible.builtin.apt:
     deb: /tmp/mypackage.deb
 
 - name: Install the build dependencies for package "foo"
-  apt:
+  ansible.builtin.apt:
     pkg: foo
     state: build-dep
 
 - name: Install a .deb package from the internet
-  apt:
+  ansible.builtin.apt:
     deb: https://example.com/python-ppq_0.1-1_all.deb
 
 - name: Remove useless packages from the cache
-  apt:
+  ansible.builtin.apt:
     autoclean: yes
 
 - name: Remove dependencies that are no longer required
-  apt:
+  ansible.builtin.apt:
     autoremove: yes
 '''
 


### PR DESCRIPTION
Switch to FQDN in the examples, as this is the recommended way also for modules from `ansible-core`.

##### SUMMARY
This is a simple substitution from `apt` to `ansible.builtin.apt` in the Examples of the apt documentation

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ansible.builtin.apt

