### PR TITLE
Add family fallback for RHEL to register as RedHat

### DIFF
--- a/changelogs/fragments/77368-rhel-os-family-compat.yaml
+++ b/changelogs/fragments/77368-rhel-os-family-compat.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- Interpreter discovery - Add ``RHEL`` to ``OS_FAMILY_MAP`` for correct family fallback for interpreter discovery
+  (https://github.com/ansible/ansible/issues/77368)

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -501,7 +501,7 @@ class Distribution(object):
     """
 
     # keep keys in sync with Conditionals page of docs
-    OS_FAMILY_MAP = {'RedHat': ['RedHat', 'Fedora', 'CentOS', 'Scientific', 'SLC',
+    OS_FAMILY_MAP = {'RedHat': ['RedHat', 'RHEL', 'Fedora', 'CentOS', 'Scientific', 'SLC',
                                 'Ascendos', 'CloudLinux', 'PSBM', 'OracleLinux', 'OVS',
                                 'OEL', 'Amazon', 'Virtuozzo', 'XenServer', 'Alibaba',
                                 'EulerOS', 'openEuler', 'AlmaLinux', 'Rocky', 'TencentOS',

--- a/test/integration/targets/interpreter_discovery_python/tasks/main.yml
+++ b/test/integration/targets/interpreter_discovery_python/tasks/main.yml
@@ -11,6 +11,7 @@
   set_fact:
     distro: '{{ ansible_distribution | default("unknown") | lower }}'
     distro_version: '{{ ansible_distribution_version | default("unknown") }}'
+    distro_major_version: '{{ ansible_distribution_major_version | default("unknown") }}'
     os_family: '{{ ansible_os_family | default("unknown") }}'
 
 - name: test that python discovery is working and that fact persistence makes it only run once
@@ -156,11 +157,11 @@
     assert:
       that:
       # rhel 6/7
-      - (auto_out.ansible_facts.discovered_interpreter_python == '/usr/bin/python' and distro_version is version('8','<')) or distro_version is version('8','>=')
+      - (auto_out.ansible_facts.discovered_interpreter_python == '/usr/bin/python' and distro_major_version is version('8','<')) or distro_major_version is version('8','>=')
       # rhel 8
-      - (auto_out.ansible_facts.discovered_interpreter_python == '/usr/libexec/platform-python' and distro_version is version('8','==')) or distro_version is version('8','!=')
+      - (auto_out.ansible_facts.discovered_interpreter_python == '/usr/libexec/platform-python' and distro_major_version is version('8','==')) or distro_major_version is version('8','!=')
       # rhel 9
-      - (auto_out.ansible_facts.discovered_interpreter_python == '/usr/bin/python3' and distro_version is version('9','==')) or distro_version is version('9','!=')
+      - (auto_out.ansible_facts.discovered_interpreter_python == '/usr/bin/python3' and distro_major_version is version('9','==')) or distro_major_version is version('9','!=')
     when: distro == 'redhat'
 
   - name: ubuntu assertions


### PR DESCRIPTION
##### SUMMARY
Add family fallback for RHEL to register as RedHat

Fixes #77368

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/facts/system/distribution.py

##### ADDITIONAL INFORMATION
In https://github.com/ansible/ansible/pull/76815 I missed that the `rhelish` fallback also supported `rhel`, but that `OS_FAMILY` did not declare `RHEL` as an alias of `RedHat`.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
