### PR TITLE
Update .travis.yml to pass Ansible-Lint expectations

### DIFF
--- a/lib/ansible/galaxy/data/default/role/.travis.yml
+++ b/lib/ansible/galaxy/data/default/role/.travis.yml
@@ -9,7 +9,7 @@ sudo: false
 addons:
   apt:
     packages:
-    - python-pip
+      - python-pip
 
 install:
   # Install ansible

--- a/test/units/cli/test_data/role_skeleton/.travis.yml
+++ b/test/units/cli/test_data/role_skeleton/.travis.yml
@@ -9,7 +9,7 @@ sudo: false
 addons:
   apt:
     packages:
-    - python-pip
+      - python-pip
 
 install:
   # Install ansible


### PR DESCRIPTION
##### SUMMARY
Currently, if you ansible-galaxy role init my_role, you get the following two errors:
```
yaml: wrong indentation: expected 6 but found 4 (indentation)
.travis.yml:12

yaml: no new line character at the end of file (new-line-at-end-of-file)      
.travis.yml:2
```
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
.travis.yml


```
ansible-galaxy init role my_role
cd my_role
ansible-lint
```

Tested on Ubuntu 20 (Focal)
