### PR TITLE
Change to correct memory variable for OpenBSD

### DIFF
--- a/fail.yml
+++ b/fail.yml
@@ -1,0 +1,7 @@
+- name: Reproducer that fails
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Include a role that does not exist
+      include_role:
+        name: does_not_exist

--- a/lib/ansible/module_utils/facts/hardware/openbsd.py
+++ b/lib/ansible/module_utils/facts/hardware/openbsd.py
@@ -94,7 +94,7 @@ class OpenBSDHardware(Hardware):
         rc, out, err = self.module.run_command("/usr/bin/vmstat")
         if rc == 0:
             memory_facts['memfree_mb'] = int(out.splitlines()[-1].split()[4]) // 1024
-            memory_facts['memtotal_mb'] = int(self.sysctl['hw.usermem']) // 1024 // 1024
+            memory_facts['memtotal_mb'] = int(self.sysctl['hw.physmem']) // 1024 // 1024
 
         # Get swapctl info. swapctl output looks like:
         # total: 69268 1K-blocks allocated, 0 used, 69268 available

--- a/lib/ansible/module_utils/facts/hardware/openbsd.py
+++ b/lib/ansible/module_utils/facts/hardware/openbsd.py
@@ -94,7 +94,7 @@ class OpenBSDHardware(Hardware):
         rc, out, err = self.module.run_command("/usr/bin/vmstat")
         if rc == 0:
             memory_facts['memfree_mb'] = int(out.splitlines()[-1].split()[4]) // 1024
-            memory_facts['memtotal_mb'] = int(self.sysctl['hw.physmem']) // 1024 // 1024
+            memory_facts['memtotal_mb'] = int(self.sysctl['hw.usermem']) // 1024 // 1024
 
         # Get swapctl info. swapctl output looks like:
         # total: 69268 1K-blocks allocated, 0 used, 69268 available

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -248,18 +248,20 @@ class StrategyModule(StrategyBase):
                     display.debug("collecting new blocks for %s" % included_file)
                     try:
                         if included_file._is_role:
-                            new_ir = self._copy_included_file(included_file)
+                            # new_ir = self._copy_included_file(included_file)
 
-                            new_blocks, handler_blocks = new_ir.get_block_list(
-                                play=iterator._play,
-                                variable_manager=self._variable_manager,
-                                loader=self._loader,
-                            )
+                            # new_blocks, handler_blocks = new_ir.get_block_list(
+                            #     play=iterator._play,
+                            #     variable_manager=self._variable_manager,
+                            #     loader=self._loader,
+                            # )
+                            new_blocks = self._load_included_role(included_file, iterator=iterator)
                         else:
                             new_blocks = self._load_included_file(included_file, iterator=iterator)
                     except AnsibleParserError:
                         raise
                     except AnsibleError as e:
+                        display.warning(to_text(e), wrap_text=False)
                         for r in included_file._results:
                             r._result['failed'] = True
 

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -350,14 +350,16 @@ class StrategyModule(StrategyBase):
                         # included hosts get the task list while those excluded get an equal-length
                         # list of noop tasks, to make sure that they continue running in lock-step
                         try:
+                            print(included_file)
                             if included_file._is_role:
-                                new_ir = self._copy_included_file(included_file)
+                                # new_ir = self._copy_included_file(included_file)
 
-                                new_blocks, handler_blocks = new_ir.get_block_list(
-                                    play=iterator._play,
-                                    variable_manager=self._variable_manager,
-                                    loader=self._loader,
-                                )
+                                # new_blocks, handler_blocks = new_ir.get_block_list(
+                                #     play=iterator._play,
+                                #     variable_manager=self._variable_manager,
+                                #     loader=self._loader,
+                                # )
+                                new_blocks = self._load_included_role(included_file, iterator=iterator)
                             else:
                                 new_blocks = self._load_included_file(included_file, iterator=iterator)
 
@@ -384,6 +386,7 @@ class StrategyModule(StrategyBase):
                         except AnsibleParserError:
                             raise
                         except AnsibleError as e:
+                            display.error(to_text(e), wrap_text=False)
                             for r in included_file._results:
                                 r._result['failed'] = True
 

--- a/roles/does_exist/tasks/main.yml
+++ b/roles/does_exist/tasks/main.yml
@@ -1,0 +1,8 @@
+  - name: does_exist inside role directory
+    my_test:
+      name: 'hello'
+      new: true
+    register: testout
+  - name: dump test output
+    debug:
+      msg: '{{ testout }}'

--- a/success.yml
+++ b/success.yml
@@ -1,0 +1,11 @@
+- name: Reproducer that does not fail
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: A successful task
+      debug:
+        msg: Hello o/
+
+    - name: Include a role that does not exist
+      include_role:
+        name: does_not_exist

--- a/success2.yml
+++ b/success2.yml
@@ -1,0 +1,10 @@
+- name: Reproducer that does not fail with a success include role
+  hosts: localhost
+  gather_facts: true
+  tasks:
+    - name: A successful task
+      debug:
+        msg: Hello o/
+    - name: Include a role that does exist
+      include_role:
+        name: does_exist


### PR DESCRIPTION
##### SUMMARY
Changed memtotal in openbsd.py to access the correct memory from the OpenBSD docs.

Should fix #77448 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/facts/hardware/openbsd.py#L97 

##### ADDITIONAL INFORMATION
I was unable to reproduce the error happening in the bug #77448 so I am not sure if this was fixed already or just an error on how I was using OpenBSD to test it. Running the setup up to get the memtotal with this change does produce the same number every time the command is run however.