### PR TITLE
Add `undef()` keyword to core 2.12 porting guide

### DIFF
--- a/docs/docsite/rst/porting_guides/porting_guide_core_2.12.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_core_2.12.rst
@@ -32,6 +32,15 @@ Playbook
        vars:
          ansible_async_dir: /path/to/my/custom/dir
 
+* The ``undef()`` function is added to the templating environment for creating undefined variables directly in a template. Optionally, a hint may be provided for variables which are intended to be overridden.
+
+.. code-block:: yaml
+
+   vars:
+     old: "{{ undef }}"
+     new: "{{ undef() }}"
+     new_with_hint: "{{ undef(hint='You must override this variable') }}"
+
 Python Interpreter Discovery
 ============================
 


### PR DESCRIPTION
##### SUMMARY

fixes #76382

In Ansible 2.12, we added the `undef` function to the Jinja environment. This breaks other uses of `undef`, especially those expecting it to be undefined. This adds a mention in the porting guide.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/porting_guides/porting_guide_core_2.12.rst

##### ADDITIONAL INFORMATION

I built the docs, nothing seems to have caught fire.
