### PR TITLE
Warn instead of error if --limit matches groups but no hosts

### DIFF
--- a/changelogs/fragments/77512-warn-no-hosts-but-valid-group-pattern.yml
+++ b/changelogs/fragments/77512-warn-no-hosts-but-valid-group-pattern.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Warn instead of error if --limit matches only empty groups.

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -525,7 +525,11 @@ class CLI(ABC):
 
         hosts = inventory.list_hosts(pattern)
         if not hosts and no_hosts is False:
-            raise AnsibleError("Specified hosts and/or --limit does not match any hosts")
+            if inventory.is_group_pattern(pattern):
+                # Valid pattern, just empty
+                display.warning("Specified hosts and/or --limit does not match any hosts, only empty group(s)")
+            else:
+                raise AnsibleError("Specified hosts and/or --limit does not match any hosts")
 
         return hosts
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -525,11 +525,11 @@ class CLI(ABC):
 
         hosts = inventory.list_hosts(pattern)
         if not hosts and no_hosts is False:
-            if inventory.is_group_pattern(pattern):
-                # Valid pattern, just empty
-                display.warning("Specified hosts and/or --limit does not match any hosts, only empty group(s)")
-            else:
-                raise AnsibleError("Specified hosts and/or --limit does not match any hosts")
+            msg = "Specified hosts and/or --limit does not match any hosts"
+            if C.HOST_PATTERN_MISMATCH == 'warning':
+                display.warning(msg)
+            elif C.HOST_PATTERN_MISMATCH == 'error':
+                raise AnsibleError(msg)
 
         return hosts
 

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -153,7 +153,6 @@ class InventoryManager(object):
         # caches
         self._hosts_patterns_cache = {}  # resolved full patterns
         self._pattern_cache = {}  # resolved individual patterns
-        self._group_pattern_cache = {}
 
         # the inventory dirs, files, script paths or lists of hosts
         if sources is None:
@@ -419,22 +418,6 @@ class InventoryManager(object):
 
         return hosts
 
-    def is_group_pattern(self, patterns):
-        """
-        Call after host patterns are evaluated.
-        Takes a list of patterns and returns True if any groups match.
-        """
-        # Check if pattern already computed
-        if isinstance(patterns, list):
-            patterns = patterns[:]
-        else:
-            patterns = [patterns]
-
-        for p in patterns:
-            if p in self._group_pattern_cache and self._group_pattern_cache[p]:
-                return True
-        return False
-
     def _evaluate_patterns(self, patterns):
         """
         Takes a list of patterns and returns a list of matching host names,
@@ -574,7 +557,6 @@ class InventoryManager(object):
         # check if pattern matches group
         matching_groups = self._match_list(self._inventory.groups, pattern)
         if matching_groups:
-            self._group_pattern_cache[pattern] = self._group_pattern_cache.get(pattern, []) + matching_groups
             for groupname in matching_groups:
                 results.extend(self._inventory.groups[groupname].get_hosts())
 
@@ -666,4 +648,3 @@ class InventoryManager(object):
 
     def clear_pattern_cache(self):
         self._pattern_cache = {}
-        self._group_pattern_cache = {}

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -153,6 +153,7 @@ class InventoryManager(object):
         # caches
         self._hosts_patterns_cache = {}  # resolved full patterns
         self._pattern_cache = {}  # resolved individual patterns
+        self._group_pattern_cache = {}
 
         # the inventory dirs, files, script paths or lists of hosts
         if sources is None:
@@ -418,6 +419,22 @@ class InventoryManager(object):
 
         return hosts
 
+    def is_group_pattern(self, patterns):
+        """
+        Call after host patterns are evaluated.
+        Takes a list of patterns and returns True if any groups match.
+        """
+        # Check if pattern already computed
+        if isinstance(patterns, list):
+            patterns = patterns[:]
+        else:
+            patterns = [patterns]
+
+        for p in patterns:
+            if p in self._group_pattern_cache and self._group_pattern_cache[p]:
+                return True
+        return False
+
     def _evaluate_patterns(self, patterns):
         """
         Takes a list of patterns and returns a list of matching host names,
@@ -557,6 +574,7 @@ class InventoryManager(object):
         # check if pattern matches group
         matching_groups = self._match_list(self._inventory.groups, pattern)
         if matching_groups:
+            self._group_pattern_cache[pattern] = self._group_pattern_cache.get(pattern, []) + matching_groups
             for groupname in matching_groups:
                 results.extend(self._inventory.groups[groupname].get_hosts())
 
@@ -648,3 +666,4 @@ class InventoryManager(object):
 
     def clear_pattern_cache(self):
         self._pattern_cache = {}
+        self._group_pattern_cache = {}

--- a/test/integration/targets/inventory/inv_with_empty_group.yml
+++ b/test/integration/targets/inventory/inv_with_empty_group.yml
@@ -1,0 +1,6 @@
+all:
+  children:
+    empty_group: {}
+    populated_group:
+      hosts:
+        host1: {}

--- a/test/integration/targets/inventory/runme.sh
+++ b/test/integration/targets/inventory/runme.sh
@@ -23,6 +23,10 @@ if ansible-playbook -i ../../inventory --limit foo playbook.yml; then
     exit 1
 fi
 
+# https://github.com/ansible/ansible/issues/77510
+# Ensure that matching limit of an empty group causes a warning with rc 0
+ansible-playbook test_limit_empty_group.yml "$@"
+
 # Ensure that non-existing limit file causes failure with rc 1
 if ansible-playbook -i ../../inventory --limit @foo playbook.yml; then
     echo "Non-existing limit file should cause failure"

--- a/test/integration/targets/inventory/test_limit_empty_group.yml
+++ b/test/integration/targets/inventory/test_limit_empty_group.yml
@@ -5,8 +5,10 @@
     - command: ansible-playbook -i inv_with_empty_group.yml --limit empty_group playbook.yml
       register: result
       environment:
+        # Override hard-coded ansible-test config
         ANSIBLE_NOCOLOR: True
         ANSIBLE_FORCE_COLOR: False
+        ANSIBLE_HOST_PATTERN_MISMATCH: warning
 
     - assert:
         that:
@@ -15,4 +17,4 @@
           - expected_warning in sanitized_error
       vars:
         sanitized_error: "{{ result.stderr | regex_replace('\n', ' ') }}"
-        expected_warning: "[WARNING]: Specified hosts and/or --limit does not match any hosts, only empty group(s)"
+        expected_warning: "[WARNING]: Specified hosts and/or --limit does not match any hosts"

--- a/test/integration/targets/inventory/test_limit_empty_group.yml
+++ b/test/integration/targets/inventory/test_limit_empty_group.yml
@@ -1,0 +1,18 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - command: ansible-playbook -i inv_with_empty_group.yml --limit empty_group playbook.yml
+      register: result
+      environment:
+        ANSIBLE_NOCOLOR: True
+        ANSIBLE_FORCE_COLOR: False
+
+    - assert:
+        that:
+          - result.rc == 0
+          - '"skipping: no hosts matched" in result.stdout'
+          - expected_warning in sanitized_error
+      vars:
+        sanitized_error: "{{ result.stderr | regex_replace('\n', ' ') }}"
+        expected_warning: "[WARNING]: Specified hosts and/or --limit does not match any hosts, only empty group(s)"


### PR DESCRIPTION
##### SUMMARY
Differentiate between an invalid limit and one that matches only empty groups.

Fixes #77510

* [ ] Needs a test

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
