### PR TITLE
[stable-2.12] ansible-test - Update alpine3 container to 3.3.0.

### DIFF
--- a/changelogs/fragments/ansible-test-alpine3-update.yaml
+++ b/changelogs/fragments/ansible-test-alpine3-update.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ansible-test - Update the ``alpine`` container to version 3.3.0.
+    This updates the base image from 3.14.2 to 3.15.0, which includes support for installing binary wheels using pip.

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,7 +1,7 @@
 base image=quay.io/ansible/base-test-container:1.1.0 python=3.9,2.6,2.7,3.5,3.6,3.7,3.8,3.10 seccomp=unconfined
 default image=quay.io/ansible/default-test-container:4.1.1 python=3.9,2.6,2.7,3.5,3.6,3.7,3.8,3.10 seccomp=unconfined context=collection
 default image=quay.io/ansible/ansible-core-test-container:4.1.1 python=3.9,2.6,2.7,3.5,3.6,3.7,3.8,3.10 seccomp=unconfined context=ansible-core
-alpine3 image=quay.io/ansible/alpine3-test-container:3.1.0 python=3.9
+alpine3 image=quay.io/ansible/alpine3-test-container:3.3.0 python=3.9
 centos6 image=quay.io/ansible/centos6-test-container:3.1.0 python=2.6 seccomp=unconfined
 centos7 image=quay.io/ansible/centos7-test-container:3.1.0 python=2.7 seccomp=unconfined
 centos8 image=quay.io/ansible/centos8-test-container:3.1.0 python=3.6 seccomp=unconfined


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/76975

This updates the base image from 3.14.2 to 3.15.0, which includes support for installing binary wheels using pip.

(cherry picked from commit e27b94c4671df95338ae770036b6efdbf3e33990)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
