### PR TITLE
[stable-2.12] Update ci-files URL in integration tests.

### DIFF
--- a/test/integration/targets/apt/tasks/url-with-deps.yml
+++ b/test/integration/targets/apt/tasks/url-with-deps.yml
@@ -13,10 +13,10 @@
     # on vim-tiny. Really any .deb will work here so long as it has
     # dependencies that exist in a repo and get brought in.
     # The source and files for building this .deb can be found here:
-    # https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/apt/echo-hello-source.tar.gz
+    # https://ci-files.testing.ansible.com/test/integration/targets/apt/echo-hello-source.tar.gz
     - name: Install deb file with dependencies from URL (check_mode)
       apt:
-        deb: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/apt/echo-hello_1.0_all.deb
+        deb: https://ci-files.testing.ansible.com/test/integration/targets/apt/echo-hello_1.0_all.deb
       check_mode: true
       register: apt_url_deps_check_mode
 
@@ -33,7 +33,7 @@
 
     - name: Install deb file with dependencies from URL (for real this time)
       apt:
-        deb: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/apt/echo-hello_1.0_all.deb
+        deb: https://ci-files.testing.ansible.com/test/integration/targets/apt/echo-hello_1.0_all.deb
       register: apt_url_deps
 
     - name: check to make sure we installed the package

--- a/test/integration/targets/apt_key/tasks/apt_key_binary.yml
+++ b/test/integration/targets/apt_key/tasks/apt_key_binary.yml
@@ -2,7 +2,7 @@
 
 - name: Ensure import of binary key downloaded using URLs works
   apt_key:
-    url: https://ansible-ci-files.s3.us-east-1.amazonaws.com/test/integration/targets/apt_key/apt-key-example-binary.gpg
+    url: https://ci-files.testing.ansible.com/test/integration/targets/apt_key/apt-key-example-binary.gpg
   register: apt_key_binary_test
 
 - name: Validate the results

--- a/test/integration/targets/apt_key/tasks/apt_key_inline_data.yml
+++ b/test/integration/targets/apt_key/tasks/apt_key_inline_data.yml
@@ -1,5 +1,5 @@
 - name: "Ensure import of a deliberately corrupted downloaded GnuPG binary key results in an 'inline data' occurence in the message"
   apt_key:
-    url: https://ansible-ci-files.s3.us-east-1.amazonaws.com/test/integration/targets/apt_key/apt-key-corrupt-zeros-2k.gpg
+    url: https://ci-files.testing.ansible.com/test/integration/targets/apt_key/apt-key-corrupt-zeros-2k.gpg
   register: gpg_inline_result
   failed_when: "not ('inline data' in gpg_inline_result.msg)"

--- a/test/integration/targets/apt_key/tasks/file.yml
+++ b/test/integration/targets/apt_key/tasks/file.yml
@@ -1,6 +1,6 @@
 - name: Get Fedora GPG Key
   get_url:
-    url: https://ansible-ci-files.s3.us-east-1.amazonaws.com/test/integration/targets/apt_key/fedora.gpg
+    url: https://ci-files.testing.ansible.com/test/integration/targets/apt_key/fedora.gpg
     dest: /tmp/fedora.gpg
 
 - name: Ensure clean slate
@@ -42,7 +42,7 @@
 
 - name: add key from url
   apt_key:
-    url: https://ansible-ci-files.s3.us-east-1.amazonaws.com/test/integration/targets/apt_key/fedora.gpg
+    url: https://ci-files.testing.ansible.com/test/integration/targets/apt_key/fedora.gpg
   register: apt_key_url
 
 - name: verify key from url

--- a/test/integration/targets/binary_modules/Makefile
+++ b/test/integration/targets/binary_modules/Makefile
@@ -3,7 +3,7 @@
 all:
 	# Compiled versions of these binary modules are available at the url below.
 	# This avoids a dependency on go and keeps the binaries out of our git repository.
-	# https://ansible-ci-files.s3.amazonaws.com/test/integration/roles/test_binary_modules/
+	# https://ci-files.testing.ansible.com/test/integration/roles/test_binary_modules/
 	cd library; \
 	GOOS=linux   GOARCH=amd64   go build -o helloworld_linux_x86_64       helloworld.go; \
 	GOOS=linux   GOARCH=ppc64le go build -o helloworld_linux_ppc64le      helloworld.go; \

--- a/test/integration/targets/binary_modules/download_binary_modules.yml
+++ b/test/integration/targets/binary_modules/download_binary_modules.yml
@@ -3,7 +3,7 @@
     - name: download binary module
       tags: test_binary_modules
       get_url:
-        url: "https://ansible-ci-files.s3.amazonaws.com/test/integration/roles/test_binary_modules/{{ filename }}"
+        url: "https://ci-files.testing.ansible.com/test/integration/roles/test_binary_modules/{{ filename }}"
         dest: "{{ playbook_dir }}/library/{{ filename }}"
         mode: 0755
       delegate_to: localhost

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -488,7 +488,7 @@
 
 - name: try to install from non existing url
   dnf:
-    name: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/dnf/non-existing-1.0.0.fc26.noarch.rpm
+    name: https://ci-files.testing.ansible.com/test/integration/targets/dnf/non-existing-1.0.0.fc26.noarch.rpm
     state: present
   register: dnf_result
   ignore_errors: yes
@@ -583,7 +583,7 @@
 
 - name: try to install not compatible arch rpm, should fail
   dnf:
-    name: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/dnf/banner-1.3.4-3.el7.ppc64le.rpm
+    name: https://ci-files.testing.ansible.com/test/integration/targets/dnf/banner-1.3.4-3.el7.ppc64le.rpm
     state: present
   register: dnf_result
   ignore_errors: True

--- a/test/integration/targets/dnf/tasks/filters.yml
+++ b/test/integration/targets/dnf/tasks/filters.yml
@@ -2,7 +2,7 @@
 # from its repomd.xml.
 - block:
     - set_fact:
-        updateinfo_repo: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/setup_rpm_repo/repo-with-updateinfo
+        updateinfo_repo: https://ci-files.testing.ansible.com/test/integration/targets/setup_rpm_repo/repo-with-updateinfo
 
     - name: Install the test repo
       yum_repository:

--- a/test/integration/targets/dnf/tasks/filters_check_mode.yml
+++ b/test/integration/targets/dnf/tasks/filters_check_mode.yml
@@ -2,7 +2,7 @@
 # from its repomd.xml.
 - block:
     - set_fact:
-        updateinfo_repo: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/setup_rpm_repo/repo-with-updateinfo
+        updateinfo_repo: https://ci-files.testing.ansible.com/test/integration/targets/setup_rpm_repo/repo-with-updateinfo
 
     - name: Install the test repo
       yum_repository:

--- a/test/integration/targets/dpkg_selections/tasks/dpkg_selections.yaml
+++ b/test/integration/targets/dpkg_selections/tasks/dpkg_selections.yaml
@@ -1,5 +1,5 @@
 - name: download and install old version of hello
-  apt: "deb=https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/dpkg_selections/hello_{{ hello_old_version }}_amd64.deb"
+  apt: "deb=https://ci-files.testing.ansible.com/test/integration/targets/dpkg_selections/hello_{{ hello_old_version }}_amd64.deb"
 
 - name: freeze version for hello
   dpkg_selections:

--- a/test/integration/targets/rpm_key/tasks/rpm_key.yaml
+++ b/test/integration/targets/rpm_key/tasks/rpm_key.yaml
@@ -21,17 +21,17 @@
 #
 - name: download EPEL GPG key
   get_url:
-    url: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/rpm_key/RPM-GPG-KEY-EPEL-7
+    url: https://ci-files.testing.ansible.com/test/integration/targets/rpm_key/RPM-GPG-KEY-EPEL-7
     dest: /tmp/RPM-GPG-KEY-EPEL-7
 
 - name: download sl rpm
   get_url:
-    url: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/rpm_key/sl-5.02-1.el7.x86_64.rpm
+    url: https://ci-files.testing.ansible.com/test/integration/targets/rpm_key/sl-5.02-1.el7.x86_64.rpm
     dest: /tmp/sl.rpm
 
 - name: download Mono key
   get_url:
-    url: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/rpm_key/mono.gpg
+    url: https://ci-files.testing.ansible.com/test/integration/targets/rpm_key/mono.gpg
     dest: /tmp/mono.gpg
 
 - name: remove EPEL GPG key from keyring
@@ -96,7 +96,7 @@
 - name: remove GPG key from url
   rpm_key:
     state: absent
-    key: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/rpm_key/RPM-GPG-KEY-EPEL-7
+    key: https://ci-files.testing.ansible.com/test/integration/targets/rpm_key/RPM-GPG-KEY-EPEL-7
 
 - name: Confirm key is missing
   shell: "rpm --checksig /tmp/sl.rpm"
@@ -112,7 +112,7 @@
 - name: add GPG key from url
   rpm_key:
     state: present
-    key: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/rpm_key/RPM-GPG-KEY-EPEL-7
+    key: https://ci-files.testing.ansible.com/test/integration/targets/rpm_key/RPM-GPG-KEY-EPEL-7
 
 - name: check GPG signature of sl. Should return okay
   shell: "rpm --checksig /tmp/sl.rpm"
@@ -128,7 +128,7 @@
 - name: add very first key on system
   rpm_key:
     state: present
-    key: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/rpm_key/RPM-GPG-KEY-EPEL-7
+    key: https://ci-files.testing.ansible.com/test/integration/targets/rpm_key/RPM-GPG-KEY-EPEL-7
 
 - name: check GPG signature of sl. Should return okay
   shell: "rpm --checksig /tmp/sl.rpm"
@@ -140,7 +140,7 @@
 
 - name: Issue 20325 - Verify fingerprint of key, invalid fingerprint - EXPECTED FAILURE
   rpm_key:
-    key: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/rpm_key/RPM-GPG-KEY.dag
+    key: https://ci-files.testing.ansible.com/test/integration/targets/rpm_key/RPM-GPG-KEY.dag
     fingerprint: 1111 1111 1111 1111 1111 1111 1111 1111 1111 1111
   register: result
   failed_when: result is success
@@ -154,7 +154,7 @@
 
 - name: Issue 20325 - Verify fingerprint of key, valid fingerprint
   rpm_key:
-    key: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/rpm_key/RPM-GPG-KEY.dag
+    key: https://ci-files.testing.ansible.com/test/integration/targets/rpm_key/RPM-GPG-KEY.dag
     fingerprint: EBC6 E12C 62B1 C734 026B 2122 A20E 5214 6B8D 79E6
   register: result
 
@@ -166,7 +166,7 @@
 
 - name: Issue 20325 - Verify fingerprint of key, valid fingerprint - Idempotent check
   rpm_key:
-    key: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/rpm_key/RPM-GPG-KEY.dag
+    key: https://ci-files.testing.ansible.com/test/integration/targets/rpm_key/RPM-GPG-KEY.dag
     fingerprint: EBC6 E12C 62B1 C734 026B 2122 A20E 5214 6B8D 79E6
   register: result
 

--- a/test/integration/targets/setup_epel/tasks/main.yml
+++ b/test/integration/targets/setup_epel/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Install EPEL
   yum:
-    name: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/setup_epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+    name: https://ci-files.testing.ansible.com/test/integration/targets/setup_epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
     disable_gpg_check: true
   when: ansible_facts.distribution in ['RedHat', 'CentOS']

--- a/test/integration/targets/setup_win_printargv/tasks/main.yml
+++ b/test/integration/targets/setup_win_printargv/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: download the PrintArgv.exe binary to temp location
   win_get_url:
-    url: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/setup_win_printargv/PrintArgv.exe
+    url: https://ci-files.testing.ansible.com/test/integration/targets/setup_win_printargv/PrintArgv.exe
     dest: '{{ remote_tmp_dir }}\PrintArgv.exe'
 
 - name: set fact containing PrintArgv binary path

--- a/test/integration/targets/yum/tasks/proxy.yml
+++ b/test/integration/targets/yum/tasks/proxy.yml
@@ -2,7 +2,7 @@
   block:
     - name: install tinyproxy
       yum:
-        name: 'https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/yum/tinyproxy-1.10.0-3.el7.x86_64.rpm'
+        name: 'https://ci-files.testing.ansible.com/test/integration/targets/yum/tinyproxy-1.10.0-3.el7.x86_64.rpm'
         state: installed
 
     # systemd doesn't play nice with this in a container for some reason
@@ -25,7 +25,7 @@
 
     - name: install ninvaders with unauthenticated proxy
       yum:
-        name: 'https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/yum/ninvaders-0.1.1-18.el7.x86_64.rpm'
+        name: 'https://ci-files.testing.ansible.com/test/integration/targets/yum/ninvaders-0.1.1-18.el7.x86_64.rpm'
         state: installed
       register: yum_proxy_result
 
@@ -84,7 +84,7 @@
 
     - name: install ninvaders with authenticated proxy
       yum:
-        name: 'https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/yum/ninvaders-0.1.1-18.el7.x86_64.rpm'
+        name: 'https://ci-files.testing.ansible.com/test/integration/targets/yum/ninvaders-0.1.1-18.el7.x86_64.rpm'
         state: installed
       register: yum_proxy_result
 
@@ -134,7 +134,7 @@
 
     - name: install ninvaders with proxy, proxy_username, and proxy_password config in yum.conf
       yum:
-        name: 'https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/yum/ninvaders-0.1.1-18.el7.x86_64.rpm'
+        name: 'https://ci-files.testing.ansible.com/test/integration/targets/yum/ninvaders-0.1.1-18.el7.x86_64.rpm'
         state: installed
       register: yum_proxy_result
 

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -532,7 +532,7 @@
 
 - name: try to install from non existing url
   yum:
-    name: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/yum/non-existing-1.0.0.fc26.noarch.rpm
+    name: https://ci-files.testing.ansible.com/test/integration/targets/yum/non-existing-1.0.0.fc26.noarch.rpm
     state: present
   register: yum_result
   ignore_errors: yes
@@ -580,7 +580,7 @@
 
 - name: try to install uncompatible arch rpm on non-ppc64le, should fail
   yum:
-    name: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/yum/banner-1.3.4-3.el7.ppc64le.rpm
+    name: https://ci-files.testing.ansible.com/test/integration/targets/yum/banner-1.3.4-3.el7.ppc64le.rpm
     state: present
   register: yum_result
   ignore_errors: True
@@ -597,7 +597,7 @@
 
 - name: try to install uncompatible arch rpm on ppc64le, should fail
   yum:
-    name: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/yum/tinyproxy-1.10.0-3.el7.x86_64.rpm
+    name: https://ci-files.testing.ansible.com/test/integration/targets/yum/tinyproxy-1.10.0-3.el7.x86_64.rpm
     state: present
   register: yum_result
   ignore_errors: True
@@ -837,8 +837,8 @@
     - name: Install test packages
       yum:
         name:
-          - https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/yum/test-package-that-provides-toaster-1.3.3.7-1.el7.noarch.rpm
-          - https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/yum/toaster-1.2.3.4-1.el7.noarch.rpm
+          - https://ci-files.testing.ansible.com/test/integration/targets/yum/test-package-that-provides-toaster-1.3.3.7-1.el7.noarch.rpm
+          - https://ci-files.testing.ansible.com/test/integration/targets/yum/toaster-1.2.3.4-1.el7.noarch.rpm
         disable_gpg_check: true
       register: install
 

--- a/test/integration/targets/yum/vars/main.yml
+++ b/test/integration/targets/yum/vars/main.yml
@@ -1,1 +1,1 @@
-multiarch_repo_baseurl: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/yum/multiarch-test-repo/RPMS/
+multiarch_repo_baseurl: https://ci-files.testing.ansible.com/test/integration/targets/yum/multiarch-test-repo/RPMS/


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/76937

This uses the CloudFront URL instead of going directly to S3..

(cherry picked from commit 6c29028f05e653bc10555f6f51bce1bc5f8ea515)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

integration tests
