### PR TITLE
[stable-2.9] ansible-test - Pin rstcheck version. (#77584)

### DIFF
--- a/changelogs/fragments/ansible-test-rstcheck-pin.yml
+++ b/changelogs/fragments/ansible-test-rstcheck-pin.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-test - Add ``rstcheck == 3.3.1`` constraint to avoid breaking changes in newer releases.
+  - ansible-test - Support newer Jinja2 versions in the ``rstcheck`` sanity test.

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -9,6 +9,7 @@ urllib3 < 1.24 ; python_version < '2.7' # urllib3 1.24 and later require python 
 pywinrm >= 0.3.0 # message encryption support
 sphinx < 1.6 ; python_version < '2.7' # sphinx 1.6 and later require python 2.7 or later
 sphinx < 1.8 ; python_version >= '2.7' # sphinx 1.8 and later are currently incompatible with rstcheck 3.3
+rstcheck == 3.3.1 # avoid compatibility issues with newer versions
 pygments >= 2.4.0 # Pygments 2.4.0 includes bugfixes for YAML and YAML+Jinja lexers
 wheel < 0.30.0 ; python_version < '2.7' # wheel 0.30.0 and later require python 2.7 or later
 yamllint != 1.8.0, < 1.14.0 ; python_version < '2.7' # yamllint 1.8.0 and 1.14.0+ require python 2.7+

--- a/test/lib/ansible_test/_data/sanity/rstcheck/rstcheck-cli.py
+++ b/test/lib/ansible_test/_data/sanity/rstcheck/rstcheck-cli.py
@@ -1,0 +1,19 @@
+"""Wrapper around rstcheck to provide Jinja2 compatibility for Sphinx."""
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import runpy
+import sys
+
+try:
+    from jinja2.filters import pass_context as _passctx, pass_environment as _passenv
+    _mod = sys.modules['jinja2']  # pylint: disable=invalid-name
+    _mod.contextfunction = _passctx
+    _mod.environmentfilter = _passenv
+except ImportError:
+    pass
+
+sys.path.remove(os.path.dirname(__file__))  # avoid recursively running sanity test
+
+runpy.run_module('rstcheck', run_name='__main__', alter_sys=True)

--- a/test/lib/ansible_test/_internal/sanity/rstcheck.py
+++ b/test/lib/ansible_test/_internal/sanity/rstcheck.py
@@ -56,7 +56,7 @@ class RstcheckTest(SanitySingleVersion):
 
         cmd = [
             find_python(python_version),
-            '-m', 'rstcheck',
+            os.path.join(SANITY_ROOT, 'rstcheck', 'rstcheck-cli.py'),
             '--report', 'warning',
             '--ignore-substitutions', ','.join(ignore_substitutions),
         ] + paths


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/77584 (originally from https://github.com/ansible/ansible/pull/77573)

* ansible-test - Pin rstcheck version.
* ansible-test - Support newer Jinja2 versions for rstcheck sanity test.

(cherry picked from commit 5859e99a30e863112a108f2cd5017e19be5a3419)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test