### PR TITLE
ansible-test - Fix cloud plugin traceback.

### DIFF
--- a/changelogs/fragments/ansible-test-remote-cloud-skip-traceback.yml
+++ b/changelogs/fragments/ansible-test-remote-cloud-skip-traceback.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Fix an integration test traceback that occurs when some tests use cloud plugins, but all tests for at least one cloud plugin are skipped. (https://github.com/ansible/ansible/issues/75711)

--- a/test/lib/ansible_test/_internal/cloud/__init__.py
+++ b/test/lib/ansible_test/_internal/cloud/__init__.py
@@ -197,6 +197,9 @@ class CloudBase(ABC):
 
         def config_callback(files):  # type: (t.List[t.Tuple[str, str]]) -> None
             """Add the config file to the payload file list."""
+            if self.platform not in self.args.metadata.cloud_config:
+                return  # callback registered, but plugin not initialized due to relevant tests being skipped
+
             if self._get_cloud_config(self._CONFIG_PATH, ''):
                 pair = (self.config_path, os.path.relpath(self.config_path, data_context().content.root))
 


### PR DESCRIPTION
##### SUMMARY

ansible-test - Fix cloud plugin traceback.

Resolves https://github.com/ansible/ansible/issues/75711

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
