### PR TITLE
make Ansible.Basic work on non-Windows

### DIFF
--- a/changelogs/fragments/76924-powershell-ansible.basic-support-non-windows.yml
+++ b/changelogs/fragments/76924-powershell-ansible.basic-support-non-windows.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Ansible.Basic - small changes to allow use in PowerShell modules running on non-Windows platforms (https://github.com/ansible/ansible/pull/76924).

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -126,11 +126,9 @@ namespace Ansible.Basic
         {
             get
             {
-#if !WINDOWS
-                throw new NotImplementedException("Tmpdir is only supported on Windows");
-#else
                 if (tmpdir == null)
                 {
+#if WINDOWS
                     SecurityIdentifier user = WindowsIdentity.GetCurrent().User;
                     DirectorySecurity dirSecurity = new DirectorySecurity();
                     dirSecurity.SetOwner(user);
@@ -186,9 +184,11 @@ namespace Ansible.Basic
 
                     if (!KeepRemoteFiles)
                         cleanupFiles.Add(tmpdir);
+#else
+                    throw new NotImplementedException("Tmpdir is only supported on Windows");
+#endif
                 }
                 return tmpdir;
-#endif
             }
         }
 

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -383,6 +383,7 @@ namespace Ansible.Basic
                 }
             }
 #else
+            // Windows Event Log is only available on Windows
             return;
 #endif
         }

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -128,7 +128,7 @@ namespace Ansible.Basic
             {
 #if !WINDOWS
                 throw new NotImplementedException("Tmpdir is only supported on Windows");
-#endif
+#else
                 if (tmpdir == null)
                 {
                     SecurityIdentifier user = WindowsIdentity.GetCurrent().User;
@@ -188,6 +188,7 @@ namespace Ansible.Basic
                         cleanupFiles.Add(tmpdir);
                 }
                 return tmpdir;
+#endif
             }
         }
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
More discussion from the WWG: https://meetbot.fedoraproject.org/ansible-windows/2022-02-01/ansible_windows_working_group.2022-02-01-20.00.html

This adds some preprocessor directives to `Ansible.Basic.cs` so that it will work with PowerShell modules running on non-Windows.

The logging function is basically completely bypassed for now, since it uses the Windows event log which is not available.

The Tmpdir getter is updated to throw a `NotImplemented` exception.

## Important Note:
https://github.com/ansible/ansible/pull/76924#pullrequestreview-869850663

> Ansible does not support pwsh modules on non-Windows and this is not a new feature added to implement such a thing right now. It's mostly just allowing collection authors the ability to experiment support for using Ansible.Basic on non-Windows platforms at this point in time.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Ansible.Basic.cs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
N/A