### PR TITLE
Update complex_data_manipulation example uptime in days/h/m/s

### DIFF
--- a/docs/docsite/rst/user_guide/complex_data_manipulation.rst
+++ b/docs/docsite/rst/user_guide/complex_data_manipulation.rst
@@ -293,7 +293,7 @@ An example on how to use facts to find a host's data that meets condition X:
   vars:
     uptime_of_host_most_recently_rebooted: "{{ansible_play_hosts_all | map('extract', hostvars, 'ansible_uptime_seconds') | sort | first}}"
 
-Using an example on `reddit <https://www.reddit.com/r/ansible/comments/gj5a93/trying_to_get_uptime_from_seconds/fqj2qr3/>`_, to show the 'uptime in days/hours/minutes/seconds' (assumes facts where gathered).
+An example to show a host uptime in days/hours/minutes/seconds (assumes facts where gathered).
 
 .. code-block:: YAML+Jinja
 

--- a/docs/docsite/rst/user_guide/complex_data_manipulation.rst
+++ b/docs/docsite/rst/user_guide/complex_data_manipulation.rst
@@ -293,15 +293,13 @@ An example on how to use facts to find a host's data that meets condition X:
   vars:
     uptime_of_host_most_recently_rebooted: "{{ansible_play_hosts_all | map('extract', hostvars, 'ansible_uptime_seconds') | sort | first}}"
 
-
-Using an example from @zoradache on reddit, to show the 'uptime in days/hours/minutes' (assumes facts where gathered).
-https://www.reddit.com/r/ansible/comments/gj5a93/trying_to_get_uptime_from_seconds/fqj2qr3/
+Using an example on `reddit <https://www.reddit.com/r/ansible/comments/gj5a93/trying_to_get_uptime_from_seconds/fqj2qr3/>`_, to show the 'uptime in days/hours/minutes/seconds' (assumes facts where gathered).
 
 .. code-block:: YAML+Jinja
 
- - name: Show the uptime in a certain format
+ - name: Show the uptime in days/hours/minutes/seconds
    ansible.builtin.debug:
-    msg: Timedelta {{ now() - now().fromtimestamp(now(fmt='%s') | int - ansible_uptime_seconds) }}
+    msg: Uptime {{ now().replace(microsecond=0) - now().fromtimestamp(now(fmt='%s') | int - ansible_uptime_seconds) }}
 
 
 .. seealso::


### PR DESCRIPTION
##### SUMMARY
Timedelta {{ now() - now().fromtimestamp(now(fmt='%s') | int - ansible_uptime_seconds) }}

Example gives uptime with microsecond precision with an original value in seconds: ansible_uptime_seconds

    "msg": [                                                                                                                                                                                                                                                                
        "Timedelta 15 days, 3:42:40.680283"                                                                                                                                      
    ]   

those microseconds are comming from {{ now() - now().fromtimestamp(now(fmt='%s') | int ) }}

Timedelta {{ now().replace(microsecond=0) - now().fromtimestamp(now(fmt='%s') | int - ansible_uptime_seconds) }}
With the change, you will get:

    "msg": [                                                                                                                                                                                                                                                                
        "Timedelta 15 days, 3:42:40"                                                                                                                                      
    ]   

##### ISSUE TYPE
- Docs Pull Request

```
