### PR TITLE
Include links to the modern homes of the windows modules

### DIFF
--- a/docs/docsite/rst/user_guide/windows_faq.rst
+++ b/docs/docsite/rst/user_guide/windows_faq.rst
@@ -177,7 +177,7 @@ In addition, the following Ansible Core modules/action-plugins work with Windows
 * template (also: win_template)
 * wait_for_connection
 
-Note that as Ansible moves towards Collections more Windows modules have been added and they have migrated into several collections namespaces: `ansible.windows <https://docs.ansible.com/ansible/latest/collections/ansible/windows/index.html>`_, `community.windows <https://docs.ansible.com/ansible/latest/collections/community/windows/index.html>`_ and `chocolatey <https://docs.ansible.com/ansible/latest/collections/chocolatey/chocolatey/index.html#plugins-in-chocolatey-chocolatey>`_.
+Note that as Ansible moves towards Collections more Windows modules have been added and they have migrated into several collections namespaces: `ansible.windows <https://docs.ansible.com/ansible/latest/collections/ansible/windows/index.html>`_, `community.windows <https://docs.ansible.com/ansible/latest/collections/community/windows/index.html>`_, and `chocolatey <https://docs.ansible.com/ansible/latest/collections/chocolatey/chocolatey/index.html#plugins-in-chocolatey-chocolatey>`_.
 
 Can I run Python modules on Windows hosts?
 ``````````````````````````````````````````

--- a/docs/docsite/rst/user_guide/windows_faq.rst
+++ b/docs/docsite/rst/user_guide/windows_faq.rst
@@ -177,6 +177,8 @@ In addition, the following Ansible Core modules/action-plugins work with Windows
 * template (also: win_template)
 * wait_for_connection
 
+Note that as Ansible moves towards Collections the Windows modules have been split between the `ansible.windows <https://docs.ansible.com/ansible/latest/collections/ansible/windows/index.html>`_ and `community.windows <https://docs.ansible.com/ansible/latest/collections/community/windows/index.html>`_ collection namespaces.
+
 Can I run Python modules on Windows hosts?
 ``````````````````````````````````````````
 No, the WinRM connection protocol is set to use PowerShell modules, so Python

--- a/docs/docsite/rst/user_guide/windows_faq.rst
+++ b/docs/docsite/rst/user_guide/windows_faq.rst
@@ -177,7 +177,7 @@ In addition, the following Ansible Core modules/action-plugins work with Windows
 * template (also: win_template)
 * wait_for_connection
 
-Note that as Ansible moves towards Collections the Windows modules have been split between the `ansible.windows <https://docs.ansible.com/ansible/latest/collections/ansible/windows/index.html>`_ and `community.windows <https://docs.ansible.com/ansible/latest/collections/community/windows/index.html>`_ collection namespaces.
+Note that as Ansible moves towards Collections more Windows modules have been added and they have migrated into several collections namespaces: `ansible.windows <https://docs.ansible.com/ansible/latest/collections/ansible/windows/index.html>`_, `community.windows <https://docs.ansible.com/ansible/latest/collections/community/windows/index.html>`_ and `chocolatey <https://docs.ansible.com/ansible/latest/collections/chocolatey/chocolatey/index.html#plugins-in-chocolatey-chocolatey>`_.
 
 Can I run Python modules on Windows hosts?
 ``````````````````````````````````````````

--- a/docs/docsite/rst/user_guide/windows_faq.rst
+++ b/docs/docsite/rst/user_guide/windows_faq.rst
@@ -177,7 +177,7 @@ In addition, the following Ansible Core modules/action-plugins work with Windows
 * template (also: win_template)
 * wait_for_connection
 
-Note that as Ansible moves towards Collections more Windows modules have been added and they have migrated into several collections namespaces: `ansible.windows <https://docs.ansible.com/ansible/latest/collections/ansible/windows/index.html>`_, `community.windows <https://docs.ansible.com/ansible/latest/collections/community/windows/index.html>`_, and `chocolatey <https://docs.ansible.com/ansible/latest/collections/chocolatey/chocolatey/index.html#plugins-in-chocolatey-chocolatey>`_.
+Ansible Windows modules exist in the :ref:`plugins_in_ansible.windows`, :ref:`plugins_in_community.windows`, and :ref:`plugins_in_chocolatey.chocolatey` collections.
 
 Can I run Python modules on Windows hosts?
 ``````````````````````````````````````````


### PR DESCRIPTION
##### SUMMARY
I've found many useful modules tucked away in the community group and felt they should be mentioned here

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
Added new links to the collection's homes.

Note that the link at the beginning of this section links to [version 2.9's docs](https://docs.ansible.com/ansible/2.9/modules/list_of_windows_modules.html#windows-modules) and if set to [latest can be seen to no longer exist](https://docs.ansible.com/ansible/latest/modules/list_of_windows_modules.html#windows-modules).

This issue is not trying to solve keeping a list of windows modules around or not, but is trying to accomplish the same goal of linking users to where many can be found. If you go through the 2.9 list you will see most went to [ansible.windows](https://docs.ansible.com/ansible/latest/collections/ansible/windows/index.html) and others like win_xml went to [community.windows](https://docs.ansible.com/ansible/latest/collections/community/windows/index.html) (which also has many others not listed).

Probably more mention could be made that these collections are not exhaustive, there are probably other unofficial modules available elsewhere as well should users go looking.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
Windows FAQ

##### ADDITIONAL INFORMATION
