### PR TITLE
add required file to collection skeleton

### DIFF
--- a/changelogs/fragments/77418-ansible-galaxy-init-include-meta-runtime.yml
+++ b/changelogs/fragments/77418-ansible-galaxy-init-include-meta-runtime.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - fix missing meta/runtime.yml in default galaxy skeleton used for ansible-galaxy collection init 

--- a/lib/ansible/galaxy/data/default/collection/meta/runtime.yml
+++ b/lib/ansible/galaxy/data/default/collection/meta/runtime.yml
@@ -1,0 +1,4 @@
+---
+# Collections must specify a minimum required ansible version to upload
+# to galaxy
+# requires_ansible: '>=2.9.10'

--- a/test/integration/targets/ansible-galaxy-collection/tasks/init.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/init.yml
@@ -19,10 +19,10 @@
   assert:
     that:
     - '"Collection ansible_test.my_collection was created successfully" in init_relative.stdout'
-    - init_relative_actual.files | length == 3
-    - (init_relative_actual.files | map(attribute='path') | list)[0] | basename in ['docs', 'plugins', 'roles']
-    - (init_relative_actual.files | map(attribute='path') | list)[1] | basename in ['docs', 'plugins', 'roles']
-    - (init_relative_actual.files | map(attribute='path') | list)[2] | basename in ['docs', 'plugins', 'roles']
+    - init_relative_actual.files | length == 4
+    - (init_relative_actual.files | map(attribute='path') | list)[0] | basename in ['docs', 'plugins', 'roles', 'meta']
+    - (init_relative_actual.files | map(attribute='path') | list)[1] | basename in ['docs', 'plugins', 'roles', 'meta']
+    - (init_relative_actual.files | map(attribute='path') | list)[2] | basename in ['docs', 'plugins', 'roles', 'meta']
 
 - name: create collection with custom init path
   command: ansible-galaxy collection init ansible_test2.my_collection --init-path "{{ galaxy_dir }}/scratch/custom-init-dir" {{ galaxy_verbosity }}
@@ -38,10 +38,10 @@
   assert:
     that:
     - '"Collection ansible_test2.my_collection was created successfully" in init_custom_path.stdout'
-    - init_custom_path_actual.files | length == 3
-    - (init_custom_path_actual.files | map(attribute='path') | list)[0] | basename in ['docs', 'plugins', 'roles']
-    - (init_custom_path_actual.files | map(attribute='path') | list)[1] | basename in ['docs', 'plugins', 'roles']
-    - (init_custom_path_actual.files | map(attribute='path') | list)[2] | basename in ['docs', 'plugins', 'roles']
+    - init_custom_path_actual.files | length == 4
+    - (init_custom_path_actual.files | map(attribute='path') | list)[0] | basename in ['docs', 'plugins', 'roles', 'meta']
+    - (init_custom_path_actual.files | map(attribute='path') | list)[1] | basename in ['docs', 'plugins', 'roles', 'meta']
+    - (init_custom_path_actual.files | map(attribute='path') | list)[2] | basename in ['docs', 'plugins', 'roles', 'meta']
 
 - name: add a directory to the init collection path to test that --force removes it
   file:
@@ -62,10 +62,10 @@
   assert:
     that:
     - '"Collection ansible_test2.my_collection was created successfully" in init_custom_path.stdout'
-    - init_custom_path_actual.files | length == 3
-    - (init_custom_path_actual.files | map(attribute='path') | list)[0] | basename in ['docs', 'plugins', 'roles']
-    - (init_custom_path_actual.files | map(attribute='path') | list)[1] | basename in ['docs', 'plugins', 'roles']
-    - (init_custom_path_actual.files | map(attribute='path') | list)[2] | basename in ['docs', 'plugins', 'roles']
+    - init_custom_path_actual.files | length == 4
+    - (init_custom_path_actual.files | map(attribute='path') | list)[0] | basename in ['docs', 'plugins', 'roles', 'meta']
+    - (init_custom_path_actual.files | map(attribute='path') | list)[1] | basename in ['docs', 'plugins', 'roles', 'meta']
+    - (init_custom_path_actual.files | map(attribute='path') | list)[2] | basename in ['docs', 'plugins', 'roles', 'meta']
 
 - name: create collection in cwd with custom init path
   command: ansible-galaxy collection init ansible_test2.my_collection --init-path ../../ --force {{ galaxy_verbosity }}
@@ -83,10 +83,10 @@
   assert:
     that:
     - '"Collection ansible_test2.my_collection was created successfully" in init_custom_path.stdout'
-    - init_custom_path_actual.files | length == 3
-    - (init_custom_path_actual.files | map(attribute='path') | list)[0] | basename in ['docs', 'plugins', 'roles']
-    - (init_custom_path_actual.files | map(attribute='path') | list)[1] | basename in ['docs', 'plugins', 'roles']
-    - (init_custom_path_actual.files | map(attribute='path') | list)[2] | basename in ['docs', 'plugins', 'roles']
+    - init_custom_path_actual.files | length == 4
+    - (init_custom_path_actual.files | map(attribute='path') | list)[0] | basename in ['docs', 'plugins', 'roles', 'meta']
+    - (init_custom_path_actual.files | map(attribute='path') | list)[1] | basename in ['docs', 'plugins', 'roles', 'meta']
+    - (init_custom_path_actual.files | map(attribute='path') | list)[2] | basename in ['docs', 'plugins', 'roles', 'meta']
 
 - name: create collection for ignored files and folders
   command: ansible-galaxy collection init ansible_test.ignore

--- a/test/integration/targets/ansible-galaxy-collection/tasks/init.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/init.yml
@@ -23,6 +23,7 @@
     - (init_relative_actual.files | map(attribute='path') | list)[0] | basename in ['docs', 'plugins', 'roles', 'meta']
     - (init_relative_actual.files | map(attribute='path') | list)[1] | basename in ['docs', 'plugins', 'roles', 'meta']
     - (init_relative_actual.files | map(attribute='path') | list)[2] | basename in ['docs', 'plugins', 'roles', 'meta']
+    - (init_relative_actual.files | map(attribute='path') | list)[3] | basename in ['docs', 'plugins', 'roles', 'meta']
 
 - name: create collection with custom init path
   command: ansible-galaxy collection init ansible_test2.my_collection --init-path "{{ galaxy_dir }}/scratch/custom-init-dir" {{ galaxy_verbosity }}
@@ -42,6 +43,7 @@
     - (init_custom_path_actual.files | map(attribute='path') | list)[0] | basename in ['docs', 'plugins', 'roles', 'meta']
     - (init_custom_path_actual.files | map(attribute='path') | list)[1] | basename in ['docs', 'plugins', 'roles', 'meta']
     - (init_custom_path_actual.files | map(attribute='path') | list)[2] | basename in ['docs', 'plugins', 'roles', 'meta']
+    - (init_custom_path_actual.files | map(attribute='path') | list)[3] | basename in ['docs', 'plugins', 'roles', 'meta']
 
 - name: add a directory to the init collection path to test that --force removes it
   file:

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -640,7 +640,7 @@ def test_collection_build(collection_artifact):
         tar_members = tar.getmembers()
 
         valid_files = ['MANIFEST.json', 'FILES.json', 'roles', 'docs', 'plugins', 'plugins/README.md', 'README.md',
-                       'runme.sh']
+                       'runme.sh', 'meta', 'meta/runtime.yml']
         assert len(tar_members) == len(valid_files)
 
         # Verify the uid and gid is 0 and the correct perms are set
@@ -696,16 +696,16 @@ def test_collection_build(collection_artifact):
         finally:
             files_file.close()
 
-        assert len(files['files']) == 7
+        assert len(files['files']) == 9
         assert files['format'] == 1
         assert len(files.keys()) == 2
 
-        valid_files_entries = ['.', 'roles', 'docs', 'plugins', 'plugins/README.md', 'README.md', 'runme.sh']
+        valid_files_entries = ['.', 'roles', 'docs', 'plugins', 'plugins/README.md', 'README.md', 'runme.sh', 'meta', 'meta/runtime.yml']
         for file_entry in files['files']:
             assert file_entry['name'] in valid_files_entries
             assert file_entry['format'] == 1
 
-            if file_entry['name'] in ['plugins/README.md', 'runme.sh']:
+            if file_entry['name'] in ['plugins/README.md', 'runme.sh', 'meta/runtime.yml']:
                 assert file_entry['ftype'] == 'file'
                 assert file_entry['chksum_type'] == 'sha256'
                 # Can't test the actual checksum as the html link changes based on the version or the file contents


### PR DESCRIPTION
This file is required to be able to upload a collection

It is present in
https://github.com/ansible-collections/collection_template/blob/main/meta/runtime.yml
but that does not get used by default.

Without this, if you use the "ansible-galaxy collection init" command
and you try and publish that collection without adding this file, you
get the error:

"ERROR! Galaxy import process failed: 'requires_ansible' in
meta/runtime.yml is mandatory, but no meta/runtime.yml found (Code:
UNKNOWN)"

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
add file to collection skeleton that is needed for uploading

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-galaxy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This file is present in this other collection skeleton repo, but didn't get added here to this skeleton which is what is actually used by the command afaik.

It would be nice to be able to backport this.
I'm not super opininonated on the ansible version, just that it should be one in which collections are supported -- I just copied what is in this other repo's meta/runtime.yml https://github.com/ansible-collections/collection_template/blob/main/meta/runtime.yml