### PR TITLE
[stable-2.11] ansible-test - Omit pyopenssl for sanity tests.

### DIFF
--- a/changelogs/fragments/ansible-test-pyopenssl.yml
+++ b/changelogs/fragments/ansible-test-pyopenssl.yml
@@ -1,4 +1,4 @@
 bugfixes:
-  - ansible-test - Install ``pyopenssl`` when installing ``cryptography`` to make sure a compatible version is used.
+  - ansible-test - Install ``pyopenssl`` when installing ``cryptography`` to make sure a compatible version is used (except for sanity tests).
 minor_changes:
   - ansible-test - Integration and unit tests no longer install ``cryptography`` if it is already installed.

--- a/test/lib/ansible_test/_internal/executor.py
+++ b/test/lib/ansible_test/_internal/executor.py
@@ -312,7 +312,12 @@ def get_cryptography_requirements(args, python, python_version):  # type: (Envir
         # pyopenssl 17.5.0 requires cryptography 2.1.4 or later
         pyopenssl = 'pyopenssl < 17.5.0'
 
-    return [cryptography, pyopenssl]
+    requirements = [cryptography, pyopenssl]
+
+    if args.command == 'sanity':
+        requirements.remove(pyopenssl)  # sanity tests do not use pyopenssl
+
+    return requirements
 
 
 def install_command_requirements(args, python_version=None, context=None, enable_pyyaml_check=False):


### PR DESCRIPTION
##### SUMMARY

ansible-test - Omit pyopenssl for sanity tests.

Follow-up to https://github.com/ansible/ansible/pull/76922

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test