### PR TITLE
ansible-test - Remove RHEL 9.0b support.

### DIFF
--- a/changelogs/fragments/ansible-test-rhel9.yaml
+++ b/changelogs/fragments/ansible-test-rhel9.yaml
@@ -1,2 +1,0 @@
-minor_changes:
-  - ansible-test - Add support for RHEL 9.

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -5,5 +5,4 @@ macos/12.0 python=3.10 python_dir=/usr/local/bin provider=parallels
 macos python_dir=/usr/local/bin provider=parallels
 rhel/7.9 python=2.7 provider=aws
 rhel/8.5 python=3.6,3.8,3.9 provider=aws
-rhel/9.0b python=3.9 provider=aws
 rhel provider=aws


### PR DESCRIPTION
##### SUMMARY

ansible-test - Remove RHEL 9.0b support.

Support can be restored once RHEL 9 has been released.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
