### PR TITLE
AL2022 package-manager detection support (Amazon Linux)

### DIFF
--- a/changelogs/fragments/77050-add-pkg-mgr-support-for-al2022.yaml
+++ b/changelogs/fragments/77050-add-pkg-mgr-support-for-al2022.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Detect package manager for Amazon Linux 2022 (AL2022) as dnf

--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -84,7 +84,11 @@ class PkgMgrFactCollector(BaseFactCollector):
         elif collected_facts['ansible_distribution'] == 'Amazon':
             try:
                 if int(collected_facts['ansible_distribution_major_version']) < 2022:
-                    pkg_mgr_name = 'yum'
+                    for dnf in [pkg_mgr for pkg_mgr in PKG_MGRS if pkg_mgr['name'] == 'dnf']:
+                        if os.path.exists(dnf['path']):
+                            pkg_mgr_name = 'dnf'
+                        else:
+                            pkg_mgr_name = 'yum'
                 else:
                     pkg_mgr_name = 'dnf'
             except ValueError:

--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -82,7 +82,10 @@ class PkgMgrFactCollector(BaseFactCollector):
                 # just default to dnf
                 pkg_mgr_name = 'dnf'
         elif collected_facts['ansible_distribution'] == 'Amazon':
-            pkg_mgr_name = 'yum'
+            if int(collected_facts['ansible_distribution_version']) < 2022:
+                pkg_mgr_name = 'yum'
+            else:
+                pkg_mgr_name = 'dnf'
         else:
             # If it's not one of the above and it's Red Hat family of distros, assume
             # RHEL or a clone. For versions of RHEL < 8 that Ansible supports, the

--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -83,7 +83,7 @@ class PkgMgrFactCollector(BaseFactCollector):
                 pkg_mgr_name = 'dnf'
         elif collected_facts['ansible_distribution'] == 'Amazon':
             try:
-                if int(collected_facts['ansible_distribution_version']) < 2022:
+                if int(collected_facts['ansible_distribution_major_version']) < 2022:
                     pkg_mgr_name = 'yum'
                 else:
                     pkg_mgr_name = 'dnf'

--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -82,9 +82,12 @@ class PkgMgrFactCollector(BaseFactCollector):
                 # just default to dnf
                 pkg_mgr_name = 'dnf'
         elif collected_facts['ansible_distribution'] == 'Amazon':
-            if int(collected_facts['ansible_distribution_version']) < 2022:
-                pkg_mgr_name = 'yum'
-            else:
+            try:
+                if int(collected_facts['ansible_distribution_version']) < 2022:
+                    pkg_mgr_name = 'yum'
+                else:
+                    pkg_mgr_name = 'dnf'
+            except ValueError:
                 pkg_mgr_name = 'dnf'
         else:
             # If it's not one of the above and it's Red Hat family of distros, assume


### PR DESCRIPTION
##### SUMMARY
Currently `ansible.builtin.package` does not correctly detect [AL2022](https://aws.amazon.com/linux/amazon-linux-2022/), as its hardcoded to `yum`. While `yum` is installed, it only works in Ansible with `/usr/bin/python` (or more precise: python2), which is not going to be included into AL2022.

This PR will set any amazon-linux version below 2022 to `yum`, and any version going forward to `dnf`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module: package

##### ADDITIONAL INFORMATION
