### PR TITLE
copy module - fix changed/dest/state for src directories with remote_src=false

### DIFF
--- a/changelogs/fragments/76996-fix-copy-return-values-with-remote-src-false.yml
+++ b/changelogs/fragments/76996-fix-copy-return-values-with-remote-src-false.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - copy remote_src=false - fix return values when src (specified with a trailing slash)
+    contains a directory and subdirectories containing a single file
+    (https://github.com/ansible/ansible/issues/38938).

--- a/test/integration/targets/copy/tasks/tests.yml
+++ b/test/integration/targets/copy/tasks/tests.yml
@@ -30,6 +30,8 @@
   assert:
     that:
       - "file_result_check.mode == '0444'"
+      - copy_result.changed
+      - copy_result.dest == "{{ remote_file }}"
 
 # same as expanduser & expandvars
 - command: 'echo {{ remote_dir }}'
@@ -466,6 +468,7 @@
   assert:
     that:
       - "recursive_copy_result is changed"
+      - recursive_copy_result.state == 'directory'
 
 - name: Check that a file in a directory was transferred
   stat:
@@ -623,6 +626,7 @@
   assert:
     that:
       - "recursive_copy_result is changed"
+      - recursive_copy_result.state == 'directory'
 
 - name: Check that a file in a directory was transferred
   stat:
@@ -1027,7 +1031,7 @@
     path: '{{ remote_dir }}/destination'
     state: absent
 
-# Try again with no trailing slash
+# Try again with trailing slash
 
 - name: Create a directory to place the test output in
   file:
@@ -1038,6 +1042,7 @@
   copy:
     src: '{{ local_temp_dir }}/source_recursive/'
     dest: '{{ remote_dir }}/destination'
+  register: recursive_copy_result
 
 - name: Stat the recursively copied directory
   stat:
@@ -1055,9 +1060,48 @@
 - name: Assert with trailing slash, only the file is copied
   assert:
     that:
+      - recursive_copy_result.changed
+      - recursive_copy_result.state == 'directory'
       - "not copied_stat.results[0].stat.exists"
       - "not copied_stat.results[1].stat.exists"
       - "copied_stat.results[2].stat.exists"
+
+#
+# Recursive copy a dir containing a subdir and within that a single file (trailing slash)
+#
+
+- name: Test recursive copy to directory trailing slash containing a single deeply nested file
+  copy:
+    src: 38938/
+    dest: "{{ remote_subdir }}"
+  register: recursive_copy_result
+
+- debug:
+    var: recursive_copy_result
+    verbosity: 1
+
+- name: Assert that the recursive copy did something
+  assert:
+    that:
+      - "recursive_copy_result is changed"
+      - recursive_copy_result.state == 'directory'
+
+- name: Test recursive copy to directory trailing slash containing a single deeply nested file
+  copy:
+    src: 38938/
+    dest: "{{ remote_subdir }}"
+  register: recursive_copy_result
+
+- debug:
+    var: recursive_copy_result
+    verbosity: 1
+
+- name: Assert that the recursive copy did something
+  assert:
+    that:
+      - "recursive_copy_result is not changed"
+      - recursive_copy_result.state == 'directory'
+      - recursive_copy_result.dest == '{{ remote_subdir }}/'
 
 #
 # Recursive copy with relative paths (#34893)


### PR DESCRIPTION
##### SUMMARY
Fixes #38938

#76982 also highlights the issue with state (and then I noticed dest was kind of wonky too).

Return 'state' result key consistently

Ensure 'dest' reflects the invocation when it's a directory

Check for a single file or symlink when using the module_return to update the action plugin result.
Before, if a file and symlink existed, the symlink module_return was used to update the result,
but if only a symlink existed, its module_return would not be used to update the result.
Now one file or one symlink are consistent.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
copy
