### PR TITLE
ansible-test - Add default for Windows remotes.

### DIFF
--- a/changelogs/fragments/ansible-test-windows-default.yaml
+++ b/changelogs/fragments/ansible-test-windows-default.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Add default entry for Windows remotes to be used with unknown versions.

--- a/test/lib/ansible_test/_data/completion/windows.txt
+++ b/test/lib/ansible_test/_data/completion/windows.txt
@@ -3,3 +3,4 @@ windows/2012-R2 provider=aws
 windows/2016 provider=aws
 windows/2019 provider=aws
 windows/2022 provider=aws
+windows provider=aws

--- a/test/lib/ansible_test/_internal/host_configs.py
+++ b/test/lib/ansible_test/_internal/host_configs.py
@@ -358,9 +358,7 @@ class WindowsRemoteConfig(RemoteConfig, WindowsConfig):
     """Configuration for a remoe Windows host."""
     def get_defaults(self, context):  # type: (HostContext) -> WindowsRemoteCompletionConfig
         """Return the default settings."""
-        return filter_completion(windows_completion()).get(self.name) or WindowsRemoteCompletionConfig(
-            name=self.name,
-        )
+        return filter_completion(windows_completion()).get(self.name) or windows_completion().get(self.platform)
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
##### SUMMARY

ansible-test - Add default for Windows remotes.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
