### PR TITLE
Remove deprecated LIBVIRT_LXC_NOSECLABEL env var

### DIFF
--- a/changelogs/fragments/77395-remove-libvirt_lxc_noseclabel.yml
+++ b/changelogs/fragments/77395-remove-libvirt_lxc_noseclabel.yml
@@ -1,0 +1,2 @@
+removed_features:
+  - Remove deprecated ``LIBVIRT_LXC_NOSECLABEL`` environment variable (https://github.com/ansible/ansible/issues/77395)

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -784,11 +784,6 @@ DEFAULT_LIBVIRT_LXC_NOSECLABEL:
     - "This setting causes libvirt to connect to lxc containers by passing --noseclabel to virsh.
       This is necessary when running on systems which do not have SELinux."
   env:
-  - name: LIBVIRT_LXC_NOSECLABEL
-    deprecated:
-      why: environment variables without ``ANSIBLE_`` prefix are deprecated
-      version: "2.12"
-      alternatives: the ``ANSIBLE_LIBVIRT_LXC_NOSECLABEL`` environment variable
   - name: ANSIBLE_LIBVIRT_LXC_NOSECLABEL
   ini:
   - {key: libvirt_lxc_noseclabel, section: selinux}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #77395
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
`lib/ansible/config/base.yml`
