### PR TITLE
Add note before configuring the Python interpreter

### DIFF
--- a/docs/docsite/rst/user_guide/intro_bsd.rst
+++ b/docs/docsite/rst/user_guide/intro_bsd.rst
@@ -49,6 +49,12 @@ Once this is done you can now use other Ansible modules apart from the ``raw`` m
 Setting the Python interpreter
 ------------------------------
 
+Before configuring the Python interpreter in FreeBSD please refer to the correct way to install Python to avoid any errors: 
+
+.. code-block:: text
+
+    pkg install python
+
 To support a variety of Unix-like operating systems and distributions, Ansible cannot always rely on the existing environment or ``env`` variables to locate the correct Python binary. By default, modules point at ``/usr/bin/python`` as this is the most common location. On BSD variants, this path may differ, so it is advised to inform Ansible of the binary's location, through the ``ansible_python_interpreter`` inventory variable. For example:
 
 .. code-block:: text


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

A note with details on how to correctly and conveniently install Python on FreeBSD through pkg in order to avoid any errors.

When installing a specific version of Python such as "pkg install python3.8" the interpreter destination folder specified in the docs for FreeBSD may not be located by ansible and will thus throw an error.

The proposed installation method will make sure that the user also gets the newest version of Python while avoiding the error above.

This was previously discussed in this PR https://github.com/ansible/ansible/pull/76796

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request





```
