### PR TITLE
Fixed handling of sleep arguments during service restarts on AIX

### DIFF
--- a/changelogs/fragments/76877-added-sleep-to-the-service-restart-for-AIX.yml
+++ b/changelogs/fragments/76877-added-sleep-to-the-service-restart-for-AIX.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- service - Fixed handling of sleep arguments during service restarts on AIX.
+  (https://github.com/ansible/ansible/issues/76877)

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -1591,6 +1591,8 @@ class AIX(Service):
             srccmd = self.refresh_cmd
         elif self.action == 'restart':
             self.execute_command("%s %s %s" % (self.stopsrc_cmd, srccmd_parameter, self.name))
+            if self.sleep:
+                time.sleep(self.sleep)
             srccmd = self.startsrc_cmd
 
         if self.arguments and self.action in ('start', 'restart'):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added sleep between stop and start of a service if parameter is set and state is restarted.

Issue: https://github.com/ansible/ansible/issues/76877
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
service

##### ADDITIONAL INFORMATION

Locally tested with Ansible on AIX.

```
root@aix00001 /root/ansible# ansible --version
ansible 2.9.14
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/freeware/lib/python3.7/site-packages/ansible
  executable location = /opt/freeware/bin/ansible
  python version = 3.7.12 (default, Dec 15 2021, 03:25:47) [GCC 8.3.0]
```
