### PR TITLE
Temporarily remove RHEL 9.0b from test matrix.

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -94,8 +94,6 @@ stages:
               test: rhel/8.5@3.6
             - name: RHEL 8.5 py38
               test: rhel/8.5@3.8
-            - name: RHEL 9.0b
-              test: rhel/9.0b
             - name: FreeBSD 12.3
               test: freebsd/12.3
             - name: FreeBSD 13.0


### PR DESCRIPTION
##### SUMMARY

Installation of `gcc` is failing while trying to install dependencies:

```
[MIRROR] libxcrypt-devel-4.4.18-3.el9.x86_64.rpm: Interrupted by header callback: Server reports Content-Length: 32565 but expected size is: 33101
```

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

.azure-pipelines/azure-pipelines.yml