### PR TITLE
[stable-2.12] Fix package-data sanity test for newer setuptools.

### DIFF
--- a/test/sanity/code-smell/package-data.py
+++ b/test/sanity/code-smell/package-data.py
@@ -223,8 +223,9 @@ def install_sdist(tmp_dir, sdist_dir):
         raise Exception('sdist install failed:\n%s' % stderr)
 
     # Determine the prefix for the installed files
-    match = re.search('^creating (%s/.*?/(?:site|dist)-packages)/ansible$' %
+    match = re.search('^copying .* -> (%s/.*?/(?:site|dist)-packages)/ansible$' %
                       tmp_dir, stdout, flags=re.M)
+
     return match.group(1)
 
 


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/77015

(cherry picked from commit 3a662ef2c11e7525a251832b329b24c9a1fa1311)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

test/sanity/code-smell/package-data.py