### PR TITLE
SID - Use literal UPN value when attempting a user to SID lookup (#77334) - 2.11

### DIFF
--- a/changelogs/fragments/ModuleUtils.SID-long-username.yml
+++ b/changelogs/fragments/ModuleUtils.SID-long-username.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Ansible.ModuleUtils.SID - Use user principal name as is for lookup in the ``Convert-ToSID`` function - https://github.com/ansible/ansible/issues/77316

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.SID.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.SID.psm1
@@ -44,10 +44,6 @@ Function Convert-ToSID {
             $domain = $account_name_split[0]
         }
         $username = $account_name_split[1]
-    } elseif ($account_name -like "*@*") {
-        $account_name_split = $account_name -split "@"
-        $domain = $account_name_split[1]
-        $username = $account_name_split[0]
     } else {
         $domain = $null
         $username = $account_name


### PR DESCRIPTION
(cherry picked from commit ff184b0815cdbf7dc222fd9d7b0cfaa93d5fe03c)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/77334

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Ansible.ModuleUtils.SID.psm1