### PR TITLE
ansible-test - Update alpine3 container to 3.3.0.

### DIFF
--- a/changelogs/fragments/ansible-test-alpine3-update.yaml
+++ b/changelogs/fragments/ansible-test-alpine3-update.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ansible-test - Update the ``alpine`` container to version 3.3.0.
+    This updates the base image from 3.14.2 to 3.15.0, which includes support for installing binary wheels using pip.

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,7 +1,7 @@
 base image=quay.io/ansible/base-test-container:2.1.0 python=3.10,2.7,3.5,3.6,3.7,3.8,3.9 seccomp=unconfined
 default image=quay.io/ansible/default-test-container:5.5.0 python=3.10,2.7,3.5,3.6,3.7,3.8,3.9 seccomp=unconfined context=collection
 default image=quay.io/ansible/ansible-core-test-container:5.5.0 python=3.10,2.7,3.5,3.6,3.7,3.8,3.9 seccomp=unconfined context=ansible-core
-alpine3 image=quay.io/ansible/alpine3-test-container:3.1.0 python=3.9
+alpine3 image=quay.io/ansible/alpine3-test-container:3.3.0 python=3.9
 centos7 image=quay.io/ansible/centos7-test-container:3.1.0 python=2.7 seccomp=unconfined
 fedora34 image=quay.io/ansible/fedora34-test-container:3.1.0 python=3.9 seccomp=unconfined
 fedora35 image=quay.io/ansible/fedora35-test-container:3.2.0 python=3.10 seccomp=unconfined


### PR DESCRIPTION
##### SUMMARY

ansible-test - Update alpine3 container to 3.3.0.

This updates the base image from 3.14.2 to 3.15.0, which includes support for installing binary wheels using pip.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
