### PR TITLE
[stable-2.12] arg_spec - Return aliases in validation result and update aliases (#77576)

### DIFF
--- a/changelogs/fragments/77576-arg_spec-no_log-aliases.yml
+++ b/changelogs/fragments/77576-arg_spec-no_log-aliases.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - arg_spec - Fix incorrect ``no_log`` warning when a parameter alias is used (https://github.com/ansible/ansible/pull/77576)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -508,6 +508,7 @@ class AnsibleModule(object):
         self.validation_result = self.validator.validate(self.params)
         self.params.update(self.validation_result.validated_parameters)
         self.no_log_values.update(self.validation_result._no_log_values)
+        self.aliases.update(self.validation_result._aliases)
 
         try:
             error = self.validation_result.errors[0]

--- a/lib/ansible/module_utils/common/arg_spec.py
+++ b/lib/ansible/module_utils/common/arg_spec.py
@@ -61,6 +61,7 @@ class ValidationResult:
         self._validated_parameters = deepcopy(parameters)
         self._deprecations = []
         self._warnings = []
+        self._aliases = {}
         self.errors = AnsibleValidationErrorMultiple()
         """
         :class:`~ansible.module_utils.errors.AnsibleValidationErrorMultiple` containing all
@@ -180,12 +181,11 @@ class ArgumentSpecValidator:
         alias_warnings = []
         alias_deprecations = []
         try:
-            aliases = _handle_aliases(self.argument_spec, result._validated_parameters, alias_warnings, alias_deprecations)
+            result._aliases.update(_handle_aliases(self.argument_spec, result._validated_parameters, alias_warnings, alias_deprecations))
         except (TypeError, ValueError) as e:
-            aliases = {}
             result.errors.append(AliasError(to_native(e)))
 
-        legal_inputs = _get_legal_inputs(self.argument_spec, result._validated_parameters, aliases)
+        legal_inputs = _get_legal_inputs(self.argument_spec, result._validated_parameters, result._aliases)
 
         for option, alias in alias_warnings:
             result._warnings.append({'option': option, 'alias': alias})

--- a/test/units/module_utils/basic/test_argument_spec.py
+++ b/test/units/module_utils/basic/test_argument_spec.py
@@ -709,3 +709,16 @@ def test_no_log_none(stdin, capfd):
     # makes it into am.no_log_values. Instead we can check for the warning
     # emitted by am._log_invocation.
     assert len(get_warning_messages()) > 0
+
+
+@pytest.mark.parametrize("stdin", [{"pass": "testing"}], indirect=["stdin"])
+def test_no_log_alias(stdin, capfd):
+    """Given module parameters that use an alias for a parameter that matches
+    PASSWORD_MATCH and has no_log=True set, a warning should not be issued.
+    """
+    arg_spec = {
+        "other_pass": {"no_log": True, "aliases": ["pass"]},
+    }
+    am = basic.AnsibleModule(arg_spec)
+
+    assert len(get_warning_messages()) == 0

--- a/test/units/module_utils/common/arg_spec/test_aliases.py
+++ b/test/units/module_utils/common/arg_spec/test_aliases.py
@@ -95,6 +95,11 @@ def test_aliases(arg_spec, parameters, expected, deprecation, warning):
     assert isinstance(result, ValidationResult)
     assert result.validated_parameters == expected
     assert result.error_messages == []
+    assert result._aliases == {
+        alias: param
+        for param, value in arg_spec.items()
+        for alias in value.get("aliases", [])
+    }
 
     if deprecation:
         assert deprecation == result._deprecations[0]

--- a/test/units/module_utils/common/arg_spec/test_aliases.py
+++ b/test/units/module_utils/common/arg_spec/test_aliases.py
@@ -95,11 +95,11 @@ def test_aliases(arg_spec, parameters, expected, deprecation, warning):
     assert isinstance(result, ValidationResult)
     assert result.validated_parameters == expected
     assert result.error_messages == []
-    assert result._aliases == {
-        alias: param
+    assert result._aliases == dict([
+        (alias, param)
         for param, value in arg_spec.items()
         for alias in value.get("aliases", [])
-    }
+    ])
 
     if deprecation:
         assert deprecation == result._deprecations[0]

--- a/test/units/module_utils/common/arg_spec/test_aliases.py
+++ b/test/units/module_utils/common/arg_spec/test_aliases.py
@@ -95,11 +95,11 @@ def test_aliases(arg_spec, parameters, expected, deprecation, warning):
     assert isinstance(result, ValidationResult)
     assert result.validated_parameters == expected
     assert result.error_messages == []
-    assert result._aliases == dict([
+    assert result._aliases == dict(
         (alias, param)
         for param, value in arg_spec.items()
         for alias in value.get("aliases", [])
-    ])
+    )
 
     if deprecation:
         assert deprecation == result._deprecations[0]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Backport of #77576 for Ansible 2.12.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/module_utils/basic.py`
`lib/ansible/module_utils/common/arg_spec.py`

##### ADDITIONAL INFORMATION
