### PR TITLE
git fix docs and wrapper script (#77588)

### DIFF
--- a/changelogs/fragments/git_fixes.yml
+++ b/changelogs/fragments/git_fixes.yml
@@ -1,3 +1,4 @@
 bugfixes:
   - git module no longer uses wrapper script for ssh options.
   - git module is more consistent and clearer about which ssh options are added to git calls.
+  - git module fix docs and proper use of ssh wrapper script and GIT_SSH_COMMAND depending on version.


### PR DESCRIPTION
* git fix docs and wrapper script

 fixes #77582

 now env var is set to wrapper or full command depending on version
 as was the intent of previous PR
 added ref to git commit from git for why/how we used the env vars

* handle key_file

(cherry picked from commit d06d99cbb6a61db043436092663de8b20f6d2017)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
git