### PR TITLE
[stable-2.13] ansible-test - Don't fail if network cannot be disconnected (#77472)

### DIFF
--- a/changelogs/fragments/77472-ansible-test-network-disconnect-warning.yml
+++ b/changelogs/fragments/77472-ansible-test-network-disconnect-warning.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- ansible-test - Don't fail if network cannot be disconnected
+  (https://github.com/ansible/ansible/pull/77472)

--- a/test/lib/ansible_test/_internal/delegation.py
+++ b/test/lib/ansible_test/_internal/delegation.py
@@ -172,7 +172,14 @@ def delegate_command(args, host_state, exclude, require):  # type: (EnvironmentC
 
             if networks is not None:
                 for network in networks:
-                    con.disconnect_network(network)
+                    try:
+                        con.disconnect_network(network)
+                    except SubprocessError:
+                        display.warning(
+                            'Unable to disconnect network "%s" (this is normal under podman). '
+                            'Tests will not be isolated from the network. Network-related tests may '
+                            'misbehave.' % (network,)
+                        )
             else:
                 display.warning('Network disconnection is not supported (this is normal under podman). '
                                 'Tests will not be isolated from the network. Network-related tests may misbehave.')


### PR DESCRIPTION
* Don't fail if network cannot be disconnected

* add clog frag
(cherry picked from commit 66c5844)


Co-authored-by: Matt Martz <matt@sivel.net>