### PR TITLE
[stable-2.12] Update codecov download URL.

### DIFF
--- a/.azure-pipelines/scripts/publish-codecov.py
+++ b/.azure-pipelines/scripts/publish-codecov.py
@@ -88,7 +88,7 @@ def download_file(url: str, dest: pathlib.Path, flags: int, dry_run: bool = Fals
 
 def main():
     args = parse_args()
-    url = 'https://ansible-ci-files.s3.amazonaws.com/codecov/linux/codecov'
+    url = 'https://ci-files.testing.ansible.com/codecov/linux/codecov'
     with tempfile.TemporaryDirectory(prefix='codecov-') as tmpdir:
         codecov_bin = pathlib.Path(tmpdir) / 'codecov'
         download_file(url, codecov_bin, 0o755, args.dry_run)


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/76946

(cherry picked from commit e2d4c41ac0220d7850879d581fd168c3e764a7ab)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

.azure-pipelines/scripts/publish-codecov.py