### PR TITLE
Add incomplete warnings when systemctl cmds hit error

### DIFF
--- a/changelogs/fragments/76867-service_facts-incomplete-warnings.yaml
+++ b/changelogs/fragments/76867-service_facts-incomplete-warnings.yaml
@@ -1,2 +1,2 @@
-bug_fixes:
+bugfixes:
   - services_facts - Set incomplete warning when systemctl commands hit error.

--- a/changelogs/fragments/76867-service_facts-incomplete-warnings.yaml
+++ b/changelogs/fragments/76867-service_facts-incomplete-warnings.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - services_facts - Set incomplete warning when systemctl commands hit error.
+  - service_facts - Set incomplete warning when systemctl commands hit an error (https://github.com/ansible/ansible/issues/76867).

--- a/changelogs/fragments/76867-service_facts-incomplete-warnings.yaml
+++ b/changelogs/fragments/76867-service_facts-incomplete-warnings.yaml
@@ -1,0 +1,2 @@
+bug_fixes:
+  - services_facts - Set incomplete warning when systemctl commands hit error.


### PR DESCRIPTION
##### SUMMARY
Fixes #76867 

service_facts doesn't set incomplete_warning flag when systemctl command may hit an error.

Add check on each systemctl command return code and set flag if rc != 0 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
service_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

