### PR TITLE
Update pip example with standard lowercase http[s]_proxy env vars

### DIFF
--- a/lib/ansible/modules/pip.py
+++ b/lib/ansible/modules/pip.py
@@ -159,12 +159,11 @@ EXAMPLES = '''
       - bottle>0.10,<0.20,!=0.11
 
 - name: Install python package using a proxy
-  # Pip doesn't use the standard environment variables, please use the CAPITALIZED ones below
   ansible.builtin.pip:
     name: six
   environment:
-    HTTP_PROXY: '127.0.0.1:8080'
-    HTTPS_PROXY: '127.0.0.1:8080'
+    http_proxy: 'http://127.0.0.1:8080'
+    https_proxy: 'https://127.0.0.1:8080'
 
 # You do not have to supply '-e' option in extra_args
 - name: Install MyApp using one of the remote protocols (bzr+,hg+,git+,svn+)


### PR DESCRIPTION
##### SUMMARY

A pip module example incorrectly states that pip doesn't support "the standard environment variables" (i.e. `http_proxy` and `https_proxy`) and suggests using `HTTP_PROXY` and `HTTPS_PROXY` instead.

However, pip does support the lowercase variables as stated below.

* https://pip.pypa.io/en/stable/user_guide/?highlight=http_proxy#using-a-proxy-server

> by setting the standard environment-variables http_proxy, https_proxy and no_proxy.

This has been true since 2013 when it started using requests library

* https://github.com/pypa/pip/commit/ff2854a855cb3643a69d8e7c2b020c153107d2b2

which has supported both uppercase and lowercase versions of the variables since 2012.

* https://github.com/psf/requests/commit/0ba8c44260209ff518809a6b5b307d443e8dfe67#diff-b4b6ac4e508ec3e142b8b8a3cf33b9ab925e3bdd03dbbe859384760746b1ac76R462


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pip
