### PR TITLE
[stable-2.12] ansible-test - Use newer pip to bootstrap FreeBSD.

### DIFF
--- a/changelogs/fragments/ansible-test-bootstrap-pip.yml
+++ b/changelogs/fragments/ansible-test-bootstrap-pip.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Update ``pip`` used to bootstrap remote FreeBSD instances from version 20.3.4 to 21.3.1.

--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -49,8 +49,11 @@ customize_bashrc()
 install_pip() {
     if ! "${python_interpreter}" -m pip.__main__ --version --disable-pip-version-check 2>/dev/null; then
         case "${python_version}" in
-            *)
+            "2.7")
                 pip_bootstrap_url="https://ci-files.testing.ansible.com/ansible-test/get-pip-20.3.4.py"
+                ;;
+            *)
+                pip_bootstrap_url="https://ci-files.testing.ansible.com/ansible-test/get-pip-21.3.1.py"
                 ;;
         esac
 


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/76995

(cherry picked from commit ef4c5cd61bf9d4c592963fbcd786fd1e7263f067)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
