### PR TITLE
ansible_distribution: Add support for Uos/Deepin

### DIFF
--- a/changelogs/fragments/77275-add-support-for-deepin-distro-info-detection.yaml
+++ b/changelogs/fragments/77275-add-support-for-deepin-distro-info-detection.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - facts - add support for deepin distro information detection (https://github.com/ansible/ansible/issues/77286).

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -375,6 +375,24 @@ class DistributionFiles:
             if version:
                 debian_facts['distribution_version'] = version.group(1)
                 debian_facts['distribution_major_version'] = version.group(1).split('.')[0]
+        elif 'UOS' in data or 'Uos' in data or 'uos' in data:
+            debian_facts['distribution'] = 'Uos'
+            release = re.search(r"VERSION_CODENAME=\"?([^\"]+)\"?", data)
+            if release:
+                debian_facts['distribution_release'] = release.groups()[0]
+            version = re.search(r"VERSION_ID=\"(.*)\"", data)
+            if version:
+                debian_facts['distribution_version'] = version.group(1)
+                debian_facts['distribution_major_version'] = version.group(1).split('.')[0]
+        elif 'Deepin' in data or 'deepin' in data:
+            debian_facts['distribution'] = 'Deepin'
+            release = re.search(r"VERSION_CODENAME=\"?([^\"]+)\"?", data)
+            if release:
+                debian_facts['distribution_release'] = release.groups()[0]
+            version = re.search(r"VERSION_ID=\"(.*)\"", data)
+            if version:
+                debian_facts['distribution_version'] = version.group(1)
+                debian_facts['distribution_major_version'] = version.group(1).split('.')[0]
         else:
             return False, debian_facts
 
@@ -490,7 +508,7 @@ class Distribution(object):
                                 'EuroLinux'],
                      'Debian': ['Debian', 'Ubuntu', 'Raspbian', 'Neon', 'KDE neon',
                                 'Linux Mint', 'SteamOS', 'Devuan', 'Kali', 'Cumulus Linux',
-                                'Pop!_OS', 'Parrot', 'Pardus GNU/Linux'],
+                                'Pop!_OS', 'Parrot', 'Pardus GNU/Linux', 'Uos', 'Deepin'],
                      'Suse': ['SuSE', 'SLES', 'SLED', 'openSUSE', 'openSUSE Tumbleweed',
                               'SLES_SAP', 'SUSE_LINUX', 'openSUSE Leap'],
                      'Archlinux': ['Archlinux', 'Antergos', 'Manjaro'],

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -778,6 +778,18 @@ class RaspbianHostname(Hostname):
     strategy_class = FileStrategy
 
 
+class UosHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Uos'
+    strategy_class = FileStrategy
+
+
+class DeepinHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Deepin'
+    strategy_class = FileStrategy
+
+
 class GentooHostname(Hostname):
     platform = 'Linux'
     distribution = 'Gentoo'

--- a/test/units/module_utils/facts/system/distribution/fixtures/deepin_20.4.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/deepin_20.4.json
@@ -1,0 +1,29 @@
+{
+    "name": "Deepin 20.4",
+    "distro": {
+        "codename": "apricot",
+        "id": "Deepin",
+        "name": "Deepin",
+        "version": "20.4",
+        "version_best": "20.4",
+        "os_release_info": {},
+        "lsb_release_info": {}
+    },
+    "input": {
+        "/etc/os-release": "PRETTY_NAME=\"Deepin 20.4\"\nNAME=\"Deepin\"\nVERSION_ID=\"20.4\"\nVERSION=\"20.4\"\nVERSION_CODENAME=\"apricot\"\nID=Deepin\nHOME_URL=\"https://www.deepin.org/\"\nBUG_REPORT_URL=\"https://bbs.deepin.org/\"\n",
+        "/etc/lsb-release": "DISTRIB_ID=Deepin\nDISTRIB_RELEASE=20.4\nDISTRIB_DESCRIPTION=\"Deepin 20.4\"\nDISTRIB_CODENAME=apricot\n",
+        "/usr/lib/os-release": "PRETTY_NAME=\"Deepin 20.4\"\nNAME=\"Deepin\"\nVERSION_ID=\"20.4\"\nVERSION=\"20.4\"\nVERSION_CODENAME=\"apricot\"\nID=Deepin\nHOME_URL=\"https://www.deepin.org/\"\nBUG_REPORT_URL=\"https://bbs.deepin.org/\"\n"
+    },
+    "platform.dist": [
+        "Deepin",
+        "20.4",
+        "apricot"
+    ],
+    "result": {
+        "distribution": "Deepin",
+        "distribution_version": "20.4",
+        "distribution_release": "apricot",
+        "distribution_major_version": "20",
+        "os_family": "Debian"
+    }
+}

--- a/test/units/module_utils/facts/system/distribution/fixtures/uos_20.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/uos_20.json
@@ -1,0 +1,29 @@
+{
+    "name": "Uos 20",
+    "distro": {
+        "codename": "fou",
+        "id": "Uos",
+        "name": "Uos",
+        "version": "20",
+        "version_best": "20",
+        "os_release_info": {},
+        "lsb_release_info": {}
+    },
+    "input": {
+        "/etc/os-release": "PRETTY_NAME=\"UnionTech OS Server 20\"\nNAME=\"UnionTech OS Server 20\"\nVERSION_ID=\"20\"\nVERSION=\"20\"\nID=UOS\nHOME_URL=\"https://www.chinauos.com/\"\nBUG_REPORT_URL=\"https://bbs.chinauos.com/\"\nVERSION_CODENAME=fou",
+        "/etc/lsb-release": "DISTRIB_ID=uos\nDISTRIB_RELEASE=20\nDISTRIB_DESCRIPTION=\"UnionTech OS Server 20\"\nDISTRIB_CODENAME=fou\n",
+        "/usr/lib/os-release": "PRETTY_NAME=\"UnionTech OS Server 20\"\nNAME=\"UnionTech OS Server 20\"\nVERSION_ID=\"20\"\nVERSION=\"20\"\nID=UOS\nHOME_URL=\"https://www.chinauos.com/\"\nBUG_REPORT_URL=\"https://bbs.chinauos.com/\"\nVERSION_CODENAME=fou"
+    },
+    "platform.dist": [
+        "uos",
+        "20",
+        "fou"
+    ],
+    "result": {
+        "distribution": "Uos",
+        "distribution_version": "20",
+        "distribution_release": "fou",
+        "distribution_major_version": "20",
+        "os_family": "Debian"
+    }
+}


### PR DESCRIPTION
##### SUMMARY

ansible_distribution: Add support for Uos/Deepin
Fixes: #77286 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ansible.module_utils.facts

##### ADDITIONAL INFORMATION

Currently, ansible is unable to detect Uos/Deepin system release info correctly. 

```bash
$  ansible all -m setup -i"`hostname`," --connection=local -a"filter=ansible_distribution*"
```

wrong output:
```json
{
    "ansible_facts": {
        "ansible_distribution": "Deepin 20.4",
        "ansible_distribution_file_parsed": true,
        "ansible_distribution_file_path": "/usr/lib/os-release",
        "ansible_distribution_file_variety": "ClearLinux",
        "ansible_distribution_major_version": "\"20.4\"",
        "ansible_distribution_release": "\"20.4\"",
        "ansible_distribution_version": "\"20.4\""
    },
    "changed": false
}
```

With this PR, ansible can handle it in the right way:

```json
{
    "ansible_facts": {
        "ansible_distribution": "Deepin",
        "ansible_distribution_file_parsed": true,
        "ansible_distribution_file_path": "/etc/os-release",
        "ansible_distribution_file_variety": "Debian",
        "ansible_distribution_major_version": "20",
        "ansible_distribution_release": "apricot",
        "ansible_distribution_version": "20.4"
    },
    "changed": false
}
```