### PR TITLE
Avoid system-site-packages in AZP coverage venvs.

### DIFF
--- a/.azure-pipelines/scripts/aggregate-coverage.sh
+++ b/.azure-pipelines/scripts/aggregate-coverage.sh
@@ -9,7 +9,7 @@ PATH="${PWD}/bin:${PATH}"
 
 mkdir "${agent_temp_directory}/coverage/"
 
-options=(--venv --venv-system-site-packages --color -v)
+options=(--venv --color -v)
 
 ansible-test coverage combine --group-by command --export "${agent_temp_directory}/coverage/" "${options[@]}"
 

--- a/.azure-pipelines/scripts/report-coverage.sh
+++ b/.azure-pipelines/scripts/report-coverage.sh
@@ -14,4 +14,4 @@ fi
 
 # Generate stubs using docker (if supported) otherwise fall back to using a virtual environment instead.
 # The use of docker is required when Powershell code is present, but Ansible 2.12 was the first version to support --docker with coverage.
-ansible-test coverage xml --group-by command --stub --docker --color -v || ansible-test coverage xml --group-by command --stub --venv --venv-system-site-packages --color -v
+ansible-test coverage xml --group-by command --stub --docker --color -v || ansible-test coverage xml --group-by command --stub --venv --color -v


### PR DESCRIPTION
##### SUMMARY

The use of `--venv-system-site-packages` was an optimization to use the `coverage` package pre-installed in the AZP test container. However, now that the venv is bootstrapped by ansible-test that optimization no longer makes sense, since other downloads are already taking place.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

AZP config
