### PR TITLE
hostname - Add Rocky Linux using the RedHat strategy

### DIFF
--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -718,6 +718,12 @@ class AmazonLinuxHostname(Hostname):
     strategy_class = RedHatStrategy
 
 
+class RockyLinuxHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Rocky'
+    strategy_class = RedHatStrategy
+
+
 class DebianHostname(Hostname):
     platform = 'Linux'
     distribution = 'Debian'


### PR DESCRIPTION
##### SUMMARY
Tried changing the hostname with the hostname module on a Rocky Linux machine and got an error

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
hostname

##### ADDITIONAL INFORMATION
Running the hostname module against a rocky linux host gives:

```
fatal: [machine1]: FAILED! => {"changed": false, "msg": "hostname module cannot be used on platform Linux (Rocky)"}
```

After this change it works as expected. Not sure if there needs to be any tests for this change?