### PR TITLE
Improve error message when using custom SSH port (known_hosts)

### DIFF
--- a/lib/ansible/modules/known_hosts.py
+++ b/lib/ansible/modules/known_hosts.py
@@ -222,7 +222,8 @@ def sanity_check(module, host, key, sshkeygen):
         rc, stdout, stderr = module.run_command(sshkeygen_command)
 
     if stdout == '':  # host not found
-        module.fail_json(msg="Host parameter does not match hashed host field in supplied key")
+        module.fail_json(msg="Host parameter does not match hashed host field in supplied key. "
+                             "For custom SSH port, name needs to specify port as well.")
 
 
 def search_for_host_key(module, host, key, path, sshkeygen):

--- a/test/integration/targets/known_hosts/tasks/main.yml
+++ b/test/integration/targets/known_hosts/tasks/main.yml
@@ -374,4 +374,4 @@
   assert:
     that:
       - result is failed
-      - result.msg == 'Host parameter does not match hashed host field in supplied key'
+      - result.msg == 'Host parameter does not match hashed host field in supplied key. For custom SSH port, name needs to specify port as well.'


### PR DESCRIPTION
##### SUMMARY
When trying to add a host that happens to use a port other than the standard 22, one gets the following error message:

> Host parameter does not match hashed host field in supplied key.

Which is correct, but the error message could give us a hint in case the host is using a non-standard port.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`known_hosts`
