### PR TITLE
[stable-2.13] Catch ImportError when pyyaml doesn't have libyaml extension (#77434)

### DIFF
--- a/lib/ansible/module_utils/common/yaml.py
+++ b/lib/ansible/module_utils/common/yaml.py
@@ -27,7 +27,7 @@ if HAS_YAML:
         from yaml.cyaml import CParser as Parser
 
         HAS_LIBYAML = True
-    except AttributeError:
+    except (ImportError, AttributeError):
         from yaml import SafeLoader  # type: ignore[misc]
         from yaml import SafeDumper  # type: ignore[misc]
         from yaml.parser import Parser  # type: ignore[misc]

--- a/test/integration/targets/pyyaml/aliases
+++ b/test/integration/targets/pyyaml/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group5
+context/controller

--- a/test/integration/targets/pyyaml/runme.sh
+++ b/test/integration/targets/pyyaml/runme.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eu
+source virtualenv.sh
+set +x
+
+# deps are already installed, using --no-deps to avoid re-installing them
+# Install PyYAML without libyaml to validate ansible can run
+PYYAML_FORCE_LIBYAML=0 pip install --no-binary PyYAML --ignore-installed --no-cache-dir --no-deps PyYAML
+
+ansible --version | tee /dev/stderr | grep 'libyaml = False'


### PR DESCRIPTION
(cherry picked from commit e3aa73c)


Co-authored-by: Matt Martz <matt@sivel.net>