### PR TITLE
Disable failing test task on openSUSE 15.2.

### DIFF
--- a/test/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/test/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -125,3 +125,4 @@
     priority: 100
     auto_import_keys: true
     state: "present"
+  when: ansible_distribution_version is version('15.2', 'gt')  # openSUSE Leap 15.2 is EOL and packages are no longer available


### PR DESCRIPTION
##### SUMMARY

Disable failing test task on openSUSE 15.2.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

test/integration/targets/zypper_repository/tasks/zypper_repository.yml