### PR TITLE
Add what to look for in PyYAML documentation

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -280,7 +280,7 @@ To avoid such behavior and generate long lines, use the ``width`` option. You mu
     {{ some_variable | to_yaml(indent=8, width=1337) }}
     {{ some_variable | to_nice_yaml(indent=8, width=1337) }}
 
-The filter does support passing through other YAML parameters. For a full list, see the `PyYAML documentation`_ for dump().
+The filter does support passing through other YAML parameters. For a full list, see the `PyYAML documentation`_ for ``dump()``.
 
 If you are reading in some already formatted data:
 

--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -280,7 +280,7 @@ To avoid such behavior and generate long lines, use the ``width`` option. You mu
     {{ some_variable | to_yaml(indent=8, width=1337) }}
     {{ some_variable | to_nice_yaml(indent=8, width=1337) }}
 
-The filter does support passing through other YAML parameters. For a full list, see the `PyYAML documentation`_.
+The filter does support passing through other YAML parameters. For a full list, see the `PyYAML documentation`_ for dump().
 
 If you are reading in some already formatted data:
 


### PR DESCRIPTION
##### SUMMARY
The `to_yaml` filter documentation points to PyYAML documentation for more on parameters. But the document is very long -- and without proper anchors so direct links are not possible -- but at least tell the user what to look for in the documentation.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr
