### PR TITLE
disable broken pexpect-dependent tests on RHEL7

### DIFF
--- a/test/integration/targets/ansible-galaxy-collection/aliases
+++ b/test/integration/targets/ansible-galaxy-collection/aliases
@@ -2,3 +2,4 @@ shippable/galaxy/group1
 shippable/galaxy/smoketest
 cloud/galaxy
 context/controller
+skip/rhel/7.9

--- a/test/integration/targets/builtin_vars_prompt/aliases
+++ b/test/integration/targets/builtin_vars_prompt/aliases
@@ -2,3 +2,4 @@ setup/always/setup_passlib
 setup/always/setup_pexpect
 shippable/posix/group4
 context/controller
+skip/rhel/7.9

--- a/test/integration/targets/cli/aliases
+++ b/test/integration/targets/cli/aliases
@@ -4,3 +4,4 @@ needs/ssh
 needs/target/setup_pexpect
 shippable/posix/group3
 context/controller
+skip/rhel/7.9

--- a/test/integration/targets/debugger/aliases
+++ b/test/integration/targets/debugger/aliases
@@ -1,3 +1,4 @@
 shippable/posix/group1
 context/controller
 setup/always/setup_pexpect
+skip/rhel/7.9

--- a/test/integration/targets/expect/aliases
+++ b/test/integration/targets/expect/aliases
@@ -1,3 +1,4 @@
 shippable/posix/group2
 destructive
 needs/target/setup_pexpect
+skip/rhel/7.9

--- a/test/integration/targets/pause/aliases
+++ b/test/integration/targets/pause/aliases
@@ -1,3 +1,4 @@
 needs/target/setup_pexpect
 shippable/posix/group1
 context/controller  # this is a controller-only action, the module is just for documentation
+skip/rhel/7.9


### PR DESCRIPTION
* Default-installed OS package `redhat-support-tool` was added to a new AMI and breaks installation of pexpect (since pip can't uninstall it). The setup_pexpect role probably needs to conditionally determine if it can add `--user` and do so.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
