### PR TITLE
[stable-2.12] Fix warning in unit tests for _yaml import.

### DIFF
--- a/test/units/parsing/yaml/test_loader.py
+++ b/test/units/parsing/yaml/test_loader.py
@@ -35,12 +35,8 @@ from ansible.parsing.yaml.dumper import AnsibleDumper
 from units.mock.yaml_helper import YamlTestUtils
 from units.mock.vault_helper import TextVaultSecret
 
-try:
-    from _yaml import ParserError
-    from _yaml import ScannerError
-except ImportError:
-    from yaml.parser import ParserError
-    from yaml.scanner import ScannerError
+from yaml.parser import ParserError
+from yaml.scanner import ScannerError
 
 
 class NameStringIO(StringIO):


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/77065

(cherry picked from commit de9a3bda2cfaace7e3d25b0c4774eefdd9514687)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

test/units/parsing/yaml/test_loader.py