### PR TITLE
Remove use of distutils in docs Makefile.

### DIFF
--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -1,5 +1,4 @@
 OS := $(shell uname -s)
-SITELIB = $(shell python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()"):
 PLUGIN_FORMATTER=../../hacking/build-ansible.py docs-build
 TESTING_FORMATTER=../bin/testing_formatter.sh
 KEYWORD_DUMPER=../../hacking/build-ansible.py document-keywords


### PR DESCRIPTION
##### SUMMARY

The current usage only works if `python` is Python 2.x since the syntax is invalid on Python 3.x.

When running on Python 3.x it would either be missing, or if Python 2.x was also present, incorrect.

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

docs/docsite/Makefile