### PR TITLE
Honor --quiet parameter properly in fish shell

### DIFF
--- a/changelogs/fragments/77180-fix-fish-env-setup-script.yml
+++ b/changelogs/fragments/77180-fix-fish-env-setup-script.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - hacking - fix incorrect usage of deprecated fish-shell redirection operators
+    that failed to honor ``--quiet`` flag when sourced (https://github.com/ansible/ansible/pull/77180).

--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -80,20 +80,15 @@ function gen_egg_info
         rm -rf $PREFIX_PYTHONPATH/ansible*.egg-info
     end
 
-    if [ $QUIET ]
-        set options '-q'
-    end
-
-    eval $PYTHON_BIN setup.py $options egg_info
-
+    eval $PYTHON_BIN setup.py egg_info
 end
 
 
 pushd $ANSIBLE_HOME
 
 if [ $QUIET ]
-    gen_egg_info ^ /dev/null
-    find . -type f -name "*.pyc" -exec rm -f '{}' ';' ^ /dev/null
+    gen_egg_info &> /dev/null
+    find . -type f -name "*.pyc" -exec rm -f '{}' ';' &> /dev/null
 else
     gen_egg_info
     find . -type f -name "*.pyc" -exec rm -f '{}' ';'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
This is a tiny cosmetic change, as it has been bothering me that my startup configuration output isn't clean when executing `source ~/ansible/hacking/env-setup.fish --quiet` as expected.

* The `^` stderr redirection is deprecated

fish-shell has moved away from using `^` for stderr redirection. See [fish-shell#6192](https://github.com/fish-shell/fish-shell/issues/6192#issuecomment-542363561) and [fish-shell#6206](https://github.com/fish-shell/fish-shell/pull/6206) for details.

* Setting `-q` for `setup.py` in `gen_egg_info` is redundant

When in quiet mode, the complete output of the `gen_egg_info` function is redirected, so adding the `-q` flag when calling `setup.py` in the function is redundant. This is symmetrical with the Bash environment setup script as well.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- Installation
  - Running the `devel` branch from a clone (`hacking/env-setup.fish`)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
**Before:**
```
philipsd6@vm001 ~/ansible (devel)> source hacking/env-setup.fish --quiet
warning: no files found matching 'SYMLINK_CACHE.json'
warning: no previously-included files found matching 'docs/docsite/rst_warnings'
warning: no previously-included files found matching 'docs/docsite/rst/conf.py'
warning: no previously-included files found matching 'docs/docsite/rst/index.rst'
warning: no previously-included files matching '*' found under directory 'docs/docsite/_build'
warning: no previously-included files matching '*.pyc' found under directory 'docs/docsite/_extensions'
warning: no previously-included files matching '*.pyo' found under directory 'docs/docsite/_extensions'
warning: no files found matching '*.ps1' under directory 'lib/ansible/modules/windows'
warning: no files found matching 'validate-modules' under directory 'test/lib/ansible_test/_util/controller/sanity/validate-modules'
find: paths must precede expression: `^'
```
**After:**
```
philipsd6@vm001 ~/ansible (fix/env-setup-fish)> source hacking/env-setup.fish --quiet
philipsd6@vm001 ~/ansible (fix/env-setup-fish)>
```