### PR TITLE
Docs:Uninstall all packages before Ubuntu reinstall

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -264,6 +264,15 @@ To configure the PPA on your machine and install Ansible run these commands:
 
 .. note:: On older Ubuntu distributions, "software-properties-common" is called "python-software-properties". You may want to use ``apt-get`` instead of ``apt`` in older versions. Also, be aware that only newer distributions (in other words, 18.04, 18.10, and so on) have a ``-u`` or ``--update`` flag, so adjust your script accordingly.
 
+If you are reinstalling Ansible, you must first fully uninstall all Ansible packages.
+The following command uninstalls ``ansible-package`` and the other packages that were installed with Ansible:
+
+.. code-block:: bash
+
+    $ sudo apt autoremove ansible
+
+The ``sudo apt remove ansible`` command only removes ``ansible-package``.
+
 Installing Ansible on Debian
 ----------------------------
 


### PR DESCRIPTION
##### SUMMARY

Fixes #76134

An Ubuntu user couldn't re-install Ansible after using `apt remove ansible` to uninstall Ansible.
`apt remove ansible` only uninstalls `ansible-package`.

Add a note in the Installation guide to say that before uninstalling Ansible, users must fully uninstall Ansible and the packages that went with it using `apt autoremove ansible`.

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
[<!--- Write the short name of the module, plugin, task or feature below -->
https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/installation_guide/intro_installation.rst

](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-ansible-on-ubuntu)

##### ADDITIONAL INFORMATION
`apt remove ansible` removes only the ansible package, with a note that other packages were installed along with it but will not be removed.
`apt autoremove ansible` uninstalls ansible and all other unused packages that go along with it.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
# apt remove ansible
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following packages were automatically installed and are no longer required:
  ansible-core python3-bcrypt python3-jmespath python3-kerberos python3-ntlm-auth python3-packaging
  python3-paramiko python3-pyparsing python3-requests-kerberos python3-requests-ntlm python3-resolvelib
  python3-winrm python3-xmltodict sshpass
Use 'apt autoremove' to remove them.
The following packages will be REMOVED:
  ansible
0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
```

```
# apt autoremove ansible
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following packages will be REMOVED:
  ansible ansible-core python3-bcrypt python3-jmespath python3-kerberos python3-ntlm-auth python3-packaging
  python3-paramiko python3-pyparsing python3-requests-kerberos python3-requests-ntlm python3-resolvelib
  python3-winrm python3-xmltodict sshpass
0 upgraded, 0 newly installed, 15 to remove and 0 not upgraded.
```
