### PR TITLE
Remove centos8 from CI.

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -132,8 +132,6 @@ stages:
               test: centos6
             - name: CentOS 7
               test: centos7
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 30
               test: fedora30
             - name: Fedora 31


### PR DESCRIPTION
##### SUMMARY

CentOS 8 has been EOL for ~1 month now.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

.azure-pipelines/azure-pipelines.yml