### PR TITLE
Features/set facts/aggrigation

### DIFF
--- a/lib/ansible/executor/stats.py
+++ b/lib/ansible/executor/stats.py
@@ -80,7 +80,7 @@ class AggregateStats:
         else:
             self.custom[host][which] = what
 
-    def update_custom_stats(self, which, what, host=None):
+    def update_custom_stats(self, which, what, host=None, list_merge='replace'):
         ''' allow aggregation of a custom stat'''
 
         if host is None:
@@ -93,7 +93,7 @@ class AggregateStats:
             return None
 
         if isinstance(what, MutableMapping):
-            self.custom[host][which] = merge_hash(self.custom[host][which], what)
+            self.custom[host][which] = merge_hash(self.custom[host][which], what, list_merge=list_merge)
         else:
             # let overloaded + take care of other types
             self.custom[host][which] += what

--- a/lib/ansible/modules/set_stats.py
+++ b/lib/ansible/modules/set_stats.py
@@ -31,6 +31,13 @@ options:
         - Whether the provided value is aggregated to the existing stat C(yes) or will replace it C(no).
     type: bool
     default: yes
+  list_merge:
+    description:
+        - Set list merge behaviour on aggregating existing stat.
+        - See L(Combining hashes/dictionaries,https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#combining-hashes-dictionaries).
+    type: str
+    default: replace
+    choices: [ replace, keep, append, prepend, append_rp, prepend_rp ]
 extends_documentation_fragment:
     - action_common_attributes
     - action_common_attributes.conn

--- a/lib/ansible/plugins/action/set_fact.py
+++ b/lib/ansible/plugins/action/set_fact.py
@@ -40,6 +40,8 @@ class ActionModule(ActionBase):
 
         facts = {}
         cacheable = boolean(self._task.args.pop('cacheable', False))
+        aggregate = boolean(self._task.args.pop('aggregate', False))
+        list_merge = self._task.args.pop('list_merge', 'replace')
 
         if self._task.args:
             for (k, v) in self._task.args.items():
@@ -61,6 +63,8 @@ class ActionModule(ActionBase):
             # just as _facts actions, we don't set changed=true as we are not modifying the actual host
             result['ansible_facts'] = facts
             result['_ansible_facts_cacheable'] = cacheable
+            result['_ansible_facts_aggregate'] = aggregate
+            result['_ansible_facts_list_merge'] = list_merge
         else:
             # this should not happen, but JIC we get here
             raise AnsibleActionFail('Unable to create any variables with provided arguments')

--- a/lib/ansible/plugins/action/set_stats.py
+++ b/lib/ansible/plugins/action/set_stats.py
@@ -18,7 +18,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.module_utils.six import string_types
+from ansible.module_utils.six import iteritems, string_types
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.action import ActionBase
 from ansible.utils.vars import isidentifier
@@ -27,7 +27,7 @@ from ansible.utils.vars import isidentifier
 class ActionModule(ActionBase):
 
     TRANSFERS_FILES = False
-    _VALID_ARGS = frozenset(('aggregate', 'data', 'per_host'))
+    _VALID_ARGS = frozenset(('aggregate', 'data', 'per_host', 'list_merge'))
 
     # TODO: document this in non-empty set_stats.py module
     def run(self, tmp=None, task_vars=None):
@@ -37,7 +37,7 @@ class ActionModule(ActionBase):
         result = super(ActionModule, self).run(tmp, task_vars)
         del tmp  # tmp no longer has any effect
 
-        stats = {'data': {}, 'per_host': False, 'aggregate': True}
+        stats = {'data': {}, 'per_host': False, 'aggregate': True, 'list_merge': 'replace'}
 
         if self._task.args:
             data = self._task.args.get('data', {})
@@ -58,6 +58,10 @@ class ActionModule(ActionBase):
                         stats[opt] = boolean(self._templar.template(val), strict=False)
                     else:
                         stats[opt] = val
+            # set list_merge option
+            list_merge = self._task.args.get('list_merge', None)
+            if (val is not None) and isinstance(list_merge, str):
+                stats[opt] = list_merge
 
             for (k, v) in data.items():
 

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -698,6 +698,8 @@ class StrategyBase:
                                     self._variable_manager.set_host_variable(target_host, var_name, var_value)
                         else:
                             cacheable = result_item.pop('_ansible_facts_cacheable', False)
+                            aggregate = result_item.pop('_ansible_facts_aggregate', False)
+                            list_merge = result_item.pop('_ansible_facts_list_merge', "replace")
                             for target_host in host_list:
                                 # so set_fact is a misnomer but 'cacheable = true' was meant to create an 'actual fact'
                                 # to avoid issues with precedence and confusion with set_fact normal operation,
@@ -708,7 +710,7 @@ class StrategyBase:
                                 if not is_set_fact or cacheable:
                                     self._variable_manager.set_host_facts(target_host, result_item['ansible_facts'].copy())
                                 if is_set_fact:
-                                    self._variable_manager.set_nonpersistent_facts(target_host, result_item['ansible_facts'].copy())
+                                    self._variable_manager.set_nonpersistent_facts(target_host, result_item['ansible_facts'].copy(), aggregate, list_merge)
 
                     if 'ansible_stats' in result_item and 'data' in result_item['ansible_stats'] and result_item['ansible_stats']['data']:
 

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -722,7 +722,7 @@ class StrategyBase:
                         for myhost in host_list:
                             for k in data.keys():
                                 if aggregate:
-                                    self._tqm._stats.update_custom_stats(k, data[k], myhost)
+                                    self._tqm._stats.update_custom_stats(k, data[k], myhost, list_merge=result_item['ansible_stats']['list_merge'])
                                 else:
                                     self._tqm._stats.set_custom_stats(k, data[k], myhost)
 


### PR DESCRIPTION
##### SUMMARY
Added the ability to aggregate set_fact data.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
set_fact

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
With this option, we are able to specify aggregate policy on set_fact action plugin. this way if a fact have been defined before, by specifying aggregate we can update(aggregate) that fact.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Setting some facts
  set_fact:
    some_fact:
       new_fact_key: fact_value
    some_list_fact:
       - value2
    aggregate: yes
    list_merge: 'append_rp'
```
