### PR TITLE
Fix final fact delegation (#77008)

### DIFF
--- a/changelogs/fragments/fix_fax_delegation_loops.yml
+++ b/changelogs/fragments/fix_fax_delegation_loops.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - task_executor reverts the change to push facts into delegated vars on loop finalization as result managing code already handles this and was duplicating effort to wrong result.

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -745,13 +745,7 @@ class TaskExecutor:
 
         if 'ansible_facts' in result and self._task.action not in C._ACTION_DEBUG:
             if self._task.action in C._ACTION_WITH_CLEAN_FACTS:
-                if self._task.delegate_to and self._task.delegate_facts:
-                    if '_ansible_delegated_vars' in variables:
-                        variables['_ansible_delegated_vars'].update(result['ansible_facts'])
-                    else:
-                        variables['_ansible_delegated_vars'] = result['ansible_facts']
-                else:
-                    variables.update(result['ansible_facts'])
+                variables.update(result['ansible_facts'])
             else:
                 # TODO: cleaning of facts should eventually become part of taskresults instead of vars
                 af = wrap_var(result['ansible_facts'])

--- a/test/integration/targets/delegate_to/delegate_facts_loop.yml
+++ b/test/integration/targets/delegate_to/delegate_facts_loop.yml
@@ -5,7 +5,6 @@
         test: 123
       delegate_to: "{{ item }}"
       delegate_facts: true
-      when: test is not defined
       loop: "{{ groups['all'] | difference(['localhost']) }}"
 
     - name: ensure we didnt create it on current host
@@ -19,3 +18,23 @@
           - "'test' in hostvars[item]"
           - hostvars[item]['test'] == 123
       loop: "{{ groups['all'] | difference(['localhost']) }}"
+
+
+- name: test that we don't polute whole group with one value
+  hosts: localhost
+  gather_facts: no
+  vars:
+    cluster_name: bleh
+  tasks:
+  - name: construct different fact per host in loop
+    set_fact:
+      vm_name: "{{ cluster_name }}-{{item}}"
+    delegate_to: "{{ item }}"
+    delegate_facts: True
+    with_items: "{{ groups['all'] }}"
+
+  - name: ensure the fact is personalized for each host
+    assert:
+      that:
+        - hostvars[item]['vm_name'].endswith(item)
+    loop: "{{ groups['all'] }}"


### PR DESCRIPTION
* fix facts delegation loop overwrite

 partial revert of change to allow facts to be present in each loop iteration
 was not needed in final results as result processing alreayd had the disctiontion
 and ended up breaking the assumptions in the calling code.

 fixes #76676

(cherry picked from commit c9d3518d2f3812787e1627806b5fa93f8fae48a6)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
task executor