### PR TITLE
Update installing_collections_file.rst

### DIFF
--- a/docs/docsite/rst/shared_snippets/installing_collections_file.rst
+++ b/docs/docsite/rst/shared_snippets/installing_collections_file.rst
@@ -16,7 +16,7 @@ Ansible can also install a collection collected with ``ansible-galaxy collection
 .. code-block:: yaml
 
     collections:
-      - source: /tmp/my_namespace-my_collection-1.0.0.tar.gz
+      - name: /tmp/my_namespace-my_collection-1.0.0.tar.gz
         type: file
 
 .. note::


### PR DESCRIPTION
Fixed issue with the collections format on installing from a file. Should be **name** and not **source**.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The current documentation and example for installing a collection from a file using the requirements file is incorrect. This was noticed when building some custom content for AAP2 course deliveries and showing students the official website documentation.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
installing_collections_file.rst

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Shared file in multiple portions of documentation were giving an incorrect example as it would not work as-is. Fixed the documentation example with working syntax.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
