### PR TITLE
Remove deprecated ALLOW_WORLD_READABLE_TMPFILES config option

### DIFF
--- a/changelogs/fragments/77393-remove-allow_world_readable_tmpfiles.yml
+++ b/changelogs/fragments/77393-remove-allow_world_readable_tmpfiles.yml
@@ -1,0 +1,2 @@
+removed_features:
+  - Remove deprecated ``ALLOW_WORLD_READABLE_TMPFILES`` configuration option (https://github.com/ansible/ansible/issues/77393)

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1,18 +1,6 @@
 # Copyright (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
-ALLOW_WORLD_READABLE_TMPFILES:
-  name: Allow world-readable temporary files
-  description:
-    - This setting has been moved to the individual shell plugins as a plugin option :ref:`shell_plugins`.
-    - The existing configuration settings are still accepted with the shell plugin adding additional options, like variables.
-    - This message will be removed in 2.14.
-  type: boolean
-  default: False
-  deprecated:  # (kept for autodetection and removal, deprecation is irrelevant since w/o settings this can never show runtime msg)
-      why: moved to shell plugins
-      version: "2.14"
-      alternatives: 'world_readable_tmp'
 ANSIBLE_CONNECTION_PATH:
   name: Path of ansible-connection script
   default: null

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -722,7 +722,7 @@ class ActionBase(ABC):
         # create an extra round trip.
         #
         # Also note that due to the above, this can prevent the
-        # ALLOW_WORLD_READABLE_TMPFILES logic below from ever getting called. We
+        # world_readable_temp logic below from ever getting called. We
         # leave this up to the user to rectify if they have both of these
         # features enabled.
         group = self.get_shell_option('common_remote_group')

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -503,7 +503,7 @@ class TestActionBase(unittest.TestCase):
             'stderr': '',
         }
         # TODO: Add test to assert warning is shown if
-        # ALLOW_WORLD_READABLE_TMPFILES is set in this case.
+        # world_readable_temp is set in this case.
         assertSuccess()
         action_base._remote_chgrp.assert_called_once_with(
             remote_paths,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #77393
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/config/base.yml`