### PR TITLE
template module: document jinja2_native behavior

### DIFF
--- a/lib/ansible/modules/template.py
+++ b/lib/ansible/modules/template.py
@@ -26,6 +26,7 @@ options:
     version_added: '2.4'
 notes:
 - For Windows you can use M(ansible.windows.win_template) which uses '\\r\\n' as C(newline_sequence) by default.
+- The C(jinja2_native) setting has no effect, native types are never used in the C(template) module which is by design used for generating text files. For working with templates and utilizing Jinja2 native types see the C(jinja2_native) parameter of the C(template lookup).
 seealso:
 - module: ansible.builtin.copy
 - module: ansible.windows.win_copy

--- a/lib/ansible/modules/template.py
+++ b/lib/ansible/modules/template.py
@@ -26,7 +26,8 @@ options:
     version_added: '2.4'
 notes:
 - For Windows you can use M(ansible.windows.win_template) which uses '\\r\\n' as C(newline_sequence) by default.
-- The C(jinja2_native) setting has no effect, native types are never used in the C(template) module which is by design used for generating text files. For working with templates and utilizing Jinja2 native types see the C(jinja2_native) parameter of the C(template lookup).
+- The C(jinja2_native) setting has no effect, native types are never used in the C(template) module which is by design used for generating text files.
+  For working with templates and utilizing Jinja2 native types see the C(jinja2_native) parameter of the C(template lookup).
 seealso:
 - module: ansible.builtin.copy
 - module: ansible.windows.win_copy

--- a/lib/ansible/modules/template.py
+++ b/lib/ansible/modules/template.py
@@ -26,7 +26,7 @@ options:
     version_added: '2.4'
 notes:
 - For Windows you can use M(ansible.windows.win_template) which uses '\\r\\n' as C(newline_sequence) by default.
-- The C(jinja2_native) setting has no effect, native types are never used in the C(template) module which is by design used for generating text files.
+- The C(jinja2_native) setting has no effect. Native types are never used in the C(template) module which is by design used for generating text files.
   For working with templates and utilizing Jinja2 native types see the C(jinja2_native) parameter of the C(template lookup).
 seealso:
 - module: ansible.builtin.copy


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Not mentioned in `lib/ansible/plugins/doc_fragments/template_common.py` but only in `lib/ansible/modules/template.py` because the restriction is not implemented in `win_template`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/modules/template.py`