### PR TITLE
docker_util: Handle error in JSON parsing

### DIFF
--- a/changelogs/fragments/ansible_test.yml
+++ b/changelogs/fragments/ansible_test.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- ansible-test - handle JSON decode error gracefully in podman environment.

--- a/test/lib/ansible_test/_internal/docker_util.py
+++ b/test/lib/ansible_test/_internal/docker_util.py
@@ -137,20 +137,22 @@ def get_podman_default_hostname():  # type: () -> str
 
     --format was added in podman 3.3.0, this functionality depends on it's availability
     """
+    hostname = None
     try:
         stdout = raw_command(['podman', 'system', 'connection', 'list', '--format=json'], capture=True)[0]
     except SubprocessError:
         stdout = '[]'
 
-    connections = json.loads(stdout)
+    try:
+        connections = json.loads(stdout)
+    except json.decoder.JSONDecodeError:
+        return hostname
 
     for connection in connections:
         # A trailing indicates the default
         if connection['Name'][-1] == '*':
             hostname = connection['URI']
             break
-    else:
-        hostname = None
 
     return hostname
 


### PR DESCRIPTION
##### SUMMARY

While getting hostname from container, podman command
fails to return JSON so wrap exception and return
hostname as 'None'

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test/lib/ansible_test/_internal/docker_util.py
