### PR TITLE
[stable-2.13] Exclude Python 2.6 from interpreter discovery.

### DIFF
--- a/changelogs/fragments/python-2.6-discovery.yml
+++ b/changelogs/fragments/python-2.6-discovery.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible - Exclude Python 2.6 from Python interpreter discovery.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1571,7 +1571,6 @@ INTERPRETER_PYTHON_FALLBACK:
   - /usr/bin/python3
   - /usr/libexec/platform-python
   - python2.7
-  - python2.6
   - /usr/bin/python
   - python
   vars:


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/77522

(cherry picked from commit 32d67ce998a88d752e2ccfa26a2e7b7c059a1115)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible
