### PR TITLE
group2 - switch to setup_remote_tmp_dir instead of using output_dir

### DIFF
--- a/test/integration/targets/apt_key/meta/main.yml
+++ b/test/integration/targets/apt_key/meta/main.yml
@@ -1,3 +1,2 @@
 dependencies:
   - prepare_tests
-  - setup_remote_tmp_dir

--- a/test/integration/targets/apt_key/tasks/main.yml
+++ b/test/integration/targets/apt_key/tasks/main.yml
@@ -16,14 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- set_fact: output_dir_test={{output_dir}}/apt_key
-
-- name: make sure our testing sub-directory does not exist
-  file: path="{{ output_dir_test }}" state=absent
-
-- name: create our testing sub-directory
-  file: path="{{ output_dir_test }}" state=directory
-
 - import_tasks: 'apt_key.yml'
   when: ansible_distribution in ('Ubuntu', 'Debian')
 

--- a/test/integration/targets/assemble/meta/main.yml
+++ b/test/integration/targets/assemble/meta/main.yml
@@ -18,3 +18,4 @@
 
 dependencies:
   - prepare_tests
+  - setup_remote_tmp_dir

--- a/test/integration/targets/assemble/tasks/main.yml
+++ b/test/integration/targets/assemble/tasks/main.yml
@@ -16,21 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- name: create a new directory for file source
-  file: dest="{{output_dir}}/src" state=directory
-  register: result
-
-- name: assert the directory was created
-  assert:
-    that:
-    - "result.state == 'directory'"
-
 - name: copy the files to a new directory
-  copy: src="./" dest="{{output_dir}}/src"
+  copy: src="./" dest="{{remote_tmp_dir}}/src"
   register: result
 
 - name: create unicode file for test
-  shell: echo "π" > {{ output_dir }}/src/ßΩ.txt
+  shell: echo "π" > {{ remote_tmp_dir }}/src/ßΩ.txt
   register: result
 
 - name: assert that the new file was created
@@ -39,7 +30,7 @@
     - "result.changed == true"
 
 - name: test assemble with all fragments
-  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled1"
+  assemble: src="{{remote_tmp_dir}}/src" dest="{{remote_tmp_dir}}/assembled1"
   register: result
 
 - name: assert the fragments were assembled
@@ -50,7 +41,7 @@
     - "result.checksum == '74152e9224f774191bc0bedf460d35de86ad90e6'"
 
 - name: test assemble with all fragments
-  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled1"
+  assemble: src="{{remote_tmp_dir}}/src" dest="{{remote_tmp_dir}}/assembled1"
   register: result
 
 - name: assert that the same assemble made no changes
@@ -61,7 +52,7 @@
     - "result.checksum == '74152e9224f774191bc0bedf460d35de86ad90e6'"
 
 - name: test assemble with all fragments and decrypt=True
-  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled2" decrypt=yes
+  assemble: src="{{remote_tmp_dir}}/src" dest="{{remote_tmp_dir}}/assembled2" decrypt=yes
   register: result
 
 - name: assert the fragments were assembled with decrypt=True
@@ -72,7 +63,7 @@
     - "result.checksum == '74152e9224f774191bc0bedf460d35de86ad90e6'"
 
 - name: test assemble with all fragments and decrypt=True
-  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled2" decrypt=yes
+  assemble: src="{{remote_tmp_dir}}/src" dest="{{remote_tmp_dir}}/assembled2" decrypt=yes
   register: result
 
 - name: assert that the same assemble made no changes with decrypt=True
@@ -83,7 +74,7 @@
     - "result.checksum == '74152e9224f774191bc0bedf460d35de86ad90e6'"
 
 - name: test assemble with fragments matching a regex
-  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled3" regexp="^fragment[1-3]$"
+  assemble: src="{{remote_tmp_dir}}/src" dest="{{remote_tmp_dir}}/assembled3" regexp="^fragment[1-3]$"
   register: result
 
 - name: assert the fragments were assembled with a regex
@@ -93,7 +84,7 @@
     - "result.checksum == 'edfe2d7487ef8f5ebc0f1c4dc57ba7b70a7b8e2b'"
 
 - name: test assemble with fragments matching a regex and decrypt=True
-  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled4" regexp="^fragment[1-3]$" decrypt=yes
+  assemble: src="{{remote_tmp_dir}}/src" dest="{{remote_tmp_dir}}/assembled4" regexp="^fragment[1-3]$" decrypt=yes
   register: result
 
 - name: assert the fragments were assembled with a regex and decrypt=True
@@ -103,7 +94,7 @@
     - "result.checksum == 'edfe2d7487ef8f5ebc0f1c4dc57ba7b70a7b8e2b'"
 
 - name: test assemble with a delimiter
-  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled5" delimiter="#--- delimiter ---#"
+  assemble: src="{{remote_tmp_dir}}/src" dest="{{remote_tmp_dir}}/assembled5" delimiter="#--- delimiter ---#"
   register: result
 
 - name: assert the fragments were assembled with a delimiter
@@ -113,7 +104,7 @@
     - "result.checksum == 'd986cefb82e34e4cf14d33a3cda132ff45aa2980'"
 
 - name: test assemble with a delimiter and decrypt=True
-  assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled6" delimiter="#--- delimiter ---#" decrypt=yes
+  assemble: src="{{remote_tmp_dir}}/src" dest="{{remote_tmp_dir}}/assembled6" delimiter="#--- delimiter ---#" decrypt=yes
   register: result
 
 - name: assert the fragments were assembled with a delimiter and decrypt=True
@@ -123,7 +114,7 @@
     - "result.checksum == 'd986cefb82e34e4cf14d33a3cda132ff45aa2980'"
 
 - name: test assemble with remote_src=False
-  assemble: src="./" dest="{{output_dir}}/assembled7" remote_src=no
+  assemble: src="./" dest="{{remote_tmp_dir}}/assembled7" remote_src=no
   register: result
 
 - name: assert the fragments were assembled without remote
@@ -133,7 +124,7 @@
     - "result.checksum == '048a1bd1951aa5ccc427eeb4ca19aee45e9c68b3'"
 
 - name: test assemble with remote_src=False and decrypt=True
-  assemble: src="./" dest="{{output_dir}}/assembled8" remote_src=no decrypt=yes
+  assemble: src="./" dest="{{remote_tmp_dir}}/assembled8" remote_src=no decrypt=yes
   register: result
 
 - name: assert the fragments were assembled without remote and decrypt=True
@@ -143,7 +134,7 @@
     - "result.checksum == '048a1bd1951aa5ccc427eeb4ca19aee45e9c68b3'"
 
 - name: test assemble with remote_src=False and a delimiter
-  assemble: src="./" dest="{{output_dir}}/assembled9" remote_src=no delimiter="#--- delimiter ---#"
+  assemble: src="./" dest="{{remote_tmp_dir}}/assembled9" remote_src=no delimiter="#--- delimiter ---#"
   register: result
 
 - name: assert the fragments were assembled without remote
@@ -153,7 +144,7 @@
     - "result.checksum == '505359f48c65b3904127cf62b912991d4da7ed6d'"
 
 - name: test assemble with remote_src=False and a delimiter and decrypt=True
-  assemble: src="./" dest="{{output_dir}}/assembled10" remote_src=no delimiter="#--- delimiter ---#" decrypt=yes
+  assemble: src="./" dest="{{remote_tmp_dir}}/assembled10" remote_src=no delimiter="#--- delimiter ---#" decrypt=yes
   register: result
 
 - name: assert the fragments were assembled without remote

--- a/test/integration/targets/binary/meta/main.yml
+++ b/test/integration/targets/binary/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
   - prepare_tests
+  - setup_remote_tmp_dir

--- a/test/integration/targets/binary/tasks/main.yml
+++ b/test/integration/targets/binary/tasks/main.yml
@@ -12,37 +12,37 @@
 - name: get checksums that we expect later files to have
   copy:
     src: from_playbook
-    dest: "{{ output_dir }}"
+    dest: "{{ remote_tmp_dir }}"
 
 - copy:
     src: b64_utf8
-    dest: "{{ output_dir }}"
+    dest: "{{ remote_tmp_dir }}"
 
 - copy:
     src: b64_latin1
-    dest: "{{ output_dir }}"
+    dest: "{{ remote_tmp_dir }}"
 
 - stat:
-    path: "{{ output_dir }}/from_playbook"
+    path: "{{ remote_tmp_dir }}/from_playbook"
   register: from_playbook
 
 - stat:
-    path: "{{ output_dir }}/b64_utf8"
+    path: "{{ remote_tmp_dir }}/b64_utf8"
   register: b64_utf8
 
 - stat:
-    path: "{{ output_dir }}/b64_latin1"
+    path: "{{ remote_tmp_dir }}/b64_latin1"
   register: b64_latin1
 
 # Tests themselves
 - name: copy with utf-8 content in a playbook
   copy:
     content: "{{ simple_accents }}\n"
-    dest: "{{ output_dir }}/from_playbook.txt"
+    dest: "{{ remote_tmp_dir }}/from_playbook.txt"
 
 - name: Check that copying utf-8 content matches
   stat:
-    path: "{{ output_dir }}/from_playbook.txt"
+    path: "{{ remote_tmp_dir }}/from_playbook.txt"
   register: results
 
 - assert:
@@ -52,11 +52,11 @@
 - name: copy with utf8 in a base64 encoded string
   copy:
     content: "{{ utf8_simple_accents|b64decode }}\n"
-    dest: "{{ output_dir }}/b64_utf8.txt"
+    dest: "{{ remote_tmp_dir }}/b64_utf8.txt"
 
 - name: Check that utf8 in a base64 string matches
   stat:
-    path: "{{ output_dir }}/b64_utf8.txt"
+    path: "{{ remote_tmp_dir }}/b64_utf8.txt"
   register: results
 
 - assert:
@@ -66,11 +66,11 @@
 - name: copy with latin1 in a base64 encoded string
   copy:
     content: "{{ latin1_simple_accents|b64decode }}\n"
-    dest: "{{ output_dir }}/b64_latin1.txt"
+    dest: "{{ remote_tmp_dir }}/b64_latin1.txt"
 
 - name: Check that latin1 in a base64 string matches
   stat:
-    path: "{{ output_dir }}/b64_latin1.txt"
+    path: "{{ remote_tmp_dir }}/b64_latin1.txt"
   register: results
 
 - assert:
@@ -83,11 +83,11 @@
 - name: Template with a unicode string from the playbook
   template:
     src: "from_playbook_template.j2"
-    dest: "{{ output_dir }}/from_playbook_template.txt"
+    dest: "{{ remote_tmp_dir }}/from_playbook_template.txt"
 
 - name: Check that writing a template from a playbook var matches
   stat:
-    path: "{{ output_dir }}/from_playbook_template.txt"
+    path: "{{ remote_tmp_dir }}/from_playbook_template.txt"
   register: results
 
 - assert:
@@ -97,11 +97,11 @@
 - name: Template with utf8 in a base64 encoded string
   template:
     src: "b64_utf8_template.j2"
-    dest: "{{ output_dir }}/b64_utf8_template.txt"
+    dest: "{{ remote_tmp_dir }}/b64_utf8_template.txt"
 
 - name: Check that writing a template from a base64 encoded utf8 string matches
   stat:
-    path: "{{ output_dir }}/b64_utf8_template.txt"
+    path: "{{ remote_tmp_dir }}/b64_utf8_template.txt"
   register: results
 
 - assert:
@@ -111,11 +111,11 @@
 - name: Template with latin1 in a base64 encoded string
   template:
     src: "b64_latin1_template.j2"
-    dest: "{{ output_dir }}/b64_latin1_template.txt"
+    dest: "{{ remote_tmp_dir }}/b64_latin1_template.txt"
 
 - name: Check that writing a template from a base64 encoded latin1 string matches
   stat:
-    path: "{{ output_dir }}/b64_latin1_template.txt"
+    path: "{{ remote_tmp_dir }}/b64_latin1_template.txt"
   register: results
 
 - assert:

--- a/test/integration/targets/command_shell/meta/main.yml
+++ b/test/integration/targets/command_shell/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
   - prepare_tests
+  - setup_remote_tmp_dir

--- a/test/integration/targets/command_shell/tasks/main.yml
+++ b/test/integration/targets/command_shell/tasks/main.yml
@@ -554,8 +554,9 @@
     assert:
       that:
         - parent_dir_chdir.stdout != parent_dir_cd.stdout
-        - 'parent_dir_cd.stdout == "{{remote_tmp_dir}}/www"'
-        - 'parent_dir_chdir.stdout == "{{remote_tmp_dir}}/www_root"'
+        # These tests use endswith, to get around /private/tmp on macos
+        - 'parent_dir_cd.stdout.endswith(remote_tmp_dir ~ "/www")'
+        - 'parent_dir_chdir.stdout.endswith(remote_tmp_dir ~ "/www_root")'
 
 - name: Set print error command for Python 2
   set_fact:

--- a/test/integration/targets/command_shell/tasks/main.yml
+++ b/test/integration/targets/command_shell/tasks/main.yml
@@ -60,34 +60,34 @@
       - argv_and_string_command.rc == 256
 
 - set_fact:
-    output_dir_test: "{{ output_dir }}/test_command_shell"
+    remote_tmp_dir_test: "{{ remote_tmp_dir }}/test_command_shell"
 
 - name: make sure our testing sub-directory does not exist
   file:
-    path: "{{ output_dir_test }}"
+    path: "{{ remote_tmp_dir_test }}"
     state: absent
 
 - name: create our testing sub-directory
   file:
-    path: "{{ output_dir_test }}"
+    path: "{{ remote_tmp_dir_test }}"
     state: directory
 
 - name: prep our test script
   copy:
     src: test.sh
-    dest: "{{ output_dir_test }}"
+    dest: "{{ remote_tmp_dir_test }}"
     mode: '0755'
 
 - name: prep our test script
   copy:
     src: create_afile.sh
-    dest: "{{ output_dir_test }}"
+    dest: "{{ remote_tmp_dir_test }}"
     mode: '0755'
 
 - name: prep our test script
   copy:
     src: remove_afile.sh
-    dest: "{{ output_dir_test }}"
+    dest: "{{ remote_tmp_dir_test }}"
     mode: '0755'
 
 - name: locate bash
@@ -99,7 +99,7 @@
 ##
 
 - name: execute the test.sh script via command
-  command: "{{ output_dir_test }}/test.sh"
+  command: "{{ remote_tmp_dir_test }}/test.sh"
   register: command_result0
 
 - name: assert that the script executed correctly
@@ -114,7 +114,7 @@
 # FIXME doesn't have the expected stdout.
 
 #- name: execute the test.sh script with executable via command
-#  command: "{{output_dir_test }}/test.sh executable={{ bash.stdout }}"
+#  command: "{{remote_tmp_dir_test }}/test.sh executable={{ bash.stdout }}"
 #  register: command_result1
 #
 #- name: assert that the script executed correctly with command
@@ -129,13 +129,13 @@
 - name: execute the test.sh script with chdir via command
   command: ./test.sh
   args:
-    chdir: "{{ output_dir_test }}"
+    chdir: "{{ remote_tmp_dir_test }}"
   register: command_result2
 
 - name: Check invalid chdir
   command: echo
   args:
-    chdir: "{{ output_dir }}/nope"
+    chdir: "{{ remote_tmp_dir }}/nope"
   ignore_errors: yes
   register: chdir_invalid
 
@@ -152,13 +152,13 @@
 
 - name: verify that afile.txt is absent
   file:
-    path: "{{ output_dir_test }}/afile.txt"
+    path: "{{ remote_tmp_dir_test }}/afile.txt"
     state: absent
 
 - name: create afile.txt with create_afile.sh via command (check mode)
-  command: "{{ output_dir_test }}/create_afile.sh {{output_dir_test }}/afile.txt"
+  command: "{{ remote_tmp_dir_test }}/create_afile.sh {{remote_tmp_dir_test }}/afile.txt"
   args:
-    creates: "{{ output_dir_test }}/afile.txt"
+    creates: "{{ remote_tmp_dir_test }}/afile.txt"
   register: check_mode_result
   check_mode: yes
 
@@ -169,24 +169,24 @@
 
 - name: verify that afile.txt still does not exist
   stat:
-    path: "{{output_dir_test}}/afile.txt"
+    path: "{{remote_tmp_dir_test}}/afile.txt"
   register: stat_result
   failed_when: stat_result.stat.exists
 
 - name: create afile.txt with create_afile.sh via command
-  command: "{{ output_dir_test }}/create_afile.sh {{output_dir_test }}/afile.txt"
+  command: "{{ remote_tmp_dir_test }}/create_afile.sh {{remote_tmp_dir_test }}/afile.txt"
   args:
-    creates: "{{ output_dir_test }}/afile.txt"
+    creates: "{{ remote_tmp_dir_test }}/afile.txt"
 
 - name: verify that afile.txt is present
   file:
-    path: "{{ output_dir_test }}/afile.txt"
+    path: "{{ remote_tmp_dir_test }}/afile.txt"
     state: file
 
 - name: re-run previous command using creates with globbing (check mode)
-  command: "{{ output_dir_test }}/create_afile.sh {{ output_dir_test }}/afile.txt"
+  command: "{{ remote_tmp_dir_test }}/create_afile.sh {{ remote_tmp_dir_test }}/afile.txt"
   args:
-    creates: "{{ output_dir_test }}/afile.*"
+    creates: "{{ remote_tmp_dir_test }}/afile.*"
   register: check_mode_result
   check_mode: yes
 
@@ -196,9 +196,9 @@
       - "'skipped' not in check_mode_result"
 
 - name: re-run previous command using creates with globbing
-  command: "{{ output_dir_test }}/create_afile.sh {{ output_dir_test }}/afile.txt"
+  command: "{{ remote_tmp_dir_test }}/create_afile.sh {{ remote_tmp_dir_test }}/afile.txt"
   args:
-    creates: "{{ output_dir_test }}/afile.*"
+    creates: "{{ remote_tmp_dir_test }}/afile.*"
   register: command_result3
 
 - name: assert that creates with globbing is working
@@ -209,9 +209,9 @@
 # removes
 
 - name: remove afile.txt with remote_afile.sh via command (check mode)
-  command: "{{ output_dir_test }}/remove_afile.sh {{ output_dir_test }}/afile.txt"
+  command: "{{ remote_tmp_dir_test }}/remove_afile.sh {{ remote_tmp_dir_test }}/afile.txt"
   args:
-    removes: "{{ output_dir_test }}/afile.txt"
+    removes: "{{ remote_tmp_dir_test }}/afile.txt"
   register: check_mode_result
   check_mode: yes
 
@@ -222,22 +222,22 @@
 
 - name: verify that afile.txt still exists
   stat:
-    path: "{{output_dir_test}}/afile.txt"
+    path: "{{remote_tmp_dir_test}}/afile.txt"
   register: stat_result
   failed_when: not stat_result.stat.exists
 
 - name: remove afile.txt with remote_afile.sh via command
-  command: "{{ output_dir_test }}/remove_afile.sh {{ output_dir_test }}/afile.txt"
+  command: "{{ remote_tmp_dir_test }}/remove_afile.sh {{ remote_tmp_dir_test }}/afile.txt"
   args:
-    removes: "{{ output_dir_test }}/afile.txt"
+    removes: "{{ remote_tmp_dir_test }}/afile.txt"
 
 - name: verify that afile.txt is absent
-  file: path={{output_dir_test}}/afile.txt state=absent
+  file: path={{remote_tmp_dir_test}}/afile.txt state=absent
 
 - name: re-run previous command using removes with globbing (check mode)
-  command: "{{ output_dir_test }}/remove_afile.sh {{ output_dir_test }}/afile.txt"
+  command: "{{ remote_tmp_dir_test }}/remove_afile.sh {{ remote_tmp_dir_test }}/afile.txt"
   args:
-    removes: "{{ output_dir_test }}/afile.*"
+    removes: "{{ remote_tmp_dir_test }}/afile.*"
   register: check_mode_result
   check_mode: yes
 
@@ -247,9 +247,9 @@
       - "'skipped' not in check_mode_result"
 
 - name: re-run previous command using removes with globbing
-  command: "{{ output_dir_test }}/remove_afile.sh {{ output_dir_test }}/afile.txt"
+  command: "{{ remote_tmp_dir_test }}/remove_afile.sh {{ remote_tmp_dir_test }}/afile.txt"
   args:
-    removes: "{{ output_dir_test }}/afile.*"
+    removes: "{{ remote_tmp_dir_test }}/afile.*"
   register: command_result4
 
 - name: assert that removes with globbing is working
@@ -289,14 +289,14 @@
 ##
 
 - name: Execute the test.sh script
-  shell: "{{ output_dir_test }}/test.sh"
+  shell: "{{ remote_tmp_dir_test }}/test.sh"
   register: shell_result0
 
 - name: Assert that the script executed correctly
   assert:
     that:
     - shell_result0 is changed
-    - shell_result0.cmd == '{{ output_dir_test }}/test.sh'
+    - shell_result0.cmd == '{{ remote_tmp_dir_test }}/test.sh'
     - shell_result0.rc == 0
     - shell_result0.stderr == ''
     - shell_result0.stdout == 'win'
@@ -306,7 +306,7 @@
 # FIXME doesn't pass the expected stdout
 
 #- name: execute the test.sh script
-#  shell: "{{output_dir_test }}/test.sh executable={{ bash.stdout }}"
+#  shell: "{{remote_tmp_dir_test }}/test.sh executable={{ bash.stdout }}"
 #  register: shell_result1
 #
 #- name: assert that the shell executed correctly
@@ -321,7 +321,7 @@
 - name: Execute the test.sh script with chdir
   shell: ./test.sh
   args:
-    chdir: "{{ output_dir_test }}"
+    chdir: "{{ remote_tmp_dir_test }}"
   register: shell_result2
 
 - name: Assert that the shell executed correctly with chdir
@@ -337,25 +337,25 @@
 
 - name: Verify that afile.txt is absent
   file:
-    path: "{{ output_dir_test }}/afile.txt"
+    path: "{{ remote_tmp_dir_test }}/afile.txt"
     state: absent
 
 - name: Execute the test.sh script with chdir
-  shell: "{{ output_dir_test }}/test.sh > {{ output_dir_test }}/afile.txt"
+  shell: "{{ remote_tmp_dir_test }}/test.sh > {{ remote_tmp_dir_test }}/afile.txt"
   args:
-    chdir: "{{ output_dir_test }}"
-    creates: "{{ output_dir_test }}/afile.txt"
+    chdir: "{{ remote_tmp_dir_test }}"
+    creates: "{{ remote_tmp_dir_test }}/afile.txt"
 
 - name: Verify that afile.txt is present
   file:
-    path: "{{ output_dir_test }}/afile.txt"
+    path: "{{ remote_tmp_dir_test }}/afile.txt"
     state: file
 
 # multiline
 
 - name: Remove test file previously created
   file:
-    path: "{{ output_dir_test }}/afile.txt"
+    path: "{{ remote_tmp_dir_test }}/afile.txt"
     state: absent
 
 - name: Execute a shell command using a literal multiline block
@@ -381,7 +381,7 @@
 - name: Execute a shell command using a literal multiline block with arguments in it
   shell: |
     executable="{{ bash.stdout }}"
-    creates={{ output_dir_test }}/afile.txt
+    creates={{ remote_tmp_dir_test }}/afile.txt
     echo "test"
   register: shell_result6
 
@@ -411,14 +411,14 @@
     - shell_result7.stdout == 'One\n  Two\n    Three'
 
 - name: execute a shell command with no trailing newline to stdin
-  shell: cat > {{output_dir_test }}/afile.txt
+  shell: cat > {{remote_tmp_dir_test }}/afile.txt
   args:
     stdin: test
     stdin_add_newline: no
 
 - name: make sure content matches expected
   copy:
-    dest: "{{output_dir_test }}/afile.txt"
+    dest: "{{remote_tmp_dir_test }}/afile.txt"
     content: test
   register: shell_result7
   failed_when:
@@ -426,14 +426,14 @@
       shell_result7 is changed
 
 - name: execute a shell command with trailing newline to stdin
-  shell: cat > {{output_dir_test }}/afile.txt
+  shell: cat > {{remote_tmp_dir_test }}/afile.txt
   args:
     stdin: test
     stdin_add_newline: yes
 
 - name: make sure content matches expected
   copy:
-    dest: "{{output_dir_test }}/afile.txt"
+    dest: "{{remote_tmp_dir_test }}/afile.txt"
     content: |
         test
   register: shell_result8
@@ -442,13 +442,13 @@
       shell_result8 is changed
 
 - name: execute a shell command with trailing newline to stdin, default
-  shell: cat > {{output_dir_test }}/afile.txt
+  shell: cat > {{remote_tmp_dir_test }}/afile.txt
   args:
     stdin: test
 
 - name: make sure content matches expected
   copy:
-    dest: "{{output_dir_test }}/afile.txt"
+    dest: "{{remote_tmp_dir_test }}/afile.txt"
     content: |
         test
   register: shell_result9
@@ -458,7 +458,7 @@
 
 - name: remove the previously created file
   file:
-    path: "{{ output_dir_test }}/afile.txt"
+    path: "{{ remote_tmp_dir_test }}/afile.txt"
     state: absent
 
 - name: test warning with command
@@ -531,31 +531,31 @@
   block:
   - name: Create target folders
     file:
-      path: '{{output_dir}}/www_root/site'
+      path: '{{remote_tmp_dir}}/www_root/site'
       state: directory
 
   - name: Create symlink
     file:
-      path: '{{output_dir}}/www'
+      path: '{{remote_tmp_dir}}/www'
       state: link
-      src: '{{output_dir}}/www_root'
+      src: '{{remote_tmp_dir}}/www_root'
 
   - name: check parent using chdir
     shell: dirname "$PWD"
     args:
-      chdir: '{{output_dir}}/www/site'
+      chdir: '{{remote_tmp_dir}}/www/site'
     register: parent_dir_chdir
 
   - name: check parent using cd
-    shell: cd "{{output_dir}}/www/site" && dirname "$PWD"
+    shell: cd "{{remote_tmp_dir}}/www/site" && dirname "$PWD"
     register: parent_dir_cd
 
   - name: check expected outputs
     assert:
       that:
         - parent_dir_chdir.stdout != parent_dir_cd.stdout
-        - 'parent_dir_cd.stdout == "{{output_dir}}/www"'
-        - 'parent_dir_chdir.stdout == "{{output_dir}}/www_root"'
+        - 'parent_dir_cd.stdout == "{{remote_tmp_dir}}/www"'
+        - 'parent_dir_chdir.stdout == "{{remote_tmp_dir}}/www_root"'
 
 - name: Set print error command for Python 2
   set_fact:

--- a/test/integration/targets/copy/meta/main.yml
+++ b/test/integration/targets/copy/meta/main.yml
@@ -1,3 +1,4 @@
 dependencies:
   - prepare_tests
   - setup_nobody
+  - setup_remote_tmp_dir

--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -7,7 +7,7 @@
 
     - set_fact:
         local_temp_dir: '{{ tempfile_result.stdout }}'
-        remote_dir: '{{ output_dir }}'
+        remote_dir: '{{ remote_tmp_dir }}/copy'
         symlinks:
           ansible-test-abs-link: /tmp/ansible-test-abs-link
           ansible-test-abs-link-dir: /tmp/ansible-test-abs-link-dir

--- a/test/integration/targets/copy/tasks/tests.yml
+++ b/test/integration/targets/copy/tasks/tests.yml
@@ -2263,7 +2263,7 @@
 - name: fail to copy an encrypted file without the password set
   copy:
     src: '{{role_path}}/files-different/vault/vault-file'
-    dest: '{{output_dir}}/file'
+    dest: '{{remote_tmp_dir}}/copy/file'
   register: fail_copy_encrypted_file
   ignore_errors: yes # weird failed_when doesn't work in this case
 
@@ -2276,7 +2276,7 @@
 - name: fail to copy a directory with an encrypted file without the password
   copy:
     src: '{{role_path}}/files-different/vault'
-    dest: '{{output_dir}}'
+    dest: '{{remote_tmp_dir}}/copy'
   register: fail_copy_directory_with_enc_file
   ignore_errors: yes
 

--- a/test/integration/targets/expect/meta/main.yml
+++ b/test/integration/targets/expect/meta/main.yml
@@ -1,3 +1,2 @@
 dependencies:
-  - prepare_tests
   - setup_remote_tmp_dir

--- a/test/integration/targets/expect/tasks/main.yml
+++ b/test/integration/targets/expect/tasks/main.yml
@@ -20,13 +20,13 @@
     name: setup_pexpect
 
 - name: record the test_command file
-  set_fact: test_command_file={{output_dir | expanduser}}/test_command.py
+  set_fact: test_command_file={{remote_tmp_dir | expanduser}}/test_command.py
 
 - name: copy script into output directory
   copy: src=test_command.py dest={{test_command_file}} mode=0444
 
 - name: record the output file
-  set_fact: output_file={{output_dir}}/foo.txt
+  set_fact: output_file={{remote_tmp_dir}}/foo.txt
 
 - copy:
    content: "foo"
@@ -104,7 +104,7 @@
 - name: test chdir
   expect:
     command: "/bin/sh -c 'pwd && sleep 1'"
-    chdir: "{{output_dir}}"
+    chdir: "{{remote_tmp_dir}}"
     responses:
       foo: bar
   register: chdir_result
@@ -112,7 +112,7 @@
 - name: assert chdir works
   assert:
     that:
-    - "'{{chdir_result.stdout |expanduser | realpath }}' == '{{output_dir | expanduser | realpath}}'"
+    - "'{{chdir_result.stdout |expanduser | realpath }}' == '{{remote_tmp_dir | expanduser | realpath}}'"
 
 - name: test timeout option
   expect:

--- a/test/integration/targets/file/meta/main.yml
+++ b/test/integration/targets/file/meta/main.yml
@@ -1,3 +1,4 @@
 dependencies:
   - prepare_tests
   - setup_nobody
+  - setup_remote_tmp_dir

--- a/test/integration/targets/file/tasks/directory_as_dest.yml
+++ b/test/integration/targets/file/tasks/directory_as_dest.yml
@@ -15,12 +15,12 @@
 
 - name: create a test sub-directory
   file:
-    dest: '{{output_dir}}/sub1'
+    dest: '{{remote_tmp_dir_test}}/sub1'
     state: directory
 
 - name: create a file for linking to
   copy:
-    dest: '{{output_dir}}/file_to_link'
+    dest: '{{remote_tmp_dir_test}}/file_to_link'
     content: 'Hello World'
 
 #
@@ -30,7 +30,7 @@
 # file raises an error
 - name: Try to create a file with directory as dest
   file:
-    dest: '{{output_dir}}/sub1'
+    dest: '{{remote_tmp_dir_test}}/sub1'
     state: file
     force: False
   ignore_errors: True
@@ -38,7 +38,7 @@
 
 - name: Get stat info to show the directory has not been changed to a file
   stat:
-    path: '{{ output_dir }}/sub1'
+    path: '{{ remote_tmp_dir_test }}/sub1'
     follow: False
   register: file1_dir_stat
 
@@ -51,8 +51,8 @@
 # link raises an error
 - name: Try to create a symlink with directory as dest
   file:
-    src: '{{ output_dir }}/file_to_link'
-    dest: '{{output_dir}}/sub1'
+    src: '{{ remote_tmp_dir_test }}/file_to_link'
+    dest: '{{remote_tmp_dir_test}}/sub1'
     state: link
     force: False
   ignore_errors: True
@@ -60,7 +60,7 @@
 
 - name: Get stat info to show the directory has not been changed to a file
   stat:
-    path: '{{ output_dir }}/sub1'
+    path: '{{ remote_tmp_dir_test }}/sub1'
     follow: False
   register: file2_dir_stat
 
@@ -76,12 +76,12 @@
 
 - copy:
     content: 'test'
-    dest: '{{ output_dir }}/sub1/passwd'
+    dest: '{{ remote_tmp_dir_test }}/sub1/passwd'
 
 # file raises an error
 - name: Try to create a file with directory as dest
   file:
-    dest: '{{output_dir}}/sub1'
+    dest: '{{remote_tmp_dir_test}}/sub1'
     state: file
     force: True
   ignore_errors: True
@@ -89,7 +89,7 @@
 
 - name: Get stat info to show the directory has not been changed to a file
   stat:
-    path: '{{ output_dir }}/sub1'
+    path: '{{ remote_tmp_dir_test }}/sub1'
     follow: False
   register: file3_dir_stat
 
@@ -102,8 +102,8 @@
 # link raises an error
 - name: Try to create a symlink with directory as dest
   file:
-    src: '{{ output_dir }}/file_to_link'
-    dest: '{{output_dir}}/sub1'
+    src: '{{ remote_tmp_dir_test }}/file_to_link'
+    dest: '{{remote_tmp_dir_test}}/sub1'
     state: link
     force: True
   ignore_errors: True
@@ -111,7 +111,7 @@
 
 - name: Get stat info to show the directory has not been changed to a file
   stat:
-    path: '{{ output_dir }}/sub1'
+    path: '{{ remote_tmp_dir_test }}/sub1'
     follow: False
   register: file4_dir_stat
 
@@ -125,7 +125,7 @@
 - name: Cleanup the file that made the directory nonempty
   file:
     state: 'absent'
-    dest: '{{ output_dir }}/sub1/passwd'
+    dest: '{{ remote_tmp_dir_test }}/sub1/passwd'
 
 #
 # Error condition: file cannot even overwrite an empty directory with force=True
@@ -134,7 +134,7 @@
 # file raises an error
 - name: Try to create a file with directory as dest
   file:
-    dest: '{{output_dir}}/sub1'
+    dest: '{{remote_tmp_dir_test}}/sub1'
     state: file
     force: True
   ignore_errors: True
@@ -142,7 +142,7 @@
 
 - name: Get stat info to show the directory has not been changed to a file
   stat:
-    path: '{{ output_dir }}/sub1'
+    path: '{{ remote_tmp_dir_test }}/sub1'
     follow: False
   register: file5_dir_stat
 
@@ -159,15 +159,15 @@
 # link can overwrite an empty directory with force=True
 - name: Try to create a symlink with directory as dest
   file:
-    src: '{{ output_dir }}/file_to_link'
-    dest: '{{output_dir}}/sub1'
+    src: '{{ remote_tmp_dir_test }}/file_to_link'
+    dest: '{{remote_tmp_dir_test}}/sub1'
     state: link
     force: True
   register: file6_result
 
 - name: Get stat info to show the directory has been overwritten
   stat:
-    path: '{{ output_dir }}/sub1'
+    path: '{{ remote_tmp_dir_test }}/sub1'
     follow: False
   register: file6_dir_stat
 
@@ -184,12 +184,12 @@
 
 - name: Cleanup the test subdirectory
   file:
-    dest: '{{output_dir}}/sub1'
+    dest: '{{remote_tmp_dir_test}}/sub1'
     state: 'absent'
 
 - name: Re-create the test sub-directory
   file:
-    dest: '{{output_dir}}/sub1'
+    dest: '{{remote_tmp_dir_test}}/sub1'
     state: 'directory'
 
 #
@@ -198,8 +198,8 @@
 
 - name: Try to create a hardlink with directory as dest
   file:
-    src: '{{ output_dir }}/file_to_link'
-    dest: '{{ output_dir }}/sub1'
+    src: '{{ remote_tmp_dir_test }}/file_to_link'
+    dest: '{{ remote_tmp_dir_test }}/sub1'
     state: hard
     force: False
   ignore_errors: True
@@ -207,13 +207,13 @@
 
 - name: Get stat info to show the directory has not been changed to a file
   stat:
-    path: '{{ output_dir }}/sub1'
+    path: '{{ remote_tmp_dir_test }}/sub1'
     follow: False
   register: file7_dir_stat
 
 - name: Get stat info to show the link has been created
   stat:
-    path: '{{ output_dir }}/sub1/file_to_link'
+    path: '{{ remote_tmp_dir_test }}/sub1/file_to_link'
     follow: False
   register: file7_link_stat
 
@@ -238,7 +238,7 @@
 
 - name: Get initial stat info to compare with later
   stat:
-    path: '{{ output_dir }}/sub1'
+    path: '{{ remote_tmp_dir_test }}/sub1'
     follow: False
   register: file8_initial_dir_stat
 
@@ -248,14 +248,14 @@
 
 - name: Use touch with directory as dest
   file:
-    dest: '{{output_dir}}/sub1'
+    dest: '{{remote_tmp_dir_test}}/sub1'
     state: touch
     force: False
   register: file8_result
 
 - name: Get stat info to show the directory has not been changed to a file
   stat:
-    path: '{{ output_dir }}/sub1'
+    path: '{{ remote_tmp_dir_test }}/sub1'
     follow: False
   register: file8_dir_stat
 
@@ -268,13 +268,13 @@
 
 - name: Get initial stat info to compare with later
   stat:
-    path: '{{ output_dir }}/sub1'
+    path: '{{ remote_tmp_dir_test }}/sub1'
     follow: False
   register: file11_initial_dir_stat
 
 - name: Use touch with directory as dest and keep mtime and atime
   file:
-    dest: '{{output_dir}}/sub1'
+    dest: '{{remote_tmp_dir_test}}/sub1'
     state: touch
     force: False
     modification_time: preserve
@@ -283,7 +283,7 @@
 
 - name: Get stat info to show the directory has not been changed
   stat:
-    path: '{{ output_dir }}/sub1'
+    path: '{{ remote_tmp_dir_test }}/sub1'
     follow: False
   register: file11_dir_stat
 
@@ -300,20 +300,20 @@
 #
 - name: Get initial stat info to compare with later
   stat:
-    path: '{{ output_dir }}/sub1'
+    path: '{{ remote_tmp_dir_test }}/sub1'
     follow: False
   register: file9_initial_dir_stat
 
 - name: Use directory with directory as dest
   file:
-    dest: '{{output_dir}}/sub1'
+    dest: '{{remote_tmp_dir_test}}/sub1'
     state: directory
     force: False
   register: file9_result
 
 - name: Get stat info to show the directory has not been changed
   stat:
-    path: '{{ output_dir }}/sub1'
+    path: '{{ remote_tmp_dir_test }}/sub1'
     follow: False
   register: file9_dir_stat
 
@@ -326,14 +326,14 @@
 
 - name: Use directory with directory as dest and force=True
   file:
-    dest: '{{output_dir}}/sub1'
+    dest: '{{remote_tmp_dir_test}}/sub1'
     state: directory
     force: True
   register: file10_result
 
 - name: Get stat info to show the directory has not been changed
   stat:
-    path: '{{ output_dir }}/sub1'
+    path: '{{ remote_tmp_dir_test }}/sub1'
     follow: False
   register: file10_dir_stat
 

--- a/test/integration/targets/file/tasks/initialize.yml
+++ b/test/integration/targets/file/tasks/initialize.yml
@@ -3,12 +3,12 @@
 #
 - name: Cleanup the output directory
   file:
-    dest: '{{ output_dir }}'
+    dest: '{{ remote_tmp_dir_test }}'
     state: 'absent'
 
 - name: Recreate the toplevel output dir
   file:
-    dest: '{{ output_dir }}'
+    dest: '{{ remote_tmp_dir_test }}'
     state: 'directory'
 
 - name: prep with a basic file to operate on

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -16,7 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- set_fact: output_file={{output_dir}}/foo.txt
+- set_fact:
+    output_file: '{{remote_tmp_dir}}/foo.txt'
+    remote_tmp_dir_test: '{{ remote_tmp_dir }}/file'
 
 # same as expanduser & expandvars called on managed host
 - command: 'echo {{ output_file }}'
@@ -81,7 +83,7 @@
       - "'cannot continue' in ghost_file_result.msg"
 
 - name: verify that we are checking an absent file
-  file: path={{output_dir}}/bar.txt state=absent
+  file: path={{remote_tmp_dir_test}}/bar.txt state=absent
   register: file2_result
 
 - name: verify that the file was marked as changed
@@ -92,7 +94,7 @@
 
 - name: verify we can touch a file
   file:
-    path: "{{output_dir}}/baz.txt"
+    path: "{{remote_tmp_dir_test}}/baz.txt"
     state: touch
     mode: '0644'
   register: file3_result
@@ -105,7 +107,7 @@
       - "file3_result.mode == '0644'"
 
 - name: change file mode
-  file: path={{output_dir}}/baz.txt mode=0600
+  file: path={{remote_tmp_dir_test}}/baz.txt mode=0600
   register: file4_result
 
 - name: verify that the file was marked as changed
@@ -116,7 +118,7 @@
 
 - name: define file to verify chattr/lsattr with
   set_fact:
-    attributes_file: "{{ output_dir }}/attributes.txt"
+    attributes_file: "{{ remote_tmp_dir_test }}/attributes.txt"
     attributes_supported: no
 
 - name: create file to verify chattr/lsattr with
@@ -150,13 +152,13 @@
     - "'A' not in attribute_A_unset.stdout_lines[0].split()[0]"
 
 - name: explicitly set file attribute "A"
-  file: path={{output_dir}}/baz.txt attributes=A
+  file: path={{remote_tmp_dir_test}}/baz.txt attributes=A
   register: file_attributes_result
   ignore_errors: True
   when: attributes_supported
 
 - name: add file attribute "A"
-  file: path={{output_dir}}/baz.txt attributes=+A
+  file: path={{remote_tmp_dir_test}}/baz.txt attributes=+A
   register: file_attributes_result_2
   when: file_attributes_result is changed
 
@@ -167,12 +169,12 @@
   when: file_attributes_result is changed
 
 - name: remove file attribute "A"
-  file: path={{output_dir}}/baz.txt attributes=-A
+  file: path={{remote_tmp_dir_test}}/baz.txt attributes=-A
   register: file_attributes_result_3
   ignore_errors: True
 
 - name: explicitly remove file attributes
-  file: path={{output_dir}}/baz.txt attributes=""
+  file: path={{remote_tmp_dir_test}}/baz.txt attributes=""
   register: file_attributes_result_4
   when: file_attributes_result_3 is changed
 
@@ -195,18 +197,18 @@
   notify: remove groups
 
 - name: change ownership and group
-  file: path={{output_dir}}/baz.txt owner=1234 group=1234
+  file: path={{remote_tmp_dir_test}}/baz.txt owner=1234 group=1234
 
 - name: Get stat info to check atime later
-  stat: path={{output_dir}}/baz.txt
+  stat: path={{remote_tmp_dir_test}}/baz.txt
   register: file_attributes_result_5_before
 
 - name: updates access time
-  file: path={{output_dir}}/baz.txt access_time=now
+  file: path={{remote_tmp_dir_test}}/baz.txt access_time=now
   register: file_attributes_result_5
 
 - name: Get stat info to check atime later
-  stat: path={{output_dir}}/baz.txt
+  stat: path={{remote_tmp_dir_test}}/baz.txt
   register: file_attributes_result_5_after
 
 - name: verify that the file was marked as changed and atime changed
@@ -239,7 +241,7 @@
   file: path=/tmp/worldwritable state=absent
 
 - name: create hard link to file
-  file: src={{output_file}} dest={{output_dir}}/hard.txt state=hard
+  file: src={{output_file}} dest={{remote_tmp_dir_test}}/hard.txt state=hard
   register: file6_result
 
 - name: verify that the file was marked as changed
@@ -249,7 +251,7 @@
 
 - name: touch a hard link
   file:
-    dest: '{{ output_dir }}/hard.txt'
+    dest: '{{ remote_tmp_dir_test }}/hard.txt'
     state: 'touch'
   register: file6_touch_result
 
@@ -263,7 +265,7 @@
   register: hlstat1
 
 - name: stat2
-  stat: path={{output_dir}}/hard.txt
+  stat: path={{remote_tmp_dir_test}}/hard.txt
   register: hlstat2
 
 - name: verify that hard link is still the same after timestamp updated
@@ -272,7 +274,7 @@
       - "hlstat1.stat.inode == hlstat2.stat.inode"
 
 - name: create hard link to file 2
-  file: src={{output_file}} dest={{output_dir}}/hard.txt state=hard
+  file: src={{output_file}} dest={{remote_tmp_dir_test}}/hard.txt state=hard
   register: hlink_result
 
 - name: verify that hard link creation is idempotent
@@ -281,7 +283,7 @@
       - "hlink_result.changed == False"
 
 - name: Change mode on a hard link
-  file: src={{output_file}} dest={{output_dir}}/hard.txt mode=0701
+  file: src={{output_file}} dest={{remote_tmp_dir_test}}/hard.txt mode=0701
   register: file6_mode_change
 
 - name: verify that the hard link was touched
@@ -294,7 +296,7 @@
   register: hlstat1
 
 - name: stat2
-  stat: path={{output_dir}}/hard.txt
+  stat: path={{remote_tmp_dir_test}}/hard.txt
   register: hlstat2
 
 - name: verify that hard link is still the same after timestamp updated
@@ -304,7 +306,7 @@
       - "hlstat1.stat.mode == '0701'"
 
 - name: create a directory
-  file: path={{output_dir}}/foobar state=directory
+  file: path={{remote_tmp_dir_test}}/foobar state=directory
   register: file7_result
 
 - name: verify that the file was marked as changed
@@ -324,19 +326,19 @@
   ignore_errors: true
 
 - name: remove directory foobar
-  file: path={{output_dir}}/foobar state=absent
+  file: path={{remote_tmp_dir_test}}/foobar state=absent
 
 - name: remove file foo.txt
-  file: path={{output_dir}}/foo.txt state=absent
+  file: path={{remote_tmp_dir_test}}/foo.txt state=absent
 
 - name: remove file bar.txt
-  file: path={{output_dir}}/foo.txt state=absent
+  file: path={{remote_tmp_dir_test}}/foo.txt state=absent
 
 - name: remove file baz.txt
-  file: path={{output_dir}}/foo.txt state=absent
+  file: path={{remote_tmp_dir_test}}/foo.txt state=absent
 
 - name: copy directory structure over
-  copy: src=foobar dest={{output_dir}}
+  copy: src=foobar dest={{remote_tmp_dir_test}}
 
 - name: check what would be removed if folder state was absent and diff is enabled
   file:
@@ -345,8 +347,8 @@
   check_mode: yes
   diff: yes
   with_items:
-    - "{{ output_dir }}"
-    - "{{ output_dir }}/foobar/fileA"
+    - "{{ remote_tmp_dir_test }}"
+    - "{{ remote_tmp_dir_test }}/foobar/fileA"
   register: folder_absent_result
 
 - name: 'assert that the "absent" state lists expected files and folders for only directories'
@@ -361,10 +363,10 @@
     test_file: "{{ folder_absent_result.results[0].path }}/foobar/fileA"
 
 - name: Change ownership of a directory with recurse=no(default)
-  file: path={{output_dir}}/foobar owner=1234
+  file: path={{remote_tmp_dir_test}}/foobar owner=1234
 
 - name: verify that the permission of the directory was set
-  file: path={{output_dir}}/foobar state=directory
+  file: path={{remote_tmp_dir_test}}/foobar state=directory
   register: file8_result
 
 - name: assert that the directory has changed to have owner 1234
@@ -373,7 +375,7 @@
       - "file8_result.uid == 1234"
 
 - name: verify that the permission of a file under the directory was not set
-  file: path={{output_dir}}/foobar/fileA state=file
+  file: path={{remote_tmp_dir_test}}/foobar/fileA state=file
   register: file9_result
 
 - name: assert the file owner has not changed to 1234
@@ -387,10 +389,10 @@
     uid: 1235
 
 - name: change the ownership of a directory with recurse=yes
-  file: path={{output_dir}}/foobar owner=1235 recurse=yes
+  file: path={{remote_tmp_dir_test}}/foobar owner=1235 recurse=yes
 
 - name: verify that the permission of the directory was set
-  file: path={{output_dir}}/foobar state=directory
+  file: path={{remote_tmp_dir_test}}/foobar state=directory
   register: file10_result
 
 - name: assert that the directory has changed to have owner 1235
@@ -399,7 +401,7 @@
       - "file10_result.uid == 1235"
 
 - name: verify that the permission of a file under the directory was not set
-  file: path={{output_dir}}/foobar/fileA state=file
+  file: path={{remote_tmp_dir_test}}/foobar/fileA state=file
   register: file11_result
 
 - name: assert that the file has changed to have owner 1235
@@ -408,7 +410,7 @@
       - "file11_result.uid == 1235"
 
 - name: remove directory foobar
-  file: path={{output_dir}}/foobar state=absent
+  file: path={{remote_tmp_dir_test}}/foobar state=absent
   register: file14_result
 
 - name: verify that the directory was removed
@@ -418,7 +420,7 @@
       - 'file14_result.state == "absent"'
 
 - name: create a test sub-directory
-  file: dest={{output_dir}}/sub1 state=directory
+  file: dest={{remote_tmp_dir_test}}/sub1 state=directory
   register: file15_result
 
 - name: verify that the new directory was created
@@ -428,7 +430,7 @@
       - 'file15_result.state == "directory"'
 
 - name: create test files in the sub-directory
-  file: dest={{output_dir}}/sub1/{{item}} state=touch
+  file: dest={{remote_tmp_dir_test}}/sub1/{{item}} state=touch
   with_items:
   - file1
   - file2
@@ -443,7 +445,7 @@
   with_items: "{{file16_result.results}}"
 
 - name: test file creation with symbolic mode
-  file: dest={{output_dir}}/test_symbolic state=touch mode=u=rwx,g=rwx,o=rwx
+  file: dest={{remote_tmp_dir_test}}/test_symbolic state=touch mode=u=rwx,g=rwx,o=rwx
   register: result
 
 - name: assert file mode
@@ -452,7 +454,7 @@
     - result.mode == '0777'
 
 - name: modify symbolic mode for all
-  file: dest={{output_dir}}/test_symbolic state=touch mode=a=r
+  file: dest={{remote_tmp_dir_test}}/test_symbolic state=touch mode=a=r
   register: result
 
 - name: assert file mode
@@ -461,7 +463,7 @@
     - result.mode == '0444'
 
 - name: modify symbolic mode for owner
-  file: dest={{output_dir}}/test_symbolic state=touch mode=u+w
+  file: dest={{remote_tmp_dir_test}}/test_symbolic state=touch mode=u+w
   register: result
 
 - name: assert file mode
@@ -470,7 +472,7 @@
     - result.mode == '0644'
 
 - name: modify symbolic mode for group
-  file: dest={{output_dir}}/test_symbolic state=touch mode=g+w
+  file: dest={{remote_tmp_dir_test}}/test_symbolic state=touch mode=g+w
   register: result
 
 - name: assert file mode
@@ -479,7 +481,7 @@
     - result.mode == '0664'
 
 - name: modify symbolic mode for world
-  file: dest={{output_dir}}/test_symbolic state=touch mode=o+w
+  file: dest={{remote_tmp_dir_test}}/test_symbolic state=touch mode=o+w
   register: result
 
 - name: assert file mode
@@ -488,7 +490,7 @@
     - result.mode == '0666'
 
 - name: modify symbolic mode for owner
-  file: dest={{output_dir}}/test_symbolic state=touch mode=u+x
+  file: dest={{remote_tmp_dir_test}}/test_symbolic state=touch mode=u+x
   register: result
 
 - name: assert file mode
@@ -497,7 +499,7 @@
     - result.mode == '0766'
 
 - name: modify symbolic mode for group
-  file: dest={{output_dir}}/test_symbolic state=touch mode=g+x
+  file: dest={{remote_tmp_dir_test}}/test_symbolic state=touch mode=g+x
   register: result
 
 - name: assert file mode
@@ -506,7 +508,7 @@
     - result.mode == '0776'
 
 - name: modify symbolic mode for world
-  file: dest={{output_dir}}/test_symbolic state=touch mode=o+x
+  file: dest={{remote_tmp_dir_test}}/test_symbolic state=touch mode=o+x
   register: result
 
 - name: assert file mode
@@ -515,7 +517,7 @@
     - result.mode == '0777'
 
 - name: remove symbolic mode for world
-  file: dest={{output_dir}}/test_symbolic state=touch mode=o-wx
+  file: dest={{remote_tmp_dir_test}}/test_symbolic state=touch mode=o-wx
   register: result
 
 - name: assert file mode
@@ -524,7 +526,7 @@
     - result.mode == '0774'
 
 - name: remove symbolic mode for group
-  file: dest={{output_dir}}/test_symbolic state=touch mode=g-wx
+  file: dest={{remote_tmp_dir_test}}/test_symbolic state=touch mode=g-wx
   register: result
 
 - name: assert file mode
@@ -533,7 +535,7 @@
     - result.mode == '0744'
 
 - name: remove symbolic mode for owner
-  file: dest={{output_dir}}/test_symbolic state=touch mode=u-wx
+  file: dest={{remote_tmp_dir_test}}/test_symbolic state=touch mode=u-wx
   register: result
 
 - name: assert file mode
@@ -542,7 +544,7 @@
     - result.mode == '0444'
 
 - name: set sticky bit with symbolic mode
-  file: dest={{output_dir}}/test_symbolic state=touch mode=o+t
+  file: dest={{remote_tmp_dir_test}}/test_symbolic state=touch mode=o+t
   register: result
 
 - name: assert file mode
@@ -551,7 +553,7 @@
     - result.mode == '01444'
 
 - name: remove sticky bit with symbolic mode
-  file: dest={{output_dir}}/test_symbolic state=touch mode=o-t
+  file: dest={{remote_tmp_dir_test}}/test_symbolic state=touch mode=o-t
   register: result
 
 - name: assert file mode
@@ -560,7 +562,7 @@
     - result.mode == '0444'
 
 - name: add setgid with symbolic mode
-  file: dest={{output_dir}}/test_symbolic state=touch mode=g+s
+  file: dest={{remote_tmp_dir_test}}/test_symbolic state=touch mode=g+s
   register: result
 
 - name: assert file mode
@@ -569,7 +571,7 @@
     - result.mode == '02444'
 
 - name: remove setgid with symbolic mode
-  file: dest={{output_dir}}/test_symbolic state=touch mode=g-s
+  file: dest={{remote_tmp_dir_test}}/test_symbolic state=touch mode=g-s
   register: result
 
 - name: assert file mode
@@ -578,7 +580,7 @@
     - result.mode == '0444'
 
 - name: add setuid with symbolic mode
-  file: dest={{output_dir}}/test_symbolic state=touch mode=u+s
+  file: dest={{remote_tmp_dir_test}}/test_symbolic state=touch mode=u+s
   register: result
 
 - name: assert file mode
@@ -587,7 +589,7 @@
     - result.mode == '04444'
 
 - name: remove setuid with symbolic mode
-  file: dest={{output_dir}}/test_symbolic state=touch mode=u-s
+  file: dest={{remote_tmp_dir_test}}/test_symbolic state=touch mode=u-s
   register: result
 
 - name: assert file mode
@@ -704,7 +706,7 @@
     - group_gid_exists.warnings is not defined
 
 # https://github.com/ansible/ansible/issues/50943
-# Need to use /tmp as nobody can't access output_dir at all
+# Need to use /tmp as nobody can't access remote_tmp_dir_test at all
 - name: create file as root with all write permissions
   file: dest=/tmp/write_utime state=touch mode=0666 owner={{ansible_user_id}}
 
@@ -743,39 +745,39 @@
 
 # Follow + recursive tests
 - name: create a toplevel directory
-  file: path={{output_dir}}/test_follow_rec state=directory mode=0755
+  file: path={{remote_tmp_dir_test}}/test_follow_rec state=directory mode=0755
 
 - name: create a file outside of the toplevel
-  file: path={{output_dir}}/test_follow_rec_target_file state=touch mode=0700
+  file: path={{remote_tmp_dir_test}}/test_follow_rec_target_file state=touch mode=0700
 
 - name: create a directory outside of the toplevel
-  file: path={{output_dir}}/test_follow_rec_target_dir state=directory mode=0700
+  file: path={{remote_tmp_dir_test}}/test_follow_rec_target_dir state=directory mode=0700
 
 - name: create a file inside of the link target directory
-  file: path={{output_dir}}/test_follow_rec_target_dir/foo state=touch mode=0700
+  file: path={{remote_tmp_dir_test}}/test_follow_rec_target_dir/foo state=touch mode=0700
 
 - name: create a symlink to the file
-  file: path={{output_dir}}/test_follow_rec/test_link state=link src="../test_follow_rec_target_file"
+  file: path={{remote_tmp_dir_test}}/test_follow_rec/test_link state=link src="../test_follow_rec_target_file"
 
 - name: create a symlink to the directory
-  file: path={{output_dir}}/test_follow_rec/test_link_dir state=link src="../test_follow_rec_target_dir"
+  file: path={{remote_tmp_dir_test}}/test_follow_rec/test_link_dir state=link src="../test_follow_rec_target_dir"
 
 - name: create a symlink to a nonexistent file
-  file: path={{output_dir}}/test_follow_rec/nonexistent state=link src=does_not_exist force=True
+  file: path={{remote_tmp_dir_test}}/test_follow_rec/nonexistent state=link src=does_not_exist force=True
 
 - name: try to change permissions without following symlinks
-  file: path={{output_dir}}/test_follow_rec follow=False mode="a-x" recurse=True
+  file: path={{remote_tmp_dir_test}}/test_follow_rec follow=False mode="a-x" recurse=True
 
 - name: stat the link file target
-  stat: path={{output_dir}}/test_follow_rec_target_file
+  stat: path={{remote_tmp_dir_test}}/test_follow_rec_target_file
   register: file_result
 
 - name: stat the link dir target
-  stat: path={{output_dir}}/test_follow_rec_target_dir
+  stat: path={{remote_tmp_dir_test}}/test_follow_rec_target_dir
   register: dir_result
 
 - name: stat the file inside the link dir target
-  stat: path={{output_dir}}/test_follow_rec_target_dir/foo
+  stat: path={{remote_tmp_dir_test}}/test_follow_rec_target_dir/foo
   register: file_in_dir_result
 
 - name: assert that the link targets were unmodified
@@ -786,18 +788,18 @@
     - file_in_dir_result.stat.mode == '0700'
 
 - name: try to change permissions with following symlinks
-  file: path={{output_dir}}/test_follow_rec follow=True mode="a-x" recurse=True
+  file: path={{remote_tmp_dir_test}}/test_follow_rec follow=True mode="a-x" recurse=True
 
 - name: stat the link file target
-  stat: path={{output_dir}}/test_follow_rec_target_file
+  stat: path={{remote_tmp_dir_test}}/test_follow_rec_target_file
   register: file_result
 
 - name: stat the link dir target
-  stat: path={{output_dir}}/test_follow_rec_target_dir
+  stat: path={{remote_tmp_dir_test}}/test_follow_rec_target_dir
   register: dir_result
 
 - name: stat the file inside the link dir target
-  stat: path={{output_dir}}/test_follow_rec_target_dir/foo
+  stat: path={{remote_tmp_dir_test}}/test_follow_rec_target_dir/foo
   register: file_in_dir_result
 
 - name: assert that the link targets were modified
@@ -821,7 +823,7 @@
 
 - name: Test missing src
   file:
-    dest: "{{ output_dir }}/hard.txt"
+    dest: "{{ remote_tmp_dir_test }}/hard.txt"
     state: hard
   register: file_error2
   ignore_errors: yes
@@ -834,7 +836,7 @@
 - name: Test non-existing src
   file:
     src: non-existing-file-that-does-not-exist.txt
-    dest: "{{ output_dir }}/hard.txt"
+    dest: "{{ remote_tmp_dir_test }}/hard.txt"
     state: hard
   register: file_error3
   ignore_errors: yes
@@ -843,7 +845,7 @@
     that:
       - "file_error3 is failed"
       - "file_error3.msg == 'src does not exist'"
-      - "file_error3.dest == '{{ output_dir }}/hard.txt' | expanduser"
+      - "file_error3.dest == '{{ remote_tmp_dir_test }}/hard.txt' | expanduser"
       - "file_error3.src == 'non-existing-file-that-does-not-exist.txt'"
 
 - block:

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -17,8 +17,10 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 - set_fact:
-    output_file: '{{remote_tmp_dir}}/foo.txt'
     remote_tmp_dir_test: '{{ remote_tmp_dir }}/file'
+
+- set_fact:
+    output_file: '{{remote_tmp_dir_test}}/foo.txt'
 
 # same as expanduser & expandvars called on managed host
 - command: 'echo {{ output_file }}'

--- a/test/integration/targets/file/tasks/selinux_tests.yml
+++ b/test/integration/targets/file/tasks/selinux_tests.yml
@@ -20,7 +20,7 @@
   import_tasks: initialize.yml
 
 - name: touch a file for testing
-  file: path={{output_dir}}/foo-se.txt state=touch
+  file: path={{remote_tmp_dir_test}}/foo-se.txt state=touch
   register: file_se_result
 
 - name: verify that the file was marked as changed
@@ -30,4 +30,4 @@
       - "file_se_result.secontext == 'unconfined_u:object_r:admin_home_t:s0'"
 
 - name: remove the file used for testing
-  file: path={{output_dir}}/foo-se.txt state=absent
+  file: path={{remote_tmp_dir_test}}/foo-se.txt state=absent

--- a/test/integration/targets/file/tasks/state_link.yml
+++ b/test/integration/targets/file/tasks/state_link.yml
@@ -7,12 +7,12 @@
 # Basic absolute symlink to a file
 #
 - name: create soft link to file
-  file: src={{output_file}} dest={{output_dir}}/soft.txt state=link
+  file: src={{output_file}} dest={{remote_tmp_dir_test}}/soft.txt state=link
   register: file1_result
 
 - name: Get stat info for the link
   stat:
-    path: '{{ output_dir }}/soft.txt'
+    path: '{{ remote_tmp_dir_test }}/soft.txt'
     follow: False
   register: file1_link_stat
 
@@ -27,12 +27,12 @@
 # Change an absolute soft link into a relative soft link
 #
 - name: change soft link to relative
-  file: src={{output_file|basename}} dest={{output_dir}}/soft.txt state=link
+  file: src={{output_file|basename}} dest={{remote_tmp_dir_test}}/soft.txt state=link
   register: file2_result
 
 - name: Get stat info for the link
   stat:
-    path: '{{ output_dir }}/soft.txt'
+    path: '{{ remote_tmp_dir_test }}/soft.txt'
     follow: False
   register: file2_link_stat
 
@@ -49,12 +49,12 @@
 # Check that creating the soft link a second time was idempotent
 #
 - name: soft link idempotency check
-  file: src={{output_file|basename}} dest={{output_dir}}/soft.txt state=link
+  file: src={{output_file|basename}} dest={{remote_tmp_dir_test}}/soft.txt state=link
   register: file3_result
 
 - name: Get stat info for the link
   stat:
-    path: '{{ output_dir }}/soft.txt'
+    path: '{{ remote_tmp_dir_test }}/soft.txt'
     follow: False
   register: file3_link_stat
 
@@ -71,7 +71,7 @@
 - name: fail to create soft link to non existent file
   file:
     src: '/nonexistent'
-    dest: '{{output_dir}}/soft2.txt'
+    dest: '{{remote_tmp_dir_test}}/soft2.txt'
     state: 'link'
     force: False
   register: file4_result
@@ -85,14 +85,14 @@
 - name: force creation soft link to non existent
   file:
     src: '/nonexistent'
-    dest: '{{ output_dir}}/soft2.txt'
+    dest: '{{ remote_tmp_dir_test}}/soft2.txt'
     state: 'link'
     force: True
   register: file5_result
 
 - name: Get stat info for the link
   stat:
-    path: '{{ output_dir }}/soft2.txt'
+    path: '{{ remote_tmp_dir_test }}/soft2.txt'
     follow: False
   register: file5_link_stat
 
@@ -106,7 +106,7 @@
 - name: Prove idempotence of force creation soft link to non existent
   file:
     src: '/nonexistent'
-    dest: '{{ output_dir }}/soft2.txt'
+    dest: '{{ remote_tmp_dir_test }}/soft2.txt'
     state: 'link'
     force: True
   register: file6a_result
@@ -207,19 +207,19 @@
 - name: create soft link to directory using absolute path
   file:
     src: '/'
-    dest: '{{ output_dir }}/root'
+    dest: '{{ remote_tmp_dir_test }}/root'
     state: 'link'
   register: file6_result
 
 - name: Get stat info for the link
   stat:
-    path: '{{ output_dir }}/root'
+    path: '{{ remote_tmp_dir_test }}/root'
     follow: False
   register: file6_link_stat
 
 - name: Get stat info for the pointed to file
   stat:
-    path: '{{ output_dir }}/root'
+    path: '{{ remote_tmp_dir_test }}/root'
     follow: True
   register: file6_links_dest_stat
 
@@ -248,41 +248,41 @@
 # Relative link to file
 - name: create a test sub-directory to link to
   file:
-    dest: '{{ output_dir }}/sub1'
+    dest: '{{ remote_tmp_dir_test }}/sub1'
     state: 'directory'
 
 - name: create a file to link to in the test sub-directory
   file:
-    dest: '{{ output_dir }}/sub1/file1'
+    dest: '{{ remote_tmp_dir_test }}/sub1/file1'
     state: 'touch'
 
 - name: create another test sub-directory to place links within
   file:
-    dest: '{{output_dir}}/sub2'
+    dest: '{{remote_tmp_dir_test}}/sub2'
     state: 'directory'
 
 - name: create soft link to relative file
   file:
     src: '../sub1/file1'
-    dest: '{{ output_dir }}/sub2/link1'
+    dest: '{{ remote_tmp_dir_test }}/sub2/link1'
     state: 'link'
   register: file7_result
 
 - name: Get stat info for the link
   stat:
-    path: '{{ output_dir }}/sub2/link1'
+    path: '{{ remote_tmp_dir_test }}/sub2/link1'
     follow: False
   register: file7_link_stat
 
 - name: Get stat info for the pointed to file
   stat:
-    path: '{{ output_dir }}/sub2/link1'
+    path: '{{ remote_tmp_dir_test }}/sub2/link1'
     follow: True
   register: file7_links_dest_stat
 
 - name: Get stat info for the file we intend to point to
   stat:
-    path: '{{ output_dir }}/sub1/file1'
+    path: '{{ remote_tmp_dir_test }}/sub1/file1'
     follow: False
   register: file7_dest_stat
 
@@ -302,25 +302,25 @@
 - name: create soft link to relative directory
   file:
     src: sub1
-    dest: '{{ output_dir }}/sub1-link'
+    dest: '{{ remote_tmp_dir_test }}/sub1-link'
     state: 'link'
   register: file8_result
 
 - name: Get stat info for the link
   stat:
-    path: '{{ output_dir }}/sub1-link'
+    path: '{{ remote_tmp_dir_test }}/sub1-link'
     follow: False
   register: file8_link_stat
 
 - name: Get stat info for the pointed to file
   stat:
-    path: '{{ output_dir }}/sub1-link'
+    path: '{{ remote_tmp_dir_test }}/sub1-link'
     follow: True
   register: file8_links_dest_stat
 
 - name: Get stat info for the file we intend to point to
   stat:
-    path: '{{ output_dir }}/sub1'
+    path: '{{ remote_tmp_dir_test }}/sub1'
     follow: False
   register: file8_dest_stat
 
@@ -341,26 +341,26 @@
 
 - name: create a test file
   copy:
-    dest: '{{output_dir}}/test_follow'
+    dest: '{{remote_tmp_dir_test}}/test_follow'
     content: 'this is a test file\n'
     mode: 0666
 
 - name: create a symlink to the test file
   file:
-    path: '{{output_dir}}/test_follow_link'
+    path: '{{remote_tmp_dir_test}}/test_follow_link'
     src: './test_follow'
     state: 'link'
 
 - name: modify the permissions on the link using follow=yes
   file:
-    path: '{{output_dir}}/test_follow_link'
+    path: '{{remote_tmp_dir_test}}/test_follow_link'
     mode: 0644
     follow: yes
   register: file9_result
 
 - name: stat the link target
   stat:
-    path: '{{output_dir}}/test_follow'
+    path: '{{remote_tmp_dir_test}}/test_follow'
   register: file9_stat
 
 - name: assert that the chmod worked
@@ -374,7 +374,7 @@
 #
 - name: attempt to modify the permissions of the link itself
   file:
-    path: '{{output_dir}}/test_follow_link'
+    path: '{{remote_tmp_dir_test}}/test_follow_link'
     src: './test_follow'
     state: 'link'
     mode: 0600
@@ -385,7 +385,7 @@
 # Just check that the underlying file was not changed
 - name: stat the link target
   stat:
-    path: '{{output_dir}}/test_follow'
+    path: '{{remote_tmp_dir_test}}/test_follow'
   register: file10_target_stat
 
 - name: assert that the link target was unmodified
@@ -399,19 +399,19 @@
 
   - name: Create a testing file
     file:
-      path: "{{ output_dir }}/test_follow1"
+      path: "{{ remote_tmp_dir_test }}/test_follow1"
       state: touch
 
   - name: Create a symlink and change mode of the original file, since follow == yes by default
     file:
-      src: "{{ output_dir }}/test_follow1"
-      dest: "{{ output_dir }}/test_follow1_link"
+      src: "{{ remote_tmp_dir_test }}/test_follow1"
+      dest: "{{ remote_tmp_dir_test }}/test_follow1_link"
       state: link
       mode: 0700
 
   - name: stat the original file
     stat:
-      path: "{{ output_dir }}/test_follow1"
+      path: "{{ remote_tmp_dir_test }}/test_follow1"
     register: stat_out
 
   - name: Check if the mode of the original file was set
@@ -425,8 +425,8 @@
         path: "{{ item }}"
         state: absent
       loop:
-        - "{{ output_dir }}/test_follow1"
-        - "{{ output_dir }}/test_follow1_link"
+        - "{{ remote_tmp_dir_test }}/test_follow1"
+        - "{{ remote_tmp_dir_test }}/test_follow1_link"
 
 # END #56928
 
@@ -435,7 +435,7 @@
 - name: Specify src without state
   file:
     src: "{{ output_file }}"
-    dest: "{{ output_dir }}/link.txt"
+    dest: "{{ remote_tmp_dir_test }}/link.txt"
   ignore_errors: yes
   register: src_state
 
@@ -448,35 +448,35 @@
 # Test creating a symlink when the destination exists and is a file
 - name: create a test file
   copy:
-    dest: '{{ output_dir }}/file.txt'
+    dest: '{{ remote_tmp_dir_test }}/file.txt'
     content: 'this is a test file\n'
     mode: 0666
 
 - name: Create a symlink with dest already a file
   file:
     src: '{{ output_file }}'
-    dest: '{{ output_dir }}/file.txt'
+    dest: '{{ remote_tmp_dir_test }}/file.txt'
     state: link
   ignore_errors: true
   register: dest_is_existing_file_fail
 
 - name: Stat to make sure the symlink was not created
   stat:
-    path: '{{ output_dir }}/file.txt'
+    path: '{{ remote_tmp_dir_test }}/file.txt'
     follow: false
   register: dest_is_existing_file_fail_stat
 
 - name: Forcefully a symlink with dest already a file
   file:
     src: '{{ output_file }}'
-    dest: '{{ output_dir }}/file.txt'
+    dest: '{{ remote_tmp_dir_test }}/file.txt'
     state: link
     force: true
   register: dest_is_existing_file_force
 
 - name: Stat to make sure the symlink was created
   stat:
-    path: '{{ output_dir }}/file.txt'
+    path: '{{ remote_tmp_dir_test }}/file.txt'
     follow: false
   register: dest_is_existing_file_force_stat
 

--- a/test/integration/targets/file/tasks/unicode_path.yml
+++ b/test/integration/targets/file/tasks/unicode_path.yml
@@ -1,10 +1,10 @@
 - name: create local file with unicode filename and content
   lineinfile:
-    dest: "{{ output_dir }}/语/汉语.txt"
+    dest: "{{ remote_tmp_dir_test }}/语/汉语.txt"
     create: true
     line: 汉语
 
 - name: remove local file with unicode filename and content
   file:
-    path: "{{ output_dir }}/语/汉语.txt"
+    path: "{{ remote_tmp_dir_test }}/语/汉语.txt"
     state: absent

--- a/test/integration/targets/known_hosts/meta/main.yml
+++ b/test/integration/targets/known_hosts/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
   - prepare_tests
+  - setup_remote_tmp_dir

--- a/test/integration/targets/known_hosts/tasks/main.yml
+++ b/test/integration/targets/known_hosts/tasks/main.yml
@@ -19,7 +19,7 @@
 - name: copy an existing file in place
   copy:
     src: existing_known_hosts
-    dest: "{{ output_dir }}/known_hosts"
+    dest: "{{ remote_tmp_dir }}/known_hosts"
 
 # test addition
 
@@ -29,14 +29,14 @@
     name: example.org
     key: "{{ example_org_rsa_key }}"
     state: present
-    path: "{{output_dir}}/known_hosts"
+    path: "{{remote_tmp_dir}}/known_hosts"
   register: diff
 
 - name: assert that the diff looks as expected (the key was added at the end)
   assert:
     that:
     - 'diff is changed'
-    - 'diff.diff.before_header == diff.diff.after_header == output_dir|expanduser + "/known_hosts"'
+    - 'diff.diff.before_header == diff.diff.after_header == remote_tmp_dir|expanduser + "/known_hosts"'
     - 'diff.diff.after.splitlines()[:-1] == diff.diff.before.splitlines()'
     - 'diff.diff.after.splitlines()[-1] == example_org_rsa_key.strip()'
 
@@ -45,11 +45,11 @@
     name: example.org
     key: "{{ example_org_rsa_key }}"
     state: present
-    path: "{{output_dir}}/known_hosts"
+    path: "{{remote_tmp_dir}}/known_hosts"
   register: result
 
 - name: get the file content
-  command: "cat {{output_dir}}/known_hosts"
+  command: "cat {{remote_tmp_dir}}/known_hosts"
   register: known_hosts
 
 - name: assert that the key was added and ordering preserved
@@ -68,7 +68,7 @@
     name: example.org
     key: "{{ example_org_rsa_key }}"
     state: present
-    path: "{{output_dir}}/known_hosts"
+    path: "{{remote_tmp_dir}}/known_hosts"
   register: check
 
 - name: assert that no changes were expected
@@ -82,11 +82,11 @@
     name: example.org
     key: "{{ example_org_rsa_key }}"
     state: present
-    path: "{{output_dir}}/known_hosts"
+    path: "{{remote_tmp_dir}}/known_hosts"
   register: result
 
 - name: get the file content
-  command: "cat {{output_dir}}/known_hosts"
+  command: "cat {{remote_tmp_dir}}/known_hosts"
   register: known_hosts_v2
 
 - name: assert that no changes happened
@@ -104,13 +104,13 @@
     name: example.org
     key: "{{ example_org_rsa_key }}"
     state: absent
-    path: "{{output_dir}}/known_hosts"
+    path: "{{remote_tmp_dir}}/known_hosts"
   register: diff
 
 - name: assert that the diff looks as expected (the key was removed)
   assert:
     that:
-    - 'diff.diff.before_header == diff.diff.after_header == output_dir|expanduser + "/known_hosts"'
+    - 'diff.diff.before_header == diff.diff.after_header == remote_tmp_dir|expanduser + "/known_hosts"'
     - 'diff.diff.before.splitlines()[-1] == example_org_rsa_key.strip()'
     - 'diff.diff.after.splitlines() == diff.diff.before.splitlines()[:-1]'
 
@@ -119,11 +119,11 @@
     name: example.org
     key: "{{ example_org_rsa_key }}"
     state: absent
-    path: "{{output_dir}}/known_hosts"
+    path: "{{remote_tmp_dir}}/known_hosts"
   register: result
 
 - name: get the file content
-  command: "cat {{output_dir}}/known_hosts"
+  command: "cat {{remote_tmp_dir}}/known_hosts"
   register: known_hosts_v3
 
 - name: assert that the key was removed and ordering preserved
@@ -142,7 +142,7 @@
     name: example.org
     key: "{{ example_org_rsa_key }}"
     state: absent
-    path: "{{output_dir}}/known_hosts"
+    path: "{{remote_tmp_dir}}/known_hosts"
   register: check
 
 - name: assert that no changes were expected
@@ -156,11 +156,11 @@
     name: example.org
     key: "{{ example_org_rsa_key }}"
     state: absent
-    path: "{{output_dir}}/known_hosts"
+    path: "{{remote_tmp_dir}}/known_hosts"
   register: result
 
 - name: get the file content
-  command: "cat {{output_dir}}/known_hosts"
+  command: "cat {{remote_tmp_dir}}/known_hosts"
   register: known_hosts_v4
 
 - name: assert that no changes happened
@@ -177,12 +177,12 @@
     name: example.org
     key: "{{ example_org_rsa_key }}"
     state: present
-    path: "{{output_dir}}/known_hosts"
+    path: "{{remote_tmp_dir}}/known_hosts"
     hash_host: yes
   register: result
 
 - name: get the file content
-  command: "cat {{output_dir}}/known_hosts"
+  command: "cat {{remote_tmp_dir}}/known_hosts"
   register: known_hosts_v5
 
 - name: assert that the key was added and ordering preserved
@@ -201,12 +201,12 @@
     name: example.org
     key: "{{ example_org_rsa_key }}"
     state: present
-    path: "{{output_dir}}/known_hosts"
+    path: "{{remote_tmp_dir}}/known_hosts"
     hash_host: yes
   register: result
 
 - name: get the file content
-  command: "cat {{output_dir}}/known_hosts"
+  command: "cat {{remote_tmp_dir}}/known_hosts"
   register: known_hosts_v6
 
 - name: assert that no changes happened
@@ -223,11 +223,11 @@
     name: example.org
     key: "{{ example_org_rsa_key }}"
     state: absent
-    path: "{{output_dir}}/known_hosts"
+    path: "{{remote_tmp_dir}}/known_hosts"
   register: result
 
 - name: get the file content
-  command: "cat {{output_dir}}/known_hosts"
+  command: "cat {{remote_tmp_dir}}/known_hosts"
   register: known_hosts_v7
 
 - name: assert that the key was removed and ordering preserved
@@ -245,11 +245,11 @@
     name: example.org
     key: "{{ example_org_rsa_key }}"
     state: absent
-    path: "{{output_dir}}/known_hosts"
+    path: "{{remote_tmp_dir}}/known_hosts"
   register: result
 
 - name: get the file content
-  command: "cat {{output_dir}}/known_hosts"
+  command: "cat {{remote_tmp_dir}}/known_hosts"
   register: known_hosts_v8
 
 - name: assert that no changes happened
@@ -267,10 +267,10 @@
     name: example.org
     key: "{{ example_org_rsa_key }}"
     state: present
-    path: "{{output_dir}}/known_hosts"
+    path: "{{remote_tmp_dir}}/known_hosts"
 
 - name: get the file content
-  command: "cat {{output_dir}}/known_hosts"
+  command: "cat {{remote_tmp_dir}}/known_hosts"
   register: known_hosts_v8
 
 - name: assert the plaintext host is there
@@ -283,11 +283,11 @@
     name: example.org
     key: "{{ example_org_rsa_key }}"
     state: present
-    path: "{{output_dir}}/known_hosts"
+    path: "{{remote_tmp_dir}}/known_hosts"
     hash_host: true
 
 - name: get the file content
-  command: "cat {{output_dir}}/known_hosts"
+  command: "cat {{remote_tmp_dir}}/known_hosts"
   register: known_hosts_v9
 
 - name: assert the hashed host is there
@@ -301,10 +301,10 @@
     name: example.org
     key: "{{ example_org_rsa_key }}"
     state: present
-    path: "{{output_dir}}/known_hosts"
+    path: "{{remote_tmp_dir}}/known_hosts"
 
 - name: get the file content
-  command: "cat {{output_dir}}/known_hosts"
+  command: "cat {{remote_tmp_dir}}/known_hosts"
   register: known_hosts_v10
 
 - name: assert the plaintext host is there
@@ -317,7 +317,7 @@
 - name: copy an existing file in place
   copy:
     src: existing_known_hosts
-    dest: "{{ output_dir }}/known_hosts"
+    dest: "{{ remote_tmp_dir }}/known_hosts"
 
 # Test key changes
 
@@ -326,7 +326,7 @@
     name: example.org
     key: "{{ example_org_rsa_key }}"
     state: present
-    path: "{{output_dir}}/known_hosts"
+    path: "{{remote_tmp_dir}}/known_hosts"
     hash_host: true
 
 - name: change the key of a hashed host
@@ -334,11 +334,11 @@
     name: example.org
     key: "{{ example_org_rsa_key.strip()[:-7] + 'RANDOM=' }}"
     state: present
-    path: "{{output_dir}}/known_hosts"
+    path: "{{remote_tmp_dir}}/known_hosts"
     hash_host: true
 
 - name: get the file content
-  command: "cat {{output_dir}}/known_hosts"
+  command: "cat {{remote_tmp_dir}}/known_hosts"
   register: known_hosts_v11
 
 - name: assert the change took place and the key got modified
@@ -352,7 +352,7 @@
   known_hosts:
     name: example.org,acme.com
     key: "{{ example_org_rsa_key }}"
-    path: "{{output_dir}}/known_hosts"
+    path: "{{remote_tmp_dir}}/known_hosts"
   ignore_errors: yes
   register: result
 
@@ -366,7 +366,7 @@
   known_hosts:
     name: example.com
     key: "{{ example_org_rsa_key }}"
-    path: "{{output_dir}}/known_hosts"
+    path: "{{remote_tmp_dir}}/known_hosts"
   ignore_errors: yes
   register: result
 


### PR DESCRIPTION
##### SUMMARY
group2 - switch to setup_remote_tmp_dir instead of using output_dir

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```

See https://github.com/ansible/ansible/pull/73546