### PR TITLE
support rescued in the v2_runner_on_failed callback

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -444,7 +444,7 @@ class CallbackBase(AnsiblePlugin):
     def on_any(self, *args, **kwargs):
         pass
 
-    def runner_on_failed(self, host, res, ignore_errors=False):
+    def runner_on_failed(self, host, res, ignore_errors=False, rescued=False):
         pass
 
     def runner_on_ok(self, host, res):
@@ -508,9 +508,9 @@ class CallbackBase(AnsiblePlugin):
     def v2_on_any(self, *args, **kwargs):
         self.on_any(args, kwargs)
 
-    def v2_runner_on_failed(self, result, ignore_errors=False):
+    def v2_runner_on_failed(self, result, ignore_errors=False, rescued=False):
         host = result._host.get_name()
-        self.runner_on_failed(host, result._result, ignore_errors)
+        self.runner_on_failed(host, result._result, ignore_errors, rescued)
 
     def v2_runner_on_ok(self, result):
         host = result._host.get_name()

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -77,7 +77,7 @@ class CallbackModule(CallbackBase):
                 value = constant
             setattr(self, option, value)
 
-    def v2_runner_on_failed(self, result, ignore_errors=False):
+    def v2_runner_on_failed(self, result, ignore_errors=False, rescued=False):
 
         host_label = self.host_label(result)
         self._clean_results(result._result, result._task.action)

--- a/lib/ansible/plugins/callback/junit.py
+++ b/lib/ansible/plugins/callback/junit.py
@@ -306,7 +306,7 @@ class CallbackModule(CallbackBase):
     def v2_playbook_on_handler_task_start(self, task):
         self._start_task(task)
 
-    def v2_runner_on_failed(self, result, ignore_errors=False):
+    def v2_runner_on_failed(self, result, ignore_errors=False, rescued=False):
         if ignore_errors and self._fail_on_ignore != 'true':
             self._finish_task('ok', result)
         else:

--- a/lib/ansible/plugins/callback/minimal.py
+++ b/lib/ansible/plugins/callback/minimal.py
@@ -42,7 +42,7 @@ class CallbackModule(CallbackBase):
 
         return buf + "\n"
 
-    def v2_runner_on_failed(self, result, ignore_errors=False):
+    def v2_runner_on_failed(self, result, ignore_errors=False, rescued=False):
 
         self._handle_exception(result._result)
         self._handle_warnings(result._result)

--- a/lib/ansible/plugins/callback/oneline.py
+++ b/lib/ansible/plugins/callback/oneline.py
@@ -38,7 +38,7 @@ class CallbackModule(CallbackBase):
         else:
             return "%s | %s | rc=%s | (stdout) %s" % (hostname, caption, result.get('rc', -1), stdout)
 
-    def v2_runner_on_failed(self, result, ignore_errors=False):
+    def v2_runner_on_failed(self, result, ignore_errors=False, rescued=False):
         if 'exception' in result._result:
             if self._display.verbosity < 3:
                 # extract just the actual error message from the exception text

--- a/lib/ansible/plugins/callback/tree.py
+++ b/lib/ansible/plugins/callback/tree.py
@@ -79,7 +79,7 @@ class CallbackModule(CallbackBase):
     def v2_runner_on_ok(self, result):
         self.result_to_tree(result)
 
-    def v2_runner_on_failed(self, result, ignore_errors=False):
+    def v2_runner_on_failed(self, result, ignore_errors=False, rescued=False):
         self.result_to_tree(result)
 
     def v2_runner_on_unreachable(self, result):

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -567,6 +567,7 @@ class StrategyBase:
             role_ran = False
             if task_result.is_failed():
                 role_ran = True
+                rescued = False
                 ignore_errors = original_task.ignore_errors
                 if not ignore_errors:
                     display.debug("marking %s as failed" % original_host.name)
@@ -600,6 +601,7 @@ class StrategyBase:
                                 ansible_failed_result=task_result._result,
                             ),
                         )
+                        rescued = True
                     else:
                         self._tqm._stats.increment('failures', original_host.name)
                 else:
@@ -607,7 +609,7 @@ class StrategyBase:
                     self._tqm._stats.increment('ignored', original_host.name)
                     if 'changed' in task_result._result and task_result._result['changed']:
                         self._tqm._stats.increment('changed', original_host.name)
-                self._tqm.send_callback('v2_runner_on_failed', task_result, ignore_errors=ignore_errors)
+                self._tqm.send_callback('v2_runner_on_failed', task_result, ignore_errors=ignore_errors, rescued=rescued)
             elif task_result.is_unreachable():
                 ignore_unreachable = original_task.ignore_unreachable
                 if not ignore_unreachable:

--- a/test/integration/targets/module_utils/callback/pure_json.py
+++ b/test/integration/targets/module_utils/callback/pure_json.py
@@ -21,7 +21,7 @@ class CallbackModule(CallbackBase):
     CALLBACK_TYPE = 'stdout'
     CALLBACK_NAME = 'pure_json'
 
-    def v2_runner_on_failed(self, result, ignore_errors=False):
+    def v2_runner_on_failed(self, result, ignore_errors=False, rescued=False):
         self._display.display(json.dumps(result._result))
 
     def v2_runner_on_ok(self, result):


### PR DESCRIPTION
##### SUMMARY

The existing rescued implementation is available in v2_playbook_on_stats but it's not available in the other callbacks.
This should help to filter when a failed task was caused within a block/rescue block.

I was not sure if the signature change in v2_runner_on_failed requires to support a similar function the new signature for backward compatibility. So please bear with me if this can be done differently.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION

https://github.com/ansible/ansible/issues/76544 contains a similar kind of request to support the rescued tasks in the junit callback plugin.
