### PR TITLE
Resubmit: Use SystemdStrategy for Debian in the hostname module

### DIFF
--- a/changelogs/fragments/76124-hostname-debianstrategy.yml
+++ b/changelogs/fragments/76124-hostname-debianstrategy.yml
@@ -1,2 +1,3 @@
+bugfixes:
   - hostname - Fix Debian strategy KeyError, use `SystemdStrategy`
     (https://github.com/ansible/ansible/issues/76124)

--- a/changelogs/fragments/76124-hostname-debianstrategy.yml
+++ b/changelogs/fragments/76124-hostname-debianstrategy.yml
@@ -1,0 +1,2 @@
+  - hostname - Fix Debian strategy KeyError, use `SystemdStrategy`
+    (https://github.com/ansible/ansible/issues/76124)

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2013, Hiroaki Nakamura <hnakamur@gmail.com>

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -84,9 +84,9 @@ from ansible.module_utils.six import PY3, text_type
 
 STRATS = {
     'alpine': 'Alpine',
-    'debian': 'Debian',
+    'debian': 'Systemd',
     'freebsd': 'FreeBSD',
-    'generic': 'Generic',
+    'generic': 'Base',
     'macos': 'Darwin',
     'macosx': 'Darwin',
     'darwin': 'Darwin',

--- a/test/integration/targets/hostname/tasks/Debian.yml
+++ b/test/integration/targets/hostname/tasks/Debian.yml
@@ -1,0 +1,20 @@
+---
+- name: Test DebianStrategy by setting hostname
+  become: 'yes'
+  hostname:
+    use: debian
+    name: "{{ ansible_distribution_release }}-bebop.ansible.example.com"
+
+- name: Test DebianStrategy by getting current hostname
+  command: hostname
+  register: get_hostname
+
+- name: Test DebianStrategy by verifying /etc/hostname content
+  command: grep -v '^#' /etc/hostname
+  register: grep_hostname
+
+- name: Test DebianStrategy using assertions
+  assert:
+    that:
+      - "'{{ ansible_distribution_release }}-bebop.ansible.example.com' in get_hostname.stdout"
+      - "'{{ ansible_distribution_release }}-bebop.ansible.example.com' in grep_hostname.stdout"

--- a/test/integration/targets/hostname/tasks/main.yml
+++ b/test/integration/targets/hostname/tasks/main.yml
@@ -30,6 +30,7 @@
   always:
     # Reset back to original hostname
     - name: Move back original file if it existed
+      become: 'yes'
       command: mv -f {{ _hostname_file }}.orig {{ _hostname_file }}
       when: hn_stat.stat.exists | default(False)
 
@@ -40,6 +41,7 @@
       when: not hn_stat.stat.exists | default(True)
 
     - name: Reset back to original hostname
+      become: 'yes'
       hostname:
         name: "{{ original.stdout }}"
       register: revert

--- a/test/integration/targets/hostname/tasks/test_normal.yml
+++ b/test/integration/targets/hostname/tasks/test_normal.yml
@@ -1,4 +1,5 @@
 - name: Run hostname module for real now
+  become: 'yes'
   hostname:
     name: crocodile.ansible.test.doesthiswork.net.example.com
   register: hn2
@@ -8,6 +9,7 @@
   register: current_after_hn2
 
 - name: Run hostname again to ensure it does not change
+  become: 'yes'
   hostname:
     name: crocodile.ansible.test.doesthiswork.net.example.com
   register: hn3

--- a/test/units/modules/test_hostname.py
+++ b/test/units/modules/test_hostname.py
@@ -38,6 +38,18 @@ class TestHostname(ModuleTestCase):
                     m.return_value.write.called,
                     msg='%s called write, should not have' % str(cls))
 
+    def test_all_named_strategies_exist(self):
+        """Loop through the STRATS and see if anything is missing."""
+        for _name, prefix in hostname.STRATS.items():
+            classname = "%sStrategy" % prefix
+            cls = getattr(hostname, classname, None)
+
+            if cls is None:
+                self.assertFalse(
+                    cls is None, "%s is None, should be a subclass" % classname
+                )
+            else:
+                self.assertTrue(issubclass(cls, hostname.BaseStrategy))
 
 class TestRedhatStrategy(ModuleTestCase):
     def setUp(self):

--- a/test/units/modules/test_hostname.py
+++ b/test/units/modules/test_hostname.py
@@ -51,6 +51,7 @@ class TestHostname(ModuleTestCase):
             else:
                 self.assertTrue(issubclass(cls, hostname.BaseStrategy))
 
+
 class TestRedhatStrategy(ModuleTestCase):
     def setUp(self):
         super(TestRedhatStrategy, self).setUp()


### PR DESCRIPTION
_This is a rebased and cleaner resubmit of https://github.com/ansible/ansible/pull/76125._

##### SUMMARY

This PR:
- Use `SystemdStrategy` for Debian in order to fix `KeyError`
- Adds integration tests for Debian
- Adds unit test to ensure all strategies exists (https://github.com/ansible/ansible/pull/76125#issuecomment-953779420)
- Ensures that the hostname manipulation test can finish by adding `become` to relevant tasks.
- Changes `'generic': 'Generic'` to `'generic': 'Base'`
- Fixes #76124
- Closes #68684

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/modules/hostname.py
