### PR TITLE
linux networking facts: Provide IPv4 prefix

### DIFF
--- a/changelogs/fragments/77193-linux-networking-facts-Provide-IPv4-prefix.yml
+++ b/changelogs/fragments/77193-linux-networking-facts-Provide-IPv4-prefix.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - facts - report prefix length for IPv4 addresses in Linux network facts.

--- a/lib/ansible/module_utils/facts/network/linux.py
+++ b/lib/ansible/module_utils/facts/network/linux.py
@@ -192,7 +192,9 @@ class LinuxNetwork(Network):
                             interfaces[iface]['ipv4'] = {'address': address,
                                                          'broadcast': broadcast,
                                                          'netmask': netmask,
-                                                         'network': network}
+                                                         'network': network,
+                                                         'prefix': netmask_length,
+                                                         }
                         else:
                             if "ipv4_secondaries" not in interfaces[iface]:
                                 interfaces[iface]["ipv4_secondaries"] = []
@@ -201,6 +203,7 @@ class LinuxNetwork(Network):
                                 'broadcast': broadcast,
                                 'netmask': netmask,
                                 'network': network,
+                                'prefix': netmask_length,
                             })
 
                         # add this secondary IP to the main device
@@ -213,6 +216,7 @@ class LinuxNetwork(Network):
                                     'broadcast': broadcast,
                                     'netmask': netmask,
                                     'network': network,
+                                    'prefix': netmask_length,
                                 })
 
                         # NOTE: default_ipv4 is ref to outside scope
@@ -221,6 +225,7 @@ class LinuxNetwork(Network):
                             default_ipv4['broadcast'] = broadcast
                             default_ipv4['netmask'] = netmask
                             default_ipv4['network'] = network
+                            default_ipv4['prefix'] = netmask_length
                             # NOTE: macaddress is ref from outside scope
                             default_ipv4['macaddress'] = macaddress
                             default_ipv4['mtu'] = interfaces[device]['mtu']


### PR DESCRIPTION
##### SUMMARY
For IPv6 addresses, Ansible already provides the prefix length for IP
addresses in the `prefix` fact. This patch adjusts the facts for IPv4
addresses to also contain the prefix length in the prefix fact. This
makes it easier to use the facts consistently when the CIDR notation is
needed.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME

gather_facts

##### ADDITIONAL INFORMATION

This came up because https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters_ipaddr.html#converting-subnet-masks-to-cidr-notation requires the python netaddr module which is an optional dependency that can be easily avoided with this patch.