### PR TITLE
Clarify docs for using tests as filters

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tests.rst
@@ -22,7 +22,7 @@ Test syntax
 
 `Test syntax <https://jinja.palletsprojects.com/en/latest/templates/#tests>`_ varies from `filter syntax <https://jinja.palletsprojects.com/en/latest/templates/#filters>`_ (``variable | filter``). Historically Ansible has registered tests as both jinja tests and jinja filters, allowing for them to be referenced using filter syntax.
 
-As of Ansible 2.5, using a jinja test as a filter will generate a warning.
+As of Ansible 2.5, using a jinja test as a filter will generate a deprecation warning. As of Ansible 2.9+ using jinja test syntax is required.
 
 The syntax for using a jinja test is as follows
 


### PR DESCRIPTION
##### SUMMARY
The docs mentioned using tests with filter syntax is a warning in Ansible 2.5, but didn't mention the feature was deprecated and later removed.

##### ISSUE TYPE
- Docs Pull Request
