### PR TITLE
More accurate help message for verbosity setting

### DIFF
--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -211,7 +211,7 @@ def add_verbosity_options(parser):
     """Add options for verbosity"""
     parser.add_argument('-v', '--verbose', dest='verbosity', default=C.DEFAULT_VERBOSITY, action="count",
                         help="Causes Ansible to print more debug messages. Adding multiple -v will increase the verbosity, "
-                             "the build in plugins currently evaluate up to -vvvvvv. A reasonable level to start is -vvv, "
+                             "the builtin plugins currently evaluate up to -vvvvvv. A reasonable level to start is -vvv, "
                              "connection debugging might require -vvvv.")
 
 

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -210,7 +210,9 @@ def create_base_parser(prog, usage="", desc=None, epilog=None):
 def add_verbosity_options(parser):
     """Add options for verbosity"""
     parser.add_argument('-v', '--verbose', dest='verbosity', default=C.DEFAULT_VERBOSITY, action="count",
-                        help="verbose mode (-vvv for more, -vvvv to enable connection debugging)")
+                        help="Causes Ansible to print more debug messages. Adding multiple -v will increase the verbosity, "
+                             "the build in plugins currently evaluate up to -vvvvvv. A reasonable level to start is -vvv, "
+                             "connection debugging might require -vvvv.")
 
 
 def add_async_options(parser):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The current help message may imply to the users that the verbosity setting only has an effect up to 4 (-vvvv).
This is not the case, many interesting messages to understand the behavior of built-in plugins  like `ansible.builtin.shell` require 5 (-vvvvv) and some even 6 (-vvvvvv).

```
lib/ansible/executor/task_executor.py
1176:            elif level in ('debug', 'v', 'vv', 'vvv', 'vvvv', 'vvvvv', 'vvvvvv'):
```

It should be beneficial to explain the possible effective value range to the users.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
CLI (cli help message)
