### PR TITLE
Add pid tracking to async_wrapper, add terminate functionality to async_status

### DIFF
--- a/changelogs/fragments/async-status-terminate.yml
+++ b/changelogs/fragments/async-status-terminate.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- async_status - Add ability to terminate a running async command

--- a/lib/ansible/modules/async_status.py
+++ b/lib/ansible/modules/async_status.py
@@ -34,7 +34,7 @@ options:
       - A symbolic signal name or non-negative decimal integer, specifying the signal to be sent instead of the default TERM
     type: raw
     default: TERM
-  version_addded: "2.13"
+    version_added: "2.13"
 extends_documentation_fragment:
 - action_common_attributes
 - action_common_attributes.flow

--- a/lib/ansible/modules/async_status.py
+++ b/lib/ansible/modules/async_status.py
@@ -181,7 +181,7 @@ def main():
         else:
             os.unlink(log_path)
             data['terminated'] = True
-    else:
+    elif mode == 'terminate':
         data['terminated'] = False
 
     # Fix error: TypeError: exit_json() keywords must be strings

--- a/lib/ansible/modules/async_wrapper.py
+++ b/lib/ansible/modules/async_wrapper.py
@@ -151,7 +151,7 @@ def jwrite(info):
 
 def _run_module(wrapped_cmd, jid):
 
-    jwrite({"started": 1, "finished": 0, "ansible_job_id": jid})
+    jwrite({"started": 1, "finished": 0, "ansible_job_id": jid, "pid": os.getpid()})
 
     result = {}
 
@@ -201,9 +201,10 @@ def _run_module(wrapped_cmd, jid):
             "cmd": wrapped_cmd,
             "msg": to_text(e),
             "outdata": outdata,  # temporary notice only
-            "stderr": stderr
+            "stderr": stderr,
+            "ansible_job_id": jid,
+            "pid": os.getpid(),
         }
-        result['ansible_job_id'] = jid
         jwrite(result)
 
     except (ValueError, Exception):
@@ -212,9 +213,10 @@ def _run_module(wrapped_cmd, jid):
             "cmd": wrapped_cmd,
             "data": outdata,  # temporary notice only
             "stderr": stderr,
-            "msg": traceback.format_exc()
+            "msg": traceback.format_exc(),
+            "ansible_job_id": jid,
+            "pid": os.getpid(),
         }
-        result['ansible_job_id'] = jid
         jwrite(result)
 
 

--- a/lib/ansible/plugins/action/async_status.py
+++ b/lib/ansible/plugins/action/async_status.py
@@ -11,7 +11,7 @@ from ansible.utils.vars import merge_hash
 
 class ActionModule(ActionBase):
 
-    _VALID_ARGS = frozenset(('jid', 'mode'))
+    _VALID_ARGS = frozenset(('jid', 'mode', 'signal'))
 
     def _get_async_dir(self):
 

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -408,10 +408,7 @@ class CallbackModule(CallbackBase):
 
     def v2_runner_on_async_poll(self, result):
         host = result._host.get_name()
-        jid = result._result.get('ansible_job_id')
-        started = result._result.get('started')
-        finished = result._result.get('finished')
-        kv = ' '.join(f'{k}={v!r}' for k, v in result._result.items())
+        kv = ' '.join(f'{k}={v!r}' for k, v in sorted(result._result.items()) if k != 'invocation')
         self._display.display(
             'ASYNC POLL on %s: %s' % (host, kv),
             color=C.COLOR_DEBUG

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -411,8 +411,9 @@ class CallbackModule(CallbackBase):
         jid = result._result.get('ansible_job_id')
         started = result._result.get('started')
         finished = result._result.get('finished')
+        kv = ' '.join(f'{k}={v!r}' for k, v in result._result.items())
         self._display.display(
-            'ASYNC POLL on %s: jid=%s started=%s finished=%s' % (host, jid, started, finished),
+            'ASYNC POLL on %s: %s' % (host, kv),
             color=C.COLOR_DEBUG
         )
 

--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -298,3 +298,7 @@
 - assert:
     that:
       - '"ASYNC POLL on localhost" in callback_output.stdout'
+
+- include_tasks: terminate.yml
+  # busybox ps makes it difficult to do the verification in these tasks
+  when: ansible_distribution != 'Alpine'

--- a/test/integration/targets/async/tasks/terminate.yml
+++ b/test/integration/targets/async/tasks/terminate.yml
@@ -1,0 +1,72 @@
+- set_fact:
+    start: '{{ now(fmt="%s") }}'
+
+- name: Start async task
+  command: sleep 30
+  async: 30
+  poll: 0
+  register: result
+
+- name: Get status of async task
+  async_status:
+    jid: '{{ result.ansible_job_id }}'
+  register: status_result
+
+- name: Get pid of async_wrapper
+  command: ps -o ppid= -p {{ status_result.pid }}
+  register: ppid
+
+- name: Ensure async_wrapper is running
+  command: ps -p {{ ppid.stdout|trim }}
+
+- name: Terminate sleep command
+  async_status:
+    jid: '{{ result.ansible_job_id }}'
+    mode: terminate
+    signal: TERM
+
+- name: Check for async job file
+  async_status:
+    jid: '{{ result.ansible_job_id }}'
+  register: fail_result
+  ignore_errors: true
+
+- name: Assert async job file is missing
+  assert:
+    that:
+      - fail_result is failed
+
+- block:
+    - name: Wait for sleep command to exit
+      command: ps -p {{ status_result.pid }}
+      register: child_result
+      failed_when: child_result.rc == 0
+      until: child_result.rc != 0
+      retries: 10
+      delay: 1
+  rescue:
+    - fail:
+        msg: command did not exit
+
+- block:
+    - name: Wait for async_wrapper to terminate
+      command: ps -p {{ ppid.stdout|trim }}
+      register: parent_result
+      failed_when: parent_result.rc == 0
+      until: parent_result.rc != 0
+      retries: 10
+      delay: 1
+  rescue:
+    - fail:
+        msg: async_wrapper did not exit
+
+- set_fact:
+    end: '{{ now(fmt="%s") }}'
+
+- debug:
+    msg: '{{ end|int - start|int }} seconds elapsed'
+
+- name: Assert that we made it here faster than the 30s async timeout
+  assert:
+    that:
+      - end|int - start|int < 30


### PR DESCRIPTION
##### SUMMARY
Add pid tracking to async_wrapper, add terminate functionality to async_status

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/async_status.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
