### PR TITLE
[2.12] ansible-galaxy collection verify - display new files/dirs  as modified content

### DIFF
--- a/changelogs/fragments/76690-fix-ansible-galaxy-collection-verify-modified-content.yaml
+++ b/changelogs/fragments/76690-fix-ansible-galaxy-collection-verify-modified-content.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy collection verify - display files/directories not included in the FILES.json as modified content.

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -220,11 +220,46 @@ def verify_local_collection(
     _verify_file_hash(b_collection_path, file_manifest_filename, expected_hash, modified_content)
     file_manifest = get_json_from_validation_source(file_manifest_filename)
 
+    collection_dirs = set()
+    collection_files = {
+        os.path.join(b_collection_path, b'MANIFEST.json'),
+        os.path.join(b_collection_path, b'FILES.json'),
+    }
+
     # Use the file manifest to verify individual file checksums
     for manifest_data in file_manifest['files']:
+        name = manifest_data['name']
+
         if manifest_data['ftype'] == 'file':
+            collection_files.add(
+                os.path.join(b_collection_path, to_bytes(name, errors='surrogate_or_strict'))
+            )
             expected_hash = manifest_data['chksum_%s' % manifest_data['chksum_type']]
-            _verify_file_hash(b_collection_path, manifest_data['name'], expected_hash, modified_content)
+            _verify_file_hash(b_collection_path, name, expected_hash, modified_content)
+
+        if manifest_data['ftype'] == 'dir':
+            collection_dirs.add(
+                os.path.join(b_collection_path, to_bytes(name, errors='surrogate_or_strict'))
+            )
+
+    # Find any paths not in the FILES.json
+    for root, dirs, files in os.walk(b_collection_path):
+        for name in files:
+            full_path = os.path.join(root, name)
+            path = to_text(full_path[len(b_collection_path) + 1::], errors='surrogate_or_strict')
+
+            if full_path not in collection_files:
+                modified_content.append(
+                    ModifiedContent(filename=path, expected='the file does not exist', installed='the file exists')
+                )
+        for name in dirs:
+            full_path = os.path.join(root, name)
+            path = to_text(full_path[len(b_collection_path) + 1::], errors='surrogate_or_strict')
+
+            if full_path not in collection_dirs:
+                modified_content.append(
+                    ModifiedContent(filename=path, expected='the directory does not exist', installed='the directory exists')
+                )
 
     if modified_content:
         result.success = False

--- a/test/integration/targets/ansible-galaxy-collection/tasks/verify.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/verify.yml
@@ -275,6 +275,16 @@
 - name: append a newline to a module to modify the checksum
   shell: "echo '' >> {{ module_path }}"
 
+- name: create a new module file
+  file:
+    path: '{{ galaxy_dir }}/ansible_collections/ansible_test/verify/plugins/modules/test_new_file.py'
+    state: touch
+
+- name: create a new directory
+  file:
+    path: '{{ galaxy_dir }}/ansible_collections/ansible_test/verify/plugins/modules/test_new_dir'
+    state: directory
+
 - name: verify modified collection locally-only (should fail)
   command: ansible-galaxy collection verify --offline ansible_test.verify
   register: verify
@@ -287,3 +297,5 @@
       - verify.rc != 0
       - "'Collection ansible_test.verify contains modified content in the following files:' in verify.stdout"
       - "'plugins/modules/test_module.py' in verify.stdout"
+      - "'plugins/modules/test_new_file.py' in verify.stdout"
+      - "'plugins/modules/test_new_dir' in verify.stdout"


### PR DESCRIPTION
##### SUMMARY
Backporting the first two commits (code change and changelog) in #76690. `ansible-galaxy collection verify` was not displaying new directories/files in a collection (i.e. paths not already in the FILES.json) as modified content.

* Fix 'ansible-galaxy collection verify' to report files/directories not listed in the FILES.json
  
  (cherry picked from commit a1d467dbb21e00cdb0ed38baf0e43e583185dc59)

*  changelog
 
  (cherry picked from commit 3d49d6f69ec1afa2234a21a1f9cd273d55cb6597)

##### ISSUE TYPE
- Bugfix Pull Request
