### PR TITLE
Only require a keyring if collections with signatures will be installed

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -654,7 +654,7 @@ class GalaxyCLI(CLI):
         """
         two_type_warning = "The requirements file '%s' contains {0}s which will be ignored. To install these {0}s " \
             "run 'ansible-galaxy {0} install -r' or to install both at the same time run " \
-           "'ansible-galaxy install -r' without a custom install path." % to_text(requirements_file)
+            "'ansible-galaxy install -r' without a custom install path." % to_text(requirements_file)
 
         requirements = {
             'roles': [],

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -271,10 +271,11 @@ class _ComputedReqKindsMixin:
         # TODO: decide how to deprecate the old src API behavior
         req_source = collection_req.get('source', None)
         req_signature_sources = collection_req.get('signatures', None)
-        if validate_signature_options and req_signature_sources is not None and art_mgr.keyring is None:
-            raise AnsibleError(
-                f"Signatures were provided to verify {req_name} but no keyring was configured."
-            )
+        if req_signature_sources is not None:
+            if validate_signature_options and art_mgr.keyring is None:
+                raise AnsibleError(
+                    f"Signatures were provided to verify {req_name} but no keyring was configured."
+                )
 
             if not isinstance(req_signature_sources, MutableSequence):
                 req_signature_sources = [req_signature_sources]

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -264,18 +264,17 @@ class _ComputedReqKindsMixin:
         return cls.from_requirement_dict(req, artifacts_manager)
 
     @classmethod
-    def from_requirement_dict(cls, collection_req, art_mgr):
+    def from_requirement_dict(cls, collection_req, art_mgr, validate_signature_options=True):
         req_name = collection_req.get('name', None)
         req_version = collection_req.get('version', '*')
         req_type = collection_req.get('type')
         # TODO: decide how to deprecate the old src API behavior
         req_source = collection_req.get('source', None)
         req_signature_sources = collection_req.get('signatures', None)
-        if req_signature_sources is not None:
-            if art_mgr.keyring is None:
-                raise AnsibleError(
-                    f"Signatures were provided to verify {req_name} but no keyring was configured."
-                )
+        if validate_signature_options and req_signature_sources is not None and art_mgr.keyring is None:
+            raise AnsibleError(
+                f"Signatures were provided to verify {req_name} but no keyring was configured."
+            )
 
             if not isinstance(req_signature_sources, MutableSequence):
                 req_signature_sources = [req_signature_sources]

--- a/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
@@ -453,6 +453,33 @@
     not_mine: "file://{{ gpg_homedir }}/namespace1-name1-1.0.0-MANIFEST.json.asc"
     also_not_mine: "file://{{ gpg_homedir }}/namespace1-name1-1.0.9-MANIFEST.json.asc"
 
+- name: installing only roles does not fail if keyring for collections is not provided
+  command: ansible-galaxy role install -r {{ galaxy_dir }}/ansible_collections/requirements.yaml
+  register: roles_only
+
+- assert:
+    that:
+      - roles_only is success
+
+- name: installing only roles implicitly does not fail if keyring for collections is not provided
+  # if -p/--roles-path are specified, only roles are installed
+  command: ansible-galaxy install -r {{ galaxy_dir }}/ansible_collections/requirements.yaml }} -p {{ galaxy_dir }}
+  register: roles_only
+
+- assert:
+    that:
+      - roles_only is success
+
+- name: installing roles and collections requires keyring if collections have signatures
+  command: ansible-galaxy install -r {{ galaxy_dir }}/ansible_collections/requirements.yaml }}
+  ignore_errors: yes
+  register: collections_and_roles
+
+- assert:
+    that:
+      - collections_and_roles is failed
+      - "'no keyring was configured' in collections_and_roles.stderr"
+
 - name: install collection with mutually exclusive options
   command: ansible-galaxy collection install -r {{ req_file }} -s {{ test_name }} {{ cli_signature }}
   vars:


### PR DESCRIPTION
##### SUMMARY
Fixes #77349

The collections in a requirements.yml were being parsed for `ansible-galaxy role install`, which was causing an error if collections had supplemental signatures. ~Now the collections are only loaded from the file if they will actually be installed.~ I made a more minimal diff which still loads collections/roles regardless of whether they will be installed and fixes the linked issue by requiring the keyring only if the collections with signatures associated will actually be installed.

##### ISSUE TYPE
- Bugfix Pull Request
