### PR TITLE
[stable-2.9] ansible-test - Use `--forked` instead of `--boxed`

### DIFF
--- a/changelogs/fragments/ansible-test-pytest-forked.yml
+++ b/changelogs/fragments/ansible-test-pytest-forked.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Update unit tests to use the ``--forked`` option instead of the deprecated ``--boxed`` option.

--- a/test/lib/ansible_test/_data/requirements/units.txt
+++ b/test/lib/ansible_test/_data/requirements/units.txt
@@ -4,4 +4,5 @@ mock
 pytest
 pytest-mock
 pytest-xdist
+pytest-forked
 pyyaml

--- a/test/lib/ansible_test/_internal/units/__init__.py
+++ b/test/lib/ansible_test/_internal/units/__init__.py
@@ -95,7 +95,7 @@ def command_units(args):
 
         cmd = [
             'pytest',
-            '--boxed',
+            '--forked',
             '-r', 'a',
             '-n', str(args.num_workers) if args.num_workers else 'auto',
             '--color',


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/76679

The `--boxed` option is deprecated.

(cherry picked from commit eaeec8a65c4bf9066c5a2c180ec11872f84e6b67)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
