### PR TITLE
[stable-2.12] ansible-test - Fix CParser import in yamllint.

### DIFF
--- a/changelogs/fragments/ansible-test-yaml-import.yaml
+++ b/changelogs/fragments/ansible-test-yaml-import.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Import ``yaml.cyaml.CParser`` instead of ``_yaml.CParser`` in the ``yamllint`` sanity test.

--- a/test/lib/ansible_test/_util/controller/sanity/yamllint/yamllinter.py
+++ b/test/lib/ansible_test/_util/controller/sanity/yamllint/yamllinter.py
@@ -13,7 +13,7 @@ import yaml
 from yaml.resolver import Resolver
 from yaml.constructor import SafeConstructor
 from yaml.error import MarkedYAMLError
-from _yaml import CParser  # pylint: disable=no-name-in-module
+from yaml.cyaml import CParser
 
 from yamllint import linter
 from yamllint.config import YamlLintConfig


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/77066

(cherry picked from commit d286c2e8b35d8324f0a1d1b9843b0501712ec9e3)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
