### PR TITLE
winrm - ensure callers PATH for kinit is set (#77401) - 2.12

### DIFF
--- a/changelogs/fragments/winrm-kinit-path.yml
+++ b/changelogs/fragments/winrm-kinit-path.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- winrm - Ensure ``kinit`` is run with the same ``PATH`` env var as the Ansible process

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -319,7 +319,7 @@ class Connection(ConnectionBase):
         display.vvvvv("creating Kerberos CC at %s" % self._kerb_ccache.name)
         krb5ccname = "FILE:%s" % self._kerb_ccache.name
         os.environ["KRB5CCNAME"] = krb5ccname
-        krb5env = dict(KRB5CCNAME=krb5ccname)
+        krb5env = dict(PATH=os.environ["PATH"], KRB5CCNAME=krb5ccname)
 
         # Add any explicit environment vars into the krb5env block
         kinit_env_vars = self.get_option('kinit_env_vars')

--- a/test/units/plugins/connection/test_winrm.py
+++ b/test/units/plugins/connection/test_winrm.py
@@ -6,6 +6,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import os
+
 import pytest
 
 from io import StringIO
@@ -255,8 +257,9 @@ class TestWinRMKerbAuth(object):
         assert len(mock_calls) == 1
         assert mock_calls[0][1] == expected
         actual_env = mock_calls[0][2]['env']
-        assert list(actual_env.keys()) == ['KRB5CCNAME']
+        assert sorted(list(actual_env.keys())) == ['KRB5CCNAME', 'PATH']
         assert actual_env['KRB5CCNAME'].startswith("FILE:/")
+        assert actual_env['PATH'] == os.environ['PATH']
 
     @pytest.mark.parametrize('options, expected', [
         [{"_extras": {}},
@@ -287,8 +290,9 @@ class TestWinRMKerbAuth(object):
         mock_calls = mock_pexpect.mock_calls
         assert mock_calls[0][1] == expected
         actual_env = mock_calls[0][2]['env']
-        assert list(actual_env.keys()) == ['KRB5CCNAME']
+        assert sorted(list(actual_env.keys())) == ['KRB5CCNAME', 'PATH']
         assert actual_env['KRB5CCNAME'].startswith("FILE:/")
+        assert actual_env['PATH'] == os.environ['PATH']
         assert mock_calls[0][2]['echo'] is False
         assert mock_calls[1][0] == "().expect"
         assert mock_calls[1][1] == (".*:",)


### PR DESCRIPTION
(cherry picked from commit 60b4200bc6fee69384da990bb7884f58577fc724)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/77401

Type annotation was dropped due to Python 2.7 compatibility and mypy not being enabled on this branch.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
winrm