### PR TITLE
Address Docs: How to report bugs #53520

### DIFF
--- a/docs/docsite/rst/community/reporting_bugs_and_features.rst
+++ b/docs/docsite/rst/community/reporting_bugs_and_features.rst
@@ -21,7 +21,7 @@ Ansible practices responsible disclosure - if this is a security-related bug, em
 Bugs in ansible-core
 --------------------
 
-Before reporting a bug, use the bug/issue search to check for :ref:`already reported issues <https://github.com/ansible/ansible/issues>`. Unsure if you found a bug? Report the behavior on the :ref:`mailing list or community chat first <communication>`.
+Before reporting a bug, use the bug/issue search to check for already reported issues <https://github.com/ansible/ansible/issues>. Unsure if you found a bug? Report the behavior on the :ref:`mailing list or community chat first <communication>`.
 
 Also, use the mailing list or chat if you are unsure whether a bug is in ``ansible-core`` or in a collection, and for "how do I do this" type questions to discuss.
 

--- a/docs/docsite/rst/community/reporting_bugs_and_features.rst
+++ b/docs/docsite/rst/community/reporting_bugs_and_features.rst
@@ -25,8 +25,8 @@ Before reporting a bug, use the bug/issue search to check for :ref:`already repo
 
 Also, use the mailing list or chat if you are unsure whether a bug is in ``ansible-core`` or in a collection, and for "how do I do this" type questions to discuss.
 
-You need a free GitHub account to report issues to `github.com/ansible/ansible/issues <https://github.com/ansible/ansible/issues>`_ for bugs
-- affecting multiple plugins
+You need a free GitHub account to report bugs to :ref:`github.com/ansible/ansible/issues <https://github.com/ansible/ansible/issues>`_ that affects
+- multiple plugins
 - a plugin that remained in the ansible/ansible repo
 - the overall functioning of Ansible
 

--- a/docs/docsite/rst/community/reporting_bugs_and_features.rst
+++ b/docs/docsite/rst/community/reporting_bugs_and_features.rst
@@ -21,7 +21,7 @@ Ansible practices responsible disclosure - if this is a security-related bug, em
 Bugs in ansible-core
 --------------------
 
-Before reporting a bug, use the bug/issue search to check for already reported issues. Unsure if you found a bug? Report the behavior on the :ref:`mailing list or community chat first <communication>`.
+Before reporting a bug, use the bug/issue search to check for :ref:`already reported issues <https://github.com/ansible/ansible/issues>. Unsure if you found a bug? Report the behavior on the :ref:`mailing list or community chat first <communication>`.
 
 Do not open issues for "how do I do this" type questions. These are great topics for community chat channels or a mailing list, where things are likely to be more of a discussion.
 

--- a/docs/docsite/rst/community/reporting_bugs_and_features.rst
+++ b/docs/docsite/rst/community/reporting_bugs_and_features.rst
@@ -55,6 +55,6 @@ Requesting a feature
 ====================
 
 Before you request a feature, check what is :ref:`planned for future Ansible Releases <roadmaps>`.
-To get your feature into Ansible, to :ref:`submit a pull request <community_pull_requests>`, either against ansible-core or against a collection. See also :ref:`ansible_collection_merge_requirements`.
+To get your feature into Ansible,  :ref:`submit a pull request <community_pull_requests>`, either against ansible-core or against a collection. See also :ref:`ansible_collection_merge_requirements`. To check already submitted pull requests, refer to :ref: `existing pull requests tagged with feature <https://github.com/ansible/ansible/issues?q=is%3Aissue+is%3Aopen+label%3Afeature>`.
 
 For ``ansible-core``, you can also open an issue in `ansible/ansible <https://github.com/ansible/ansible/issues>`_  or in a corresponding collection repository (to learn how to find a proper issue tracker, refer to :ref:`Bugs in collections<reporting_bugs_in_collections>` section ).

--- a/docs/docsite/rst/community/reporting_bugs_and_features.rst
+++ b/docs/docsite/rst/community/reporting_bugs_and_features.rst
@@ -21,7 +21,7 @@ Ansible practices responsible disclosure - if this is a security-related bug, em
 Bugs in ansible-core
 --------------------
 
-Before reporting a bug, use the bug/issue search to check for :ref:`already reported issues <https://github.com/ansible/ansible/issues>. Unsure if you found a bug? Report the behavior on the :ref:`mailing list or community chat first <communication>`.
+Before reporting a bug, use the bug/issue search to check for :ref:`already reported issues <https://github.com/ansible/ansible/issues>`. Unsure if you found a bug? Report the behavior on the :ref:`mailing list or community chat first <communication>`.
 
 Do not open issues for "how do I do this" type questions. These are great topics for community chat channels or a mailing list, where things are likely to be more of a discussion.
 

--- a/docs/docsite/rst/community/reporting_bugs_and_features.rst
+++ b/docs/docsite/rst/community/reporting_bugs_and_features.rst
@@ -21,7 +21,7 @@ Ansible practices responsible disclosure - if this is a security-related bug, em
 Bugs in ansible-core
 --------------------
 
-Before reporting a bug, use the bug/issue search to check for already reported issues <https://github.com/ansible/ansible/issues>. Unsure if you found a bug? Report the behavior on the :ref:`mailing list or community chat first <communication>`.
+Before reporting a bug, use the bug/issue search to check for `already reported issues <https://github.com/ansible/ansible/issues>`. Unsure if you found a bug? Report the behavior on the :ref:`mailing list or community chat first <communication>`.
 
 Also, use the mailing list or chat if you are unsure whether a bug is in ``ansible-core`` or in a collection, and for "how do I do this" type questions to discuss.
 

--- a/docs/docsite/rst/community/reporting_bugs_and_features.rst
+++ b/docs/docsite/rst/community/reporting_bugs_and_features.rst
@@ -1,3 +1,4 @@
+
 .. _reporting_bugs_and_features:
 
 **************************************
@@ -15,29 +16,38 @@ Reporting a bug
 Security bugs
 -------------
 
-Ansible practices responsible disclosure - if this is a security-related bug, email `security@ansible.com <mailto:security@ansible.com>`_ instead of filing a ticket or posting to any public groups, and you will receive a prompt response.
+Ansible practices responsible disclosure - if this is a security-related bug, email `security@ansible.com <mailto:security@ansible.com>`_ instead of filing a ticket or posting to any public groups to receive a prompt response.
 
 Bugs in ansible-core
 --------------------
 
-If you find a bug that affects multiple plugins, a plugin that remained in the ansible/ansible repo, or the overall functioning of Ansible, report it to `github.com/ansible/ansible/issues <https://github.com/ansible/ansible/issues>`_. You need a free GitHub account.  Before reporting a bug, use the bug/issue search to see if the issue has already been reported. If you are not sure if something is a bug yet, you can report the behavior on the :ref:`mailing list or community chat first <communication>`.
+Before reporting a bug, use the bug/issue search to check for already reported issues. Unsure if you found a bug? Report the behavior on the :ref:`mailing list or community chat first <communication>`.
 
-Do not open issues for "how do I do this" type questions.  These are great topics for community chat channels or a mailing list, where things are likely to be more of a discussion.
+Do not open issues for "how do I do this" type questions. These are great topics for community chat channels or a mailing list, where things are likely to be more of a discussion.
 
-If you find a bug, open the issue yourself to ensure we have a record of it. Do not rely on someone else in the community to file the bug report for you. We have created an issue template, which saves time and helps us help everyone with their issues more quickly. Please fill it out as completely and as accurately as possible:
+If you are unsure whether a bug is in ansible-core or in a collection, report the behavior on the :ref:`mailing list or community chat channel first <communication>`.
 
-  * Include the Ansible version
-  * Include any relevant configuration
-  * Include the exact commands or tasks you are running
-  * Describe the behavior you expected
-  * Provide steps to reproduce the bug
-    * Use minimal well-reduced and well-commented examples, not your entire production playbook
-    * When sharing YAML in playbooks, preserve the formatting by using `code blocks  <https://help.github.com/articles/creating-and-highlighting-code-blocks/>`_.
-  * Document the behavior you got
-  * Include output where possible
-  * For multiple-file content, use gist.github.com, which is more durable than pastebin content
+You need a free GitHub account to report a bug to `github.com/ansible/ansible/issues <https://github.com/ansible/ansible/issues>`_ for bugs
+- affecting multiple plugins
+- a plugin that remained in the ansible/ansible repo
+- the overall functioning of Ansible
 
-If you are not sure whether a bug is in ansible-core or in a collection, you can report the behavior on the :ref:`mailing list or community chat channel first <communication>`.
+How to write a good bug report
+------------------------------
+
+If you find a bug, open an issue using the `issue template <https://github.com/ansible/ansible/issues/new?assignees=&labels=&template=bug_report.yml>`. Detail what you've tried, why you think this is a bug, and what component to use. Fill it out as completely and as accurately as possible, include:
+
+  * your Ansible version
+  * any relevant configurations
+  * the exact commands or tasks you are running
+  * the expected behavior
+  * the steps to reproduce the bug
+    * Use minimal reproducible examples, not your entire production playbook. Use comments to describe your case.
+    * When sharing YAML in playbooks, preserve formatting using `code blocks  <https://help.github.com/articles/creating-and-highlighting-code-blocks/>`_.
+  * the current behavior you got
+  * output where possible
+
+For multiple-file content, use gist.github.com, which is more durable than pastebin content.
 
 .. _request_features:
 
@@ -45,6 +55,6 @@ Requesting a feature
 ====================
 
 Before you request a feature, check what is :ref:`planned for future Ansible Releases <roadmaps>`.
-The best way to get a feature into Ansible is to :ref:`submit a pull request <community_pull_requests>`, either against ansible-core or against a collection. See also :ref:`ansible_collection_merge_requirements`.
+To get your feature into Ansible, to :ref:`submit a pull request <community_pull_requests>`, either against ansible-core or against a collection. See also :ref:`ansible_collection_merge_requirements`.
 
-You can also submit a feature request through opening an issue in the `ansible/ansible <https://github.com/ansible/ansible/issues>`_ for ``ansible-core`` or in a corresponding collection repository (refer to the :ref:`Bugs in collections<reporting_bugs_in_collections>` section to learn how to find a proper issue tracker).
+You can also open an issue in the `ansible/ansible <https://github.com/ansible/ansible/issues>`_ for ``ansible-core`` or in a corresponding collection repository (refer to the :ref:`Bugs in collections<reporting_bugs_in_collections>` section to learn how to find a proper issue tracker).

--- a/docs/docsite/rst/community/reporting_bugs_and_features.rst
+++ b/docs/docsite/rst/community/reporting_bugs_and_features.rst
@@ -25,9 +25,9 @@ Before reporting a bug, use the bug/issue search to check for already reported i
 
 Do not open issues for "how do I do this" type questions. These are great topics for community chat channels or a mailing list, where things are likely to be more of a discussion.
 
-If you are unsure whether a bug is in ansible-core or in a collection, report the behavior on the :ref:`mailing list or community chat channel first <communication>`.
+If you are unsure whether a bug is in ``ansible-core`` or in a collection, report the behavior on the :ref:`mailing list or community chat channel first <communication>`.
 
-You need a free GitHub account to report a bug to `github.com/ansible/ansible/issues <https://github.com/ansible/ansible/issues>`_ for bugs
+You need a free GitHub account to report issues to `github.com/ansible/ansible/issues <https://github.com/ansible/ansible/issues>`_ for bugs
 - affecting multiple plugins
 - a plugin that remained in the ansible/ansible repo
 - the overall functioning of Ansible
@@ -42,9 +42,9 @@ If you find a bug, open an issue using the `issue template <https://github.com/a
   * the exact commands or tasks you are running
   * the expected behavior
   * the steps to reproduce the bug
-    * Use minimal reproducible examples, not your entire production playbook. Use comments to describe your case.
-    * When sharing YAML in playbooks, preserve formatting using `code blocks  <https://help.github.com/articles/creating-and-highlighting-code-blocks/>`_.
-  * the current behavior you got
+    * Use a minimal reproducible example and comments describing examples
+    * Preserve formatting using `code blocks  <https://help.github.com/articles/creating-and-highlighting-code-blocks/>`_ when sharing YAML in playbooks.
+  * the behavior you currently see
   * output where possible
 
 For multiple-file content, use gist.github.com, which is more durable than pastebin content.
@@ -57,4 +57,4 @@ Requesting a feature
 Before you request a feature, check what is :ref:`planned for future Ansible Releases <roadmaps>`.
 To get your feature into Ansible, to :ref:`submit a pull request <community_pull_requests>`, either against ansible-core or against a collection. See also :ref:`ansible_collection_merge_requirements`.
 
-You can also open an issue in the `ansible/ansible <https://github.com/ansible/ansible/issues>`_ for ``ansible-core`` or in a corresponding collection repository (refer to the :ref:`Bugs in collections<reporting_bugs_in_collections>` section to learn how to find a proper issue tracker).
+For ``ansible-core``, you can also open an issue in `ansible/ansible <https://github.com/ansible/ansible/issues>`_  or in a corresponding collection repository (to learn how to find a proper issue tracker, refer to :ref:`Bugs in collections<reporting_bugs_in_collections>` section ).

--- a/docs/docsite/rst/community/reporting_bugs_and_features.rst
+++ b/docs/docsite/rst/community/reporting_bugs_and_features.rst
@@ -25,7 +25,7 @@ Before reporting a bug, use the bug/issue search to check for :ref:`already repo
 
 Also, use the mailing list or chat if you are unsure whether a bug is in ``ansible-core`` or in a collection, and for "how do I do this" type questions to discuss.
 
-You need a free GitHub account to report bugs to :ref:`github.com/ansible/ansible/issues <https://github.com/ansible/ansible/issues>`_ that affects
+You need a free GitHub account to `report bugs <https://github.com/ansible/ansible/issues>`_ that affects
 - multiple plugins
 - a plugin that remained in the ansible/ansible repo
 - the overall functioning of Ansible

--- a/docs/docsite/rst/community/reporting_bugs_and_features.rst
+++ b/docs/docsite/rst/community/reporting_bugs_and_features.rst
@@ -23,9 +23,7 @@ Bugs in ansible-core
 
 Before reporting a bug, use the bug/issue search to check for :ref:`already reported issues <https://github.com/ansible/ansible/issues>`. Unsure if you found a bug? Report the behavior on the :ref:`mailing list or community chat first <communication>`.
 
-Do not open issues for "how do I do this" type questions. These are great topics for community chat channels or a mailing list, where things are likely to be more of a discussion.
-
-If you are unsure whether a bug is in ``ansible-core`` or in a collection, report the behavior on the :ref:`mailing list or community chat channel first <communication>`.
+Also, use the mailing list or chat if you are unsure whether a bug is in ``ansible-core`` or in a collection, and for "how do I do this" type questions to discuss.
 
 You need a free GitHub account to report issues to `github.com/ansible/ansible/issues <https://github.com/ansible/ansible/issues>`_ for bugs
 - affecting multiple plugins

--- a/docs/docsite/rst/community/reporting_bugs_and_features.rst
+++ b/docs/docsite/rst/community/reporting_bugs_and_features.rst
@@ -44,6 +44,7 @@ If you find a bug, open an issue using the `issue template <https://github.com/a
     * Preserve formatting using `code blocks  <https://help.github.com/articles/creating-and-highlighting-code-blocks/>`_ when sharing YAML in playbooks.
   * the behavior you currently see
   * output where possible
+  * ``ansible -vvvv`` (debugging) output
 
 For multiple-file content, use gist.github.com, which is more durable than pastebin content.
 


### PR DESCRIPTION
##### SUMMARY
I have tried to update the how to report bugs page as suggested in https://github.com/ansible/ansible/issues/53520

Basically, I have 
- added another heading
- changed the order of information
- included a list

As I don't have a clue what this means, I could not include: 

	What component to use
		Need lots of examples here to avoid massive pings
		From ansible/ansibullbot#1120
		Also link directly here from ##### COMPONENT NAME
		It would be nice if the template itself contained a link to some list of "modules, plugins, tasks, and features".

**Feel free to edit my changes and include the things above!**

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task, or feature below -->
none

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
