### PR TITLE
Support for Python 3.11+ tomllib for inventory

### DIFF
--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -180,13 +180,17 @@ class InventoryCLI(CLI):
             from ansible.parsing.yaml.dumper import AnsibleDumper
             results = to_text(yaml.dump(stuff, Dumper=AnsibleDumper, default_flow_style=False, allow_unicode=True))
         elif context.CLIARGS['toml']:
-            from ansible.plugins.inventory.toml import toml_dumps, HAS_TOML
-            if not HAS_TOML:
+            from ansible.plugins.inventory.toml import toml_dumps, HAS_TOML, HAS_TOMLIW
+            if not HAS_TOML and not HAS_TOMLIW:
                 raise AnsibleError(
-                    'The python "toml" library is required when using the TOML output format'
+                    'The python "toml" or "tomli-w" library is required when using the TOML output format'
                 )
             try:
                 results = toml_dumps(stuff)
+            except TypeError as e:
+                raise AnsibleError(
+                    'The source inventory contains a value that cannot be represented in TOML: %s' % e
+                )
             except KeyError as e:
                 raise AnsibleError(
                     'The source inventory contains a non-string key (%s) which cannot be represented in TOML. '

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -180,11 +180,7 @@ class InventoryCLI(CLI):
             from ansible.parsing.yaml.dumper import AnsibleDumper
             results = to_text(yaml.dump(stuff, Dumper=AnsibleDumper, default_flow_style=False, allow_unicode=True))
         elif context.CLIARGS['toml']:
-            from ansible.plugins.inventory.toml import toml_dumps, HAS_TOML, HAS_TOMLIW
-            if not HAS_TOML and not HAS_TOMLIW:
-                raise AnsibleError(
-                    'The python "toml" or "tomli-w" library is required when using the TOML output format'
-                )
+            from ansible.plugins.inventory.toml import toml_dumps
             try:
                 results = toml_dumps(stuff)
             except TypeError as e:

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -12,7 +12,7 @@ DOCUMENTATION = r'''
         - TOML based inventory format
         - File MUST have a valid '.toml' file extension
     notes:
-        - Requires the 'toml' python library
+        - Requires one of the following python libraries: 'toml', 'tomli', or 'tomllib'
 '''
 
 EXAMPLES = r'''# fmt: toml
@@ -100,17 +100,28 @@ from ansible.plugins.inventory import BaseFileInventoryPlugin
 from ansible.utils.display import Display
 from ansible.utils.unsafe_proxy import AnsibleUnsafeBytes, AnsibleUnsafeText
 
+HAS_TOMLIW = False
 try:
     import toml
     HAS_TOML = True
 except ImportError:
     HAS_TOML = False
+    try:
+        import tomli_w as toml
+        HAS_TOMLIW = True
+    except ImportError:
+        pass
 
+HAS_TOMLLIB = False
 try:
     import tomllib
     HAS_TOMLLIB = True
 except ImportError:
-    HAS_TOMLLIB = False
+    try:
+        import tomli as tomllib
+        HAS_TOMLLIB = True
+    except ImportError:
+        pass
 
 display = Display()
 
@@ -243,7 +254,7 @@ class InventoryModule(BaseFileInventoryPlugin):
         ''' parses the inventory file '''
         if not HAS_TOMLLIB and not HAS_TOML:
             raise AnsibleParserError(
-                'The TOML inventory plugin requires the python "toml" library'
+                'The TOML inventory plugin requires the python "toml", or "tomli" library'
             )
 
         super(InventoryModule, self).parse(inventory, loader, path)

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -12,7 +12,8 @@ DOCUMENTATION = r'''
         - TOML based inventory format
         - File MUST have a valid '.toml' file extension
     notes:
-        - Requires one of the following python libraries: 'toml', 'tomli', or 'tomllib'
+        - >
+          Requires one of the following python libraries: 'toml', 'tomli', or 'tomllib'
 '''
 
 EXAMPLES = r'''# fmt: toml

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -108,18 +108,18 @@ try:
     HAS_TOML = True
 except ImportError:
     try:
-        import tomli_w as toml
+        import tomli_w as toml  # type: ignore[import,no-redef]
         HAS_TOMLIW = True
     except ImportError:
         pass
 
 HAS_TOMLLIB = False
 try:
-    import tomllib
+    import tomllib  # type: ignore[import]
     HAS_TOMLLIB = True
 except ImportError:
     try:
-        import tomli as tomllib
+        import tomli as tomllib  # type: ignore[no-redef]
         HAS_TOMLLIB = True
     except ImportError:
         pass
@@ -150,10 +150,10 @@ else:
 if HAS_TOML:
     # prefer toml if installed, since it supports both encoding and decoding
     toml_loads = toml.loads
-    TOMLDecodeError = toml.TomlDecodeError
+    TOMLDecodeError = toml.TomlDecodeError  # type: t.Any
 elif HAS_TOMLLIB:
     toml_loads = tomllib.loads
-    TOMLDecodeError = tomllib.TOMLDecodeError
+    TOMLDecodeError = tomllib.TOMLDecodeError  # type: t.Any  # type: ignore[no-redef]
 
 
 def convert_yaml_objects_to_native(obj):

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -156,10 +156,10 @@ else:
 
 if HAS_TOML:
     # prefer toml if installed, since it supports both encoding and decoding
-    toml_loads = toml.loads
+    toml_loads = toml.loads  # type: ignore[assignment]
     TOMLDecodeError = toml.TomlDecodeError  # type: t.Any
 elif HAS_TOMLLIB:
-    toml_loads = tomllib.loads
+    toml_loads = tomllib.loads  # type: ignore[assignment]
     TOMLDecodeError = tomllib.TOMLDecodeError  # type: t.Any  # type: ignore[no-redef]
 
 

--- a/lib/ansible/plugins/inventory/toml.py
+++ b/lib/ansible/plugins/inventory/toml.py
@@ -129,6 +129,7 @@ except ImportError:
 display = Display()
 
 
+# dumps
 if HAS_TOML and hasattr(toml, 'TomlEncoder'):
     # toml>=0.10.0
     class AnsibleTomlEncoder(toml.TomlEncoder):
@@ -154,6 +155,7 @@ else:
             'The python "toml" or "tomli-w" library is required when using the TOML output format'
         )
 
+# loads
 if HAS_TOML:
     # prefer toml if installed, since it supports both encoding and decoding
     toml_loads = toml.loads  # type: ignore[assignment]
@@ -164,15 +166,17 @@ elif HAS_TOMLLIB:
 
 
 def convert_yaml_objects_to_native(obj):
-    """Older versions of the ``toml`` python library, don't have a pluggable
-    way to tell the encoder about custom types, so we need to ensure objects
-    that we pass are native types.
+    """Older versions of the ``toml`` python library, and tomllib, don't have
+    a pluggable way to tell the encoder about custom types, so we need to
+    ensure objects that we pass are native types.
 
-    Only used on ``toml<0.10.0`` where ``toml.TomlEncoder`` is missing.
+    Used with:
+      - ``toml<0.10.0`` where ``toml.TomlEncoder`` is missing
+      - ``tomli`` or ``tomllib``
 
     This function recurses an object and ensures we cast any of the types from
     ``ansible.parsing.yaml.objects`` into their native types, effectively cleansing
-    the data before we hand it over to ``toml``
+    the data before we hand it over to the toml library.
 
     This function doesn't directly check for the types from ``ansible.parsing.yaml.objects``
     but instead checks for the types those objects inherit from, to offer more flexibility.

--- a/test/integration/targets/ansible-inventory/files/valid_sample.toml
+++ b/test/integration/targets/ansible-inventory/files/valid_sample.toml
@@ -1,0 +1,2 @@
+[somegroup.hosts.something]
+foo = "bar"

--- a/test/integration/targets/ansible-inventory/runme.sh
+++ b/test/integration/targets/ansible-inventory/runme.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+source virtualenv.sh
+export ANSIBLE_ROLES_PATH=../
+set -euvx
+
+ansible-playbook test.yml "$@"

--- a/test/integration/targets/ansible-inventory/tasks/main.yml
+++ b/test/integration/targets/ansible-inventory/tasks/main.yml
@@ -82,30 +82,6 @@
         - result is failed
         - '"ERROR! Could not match supplied host pattern, ignoring: invalid" in result.stderr'
 
-- name: Install toml package
-  pip:
-    name:
-      - toml
-    state: present
-
-- name: "test option: --toml with valid group name"
-  command: ansible-inventory --list --toml -i {{ role_path }}/files/valid_sample.yml
-  register: result
-
-- assert:
-    that:
-        - result is succeeded
-
-- name: "test option: --toml with invalid group name"
-  command: ansible-inventory --list --toml -i {{ role_path }}/files/invalid_sample.yml
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-        - result is failed
-        - '"ERROR! The source inventory contains a non-string key" in result.stderr'
-
 - name: "test json output with unicode characters"
   command: ansible-inventory --list -i {{ role_path }}/files/unicode.yml
   register: result
@@ -154,28 +130,13 @@
         name: unicode_inventory.yaml
         state: absent
 
-- block:
-  - name: "test toml output with unicode characters"
-    command: ansible-inventory --list --toml -i {{ role_path }}/files/unicode.yml
-    register: result
-
-  - assert:
-      that:
-          - result is succeeded
-          - result.stdout is contains('příbor')
-
-  - block:
-    - name: "test toml output file with unicode characters"
-      command: ansible-inventory --list --toml --output unicode_inventory.toml -i {{ role_path }}/files/unicode.yml
-
-    - set_fact:
-        toml_inventory_file: "{{ lookup('file', 'unicode_inventory.toml') | string }}"
-
-    - assert:
-        that:
-            - toml_inventory_file is contains('příbor')
-    always:
-      - file:
-          name: unicode_inventory.toml
-          state: absent
-  when: ansible_python.version.major|int == 3
+- include_tasks: toml.yml
+  loop:
+    - toml
+    -
+      - tomli
+      - tomli-w
+    - tomllib
+  loop_control:
+    loop_var: toml_package
+  when: toml_package != 'tomllib' or (toml_package == 'tomllib' and ansible_facts.python.version_info >= [3, 11])

--- a/test/integration/targets/ansible-inventory/tasks/main.yml
+++ b/test/integration/targets/ansible-inventory/tasks/main.yml
@@ -132,11 +132,16 @@
 
 - include_tasks: toml.yml
   loop:
-    - toml
+    -
+      - toml<0.10.0
+    -
+      - toml
     -
       - tomli
       - tomli-w
-    - tomllib
+    -
+      - tomllib
+      - tomli-w
   loop_control:
     loop_var: toml_package
-  when: toml_package != 'tomllib' or (toml_package == 'tomllib' and ansible_facts.python.version_info >= [3, 11])
+  when: toml_package is not contains 'tomllib' or (toml_package is contains 'tomllib' and ansible_facts.python.version_info >= [3, 11])

--- a/test/integration/targets/ansible-inventory/tasks/toml.yml
+++ b/test/integration/targets/ansible-inventory/tasks/toml.yml
@@ -1,0 +1,56 @@
+- name: Ensure no toml packages are installed
+  pip:
+    name:
+      - tomli
+      - tomli-w
+      - toml
+
+- name: Install toml package
+  pip:
+    name: '{{ toml_package }}'
+    state: present
+  when: toml_package != 'tomllib'
+
+- name: "test option: --toml with valid group name"
+  command: ansible-inventory --list --toml -i {{ role_path }}/files/valid_sample.yml
+  register: result
+
+- assert:
+    that:
+        - result is succeeded
+
+- name: "test option: --toml with invalid group name"
+  command: ansible-inventory --list --toml -i {{ role_path }}/files/invalid_sample.yml
+  ignore_errors: true
+  register: result
+
+- assert:
+    that:
+        - result is failed
+        - '"ERROR! The source inventory contains a non-string key" in result.stderr'
+
+- block:
+  - name: "test toml output with unicode characters"
+    command: ansible-inventory --list --toml -i {{ role_path }}/files/unicode.yml
+    register: result
+
+  - assert:
+      that:
+          - result is succeeded
+          - result.stdout is contains('příbor')
+
+  - block:
+    - name: "test toml output file with unicode characters"
+      command: ansible-inventory --list --toml --output unicode_inventory.toml -i {{ role_path }}/files/unicode.yml
+
+    - set_fact:
+        toml_inventory_file: "{{ lookup('file', 'unicode_inventory.toml') | string }}"
+
+    - assert:
+        that:
+            - toml_inventory_file is contains('příbor')
+    always:
+      - file:
+          name: unicode_inventory.toml
+          state: absent
+  when: ansible_python.version.major|int == 3

--- a/test/integration/targets/ansible-inventory/tasks/toml.yml
+++ b/test/integration/targets/ansible-inventory/tasks/toml.yml
@@ -4,12 +4,21 @@
       - tomli
       - tomli-w
       - toml
+    state: absent
 
 - name: Install toml package
   pip:
-    name: '{{ toml_package }}'
+    name: '{{ toml_package|difference(["tomllib"]) }}'
     state: present
-  when: toml_package != 'tomllib'
+
+- name: test toml parsing
+  command: ansible-inventory --list --toml -i {{ role_path }}/files/valid_sample.toml
+  register: toml_in
+
+- assert:
+    that:
+      - >
+        'foo = "bar"' in toml_in.stdout
 
 - name: "test option: --toml with valid group name"
   command: ansible-inventory --list --toml -i {{ role_path }}/files/valid_sample.yml
@@ -27,7 +36,8 @@
 - assert:
     that:
         - result is failed
-        - '"ERROR! The source inventory contains a non-string key" in result.stderr'
+        - >
+          "ERROR! The source inventory contains" in result.stderr
 
 - block:
   - name: "test toml output with unicode characters"

--- a/test/integration/targets/ansible-inventory/test.yml
+++ b/test/integration/targets/ansible-inventory/test.yml
@@ -1,0 +1,3 @@
+- hosts: localhost
+  roles:
+    - ansible-inventory


### PR DESCRIPTION
##### SUMMARY
Support for Python 3.11+ `tomllib`

`tomllib` only supports parsing, so when using `tomllib` users can also install `tomli-w` for `--toml` output with `ansible-inventory.

The `toml` library is still supported, and if installed will be preferred, since it supports both parsing and emitting.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/toml.py

##### ADDITIONAL INFORMATION
https://docs.python.org/3.11/library/tomllib.html