### PR TITLE
Data tagging and sidecar docs are delayed, and will be retargeted for 2.14

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_13.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_13.rst
@@ -49,12 +49,18 @@ Release Manager
 Planned work
 ============
 
-* Data Tagging
 * ``ansible-doc`` extended dump support for devtools integration
 * ``ansible-galaxy`` CLI collection verification, source, and trust
 * ``jinja2`` 3.0+ dependency
 * Consolidate template handling to always use ``jinja2`` native
 * Drop Python 2.6 support for module execution
-* Implement sidecar docs to support documenting filter/test plugins, as well as non Python modules
 * Update the collection loader to Python 3.x loader API, due to removal of the Python 2 API in Python 3.12
 * Modernize python packaging and installation
+
+Delayed work
+============
+
+The following work has been delayed and retargeted for a future release
+
+* Data Tagging
+* Implement sidecar docs to support documenting filter/test plugins, as well as non Python modules


### PR DESCRIPTION
##### SUMMARY
Data tagging and sidecar docs are delayed, and will be retargeted for 2.14

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/roadmap/ROADMAP_2_13.rst

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
