### PR TITLE
SID - Use literal UPN value when attempting a user to SID lookup

### DIFF
--- a/changelogs/fragments/ModuleUtils.SID-long-username.yml
+++ b/changelogs/fragments/ModuleUtils.SID-long-username.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Ansible.ModuleUtils.SID - Use user principal name as is for lookup in the ``Convert-ToSID`` function - https://github.com/ansible/ansible/issues/77316

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.SID.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.SID.psm1
@@ -49,11 +49,6 @@ Function Convert-ToSID {
         }
         $username = $account_name_split[1]
     }
-    elseif ($account_name -like "*@*") {
-        $account_name_split = $account_name -split "@"
-        $domain = $account_name_split[1]
-        $username = $account_name_split[0]
-    }
     else {
         $domain = $null
         $username = $account_name


### PR DESCRIPTION
##### SUMMARY
The code incorrectly splits the UPN into `username` and `domain` fields which does not work well when the `username` exceeds the `sAMAccountName` limits of 20 chars. By using the username as the full UPN Windows will lookup the SID value correctly.

Fixes https://github.com/ansible/ansible/issues/77316

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Ansible.ModuleUtils.SID