### PR TITLE
doc: fix Jinja2 doc link in templating playbook

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_templating.rst
+++ b/docs/docsite/rst/user_guide/playbooks_templating.rst
@@ -53,7 +53,7 @@ fmt
        Playbook organization by roles
    :ref:`playbooks_best_practices`
        Tips and tricks for playbooks
-   `Jinja2 Docs <https://jinja.palletsprojects.com/en/master/templates/>`_
+   `Jinja2 Docs <https://jinja.palletsprojects.com/en/latest/templates/>`_
       Jinja2 documentation, includes the syntax and semantics of the templates
    `User Mailing List <https://groups.google.com/group/ansible-devel>`_
        Have a question?  Stop by the google group!


### PR DESCRIPTION
Fix the link to the Jinja2 template documentation in playbooks_templating.rst

- Docs Pull Request

+label: docsite_pr

Signed-off-by: Stephen Lawrence <stephen.lawrence@renesas.com>
