### PR TITLE
add core roadmaps to ansible docs

### DIFF
--- a/docs/docsite/rst/ansible_index.rst
+++ b/docs/docsite/rst/ansible_index.rst
@@ -106,3 +106,4 @@ Ansible releases a new major release approximately twice a year. The core applic
    :caption: Roadmaps
 
    roadmap/ansible_roadmap_index.rst
+   roadmap/ansible_core_roadmap_index.rst

--- a/docs/docsite/sphinx_conf/ansible_conf.py
+++ b/docs/docsite/sphinx_conf/ansible_conf.py
@@ -98,8 +98,11 @@ exclude_patterns = [
     'porting_guides/porting_guide_base_2.10.rst',
     'porting_guides/porting_guide_core_*',
     'roadmap/index.rst',
-    'roadmap/ansible_core_roadmap_index.rst',
-    'roadmap/ROADMAP_2_1*',
+    'roadmap/ROADMAP_2_5.rst',
+    'roadmap/ROADMAP_2_6.rst',
+    'roadmap/ROADMAP_2_7.rst',
+    'roadmap/ROADMAP_2_8.rst',
+    'roadmap/ROADMAP_2_9.rst',
 ]
 
 # The reST default role (used for this markup: `text`) to use for all

--- a/docs/docsite/sphinx_conf/ansible_conf.py
+++ b/docs/docsite/sphinx_conf/ansible_conf.py
@@ -98,11 +98,6 @@ exclude_patterns = [
     'porting_guides/porting_guide_base_2.10.rst',
     'porting_guides/porting_guide_core_*',
     'roadmap/index.rst',
-    'roadmap/ROADMAP_2_5.rst',
-    'roadmap/ROADMAP_2_6.rst',
-    'roadmap/ROADMAP_2_7.rst',
-    'roadmap/ROADMAP_2_8.rst',
-    'roadmap/ROADMAP_2_9.rst',
 ]
 
 # The reST default role (used for this markup: `text`) to use for all


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Users want to find the core roadmaps so bring them back to the Ansible pkg docs.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs/docsite/rst/ansible_index.rst
docs/docsite/sphinx_conf/ansible_conf.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
