### PR TITLE
ansible-test - Remove obsolete display of MAXFD.

### DIFF
--- a/changelogs/fragments/ansible-test-maxfd.yaml
+++ b/changelogs/fragments/ansible-test-maxfd.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Remove obsolete ``MAXFD`` display.

--- a/test/lib/ansible_test/_internal/__init__.py
+++ b/test/lib/ansible_test/_internal/__init__.py
@@ -14,7 +14,6 @@ from .init import (
 from .util import (
     ApplicationError,
     display,
-    MAXFD,
 )
 
 from .delegation import (
@@ -62,7 +61,6 @@ def main(cli_args=None):  # type: (t.Optional[t.List[str]]) -> None
         configure_timeout(config)
 
         display.info('RLIMIT_NOFILE: %s' % (CURRENT_RLIMIT_NOFILE,), verbosity=2)
-        display.info('MAXFD: %d' % MAXFD, verbosity=2)
 
         delegate_args = None
         target_names = None

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -52,12 +52,6 @@ TValue = t.TypeVar('TValue')
 
 PYTHON_PATHS = {}  # type: t.Dict[str, str]
 
-try:
-    # noinspection PyUnresolvedReferences
-    MAXFD = subprocess.MAXFD
-except AttributeError:
-    MAXFD = -1
-
 COVERAGE_CONFIG_NAME = 'coveragerc'
 
 ANSIBLE_TEST_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
##### SUMMARY

Use of ``subprocess.MAXFD`` only worked on Python 2.x, which is no longer supported.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
