### PR TITLE
Update example in with_first_found documentation to work

### DIFF
--- a/lib/ansible/plugins/lookup/first_found.py
+++ b/lib/ansible/plugins/lookup/first_found.py
@@ -67,10 +67,10 @@ EXAMPLES = """
   ansible.builtin.include_tasks:
     file: "{{ item }}"
   with_first_found:
-    files:
-     - path/tasks.yaml
-     - path/other_tasks.yaml
-    skip: True
+    - files:
+      - path/tasks.yaml
+      - path/other_tasks.yaml
+      skip: True
 
 - name: Include tasks only if one of the files exists, otherwise skip
   ansible.builtin.include_tasks: '{{ tasks_file }}'


### PR DESCRIPTION
##### SUMMARY
`with_first_found` only takes a list of things, it's not like `tags`
where it can take a thing or a list of things.

Inspired by locally discovered breakage and then finding
https://github.com/ansible/ansible/issues/77136 where someone was also
doing this and getting into trouble.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lookup/first_found.py