### PR TITLE
Update galaxy.py

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1279,7 +1279,7 @@ class GalaxyCLI(CLI):
                 if not role.metadata:
                     display.warning("Meta file %s is empty. Skipping dependencies." % role.path)
                 else:
-                    role_dependencies = (role.metadata.get('dependencies') or []) + role.requirements
+                    role_dependencies = (role.metadata.get('dependencies') or []) + (role.requirements or [])
                     for dep in role_dependencies:
                         display.debug('Installing dep %s' % dep)
                         dep_req = RoleRequirement()


### PR DESCRIPTION
Fix problem with role.requirements == none

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy

##### ADDITIONAL INFORMATION
```Stack of ansible-galaxy install -r sup02_os_configuration_requirements.yml -vvv
Processing role setup_dns_config
archiving ['/usr/bin/git', 'archive', '--prefix=setup_dns_config/', '--output=/.ansible/tmp/ansible-local-694755ad8u6dfs/tmprzzoihqx.tar', 'v1.0.0']
- extracting setup_dns_config to /etc/ansible/playbooks/name/roles/setup_dns_config
- setup_dns_config (v1.0.0) was installed successfully
None # <-- Debug print print(role.metadata.get('dependencies'))
None # <-- Debug print print(role.requirements)
ERROR! Unexpected Exception, this is probably a bug: can only concatenate list (not "NoneType") to list
the full traceback was:

Traceback (most recent call last):
  File "/usr/local/bin/ansible-galaxy", line 128, in <module>
    exit_code = cli.run()
  File "/usr/local/lib/python3.9/site-packages/ansible/cli/galaxy.py", line 569, in run
    return context.CLIARGS['func']()
  File "/usr/local/lib/python3.9/site-packages/ansible/cli/galaxy.py", line 86, in method_wrapper
    return wrapped_method(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/ansible/cli/galaxy.py", line 1197, in execute_install
    self._execute_install_role(role_requirements)
  File "/usr/local/lib/python3.9/site-packages/ansible/cli/galaxy.py", line 1285, in _execute_install_role
    role_dependencies = (role.metadata.get('dependencies') or []) + role.requirements
TypeError: can only concatenate list (not "NoneType") to list
```

After the fix, the issue was gone.
