### PR TITLE
[stable-2.12] ansible-test - Limit installed pyopenssl version.

### DIFF
--- a/changelogs/fragments/ansible-test-pyopenssl.yaml
+++ b/changelogs/fragments/ansible-test-pyopenssl.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - When installing ``cryptography < 3.4`` also install ``pyopenssl < 22`` to avoid conflicts.

--- a/test/lib/ansible_test/_internal/python_requirements.py
+++ b/test/lib/ansible_test/_internal/python_requirements.py
@@ -455,8 +455,8 @@ def get_cryptography_requirements(python):  # type: (PythonConfig) -> t.List[str
         # cryptography 3.4+ fails to install on many systems
         # this is a temporary work-around until a more permanent solution is available
         cryptography = 'cryptography < 3.4'
-        # no specific version of pyopenssl required, don't install it
-        pyopenssl = None
+        # pyopenssl 20.0.0 requires cryptography 35 or later
+        pyopenssl = 'pyopenssl < 22.0.0'
 
     requirements = [
         cryptography,


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/76907

(cherry picked from commit 995d7e4db30ff1574d0db181b6ebe9868b2853a2)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
