### PR TITLE
Exclude Python 2.6 from interpreter discovery.

### DIFF
--- a/changelogs/fragments/python-2.6-discovery.yml
+++ b/changelogs/fragments/python-2.6-discovery.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible - Exclude Python 2.6 from Python interpreter discovery.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1558,7 +1558,6 @@ INTERPRETER_PYTHON_FALLBACK:
   - /usr/bin/python3
   - /usr/libexec/platform-python
   - python2.7
-  - python2.6
   - /usr/bin/python
   - python
   vars:


### PR DESCRIPTION
##### SUMMARY

Exclude Python 2.6 from interpreter discovery.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible