### PR TITLE
Add test to assert that missing libyaml doesn't result in an error

### DIFF
--- a/test/integration/targets/pyyaml/aliases
+++ b/test/integration/targets/pyyaml/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group5
+context/controller

--- a/test/integration/targets/pyyaml/runme.sh
+++ b/test/integration/targets/pyyaml/runme.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eu
+source virtualenv.sh
+set +x
+
+# deps are already installed, using --no-deps to avoid re-installing them
+# Install PyYAML without libyaml to validate ansible can run
+PYYAML_FORCE_LIBYAML=0 pip install --no-binary PyYAML --ignore-installed --no-cache-dir --no-deps PyYAML
+
+ansible --version | tee /dev/stderr | grep 'libyaml = False'


### PR DESCRIPTION
##### SUMMARY
Add test to assert that missing libyaml doesn't result in an error. Fixes #77437

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/integration/targets/pyyaml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
