### PR TITLE
Allow keyboard-interactive SSH connections (RFC 4256)

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -726,8 +726,7 @@ class Connection(ConnectionBase):
         if not conn_password:
             self._add_args(
                 b_command, (
-                    b"-o", b"KbdInteractiveAuthentication=no",
-                    b"-o", b"PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey",
+                    b"-o", b"PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey,keyboard-interactive",
                     b"-o", b"PasswordAuthentication=no"
                 ),
                 u"ansible_password/ansible_ssh_password not set"


### PR DESCRIPTION
##### SUMMARY

`keyboard-interactive` is specified by [RFC 4256](https://datatracker.ietf.org/doc/html/rfc4256) and basically allows for ad-hoc exchange between the SSH server and the authenticating client. One important use case for such feature is MFA (multi-factor authentication), where the client first authenticates by "traditional" means, e.g. publickey, and is then required to provide the server with a second factor, such as an OTP (one-time password) generated by an authenticator app. One such OTP is specified by [RFC 4226](https://datatracker.ietf.org/doc/html/rfc4226) and [RFC 6238](https://datatracker.ietf.org/doc/html/rfc6238) and an example implementation is [google-authenticator-libpam](https://github.com/google/google-authenticator-libpam), which is available as the `google-authenticator` package on EL (=Red Hat based distros, e.g. RHEL, CentOS, Alma, Rocky, Fedora) and as `libpam-google-authenticator` on Ubuntu. See [sshd_config (5)](https://man7.org/linux/man-pages/man5/sshd_config.5.html) / `AuthenticationMethods` for an explanation on how `sshd` may require multiple authentication methods.

I've been successfully connecting to such servers using PuTTY, FileZilla, and `ssh`, but unfortunately, Ansible currently fails to connect:

```
$ ansible-playbook ansible/sshd.yml -e "target=x.x.x.x"

PLAY [x.x.x.x] ********************************************************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************************
Enter passphrase for key '/home/bviktor/.ssh/id_rsa':
fatal: [x.x.x.x]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: bviktor@x.x.x.x: Permission denied (keyboard-interactive).", "unreachable": true}

PLAY RECAP *************************************************************************************************************************************************************
x.x.x.x               : ok=0    changed=0    unreachable=1    failed=0    skipped=0    rescued=0    ignored=0
```

As it turns out, this is because Ansible has a hardcoded list of supported authentication methods for connections that have no password defined. This commit extends that list to include `keyboard-interactive`.

Please note that while merely adding `keyboard-interactive` to `PreferredAuthentications` already fixed connections for me, it directly conflicts with the preceding `KbdInteractiveAuthentication=no` option (see [ssh_config (5)](https://man7.org/linux/man-pages/man5/ssh_config.5.html) / `KbdInteractiveAuthentication`). Apparently `PreferredAuthentications` takes precedence over `KbdInteractiveAuthentication`, but since it doesn't make sense to disable `keyboard-interactive` only to re-enable it on the next line, I extended the patch to remove the disabling part, too.

Allowing `keyboard-interactive` as an authentication method doesn't seem to introduce any kind of security risk (in fact, to me it'd actually _increase_ security), and I also can't think of a way in which it could break existing functionality.

I file this as a bugfix, as it fixes an issue for me, but you might also consider it a feature.

Fixes #16259 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

SSH connection plugin.

##### ADDITIONAL INFORMATION

The basic principle in the case of `google-authenticator-libpam` is that the user has a `.google_authenticator` file in their home, and `sshd` uses that file to verify the OTP the user enters during login. This is the same exact mechanism that happens during publickey auth (the only difference is the filename, i.e. `~/.ssh/authorized_keys)`.

To set up such a server for yourself, there are several tutorials available:

- [Ubuntu / Configure SSH to use two-factor authentication](https://ubuntu.com/tutorials/configure-ssh-2fa)
- [FedoraForum.org / Trying to set up Google Authenitcator for SSH login](https://forums.fedoraforum.org/showthread.php?322671-Trying-to-set-up-Google-Authenitcator-for-SSH-login)
- [Duo Security / How do I enable pam_duo to use both passwords and public key authentication?](https://help.duo.com/s/article/3745?language=en_US)
- [Automox / Using Google Authenticator for 2FA](https://www.automox.com/blog/linux-tip-9-using-google-authenticator-for-2fa)
- [ArchWiki / Google Authenticator](https://wiki.archlinux.org/title/Google_Authenticator)

---

SELinux notes:

This was first noted in the FedoraForum thread, that on EL, SELinux will cause issues if you use the default `~/.google_authenticator` filename, because for some weird reason `sshd` apparently writes temporary files next to these "keys" during login (e.g. `~/.google_authenticator-xYastOp`. I'm not here to investigate the why, as it's irrelevant to the current PR, but the point is that while `sshd` will succeed writing such temp files to `~/.ssh`, since it has an SELinux context of `ssh_home_t`, it will fail to write to `~` where the Google auth key is, as that has a different context, namely `user_home_dir_t`. You could adjust the SELinux policies to allow `sshd` to write to `user_home_dir_t`, but I don't think that's a good idea, so a better approach is to move the Google auth keys to `~/.ssh`. 

On the server side, you need to adjust your `/etc/pam.d/sshd` line like so:

```
auth required pam_google_authenticator.so secret=/home/${USER}/.ssh/.google_authenticator
```

On the client, the `google-authenticator` util sadly doesn't allow to specify a different path, it always saves the key as `~/.google_authenticator`. SELinux contexts behave like file permissions, so on `cp` it inherits the context, on `mv` it retains its own. So you either `mv` then `restorecon` on the new path, or `cp` and then `rm` the old path.

---

I already have an Ansible playbook for my private use that sets up `sshd` for Google auth MFA on Fedora Server 35, and even generates a key for the remote user and displays the QR code needed to add the account to the auth app (I use Microsoft Authenticator, but it should work with any app that's compatible with Google Authenticator). I can release the playbook publicly if you wish, but in a nutshell, on the (Fedora) server:

```
dnf install google-authenticator
```

Then as a user, generate your key:

```
google-authenticator --time-based --disallow-reuse --force --minimal-window --qr-mode=ANSI --no-confirm --no-rate-limit
mv ~/.google_authenticator ~/.ssh/
restorecon -v ~/.ssh/.google_authenticator
```

Then edit `/etc/pam.d/sshd` like so:

```
#%PAM-1.0
auth required pam_google_authenticator.so secret=/home/${USER}/.ssh/.google_authenticator
#auth       substack     password-auth
auth       include      postlogin
account    required     pam_sepermit.so
account    required     pam_nologin.so
account    include      password-auth
password   include      password-auth
# pam_selinux.so close should be the first session rule
session    required     pam_selinux.so close
session    required     pam_loginuid.so
# pam_selinux.so open should only be followed by sessions to be executed in the user context
session    required     pam_selinux.so open env_params
session    required     pam_namespace.so
session    optional     pam_keyinit.so force revoke
session    optional     pam_motd.so
session    include      password-auth
session    include      postlogin
```

And an `/etc/ssh/sshd_config.d/10-mfa.conf` like so:

```
UsePAM yes
KbdInteractiveAuthentication yes
AuthenticationMethods publickey,keyboard-interactive:pam
```

Restart `sshd`:

```
systemctl restart sshd.service
```

And you're good to go. A successful connection looks like this:

```
$ ssh bviktor@x.x.x.x
Enter passphrase for key 'id_rsa':
(bviktor@x.x.x.x) Verification code:

Last login: Sun Mar 13 15:06:35 2022 from y.y.y.y
[bviktor@foobar~]$
```

After the patch, Ansible works as it should:

```
$ ansible-playbook ansible/sshd.yml -e "target=x.x.x.x"

PLAY [x.x.x.x] ********************************************************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************************
Enter passphrase for key '/home/bviktor/.ssh/id_rsa':
Verification code:
ok: [x.x.x.x]

TASK [update : include_tasks] ******************************************************************************************************************************************

[...]
```

I'm using Ansible on Ubuntu 21.10 with the packages from [ppa:ansible/ansible](https://launchpad.net/~ansible/+archive/ubuntu/ansible). `ansible-core` is 2.12.2, `ansible` is 5.4.0.