### PR TITLE
doc: 2.9: firewalld module (correct required version for permanent parameter)

### DIFF
--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -63,7 +63,7 @@ options:
   permanent:
     description:
       - Should this configuration be in the running firewalld configuration or persist across reboots.
-      - As of Ansible 2.3, permanent operations can operate on firewalld configs when it is not running (requires firewalld >= 3.0.9).
+      - As of Ansible 2.3, permanent operations can operate on firewalld configs when it is not running (requires firewalld >= 0.3.9).
       - Note that if this is C(no), immediate is assumed C(yes).
     type: bool
   immediate:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Corrects documentation for Ansible 2.9: `firewalld` module's `permanent` parameter.

(Required version of firewalld: ~3.0.9~ 0.3.9.)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

Documentation: Ansible 2.9: `firewalld` module: `permanent` parameter (required version of `firewalld`)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

https://docs.ansible.com/ansible/2.9/modules/firewalld_module.html states in part:

> **permanent** ... As of Ansible 2.3, permanent operations can operate on firewalld configs when it is not running (requires firewalld >= 3.0.9).

However, there is no firewalld 3.0.9. (Newest release at https://firewalld.org/download/all.html is 1.0.1.)

The "3.0.9" Language appears to have been added ~5 years ago in [3ac2a498ae527cc92cd770dc000db7dd92e585f9](https://github.com/ansible/ansible/commit/3ac2a498ae527cc92cd770dc000db7dd92e585f9), and appears to be a typo. (Code in the same commit includes lines such as `if FW_VERSION < "0.3.9"` while documentation in same commit references a non-existent firewalld 3.0.9.)

Pull request is against `stable-2.9` branch, not `devel`, because fix is intended for the Ansible 2.9 documentation. (Module no longer exists in `devel`.)

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
