### PR TITLE
Bump requirements for antsibull to 0.42.0 for new docs features and 

### DIFF
--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -4,7 +4,7 @@
 #    test/sanity/code-smell/docs-build.requirements.txt
 #    test/sanity/code-smell/rstcheck.requirements.txt
 
-antsibull == 0.41.0
+antsibull == 0.42.0
 # sphinx 4.2.0 requires docutils < 0.18
 docutils == 0.17.1
 jinja2 == 3.0.3

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -3,7 +3,7 @@
 # if you want known good versions of these dependencies
 # use known_good_reqs.txt instead
 
-antsibull >= 0.41.0
+antsibull >= 0.42.0
 docutils
 jinja2
 pygments >= 2.10.0

--- a/test/lib/ansible_test/_data/requirements/sanity.changelog.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.changelog.txt
@@ -1,5 +1,5 @@
 # edit "sanity.changelog.in" and generate with: hacking/update-sanity-requirements.py --test changelog
-antsibull-changelog==0.12.0
+antsibull-changelog==0.14.0
 docutils==0.17.1
 packaging==21.2
 pyparsing==2.4.7

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -4,8 +4,8 @@ aiohttp==3.8.0
 aiosignal==1.2.0
 alabaster==0.7.12
 ansible-pygments==0.1.0
-antsibull==0.41.0
-antsibull-changelog==0.12.0
+antsibull==0.42.0
+antsibull-changelog==0.14.0
 async-timeout==4.0.1
 asyncio-pool==0.5.2
 attrs==21.2.0

--- a/test/sanity/code-smell/package-data.requirements.txt
+++ b/test/sanity/code-smell/package-data.requirements.txt
@@ -1,5 +1,5 @@
 # edit "package-data.requirements.in" and generate with: hacking/update-sanity-requirements.py --test package-data
-antsibull-changelog==0.12.0
+antsibull-changelog==0.14.0
 docutils==0.17.1
 Jinja2==3.0.3
 MarkupSafe==2.0.1


### PR DESCRIPTION
##### SUMMARY
Now that #77035 has been merged, there's finally the proper antsibull 0.42.0 release (instead of the prerelase in #77121). This is required for #74963 as well as for some docs features:
1. New collection links feature (https://github.com/ansible-community/antsibull/pull/355), a new major docs feature for Ansible 6;
2. Improved attributes tables.

This also bumps the antsibull-changelog version to 0.14.0 since antsibull 0.42.0 depends on that version. antsibull-changelog is needed for the changelog sanity test, and there are no changes in the changelog fragment linter between 0.12.0 (included now) and 0.14.0.

##### ISSUE TYPE
- Docs Pull Request
- Test Pull Request

##### COMPONENT NAME
docsite build
docsite build sanity test
changelog sanity test
