### PR TITLE
get_url: remove deprecated sha256sum module param

### DIFF
--- a/changelogs/fragments/get_url-remove-deprecated-sha256sum.yml
+++ b/changelogs/fragments/get_url-remove-deprecated-sha256sum.yml
@@ -1,0 +1,2 @@
+removed_features:
+  - get_url - remove deprecated ``sha256sum`` module param

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -67,16 +67,6 @@ options:
     type: bool
     default: no
     version_added: '2.1'
-  sha256sum:
-    description:
-      - If a SHA-256 checksum is passed to this parameter, the digest of the
-        destination file will be calculated after it is downloaded to ensure
-        its integrity and verify that the transfer completed successfully.
-        This option is deprecated and will be removed in version 2.14. Use
-        option C(checksum) instead.
-    default: ''
-    type: str
-    version_added: "1.3"
   checksum:
     description:
       - 'If a checksum is passed to this parameter, the digest of the
@@ -462,7 +452,6 @@ def main():
         url=dict(type='str', required=True),
         dest=dict(type='path', required=True),
         backup=dict(type='bool', default=False),
-        sha256sum=dict(type='str', default=''),
         checksum=dict(type='str', default=''),
         timeout=dict(type='int', default=10),
         headers=dict(type='dict'),
@@ -475,18 +464,12 @@ def main():
         argument_spec=argument_spec,
         add_file_common_args=True,
         supports_check_mode=True,
-        mutually_exclusive=[['checksum', 'sha256sum']],
     )
-
-    if module.params.get('sha256sum'):
-        module.deprecate('The parameter "sha256sum" has been deprecated and will be removed, use "checksum" instead',
-                         version='2.14', collection_name='ansible.builtin')
 
     url = module.params['url']
     dest = module.params['dest']
     backup = module.params['backup']
     force = module.params['force']
-    sha256sum = module.params['sha256sum']
     checksum = module.params['checksum']
     use_proxy = module.params['use_proxy']
     timeout = module.params['timeout']
@@ -505,10 +488,6 @@ def main():
 
     dest_is_dir = os.path.isdir(dest)
     last_mod_time = None
-
-    # workaround for usage of deprecated sha256sum parameter
-    if sha256sum:
-        checksum = 'sha256:%s' % (sha256sum)
 
     # checksum specified, parse for algorithm and checksum
     if checksum:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -333,7 +333,6 @@ lib/ansible/module_utils/compat/_selectors2.py mypy-3.9:assignment  # vendored c
 lib/ansible/module_utils/compat/_selectors2.py mypy-3.10:assignment  # vendored code
 lib/ansible/module_utils/compat/_selectors2.py mypy-2.7:attr-defined  # vendored code
 lib/ansible/modules/apt_key.py validate-modules:ansible-deprecated-version
-lib/ansible/modules/get_url.py pylint:ansible-deprecated-version
 lib/ansible/plugins/cache/__init__.py pylint:ansible-deprecated-version
 lib/ansible/plugins/callback/default.py pylint:ansible-deprecated-version
 test/support/integration/plugins/modules/ec2.py pylint:ansible-deprecated-version


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/get_url.py`