### PR TITLE
callback: query strategy whether to cache taskname

### DIFF
--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -278,8 +278,6 @@ class TaskQueueManager:
             if hasattr(callback_plugin, 'set_play_context'):
                 callback_plugin.set_play_context(play_context)
 
-        self.send_callback('v2_playbook_on_play_start', new_play)
-
         # build the iterator
         iterator = PlayIterator(
             inventory=self._inventory,
@@ -297,6 +295,9 @@ class TaskQueueManager:
         strategy = strategy_loader.get(new_play.strategy, self)
         if strategy is None:
             raise AnsibleError("Invalid play strategy specified: %s" % new_play.strategy, obj=play._ds)
+
+        new_play.preserve_task_name = strategy.preserve_task_name()
+        self.send_callback('v2_playbook_on_play_start', new_play)
 
         # Because the TQM may survive multiple play runs, we start by marking
         # any hosts as failed in the iterator here which may have been marked

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -178,7 +178,7 @@ class CallbackModule(CallbackBase):
 
         # Preserve task name, as all vars may not be available for templating
         # when we need it later
-        if self._play.strategy in add_internal_fqcns(('free', 'host_pinned')):
+        if self._play.preserve_task_name is False:
             # Explicitly set to None for strategy free/host_pinned to account for any cached
             # task title from a previous non-free play
             self._last_task_name = None

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -1346,6 +1346,10 @@ class StrategyBase:
                     if r._host not in self._active_connections:
                         self._active_connections[r._host] = socket_path
 
+    def preserve_task_name(self):
+        ''' hint to callback plugin whether last task name should be cached '''
+        return True
+
 
 class NextAction(object):
     """ The next action after an interpreter's exit. """

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -292,3 +292,7 @@ class StrategyModule(StrategyBase):
         # run the base class run() method, which executes the cleanup function
         # and runs any outstanding handlers which have been triggered
         return super(StrategyModule, self).run(iterator, play_context, result)
+
+    def preserve_task_name(self):
+        ''' hint to callback plugin not to cache last task names for the free strategy '''
+        return False


### PR DESCRIPTION
##### SUMMARY

With the free strategy, the last task name should not be cached. Ref: #43950

However, the same might be true of a strategy plugin, a popular example being
mitogen_free. Otherwise, task names will be incorrect for mitogen_free just
like in #43950

Rather than checking for the name of the strategy in the callback plugin, we
can query the strategy itself whether task names should be cached or not.

Since the strategy is not available directly from the callback, passing a flag
on the play object via v2_playbook_on_play_start. A play has only one strategy.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
default callback / free strategy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
