### PR TITLE
Remove scheduled CI runs.

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -12,15 +12,6 @@ pr:
       - devel
       - stable-*
 
-schedules:
-  - cron: 0 7 * * *
-    displayName: Nightly
-    always: true
-    branches:
-      include:
-        - devel
-        - stable-*
-
 variables:
   - name: checkoutPath
     value: ansible


### PR DESCRIPTION
##### SUMMARY

The 2.10 release reaches EOL next month, so scheduled runs are being removed to free up CI resources.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

.azure-pipelines/azure-pipelines.yml