### PR TITLE
Fix callback error with an undefined include_role task

### DIFF
--- a/failure.yml
+++ b/failure.yml
@@ -1,0 +1,7 @@
+- name: Reproducer that fails
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Include a role that does not exist
+      include_role:
+        name: does_not_exist

--- a/lib/ansible/module_utils/facts/hardware/openbsd.py
+++ b/lib/ansible/module_utils/facts/hardware/openbsd.py
@@ -94,7 +94,7 @@ class OpenBSDHardware(Hardware):
         rc, out, err = self.module.run_command("/usr/bin/vmstat")
         if rc == 0:
             memory_facts['memfree_mb'] = int(out.splitlines()[-1].split()[4]) // 1024
-            memory_facts['memtotal_mb'] = int(self.sysctl['hw.usermem']) // 1024 // 1024
+            memory_facts['memtotal_mb'] = int(self.sysctl['hw.physmem']) // 1024 // 1024
 
         # Get swapctl info. swapctl output looks like:
         # total: 69268 1K-blocks allocated, 0 used, 69268 available

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -248,18 +248,20 @@ class StrategyModule(StrategyBase):
                     display.debug("collecting new blocks for %s" % included_file)
                     try:
                         if included_file._is_role:
-                            new_ir = self._copy_included_file(included_file)
+                            # new_ir = self._copy_included_file(included_file)
 
-                            new_blocks, handler_blocks = new_ir.get_block_list(
-                                play=iterator._play,
-                                variable_manager=self._variable_manager,
-                                loader=self._loader,
-                            )
+                            # new_blocks, handler_blocks = new_ir.get_block_list(
+                            #     play=iterator._play,
+                            #     variable_manager=self._variable_manager,
+                            #     loader=self._loader,
+                            # )
+                            new_blocks = self._load_included_role(included_file, iterator=iterator)
                         else:
                             new_blocks = self._load_included_file(included_file, iterator=iterator)
                     except AnsibleParserError:
                         raise
                     except AnsibleError as e:
+                        display.warning(to_text(e), wrap_text=False)
                         for r in included_file._results:
                             r._result['failed'] = True
 

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -350,14 +350,16 @@ class StrategyModule(StrategyBase):
                         # included hosts get the task list while those excluded get an equal-length
                         # list of noop tasks, to make sure that they continue running in lock-step
                         try:
+                            print(included_file)
                             if included_file._is_role:
-                                new_ir = self._copy_included_file(included_file)
+                                # new_ir = self._copy_included_file(included_file)
 
-                                new_blocks, handler_blocks = new_ir.get_block_list(
-                                    play=iterator._play,
-                                    variable_manager=self._variable_manager,
-                                    loader=self._loader,
-                                )
+                                # new_blocks, handler_blocks = new_ir.get_block_list(
+                                #     play=iterator._play,
+                                #     variable_manager=self._variable_manager,
+                                #     loader=self._loader,
+                                # )
+                                new_blocks = self._load_included_role(included_file, iterator=iterator)
                             else:
                                 new_blocks = self._load_included_file(included_file, iterator=iterator)
 
@@ -384,6 +386,7 @@ class StrategyModule(StrategyBase):
                         except AnsibleParserError:
                             raise
                         except AnsibleError as e:
+                            display.error(to_text(e), wrap_text=False)
                             for r in included_file._results:
                                 r._result['failed'] = True
 

--- a/main.yml
+++ b/main.yml
@@ -1,0 +1,8 @@
+  - name: does_exist inside role directory
+    my_test:
+      name: 'hello'
+      new: true
+    register: testout
+  - name: dump test output
+    debug:
+      msg: '{{ testout }}'

--- a/site.yml
+++ b/site.yml
@@ -1,0 +1,11 @@
+- name: test my new module
+  hosts: localhost
+  tasks:
+  - name: run the new module
+    my_test:
+      name: 'hello'
+      new: true
+    register: testout
+  - name: dump test output
+    debug:
+      msg: '{{ testout }}'

--- a/success.yml
+++ b/success.yml
@@ -1,0 +1,11 @@
+- name: Reproducer that does not fail
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: A successful task
+      debug:
+        msg: Hello o/
+
+    - name: Include a role that does not exist
+      include_role:
+        name: does_not_exist

--- a/success2.yml
+++ b/success2.yml
@@ -1,0 +1,10 @@
+- name: Reproducer that does not fail with a success include role
+  hosts: localhost
+  gather_facts: true
+  tasks:
+    - name: A successful task
+      debug:
+        msg: Hello o/
+    - name: Include a role that does exist
+      include_role:
+        name: does_exist


### PR DESCRIPTION
##### SUMMARY
I saw there was a proposed solution for #77336 so I started to rework some of the code in the __int__.py file plugins strategy. I added a load_included_role function and abstracted some of the code chunks that were similar to load_include_files to reduce redundancy. I wrote a few more test cases with mixtures of 'ok' and 'failure' states for include_role, and found that with these changes it was accurately reporting how many succeeded and how many failed on my local machine instead of crashing and not reporting it.


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/strategy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
