### PR TITLE
remove list of container images

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections_testing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_testing.rst
@@ -67,13 +67,13 @@ You can write two different kinds of integration tests:
 
 For examples, see the `integration tests in community.general <https://github.com/ansible-collections/community.general/tree/master/tests/integration/targets/>`_. See also :ref:`testing_integration` for more details.
 
-Since integration tests can install requirements, and set-up, start and stop services, we recommended running them in docker containers or otherwise restricted environments whenever possible. By default, ``ansible-test`` supports Docker images for several operating systems. See the `list of supported docker images <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt>`_ for all options. Use the ``default`` image mainly for platform-independent integration tests, such as those for cloud modules. The following examples use the ``centos8`` image.
+Since integration tests can install requirements, and set-up, start and stop services, we recommended running them in docker containers or otherwise restricted environments whenever possible. By default, ``ansible-test`` supports Docker images for several operating systems. See the `list of supported docker images <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt>`_ for all options. Use the ``default`` image mainly for platform-independent integration tests, such as those for cloud modules. The following examples use the ``fedora35`` image.
 
 To execute all integration tests for a collection:
 
 .. code-block:: shell-session
 
-    ansible-test integration --docker centos8 -v
+    ansible-test integration --docker fedora35 -v
 
 If you want more detailed output, run the command with ``-vvv`` instead of ``-v``. Alternatively, specify ``--retry-on-error`` to automatically re-run failed tests with higher verbosity levels.
 
@@ -81,7 +81,7 @@ To execute only the integration tests in a specific directory:
 
 .. code-block:: shell-session
 
-    ansible-test integration --docker centos8 -v connection_bar
+    ansible-test integration --docker fedora35 -v connection_bar
 
 You can specify multiple target names. Each target name is the name of a directory in ``tests/integration/targets/``.
 

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -72,7 +72,7 @@ outside of those test subdirectories.  They will also not reconfigure or bounce 
 
 .. note:: Running integration tests within containers
 
-   To protect your system from any potential changes caused by integration tests, and to ensure a sensible set of dependencies are available we recommend that you always run integration tests with the ``--docker`` option, for example ``--docker centos8``. See the `list of supported container images <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt>`_ for options (the ``default`` image is used for sanity and unit tests, as well as for platform independent integration tests such as those for cloud modules).
+   To protect your system from any potential changes caused by integration tests, and to ensure a sensible set of dependencies are available we recommend that you always run integration tests with the ``--docker`` option, for example ``--docker ubuntu2004``. See the `list of supported container images <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt>`_ for options (the ``default`` image is used for sanity and unit tests, as well as for platform independent integration tests such as those for cloud modules).
 
 Run as follows for all POSIX platform tests executed by our CI system in a Fedora 34 container:
 
@@ -177,27 +177,13 @@ For example, to run tests for the ``ping`` module on a Ubuntu 18.04 container:
 Container Images
 ----------------
 
-Python 3
-^^^^^^^^
+Container images are updated regularly. To see the current list of container images:
 
-Most container images are for testing with Python 3:
+.. code-block:: bash
 
-  - alpine3
-  - centos8
-  - fedora33
-  - fedora34
-  - opensuse15
-  - ubuntu1804
-  - ubuntu2004
+  ansible-test integration --help
 
-Python 2
-^^^^^^^^
-
-To test with Python 2 use the following images:
-
-  - centos7
-  - opensuse15py2
-
+The list is under the **target docker images and supported python version** heading.
 
 Legacy Cloud Tests
 ==================


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Container images are a list that changes. Rather than keep updating it in docs, give users the command that shows them the list of container images available to them.

Also avoid centos8 in examples :-P
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs/docsite/rst/dev_guide/testing_integration.rst

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
