### PR TITLE
ensure dependencies are a dict

### DIFF
--- a/changelogs/fragments/77561-ansible-galaxy-coll-install-null-dependencies.yml
+++ b/changelogs/fragments/77561-ansible-galaxy-coll-install-null-dependencies.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    ansible-galaxy - fix installing collections that have dependencies in the metadata set to
+    null instead of an empty dictionary (https://github.com/ansible/ansible/issues/77560).

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -268,7 +268,10 @@ class ConcreteArtifactsManager:
     def get_direct_collection_dependencies(self, collection):
         # type: (Candidate | Requirement) -> dict[str, str]
         """Extract deps from the given on-disk collection artifact."""
-        return self.get_direct_collection_meta(collection)['dependencies']  # type: ignore[return-value]
+        collection_dependencies = self.get_direct_collection_meta(collection)['dependencies']
+        if collection_dependencies is None:
+            collection_dependencies = {}
+        return collection_dependencies  # type: ignore[return-value]
 
     def get_direct_collection_meta(self, collection):
         # type: (Candidate | Requirement) -> dict[str, str | dict[str, str] | list[str] | None]

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -132,7 +132,7 @@ def reset_cli_args():
     co.GlobalCLIArgs._Singleton__instance = None
 
 
-@pytest.fixture()
+@pytest.fixture(params=[{}, None], ids=["not-none-deps", "none-deps"])
 def collection_artifact(request, tmp_path_factory):
     test_dir = to_text(tmp_path_factory.mktemp('test-ÅÑŚÌβŁÈ Collections Input'))
     namespace = 'ansible_namespace'
@@ -144,15 +144,15 @@ def collection_artifact(request, tmp_path_factory):
     call_galaxy_cli(['init', '%s.%s' % (namespace, collection), '-c', '--init-path', test_dir,
                      '--collection-skeleton', skeleton_path])
     dependencies = getattr(request, 'param', None)
-    if dependencies:
-        galaxy_yml = os.path.join(collection_path, 'galaxy.yml')
-        with open(galaxy_yml, 'rb+') as galaxy_obj:
-            existing_yaml = yaml.safe_load(galaxy_obj)
-            existing_yaml['dependencies'] = dependencies
 
-            galaxy_obj.seek(0)
-            galaxy_obj.write(to_bytes(yaml.safe_dump(existing_yaml)))
-            galaxy_obj.truncate()
+    galaxy_yml = os.path.join(collection_path, 'galaxy.yml')
+    with open(galaxy_yml, 'rb+') as galaxy_obj:
+        existing_yaml = yaml.safe_load(galaxy_obj)
+        existing_yaml['dependencies'] = dependencies
+
+        galaxy_obj.seek(0)
+        galaxy_obj.write(to_bytes(yaml.safe_dump(existing_yaml)))
+        galaxy_obj.truncate()
 
     # Create a file with +x in the collection so we can test the permissions
     execute_path = os.path.join(collection_path, 'runme.sh')

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -132,7 +132,7 @@ def reset_cli_args():
     co.GlobalCLIArgs._Singleton__instance = None
 
 
-@pytest.fixture(params=[{}, None], ids=["not-none-deps", "none-deps"])
+@pytest.fixture()
 def collection_artifact(request, tmp_path_factory):
     test_dir = to_text(tmp_path_factory.mktemp('test-ÅÑŚÌβŁÈ Collections Input'))
     namespace = 'ansible_namespace'
@@ -143,7 +143,7 @@ def collection_artifact(request, tmp_path_factory):
 
     call_galaxy_cli(['init', '%s.%s' % (namespace, collection), '-c', '--init-path', test_dir,
                      '--collection-skeleton', skeleton_path])
-    dependencies = getattr(request, 'param', None)
+    dependencies = getattr(request, 'param', {})
 
     galaxy_yml = os.path.join(collection_path, 'galaxy.yml')
     with open(galaxy_yml, 'rb+') as galaxy_obj:
@@ -995,6 +995,7 @@ def test_install_collection_with_circular_dependency(collection_artifact, monkey
     assert actual_manifest['collection_info']['namespace'] == 'ansible_namespace'
     assert actual_manifest['collection_info']['name'] == 'collection'
     assert actual_manifest['collection_info']['version'] == '0.1.0'
+    assert actual_manifest['collection_info']['dependencies'] == {'ansible_namespace.collection': '>=0.0.1'}
 
     # Filter out the progress cursor display calls.
     display_msgs = [m[1][0] for m in mock_display.mock_calls if 'newline' not in m[2] and len(m[1]) == 1]
@@ -1003,6 +1004,30 @@ def test_install_collection_with_circular_dependency(collection_artifact, monkey
     assert display_msgs[1] == "Starting collection install process"
     assert display_msgs[2] == "Installing 'ansible_namespace.collection:0.1.0' to '%s'" % to_text(collection_path)
     assert display_msgs[3] == "ansible_namespace.collection:0.1.0 was installed successfully"
+
+
+@pytest.mark.parametrize('collection_artifact', [
+    None,
+    {},
+], indirect=True)
+def test_install_collection_with_no_dependency(collection_artifact, monkeypatch):
+    collection_path, collection_tar = collection_artifact
+    temp_path = os.path.split(collection_tar)[0]
+    shutil.rmtree(collection_path)
+
+    concrete_artifact_cm = collection.concrete_artifact_manager.ConcreteArtifactsManager(temp_path, validate_certs=False)
+    requirements = [Requirement('ansible_namespace.collection', '0.1.0', to_text(collection_tar), 'file', None)]
+    collection.install_collections(requirements, to_text(temp_path), [], False, False, False, False, False, False, concrete_artifact_cm, True)
+
+    assert os.path.isdir(collection_path)
+
+    with open(os.path.join(collection_path, b'MANIFEST.json'), 'rb') as manifest_obj:
+        actual_manifest = json.loads(to_text(manifest_obj.read()))
+
+    assert not actual_manifest['collection_info']['dependencies']
+    assert actual_manifest['collection_info']['namespace'] == 'ansible_namespace'
+    assert actual_manifest['collection_info']['name'] == 'collection'
+    assert actual_manifest['collection_info']['version'] == '0.1.0'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ensure the type of `collection_dependencies` is `dict`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #77560
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-galaxy
##### ADDITIONAL INFORMATION

Assume:

1. namespace is `ns1`
2. `dependencies` in `collection1`, is defined, but no value is assigned.
3.`dependencies` in `collection2`, is set to `collection1`. 

Scenarios:

1. `ansible-galaxy collection install ns1.collection1` works.
  Why does it work even the `dependencies` is `None`? It is because the `dependencies` of ``collection1` is retrieved from galaxy api, and the api would return a black dict.
  
  https://github.com/ansible/ansible/blob/devel/lib/ansible/galaxy/collection/galaxy_api_proxy.py#L151-L166.

2. If we clone the source code of `ns1.collection1`, and install it from source code, `ansible-galaxy collection install .` doesn't work

Then we install `ns1.collection1` from source code.

3. If `ns1.collection1` is not installed, and we run `ansible-galaxy collection install .`. It works
4. If `ns1.collection1` is installed, and we run `ansible-galaxy collection install .`. It doesn't work. 

  For 3rd and 4th, it is because the `ansible-galaxy` will firstly try to get the `dependencies` in `MANIFEST.json`, and the value is set to `None` as below
  https://github.com/ansible/ansible/blob/devel/lib/ansible/galaxy/collection/concrete_artifact_manager.py#L568-L574
  
  ```shell
  $ grep dependencies ~/.ansible/collections/ansible_collections/my_namespace/my_collection/MANIFEST.json
    "dependencies": null,
  ```
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
### How to reprocuce
```shell
$ ansible-galaxy collection init my_namespace.my_collection
$ cd my_namespace.my_collection
$ gsed -ri 's/^(dependencies:)(.*)$/\1/' galaxy.yml
$ ansible-galaxy collection install -vvv .
```

<!--- Paste verbatim command output below, e.g. before and after your change -->

##### Before
```shell
$ ansible-galaxy collection install -vvvv .
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying
the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become
unstable at any point.
ansible-galaxy [core 2.14.0.dev0] (devel abdd237de7) last updated 2022/04/19 11:12:55 (GMT +800)
  config file = None
  configured module search path = ['/Users/jackzhang/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jackzhang/src/github/ansible/lib/ansible
  ansible collection location = /Users/jackzhang/.ansible/collections:/usr/share/ansible/collections
  executable location = /Users/jackzhang/.pyenv/versions/v-397/bin/ansible-galaxy
  python version = 3.9.7 (default, Oct 28 2021, 19:01:53) [Clang 12.0.5 (clang-1205.0.22.11)]
  jinja version = 3.1.1
  libyaml = True
No config file found; using defaults
Starting galaxy collection install process
Found installed collection geerlingguy.testing:1.0.0 at '/Users/jackzhang/.ansible/collections/ansible_collections/geerlingguy/testing'
Found installed collection lablabs.wireguard:0.1.1 at '/Users/jackzhang/.ansible/collections/ansible_collections/lablabs/wireguard'
[WARNING]: Collection at '/Users/jackzhang/.ansible/collections/ansible_collections/foo/bar' does not have a MANIFEST.json
file, nor has it galaxy.yml: cannot detect version.
Found installed collection foo.bar:* at '/Users/jackzhang/.ansible/collections/ansible_collections/foo/bar'
Found installed collection robertdebock.development_environment:2.1.1 at '/Users/jackzhang/.ansible/collections/ansible_collections/robertdebock/development_environment'
Found installed collection containers.podman:1.9.3 at '/Users/jackzhang/.ansible/collections/ansible_collections/containers/podman'
Found installed collection community.docker:2.3.0 at '/Users/jackzhang/.ansible/collections/ansible_collections/community/docker'
Found installed collection community.general:4.7.0 at '/Users/jackzhang/.ansible/collections/ansible_collections/community/general'
Found installed collection community.molecule:0.1.0 at '/Users/jackzhang/.ansible/collections/ansible_collections/community/molecule'
Process install dependency map
ERROR! Unexpected Exception, this is probably a bug: 'NoneType' object has no attribute 'items'
the full traceback was:

Traceback (most recent call last):
  File "/Users/jackzhang/src/github/ansible/lib/ansible/cli/__init__.py", line 601, in cli_executor
    exit_code = cli.run()
  File "/Users/jackzhang/src/github/ansible/lib/ansible/cli/galaxy.py", line 646, in run
    return context.CLIARGS['func']()
  File "/Users/jackzhang/src/github/ansible/lib/ansible/cli/galaxy.py", line 102, in method_wrapper
    return wrapped_method(*args, **kwargs)
  File "/Users/jackzhang/src/github/ansible/lib/ansible/cli/galaxy.py", line 1300, in execute_install
    self._execute_install_collection(
  File "/Users/jackzhang/src/github/ansible/lib/ansible/cli/galaxy.py", line 1328, in _execute_install_collection
    install_collections(
  File "/Users/jackzhang/src/github/ansible/lib/ansible/galaxy/collection/__init__.py", line 683, in install_collections
    dependency_map = _resolve_depenency_map(
  File "/Users/jackzhang/src/github/ansible/lib/ansible/galaxy/collection/__init__.py", line 1594, in _resolve_depenency_map
    return collection_dep_resolver.resolve(
  File "/Users/jackzhang/.pyenv/versions/3.9.7/envs/v-397/lib/python3.9/site-packages/resolvelib/resolvers.py", line 453, in resolve
    state = resolution.resolve(requirements, max_rounds=max_rounds)
  File "/Users/jackzhang/.pyenv/versions/3.9.7/envs/v-397/lib/python3.9/site-packages/resolvelib/resolvers.py", line 347, in resolve
    failure_causes = self._attempt_to_pin_criterion(name, criterion)
  File "/Users/jackzhang/.pyenv/versions/3.9.7/envs/v-397/lib/python3.9/site-packages/resolvelib/resolvers.py", line 207, in _attempt_to_pin_criterion
    criteria = self._get_criteria_to_update(candidate)
  File "/Users/jackzhang/.pyenv/versions/3.9.7/envs/v-397/lib/python3.9/site-packages/resolvelib/resolvers.py", line 198, in _get_criteria_to_update
    for r in self._p.get_dependencies(candidate):
  File "/Users/jackzhang/src/github/ansible/lib/ansible/galaxy/dependency_resolution/providers.py", line 425, in get_dependencies
    for dep_name, dep_req in req_map.items()
AttributeError: 'NoneType' object has no attribute 'items'
```

##### After

```shell
$ ansible-galaxy collection install -vvvv .
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible
engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
ansible-galaxy [core 2.14.0.dev0] (feature/dependencies-as-a-dict 5190156a61) last updated 2022/04/19 15:43:49 (GMT +800)
  config file = None
  configured module search path = ['/Users/jackzhang/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jackzhang/src/github/ansible/lib/ansible
  ansible collection location = /Users/jackzhang/.ansible/collections:/usr/share/ansible/collections
  executable location = /Users/jackzhang/.pyenv/versions/v-397/bin/ansible-galaxy
  python version = 3.9.7 (default, Oct 28 2021, 19:01:53) [Clang 12.0.5 (clang-1205.0.22.11)]
  jinja version = 3.1.1
  libyaml = True
No config file found; using defaults
Starting galaxy collection install process
Found installed collection geerlingguy.testing:1.0.0 at '/Users/jackzhang/.ansible/collections/ansible_collections/geerlingguy/testing'
Found installed collection lablabs.wireguard:0.1.1 at '/Users/jackzhang/.ansible/collections/ansible_collections/lablabs/wireguard'
[WARNING]: Collection at '/Users/jackzhang/.ansible/collections/ansible_collections/foo/bar' does not have a MANIFEST.json file, nor has
it galaxy.yml: cannot detect version.
Found installed collection foo.bar:* at '/Users/jackzhang/.ansible/collections/ansible_collections/foo/bar'
Found installed collection robertdebock.development_environment:2.1.1 at '/Users/jackzhang/.ansible/collections/ansible_collections/robertdebock/development_environment'
Found installed collection containers.podman:1.9.3 at '/Users/jackzhang/.ansible/collections/ansible_collections/containers/podman'
Found installed collection community.docker:2.3.0 at '/Users/jackzhang/.ansible/collections/ansible_collections/community/docker'
Found installed collection community.general:4.7.0 at '/Users/jackzhang/.ansible/collections/ansible_collections/community/general'
Found installed collection community.molecule:0.1.0 at '/Users/jackzhang/.ansible/collections/ansible_collections/community/molecule'
Process install dependency map
Starting collection install process
Installing 'my_namespace.my_collection:1.0.0' to '/Users/jackzhang/.ansible/collections/ansible_collections/my_namespace/my_collection'
Skipping './galaxy.yml' for collection build
Created collection for my_namespace.my_collection:1.0.0 at /Users/jackzhang/.ansible/collections/ansible_collections/my_namespace/my_collection
my_namespace.my_collection:1.0.0 was installed successfully
```
