### PR TITLE
[stable-2.9] ansible-test - Use relative paths in junit output.

### DIFF
--- a/changelogs/fragments/ansible-test-junit-relative-paths.yml
+++ b/changelogs/fragments/ansible-test-junit-relative-paths.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - ansible-test - Use relative paths in JUnit files generated during integration test runs.
+  - ansible-test - Replace the directory portion of out-of-tree paths in JUnit files from integration tests with the ``out-of-tree:`` prefix.
+  - junit callback - Fix traceback during automatic fact gathering when using relative paths.
+minor_changes:
+  - junit callback - Add support for replacing the directory portion of out-of-tree relative task paths with a placeholder.

--- a/changelogs/fragments/junit-callback-task-path-unicode.yml
+++ b/changelogs/fragments/junit-callback-task-path-unicode.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - junit callback - Fix unicode error when handling non-ASCII task paths.

--- a/lib/ansible/plugins/callback/junit.py
+++ b/lib/ansible/plugins/callback/junit.py
@@ -182,6 +182,9 @@ class CallbackModule(CallbackBase):
             self._display.warning('The `ordereddict` python module is not installed. '
                                   'Disabling the `junit` callback plugin.')
 
+        if self._replace_out_of_tree_path is not None:
+            self._replace_out_of_tree_path = to_text(self._replace_out_of_tree_path)
+
         if not os.path.exists(self._output_dir):
             os.makedirs(self._output_dir)
 
@@ -241,12 +244,12 @@ class CallbackModule(CallbackBase):
         duration = host_data.finish - task_data.start
 
         if self._task_relative_path and task_data.path:
-            junit_classname = os.path.relpath(task_data.path, self._task_relative_path)
+            junit_classname = to_text(os.path.relpath(to_bytes(task_data.path), to_bytes(self._task_relative_path)))
         else:
             junit_classname = task_data.path
 
         if self._replace_out_of_tree_path is not None and junit_classname.startswith('../'):
-            junit_classname = self._replace_out_of_tree_path + os.path.basename(junit_classname)
+            junit_classname = self._replace_out_of_tree_path + to_text(os.path.basename(to_bytes(junit_classname)))
 
         if self._task_class == 'true':
             junit_classname = re.sub(r'\.yml:[0-9]+$', '', junit_classname)

--- a/lib/ansible/plugins/callback/junit.py
+++ b/lib/ansible/plugins/callback/junit.py
@@ -40,6 +40,13 @@ DOCUMENTATION = '''
         version_added: "2.8"
         env:
           - name: JUNIT_TASK_RELATIVE_PATH
+      replace_out_of_tree_path:
+        name: Replace out of tree path
+        default: none
+        description: Replace the directory portion of an out-of-tree relative task path with the given placeholder
+        version_added: "2.12.3"
+        env:
+          - name: JUNIT_REPLACE_OUT_OF_TREE_PATH
       fail_on_change:
         name: JUnit fail on change
         default: False
@@ -155,6 +162,7 @@ class CallbackModule(CallbackBase):
         self._include_setup_tasks_in_report = os.getenv('JUNIT_INCLUDE_SETUP_TASKS_IN_REPORT', 'True').lower()
         self._hide_task_arguments = os.getenv('JUNIT_HIDE_TASK_ARGUMENTS', 'False').lower()
         self._test_case_prefix = os.getenv('JUNIT_TEST_CASE_PREFIX', '')
+        self._replace_out_of_tree_path = os.getenv('JUNIT_REPLACE_OUT_OF_TREE_PATH', None)
         self._playbook_path = None
         self._playbook_name = None
         self._play_name = None
@@ -232,10 +240,13 @@ class CallbackModule(CallbackBase):
         name = '[%s] %s: %s' % (host_data.name, task_data.play, task_data.name)
         duration = host_data.finish - task_data.start
 
-        if self._task_relative_path:
+        if self._task_relative_path and task_data.path:
             junit_classname = os.path.relpath(task_data.path, self._task_relative_path)
         else:
             junit_classname = task_data.path
+
+        if self._replace_out_of_tree_path is not None and junit_classname.startswith('../'):
+            junit_classname = self._replace_out_of_tree_path + os.path.basename(junit_classname)
 
         if self._task_class == 'true':
             junit_classname = re.sub(r'\.yml:[0-9]+$', '', junit_classname)

--- a/test/lib/ansible_test/_internal/integration/__init__.py
+++ b/test/lib/ansible_test/_internal/integration/__init__.py
@@ -206,7 +206,7 @@ def integration_test_environment(args, target, inventory_path_src):
         ansible_config = ansible_config_src
         vars_file = os.path.join(data_context().content.root, data_context().content.integration_vars_path)
 
-        yield IntegrationEnvironment(integration_dir, targets_dir, inventory_path, ansible_config, vars_file)
+        yield IntegrationEnvironment(data_context().content.root, integration_dir, targets_dir, inventory_path, ansible_config, vars_file)
         return
 
     # When testing a collection, the temporary directory must reside within the collection.
@@ -284,7 +284,7 @@ def integration_test_environment(args, target, inventory_path_src):
                 make_dirs(os.path.dirname(file_dst))
                 shutil.copy2(file_src, file_dst)
 
-        yield IntegrationEnvironment(integration_dir, targets_dir, inventory_path, ansible_config, vars_file)
+        yield IntegrationEnvironment(temp_dir, integration_dir, targets_dir, inventory_path, ansible_config, vars_file)
     finally:
         if not args.explain:
             shutil.rmtree(temp_dir)
@@ -322,7 +322,8 @@ def integration_test_config_file(args, env_config, integration_dir):
 
 class IntegrationEnvironment:
     """Details about the integration environment."""
-    def __init__(self, integration_dir, targets_dir, inventory_path, ansible_config, vars_file):
+    def __init__(self, test_dir, integration_dir, targets_dir, inventory_path, ansible_config, vars_file):
+        self.test_dir = test_dir
         self.integration_dir = integration_dir
         self.targets_dir = targets_dir
         self.inventory_path = inventory_path


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/76871

* ansible-test - Use relative paths in junit output.
* ansible-test - Handle out-of-tree JUnit paths.
* Also fix a traceback in the junit callback during automatic fact gathering.

(cherry picked from commit fbb5d56bd274c44b193cb95f0230b9352f62aab2)

Backport of https://github.com/ansible/ansible/pull/76918

(cherry picked from commit 41db6d8d35900d425df3228406db3fec61ab2269)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
