### PR TITLE
ansible-test - Fix rstcheck compatibility issues.

### DIFF
--- a/changelogs/fragments/ansible-test-rstcheck-fix.yml
+++ b/changelogs/fragments/ansible-test-rstcheck-fix.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - ansible-test - Fix ``rstcheck`` sanity test to work with newer Jinja2 releases.
+  - ansible-test - Add ``docutils < 0.18`` constraint for compatibility with the Sphinx version used for docs builds.
+  - ansible-test - Add ``rstcheck == 3.3.1`` constraint to avoid issues with later versions which are incompatible.

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -13,7 +13,8 @@ urllib3 < 1.24 ; python_version < '2.7' # urllib3 1.24 and later require python 
 pywinrm >= 0.3.0 # message encryption support
 sphinx < 1.6 ; python_version < '2.7' # sphinx 1.6 and later require python 2.7 or later
 sphinx <= 2.1.2 ; python_version >= '2.7' # docs team hasn't  tested beyond 2.1.2 yet
-rstcheck >=3.3.1  # required for sphinx version >= 1.8
+rstcheck == 3.3.1  # required for sphinx version >= 1.8
+docutils < 0.18 # required for sphinx compatibility
 pygments >= 2.4.0 # Pygments 2.4.0 includes bugfixes for YAML and YAML+Jinja lexers
 wheel < 0.30.0 ; python_version < '2.7' # wheel 0.30.0 and later require python 2.7 or later
 pycrypto >= 2.6 # Need features found in 2.6 and greater

--- a/test/sanity/code-smell/rstcheck-cli.py
+++ b/test/sanity/code-smell/rstcheck-cli.py
@@ -1,0 +1,19 @@
+"""Wrapper around rstcheck to provide Jinja2 compatibility for Sphinx."""
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import runpy
+import sys
+
+try:
+    from jinja2.filters import pass_context as _passctx, pass_environment as _passenv
+    _mod = sys.modules['jinja2']
+    _mod.contextfunction = _passctx
+    _mod.environmentfilter = _passenv
+except ImportError:
+    pass
+
+sys.path.remove(os.path.dirname(__file__))  # avoid recursively running sanity test
+
+runpy.run_module('rstcheck', run_name='__main__', alter_sys=True)

--- a/test/sanity/code-smell/rstcheck.py
+++ b/test/sanity/code-smell/rstcheck.py
@@ -3,6 +3,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import os
 import re
 import subprocess
 import sys
@@ -19,7 +20,7 @@ def main():
 
     cmd = [
         sys.executable,
-        '-m', 'rstcheck',
+        os.path.join(os.path.dirname(__file__), 'rstcheck-cli.py'),
         '--report', 'warning',
         '--ignore-substitutions', ','.join(ignore_substitutions),
     ] + paths


### PR DESCRIPTION
##### SUMMARY

- Fix `rstcheck` sanity test to work with newer Jinja2 releases.
- Add `docutils < 0.18` constraint for compatibility with the Sphinx version used for docs builds.
- Add `rstcheck == 3.3.1` constraint to avoid issues with later versions which are incompatible.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
