### PR TITLE
Pin antsibull to 0.42.0

### DIFF
--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -1,7 +1,7 @@
 # pip packages required to build docsite
 # tested April 14 2022
 
-antsibull==0.43.0
+antsibull==0.42.0
 # version floats free, since we control features and releases
 docutils==0.16
 # check unordered lists when testing more recent docutils versions

--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -1,18 +1,18 @@
 # pip packages required to build docsite
-# tested April 14 2022 - match requirements to docs-build.requirements.txt
+# tested April 14 2022
 
-antsibull==0.26
+antsibull==0.43.0
 # version floats free, since we control features and releases
 docutils==0.16
 # check unordered lists when testing more recent docutils versions
 # see https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
 jinja2==3.0.1
-Pygments==2.10.0
+Pygments==2.9.0
 PyYAML==5.4.1
 resolvelib==0.5.4
 rstcheck==3.3.1
-sphinx==2.1.2
+sphinx==4.0.2
 sphinx-notfound-page==0.7.1 # must be >= 0.6
 sphinx-intl==2.0.1
-sphinx-ansible-theme===0.8.0
+sphinx-ansible-theme===0.7.0
 straight.plugin==1.5.0 # Needed for hacking/build-ansible.py which is the backend build script

--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -1,18 +1,18 @@
 # pip packages required to build docsite
-# tested June 9 2021
+# tested April 14 2022 - match requirements to docs-build.requirements.txt
 
-antsibull
+antsibull==0.26
 # version floats free, since we control features and releases
 docutils==0.16
 # check unordered lists when testing more recent docutils versions
 # see https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
 jinja2==3.0.1
-Pygments==2.9.0
+Pygments==2.10.0
 PyYAML==5.4.1
 resolvelib==0.5.4
 rstcheck==3.3.1
-sphinx==4.0.2
+sphinx==2.1.2
 sphinx-notfound-page==0.7.1 # must be >= 0.6
 sphinx-intl==2.0.1
-sphinx-ansible-theme===0.7.0
+sphinx-ansible-theme===0.8.0
 straight.plugin==1.5.0 # Needed for hacking/build-ansible.py which is the backend build script


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
antsibull > 0.43 makes the docs build fail in older branches. Pin it to remove this problem.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request



##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
