### PR TITLE
winrm - ensure callers PATH for kinit is set

### DIFF
--- a/changelogs/fragments/winrm-kinit-path.yml
+++ b/changelogs/fragments/winrm-kinit-path.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- winrm - Ensure ``kinit`` is run with the same ``PATH`` env var as the Ansible process

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -8,6 +8,7 @@ __metaclass__ = type
 import fcntl
 import os
 import shlex
+import typing as t
 
 from abc import abstractmethod
 from functools import wraps
@@ -48,7 +49,7 @@ class ConnectionBase(AnsiblePlugin):
     # When running over this connection type, prefer modules written in a certain language
     # as discovered by the specified file extension.  An empty string as the
     # language means any language.
-    module_implementation_preferences = ('',)  # type: tuple[str, ...]
+    module_implementation_preferences = ('',)  # type: t.Iterable[str]
     allow_executable = True
 
     # the following control whether or not the connection supports the

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -320,7 +320,7 @@ class Connection(ConnectionBase):
         display.vvvvv("creating Kerberos CC at %s" % self._kerb_ccache.name)
         krb5ccname = "FILE:%s" % self._kerb_ccache.name
         os.environ["KRB5CCNAME"] = krb5ccname
-        krb5env = dict(KRB5CCNAME=krb5ccname)
+        krb5env = dict(PATH=os.environ["PATH"], KRB5CCNAME=krb5ccname)
 
         # Add any explicit environment vars into the krb5env block
         kinit_env_vars = self.get_option('kinit_env_vars')

--- a/test/units/plugins/connection/test_winrm.py
+++ b/test/units/plugins/connection/test_winrm.py
@@ -6,6 +6,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import os
+
 import pytest
 
 from io import StringIO
@@ -255,8 +257,9 @@ class TestWinRMKerbAuth(object):
         assert len(mock_calls) == 1
         assert mock_calls[0][1] == expected
         actual_env = mock_calls[0][2]['env']
-        assert list(actual_env.keys()) == ['KRB5CCNAME']
+        assert sorted(list(actual_env.keys())) == ['KRB5CCNAME', 'PATH']
         assert actual_env['KRB5CCNAME'].startswith("FILE:/")
+        assert actual_env['PATH'] == os.environ['PATH']
 
     @pytest.mark.parametrize('options, expected', [
         [{"_extras": {}},
@@ -287,8 +290,9 @@ class TestWinRMKerbAuth(object):
         mock_calls = mock_pexpect.mock_calls
         assert mock_calls[0][1] == expected
         actual_env = mock_calls[0][2]['env']
-        assert list(actual_env.keys()) == ['KRB5CCNAME']
+        assert sorted(list(actual_env.keys())) == ['KRB5CCNAME', 'PATH']
         assert actual_env['KRB5CCNAME'].startswith("FILE:/")
+        assert actual_env['PATH'] == os.environ['PATH']
         assert mock_calls[0][2]['echo'] is False
         assert mock_calls[1][0] == "().expect"
         assert mock_calls[1][1] == (".*:",)


### PR DESCRIPTION
##### SUMMARY
The `winrm` connection plugin calls `kinit` in a new subprocess but explicitly defines a new environment dict to run with. This means that any changes in the `PATH` as seen by the Ansible process are lost causing it to potentially fail to find `kinit`. By preserving the `PATH` for this subprocess it will be able to lookup `kinit` in the same environment as the caller.

Fixes https://github.com/ansible/ansible/issues/77390

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
winrm