### PR TITLE
[stable-2.12] ansible-test - Fix origin host target filtering.

### DIFF
--- a/changelogs/fragments/ansible-test-target-filter.yml
+++ b/changelogs/fragments/ansible-test-target-filter.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - ansible-test - Correctly detect when running as the ``root`` user (UID 0) on the origin host.
+                   The result of the detection was incorrectly being inverted.
+  - ansible-test - Fix skipping of tests marked ``needs/root`` on the origin host.
+  - ansible-test - Fix skipping of tests marked ``needs/python`` on the origin host.

--- a/test/lib/ansible_test/_internal/commands/integration/filters.py
+++ b/test/lib/ansible_test/_internal/commands/integration/filters.py
@@ -221,7 +221,7 @@ class NetworkInventoryTargetFilter(TargetFilter[NetworkInventoryConfig]):
     """Target filter for network inventory."""
 
 
-class OriginTargetFilter(TargetFilter[OriginConfig]):
+class OriginTargetFilter(PosixTargetFilter[OriginConfig]):
     """Target filter for localhost."""
 
 

--- a/test/lib/ansible_test/_internal/host_configs.py
+++ b/test/lib/ansible_test/_internal/host_configs.py
@@ -412,7 +412,7 @@ class OriginConfig(ControllerHostConfig, PosixConfig):
     @property
     def have_root(self):  # type: () -> bool
         """True if root is available, otherwise False."""
-        return os.getuid() != 0
+        return os.getuid() == 0
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/77419

(cherry picked from commit 4b51e61645da35861b872a8d1033965792255092)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
