### PR TITLE
cli - deprecated setting verbosity before sub command, cont'd

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -171,9 +171,7 @@ class GalaxyCLI(CLI):
             # Inject role into sys.argv[1] as a backwards compatibility step
             if args[1] not in ['-h', '--help', '--version'] and 'role' not in args and 'collection' not in args:
                 # TODO: Should we add a warning here and eventually deprecate the implicit role subcommand choice
-                # Remove this in Ansible 2.13 when we also remove -v as an option on the root parser for ansible-galaxy.
-                idx = 2 if args[1].startswith('-v') else 1
-                args.insert(idx, 'role')
+                args.insert(1, 'role')
                 self._implicit_role = True
             # since argparse doesn't allow hidden subparsers, handle dead login arg from raw args after "role" normalization
             if args[1:3] == ['role', 'login']:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Follow up on #75840
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/cli/galaxy.py`