### PR TITLE
docs: fix spelling err in modules desc

### DIFF
--- a/lib/ansible/modules/include_vars.py
+++ b/lib/ansible/modules/include_vars.py
@@ -98,7 +98,7 @@ attributes:
         support: full
     delegation:
         details:
-            - while variable assignment can be delegated to a different host the execution context is always the current invenotory_hostname
+            - while variable assignment can be delegated to a different host the execution context is always the current inventory_hostname
             - connection variables, if set at all, would reflect the host it would target, even if we are not connecting at all in this case
         support: partial
     diff_mode:

--- a/lib/ansible/modules/set_fact.py
+++ b/lib/ansible/modules/set_fact.py
@@ -58,7 +58,7 @@ attributes:
         support: partial
     delegation:
         details:
-            - while variable assignment can be delegated to a different host the execution context is always the current invenotory_hostname
+            - while variable assignment can be delegated to a different host the execution context is always the current inventory_hostname
             - connection variables, if set at all, would reflect the host it would target, even if we are not connecting at all in this case
         support: partial
     diff_mode:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

correct inventory_hostname spelling error in include_vars and set_fact
modules

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
set_fact
include_vars

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

error can be seen here
https://docs.ansible.com/ansible/latest/collections/ansible/builtin/include_vars_module.html#attributes
in `delegation`

Signed-off-by: jbpratt <jbpratt78@gmail.com>
