### PR TITLE
Attempt 2: Catch errors getting filters and tests

### DIFF
--- a/changelogs/fragments/74127-bad-filter-2.yml
+++ b/changelogs/fragments/74127-bad-filter-2.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- Templating - Ensure we catch exceptions when getting ``.filters`` and
+  ``.tests`` attributes on their respective plugins and properly error,
+  instead of aborting which results in no filters being added to the
+  jinja2 environment

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -546,9 +546,8 @@ class JinjaPluginIntercept(MutableMapping):
                 except Exception as e:
                     raise TemplateSyntaxError(to_native(e), 0)
 
-                method_map = getattr(plugin_impl, self._method_map_name)
-
                 try:
+                    method_map = getattr(plugin_impl, self._method_map_name)
                     func_items = method_map().items()
                 except Exception as e:
                     display.warning(

--- a/test/integration/targets/jinja_plugins/collections/ansible_collections/foo/bar/plugins/filter/bad_collection_filter2.py
+++ b/test/integration/targets/jinja_plugins/collections/ansible_collections/foo/bar/plugins/filter/bad_collection_filter2.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2021 Matt Martz <matt@sivel.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class FilterModule:
+    pass

--- a/test/integration/targets/jinja_plugins/tasks/main.yml
+++ b/test/integration/targets/jinja_plugins/tasks/main.yml
@@ -17,6 +17,8 @@
       - |
         result.stderr|regex_findall('bad_test')|length == 2
       - |
-        result.stderr|regex_findall('bad_collection_filter')|length == 2
+        result.stderr|regex_findall('bad_collection_filter')|length == 3
+      - |
+        result.stderr|regex_findall('bad_collection_filter2')|length == 1
       - |
         result.stderr|regex_findall('bad_collection_test')|length == 2


### PR DESCRIPTION
##### SUMMARY
If `FilterModule` or `TestModule` does not contain their respective method (`.filter` or `.test`) loading plugins could fail.

This is a follow up to #74127

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
```
lib/ansible/template/__init__.py
```
##### ADDITIONAL INFORMATION
```
[WARNING]: an unexpected error occurred during Jinja2 environment setup:
'NoneType' object has no attribute 'filters'
exception during Jinja2 environment setup: Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/ansible/template/{}init{}.py", line 576, in _getitem_
    method_map = getattr(plugin_impl, self._method_map_name)
AttributeError: 'NoneType' object has no attribute 'filters'
```
