### PR TITLE
Docfix - ignore.txt file path

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/ignores.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/ignores.rst
@@ -49,7 +49,7 @@ Maintaining a separate file for each Ansible release allows a collection to pass
 Ansible
 ^^^^^^^
 
-When testing Ansible, all ignores are placed in the ``test/sanity/ignore.txt`` file.
+When testing Ansible, all ignores are placed in the ``tests/sanity/ignore.txt`` file.
 
 Only a single file is needed because ``ansible-test`` is developed and released as a part of Ansible itself.
 


### PR DESCRIPTION
##### SUMMARY
Fix `ignore.txt` file path in documentation


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
