### PR TITLE
[stable-2.11] ansible-test - Use quay.io containers in plugins.

### DIFF
--- a/changelogs/fragments/ansible-test-container-images.yml
+++ b/changelogs/fragments/ansible-test-container-images.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ansible-test - Update the ``galaxy`` test plugin to get its container from a copy on quay.io.
+  - ansible-test - Update the ``openshift`` test plugin to get its container from a copy on quay.io.

--- a/test/lib/ansible_test/_internal/cloud/galaxy.py
+++ b/test/lib/ansible_test/_internal/cloud/galaxy.py
@@ -100,7 +100,7 @@ class GalaxyProvider(CloudProvider):
         # the newer update is available.
         self.pulp = os.environ.get(
             'ANSIBLE_PULP_CONTAINER',
-            'docker.io/pulp/pulp-galaxy-ng@sha256:b79a7be64eff86d8f58db9ca83ed4967bd8b4e45c99addb17a91d11926480cf1'
+            'quay.io/ansible/pulp-galaxy-ng:b79a7be64eff'
         )
 
         self.containers = []

--- a/test/lib/ansible_test/_internal/cloud/openshift.py
+++ b/test/lib/ansible_test/_internal/cloud/openshift.py
@@ -53,7 +53,7 @@ class OpenShiftCloudProvider(CloudProvider):
         super(OpenShiftCloudProvider, self).__init__(args, config_extension='.kubeconfig')
 
         # The image must be pinned to a specific version to guarantee CI passes with the version used.
-        self.image = 'openshift/origin:v3.9.0'
+        self.image = 'quay.io/ansible/openshift-origin:v3.9.0'
         self.container_name = ''
 
     def filter(self, targets, exclude):


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/77058

(cherry picked from commit c27fd777f4d82fc1eefaa20114cf1f76b7ce1bee)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
