### PR TITLE
Catch ImportError when pyyaml doesn't have libyaml extension

### DIFF
--- a/lib/ansible/module_utils/common/yaml.py
+++ b/lib/ansible/module_utils/common/yaml.py
@@ -27,7 +27,7 @@ if HAS_YAML:
         from yaml.cyaml import CParser as Parser
 
         HAS_LIBYAML = True
-    except AttributeError:
+    except (ImportError, AttributeError):
         from yaml import SafeLoader  # type: ignore[misc]
         from yaml import SafeDumper  # type: ignore[misc]
         from yaml.parser import Parser  # type: ignore[misc]


### PR DESCRIPTION
##### SUMMARY
Catch ImportError when pyyaml doesn't have libyaml extension

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/common/yaml.py

##### ADDITIONAL INFORMATION
Result of the refactor in https://github.com/ansible/ansible/commit/822fddd627af5fe5648466eb418f144409e6e402
