### PR TITLE
Added restart to the argument condition for AIX

### DIFF
--- a/changelogs/fragments/76840-added-restart-to-the-argument-condition-for-AIX.yml
+++ b/changelogs/fragments/76840-added-restart-to-the-argument-condition-for-AIX.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- service - Fixed service restarts with arguments on AIX.
+  (https://github.com/ansible/ansible/issues/76840)

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -1593,7 +1593,7 @@ class AIX(Service):
             self.execute_command("%s %s %s" % (self.stopsrc_cmd, srccmd_parameter, self.name))
             srccmd = self.startsrc_cmd
 
-        if self.arguments and self.action == 'start':
+        if self.arguments and self.action == 'start' or self.arguments and self.action == 'restart':
             return self.execute_command("%s -a \"%s\" %s %s" % (srccmd, self.arguments, srccmd_parameter, self.name))
         else:
             return self.execute_command("%s %s %s" % (srccmd, srccmd_parameter, self.name))

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -1593,7 +1593,7 @@ class AIX(Service):
             self.execute_command("%s %s %s" % (self.stopsrc_cmd, srccmd_parameter, self.name))
             srccmd = self.startsrc_cmd
 
-        if self.arguments and self.action == 'start' or self.arguments and self.action == 'restart':
+        if self.arguments and self.action in ('start', 'restart'):
             return self.execute_command("%s -a \"%s\" %s %s" % (srccmd, self.arguments, srccmd_parameter, self.name))
         else:
             return self.execute_command("%s %s %s" % (srccmd, srccmd_parameter, self.name))


### PR DESCRIPTION
##### SUMMARY
Added restart to the argument condition for AIX to allow the service modul a restart with arguments.

Issue: https://github.com/ansible/ansible/issues/76840

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
service

##### ADDITIONAL INFORMATION
Locally tested with Ansible on AIX.

```paste below
root@aix00001 /root/ansible# ansible --version
ansible 2.9.14
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/freeware/lib/python3.7/site-packages/ansible
  executable location = /opt/freeware/bin/ansible
  python version = 3.7.12 (default, Dec 15 2021, 03:25:47) [GCC 8.3.0]
```
