### PR TITLE
Update windows_winrm.rst

### DIFF
--- a/docs/docsite/rst/user_guide/windows_winrm.rst
+++ b/docs/docsite/rst/user_guide/windows_winrm.rst
@@ -187,7 +187,7 @@ Following example shows how to import the issuing certificate:
 
 .. code-block:: powershell
 
-    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2("cert.pem")
+    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2 "cert.pem"
 
     $store_name = [System.Security.Cryptography.X509Certificates.StoreName]::Root
     $store_location = [System.Security.Cryptography.X509Certificates.StoreLocation]::LocalMachine
@@ -204,7 +204,7 @@ The code to import the client certificate public key is:
 
 .. code-block:: powershell
 
-    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2("cert.pem")
+    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2 "cert.pem"
 
     $store_name = [System.Security.Cryptography.X509Certificates.StoreName]::TrustedPeople
     $store_location = [System.Security.Cryptography.X509Certificates.StoreLocation]::LocalMachine

--- a/docs/docsite/rst/user_guide/windows_winrm.rst
+++ b/docs/docsite/rst/user_guide/windows_winrm.rst
@@ -187,8 +187,7 @@ Following example shows how to import the issuing certificate:
 
 .. code-block:: powershell
 
-    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
-    $cert.Import("cert.pem")
+    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2("cert.pem")
 
     $store_name = [System.Security.Cryptography.X509Certificates.StoreName]::Root
     $store_location = [System.Security.Cryptography.X509Certificates.StoreLocation]::LocalMachine
@@ -205,8 +204,7 @@ The code to import the client certificate public key is:
 
 .. code-block:: powershell
 
-    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
-    $cert.Import("cert.pem")
+    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2("cert.pem")
 
     $store_name = [System.Security.Cryptography.X509Certificates.StoreName]::TrustedPeople
     $store_location = [System.Security.Cryptography.X509Certificates.StoreLocation]::LocalMachine


### PR DESCRIPTION
##### SUMMARY
`$cert.Import('cert.pem')` throws exception "X509Certificate is immutable on this platform. Use the equivalent constructor instead."
Until I put them in the same line as in proposed changes

PSVersion: 7.2.1
OS: Microsoft Windows 10.0.19044


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
