### PR TITLE
[2.11] Fix collection redirects for filter and test plugins (#77210)

### DIFF
--- a/changelogs/fragments/77210-fix-collection-filter-test-redirects.yml
+++ b/changelogs/fragments/77210-fix-collection-filter-test-redirects.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix collection filter/test plugin redirects (https://github.com/ansible/ansible/issues/77192).

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testredirect/meta/runtime.yml
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testredirect/meta/runtime.yml
@@ -2,3 +2,20 @@ plugin_routing:
   modules:
     ping:
       redirect: testns.testcoll.ping
+  filter:
+    multi_redirect_filter:
+      redirect: testns.testredirect.redirect_filter1
+      deprecation:
+        warning_text: deprecation1
+    redirect_filter1:
+      redirect: redirect_filter2
+      deprecation:
+        warning_text: deprecation2
+    redirect_filter2:
+      redirect: testns.testcoll.testfilter
+      deprecation:
+        warning_text: deprecation3
+    dead_end:
+      redirect: bad_redirect
+    recursive_redirect:
+      redirect: recursive_redirect

--- a/test/integration/targets/collections/runme.sh
+++ b/test/integration/targets/collections/runme.sh
@@ -69,6 +69,16 @@ else
   ansible-playbook -i "${INVENTORY_PATH}" collection_root_user/ansible_collections/testns/testcoll/playbooks/default_collection_playbook.yml "$@"
 fi
 
+# test redirects and warnings for filter redirects
+echo "testing redirect and deprecation display"
+ANSIBLE_DEPRECATION_WARNINGS=yes ansible localhost -m debug -a msg='{{ "data" | testns.testredirect.multi_redirect_filter }}' -vvvvv 2>&1 | tee out.txt
+cat out.txt
+
+test "$(grep out.txt -ce 'deprecation1' -ce 'deprecation2' -ce 'deprecation3')" == 3
+grep out.txt -e 'redirecting (type: filter) testns.testredirect.multi_redirect_filter to testns.testredirect.redirect_filter1'
+grep out.txt -e 'redirecting (type: filter) testns.testredirect.redirect_filter1 to testns.testredirect.redirect_filter2'
+grep out.txt -e 'redirecting (type: filter) testns.testredirect.redirect_filter2 to testns.testcoll.testfilter'
+
 echo "--- validating collections support in playbooks/roles"
 # run test playbooks
 ansible-playbook -i "${INVENTORY_PATH}" -v "${TEST_PLAYBOOK}" "$@"

--- a/test/integration/targets/collections/test_collection_meta.yml
+++ b/test/integration/targets/collections/test_collection_meta.yml
@@ -21,6 +21,25 @@
   # redirect filter
   - assert:
       that: ('yes' | formerly_core_filter) == True
+  # redirect filter (multiple levels)
+  - assert:
+      that: ('data' | testns.testredirect.multi_redirect_filter) == 'data_via_testfilter_from_userdir'
+  # invalid filter redirect
+  - debug: msg="{{ 'data' | testns.testredirect.dead_end }}"
+    ignore_errors: yes
+    register: redirect_failure
+  - assert:
+      that:
+        - redirect_failure is failed
+        - '"No filter named ''testns.testredirect.dead_end''" in redirect_failure.msg'
+  # recursive filter redirect
+  - debug: msg="{{ 'data' | testns.testredirect.recursive_redirect }}"
+    ignore_errors: yes
+    register: redirect_failure
+  - assert:
+      that:
+        - redirect_failure is failed
+        - '"recursive collection redirect found for ''testns.testredirect.recursive_redirect''" in redirect_failure.msg'
   # legacy filter should mask redirected
   - assert:
       that: ('' | formerly_core_masked_filter) == 'hello from overridden formerly_core_masked_filter'

--- a/test/integration/targets/collections/test_collection_meta.yml
+++ b/test/integration/targets/collections/test_collection_meta.yml
@@ -31,7 +31,7 @@
   - assert:
       that:
         - redirect_failure is failed
-        - '"No filter named ''testns.testredirect.dead_end''" in redirect_failure.msg'
+        - '"no filter named ''testns.testredirect.dead_end''" in (redirect_failure.msg | lower)'
   # recursive filter redirect
   - debug: msg="{{ 'data' | testns.testredirect.recursive_redirect }}"
     ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
Backport #77210

* Fix collection redirects for jinja2 filters/tests

* Handle recursive redirects

Co-authored-by: Matt Martz <matt@sivel.net>
(cherry picked from commit 8063643b4cec51a72377da5f3fa354d3ff9e737a)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
