### PR TITLE
Fallback to os family for interpreter discovery distro map

### DIFF
--- a/changelogs/fragments/75560-interp-discovery-family-fallback.yml
+++ b/changelogs/fragments/75560-interp-discovery-family-fallback.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- Interpreter Discovery - Fallback to OS family if the distro is not found in
+  ``INTERPRETER_PYTHON_DISTRO_MAP``
+  (https://github.com/ansible/ansible/issues/75560)

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1477,7 +1477,7 @@ INTERPRETER_PYTHON:
 INTERPRETER_PYTHON_DISTRO_MAP:
   name: Mapping of known included platform pythons for various Linux distros
   default:
-    centos: &rhelish
+    redhat:
       '6': /usr/bin/python
       '8': /usr/libexec/platform-python
       '9': /usr/bin/python3
@@ -1486,10 +1486,6 @@ INTERPRETER_PYTHON_DISTRO_MAP:
       '10': /usr/bin/python3
     fedora:
       '23': /usr/bin/python3
-    oracle: *rhelish
-    redhat: *rhelish
-    rhel: *rhelish
-    rocky: *rhelish
     ubuntu:
       '14': /usr/bin/python
       '16': /usr/bin/python3

--- a/lib/ansible/executor/interpreter_discovery.py
+++ b/lib/ansible/executor/interpreter_discovery.py
@@ -15,7 +15,10 @@ from ansible.module_utils.distro import LinuxDistribution
 from ansible.utils.display import Display
 from ansible.utils.plugin_docs import get_versioned_doclink
 from ansible.module_utils.compat.version import LooseVersion
+from ansible.module_utils.facts.system.distribution import Distribution
 from traceback import format_exc
+
+OS_FAMILY_LOWER = {k.lower(): v.lower() for k, v in Distribution.OS_FAMILY.items()}
 
 display = Display()
 foundre = re.compile(r'(?s)PLATFORM[\r\n]+(.*)FOUND(.*)ENDFOUND')
@@ -107,7 +110,9 @@ def discover_interpreter(action, interpreter_name, discovery_mode, task_vars):
         if not distro or not version:
             raise NotImplementedError('unable to get Linux distribution/version info')
 
-        version_map = platform_python_map.get(distro.lower().strip())
+        family = OS_FAMILY_LOWER.get(distro.lower().strip())
+
+        version_map = platform_python_map.get(distro.lower().strip()) or platform_python_map.get(family)
         if not version_map:
             raise NotImplementedError('unsupported Linux distribution: {0}'.format(distro))
 


### PR DESCRIPTION
##### SUMMARY
Fallback to os family for interpreter discovery distro map. Fixes #75560

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/executor/interpreter_discovery.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
