### PR TITLE
Update playbooks_tags.rst

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/user_guide/playbooks_tags.rst
@@ -320,7 +320,7 @@ For example:
      - name: Run the rarely-used debug task
        ansible.builtin.debug:
         msg: '{{ showmevar }}'
-       tags: [ never, debug ]
+       tags: [never, debug]
 
 The rarely-used debug task in the example above only runs when you specifically request the ``debug`` or ``never`` tags.
 


### PR DESCRIPTION
##### SUMMARY
tags: [ never, debug ] <- gives lint errors
tags: [never, debug] <- does not give lint errors

errors seen from lint (Ansible lint 4.3.7)
  9:10      error    too many spaces inside brackets  (brackets)
  9:24      error    too many spaces inside brackets  (brackets)

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
 Fixed single line entry in documentation so they do not produce lint errors
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
errors seen from lint (Ansible lint 4.3.7)
  9:10      error    too many spaces inside brackets  (brackets)
  9:24      error    too many spaces inside brackets  (brackets)
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
use the following in a task and pass it through ansible lint 4.3.7 which will fail
tags: [ never, debug ] < fail
tags: [never, debug] < pass
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
