### PR TITLE
Added a powershell example for ansible.builtin.script

### DIFF
--- a/lib/ansible/modules/script.py
+++ b/lib/ansible/modules/script.py
@@ -102,7 +102,7 @@ EXAMPLES = r'''
   ansible.builtin.script: /some/local/script.py
   args:
     executable: python3
-    
+
 - name: Run a Powershell script on a windows host
   script: subdirectories/under/path/with/your/playbook/script.ps1
 '''

--- a/lib/ansible/modules/script.py
+++ b/lib/ansible/modules/script.py
@@ -102,4 +102,7 @@ EXAMPLES = r'''
   ansible.builtin.script: /some/local/script.py
   args:
     executable: python3
+    
+- name: Run a Powershell script on a windows host
+  script: subdirectories/under/path/with/your/playbook/script.ps1
 '''


### PR DESCRIPTION
##### SUMMARY
Added windows-relevant example use for ansible.builtin.script module

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ansible.builtin.script

##### ADDITIONAL INFORMATION
The examples we give for how the ansible.builtin.script module works do not work with Windows hosts. We report that the module is windows-compatible and it is, but we should give an example that actually works with windows too. Therefore, this change adds one more use example that specifically works with windows.