### PR TITLE
Update pylint deprecated plugin to use ansible-invalid* symbols

### DIFF
--- a/changelogs/fragments/77086-correct-pylint-symbols.yml
+++ b/changelogs/fragments/77086-correct-pylint-symbols.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- Pylint Deprecated Plugin - Use correct message symbols when date or version is not a float or str
+  (https://github.com/ansible/ansible/issues/77085)

--- a/changelogs/fragments/77086-correct-pylint-symbols.yml
+++ b/changelogs/fragments/77086-correct-pylint-symbols.yml
@@ -1,3 +1,3 @@
 bugfixes:
-- Pylint Deprecated Plugin - Use correct message symbols when date or version is not a float or str
+- ansible-test - Pylint Deprecated Plugin - Use correct message symbols when date or version is not a float or str
   (https://github.com/ansible/ansible/issues/77085)

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/deprecated.py
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/deprecated.py
@@ -158,7 +158,7 @@ class AnsibleDeprecatedChecker(BaseChecker):
 
     def _check_date(self, node, date):
         if not isinstance(date, str):
-            self.add_message('invalid-date', node=node, args=(date,))
+            self.add_message('ansible-invalid-deprecated-date', node=node, args=(date,))
             return
 
         try:
@@ -172,7 +172,7 @@ class AnsibleDeprecatedChecker(BaseChecker):
 
     def _check_version(self, node, version, collection_name):
         if not isinstance(version, (str, float)):
-            self.add_message('invalid-version', node=node, args=(version,))
+            self.add_message('ansible-invalid-deprecated-version', node=node, args=(version,))
             return
 
         version_no = str(version)

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/deprecated.py
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/deprecated.py
@@ -172,7 +172,11 @@ class AnsibleDeprecatedChecker(BaseChecker):
 
     def _check_version(self, node, version, collection_name):
         if not isinstance(version, (str, float)):
-            self.add_message('ansible-invalid-deprecated-version', node=node, args=(version,))
+            if collection_name == 'ansible.builtin':
+                symbol = 'ansible-invalid-deprecated-version'
+            else:
+                symbol = 'collection-invalid-deprecated-version'
+            self.add_message(symbol, node=node, args=(version,))
             return
 
         version_no = str(version)


### PR DESCRIPTION
##### SUMMARY
Update pylint deprecated plugin to use ansible-invalid* symbols

Fixes #77085 
##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/lib/ansible_test/_util/controller/sanity/pylint/plugins/deprecated.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
