### PR TITLE
2.13: Ensure correct environment_class is set on Template (#77485)

### DIFF
--- a/changelogs/fragments/templar-correct-environment_class-template.yml
+++ b/changelogs/fragments/templar-correct-environment_class-template.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Ensure the correct ``environment_class`` is set on ``AnsibleJ2Template``

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -674,6 +674,7 @@ class Templar:
             extensions=self._get_extensions(),
             loader=FileSystemLoader(loader.get_basedir() if loader else '.'),
         )
+        self.environment.template_class.environment_class = environment_class
 
         # jinja2 global is inconsistent across versions, this normalizes them
         self.environment.globals['dict'] = dict


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #77485

(cherry picked from commit https://github.com/ansible/ansible/commit/c7e198b907e2b3842270252e6fc94e32388e18e3)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/template/__init__.py`
