### PR TITLE
Remove more Python 2.x compatibility code from controller

### DIFF
--- a/changelogs/fragments/77320-python-2.yml
+++ b/changelogs/fragments/77320-python-2.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Remove more Python 2.x compatibility code from controller (https://github.com/ansible/ansible/pull/77320)."

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1314,8 +1314,8 @@ def _extract_interpreter(b_module_data):
     if b_lines[0].startswith(b"#!"):
         b_shebang = b_lines[0].strip()
 
-        # shlex.split on python-2.6 needs bytes.  On python-3.x it needs text
-        cli_split = shlex.split(to_native(b_shebang[2:], errors='surrogate_or_strict'))
+        # shlex.split needs text on Python 3
+        cli_split = shlex.split(to_text(b_shebang[2:], errors='surrogate_or_strict'))
 
         # convert args to text
         cli_split = [to_text(a, errors='surrogate_or_strict') for a in cli_split]

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -109,17 +109,8 @@ class ConnectionBase(AnsiblePlugin):
         list ['-o', 'Foo=1', '-o', 'Bar=foo bar'] that can be added to
         the argument list. The list will not contain any empty elements.
         """
-        try:
-            # Python 2.6.x shlex doesn't handle unicode type so we have to
-            # convert args to byte string for that case.  More efficient to
-            # try without conversion first but python2.6 doesn't throw an
-            # exception, it merely mangles the output:
-            # >>> shlex.split(u't e')
-            # ['t\x00\x00\x00', '\x00\x00\x00e\x00\x00\x00']
-            return [to_text(x.strip()) for x in shlex.split(to_bytes(argstring)) if x.strip()]
-        except AttributeError:
-            # In Python3, shlex.split doesn't work on a byte string.
-            return [to_text(x.strip()) for x in shlex.split(argstring) if x.strip()]
+        # In Python3, shlex.split doesn't work on a byte string.
+        return [to_text(x.strip()) for x in shlex.split(argstring) if x.strip()]
 
     @property
     @abstractmethod

--- a/lib/ansible/utils/cmd_functions.py
+++ b/lib/ansible/utils/cmd_functions.py
@@ -30,8 +30,7 @@ from ansible.module_utils._text import to_bytes
 def run_cmd(cmd, live=False, readsize=10):
     cmdargs = shlex.split(cmd)
 
-    # subprocess should be passed byte strings.  (on python2.6 it must be
-    # passed byte strtings)
+    # subprocess should be passed byte strings.
     cmdargs = [to_bytes(a, errors='surrogate_or_strict') for a in cmdargs]
 
     p = subprocess.Popen(cmdargs, stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
##### SUMMARY
I noticed some Python 2.6 compatibility code in controller and removed it.

Note that there's also some 2.6 compatibility code in module_utils and modules that can probably go as well (as 2.6 is no longer supported on the remote side as well). (Searching for `2.6` should find some.)

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
controller
