### PR TITLE
Added package reference for Debian to resolve error

### DIFF
--- a/docs/docsite/rst/user_guide/become.rst
+++ b/docs/docsite/rst/user_guide/become.rst
@@ -141,7 +141,7 @@ However, on POSIX systems, Ansible solves this problem in the following way:
 First, if :command:`setfacl` is installed and available in the remote ``PATH``,
 and the temporary directory on the remote host is mounted with POSIX.1e
 filesystem ACL support, Ansible will use POSIX ACLs to share the module file
-with the second unprivileged user.
+with the second unprivileged user. 
 
 Next, if POSIX ACLs are **not** available or :command:`setfacl` could not be
 run, Ansible will attempt to change ownership of the module file using
@@ -748,6 +748,13 @@ Limitations of become on Windows
   except Windows Server 2008 (non R2 version).
 
 * The Secondary Logon service ``seclogon`` must be running to use ``ansible_become_method: runas``
+
+Resolving Temporary File Error Messsages
+--------------------------------
+
+"Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user"
+* In Debian systems, this error can be resolved by installing the `acl` package, which provides the `setfacl` command.
+
 
 .. seealso::
 

--- a/docs/docsite/rst/user_guide/become.rst
+++ b/docs/docsite/rst/user_guide/become.rst
@@ -141,7 +141,7 @@ However, on POSIX systems, Ansible solves this problem in the following way:
 First, if :command:`setfacl` is installed and available in the remote ``PATH``,
 and the temporary directory on the remote host is mounted with POSIX.1e
 filesystem ACL support, Ansible will use POSIX ACLs to share the module file
-with the second unprivileged user. 
+with the second unprivileged user.
 
 Next, if POSIX ACLs are **not** available or :command:`setfacl` could not be
 run, Ansible will attempt to change ownership of the module file using

--- a/docs/docsite/rst/user_guide/become.rst
+++ b/docs/docsite/rst/user_guide/become.rst
@@ -753,7 +753,7 @@ Resolving Temporary File Error Messsages
 ----------------------------------------
 
 "Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user"
-* In Debian systems, this error can be resolved by installing the `acl` package, which provides the `setfacl` command.
+* This error can be resolved by installing the package that provides the ``setfacl`` command. (This is frequently the ``acl`` package but check your OS documentation.
 
 
 .. seealso::

--- a/docs/docsite/rst/user_guide/become.rst
+++ b/docs/docsite/rst/user_guide/become.rst
@@ -750,7 +750,7 @@ Limitations of become on Windows
 * The Secondary Logon service ``seclogon`` must be running to use ``ansible_become_method: runas``
 
 Resolving Temporary File Error Messsages
---------------------------------
+----------------------------------------
 
 "Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user"
 * In Debian systems, this error can be resolved by installing the `acl` package, which provides the `setfacl` command.


### PR DESCRIPTION
##### SUMMARY
Added a reference that in Debian systems, this error can be quickly and easily resolved by installing the `acl` package, which allows / implements the `setfacl` command. 


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
This error comes up when using the community.postgres collection. That collection points to using `become_user: postgres`, but then the "Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user" error occurs, and points to this document to resolve that error, without indicating a missing package or inability to use `setfacl`. 

Making this change adds clarity for users, and enables adoption of the postgres module vs. using shell modules to control postgres because of an unclear error message. 

##### ISSUE TYPE
- Docs Pull Request

