### PR TITLE
Some tests are skipped due to duplicate names fix

### DIFF
--- a/test/units/module_utils/basic/test_deprecate_warn.py
+++ b/test/units/module_utils/basic/test_deprecate_warn.py
@@ -71,7 +71,7 @@ def test_deprecate_without_list(am, capfd):
 
 
 @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
-def test_deprecate_without_list(am, capfd):
+def test_deprecate_without_list_two(am, capfd):
     with pytest.raises(AssertionError) as ctx:
         am.deprecate('Simple deprecation warning', date='', version='')
     assert ctx.value.args[0] == "implementation error -- version and date must not both be set"

--- a/test/units/module_utils/common/validation/test_check_required_if.py
+++ b/test/units/module_utils/common/validation/test_check_required_if.py
@@ -53,7 +53,7 @@ def test_check_required_if_missing_multiple():
     assert to_native(e.value) == expected
 
 
-def test_check_required_if_missing_multiple():
+def test_check_required_if_missing_multiple_two():
     arguments_terms = [["state", "present", ("path", "owner")]]
     params = {
         "state": "present",

--- a/test/units/module_utils/facts/test_collectors.py
+++ b/test/units/module_utils/facts/test_collectors.py
@@ -410,7 +410,7 @@ class TestServiceMgrFacts(BaseFactsTest):
     @patch('ansible.module_utils.facts.system.service_mgr.get_file_content', return_value='runit-init')
     @patch('ansible.module_utils.facts.system.service_mgr.os.path.islink', side_effect=lambda x: x == '/sbin/init')
     @patch('ansible.module_utils.facts.system.service_mgr.os.readlink', side_effect=lambda x: '/sbin/runit-init' if x == '/sbin/init' else '/bin/false')
-    def test_service_mgr_runit_two(self, mock_gfc, mock_opl, mock_orl):
+    def test_service_mgr_runit_three(self, mock_gfc, mock_opl, mock_orl):
         # /proc/1/comm contains 'runit-init', ps fails, service manager is runit
         # should end up return 'runit'
         module = self._mock_module()

--- a/test/units/module_utils/facts/test_collectors.py
+++ b/test/units/module_utils/facts/test_collectors.py
@@ -394,7 +394,7 @@ class TestServiceMgrFacts(BaseFactsTest):
     @patch('ansible.module_utils.facts.system.service_mgr.ServiceMgrFactCollector.is_systemd_managed', return_value=False)
     @patch('ansible.module_utils.facts.system.service_mgr.ServiceMgrFactCollector.is_systemd_managed_offline', return_value=False)
     @patch('ansible.module_utils.facts.system.service_mgr.os.path.exists', return_value=False)
-    def test_service_mgr_runit(self, mock_gfc, mock_ism, mock_ismo, mock_ope):
+    def test_service_mgr_runit_two(self, mock_gfc, mock_ism, mock_ismo, mock_ope):
         # no /proc/1/comm, ps fails, distro and system are clowncar
         # should end up return 'sys11'
         module = self._mock_module()
@@ -410,7 +410,7 @@ class TestServiceMgrFacts(BaseFactsTest):
     @patch('ansible.module_utils.facts.system.service_mgr.get_file_content', return_value='runit-init')
     @patch('ansible.module_utils.facts.system.service_mgr.os.path.islink', side_effect=lambda x: x == '/sbin/init')
     @patch('ansible.module_utils.facts.system.service_mgr.os.readlink', side_effect=lambda x: '/sbin/runit-init' if x == '/sbin/init' else '/bin/false')
-    def test_service_mgr_runit(self, mock_gfc, mock_opl, mock_orl):
+    def test_service_mgr_runit_two(self, mock_gfc, mock_opl, mock_orl):
         # /proc/1/comm contains 'runit-init', ps fails, service manager is runit
         # should end up return 'runit'
         module = self._mock_module()

--- a/test/units/parsing/test_mod_args.py
+++ b/test/units/parsing/test_mod_args.py
@@ -118,7 +118,7 @@ class TestModArgsDwim:
 
         assert err.value.args[0] == msg
 
-    def test_multiple_actions(self):
+    def test_multiple_actions_two(self):
         args_dict = {'ping': 'data=hi', 'shell': 'echo hi'}
         m = ModuleArgsParser(args_dict)
         with pytest.raises(AnsibleParserError) as err:


### PR DESCRIPTION
Fixes #77079.

These tests were overriding other tests in the same file with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.

