### PR TITLE
Ensure tests that need to validate higher verbosity messages run with vvvv

### DIFF
--- a/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
@@ -507,8 +507,9 @@
     - '"Installing ''namespace8.name:1.0.0'' to" not in install_req.stdout'
     - '"Installing ''namespace9.name:1.0.0'' to" not in install_req.stdout'
 
+# This command is hardcoded with -vvvv purposefully to evaluate extra verbosity messages
 - name: install collections with ansible-galaxy install and --ignore-errors - {{ test_name }}
-  command: ansible-galaxy install -r {{ req_file }} {{ cli_opts }} {{ galaxy_verbosity }}
+  command: ansible-galaxy install -r {{ req_file }} {{ cli_opts }} -vvvv
   register: install_req
   vars:
     req_file: "{{ galaxy_dir }}/ansible_collections/requirements.yaml"
@@ -527,6 +528,7 @@
   - namespace8
   - namespace9
 
+# SIVEL
 - name: assert invalid signature is not fatal with ansible-galaxy install --ignore-errors - {{ test_name }}
   assert:
     that:
@@ -672,8 +674,9 @@
     path: '{{ galaxy_dir }}/ansible_collections'
     state: absent
 
+# This command is hardcoded with -vvvv purposefully to evaluate extra verbosity messages
 - name: install collection with signature with invalid keyring
-  command: ansible-galaxy collection install namespace1.name1 {{ galaxy_verbosity }} {{ signature_option }} {{ keyring_option }}
+  command: ansible-galaxy collection install namespace1.name1 -vvvv {{ signature_option }} {{ keyring_option }}
   environment:
     ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
   vars:
@@ -775,8 +778,9 @@
     path: '{{ galaxy_dir }}/ansible_collections/namespace1'
     state: absent
 
+# This command is hardcoded with -vvvv purposefully to evaluate extra verbosity messages
 - name: install simple collection with invalid detached signature
-  command: ansible-galaxy collection install namespace1.name1 {{ galaxy_verbosity }} {{ signature_options }}
+  command: ansible-galaxy collection install namespace1.name1 -vvvv {{ signature_options }}
   environment:
     ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
   vars:

--- a/test/integration/targets/ansible-galaxy-collection/tasks/verify.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/verify.yml
@@ -279,8 +279,9 @@
     that:
       - verify.rc == 0
 
+# This command is hardcoded with -vvvv purposefully to evaluate extra verbosity messages
 - name: verify the installed collection with invalid detached signature
-  command: ansible-galaxy collection verify namespace1.name1:1.0.0 {{ galaxy_verbosity }} {{ signature_options }}
+  command: ansible-galaxy collection verify namespace1.name1:1.0.0 -vvvv {{ signature_options }}
   vars:
     signature_options: "--signature {{ signature }} --keyring {{ keyring }}"
     signature: "file://{{ gpg_homedir }}/namespace1-name1-1.0.9-MANIFEST.json.asc"
@@ -306,8 +307,9 @@
 
 - include_tasks: revoke_gpg_key.yml
 
+# This command is hardcoded with -vvvv purposefully to evaluate extra verbosity messages
 - name: verify the installed collection with a revoked detached signature
-  command: ansible-galaxy collection verify namespace1.name1:1.0.0 {{ galaxy_verbosity }} {{ signature_options }}
+  command: ansible-galaxy collection verify namespace1.name1:1.0.0 -vvvv {{ signature_options }}
   vars:
     signature_options: "--signature {{ signature }} --keyring {{ keyring }}"
     signature: "file://{{ gpg_homedir }}/namespace1-name1-1.0.0-MANIFEST.json.asc"


### PR DESCRIPTION
##### SUMMARY
Ensure tests that need to validate higher verbosity messages run with vvvv

These tests were passing in CI, because they failed and were subsequently retried with higher verbosity, and then passed

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/integration/targets/ansible-galaxy-collection/tasks/

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
