### PR TITLE
Limit Galaxy API calls during ansible-galaxy dependency resolution

### DIFF
--- a/changelogs/fragments/77468-ansible-galaxy-remove-unnecessary-api-call.yml
+++ b/changelogs/fragments/77468-ansible-galaxy-remove-unnecessary-api-call.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- >-
+  ``ansible-galaxy`` - remove extra server api call during dependency resolution
+  for requirements and dependencies that are already satisfied
+  (https://github.com/ansible/ansible/issues/77443).

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -320,7 +320,7 @@ class CollectionDependencyProviderBase(AbstractProvider):
 
         # If we're upgrading collections, we can't calculate preinstalled_candidates until the latest matches are found.
         # Otherwise, we can potentially avoid a Galaxy API call by doing this first.
-        preinstalled_candidates = None
+        preinstalled_candidates = set()
         if not self._upgrade and first_req.type == 'galaxy':
             preinstalled_candidates = {
                 candidate for candidate in self._preferred_candidates

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -327,20 +327,16 @@ class CollectionDependencyProviderBase(AbstractProvider):
                 if candidate.fqcn == fqcn and
                 all(self.is_satisfied_by(requirement, candidate) for requirement in requirements)
             }
-        if preinstalled_candidates:
-            # Since we're not upgrading and a sufficient match was found, don't look for more recent versions
-            coll_versions = []  # type: t.Iterable[t.Tuple[str, GalaxyAPI]]
-        else:
-            try:
-                coll_versions = self._api_proxy.get_collection_versions(first_req)
-            except TypeError as exc:
-                if first_req.is_concrete_artifact:
-                    # Non hashable versions will cause a TypeError
-                    raise ValueError(
-                        f"Invalid version found for the collection '{first_req}'. {version_req}"
-                    ) from exc
-                # Unexpected error from a Galaxy server
-                raise
+        try:
+            coll_versions = [] if preinstalled_candidates else self._api_proxy.get_collection_versions(first_req)  # type: t.Iterable[t.Tuple[str, GalaxyAPI]]
+        except TypeError as exc:
+            if first_req.is_concrete_artifact:
+                # Non hashable versions will cause a TypeError
+                raise ValueError(
+                    f"Invalid version found for the collection '{first_req}'. {version_req}"
+                ) from exc
+            # Unexpected error from a Galaxy server
+            raise
 
         if first_req.is_concrete_artifact:
             # FIXME: do we assume that all the following artifacts are also concrete?

--- a/test/integration/targets/ansible-galaxy-collection/tasks/install_offline.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/install_offline.yml
@@ -1,0 +1,51 @@
+- set_fact:
+    init_dir: "{{ galaxy_dir }}/offline/setup"
+    build_dir: "{{ galaxy_dir }}/offline/build"
+    install_dir: "{{ galaxy_dir }}/offline/collections"
+
+- name: create test directories
+  file:
+    path: "{{ item }}"
+    state: directory
+  loop:
+    - "{{ init_dir }}"
+    - "{{ build_dir }}"
+    - "{{ install_dir }}"
+
+- name: test installing a tarfile with an installed dependency offline
+  block:
+    - name: init two collections
+      command: ansible-galaxy collection init ns.{{ item }} --init-path {{ init_dir }}
+      loop:
+        - coll1
+        - coll2
+
+    - name: add one collection as the dependency of the other
+      lineinfile:
+        path: "{{ galaxy_dir }}/offline/setup/ns/coll1/galaxy.yml"
+        regexp: "^dependencies:*"
+        line: "dependencies: {'ns.coll2': '1.0.0'}"
+
+    - name: build both collections
+      command: ansible-galaxy collection build {{ init_dir }}/ns/{{ item }}
+      args:
+        chdir: "{{ build_dir }}"
+      loop:
+        - coll1
+        - coll2
+
+    - name: install the dependency from the tarfile
+      command: ansible-galaxy collection install {{ build_dir }}/ns-coll2-1.0.0.tar.gz -p {{ install_dir }} -s offline
+
+    - name: install the tarfile with the installed dependency
+      command: ansible-galaxy collection install {{ build_dir }}/ns-coll1-1.0.0.tar.gz -p {{ install_dir }} -s offline
+
+  always:
+    - name: clean up test directories
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ init_dir }}"
+        - "{{ build_dir }}"
+        - "{{ install_dir }}"

--- a/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
@@ -56,6 +56,13 @@
   loop_control:
     loop_var: resolvelib_version
 
+- name: run ansible-galaxy collection offline installation tests
+  include_tasks: install_offline.yml
+  args:
+    apply:
+      environment:
+        ANSIBLE_CONFIG: '{{ galaxy_dir }}/ansible.cfg'
+
 - name: run ansible-galaxy collection publish tests for {{ test_name }}
   include_tasks: publish.yml
   args:


### PR DESCRIPTION
##### SUMMARY

Fixes #77443.

If `--upgrade` isn't provided and a sufficient version of a collection is already installed, we don't need to find the latest available versions. Marked as a draft while I'm still looking to see if this has unintended side effects. A possible alternative would be to add an `--offline` option to collection installation, similar to collection verification and roles.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request