### PR TITLE
ansible should not generate warning for python interpreters on Oracle Solaris

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1519,6 +1519,8 @@ INTERPRETER_PYTHON_DISTRO_MAP:
     ubuntu:
       '14': /usr/bin/python
       '16': /usr/bin/python3
+    solaris:
+      '11': /usr/bin/python
   version_added: "2.8"
   # FUTURE: add inventory override once we're sure it can't be abused by a rogue target
   # FUTURE: add a platform layer to the map so we could use for, eg, freebsd/macos/etc?

--- a/lib/ansible/executor/interpreter_discovery.py
+++ b/lib/ansible/executor/interpreter_discovery.py
@@ -91,7 +91,7 @@ def discover_interpreter(action, interpreter_name, discovery_mode, task_vars):
             # this is lame, but returning None or throwing an exception is uglier
             return u'/usr/bin/python'
 
-        if platform_type != 'linux':
+        if platform_type != 'linux' and platform_type != 'sunos':
             raise NotImplementedError('unsupported platform for extended discovery: {0}'.format(to_native(platform_type)))
 
         platform_script = pkgutil.get_data('ansible.executor.discovery', 'python_target.py')


### PR DESCRIPTION
##### SUMMARY
Fixes #77453

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
config

##### ADDITIONAL INFORMATION
Before my Fix
```
$ ansible myhost -m ping
[WARNING]: Unhandled error in Python interpreter discovery for host
myhost: unexpected output from Python interpreter
discovery
[WARNING]: Platform unknown on host myhost is using the
discovered Python interpreter at /usr/bin/python, but future
installation of another Python interpreter could change the meaning of that
path. See
https://docs.ansible.com/ansible/2.10/reference_appendices/interpreter_discovery.html for more information
myhost | SUCCESS => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": false,
    "ping": "pong"
}
```

After my Fix
```

$ ansible myhost -m ping
myhost | SUCCESS => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": false,
    "ping": "pong"
}

```