### PR TITLE
Incorrect parent role paths var description

### DIFF
--- a/docs/docsite/rst/reference_appendices/special_variables.rst
+++ b/docs/docsite/rst/reference_appendices/special_variables.rst
@@ -44,7 +44,7 @@ ansible_parent_role_names
     For example: When role **A** includes role **B**, inside role B, ``ansible_parent_role_names`` will equal to ``['A']``. If role **B** then includes role **C**, the list becomes ``['B', 'A']``.
 
 ansible_parent_role_paths
-    When the current role is being executed by means of an :ref:`include_role <include_role_module>` or :ref:`import_role <import_role_module>` action, this variable contains a list of all parent roles, with the most recent role (in other words, the role that included/imported this role) being the first item in the list.
+    When the current role is being executed by means of an :ref:`include_role <include_role_module>` or :ref:`import_role <import_role_module>` action, this variable contains a list of all parent roles paths, with the most recent role (in other words, the role that included/imported this role) being the first item in the list.
     Please refer to ``ansible_parent_role_names`` for the order of items in this list.
 
 ansible_play_batch


### PR DESCRIPTION
##### SUMMARY
<!--- Your description here -->
The file `special_variables.rst` currently has exact same copy-pasted description for both `ansible_parent_role_names` and `ansible_parent_role_paths`.  
It is missing the key word "paths" in description of `ansible_parent_role_paths` that differentiates it from `ansible_parent_role_names`.

So add the important word to explain what this special variable actually does.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr