### PR TITLE
[stable-2.10] Update setup_pexpect to prefer pip user installs.

### DIFF
--- a/test/integration/targets/setup_pexpect/tasks/main.yml
+++ b/test/integration/targets/setup_pexpect/tasks/main.yml
@@ -3,8 +3,17 @@
     src: constraints.txt
     dest: "{{ remote_tmp_dir }}/pexpect-constraints.txt"
 
+- name: Install pexpect with --user
+  pip:
+    name: pexpect
+    extra_args: '--user --constraint "{{ remote_tmp_dir }}/pexpect-constraints.txt"'
+    state: present
+  ignore_errors: yes  # fails when inside a virtual environment
+  register: pip_user
+
 - name: Install pexpect
   pip:
     name: pexpect
     extra_args: '--constraint "{{ remote_tmp_dir }}/pexpect-constraints.txt"'
     state: present
+  when: pip_user is failed


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/77164

This works around issues on RHEL 7.9 when an old version of pexpect is installed from an OS package.

(cherry picked from commit 27fe26edbf57a39a11de7dea14dc60d4a6b1384e)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

test/integration/targets/setup_pexpect/tasks/main.yml