### PR TITLE
ssh connection: use 'correct' host in all cases (#76017)

### DIFF
--- a/changelogs/fragments/ssh_use_right_host.yml
+++ b/changelogs/fragments/ssh_use_right_host.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ssh connection now uses more correct host source as play_context can ignore loop/delegation variations.

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1273,6 +1273,8 @@ class Connection(ConnectionBase):
 
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
 
+        self.host = self.get_option('host') or self._play_context.remote_addr
+
         display.vvv(u"ESTABLISH SSH CONNECTION FOR USER: {0}".format(self.user), host=self.host)
 
         if getattr(self._shell, "_IS_WINDOWS", False):
@@ -1317,6 +1319,8 @@ class Connection(ConnectionBase):
 
         super(Connection, self).put_file(in_path, out_path)
 
+        self.host = self.get_option('host') or self._play_context.remote_addr
+
         display.vvv(u"PUT {0} TO {1}".format(in_path, out_path), host=self.host)
         if not os.path.exists(to_bytes(in_path, errors='surrogate_or_strict')):
             raise AnsibleFileNotFound("file or module does not exist: {0}".format(to_native(in_path)))
@@ -1331,6 +1335,8 @@ class Connection(ConnectionBase):
 
         super(Connection, self).fetch_file(in_path, out_path)
 
+        self.host = self.get_option('host') or self._play_context.remote_addr
+
         display.vvv(u"FETCH {0} TO {1}".format(in_path, out_path), host=self.host)
 
         # need to add / if path is rooted
@@ -1342,6 +1348,7 @@ class Connection(ConnectionBase):
     def reset(self):
 
         run_reset = False
+        self.host = self.get_option('host') or self._play_context.remote_addr
 
         # If we have a persistent ssh connection (ControlPersist), we can ask it to stop listening.
         # only run the reset if the ControlPath already exists or if it isn't configured and ControlPersist is set

--- a/test/integration/targets/delegate_to/inventory
+++ b/test/integration/targets/delegate_to/inventory
@@ -7,3 +7,11 @@ testhost5 ansible_connection=fakelocal
 
 [all:vars]
 ansible_python_interpreter="{{ ansible_playbook_python }}"
+
+[delegated_vars]
+testhost6 myhost=127.0.0.3
+testhost7 myhost=127.0.0.4
+
+[delegated_vars:vars]
+ansible_host={{myhost}}
+ansible_connection=ssh

--- a/test/integration/targets/delegate_to/runme.sh
+++ b/test/integration/targets/delegate_to/runme.sh
@@ -48,7 +48,7 @@ ANSIBLE_SSH_ARGS='-C -o ControlMaster=auto -o ControlPersist=60s -o UserKnownHos
 # this test is not doing what it says it does, also relies on var that should not be available
 #ansible-playbook test_loop_control.yml -v "$@"
 
-ansible-playbook test_delegate_to_loop_randomness.yml -v "$@"
+ansible-playbook test_delegate_to_loop_randomness.yml -i inventory -v "$@"
 
 ansible-playbook delegate_and_nolog.yml -i inventory -v "$@"
 

--- a/test/integration/targets/delegate_to/test_delegate_to.yml
+++ b/test/integration/targets/delegate_to/test_delegate_to.yml
@@ -56,3 +56,27 @@
 
     - name: remove test file
       file: path={{ output_dir }}/tmp.txt state=absent
+
+
+- name: verify delegation with per host vars
+  hosts: testhost6
+  gather_facts: yes
+  tasks:
+    - debug: msg={{ansible_facts['env']}}
+
+    - name: ensure normal facts still work as expected
+      assert:
+        that:
+          - '"127.0.0.3" in ansible_facts["env"]["SSH_CONNECTION"]'
+
+    - name: Test delegate_to with other host defined using same named var
+      setup:
+      register: setup_results
+      delegate_to: testhost7
+
+    - debug: msg={{setup_results.ansible_facts.ansible_env}}
+
+    - name: verify ssh plugin resolves variable for ansible_host correctly
+      assert:
+        that:
+          - '"127.0.0.4" in setup_results.ansible_facts.ansible_env["SSH_CONNECTION"]'


### PR DESCRIPTION
 ssh plugin, use 'correct' information source in all cases
  * still fallback to pc
  * added inventory to new test
  * undef var can still show as parser error on pc
    now task_exectuer has a  more accurate error handling

(cherry picked from commit be19863e44cc6b78706147b25489a73d7c8fbcb5)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
connection/ssh