### PR TITLE
Re-organize CI test groups for POSIX tests. 

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -104,6 +104,18 @@ stages:
           groups:
             - 1
             - 2
+      - template: templates/matrix.yml
+        parameters:
+          targets:
+            - name: macOS 12.0
+              test: macos/12.0
+            - name: RHEL 8.6
+              test: rhel/8.6
+            - name: RHEL 9.0
+              test: rhel/9.0
+            - name: FreeBSD 13.1
+              test: freebsd/13.1
+          groups:
             - 3
             - 4
             - 5
@@ -131,6 +143,19 @@ stages:
           groups:
             - 1
             - 2
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: linux/{0}
+          targets:
+            - name: Alpine 3
+              test: alpine3
+            - name: Fedora 35
+              test: fedora35
+            - name: Fedora 36
+              test: fedora36
+            - name: Ubuntu 22.04
+              test: ubuntu2204
+          groups:
             - 3
             - 4
             - 5

--- a/test/integration/targets/adhoc/aliases
+++ b/test/integration/targets/adhoc/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group2
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/ansible-doc/aliases
+++ b/test/integration/targets/ansible-doc/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group1
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/ansible-galaxy-collection-scm/aliases
+++ b/test/integration/targets/ansible-galaxy-collection-scm/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group4
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/ansible-galaxy-role/aliases
+++ b/test/integration/targets/ansible-galaxy-role/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group4
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/ansible-galaxy/aliases
+++ b/test/integration/targets/ansible-galaxy/aliases
@@ -1,3 +1,3 @@
 destructive
-shippable/posix/group4
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/ansible-inventory/aliases
+++ b/test/integration/targets/ansible-inventory/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group5
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/ansible-pull/aliases
+++ b/test/integration/targets/ansible-pull/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/ansible-runner/aliases
+++ b/test/integration/targets/ansible-runner/aliases
@@ -1,4 +1,4 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller
 skip/osx
 skip/macos

--- a/test/integration/targets/ansible-test-cloud-httptester/aliases
+++ b/test/integration/targets/ansible-test-cloud-httptester/aliases
@@ -1,3 +1,3 @@
 needs/httptester  # using legacy alias for testing purposes
-shippable/posix/group1
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/ansible-test-config-invalid/aliases
+++ b/test/integration/targets/ansible-test-config-invalid/aliases
@@ -1,4 +1,4 @@
-shippable/posix/group1  # runs in the distro test containers
+shippable/posix/group3  # runs in the distro test containers
 shippable/generic/group1  # runs in the default test container
 context/controller
 needs/target/collection

--- a/test/integration/targets/ansible-test-config/aliases
+++ b/test/integration/targets/ansible-test-config/aliases
@@ -1,4 +1,4 @@
-shippable/posix/group1  # runs in the distro test containers
+shippable/posix/group3  # runs in the distro test containers
 shippable/generic/group1  # runs in the default test container
 context/controller
 needs/target/collection

--- a/test/integration/targets/ansible-test-no-tty/aliases
+++ b/test/integration/targets/ansible-test-no-tty/aliases
@@ -1,4 +1,4 @@
 context/controller
-shippable/posix/group1  # runs in the distro test containers
+shippable/posix/group3  # runs in the distro test containers
 shippable/generic/group1  # runs in the default test container
 needs/target/collection

--- a/test/integration/targets/ansible-test-sanity-lint/aliases
+++ b/test/integration/targets/ansible-test-sanity-lint/aliases
@@ -1,4 +1,4 @@
-shippable/posix/group1  # runs in the distro test containers
+shippable/posix/group3  # runs in the distro test containers
 shippable/generic/group1  # runs in the default test container
 context/controller
 needs/target/collection

--- a/test/integration/targets/ansible-test-sanity-shebang/aliases
+++ b/test/integration/targets/ansible-test-sanity-shebang/aliases
@@ -1,4 +1,4 @@
-shippable/posix/group1  # runs in the distro test containers
+shippable/posix/group3  # runs in the distro test containers
 shippable/generic/group1  # runs in the default test container
 context/controller
 needs/target/collection

--- a/test/integration/targets/ansible-test-shell/aliases
+++ b/test/integration/targets/ansible-test-shell/aliases
@@ -1,4 +1,4 @@
-shippable/posix/group1  # runs in the distro test containers
+shippable/posix/group3  # runs in the distro test containers
 shippable/generic/group1  # runs in the default test container
 context/controller
 needs/target/collection

--- a/test/integration/targets/ansible-test/aliases
+++ b/test/integration/targets/ansible-test/aliases
@@ -1,4 +1,4 @@
-shippable/posix/group1  # runs in the distro test containers
+shippable/posix/group3  # runs in the distro test containers
 shippable/generic/group1  # runs in the default test container
 context/controller
 needs/target/collection

--- a/test/integration/targets/ansible-vault/aliases
+++ b/test/integration/targets/ansible-vault/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/ansible/aliases
+++ b/test/integration/targets/ansible/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group4
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/any_errors_fatal/aliases
+++ b/test/integration/targets/any_errors_fatal/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/apt/aliases
+++ b/test/integration/targets/apt/aliases
@@ -1,4 +1,4 @@
-shippable/posix/group5
+shippable/posix/group2
 destructive
 skip/freebsd
 skip/osx

--- a/test/integration/targets/args/aliases
+++ b/test/integration/targets/args/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/argspec/aliases
+++ b/test/integration/targets/argspec/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group5
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/assert/aliases
+++ b/test/integration/targets/assert/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller  # this is a controller-only action, the module is just for documentation

--- a/test/integration/targets/async_extra_data/aliases
+++ b/test/integration/targets/async_extra_data/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group5
+shippable/posix/group2
 context/target

--- a/test/integration/targets/become_su/aliases
+++ b/test/integration/targets/become_su/aliases
@@ -1,3 +1,3 @@
 destructive
-shippable/posix/group1
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/become_unprivileged/aliases
+++ b/test/integration/targets/become_unprivileged/aliases
@@ -1,5 +1,5 @@
 destructive
-shippable/posix/group1
+shippable/posix/group3
 needs/ssh
 needs/root
 context/controller

--- a/test/integration/targets/binary_modules_posix/aliases
+++ b/test/integration/targets/binary_modules_posix/aliases
@@ -1,3 +1,3 @@
-shippable/posix/group3
+shippable/posix/group2
 needs/target/binary_modules
 context/target

--- a/test/integration/targets/blocks/aliases
+++ b/test/integration/targets/blocks/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/builtin_vars_prompt/aliases
+++ b/test/integration/targets/builtin_vars_prompt/aliases
@@ -1,4 +1,4 @@
 setup/always/setup_passlib
 setup/always/setup_pexpect
-shippable/posix/group4
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/callback_default/aliases
+++ b/test/integration/targets/callback_default/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group1
+shippable/posix/group3

--- a/test/integration/targets/changed_when/aliases
+++ b/test/integration/targets/changed_when/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group2
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/check_mode/aliases
+++ b/test/integration/targets/check_mode/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/cli/aliases
+++ b/test/integration/targets/cli/aliases
@@ -2,5 +2,5 @@ destructive
 needs/root
 needs/ssh
 needs/target/setup_pexpect
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/collections/aliases
+++ b/test/integration/targets/collections/aliases
@@ -1,4 +1,4 @@
 posix
-shippable/posix/group4
+shippable/posix/group1
 shippable/windows/group1
 windows

--- a/test/integration/targets/collections_plugin_namespace/aliases
+++ b/test/integration/targets/collections_plugin_namespace/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group1
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/collections_runtime_pythonpath/aliases
+++ b/test/integration/targets/collections_runtime_pythonpath/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group4
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/command_nonexisting/aliases
+++ b/test/integration/targets/command_nonexisting/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group2
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/common_network/aliases
+++ b/test/integration/targets/common_network/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group5
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/conditionals/aliases
+++ b/test/integration/targets/conditionals/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group1
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/config/aliases
+++ b/test/integration/targets/config/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group1
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/connection_delegation/aliases
+++ b/test/integration/targets/connection_delegation/aliases
@@ -1,4 +1,4 @@
-shippable/posix/group1
+shippable/posix/group3
 context/controller
 skip/freebsd  # No sshpass
 skip/osx  # No sshpass

--- a/test/integration/targets/connection_local/aliases
+++ b/test/integration/targets/connection_local/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 needs/target/connection

--- a/test/integration/targets/connection_paramiko_ssh/aliases
+++ b/test/integration/targets/connection_paramiko_ssh/aliases
@@ -1,5 +1,5 @@
 needs/ssh
-shippable/posix/group3
+shippable/posix/group5
 needs/target/setup_paramiko
 needs/target/connection
 destructive  # potentially installs/uninstalls OS packages via setup_paramiko

--- a/test/integration/targets/connection_remote_is_local/aliases
+++ b/test/integration/targets/connection_remote_is_local/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/connection_ssh/aliases
+++ b/test/integration/targets/connection_ssh/aliases
@@ -1,3 +1,3 @@
 needs/ssh
-shippable/posix/group1
+shippable/posix/group3
 needs/target/connection

--- a/test/integration/targets/controller/aliases
+++ b/test/integration/targets/controller/aliases
@@ -1,2 +1,2 @@
 context/controller
-shippable/posix/group1
+shippable/posix/group3

--- a/test/integration/targets/cron/aliases
+++ b/test/integration/targets/cron/aliases
@@ -1,4 +1,4 @@
 destructive
-shippable/posix/group4
+shippable/posix/group1
 skip/osx
 skip/macos

--- a/test/integration/targets/dataloader/aliases
+++ b/test/integration/targets/dataloader/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group1
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/debug/aliases
+++ b/test/integration/targets/debug/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group1
+shippable/posix/group3
 context/controller  # this is a controller-only action, the module is just for documentation

--- a/test/integration/targets/debugger/aliases
+++ b/test/integration/targets/debugger/aliases
@@ -1,3 +1,3 @@
-shippable/posix/group1
+shippable/posix/group3
 context/controller
 setup/always/setup_pexpect

--- a/test/integration/targets/delegate_to/aliases
+++ b/test/integration/targets/delegate_to/aliases
@@ -1,4 +1,4 @@
-shippable/posix/group3
+shippable/posix/group5
 needs/ssh
 needs/root  # only on macOS and FreeBSD to configure network interfaces
 context/controller

--- a/test/integration/targets/dict_transformations/aliases
+++ b/test/integration/targets/dict_transformations/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group1
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/dnf/aliases
+++ b/test/integration/targets/dnf/aliases
@@ -1,5 +1,5 @@
 destructive
-shippable/posix/group4
+shippable/posix/group1
 skip/power/centos
 skip/freebsd
 skip/osx

--- a/test/integration/targets/egg-info/aliases
+++ b/test/integration/targets/egg-info/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group1
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/entry_points/aliases
+++ b/test/integration/targets/entry_points/aliases
@@ -1,2 +1,2 @@
 context/controller
-shippable/posix/group5
+shippable/posix/group4

--- a/test/integration/targets/environment/aliases
+++ b/test/integration/targets/environment/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group2
 context/target

--- a/test/integration/targets/error_from_connection/aliases
+++ b/test/integration/targets/error_from_connection/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group2
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/facts_linux_network/aliases
+++ b/test/integration/targets/facts_linux_network/aliases
@@ -1,5 +1,5 @@
 needs/privileged
-shippable/posix/group2
+shippable/posix/group1
 skip/freebsd
 skip/osx
 skip/macos

--- a/test/integration/targets/failed_when/aliases
+++ b/test/integration/targets/failed_when/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group2
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/filter_core/aliases
+++ b/test/integration/targets/filter_core/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/filter_encryption/aliases
+++ b/test/integration/targets/filter_encryption/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/filter_mathstuff/aliases
+++ b/test/integration/targets/filter_mathstuff/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/filter_urls/aliases
+++ b/test/integration/targets/filter_urls/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/filter_urlsplit/aliases
+++ b/test/integration/targets/filter_urlsplit/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/gathering/aliases
+++ b/test/integration/targets/gathering/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/gathering_facts/aliases
+++ b/test/integration/targets/gathering_facts/aliases
@@ -1,3 +1,3 @@
-shippable/posix/group3
+shippable/posix/group5
 needs/root
 context/controller

--- a/test/integration/targets/git/aliases
+++ b/test/integration/targets/git/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group4
+shippable/posix/group1

--- a/test/integration/targets/group_by/aliases
+++ b/test/integration/targets/group_by/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group3
+shippable/posix/group2

--- a/test/integration/targets/groupby_filter/aliases
+++ b/test/integration/targets/groupby_filter/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group2
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/handler_race/aliases
+++ b/test/integration/targets/handler_race/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group5
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/handlers/aliases
+++ b/test/integration/targets/handlers/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group5
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/hardware_facts/aliases
+++ b/test/integration/targets/hardware_facts/aliases
@@ -1,4 +1,4 @@
 destructive
 needs/privileged
-shippable/posix/group2
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/hash/aliases
+++ b/test/integration/targets/hash/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/hosts_field/aliases
+++ b/test/integration/targets/hosts_field/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/ignore_errors/aliases
+++ b/test/integration/targets/ignore_errors/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group4
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/ignore_unreachable/aliases
+++ b/test/integration/targets/ignore_unreachable/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/import_tasks/aliases
+++ b/test/integration/targets/import_tasks/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group5
+shippable/posix/group4
 context/controller  # this is a controller-only action, the module is just for documentation

--- a/test/integration/targets/include_import/aliases
+++ b/test/integration/targets/include_import/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group5
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/include_vars-ad-hoc/aliases
+++ b/test/integration/targets/include_vars-ad-hoc/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group2
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/include_when_parent_is_dynamic/aliases
+++ b/test/integration/targets/include_when_parent_is_dynamic/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/include_when_parent_is_static/aliases
+++ b/test/integration/targets/include_when_parent_is_static/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/includes/aliases
+++ b/test/integration/targets/includes/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/includes_race/aliases
+++ b/test/integration/targets/includes_race/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group5
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/infra/aliases
+++ b/test/integration/targets/infra/aliases
@@ -1,4 +1,4 @@
-shippable/posix/group3
+shippable/posix/group5
 needs/file/hacking/test-module.py
 needs/file/lib/ansible/modules/ping.py
 context/controller

--- a/test/integration/targets/interpreter_discovery_python_delegate_facts/aliases
+++ b/test/integration/targets/interpreter_discovery_python_delegate_facts/aliases
@@ -1,3 +1,3 @@
-shippable/posix/group1
+shippable/posix/group3
 non_local  # this test requires interpreter discovery, which means code coverage must be disabled
 context/controller

--- a/test/integration/targets/inventory/aliases
+++ b/test/integration/targets/inventory/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/inventory_advanced_host_list/aliases
+++ b/test/integration/targets/inventory_advanced_host_list/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group1
+shippable/posix/group3

--- a/test/integration/targets/inventory_cache/aliases
+++ b/test/integration/targets/inventory_cache/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group5
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/inventory_constructed/aliases
+++ b/test/integration/targets/inventory_constructed/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group3
+shippable/posix/group5

--- a/test/integration/targets/inventory_ini/aliases
+++ b/test/integration/targets/inventory_ini/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group5
+shippable/posix/group4

--- a/test/integration/targets/inventory_script/aliases
+++ b/test/integration/targets/inventory_script/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group1
+shippable/posix/group3

--- a/test/integration/targets/inventory_yaml/aliases
+++ b/test/integration/targets/inventory_yaml/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group1
+shippable/posix/group3

--- a/test/integration/targets/jinja2_native_types/aliases
+++ b/test/integration/targets/jinja2_native_types/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/jinja_plugins/aliases
+++ b/test/integration/targets/jinja_plugins/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group5
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/json_cleanup/aliases
+++ b/test/integration/targets/json_cleanup/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group2
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/limit_inventory/aliases
+++ b/test/integration/targets/limit_inventory/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group4
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/lookup_config/aliases
+++ b/test/integration/targets/lookup_config/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/lookup_csvfile/aliases
+++ b/test/integration/targets/lookup_csvfile/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/lookup_dict/aliases
+++ b/test/integration/targets/lookup_dict/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group1
+shippable/posix/group3

--- a/test/integration/targets/lookup_env/aliases
+++ b/test/integration/targets/lookup_env/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group1
+shippable/posix/group3

--- a/test/integration/targets/lookup_file/aliases
+++ b/test/integration/targets/lookup_file/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group1
+shippable/posix/group3

--- a/test/integration/targets/lookup_fileglob/aliases
+++ b/test/integration/targets/lookup_fileglob/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group1
+shippable/posix/group3

--- a/test/integration/targets/lookup_first_found/aliases
+++ b/test/integration/targets/lookup_first_found/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/lookup_indexed_items/aliases
+++ b/test/integration/targets/lookup_indexed_items/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/lookup_ini/aliases
+++ b/test/integration/targets/lookup_ini/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group3
+shippable/posix/group5

--- a/test/integration/targets/lookup_inventory_hostnames/aliases
+++ b/test/integration/targets/lookup_inventory_hostnames/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/lookup_items/aliases
+++ b/test/integration/targets/lookup_items/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/lookup_lines/aliases
+++ b/test/integration/targets/lookup_lines/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/lookup_list/aliases
+++ b/test/integration/targets/lookup_list/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/lookup_nested/aliases
+++ b/test/integration/targets/lookup_nested/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/lookup_password/aliases
+++ b/test/integration/targets/lookup_password/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group1
+shippable/posix/group3

--- a/test/integration/targets/lookup_pipe/aliases
+++ b/test/integration/targets/lookup_pipe/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group1
+shippable/posix/group3

--- a/test/integration/targets/lookup_random_choice/aliases
+++ b/test/integration/targets/lookup_random_choice/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/lookup_sequence/aliases
+++ b/test/integration/targets/lookup_sequence/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/lookup_subelements/aliases
+++ b/test/integration/targets/lookup_subelements/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/lookup_template/aliases
+++ b/test/integration/targets/lookup_template/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group1
+shippable/posix/group3

--- a/test/integration/targets/lookup_together/aliases
+++ b/test/integration/targets/lookup_together/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/lookup_unvault/aliases
+++ b/test/integration/targets/lookup_unvault/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group2
+shippable/posix/group4
 needs/root

--- a/test/integration/targets/lookup_url/aliases
+++ b/test/integration/targets/lookup_url/aliases
@@ -1,4 +1,4 @@
 destructive
-shippable/posix/group1
+shippable/posix/group3
 needs/httptester
 skip/macos/12.0  # This test crashes Python due to https://wefearchange.org/2018/11/forkmacos.rst.html

--- a/test/integration/targets/lookup_varnames/aliases
+++ b/test/integration/targets/lookup_varnames/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group2
+shippable/posix/group4

--- a/test/integration/targets/lookup_vars/aliases
+++ b/test/integration/targets/lookup_vars/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group1
+shippable/posix/group3

--- a/test/integration/targets/loop-until/aliases
+++ b/test/integration/targets/loop-until/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group2
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/loop_control/aliases
+++ b/test/integration/targets/loop_control/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group2
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/loops/aliases
+++ b/test/integration/targets/loops/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group2
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/meta_tasks/aliases
+++ b/test/integration/targets/meta_tasks/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/missing_required_lib/aliases
+++ b/test/integration/targets/missing_required_lib/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group5
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/module_defaults/aliases
+++ b/test/integration/targets/module_defaults/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group1
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/module_no_log/aliases
+++ b/test/integration/targets/module_no_log/aliases
@@ -1,4 +1,4 @@
-shippable/posix/group1
+shippable/posix/group3
 context/controller
 skip/freebsd  # not configured to log user.info to /var/log/syslog
 skip/osx  # not configured to log user.info to /var/log/syslog

--- a/test/integration/targets/module_precedence/aliases
+++ b/test/integration/targets/module_precedence/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group1
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/module_tracebacks/aliases
+++ b/test/integration/targets/module_tracebacks/aliases
@@ -1,3 +1,3 @@
-shippable/posix/group4
+shippable/posix/group3
 needs/ssh
 context/controller

--- a/test/integration/targets/module_utils/aliases
+++ b/test/integration/targets/module_utils/aliases
@@ -1,4 +1,4 @@
-shippable/posix/group3
+shippable/posix/group2
 needs/root
 needs/target/setup_test_user
 needs/target/setup_remote_tmp_dir

--- a/test/integration/targets/module_utils_distro/aliases
+++ b/test/integration/targets/module_utils_distro/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/no_log/aliases
+++ b/test/integration/targets/no_log/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group5
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/noexec/aliases
+++ b/test/integration/targets/noexec/aliases
@@ -1,4 +1,4 @@
-shippable/posix/group2
+shippable/posix/group4
 context/controller
 skip/docker
 skip/macos

--- a/test/integration/targets/old_style_cache_plugins/aliases
+++ b/test/integration/targets/old_style_cache_plugins/aliases
@@ -1,6 +1,6 @@
 destructive
 needs/root
-shippable/posix/group3
+shippable/posix/group5
 context/controller
 skip/osx
 skip/macos

--- a/test/integration/targets/old_style_modules_posix/aliases
+++ b/test/integration/targets/old_style_modules_posix/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group2
 context/target

--- a/test/integration/targets/omit/aliases
+++ b/test/integration/targets/omit/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/order/aliases
+++ b/test/integration/targets/order/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group1
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/package_facts/aliases
+++ b/test/integration/targets/package_facts/aliases
@@ -1,3 +1,3 @@
-shippable/posix/group3
+shippable/posix/group2
 skip/osx
 skip/macos

--- a/test/integration/targets/parsing/aliases
+++ b/test/integration/targets/parsing/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/path_lookups/aliases
+++ b/test/integration/targets/path_lookups/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/path_with_comma_in_inventory/aliases
+++ b/test/integration/targets/path_with_comma_in_inventory/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group5
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/pause/aliases
+++ b/test/integration/targets/pause/aliases
@@ -1,3 +1,3 @@
 needs/target/setup_pexpect
-shippable/posix/group1
+shippable/posix/group3
 context/controller  # this is a controller-only action, the module is just for documentation

--- a/test/integration/targets/pip/aliases
+++ b/test/integration/targets/pip/aliases
@@ -1,2 +1,2 @@
 destructive
-shippable/posix/group5
+shippable/posix/group2

--- a/test/integration/targets/pkg_resources/aliases
+++ b/test/integration/targets/pkg_resources/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group1
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/play_iterator/aliases
+++ b/test/integration/targets/play_iterator/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group4
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/playbook/aliases
+++ b/test/integration/targets/playbook/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group1
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/plugin_config_for_inventory/aliases
+++ b/test/integration/targets/plugin_config_for_inventory/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/plugin_filtering/aliases
+++ b/test/integration/targets/plugin_filtering/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group4
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/plugin_loader/aliases
+++ b/test/integration/targets/plugin_loader/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/plugin_namespace/aliases
+++ b/test/integration/targets/plugin_namespace/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group1
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/preflight_encoding/aliases
+++ b/test/integration/targets/preflight_encoding/aliases
@@ -1,2 +1,2 @@
 context/controller
-shippable/posix/group1
+shippable/posix/group3

--- a/test/integration/targets/rel_plugin_loading/aliases
+++ b/test/integration/targets/rel_plugin_loading/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/remote_tmp/aliases
+++ b/test/integration/targets/remote_tmp/aliases
@@ -1,3 +1,3 @@
-shippable/posix/group3
+shippable/posix/group2
 context/target
 needs/target/setup_remote_tmp_dir

--- a/test/integration/targets/retry_task_name_in_callback/aliases
+++ b/test/integration/targets/retry_task_name_in_callback/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/roles/aliases
+++ b/test/integration/targets/roles/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/roles_arg_spec/aliases
+++ b/test/integration/targets/roles_arg_spec/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group5
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/roles_var_inheritance/aliases
+++ b/test/integration/targets/roles_var_inheritance/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group5
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/run_modules/aliases
+++ b/test/integration/targets/run_modules/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/service_facts/aliases
+++ b/test/integration/targets/service_facts/aliases
@@ -1,4 +1,4 @@
-shippable/posix/group3
+shippable/posix/group2
 skip/freebsd
 skip/osx
 skip/macos

--- a/test/integration/targets/set_fact/aliases
+++ b/test/integration/targets/set_fact/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller  # this is a controller-only action, the module is just for documentation

--- a/test/integration/targets/set_stats/aliases
+++ b/test/integration/targets/set_stats/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group5
+shippable/posix/group4
 context/controller  # this is a controller-only action, the module is just for documentation

--- a/test/integration/targets/special_vars/aliases
+++ b/test/integration/targets/special_vars/aliases
@@ -1,3 +1,3 @@
-shippable/posix/group2
+shippable/posix/group4
 needs/target/include_parent_role_vars
 context/controller

--- a/test/integration/targets/special_vars_hosts/aliases
+++ b/test/integration/targets/special_vars_hosts/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group5
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/strategy_free/aliases
+++ b/test/integration/targets/strategy_free/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group3
+shippable/posix/group5

--- a/test/integration/targets/strategy_linear/aliases
+++ b/test/integration/targets/strategy_linear/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group3
+shippable/posix/group5

--- a/test/integration/targets/tags/aliases
+++ b/test/integration/targets/tags/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/task_ordering/aliases
+++ b/test/integration/targets/task_ordering/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group2
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/tasks/aliases
+++ b/test/integration/targets/tasks/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group1
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/template/aliases
+++ b/test/integration/targets/template/aliases
@@ -1,3 +1,3 @@
 needs/root
-shippable/posix/group5
+shippable/posix/group4
 context/controller  # this "module" is actually an action that runs on the controller

--- a/test/integration/targets/template_jinja2_non_native/aliases
+++ b/test/integration/targets/template_jinja2_non_native/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/templating/aliases
+++ b/test/integration/targets/templating/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group1
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/templating_lookups/aliases
+++ b/test/integration/targets/templating_lookups/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group1
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/templating_settings/aliases
+++ b/test/integration/targets/templating_settings/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/test_core/aliases
+++ b/test/integration/targets/test_core/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group5
+shippable/posix/group4

--- a/test/integration/targets/test_files/aliases
+++ b/test/integration/targets/test_files/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group5
+shippable/posix/group4

--- a/test/integration/targets/test_mathstuff/aliases
+++ b/test/integration/targets/test_mathstuff/aliases
@@ -1,1 +1,1 @@
-shippable/posix/group5
+shippable/posix/group4

--- a/test/integration/targets/throttle/aliases
+++ b/test/integration/targets/throttle/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group2
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/undefined/aliases
+++ b/test/integration/targets/undefined/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group5
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/unexpected_executor_exception/aliases
+++ b/test/integration/targets/unexpected_executor_exception/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/unicode/aliases
+++ b/test/integration/targets/unicode/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/unsafe_writes/aliases
+++ b/test/integration/targets/unsafe_writes/aliases
@@ -3,5 +3,5 @@ needs/root
 skip/freebsd
 skip/osx
 skip/macos
-shippable/posix/group3
+shippable/posix/group2
 needs/target/setup_remote_tmp_dir

--- a/test/integration/targets/until/aliases
+++ b/test/integration/targets/until/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group2
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/unvault/aliases
+++ b/test/integration/targets/unvault/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group2
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/uri/aliases
+++ b/test/integration/targets/uri/aliases
@@ -1,3 +1,3 @@
 destructive
-shippable/posix/group4
+shippable/posix/group1
 needs/httptester

--- a/test/integration/targets/var_blending/aliases
+++ b/test/integration/targets/var_blending/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/var_inheritance/aliases
+++ b/test/integration/targets/var_inheritance/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group4
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/var_precedence/aliases
+++ b/test/integration/targets/var_precedence/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group4
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/var_reserved/aliases
+++ b/test/integration/targets/var_reserved/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group2
+shippable/posix/group4
 context/controller

--- a/test/integration/targets/var_templating/aliases
+++ b/test/integration/targets/var_templating/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/want_json_modules_posix/aliases
+++ b/test/integration/targets/want_json_modules_posix/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/yaml_parsing/aliases
+++ b/test/integration/targets/yaml_parsing/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group3
+shippable/posix/group5
 context/controller

--- a/test/integration/targets/yum/aliases
+++ b/test/integration/targets/yum/aliases
@@ -1,5 +1,5 @@
 destructive
-shippable/posix/group4
+shippable/posix/group1
 skip/freebsd
 skip/osx
 skip/macos

--- a/test/lib/ansible_test/_internal/commands/sanity/integration_aliases.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/integration_aliases.py
@@ -5,6 +5,7 @@ import dataclasses
 import json
 import textwrap
 import os
+import re
 import typing as t
 
 from . import (
@@ -31,6 +32,7 @@ from ...target import (
     walk_integration_targets,
     walk_module_targets,
     CompletionTarget,
+    IntegrationTargetType,
 )
 
 from ..integration.cloud import (
@@ -274,6 +276,30 @@ class IntegrationAliasesTest(SanitySingleVersion):
                 find=find,
                 find_incidental=find_incidental,
             )
+
+        target_type_groups = {
+            IntegrationTargetType.TARGET: (1, 2),
+            IntegrationTargetType.CONTROLLER: (3, 4, 5),
+            IntegrationTargetType.CONFLICT: (),
+            IntegrationTargetType.UNKNOWN: (),
+        }
+
+        for target in posix_targets:
+            if f'{self.TEST_ALIAS_PREFIX}/posix/' not in target.aliases:
+                continue
+
+            found_groups = [alias for alias in target.aliases if re.search(f'^{self.TEST_ALIAS_PREFIX}/posix/group[0-9]+/$', alias)]
+            expected_groups = [f'{self.TEST_ALIAS_PREFIX}/posix/group{group}/' for group in target_type_groups[target.target_type]]
+            valid_groups = [group for group in found_groups if group in expected_groups]
+            invalid_groups = [group for group in found_groups if not any(group.startswith(expected_group) for expected_group in expected_groups)]
+
+            if not valid_groups:
+                messages.append(SanityMessage(f'Target of type {target.target_type.name} must be in at least one of these groups: {", ".join(expected_groups)}',
+                                              f'{target.path}/aliases'))
+
+            if invalid_groups:
+                messages.append(SanityMessage(f'Target of type {target.target_type.name} cannot be in these groups: {", ".join(invalid_groups)}',
+                                              f'{target.path}/aliases'))
 
         return messages
 


### PR DESCRIPTION
##### SUMMARY

Re-organize CI test groups for POSIX tests:

* `context/target` tests must be in groups 1 - 2.
* `context/controller` tests must be in groups 3 - 5.

This makes it easier to efficiently organize groups and balance test runtimes.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

.azure-pipelines/azure-pipelines.yml
