### PR TITLE
Update docs to recommend the TTY for prompts over stderr

### DIFF
--- a/docs/docsite/rst/user_guide/vault.rst
+++ b/docs/docsite/rst/user_guide/vault.rst
@@ -101,7 +101,7 @@ To create a vault password client script:
   * Within the script itself:
       * Print the passwords to standard output
       * Accept a ``--vault-id`` option
-      * If the script prompts for data (for example, a database password), send the prompts to standard error
+      * If the script prompts for data (for example, a database password), display the prompts to the TTY.
 
 When you run a playbook that uses vault passwords stored in a third-party tool, specify the script as the source within the ``--vault-id`` flag. For example:
 


### PR DESCRIPTION
##### SUMMARY
Update docs to recommend the TTY for prompts over stderr.

The existing docs are a bit naive.  stderr should be left for actual errors, and use the TTY like most modern utilities such as the python `getpass` module.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/user_guide/vault.rst

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
