### PR TITLE
Fix error message for non-str hosts in yaml inventory

### DIFF
--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -174,6 +174,10 @@ class InventoryModule(BaseFileInventoryPlugin):
         '''
         Each host key can be a pattern, try to process it and add variables as needed
         '''
-        (hostnames, port) = self._expand_hostpattern(host_pattern)
-
+        try:
+            (hostnames, port) = self._expand_hostpattern(host_pattern)
+        except TypeError:
+            raise AnsibleParserError(
+                f"Host pattern {host_pattern} must be a string. Enclose integers/floats in quotation marks."
+            )
         return hostnames, port


### PR DESCRIPTION
##### SUMMARY
Improves error for unexpected host strings. The error before (`argument of type 'int' is not iterable`) doesn't indicate host patterns need to be strings.

Fixes #77519

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/inventory/yaml.py