### PR TITLE
Improve documentation to fix outdated file paths

### DIFF
--- a/hacking/README.md
+++ b/hacking/README.md
@@ -29,7 +29,7 @@ a module outside of the ansible program, locally, on the current machine.
 
 Example:
 
-    $ ./hacking/test-module.py -m lib/ansible/modules/commands/command.py -a "echo hi"
+    $ ./hacking/test-module.py -m lib/ansible/modules/command.py -a "echo hi"
 
 This is a good way to insert a breakpoint into a module, for instance.
 

--- a/hacking/test-module.py
+++ b/hacking/test-module.py
@@ -23,10 +23,10 @@
 # modules
 #
 # example:
-#    ./hacking/test-module.py -m lib/ansible/modules/commands/command.py -a "/bin/sleep 3"
-#    ./hacking/test-module.py -m lib/ansible/modules/commands/command.py -a "/bin/sleep 3" --debugger /usr/bin/pdb
-#    ./hacking/test-module.py -m lib/ansible/modules/files/lineinfile.py -a "dest=/etc/exports line='/srv/home hostname1(rw,sync)'" --check
-#    ./hacking/test-module.py -m lib/ansible/modules/commands/command.py -a "echo hello" -n -o "test_hello"
+#    ./hacking/test-module.py -m lib/ansible/modules/command.py -a "/bin/sleep 3"
+#    ./hacking/test-module.py -m lib/ansible/modules/command.py -a "/bin/sleep 3" --debugger /usr/bin/pdb
+#    ./hacking/test-module.py -m lib/ansible/modules/lineinfile.py -a "dest=/etc/exports line='/srv/home hostname1(rw,sync)'" --check
+#    ./hacking/test-module.py -m lib/ansible/modules/command.py -a "echo hello" -n -o "test_hello"
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type


### PR DESCRIPTION
##### SUMMARY
Existing file path examples for hacking/README.md and hacking/test-module.py are obsolete, so we updated the file paths to correspond to the current directory structure. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- Documentation

##### ADDITIONAL INFORMATION

