### PR TITLE
[stable-2.12] Use --no-deps when installing amazon.aws and not testing dependencies (#77091)

### DIFF
--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/download.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/download.yml
@@ -8,6 +8,7 @@
     ansible-galaxy collection download
     git+https://github.com/ansible-collections/amazon.aws.git,37875c5b4ba5bf3cc43e07edf29f3432fd76def5
     git+https://github.com/AlanCoding/awx.git#awx_collection,750c22a150d04eef1cb625fd4f83cce57949416c
+    --no-deps
   args:
     chdir: '{{ galaxy_dir }}/download'
   register: download_collection
@@ -30,7 +31,7 @@
       - download_collection_awx_actual.stat.exists
 
 - name: test the downloaded repository can be installed
-  command: 'ansible-galaxy collection install -r requirements.yml'
+  command: 'ansible-galaxy collection install -r requirements.yml --no-deps'
   args:
     chdir: '{{ galaxy_dir }}/download/collections/'
 

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/individual_collection_repo.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/individual_collection_repo.yml
@@ -4,7 +4,7 @@
     dest: '{{ scm_path }}/amazon.aws/'
 
 - name: install
-  command: 'ansible-galaxy collection install git+file://{{ scm_path }}/amazon.aws/.git'
+  command: 'ansible-galaxy collection install git+file://{{ scm_path }}/amazon.aws/.git --no-deps'
 
 - name: list installed collections
   command: 'ansible-galaxy collection list'

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/requirements.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/requirements.yml
@@ -66,7 +66,7 @@
         appear to be a git repository")
 
 - name: test using name as a git repo without git+ prefix
-  command: 'ansible-galaxy collection install -r name_without_type.yml'
+  command: 'ansible-galaxy collection install -r name_without_type.yml --no-deps'
   register: result
   ignore_errors: true
   args:
@@ -83,13 +83,13 @@
     dest: '{{ scm_path }}/amazon.aws/'
 
 - name: test using name as a git repo
-  command: 'ansible-galaxy collection install -r git_prefix_name.yml'
+  command: 'ansible-galaxy collection install -r git_prefix_name.yml --no-deps'
   register: result
   args:
     chdir: '{{ galaxy_dir }}/requirements'
 
 - name: test using name plus type as a git repo
-  command: 'ansible-galaxy collection install -r name_and_type.yml --force'
+  command: 'ansible-galaxy collection install -r name_and_type.yml --force --no-deps'
   register: result
   args:
     chdir: '{{ galaxy_dir }}/requirements'


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/77091

(cherry picked from commit 88bfb7193e729578a570e3c73becfc6613f512da)

Co-authored-by: Sloane Hertel <19572925+s-hertel@users.noreply.github.com>

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

integration tests