### PR TITLE
[stable-2.12] ansible-test - Update bootstrap URL to not use S3.

### DIFF
--- a/changelogs/fragments/ansible-test-ci-files.yaml
+++ b/changelogs/fragments/ansible-test-ci-files.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Use https://ci-files.testing.ansible.com/ for instance bootstrapping instead of an S3 endpoint.

--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -50,7 +50,7 @@ install_pip() {
     if ! "${python_interpreter}" -m pip.__main__ --version --disable-pip-version-check 2>/dev/null; then
         case "${python_version}" in
             *)
-                pip_bootstrap_url="https://ansible-ci-files.s3.amazonaws.com/ansible-test/get-pip-20.3.4.py"
+                pip_bootstrap_url="https://ci-files.testing.ansible.com/ansible-test/get-pip-20.3.4.py"
                 ;;
         esac
 


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/76936

(cherry picked from commit 7e64c4fe55eaf6a760e777825c81d4c238a031ee)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

ansible-test