### PR TITLE
[stable-2.11] ansible-test - Add MarkupSafe constraint.

### DIFF
--- a/changelogs/fragments/ansible-test-markupsafe-constraint-update.yml
+++ b/changelogs/fragments/ansible-test-markupsafe-constraint-update.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-test - Add constraint for ``MarkupSafe < 2.1.0`` on Python 3.6 and later.
+                   This avoids installation failures when old ``pip`` or ``setuptools`` packages are present.

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -48,3 +48,4 @@ setuptools < 37 ; python_version == '2.6' # setuptools 37 and later require pyth
 setuptools < 45 ; python_version == '2.7' # setuptools 45 and later require python 3.5 or later
 gssapi < 1.6.0 ; python_version <= '2.7' # gssapi 1.6.0 and later require python 3 or later
 MarkupSafe < 2.0.0 ; python_version < '3.6' # MarkupSafe >= 2.0.0. requires Python >= 3.6
+MarkupSafe < 2.1.0 ; python_version >= '3.6' # MarkupSafe 2.1.0 and later require setuptools 39.2+ or installation from a wheel, which not all environments support


### PR DESCRIPTION
##### SUMMARY

Installation of MarkupSafe 2.1.0 and later require setuptools 39.2 or later,
or a recent version of pip which supports installation using a wheel.

Some systems will not have new enough versions of pip and/or setuptools,
especially virtual environments -- including those created by ansible-test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
