### PR TITLE
compile sanity test: fix crash

### DIFF
--- a/changelogs/fragments/77465-ansible-test-compile-crash.yml
+++ b/changelogs/fragments/77465-ansible-test-compile-crash.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "ansible-test compile sanity test - do not crash if a column could not be determined for an error (https://github.com/ansible/ansible/pull/77465)."

--- a/test/lib/ansible_test/_util/target/sanity/compile/compile.py
+++ b/test/lib/ansible_test/_util/target/sanity/compile/compile.py
@@ -24,6 +24,10 @@ def main():
         else:
             continue
 
+        # In some situations offset can be None. This can happen for syntax errors on Python 2.6
+        # (__future__ import following after a regular import).
+        offset = offset or 0
+
         result = "%s:%d:%d: %s: %s" % (path, lineno, offset, extype.__name__, safe_message(message))
 
         if sys.version_info <= (3,):


### PR DESCRIPTION
##### SUMMARY
The following crash: https://github.com/adhawkins/ansible-borgbase/runs/5831772017?check_suite_focus=true#step:7:192 is caused by a `__future__` import following a regular import (https://github.com/adhawkins/ansible-borgbase/commit/4d9dbd04aa8b875772823b84f6ea05ce880362fb#diff-57ead8c67a66f2baa2b50b3742694c3e27830423eb50506dca991ac187504dc2R2). In that case, Python 2.6 apparently sets `ex.offset` to `None`. To avoid this crash, make sure offset is set to `0` if it's falsy.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test compile sanity test
