### PR TITLE
[2.11 backport] use same timeout for galaxy api interactions (#77088)

### DIFF
--- a/changelogs/fragments/ansible_galaxy_timeout.yml
+++ b/changelogs/fragments/ansible_galaxy_timeout.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - extend timeout for ansible-galaxy when communicating with the galaxy server api, and apply it to all interactions with the api

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -258,6 +258,7 @@ class GalaxyAPI:
             available_api_versions=None,
             clear_response_cache=False, no_cache=True,
             priority=float('inf'),
+            timeout=60,
     ):
         self.galaxy = galaxy
         self.name = name
@@ -266,6 +267,7 @@ class GalaxyAPI:
         self.token = token
         self.api_server = url
         self.validate_certs = validate_certs
+        self.timeout = timeout
         self._available_api_versions = available_api_versions or {}
         self._priority = priority
 
@@ -377,7 +379,7 @@ class GalaxyAPI:
         try:
             display.vvvv("Calling Galaxy at %s" % url)
             resp = open_url(to_native(url), data=args, validate_certs=self.validate_certs, headers=headers,
-                            method=method, timeout=20, http_agent=user_agent(), follow_redirects='safe')
+                            method=method, timeout=self.timeout, http_agent=user_agent(), follow_redirects='safe')
         except HTTPError as e:
             raise GalaxyError(e, error_context_msg)
         except Exception as e:
@@ -435,7 +437,7 @@ class GalaxyAPI:
         """
         url = _urljoin(self.api_server, self.available_api_versions['v1'], "tokens") + '/'
         args = urlencode({"github_token": github_token})
-        resp = open_url(url, data=args, validate_certs=self.validate_certs, method="POST", http_agent=user_agent())
+        resp = open_url(url, data=args, validate_certs=self.validate_certs, method="POST", http_agent=user_agent(), timeout=self.timeout)
         data = json.loads(to_text(resp.read(), errors='surrogate_or_strict'))
         return data
 

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -385,7 +385,7 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
 
 # FIXME: use random subdirs while preserving the file names
 def _download_file(url, b_path, expected_hash, validate_certs, token=None, timeout=60):
-    # type: (str, bytes, Optional[str], bool, GalaxyToken) -> bytes
+    # type: (str, bytes, Optional[str], bool, GalaxyToken, int) -> bytes
     # ^ NOTE: used in download and verify_collections ^
     b_tarball_name = to_bytes(
         url.rsplit('/', 1)[1], errors='surrogate_or_strict',

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -65,8 +65,8 @@ class ConcreteArtifactsManager:
         * retrieving the metadata out of the downloaded artifacts
     """
 
-    def __init__(self, b_working_directory, validate_certs=True):
-        # type: (bytes, bool) -> None
+    def __init__(self, b_working_directory, validate_certs=True, timeout=60):
+        # type: (bytes, bool, int) -> None
         """Initialize ConcreteArtifactsManager caches and costraints."""
         self._validate_certs = validate_certs  # type: bool
         self._artifact_cache = {}  # type: Dict[bytes, bytes]
@@ -74,6 +74,7 @@ class ConcreteArtifactsManager:
         self._artifact_meta_cache = {}  # type: Dict[bytes, Dict[str, Optional[Union[str, List[str], Dict[str, str]]]]]
         self._galaxy_collection_cache = {}  # type: Dict[Union[Candidate, Requirement], Tuple[str, str, GalaxyToken]]
         self._b_working_directory = b_working_directory  # type: bytes
+        self.timeout = timeout  # type: int
 
     def get_galaxy_artifact_path(self, collection):
         # type: (Union[Candidate, Requirement]) -> bytes
@@ -168,6 +169,7 @@ class ConcreteArtifactsManager:
                     self._b_working_directory,
                     expected_hash=None,  # NOTE: URLs don't support checksums
                     validate_certs=self._validate_certs,
+                    timeout=self.timeout
                 )
             except URLError as err:
                 raise_from(
@@ -382,7 +384,7 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
 
 
 # FIXME: use random subdirs while preserving the file names
-def _download_file(url, b_path, expected_hash, validate_certs, token=None):
+def _download_file(url, b_path, expected_hash, validate_certs, token=None, timeout=60):
     # type: (str, bytes, Optional[str], bool, GalaxyToken) -> bytes
     # ^ NOTE: used in download and verify_collections ^
     b_tarball_name = to_bytes(
@@ -405,6 +407,7 @@ def _download_file(url, b_path, expected_hash, validate_certs, token=None):
         validate_certs=validate_certs,
         headers=None if token is None else token.headers(),
         unredirected_headers=['Authorization'], http_agent=user_agent(),
+        timeout=timeout
     )
 
     with open(b_file_path, 'wb') as download_file:  # type: BinaryIO


### PR DESCRIPTION
Also, bump the default. A number of people have reported problems with
this 20 second timeout for a couple of years on
https://github.com/ansible/galaxy/issues/2302

It is mentioned in the issue that resolving dns can sometimes take up to
30 seconds, and that this timeout includes dns resolution.

Includes a changelog message

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
backport of #77088 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
