### PR TITLE
Remove openSUSE Python 2.7 from test matrix.

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -119,9 +119,7 @@ stages:
               test: fedora34
             - name: Fedora 35
               test: fedora35
-            - name: openSUSE 15 py2
-              test: opensuse15py2
-            - name: openSUSE 15 py3
+            - name: openSUSE 15
               test: opensuse15
             - name: Ubuntu 18.04
               test: ubuntu1804


### PR DESCRIPTION
##### SUMMARY

Remove openSUSE Python 2.7 from test matrix.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

.azure-pipelines/azure-pipelines.yml