### PR TITLE
[lookup/password] Handle vault encrypted files correctly

### DIFF
--- a/changelogs/fragments/77072-password-handle-vault-encrypted-files-correctly.yml
+++ b/changelogs/fragments/77072-password-handle-vault-encrypted-files-correctly.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Handle vault encrypted files correctly in password lookup

--- a/changelogs/fragments/77072-password-handle-vault-encrypted-files-correctly.yml
+++ b/changelogs/fragments/77072-password-handle-vault-encrypted-files-correctly.yml
@@ -1,2 +1,2 @@
-bugfixes:
-  - Handle vault encrypted files correctly in password lookup
+minor_changes:
+  - Handle vault encrypted files correctly in password lookup, add flag to encrypt new passwords directly with vault

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -139,7 +139,7 @@ from ansible.utils.path import makedirs_safe
 
 
 DEFAULT_LENGTH = 20
-VALID_PARAMS = frozenset(('length', 'encrypt', 'chars', 'ident', 'seed'))
+VALID_PARAMS = frozenset(('length', 'encrypt', 'chars', 'ident', 'seed', 'vault'))
 
 
 def _parse_parameters(term, kwargs=None):
@@ -182,6 +182,7 @@ def _parse_parameters(term, kwargs=None):
     params['encrypt'] = params.get('encrypt', kwargs.get('encrypt', None))
     params['ident'] = params.get('ident', kwargs.get('ident', None))
     params['seed'] = params.get('seed', kwargs.get('seed', None))
+    params['vault'] = params.get('vault', kwargs.get('vault', None))
 
     params['chars'] = params.get('chars', kwargs.get('chars', None))
     if params['chars']:
@@ -286,7 +287,7 @@ def _write_password_file(b_path, content, vault):
     b_content = to_bytes(content, errors='surrogate_or_strict') + b'\n'
 
     if vault:
-        veditor = VaultEditor(VaultLib(vault))
+        veditor = VaultEditor(VaultLib())
         veditor.create_file(b_path, b_content)
     else:
         with open(b_path, 'wb') as f:
@@ -375,7 +376,7 @@ class LookupModule(LookupBase):
 
             if changed and b_path != to_bytes('/dev/null'):
                 content = _format_content(plaintext_password, salt, encrypt=encrypt, ident=ident)
-                _write_password_file(b_path, content, self.get_option('vault'))
+                _write_password_file(b_path, content, params['vault'])
 
             if first_process:
                 # let other processes continue

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -193,22 +193,6 @@ def _parse_parameters(term, kwargs=None):
     return relpath, params
 
 
-def _read_password_file(b_path):
-    """Read the contents of a password file and return it
-    :arg b_path: A byte string containing the path to the password file
-    :returns: a text string containing the contents of the password file or
-        None if no password file was present.
-    """
-    content = None
-
-    if os.path.exists(b_path):
-        with open(b_path, 'rb') as f:
-            b_content = f.read().rstrip()
-        content = to_text(b_content, errors='surrogate_or_strict')
-
-    return content
-
-
 def _gen_candidate_chars(characters):
     '''Generate a string containing all valid chars as defined by ``characters``
 
@@ -349,7 +333,13 @@ class LookupModule(LookupBase):
             # make sure only one process finishes all the job first
             first_process, lockfile = _get_lock(b_path)
 
-            content = _read_password_file(b_path)
+            content = None
+
+            # Read the contents of a password file and return it
+            if os.path.exists(b_path):
+                b_contents, show_data = self._loader._get_file_contents(b_path)
+                content = to_text(b_contents, errors='surrogate_or_strict')
+                content = content.rstrip()
 
             if content is None or b_path == to_bytes('/dev/null'):
                 plaintext_password = random_password(params['length'], chars, params['seed'])

--- a/test/integration/targets/lookup_password/runme.sh
+++ b/test/integration/targets/lookup_password/runme.sh
@@ -6,6 +6,6 @@ source virtualenv.sh
 
 # Requirements have to be installed prior to running ansible-playbook
 # because plugins and requirements are loaded before the task runs
-pip install passlib
+pip install passlib cryptography jinja2 PyYAML
 
-ANSIBLE_ROLES_PATH=../ ansible-playbook runme.yml -e "output_dir=${OUTPUT_DIR}" "$@"
+ANSIBLE_VAULT_PASSWORD_FILE=vault_password.txt ANSIBLE_ROLES_PATH=../ ansible-playbook runme.yml -e "output_dir=${OUTPUT_DIR}" "$@"

--- a/test/integration/targets/lookup_password/tasks/main.yml
+++ b/test/integration/targets/lookup_password/tasks/main.yml
@@ -147,3 +147,30 @@
         - kv[0]['msg'] == kv[1]['msg']
         - kv[0]['msg'] == kv[2]['msg']
         - kv[0]['msg'] == inl[0]['msg']
+
+- name: create a vaulted password file
+  set_fact:
+    pass_vault: "{{ lookup('password', output_dir + '/lookup/password_vault_encrypted vault=True') }}"
+
+- name: read encrypted password
+  shell: cat {{output_dir}}/lookup/password_vault_encrypted
+  register: cat_pass_vault
+
+- debug: var=cat_pass_vault.stdout
+
+- name: verify password is encrypted
+  assert:
+    that:
+        - "cat_pass_vault.stdout != pass_vault"
+        - "cat_pass_vault.stdout.startswith('$ANSIBLE_VAULT')"
+
+- name: lookup vaulted password file (again)
+  set_fact:
+    pass_vault2: "{{ lookup('password', output_dir + '/lookup/password_vault_encrypted') }}"
+
+- debug: var=pass_vault2
+
+- name: verify password (again)
+  assert:
+    that:
+        - "pass_vault == pass_vault2"

--- a/test/integration/targets/lookup_password/vault_password.txt
+++ b/test/integration/targets/lookup_password/vault_password.txt
@@ -1,0 +1,1 @@
+very_secret

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -231,23 +231,6 @@ class TestParseParameters(unittest.TestCase):
         self.assertRaises(AnsibleError, password._parse_parameters, testcase['term'])
 
 
-class TestReadPasswordFile(unittest.TestCase):
-    def setUp(self):
-        self.os_path_exists = password.os.path.exists
-
-    def tearDown(self):
-        password.os.path.exists = self.os_path_exists
-
-    def test_no_password_file(self):
-        password.os.path.exists = lambda x: False
-        self.assertEqual(password._read_password_file(b'/nonexistent'), None)
-
-    def test_with_password_file(self):
-        password.os.path.exists = lambda x: True
-        with patch.object(builtins, 'open', mock_open(read_data=b'Testing\n')) as m:
-            self.assertEqual(password._read_password_file(b'/etc/motd'), u'Testing')
-
-
 class TestGenCandidateChars(unittest.TestCase):
     def _assert_gen_candidate_chars(self, testcase):
         expected_candidate_chars = testcase['candidate_chars']


### PR DESCRIPTION
##### SUMMARY
Files encrypted with `ansible-vault` and read with the `password` lookup return the **encrypted** content of the file. This commit aligns the behavior with the `copy` module and the `file` lookup plugin.

Ref: https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/lookup/file.py#L76-L77

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
password

##### ADDITIONAL INFORMATION
The current implementation of the password lookup deviates in its behavior from other modules.

Encrypt a file with `ansible-vault`:

- Ansible's `copy` module decrypts the file, writes the decrypted content to the target host.
- The `file` lookup module decrypts the file, returns the decrypted content.
- The `password` lookup module … well, it returns the **encrypted** content of the file.

This causes all kinds of trouble when you use the password plugin to create randomized, low-impact passwords (e.g. for technical `.htaccess` users, cookie secrets, etc.) which are stored encrypted inside the repository.