### PR TITLE
[bp-2.12] hostname - fix TypeError in FileStrategy

### DIFF
--- a/changelogs/fragments/77074-hostname-fix-typeerror-in-filestrategy.yml
+++ b/changelogs/fragments/77074-hostname-fix-typeerror-in-filestrategy.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hostname - use ``file_get_content()`` to read the file containing the host name in the ``FileStrategy.get_permanent_hostname()`` method. This prevents a ``TypeError`` from being raised when the strategy is used (https://github.com/ansible/ansible/issues/77025).

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -78,7 +78,7 @@ from ansible.module_utils.basic import (
 )
 from ansible.module_utils.common.sys_info import get_platform_subclass
 from ansible.module_utils.facts.system.service_mgr import ServiceMgrFactCollector
-from ansible.module_utils.facts.utils import get_file_lines
+from ansible.module_utils.facts.utils import get_file_lines, get_file_content
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.six import PY3, text_type
 
@@ -257,7 +257,7 @@ class FileStrategy(BaseStrategy):
             return ''
 
         try:
-            return get_file_lines(self.FILE)
+            return get_file_content(self.FILE, default='', strip=True)
         except Exception as e:
             self.module.fail_json(
                 msg="failed to read hostname: %s" % to_native(e),


### PR DESCRIPTION
##### SUMMARY

* Use file_get_content() to read the file containing the host name

(cherry picked from commit d60efd97687803fd184ac53aa691bd4e0ec43170)


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/77074-hostname-fix-typeerror-in-filestrategy.yml
lib/ansible/modules/hostname.py
