### PR TITLE
Don't use __import__ and a loop, just use import_module

### DIFF
--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -315,10 +315,7 @@ class PluginLoader:
         if not self.package:
             return []
         if not hasattr(self, 'package_path'):
-            m = __import__(self.package)
-            parts = self.package.split('.')[1:]
-            for parent_mod in parts:
-                m = getattr(m, parent_mod)
+            m = import_module(self.package)
             self.package_path = to_text(os.path.dirname(m.__file__), errors='surrogate_or_strict')
         if subdirs:
             return self._all_directories(self.package_path)

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -262,7 +262,6 @@ test/units/module_utils/urls/test_fetch_url.py replace-urlopen
 test/units/module_utils/urls/test_Request.py replace-urlopen
 test/units/parsing/vault/test_vault.py pylint:disallowed-name
 test/units/playbook/role/test_role.py pylint:disallowed-name
-test/units/plugins/test_plugins.py pylint:disallowed-name
 test/units/template/test_templar.py pylint:disallowed-name
 test/units/utils/collection_loader/fixtures/collections/ansible_collections/testns/testcoll/plugins/action/my_action.py pylint:relative-beyond-top-level
 test/units/utils/collection_loader/fixtures/collections/ansible_collections/testns/testcoll/plugins/modules/__init__.py empty-init  # testing that collections don't need inits

--- a/test/units/plugins/test_plugins.py
+++ b/test/units/plugins/test_plugins.py
@@ -46,14 +46,11 @@ class TestErrors(unittest.TestCase):
         # python library, and then uses the __file__ attribute of
         # the result for that to get the library path, so we mock
         # that here and patch the builtin to use our mocked result
-        foo = MagicMock()
-        bar = MagicMock()
-        bam = MagicMock()
+        bam = type(os)('bam')
         bam.__file__ = '/path/to/my/foo/bar/bam/__init__.py'
-        bar.bam = bam
-        foo.return_value.bar = bar
+
         pl = PluginLoader('test', 'foo.bar.bam', 'test', 'test_plugin')
-        with patch('builtins.__import__', foo):
+        with patch('ansible.plugins.loader.import_module', lambda x: bam):
             self.assertEqual(pl._get_package_paths(), ['/path/to/my/foo/bar/bam'])
 
     def test_plugins__get_paths(self):


### PR DESCRIPTION
##### SUMMARY
Don't use `__import__` and a loop, just use `import_module`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansibe/plugins/loader.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
