### PR TITLE
Add toggle to fix module_defaults with module-as-redirected-action on a per-module basis

### DIFF
--- a/changelogs/fragments/77265-module_defaults-with-modules-as-redirected-actions.yaml
+++ b/changelogs/fragments/77265-module_defaults-with-modules-as-redirected-actions.yaml
@@ -23,10 +23,12 @@ minor_changes:
 
   .. code: yaml
 
-     - ns.coll.facts:
+     - hosts: all
        module_defaults:
          ns.coll.eos_facts: {'valid_for_eos_facts': 'value'}
          ns.coll.eos_command: {'not_valid_for_eos_facts': 'value'}
+       tasks:
+         - ns.coll.facts:
 
   will end up with defaults for eos_facts and eos_command
   since both modules redirect to the same action.

--- a/changelogs/fragments/77265-module_defaults-with-modules-as-redirected-actions.yaml
+++ b/changelogs/fragments/77265-module_defaults-with-modules-as-redirected-actions.yaml
@@ -1,0 +1,53 @@
+minor_changes:
+- |
+  Add an 'action_plugin' field for modules in runtime.yml plugin_routing.
+
+  This fixes module_defaults by supporting modules-as-redirected-actions
+  without redirecting module_defaults entries to the common action.
+
+  .. code: yaml
+
+     plugin_routing:
+       action:
+         facts:
+           redirect: ns.coll.eos
+         command:
+           redirect: ns.coll.eos
+       modules:
+         facts:
+           redirect: ns.coll.eos_facts
+         command:
+           redirect: ns.coll.eos_command
+
+  With the runtime.yml above for ns.coll, a task such as
+
+  .. code: yaml
+
+     - ns.coll.facts:
+       module_defaults:
+         ns.coll.eos_facts: {'valid_for_eos_facts': 'value'}
+         ns.coll.eos_command: {'not_valid_for_eos_facts': 'value'}
+
+  will end up with defaults for eos_facts and eos_command
+  since both modules redirect to the same action.
+
+  To select an action plugin for a module without merging
+  module_defaults, define an action_plugin field for the resolved
+  module in the runtime.yml.
+
+  .. code: yaml
+
+     plugin_routing:
+       modules:
+         facts:
+           redirect: ns.coll.eos_facts
+           action_plugin: ns.coll.eos
+         command:
+           redirect: ns.coll.eos_command
+           action_plugin: ns.coll.eos
+
+  The action_plugin field can be a redirected action plugin, as
+  it is resolved normally.
+
+  Using the modified runtime.yml, the example task will only use
+  the ns.coll.eos_facts defaults.

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -25,9 +25,8 @@ from ansible.module_utils.connection import write_to_file_descriptor
 from ansible.playbook.conditional import Conditional
 from ansible.playbook.task import Task
 from ansible.plugins.loader import become_loader, cliconf_loader, connection_loader, httpapi_loader, netconf_loader, terminal_loader
-from ansible.plugins.loader import module_loader
 from ansible.template import Templar
-from ansible.utils.collection_loader import AnsibleCollectionConfig
+from ansible.utils.collection_loader import AnsibleCollectionConfig, AnsibleCollectionRef
 from ansible.utils.listify import listify_lookup_plugin_terms
 from ansible.utils.unsafe_proxy import to_unsafe_text, wrap_var
 from ansible.vars.clean import namespace_facts, clean_facts
@@ -591,18 +590,14 @@ class TaskExecutor:
             cvars['ansible_python_interpreter'] = sys.executable
 
         # get handler
-        self._handler, handler_context = self._get_action_handler_with_context(connection=self._connection, templar=templar)
+        self._handler, module_context = self._get_action_handler_with_module_context(connection=self._connection, templar=templar)
+
+        if module_context is not None and module_context.action_plugin:
+            module_defaults_fqcn = module_context.resolved_fqcn
+        else:
+            module_defaults_fqcn = self._task.resolved_action
 
         # Apply default params for action/module, if present
-        module_defaults_fqcn = self._task.resolved_action
-        common_action = self._get_common_action_handler()
-
-        if handler_context.action_plugin or common_action:
-            # If a common action handler is used, get module-specific defaults
-            context = module_loader.find_plugin_with_context(self._task.action, collection_list=self._task.collections)
-            if context.resolved:
-                module_defaults_fqcn = context.resolved_fqcn
-
         self._task.args = get_action_args_with_defaults(
             module_defaults_fqcn, self._task.args, self._task.module_defaults, templar,
             action_groups=self._task._parent._play._action_groups
@@ -1099,18 +1094,16 @@ class TaskExecutor:
 
         return varnames
 
-    def _get_common_action_handler(self):
-        if self._shared_loader_obj.module_loader.has_plugin(self._task.action, collection_list=self._task.collections):
-            context = self._shared_loader_obj.module_loader.find_plugin_with_context(
-                self._task.action, collection_list=self._task.collections
-            )
-            if context.action_plugin:
-                return context.action_plugin
-            action_name = context.resolved_fqcn
-        else:
-            action_name = self._task.action
+    def _get_action_handler(self, connection, templar):
+        '''
+        Returns the correct action plugin to handle the requestion task action
+        '''
+        return self._get_action_handler_with_module_context(connection, templar)[0]
 
-        module_collection, separator, module_name = action_name.rpartition(".")
+    def _get_action_handler_with_module_context(self, connection, templar):
+        collections = self._task.collections
+
+        module_collection, separator, module_name = self._task.action.rpartition(".")
         module_prefix = module_name.split('_')[0]
         if module_collection:
             # For network modules, which look for one action plugin per platform, look for the
@@ -1120,22 +1113,18 @@ class TaskExecutor:
         else:
             network_action = module_prefix
 
-        collections = self._task.collections
-
-        if (
-            not self._shared_loader_obj.action_loader.has_plugin(self._task.action, collection_list=collections)
-            and all((module_prefix in C.NETWORK_GROUP_MODULES, self._shared_loader_obj.action_loader.has_plugin(network_action, collection_list=collections)))
-        ):
-            return network_action
-        return None
-
-    def _get_action_handler_with_context(self, connection, templar):
-        collections = self._task.collections
-
+        # Check if the module has specified to action handler
+        module = None
+        if self._shared_loader_obj.module_loader.has_plugin(self._task.action, collection_list=collections):
+            module = self._shared_loader_obj.module_loader.find_plugin_with_context(
+                self._task.action, collection_list=self._task.collections
+            )
+        if module is not None and module.resolved and module.action_plugin:
+            handler_name = module.action_plugin
         # let action plugin override module, fallback to 'normal' action plugin otherwise
-        if self._shared_loader_obj.action_loader.has_plugin(self._task.action, collection_list=collections):
+        elif self._shared_loader_obj.action_loader.has_plugin(self._task.action, collection_list=collections):
             handler_name = self._task.action
-        elif (network_action := self._get_common_action_handler()):
+        elif all((module_prefix in C.NETWORK_GROUP_MODULES, self._shared_loader_obj.action_loader.has_plugin(network_action, collection_list=collections))):
             handler_name = network_action
             display.vvvv("Using network group action {handler} for {action}".format(handler=handler_name,
                                                                                     action=self._task.action),
@@ -1145,7 +1134,7 @@ class TaskExecutor:
             handler_name = 'ansible.legacy.normal'
             collections = None  # until then, we don't want the task's collection list to be consulted; use the builtin
 
-        plugin = self._shared_loader_obj.action_loader.get_with_context(
+        handler = self._shared_loader_obj.action_loader.get(
             handler_name,
             task=self._task,
             connection=connection,
@@ -1156,19 +1145,10 @@ class TaskExecutor:
             collection_list=collections
         )
 
-        handler = plugin.object
-        context = plugin.plugin_load_context
-
         if not handler:
             raise AnsibleError("the handler '%s' was not found" % handler_name)
 
-        return handler, context
-
-    def _get_action_handler(self, connection, templar):
-        '''
-        Returns the correct action plugin to handle the requestion task action
-        '''
-        return self._get_action_handler_with_context(connection, templar)[0]
+        return handler, module
 
 
 def start_connection(play_context, variables, task_uuid):

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -592,7 +592,7 @@ class TaskExecutor:
         # get handler
         self._handler, module_context = self._get_action_handler_with_module_context(connection=self._connection, templar=templar)
 
-        if module_context is not None and module_context.action_plugin:
+        if module_context is not None:
             module_defaults_fqcn = module_context.resolved_fqcn
         else:
             module_defaults_fqcn = self._task.resolved_action
@@ -1116,13 +1116,13 @@ class TaskExecutor:
 
         collections = self._task.collections
 
-        # Check if the module has specified to action handler
-        module = None
-        if self._shared_loader_obj.module_loader.has_plugin(self._task.action, collection_list=collections):
-            module = self._shared_loader_obj.module_loader.find_plugin_with_context(
-                self._task.action, collection_list=self._task.collections
-            )
-        if module is not None and module.resolved and module.action_plugin:
+        # Check if the module has specified an action handler
+        module = self._shared_loader_obj.module_loader.find_plugin_with_context(
+            self._task.action, collection_list=collections
+        )
+        if not module.resolved or not module.action_plugin:
+            module = None
+        if module is not None:
             handler_name = module.action_plugin
         # let action plugin override module, fallback to 'normal' action plugin otherwise
         elif self._shared_loader_obj.action_loader.has_plugin(self._task.action, collection_list=collections):

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -597,7 +597,8 @@ class TaskExecutor:
         module_defaults_fqcn = self._task.resolved_action
         common_action = self._get_common_action_handler()
 
-        if handler_context._prefer_module_args or (handler_context._prefer_module_args is None and common_action):
+        if handler_context.action_plugin or common_action:
+            # If a common action handler is used, get module-specific defaults
             context = module_loader.find_plugin_with_context(self._task.action, collection_list=self._task.collections)
             if context.resolved:
                 module_defaults_fqcn = context.resolved_fqcn
@@ -1103,6 +1104,8 @@ class TaskExecutor:
             context = self._shared_loader_obj.module_loader.find_plugin_with_context(
                 self._task.action, collection_list=self._task.collections
             )
+            if context.action_plugin:
+                return context.action_plugin
             action_name = context.resolved_fqcn
         else:
             action_name = self._task.action

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -595,7 +595,7 @@ class TaskExecutor:
 
         # Apply default params for action/module, if present
         module_defaults_fqcn = self._task.resolved_action
-        common_action = self._get_handler_common_action()
+        common_action = self._get_common_action_handler()
 
         if handler_context._prefer_module_args or (handler_context._prefer_module_args is None and common_action):
             context = module_loader.find_plugin_with_context(self._task.action, collection_list=self._task.collections)
@@ -1098,7 +1098,7 @@ class TaskExecutor:
 
         return varnames
 
-    def _get_handler_common_action(self):
+    def _get_common_action_handler(self):
         if self._shared_loader_obj.module_loader.has_plugin(self._task.action, collection_list=self._task.collections):
             context = self._shared_loader_obj.module_loader.find_plugin_with_context(
                 self._task.action, collection_list=self._task.collections
@@ -1132,7 +1132,7 @@ class TaskExecutor:
         # let action plugin override module, fallback to 'normal' action plugin otherwise
         if self._shared_loader_obj.action_loader.has_plugin(self._task.action, collection_list=collections):
             handler_name = self._task.action
-        elif (network_action := self._get_handler_common_action()):
+        elif (network_action := self._get_common_action_handler()):
             handler_name = network_action
             display.vvvv("Using network group action {handler} for {action}".format(handler=handler_name,
                                                                                     action=self._task.action),

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -1101,8 +1101,9 @@ class TaskExecutor:
         return self._get_action_handler_with_module_context(connection, templar)[0]
 
     def _get_action_handler_with_module_context(self, connection, templar):
-        collections = self._task.collections
-
+        '''
+        Returns the correct action plugin to handle the requestion task action and the module context
+        '''
         module_collection, separator, module_name = self._task.action.rpartition(".")
         module_prefix = module_name.split('_')[0]
         if module_collection:
@@ -1112,6 +1113,8 @@ class TaskExecutor:
             network_action = "{0}.{1}".format(module_collection, module_prefix)
         else:
             network_action = module_prefix
+
+        collections = self._task.collections
 
         # Check if the module has specified to action handler
         module = None

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -508,28 +508,14 @@ class FieldAttributeBase(metaclass=BaseMeta):
 
     def _resolve_action(self, action_name, mandatory=True):
 
-        # Network modules look for one action plugin per platform so we should preserve module_defaults
-        # with the module name instead. Otherwise all modules for a platform would get the same defaults.
-        module_collection, separator, module_name = action_name.rpartition(".")
-        module_prefix = module_name.split('_')[0]
-        network_action = "{0}.{1}".format(module_collection, module_prefix)
+        context = module_loader.find_plugin_with_context(action_name)
 
-        common_action = bool(
-            not action_loader.has_plugin(action_name) and
-            all((module_prefix in C.NETWORK_GROUP_MODULES, action_loader.has_plugin(network_action)))
-        )
-
-        context = action_loader.find_plugin_with_context(action_name)
-
-        # Allow collections to override common_action by setting action_plugin
-        prefer_module = bool(context.action_plugin or common_action)
-
-        if prefer_module:
-            prefer = module_loader.find_plugin_with_context(action_name)
+        if context.resolved and not context.action_plugin:
+            prefer = action_loader.find_plugin_with_context(action_name)
             if prefer.resolved:
                 context = prefer
         elif not context.resolved:
-            context = module_loader.find_plugin_with_context(action_name)
+            context = action_loader.find_plugin_with_context(action_name)
 
         if context.resolved:
             return context.resolved_fqcn

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -507,9 +507,7 @@ class FieldAttributeBase(metaclass=BaseMeta):
         return fq_group_name, resolved_actions
 
     def _resolve_action(self, action_name, mandatory=True):
-
         context = module_loader.find_plugin_with_context(action_name)
-
         if context.resolved and not context.action_plugin:
             prefer = action_loader.find_plugin_with_context(action_name)
             if prefer.resolved:

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -521,8 +521,8 @@ class FieldAttributeBase(metaclass=BaseMeta):
 
         context = action_loader.find_plugin_with_context(action_name)
 
-        # Allow collections to override common_action by setting prefer_module_args to True or False
-        prefer_module = bool(context._prefer_module_args or (context._prefer_module_args is None and common_action))
+        # Allow collections to override common_action by setting action_plugin
+        prefer_module = bool(context.action_plugin or common_action)
 
         if prefer_module:
             prefer = module_loader.find_plugin_with_context(action_name)

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -126,6 +126,7 @@ class PluginLoadContext(object):
         self.deprecation_warnings = []
         self.resolved = False
         self._resolved_fqcn = None
+        self._prefer_module_args = None
 
     @property
     def resolved_fqcn(self):
@@ -166,13 +167,14 @@ class PluginLoadContext(object):
         self.deprecation_warnings.append(warning_text)
         return self
 
-    def resolve(self, resolved_name, resolved_path, resolved_collection, exit_reason):
+    def resolve(self, resolved_name, resolved_path, resolved_collection, exit_reason, prefer_module_args):
         self.pending_redirect = None
         self.plugin_resolved_name = resolved_name
         self.plugin_resolved_path = resolved_path
         self.plugin_resolved_collection = resolved_collection
         self.exit_reason = exit_reason
         self.resolved = True
+        self._prefer_module_args = prefer_module_args
         return self
 
     def redirect(self, redirect_name):
@@ -231,8 +233,12 @@ class PluginLoader:
 
         self._searched_paths = set()
 
+    @property
+    def type(self):
+        return AnsibleCollectionRef.legacy_plugin_dir_to_plugin_type(self.subdir)
+
     def __repr__(self):
-        return 'PluginLoader(type={0})'.format(AnsibleCollectionRef.legacy_plugin_dir_to_plugin_type(self.subdir))
+        return 'PluginLoader(type={0})'.format(self.type)
 
     def _clear_caches(self):
 
@@ -459,6 +465,7 @@ class PluginLoader:
         # check collection metadata to see if any special handling is required for this plugin
         routing_metadata = self._query_collection_routing_meta(acr, plugin_type, extension=extension)
 
+        prefer_module_args = None
         # TODO: factor this into a wrapper method
         if routing_metadata:
             deprecation = routing_metadata.get('deprecation', None)
@@ -497,6 +504,9 @@ class PluginLoader:
                 return plugin_load_context.redirect(redirect)
                 # TODO: non-FQCN case, do we support `.` prefix for current collection, assume it with no dots, require it for subdirs in current, or ?
 
+            if self.type == 'action':
+                prefer_module_args = routing_metadata.get('prefer_module_args')  # Use sentinel value None to differentiate between False and unspecified
+
         n_resource = to_native(acr.resource, errors='strict')
         # we want this before the extension is added
         full_name = '{0}.{1}'.format(acr.n_python_package_name, n_resource)
@@ -519,7 +529,7 @@ class PluginLoader:
         # FIXME: and is file or file link or ...
         if os.path.exists(n_resource_path):
             return plugin_load_context.resolve(
-                full_name, to_text(n_resource_path), acr.collection, 'found exact match for {0} in {1}'.format(full_name, acr.collection))
+                full_name, to_text(n_resource_path), acr.collection, 'found exact match for {0} in {1}'.format(full_name, acr.collection), prefer_module_args)
 
         if extension:
             # the request was extension-specific, don't try for an extensionless match
@@ -538,7 +548,8 @@ class PluginLoader:
             pass
 
         return plugin_load_context.resolve(
-            full_name, to_text(found_files[0]), acr.collection, 'found fuzzy extension match for {0} in {1}'.format(full_name, acr.collection))
+            full_name, to_text(found_files[0]), acr.collection,
+            'found fuzzy extension match for {0} in {1}'.format(full_name, acr.collection), prefer_module_args)
 
     def find_plugin(self, name, mod_type='', ignore_deprecated=False, check_aliases=False, collection_list=None):
         ''' Find a plugin named name '''

--- a/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/meta/runtime.yml
+++ b/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/meta/runtime.yml
@@ -1,30 +1,36 @@
 plugin_routing:
   action:
-    # Use module-redirected-as-action to ensure module not using prefix
-    # magic uses platform-specific action plugin
-    # Ensure eos always prefers module_defaults for the module name (eosfacts) not eos
-    eosfacts:
+    # Test for action plugin redirects for module_defaults.
+    # Each module_defaults entry is first resolved as an action plugin, and if it does not exist, it is resolved as a module.
+    # If multiple modules use the same action plugin redirect, module defaults for any of the modules as redirected actions will apply.
+    # Since they will all resolve to the same thing, last defined wins.
+    module_uses_action_defaults:
       redirect: testns.testcoll.eos
-    eos:
-      prefer_module_args: true
-
-    # Ensure vyosfacts/vyos_facts use action plugin vyos (via symlink)
-    # and that only vyosfacts/vyos_facts module_defaults are applied (not vyos module_defaults)
-    vyosfacts:
-      redirect: testns.testcoll.vyos_facts  # symlink of testns.testcoll.vyos
-    vyos_facts:
-      prefer_module_args: true
-
-    # Ensure module that uses action plugin from prefix does not need
-    # module-as-redirected-action (resolved module is used by TE to find handler using prefix)
-    # and that action plugin does not need to opt into preferring module-specific args. Implicitly:
-    # ios:
-    #   prefer_module_args: true
-
   modules:
-    # No action redirect necessary if resolved module name is used by TE to find handler using prefix
-    # iosfacts/ios_facts tasks should get iosfacts/ios_facts module defaults (not ios module_defaults)
+    # Any module_defaults for testns.testcoll.module will not apply to a module_uses_action_defaults task:
+    #
+    # module_defaults:
+    #   testns.testcoll.module:
+    #     option: value
+    #
+    # But defaults for testns.testcoll.module_uses_action_defaults or testns.testcoll.eos will:
+    #
+    # module_defaults:
+    #   testns.testcoll.module_uses_action_defaults:
+    #     option: value
+    #   testns.testcoll.eos:
+    #     option: defined_last_i_win
+    module_uses_action_defaults:
+      redirect: testns.testcoll.module
+
+    # Not "eos_facts" to ensure TE is not finding handler via prefix
+    # eosfacts tasks should not get eos module_defaults (or defaults for other modules that use eos action plugin)
+    eosfacts:
+      action_plugin: testns.testcoll.eos
+
+    # iosfacts/ios_facts tasks should get iosfacts/ios_facts module_defaults (not ios defaults)
     iosfacts:
+      # No "action_plugin: ios" here to test the resolved module name is used by TE to find handler using prefix
       redirect: testns.testcoll.ios_facts
 
 action_groups:

--- a/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/meta/runtime.yml
+++ b/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/meta/runtime.yml
@@ -1,3 +1,32 @@
+plugin_routing:
+  action:
+    # Use module-redirected-as-action to ensure module not using prefix
+    # magic uses platform-specific action plugin
+    # Ensure eos always prefers module_defaults for the module name (eosfacts) not eos
+    eosfacts:
+      redirect: testns.testcoll.eos
+    eos:
+      prefer_module_args: true
+
+    # Ensure vyosfacts/vyos_facts use action plugin vyos (via symlink)
+    # and that only vyosfacts/vyos_facts module_defaults are applied (not vyos module_defaults)
+    vyosfacts:
+      redirect: testns.testcoll.vyos_facts  # symlink of testns.testcoll.vyos
+    vyos_facts:
+      prefer_module_args: true
+
+    # Ensure module that uses action plugin from prefix does not need
+    # module-as-redirected-action (resolved module is used by TE to find handler using prefix)
+    # and that action plugin does not need to opt into preferring module-specific args. Implicitly:
+    # ios:
+    #   prefer_module_args: true
+
+  modules:
+    # No action redirect necessary if resolved module name is used by TE to find handler using prefix
+    # iosfacts/ios_facts tasks should get iosfacts/ios_facts module defaults (not ios module_defaults)
+    iosfacts:
+      redirect: testns.testcoll.ios_facts
+
 action_groups:
   testgroup:
     # Test metadata 'extend_group' feature does not get stuck in a recursive loop

--- a/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/meta/runtime.yml
+++ b/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/meta/runtime.yml
@@ -1,11 +1,20 @@
 plugin_routing:
   action:
-    # Test for action plugin redirects for module_defaults.
-    # Each module_defaults entry is first resolved as an action plugin, and if it does not exist, it is resolved as a module.
-    # If multiple modules use the same action plugin redirect, module defaults for any of the modules as redirected actions will apply.
-    # Since they will all resolve to the same thing, last defined wins.
+    # Backwards compat for modules-redirected-as-actions:
+    # By default, each module_defaults entry is resolved as an action plugin,
+    # and if it does not exist, it is resolved a a module.
+    # All modules that redirect to the same action will resolve to the same action.
     module_uses_action_defaults:
       redirect: testns.testcoll.eos
+
+    # module-redirected-as-action overridden by action_plugin
+    iosfacts:
+      redirect: testns.testcoll.nope
+    ios_facts:
+      redirect: testns.testcoll.nope
+
+    redirected_action:
+      redirect: testns.testcoll.ios
   modules:
     # Any module_defaults for testns.testcoll.module will not apply to a module_uses_action_defaults task:
     #
@@ -28,10 +37,12 @@ plugin_routing:
     eosfacts:
       action_plugin: testns.testcoll.eos
 
-    # iosfacts/ios_facts tasks should get iosfacts/ios_facts module_defaults (not ios defaults)
+    # Test that `action_plugin` has higher precedence than module-redirected-as-action  - reverse this?
+    # Current behavior is iosfacts/ios_facts do not get ios defaults.
     iosfacts:
-      # No "action_plugin: ios" here to test the resolved module name is used by TE to find handler using prefix
       redirect: testns.testcoll.ios_facts
+    ios_facts:
+      action_plugin: testns.testcoll.redirected_action
 
 action_groups:
   testgroup:

--- a/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/action/eos.py
+++ b/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/action/eos.py
@@ -1,0 +1,18 @@
+# Copyright: (c) 2022, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action.normal import ActionModule as ActionBase
+from ansible.utils.vars import merge_hash
+
+
+class ActionModule(ActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        result['action_plugin'] = 'eos'
+
+        return result

--- a/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/action/ios.py
+++ b/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/action/ios.py
@@ -1,0 +1,18 @@
+# Copyright: (c) 2022, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action.normal import ActionModule as ActionBase
+from ansible.utils.vars import merge_hash
+
+
+class ActionModule(ActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        result['action_plugin'] = 'ios'
+
+        return result

--- a/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/action/vyos.py
+++ b/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/action/vyos.py
@@ -1,0 +1,18 @@
+# Copyright: (c) 2022, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action.normal import ActionModule as ActionBase
+from ansible.utils.vars import merge_hash
+
+
+class ActionModule(ActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        result['action_plugin'] = 'vyos'
+
+        return result

--- a/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/modules/eosfacts.py
+++ b/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/modules/eosfacts.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2022, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: eosfacts
+short_description: module to test module_defaults
+description: module to test module_defaults
+version_added: '2.13'
+'''
+
+EXAMPLES = r'''
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            eosfacts=dict(type=bool),
+        ),
+        supports_check_mode=True
+    )
+    module.exit_json(eosfacts=module.params['eosfacts'])
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/modules/ios_facts.py
+++ b/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/modules/ios_facts.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2022, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: ios_facts
+short_description: module to test module_defaults
+description: module to test module_defaults
+version_added: '2.13'
+'''
+
+EXAMPLES = r'''
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            ios_facts=dict(type=bool),
+        ),
+        supports_check_mode=True
+    )
+    module.exit_json(ios_facts=module.params['ios_facts'])
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/modules/module.py
+++ b/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/modules/module.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2022, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: module
+short_description: module to test module_defaults
+description: module to test module_defaults
+version_added: '2.13'
+'''
+
+EXAMPLES = r'''
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            action_option=dict(type=bool),
+        ),
+        supports_check_mode=True
+    )
+    module.exit_json(action_option=module.params['action_option'])
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/modules/vyosfacts.py
+++ b/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/modules/vyosfacts.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2022, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: vyosfacts
+short_description: module to test module_defaults
+description: module to test module_defaults
+version_added: '2.13'
+'''
+
+EXAMPLES = r'''
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            vyosfacts=dict(type=bool),
+        ),
+        supports_check_mode=True
+    )
+    module.exit_json(vyosfacts=module.params['vyosfacts'])
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/module_defaults/runme.sh
+++ b/test/integration/targets/module_defaults/runme.sh
@@ -2,11 +2,12 @@
 
 set -eux
 
-sudo ln -s "${PWD}/collections/ansible_collections/testns/testcoll/plugins/action/vyos.py" ./collections/ansible_collections/testns/testcoll/plugins/action/vyos_facts.py
+# Symlink is test for backwards-compat (only workaround for https://github.com/ansible/ansible/issues/77059)
+sudo ln -s "${PWD}/collections/ansible_collections/testns/testcoll/plugins/action/vyos.py" ./collections/ansible_collections/testns/testcoll/plugins/action/vyosfacts.py
 
 ansible-playbook test_defaults.yml "$@"
 
-sudo rm ./collections/ansible_collections/testns/testcoll/plugins/action/vyos_facts.py
+sudo rm ./collections/ansible_collections/testns/testcoll/plugins/action/vyosfacts.py
 
 ansible-playbook test_action_groups.yml "$@"
 

--- a/test/integration/targets/module_defaults/runme.sh
+++ b/test/integration/targets/module_defaults/runme.sh
@@ -2,7 +2,11 @@
 
 set -eux
 
+sudo ln -s "${PWD}/collections/ansible_collections/testns/testcoll/plugins/action/vyos.py" ./collections/ansible_collections/testns/testcoll/plugins/action/vyos_facts.py
+
 ansible-playbook test_defaults.yml "$@"
+
+sudo rm ./collections/ansible_collections/testns/testcoll/plugins/action/vyos_facts.py
 
 ansible-playbook test_action_groups.yml "$@"
 

--- a/test/integration/targets/module_defaults/test_defaults.yml
+++ b/test/integration/targets/module_defaults/test_defaults.yml
@@ -151,23 +151,66 @@
         - result.vyosfacts
         - result.action_plugin == 'vyos'
 
-  - name: ensure ios_facts does not use action plugin default
-    testns.testcoll.ios_facts:
+  - name: iosfacts/ios_facts does not use action plugin default (module action_plugin field has precedence over module-as-action-redirect)
+    collections:
+      - testns.testcoll
     module_defaults:
       testns.testcoll.ios:
         fail: true
+    block:
+      - ios_facts:
+        register: result
+      - assert:
+          that:
+            - result.action_plugin == 'ios'
 
-  - name: ensure ios_facts does use ios_facts defaults
-    testns.testcoll.ios_facts:
+      - iosfacts:
+        register: result
+      - assert:
+          that:
+            - result.action_plugin == 'ios'
+
+  - name: ensure iosfacts/ios_facts uses ios_facts defaults
+    collections:
+      - testns.testcoll
     module_defaults:
       testns.testcoll.ios_facts:
         ios_facts: true
-    register: result
+    block:
+      - ios_facts:
+        register: result
+      - assert:
+          that:
+            - result.ios_facts
+            - result.action_plugin == 'ios'
 
-  - assert:
-      that:
-        - result.ios_facts
-        - result.action_plugin == 'ios'
+      - iosfacts:
+        register: result
+      - assert:
+          that:
+            - result.ios_facts
+            - result.action_plugin == 'ios'
+
+  - name: ensure iosfacts/ios_facts uses iosfacts defaults
+    collections:
+      - testns.testcoll
+    module_defaults:
+      testns.testcoll.iosfacts:
+        ios_facts: true
+    block:
+      - ios_facts:
+        register: result
+      - assert:
+          that:
+            - result.ios_facts
+            - result.action_plugin == 'ios'
+
+      - iosfacts:
+        register: result
+      - assert:
+          that:
+            - result.ios_facts
+            - result.action_plugin == 'ios'
 
   - name: ensure redirected action gets redirected action defaults
     testns.testcoll.module_uses_action_defaults:

--- a/test/integration/targets/module_defaults/test_defaults.yml
+++ b/test/integration/targets/module_defaults/test_defaults.yml
@@ -110,3 +110,67 @@
         - "builtin_legacy_defaults_2.msg == 'legacy default'"
 
   - include_tasks: tasks/main.yml
+
+- name: test preferring module name defaults for platform-specific actions
+  hosts: localhost
+  gather_facts: no
+  tasks:
+  - name: ensure eosfacts does not use action plugin default
+    testns.testcoll.eosfacts:
+    module_defaults:
+      testns.testcoll.eos:
+        fail: true
+
+  - name: eosfacts does use module name defaults
+    testns.testcoll.eosfacts:
+    module_defaults:
+      testns.testcoll.eosfacts:
+        eosfacts: true
+    register: result
+
+  - assert:
+      that:
+        - result.eosfacts
+        - result.action_plugin == 'eos'
+
+  - name: ensure vyosfacts does not use action plugin default
+    testns.testcoll.vyosfacts:
+    module_defaults:
+      testns.testcoll.vyos:
+        fail: true
+
+  - name: ensure vyosfacts does not use vyos_facts action plugin default either
+    testns.testcoll.vyosfacts:
+    module_defaults:
+      testns.testcoll.vyos_facts:
+        fail: true
+
+  - name: vyosfacts does use vyosfacts defaults
+    testns.testcoll.vyosfacts:
+    module_defaults:
+      testns.testcoll.vyosfacts:
+        vyosfacts: true
+    register: result
+
+  - assert:
+      that:
+        - result.vyosfacts
+        - result.action_plugin == 'vyos'
+
+  - name: ensure ios_facts does not use action plugin default
+    testns.testcoll.ios_facts:
+    module_defaults:
+      testns.testcoll.ios:
+        fail: true
+
+  - name: ensure ios_facts does use ios_facts defaults
+    testns.testcoll.ios_facts:
+    module_defaults:
+      testns.testcoll.ios_facts:
+        ios_facts: true
+    register: result
+
+  - assert:
+      that:
+        - result.ios_facts
+        - result.action_plugin == 'ios'

--- a/test/integration/targets/module_defaults/test_defaults.yml
+++ b/test/integration/targets/module_defaults/test_defaults.yml
@@ -139,12 +139,6 @@
       testns.testcoll.vyos:
         fail: true
 
-  - name: ensure vyosfacts does not use vyos_facts action plugin default either
-    testns.testcoll.vyosfacts:
-    module_defaults:
-      testns.testcoll.vyos_facts:
-        fail: true
-
   - name: vyosfacts does use vyosfacts defaults
     testns.testcoll.vyosfacts:
     module_defaults:
@@ -174,3 +168,39 @@
       that:
         - result.ios_facts
         - result.action_plugin == 'ios'
+
+  - name: ensure redirected action gets redirected action defaults
+    testns.testcoll.module_uses_action_defaults:
+    module_defaults:
+      testns.testcoll.module_uses_action_defaults:
+        action_option: true
+    register: result
+
+  - assert:
+      that:
+        - result.action_option
+        - result.action_plugin == 'eos'
+
+  - name: ensure redirected action gets resolved action defaults
+    testns.testcoll.module_uses_action_defaults:
+    module_defaults:
+      testns.testcoll.eos:
+        action_option: true
+    register: result
+
+  - assert:
+      that:
+        - result.action_option
+        - result.action_plugin == 'eos'
+
+  - name: ensure redirected action does not use module-specific defaults
+    testns.testcoll.module_uses_action_defaults:
+    module_defaults:
+      testns.testcoll.module:
+        fail: true
+    register: result
+
+  - assert:
+      that:
+        - not result.action_option
+        - result.action_plugin == 'eos'

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -179,6 +179,9 @@ test/integration/targets/incidental_win_reboot/templates/post_reboot.ps1 pslint!
 test/integration/targets/json_cleanup/library/bad_json shebang
 test/integration/targets/lookup_csvfile/files/crlf.csv line-endings
 test/integration/targets/lookup_ini/lookup-8859-15.ini no-smart-quotes
+test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/action/eos.py pylint:relative-beyond-top-level
+test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/action/ios.py pylint:relative-beyond-top-level
+test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/action/vyos.py pylint:relative-beyond-top-level
 test/integration/targets/module_precedence/lib_with_extension/a.ini shebang
 test/integration/targets/module_precedence/lib_with_extension/ping.ini shebang
 test/integration/targets/module_precedence/roles_with_extension/foo/library/a.ini shebang

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -179,9 +179,6 @@ test/integration/targets/incidental_win_reboot/templates/post_reboot.ps1 pslint!
 test/integration/targets/json_cleanup/library/bad_json shebang
 test/integration/targets/lookup_csvfile/files/crlf.csv line-endings
 test/integration/targets/lookup_ini/lookup-8859-15.ini no-smart-quotes
-test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/action/eos.py pylint:relative-beyond-top-level
-test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/action/ios.py pylint:relative-beyond-top-level
-test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/plugins/action/vyos.py pylint:relative-beyond-top-level
 test/integration/targets/module_precedence/lib_with_extension/a.ini shebang
 test/integration/targets/module_precedence/lib_with_extension/ping.ini shebang
 test/integration/targets/module_precedence/roles_with_extension/foo/library/a.ini shebang

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -212,7 +212,6 @@ class TestTaskExecutor(unittest.TestCase):
         te._shared_loader_obj.module_loader.find_plugin_with_context.return_value = context
         action_loader = te._shared_loader_obj.action_loader
         action_loader.has_plugin.return_value = True
-
         action_loader.get.return_value = mock.sentinel.handler
 
         mock_connection = MagicMock()

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -208,7 +208,8 @@ class TestTaskExecutor(unittest.TestCase):
             final_q=MagicMock(),
         )
 
-        te._shared_loader_obj.module_loader.has_plugin.return_value = False
+        context = MagicMock(resolved=False)
+        te._shared_loader_obj.module_loader.find_plugin_with_context.return_value = context
         action_loader = te._shared_loader_obj.action_loader
         action_loader.has_plugin.return_value = True
 
@@ -244,7 +245,8 @@ class TestTaskExecutor(unittest.TestCase):
             final_q=MagicMock(),
         )
 
-        te._shared_loader_obj.module_loader.has_plugin = MagicMock(return_value=False)
+        context = MagicMock(resolved=False)
+        te._shared_loader_obj.module_loader.find_plugin_with_context.return_value = context
         action_loader = te._shared_loader_obj.action_loader
         action_loader.has_plugin.side_effect = [False, True]
         action_loader.get.return_value = mock.sentinel.handler
@@ -285,7 +287,8 @@ class TestTaskExecutor(unittest.TestCase):
         action_loader.get.return_value = mock.sentinel.handler
         action_loader.__contains__.return_value = False
         module_loader = te._shared_loader_obj.module_loader
-        module_loader.has_plugin.return_value = False  # True/False doesn't matter, but need to set more mock objects if True
+        context = MagicMock(resolved=False)
+        module_loader.find_plugin_with_context.return_value = context
 
         mock_connection = MagicMock()
         mock_templar = MagicMock()
@@ -339,8 +342,6 @@ class TestTaskExecutor(unittest.TestCase):
         mock_queue = MagicMock()
 
         shared_loader = MagicMock()
-        shared_loader.module_loader = module_loader
-        shared_loader.module_loader.has_plugin = MagicMock(return_value=False)  # True needs extra MagicMock of find_plugin_with_context
         new_stdin = None
         job_vars = dict(omit="XXXXXXXXXXXXXXXXXXX")
 

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -208,10 +208,11 @@ class TestTaskExecutor(unittest.TestCase):
             final_q=MagicMock(),
         )
 
+        te._shared_loader_obj.module_loader.has_plugin.return_value = False
         action_loader = te._shared_loader_obj.action_loader
         action_loader.has_plugin.return_value = True
 
-        action_loader.get_with_context.return_value = get_with_context_result(mock.sentinel.handler, mock.sentinel.context)
+        action_loader.get.return_value = mock.sentinel.handler
 
         mock_connection = MagicMock()
         mock_templar = MagicMock()
@@ -225,7 +226,7 @@ class TestTaskExecutor(unittest.TestCase):
         action_loader.has_plugin.assert_called_once_with(
             action, collection_list=te._task.collections)
 
-        action_loader.get_with_context.assert_called_once_with(
+        action_loader.get.assert_called_once_with(
             te._task.action, task=te._task, connection=mock_connection,
             play_context=te._play_context, loader=te._loader,
             templar=mock_templar, shared_loader_obj=te._shared_loader_obj,
@@ -245,8 +246,8 @@ class TestTaskExecutor(unittest.TestCase):
 
         te._shared_loader_obj.module_loader.has_plugin = MagicMock(return_value=False)
         action_loader = te._shared_loader_obj.action_loader
-        action_loader.has_plugin.side_effect = [False, False, True]
-        action_loader.get_with_context.return_value = get_with_context_result(mock.sentinel.handler, mock.sentinel.context)
+        action_loader.has_plugin.side_effect = [False, True]
+        action_loader.get.return_value = mock.sentinel.handler
         action_loader.__contains__.return_value = True
 
         mock_connection = MagicMock()
@@ -261,7 +262,7 @@ class TestTaskExecutor(unittest.TestCase):
         action_loader.has_plugin.assert_has_calls([mock.call(action, collection_list=te._task.collections),  # called twice
                                                    mock.call(module_prefix, collection_list=te._task.collections)])
 
-        action_loader.get_with_context.assert_called_once_with(
+        action_loader.get.assert_called_once_with(
             module_prefix, task=te._task, connection=mock_connection,
             play_context=te._play_context, loader=te._loader,
             templar=mock_templar, shared_loader_obj=te._shared_loader_obj,
@@ -281,7 +282,7 @@ class TestTaskExecutor(unittest.TestCase):
 
         action_loader = te._shared_loader_obj.action_loader
         action_loader.has_plugin.return_value = False
-        action_loader.get_with_context.return_value = get_with_context_result(mock.sentinel.handler, mock.sentinel.context)
+        action_loader.get.return_value = mock.sentinel.handler
         action_loader.__contains__.return_value = False
         module_loader = te._shared_loader_obj.module_loader
         module_loader.has_plugin.return_value = False  # True/False doesn't matter, but need to set more mock objects if True
@@ -298,7 +299,7 @@ class TestTaskExecutor(unittest.TestCase):
         action_loader.has_plugin.assert_has_calls([mock.call(action, collection_list=te._task.collections),
                                                    mock.call(module_prefix, collection_list=te._task.collections)])
 
-        action_loader.get_with_context.assert_called_once_with(
+        action_loader.get.assert_called_once_with(
             'ansible.legacy.normal', task=te._task, connection=mock_connection,
             play_context=te._play_context, loader=te._loader,
             templar=mock_templar, shared_loader_obj=te._shared_loader_obj,
@@ -356,7 +357,6 @@ class TestTaskExecutor(unittest.TestCase):
 
         te._get_connection = MagicMock(return_value=mock_connection)
         context = MagicMock()
-        context._prefer_module_args = None
         te._get_action_handler_with_context = MagicMock(return_value=get_with_context_result(mock_action, context))
 
         mock_action.run.return_value = dict(ansible_facts=dict())


### PR DESCRIPTION
##### SUMMARY

Possible solution for #77059.

This adds a new `action_plugin` routing field for modules to support modules that need to use a common action plugin but don't want module_defaults resolved to the action plugin.

Instead of hijacking the action plugin redirection to ensure a platform-specific handler is used for a module:

```
plugin_routing:
  action:
    somemodule:  # Was never an action plugin, just here to replicate platform_somemodule prefix magic for determining the action plugin
      redirect: testns.testcoll.platform
  modules:
    somemodule:
      redirect: testns.testcoll.platform_somemodule
```

The resolved module can specify an action plugin directly:

```
plugin_routing:
  modules:
    somemodule:
      redirect: testns.testcoll.platform_somemodule
    platform_somemodule:
      action_plugin: testns.testcoll.platform
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
lib/ansible/executor/task_executor.py
lib/ansible/playbook/base.py