### PR TITLE
unarchive: fix io_buffer_size option, remove ignore.txt entry

### DIFF
--- a/changelogs/fragments/77271-unarchive.yml
+++ b/changelogs/fragments/77271-unarchive.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "unarchive - the ``io_buffer_size`` option added in 2.12 was not accepted by the module (https://github.com/ansible/ansible/pull/77271)."

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -977,6 +977,12 @@ def main():
             extra_opts=dict(type='list', elements='str', default=[]),
             validate_certs=dict(type='bool', default=True),
             io_buffer_size=dict(type='int', default=64 * 1024),
+
+            # Options that are for the action plugin, but ignored by the module itself.
+            # We have them here so that the sanity tests pass without ignores, which
+            # reduces the likelihood of further bugs added.
+            copy=dict(type='bool', default=True),
+            decrypt=dict(type='bool', default=True),
         ),
         add_file_common_args=True,
         # check-mode only works for zip files, we cover that later

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -52,7 +52,7 @@ options:
     description:
       - Size of the volatile memory buffer that is used for extracting files from the archive in bytes.
     type: int
-    default: 64 KiB
+    default: 65536
     version_added: "2.12"
   list_files:
     description:
@@ -304,7 +304,7 @@ class ZipArchive(object):
         self.file_args = file_args
         self.opts = module.params['extra_opts']
         self.module = module
-        self.io_buffer_size = module.params.get("io_buffer_size", 64 * 1024)
+        self.io_buffer_size = module.params["io_buffer_size"]
         self.excludes = module.params['exclude']
         self.includes = []
         self.include_files = self.module.params['include']
@@ -976,6 +976,7 @@ def main():
             include=dict(type='list', elements='str', default=[]),
             extra_opts=dict(type='list', elements='str', default=[]),
             validate_certs=dict(type='bool', default=True),
+            io_buffer_size=dict(type='int', default=64 * 1024),
         ),
         add_file_common_args=True,
         # check-mode only works for zip files, we cover that later

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -94,7 +94,6 @@ lib/ansible/modules/stat.py validate-modules:undocumented-parameter
 lib/ansible/modules/systemd.py validate-modules:parameter-invalid
 lib/ansible/modules/systemd.py validate-modules:return-syntax-error
 lib/ansible/modules/sysvinit.py validate-modules:return-syntax-error
-lib/ansible/modules/unarchive.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/uri.py validate-modules:doc-required-mismatch
 lib/ansible/modules/user.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/user.py validate-modules:doc-default-incompatible-type

--- a/test/units/modules/test_unarchive.py
+++ b/test/units/modules/test_unarchive.py
@@ -52,6 +52,7 @@ class TestCaseZipArchive:
             "extra_opts": "",
             "exclude": "",
             "include": "",
+            "io_buffer_size": 65536,
         }
 
         z = ZipArchive(
@@ -74,6 +75,7 @@ class TestCaseTgzArchive:
             "extra_opts": "",
             "exclude": "",
             "include": "",
+            "io_buffer_size": 65536,
         }
         fake_ansible_module.check_mode = False
 


### PR DESCRIPTION
##### SUMMARY
Fixes #77267.

Removes the ignore.txt entry by declaring the action plugin only options in the argument spec as well as suggested by @sivel on IRC.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
unarchive
