### PR TITLE
Remove deprecated default.plugin_filters_cfg config option

### DIFF
--- a/changelogs/fragments/77398-remove-plugin_filters_cfg-default.yml
+++ b/changelogs/fragments/77398-remove-plugin_filters_cfg-default.yml
@@ -1,0 +1,2 @@
+removed_features:
+  - Remove deprecated ``plugin_filters_cfg`` config option from ``default`` section (https://github.com/ansible/ansible/issues/77398)

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1831,12 +1831,6 @@ PLUGIN_FILTERS_CFG:
     - " The default is /etc/ansible/plugin_filters.yml"
   ini:
   - key: plugin_filters_cfg
-    section: default
-    deprecated:
-      why: specifying "plugin_filters_cfg" under the "default" section is deprecated
-      version: "2.12"
-      alternatives: the "defaults" section instead
-  - key: plugin_filters_cfg
     section: defaults
   type: path
 PYTHON_MODULE_RLIMIT_NOFILE:

--- a/test/integration/targets/plugin_filtering/filter_lookup.ini
+++ b/test/integration/targets/plugin_filtering/filter_lookup.ini
@@ -1,4 +1,4 @@
-[default]
+[defaults]
 retry_files_enabled = False
 plugin_filters_cfg = ./filter_lookup.yml
 

--- a/test/integration/targets/plugin_filtering/filter_modules.ini
+++ b/test/integration/targets/plugin_filtering/filter_modules.ini
@@ -1,4 +1,4 @@
-[default]
+[defaults]
 retry_files_enabled = False
 plugin_filters_cfg = ./filter_modules.yml
 

--- a/test/integration/targets/plugin_filtering/filter_ping.ini
+++ b/test/integration/targets/plugin_filtering/filter_ping.ini
@@ -1,4 +1,4 @@
-[default]
+[defaults]
 retry_files_enabled = False
 plugin_filters_cfg = ./filter_ping.yml
 

--- a/test/integration/targets/plugin_filtering/filter_stat.ini
+++ b/test/integration/targets/plugin_filtering/filter_stat.ini
@@ -1,4 +1,4 @@
-[default]
+[defaults]
 retry_files_enabled = False
 plugin_filters_cfg = ./filter_stat.yml
 

--- a/test/integration/targets/plugin_filtering/no_filters.ini
+++ b/test/integration/targets/plugin_filtering/no_filters.ini
@@ -1,4 +1,4 @@
-[default]
+[defaults]
 retry_files_enabled = False
 plugin_filters_cfg = ./empty.yml
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #77398

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
`lib/ansible/config/base.yml`
