### PR TITLE
Use antsibull 0.42.0b1 for docs build sanity test and docs build

### DIFF
--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -4,7 +4,7 @@
 #    test/sanity/code-smell/docs-build.requirements.txt
 #    test/sanity/code-smell/rstcheck.requirements.txt
 
-antsibull == 0.41.0
+antsibull == 0.42.0b1
 # sphinx 4.2.0 requires docutils < 0.18
 docutils == 0.17.1
 jinja2 == 3.0.3

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -3,7 +3,7 @@
 # if you want known good versions of these dependencies
 # use known_good_reqs.txt instead
 
-antsibull >= 0.41.0
+antsibull >= 0.42.0b1
 docutils
 jinja2
 pygments >= 2.10.0

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -4,7 +4,7 @@ aiohttp==3.8.0
 aiosignal==1.2.0
 alabaster==0.7.12
 ansible-pygments==0.1.0
-antsibull==0.41.0
+antsibull==0.42.0b1
 antsibull-changelog==0.12.0
 async-timeout==4.0.1
 asyncio-pool==0.5.2

--- a/test/sanity/code-smell/test-constraints.py
+++ b/test/sanity/code-smell/test-constraints.py
@@ -36,7 +36,7 @@ def main():
             constraints = raw_constraints.strip()
             comment = requirement.group('comment')
 
-            is_pinned = re.search('^ *== *[0-9.]+(\\.post[0-9]+)?$', constraints)
+            is_pinned = re.search('^ *== *[0-9.]+(\\.post[0-9]+|a[0-9]+|b[0-9]+)?$', constraints)
 
             if is_sanity:
                 sanity = frozen_sanity.setdefault(name, [])


### PR DESCRIPTION
##### SUMMARY
So that @bcoca's https://github.com/ansible/ansible/pull/74963 can pass tests and get merged.

@samccann needs to build the test docsite with this first so we can check whether there is no unintentional breakage.

##### ISSUE TYPE
- Docs Pull Request
- Test Pull Request

##### COMPONENT NAME
CI
docsite
