### PR TITLE
Reorganize ansible-doc options

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -341,7 +341,7 @@ class CLI(ABC):
         return op
 
     @abstractmethod
-    def init_parser(self, usage="", desc=None, epilog=None):
+    def init_parser(self, usage="", desc=None, epilog=None, parents=None):
         """
         Create an options parser for most ansible scripts
 
@@ -355,7 +355,7 @@ class CLI(ABC):
                 ansible.arguments.option_helpers.add_runas_options(self.parser)
                 self.parser.add_option('--my-option', dest='my_option', action='store')
         """
-        self.parser = opt_help.create_base_parser(self.name, usage=usage, desc=desc, epilog=epilog)
+        self.parser = opt_help.create_base_parser(self.name, usage=usage, desc=desc, epilog=epilog, parents=parents)
 
     @abstractmethod
     def post_process_args(self, options):

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -187,7 +187,7 @@ def version(prog=None):
 # Functions to add pre-canned options to an OptionParser
 #
 
-def create_base_parser(prog, usage="", desc=None, epilog=None):
+def create_base_parser(prog, usage="", desc=None, epilog=None, parents=None):
     """
     Create an options parser for all ansible scripts
     """
@@ -198,6 +198,7 @@ def create_base_parser(prog, usage="", desc=None, epilog=None):
         epilog=epilog,
         description=desc,
         conflict_handler='resolve',
+        parents=parents or [],
     )
     version_help = "show program's version number, config file location, configured module search path," \
                    " module location, executable location and exit"


### PR DESCRIPTION
##### SUMMARY
This is kind of just spaghetti thrown at the wall for discussion as a follow up to my [suggestion](https://github.com/ansible/ansible/pull/77035#discussion_r833749735
) to prevent `--no-fail-on-errors` from being silently ignored with options other than `--metadata-dump`.

This isn't really any different from the initial solution https://github.com/ansible/ansible/commit/5b0f970dc74777c8f43844d2312c75f644e0ae2d, except that it's done while adding parser arguments (by using parser.parse_known_args()), so the --help matches the usage.

If the top level options looked more like commands, this would be much nicer with subparsers. I couldn't figure out a way to do this without breaking changes though. For example:

```python
common_subparsers = self.parser.add_subparsers()

# breaking change: no longer positional
name_subparser = common_subparsers.add_parser('plugin', add_help=False)
name_subparser.add_argument('args', nargs='*', help='Plugin', metavar='plugin', default=['ansible.builtin'], action='store')

# breaking change: no longer --type, because that doesn't work 
type_subparser = common_subparsers.add_parser('type')
plugin_subparsers = type_subparser.add_subparsers(dest='type')

for t in TARGET_OPTIONS:
    plugin_parser = plugin_subparsers.add_parser(t)

    if t in ('inventory', 'lookup', 'module'):
        exclusive_opts = plugin_parser.add_mutually_exclusive_group()
        exclusive_opts.add_argument("-s", "--snippet", action="store_true", default=False, dest='show_snippet',
                                                         help='Show playbook snippet for these plugin types: %s' % ', '.join(SNIPPETS))
        exclusive_opts.add_argument("-j", "--json", action="store_true", default=False, dest='json_format',
                                                         help='Change output into json format.')
    elif t == 'role':
        plugin_parser.add_argument("-j", "--json", action="store_true", default=False, dest='json_format',
                                                       help='Change output into json format.')
        plugin_parser.add_argument("-r", "--roles-path", dest='roles_path', default=C.DEFAULT_ROLES_PATH,
                                                       type=opt_help.unfrack_path(pathsep=True),
                                                       action=opt_help.PrependListAction,
                                                       help='The path to the directory containing your roles.')
        plugin_parser.add_argument("-e", "--entry-point", dest="entry_point",
                                                       help="Select the entry point for role(s).")
    else:
        plugin_parser.add_argument("-j", "--json", action="store_true", default=False, dest='json_format',
                                                       help='Change output into json format.')
...
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
