### PR TITLE
[2.12] fix shell/command/script tasks skipping in check mode (#76353)

### DIFF
--- a/changelogs/fragments/76353-fix-check-mode-skipping.yaml
+++ b/changelogs/fragments/76353-fix-check-mode-skipping.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - shell/command - only skip in check mode if the options `creates` and `removes` are both None.
+  - script - skip in check mode since the plugin cannot determine if a change will occur.

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -373,7 +373,8 @@ def main():
         # this is partial check_mode support, since we end up skipping if we get here
         r['rc'] = 0
         r['msg'] = "Command would have run if not in check mode"
-        r['skipped'] = True
+        if creates is None and removes is None:
+            r['skipped'] = True
 
     r['changed'] = True
 

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -119,7 +119,9 @@ class ActionModule(ActionBase):
                     script_cmd = ' '.join([env_string, target_command])
 
             if self._play_context.check_mode:
-                raise _AnsibleActionDone()
+                # If the script doesn't return changed in the result, it defaults to True,
+                # but since the script may override 'changed', just skip instead of guessing.
+                raise AnsibleActionSkip('Check mode is not supported for this task.')
 
             script_cmd = self._connection._shell.wrap_for_exec(script_cmd)
 

--- a/test/integration/targets/command_shell/tasks/main.yml
+++ b/test/integration/targets/command_shell/tasks/main.yml
@@ -155,6 +155,24 @@
     path: "{{ output_dir_test }}/afile.txt"
     state: absent
 
+- name: create afile.txt with create_afile.sh via command (check mode)
+  command: "{{ output_dir_test }}/create_afile.sh {{output_dir_test }}/afile.txt"
+  args:
+    creates: "{{ output_dir_test }}/afile.txt"
+  register: check_mode_result
+  check_mode: yes
+
+- assert:
+    that:
+      - check_mode_result.changed
+      - "'skipped' not in check_mode_result"
+
+- name: verify that afile.txt still does not exist
+  stat:
+    path: "{{output_dir_test}}/afile.txt"
+  register: stat_result
+  failed_when: stat_result.stat.exists
+
 - name: create afile.txt with create_afile.sh via command
   command: "{{ output_dir_test }}/create_afile.sh {{output_dir_test }}/afile.txt"
   args:
@@ -164,6 +182,18 @@
   file:
     path: "{{ output_dir_test }}/afile.txt"
     state: file
+
+- name: re-run previous command using creates with globbing (check mode)
+  command: "{{ output_dir_test }}/create_afile.sh {{ output_dir_test }}/afile.txt"
+  args:
+    creates: "{{ output_dir_test }}/afile.*"
+  register: check_mode_result
+  check_mode: yes
+
+- assert:
+    that:
+      - not check_mode_result.changed
+      - "'skipped' not in check_mode_result"
 
 - name: re-run previous command using creates with globbing
   command: "{{ output_dir_test }}/create_afile.sh {{ output_dir_test }}/afile.txt"
@@ -178,6 +208,24 @@
 
 # removes
 
+- name: remove afile.txt with remote_afile.sh via command (check mode)
+  command: "{{ output_dir_test }}/remove_afile.sh {{ output_dir_test }}/afile.txt"
+  args:
+    removes: "{{ output_dir_test }}/afile.txt"
+  register: check_mode_result
+  check_mode: yes
+
+- assert:
+    that:
+      - check_mode_result.changed
+      - "'skipped' not in check_mode_result"
+
+- name: verify that afile.txt still exists
+  stat:
+    path: "{{output_dir_test}}/afile.txt"
+  register: stat_result
+  failed_when: not stat_result.stat.exists
+
 - name: remove afile.txt with remote_afile.sh via command
   command: "{{ output_dir_test }}/remove_afile.sh {{ output_dir_test }}/afile.txt"
   args:
@@ -185,6 +233,18 @@
 
 - name: verify that afile.txt is absent
   file: path={{output_dir_test}}/afile.txt state=absent
+
+- name: re-run previous command using removes with globbing (check mode)
+  command: "{{ output_dir_test }}/remove_afile.sh {{ output_dir_test }}/afile.txt"
+  args:
+    removes: "{{ output_dir_test }}/afile.*"
+  register: check_mode_result
+  check_mode: yes
+
+- assert:
+    that:
+      - not check_mode_result.changed
+      - "'skipped' not in check_mode_result"
 
 - name: re-run previous command using removes with globbing
   command: "{{ output_dir_test }}/remove_afile.sh {{ output_dir_test }}/afile.txt"
@@ -450,6 +510,7 @@
   assert:
     that:
       - "'Command would have run if not in check mode' in result.msg"
+      - result.skipped
 
 - name: test check mode creates/removes message
   command:
@@ -462,6 +523,7 @@
   assert:
     that:
       - "'Command would have run if not in check mode' in result.msg"
+      - "'skipped' not in result"
 
 - name: command symlink handling
   block:


### PR DESCRIPTION
##### SUMMARY
Backport for #76353

* fix shell/command/script tasks skipping in check mode

* changelog

(cherry picked from commit de11a1ce781482e280c55d99ce571a130ae474bc)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
