### PR TITLE
hostname module - fix TypeError in FileStrategy (#77025)

### DIFF
--- a/changelogs/fragments/77074-hostname-fix-typeerror-in-filestrategy.yml
+++ b/changelogs/fragments/77074-hostname-fix-typeerror-in-filestrategy.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hostname - use ``file_get_content()`` to read the file containing the host name in the ``FileStrategy.get_permanent_hostname()`` method. This prevents a ``TypeError`` from being raised when the strategy is used (https://github.com/ansible/ansible/issues/77025).

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -257,7 +257,7 @@ class FileStrategy(BaseStrategy):
             return ''
 
         try:
-            return get_file_lines(self.FILE)
+            return get_file_content(self.FILE, default='', strip=True)
         except Exception as e:
             self.module.fail_json(
                 msg="failed to read hostname: %s" % to_native(e),


### PR DESCRIPTION
  * Use file_get_content() to read the file containing the host name

##### SUMMARY

Use `file_get_content()` to read the file containing the host name in the `FileStrategy.get_permanent_hostname()` method. This fixes #77025 .

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`hostname`

##### ADDITIONAL INFORMATION

  * This patch is against branch `stable-2.12`. Please tell me if it needs to be ported to the `devel` branch.
  * While I'm not sure the `os.path.isfile()` check is actually necessary due to the checks in `get_file_content()`, it is semantically different from them so I kept it.

