### PR TITLE
Fix task debugger to work with run_once using linear strategy

### DIFF
--- a/changelogs/fragments/76049-task-debugger-run_once.yml
+++ b/changelogs/fragments/76049-task-debugger-run_once.yml
@@ -1,0 +1,2 @@
+- bugfixes:
+  - "Fix task debugger to work with ``run_once`` using ``linear`` strategy (https://github.com/ansible/ansible/issues/76049)"

--- a/changelogs/fragments/76049-task-debugger-run_once.yml
+++ b/changelogs/fragments/76049-task-debugger-run_once.yml
@@ -1,2 +1,2 @@
-- bugfixes:
+bugfixes:
   - "Fix task debugger to work with ``run_once`` using ``linear`` strategy (https://github.com/ansible/ansible/issues/76049)"

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -52,6 +52,7 @@ from ansible.playbook.task_include import TaskInclude
 from ansible.plugins import loader as plugin_loader
 from ansible.template import Templar
 from ansible.utils.display import Display
+from ansible.utils.fqcn import add_internal_fqcns
 from ansible.utils.unsafe_proxy import wrap_var
 from ansible.utils.vars import combine_vars
 from ansible.vars.clean import strip_internal_keys, module_response_deepcopy
@@ -157,6 +158,12 @@ def debug_closure(func):
                 if next_action.result == NextAction.REDO:
                     # rollback host state
                     self._tqm.clear_failed_hosts()
+                    if task.run_once and iterator._play.strategy in add_internal_fqcns(('linear',)) and result.is_failed():
+                        for host_name, state in prev_host_states.items():
+                            if host_name == host.name:
+                                continue
+                            iterator.set_state_for_host(host_name, state)
+                            iterator._play._removed_hosts.remove(host_name)
                     iterator.set_state_for_host(host.name, prev_host_state)
                     for method, what in status_to_stats_map:
                         if getattr(result, method)():

--- a/test/integration/targets/debugger/aliases
+++ b/test/integration/targets/debugger/aliases
@@ -1,0 +1,3 @@
+shippable/posix/group1
+context/controller
+setup/always/setup_pexpect

--- a/test/integration/targets/debugger/inventory
+++ b/test/integration/targets/debugger/inventory
@@ -1,0 +1,2 @@
+testhost ansible_connection=local
+testhost2 ansible_connection=local

--- a/test/integration/targets/debugger/runme.sh
+++ b/test/integration/targets/debugger/runme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eux
+
+./test_run_once.py -i inventory "$@"

--- a/test/integration/targets/debugger/test_run_once.py
+++ b/test/integration/targets/debugger/test_run_once.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+import io
+import os
+import sys
+
+import pexpect
+
+
+env_vars = {
+    'ANSIBLE_NOCOLOR': 'True',
+    'ANSIBLE_RETRY_FILES_ENABLED': 'False',
+}
+
+env = os.environ.copy()
+env.update(env_vars)
+
+with io.BytesIO() as logfile:
+    debugger_test_test = pexpect.spawn(
+        'ansible-playbook',
+        args=['test_run_once_playbook.yml'] + sys.argv[1:],
+        timeout=10,
+        env=env
+    )
+
+    debugger_test_test.logfile = logfile
+
+    debugger_test_test.expect_exact('TASK: Task 1 (debug)> ')
+    debugger_test_test.send('task.args["that"] = "true"\r')
+    debugger_test_test.expect_exact('TASK: Task 1 (debug)> ')
+    debugger_test_test.send('r\r')
+    debugger_test_test.expect(pexpect.EOF)
+    debugger_test_test.close()
+
+    assert str(logfile.getvalue()).count('Task 2 executed') == 2

--- a/test/integration/targets/debugger/test_run_once_playbook.yml
+++ b/test/integration/targets/debugger/test_run_once_playbook.yml
@@ -1,0 +1,12 @@
+- hosts: testhost, testhost2
+  gather_facts: false
+  debugger: on_failed
+  tasks:
+    - name: Task 1
+      assert:
+        that: 'false'
+      run_once: yes
+
+    - name: Task 2
+      debug:
+        msg: "Task 2 executed"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #76049
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/strategy/__init__.py`