### PR TITLE
[stable-2.13] Replace antsibull with antsibull-docs (#77504)

### DIFF
--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -4,7 +4,7 @@
 #    test/sanity/code-smell/docs-build.requirements.txt
 #    test/sanity/code-smell/rstcheck.requirements.txt
 
-antsibull == 0.42.0
+antsibull-docs == 1.0.0
 # sphinx 4.2.0 requires docutils < 0.18
 docutils == 0.17.1
 jinja2 == 3.0.3

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -3,7 +3,7 @@
 # if you want known good versions of these dependencies
 # use known_good_reqs.txt instead
 
-antsibull >= 0.42.0
+antsibull-docs >= 1.0.0, < 2.0.0
 docutils
 jinja2
 pygments >= 2.10.0

--- a/hacking/build_library/build_ansible/command_plugins/collection_meta.py
+++ b/hacking/build_library/build_ansible/command_plugins/collection_meta.py
@@ -13,7 +13,7 @@ import pathlib
 import yaml
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_bytes
-from antsibull.jinja2.environment import doc_environment
+from antsibull_docs.jinja2.environment import doc_environment
 
 # Pylint doesn't understand Python3 namespace modules.
 from ..change_detection import update_file_if_different  # pylint: disable=relative-beyond-top-level

--- a/hacking/build_library/build_ansible/command_plugins/docs_build.py
+++ b/hacking/build_library/build_ansible/command_plugins/docs_build.py
@@ -102,7 +102,7 @@ def find_latest_deps_file(build_data_working, ansible_version):
 def generate_base_docs(args):
     """Regenerate the documentation for all plugins listed in the plugin_to_collection_file."""
     # imports here so that they don't cause unnecessary deps for all of the plugins
-    from antsibull.cli import antsibull_docs
+    from antsibull_docs.cli import antsibull_docs
 
     with TemporaryDirectory() as tmp_dir:
         #
@@ -135,7 +135,7 @@ def generate_full_docs(args):
     """Regenerate the documentation for all plugins listed in the plugin_to_collection_file."""
     # imports here so that they don't cause unnecessary deps for all of the plugins
     import sh
-    from antsibull.cli import antsibull_docs
+    from antsibull_docs.cli import antsibull_docs
 
     with TemporaryDirectory() as tmp_dir:
         sh.git(['clone', 'https://github.com/ansible-community/ansible-build-data'], _cwd=tmp_dir)

--- a/test/sanity/code-smell/docs-build.requirements.in
+++ b/test/sanity/code-smell/docs-build.requirements.in
@@ -5,4 +5,4 @@ sphinx == 4.2.0
 sphinx-notfound-page
 sphinx-ansible-theme
 straight.plugin
-antsibull
+antsibull-docs

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -4,8 +4,8 @@ aiohttp==3.8.0
 aiosignal==1.2.0
 alabaster==0.7.12
 ansible-pygments==0.1.0
-antsibull==0.42.0
-antsibull-changelog==0.14.0
+antsibull-core==1.0.0
+antsibull-docs==1.0.0
 async-timeout==4.0.1
 asyncio-pool==0.5.2
 attrs==21.2.0


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/77504

(cherry picked from commit 841bdb74eb3181f50b45ad62796ca7c4586f6790)

Co-authored-by: Felix Fontein <felix@fontein.de>

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

docs build