### PR TITLE
[stable-2.12] Stop publishing code coverage to the AZP UI.

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -26,8 +26,6 @@ variables:
     value: ansible
   - name: coverageBranches
     value: devel
-  - name: pipelinesCoverage
-    value: coverage
   - name: entryPoint
     value: test/utils/shippable/shippable.sh
   - name: fetchDepth

--- a/.azure-pipelines/templates/coverage.yml
+++ b/.azure-pipelines/templates/coverage.yml
@@ -23,19 +23,6 @@ jobs:
       - bash: .azure-pipelines/scripts/report-coverage.sh
         displayName: Generate Coverage Report
         condition: gt(variables.coverageFileCount, 0)
-      - task: PublishCodeCoverageResults@1
-        inputs:
-          codeCoverageTool: Cobertura
-          # Azure Pipelines only accepts a single coverage data file.
-          # That means only Python or PowerShell coverage can be uploaded, but not both.
-          # Set the "pipelinesCoverage" variable to determine which type is uploaded.
-          # Use "coverage" for Python and "coverage-powershell" for PowerShell.
-          summaryFileLocation: "$(outputPath)/reports/$(pipelinesCoverage).xml"
-          # Override the root (sources) path specified in the coverage XML files.
-          # This allows coverage to be reported in Azure Pipelines even if the report was generated in a container.
-          pathToSources: "$(Agent.BuildDirectory)/$(checkoutPath)"
-        displayName: Publish to Azure Pipelines
-        condition: gt(variables.coverageFileCount, 0)
       - bash: .azure-pipelines/scripts/publish-codecov.py "$(outputPath)"
         displayName: Publish to codecov.io
         condition: gt(variables.coverageFileCount, 0)


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/76945

Azure Pipelines only supports publishing a single code coverage file.
This limits us to reporting on either Python or PowerShell.
It also prevents us from reporting coverage per test command without further aggregation.
Most of our users are only aware of the reports published to codecov.io.

(cherry picked from commit a926b1dbab536655ce1807aadffa26750170b86f)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

.azure-pipelines/azure-pipelines.yml