### PR TITLE
Fall back to implicit namespace.name:version if metadata is invalid

### DIFF
--- a/changelogs/fragments/77014-ansible-galaxy-list-fix-null-metadata-namespace-name.yml
+++ b/changelogs/fragments/77014-ansible-galaxy-list-fix-null-metadata-namespace-name.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - fix listing collections that contains metadata but the namespace or name are not strings.

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -238,8 +238,24 @@ class _ComputedReqKindsMixin:
             )
 
         tmp_inst_req = cls(None, None, dir_path, 'dir', None)
-        req_name = art_mgr.get_direct_collection_fqcn(tmp_inst_req)
-        req_version = art_mgr.get_direct_collection_version(tmp_inst_req)
+        try:
+            req_name = art_mgr.get_direct_collection_fqcn(tmp_inst_req)
+            req_version = art_mgr.get_direct_collection_version(tmp_inst_req)
+        except TypeError as err:
+            # Looks like installed/source dir but isn't: doesn't have valid metadata.
+            display.warning(
+                u"Collection at '{path!s}' has a {manifest_json!s} "
+                u"or {galaxy_yml!s} file but it contains invalid metadata.".
+                format(
+                    galaxy_yml=to_text(_GALAXY_YAML),
+                    manifest_json=to_text(_MANIFEST_JSON),
+                    path=to_text(dir_path, errors='surrogate_or_strict'),
+                ),
+            )
+            raise ValueError(
+                "Collection at '{path!s}' has invalid metadata".
+                format(path=to_text(dir_path, errors='surrogate_or_strict'))
+            ) from err
 
         return cls(req_name, req_version, dir_path, 'dir', None)
 

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -238,9 +238,9 @@ class _ComputedReqKindsMixin:
             )
 
         tmp_inst_req = cls(None, None, dir_path, 'dir', None)
+        req_version = art_mgr.get_direct_collection_version(tmp_inst_req)
         try:
             req_name = art_mgr.get_direct_collection_fqcn(tmp_inst_req)
-            req_version = art_mgr.get_direct_collection_version(tmp_inst_req)
         except TypeError as err:
             # Looks like installed/source dir but isn't: doesn't have valid metadata.
             display.warning(

--- a/test/integration/targets/ansible-galaxy-collection/tasks/list.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/list.yml
@@ -4,6 +4,7 @@
     - 'dev.collection1'
     - 'dev.collection2'
     - 'dev.collection3'
+    - 'dev.collection4'
 
 - name: replace the default version of the collections
   lineinfile:
@@ -18,6 +19,19 @@
     - name: "collection3"
       version: "version: ''"
 
+- name: set the namespace, name, and version keys to None
+  lineinfile:
+    path: "{{ galaxy_dir }}/dev/ansible_collections/dev/collection4/galaxy.yml"
+    line: "{{ item.after }}"
+    regexp: "{{ item.before }}"
+  loop:
+  - before: "^namespace: dev"
+    after: "namespace:"
+  - before: "^name: collection4"
+    after: "name:"
+  - before: "^version: 1.0.0"
+    after: "version:"
+
 - name: list collections in development without semver versions
   command: ansible-galaxy collection list {{ galaxy_verbosity }}
   register: list_result
@@ -30,6 +44,7 @@
       # Note the version displayed is the 'placeholder' string rather than "*" since it is not falsey
       - "'dev.collection2 placeholder' in list_result.stdout"
       - "'dev.collection3 *' in list_result.stdout"
+      - "'dev.collection4 *' in list_result.stdout"
 
 - name: list collections in human format
   command: ansible-galaxy collection list --format human

--- a/test/integration/targets/ansible-galaxy-collection/tasks/list.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/list.yml
@@ -67,7 +67,7 @@
 
 - assert:
     that:
-      - "item.value | length == 3"
+      - "item.value | length == 4"
       - "item.value['dev.collection1'].version == '*'"
       - "item.value['dev.collection2'].version == 'placeholder'"
       - "item.value['dev.collection3'].version == '*'"
@@ -81,7 +81,7 @@
 
 - assert:
     that:
-      - "item.value | length == 3"
+      - "item.value | length == 4"
       - "item.value['dev.collection1'].version == '*'"
       - "item.value['dev.collection2'].version == 'placeholder'"
       - "item.value['dev.collection3'].version == '*'"


### PR DESCRIPTION
##### SUMMARY
Fixes listing collections that contain metadata but have non-str namespace/name. ~Working on adding tests.~ Added a test for null namespace/name/version fields.

There is a similar bug for missing metadata keys that are required by `ansible-galaxy collection build`. I have a PR in progress for that here that I'm working on cleaning up: https://github.com/ansible/ansible/pull/76596.

##### ISSUE TYPE
- Bugfix Pull Request
