### PR TITLE
Added 'changed' for systemd daemon-reload and daemon-reexec

### DIFF
--- a/lib/ansible/modules/systemd.py
+++ b/lib/ansible/modules/systemd.py
@@ -390,12 +390,14 @@ def main():
     # Run daemon-reload first, if requested
     if module.params['daemon_reload'] and not module.check_mode:
         (rc, out, err) = module.run_command("%s daemon-reload" % (systemctl))
+        result['changed'] = True
         if rc != 0:
             module.fail_json(msg='failure %d during daemon-reload: %s' % (rc, err))
 
     # Run daemon-reexec
     if module.params['daemon_reexec'] and not module.check_mode:
         (rc, out, err) = module.run_command("%s daemon-reexec" % (systemctl))
+        result['changed'] = True
         if rc != 0:
             module.fail_json(msg='failure %d during daemon-reexec: %s' % (rc, err))
 


### PR DESCRIPTION
##### SUMMARY
Adding 'changed' for a systemd daemon-reload and daemon-reexec.

Fixes #77606 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
systemd

##### ADDITIONAL INFORMATION
systemd module does not report 'changed' for daemon-reload or daemon-reexec - not sure if this was on purpose or if there is a reason. If it can be changed, this pull request would enable the 'changed' for these.
