### PR TITLE
[PoC] Add loop_control.lookup

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -216,10 +216,12 @@ class TaskExecutor:
 
         templar = Templar(loader=self._loader, variables=self._job_vars)
 
-        if self._task.loop_control:
+        if self._task.loop_with:
+            loop_with = self._task.loop_with
+        elif self._task.loop_control:
             loop_with = templar.template(self._task.loop_control.lookup)
         else:
-            loop_with = self._task.loop_with
+            loop_with = None
 
         items = None
         if loop_with:

--- a/lib/ansible/playbook/loop_control.py
+++ b/lib/ansible/playbook/loop_control.py
@@ -31,6 +31,7 @@ class LoopControl(FieldAttributeBase):
     pause = NonInheritableFieldAttribute(isa='float', default=0, always_post_validate=True)
     extended = NonInheritableFieldAttribute(isa='bool', always_post_validate=True)
     extended_allitems = NonInheritableFieldAttribute(isa='bool', default=True, always_post_validate=True)
+    lookup = NonInheritableFieldAttribute(isa='str', always_post_validate=True)
 
     def __init__(self):
         super(LoopControl, self).__init__()

--- a/lib/ansible/playbook/loop_control.py
+++ b/lib/ansible/playbook/loop_control.py
@@ -31,7 +31,7 @@ class LoopControl(FieldAttributeBase):
     pause = NonInheritableFieldAttribute(isa='float', default=0, always_post_validate=True)
     extended = NonInheritableFieldAttribute(isa='bool', always_post_validate=True)
     extended_allitems = NonInheritableFieldAttribute(isa='bool', default=True, always_post_validate=True)
-    lookup = NonInheritableFieldAttribute(isa='str', always_post_validate=True)
+    lookup = NonInheritableFieldAttribute(isa='string', always_post_validate=True)
 
     def __init__(self):
         super(LoopControl, self).__init__()

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -580,10 +580,12 @@ class VariableManager:
 
         templar = Templar(loader=self._loader, variables=vars_copy)
 
-        if task.loop_control:
-            loop_with = templar.template(task.loop_control.lookup)
+        if self._task.loop_with:
+            loop_with = self._task.loop_with
+        elif self._task.loop_control:
+            loop_with = templar.template(self._task.loop_control.lookup)
         else:
-            loop_with = task.loop_with
+            loop_with = None
 
         items = []
         has_loop = True

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -580,12 +580,17 @@ class VariableManager:
 
         templar = Templar(loader=self._loader, variables=vars_copy)
 
+        if task.loop_control:
+            loop_with = templar.template(task.loop_control.lookup)
+        else:
+            loop_with = task.loop_with
+
         items = []
         has_loop = True
-        if task.loop_with is not None:
-            if task.loop_with in lookup_loader:
+        if loop_with is not None:
+            if loop_with in lookup_loader:
                 fail = True
-                if task.loop_with == 'first_found':
+                if loop_with == 'first_found':
                     # first_found loops are special. If the item is undefined then we want to fall through to the next
                     fail = False
                 try:
@@ -594,7 +599,7 @@ class VariableManager:
                     if not fail:
                         loop_terms = [t for t in loop_terms if not templar.is_template(t)]
 
-                    mylookup = lookup_loader.get(task.loop_with, loader=self._loader, templar=templar)
+                    mylookup = lookup_loader.get(loop_with, loader=self._loader, templar=templar)
 
                     # give lookup task 'context' for subdir (mostly needed for first_found)
                     for subdir in ['template', 'var', 'file']:  # TODO: move this to constants?

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -580,10 +580,10 @@ class VariableManager:
 
         templar = Templar(loader=self._loader, variables=vars_copy)
 
-        if self._task.loop_with:
-            loop_with = self._task.loop_with
-        elif self._task.loop_control:
-            loop_with = templar.template(self._task.loop_control.lookup)
+        if task.loop_with:
+            loop_with = task.loop_with
+        elif task.loop_control:
+            loop_with = templar.template(task.loop_control.lookup)
         else:
             loop_with = None
 

--- a/test/integration/targets/loop_control/lookup.yml
+++ b/test/integration/targets/loop_control/lookup.yml
@@ -1,0 +1,25 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - debug:
+        var: item
+      with_fileglob:
+        - '{{ playbook_dir }}/*.yml'
+      register: with_fileglob
+
+    - debug:
+        var: item
+      loop: '{{ q("fileglob", "{{ playbook_dir }}/*.yml") }}'
+      register: loop_q
+
+    - debug:
+        var: item
+      loop:
+        - '{{ playbook_dir }}/*.yml'
+      loop_control:
+        lookup: fileglob
+      register: loop_control_lookup
+
+    - assert:
+        that:
+          - with_fileglob == loop_q == loop_control_lookup

--- a/test/integration/targets/loop_control/runme.sh
+++ b/test/integration/targets/loop_control/runme.sh
@@ -10,3 +10,4 @@ bar_label'
 [ "$(ansible-playbook label.yml "$@" |grep 'item='|sed -e 's/^.*(item=looped_var \(.*\)).*$/\1/')" == "${MATCH}" ]
 
 ansible-playbook extended.yml "$@"
+ansible-playbook lookup.yml "$@"


### PR DESCRIPTION
##### SUMMARY
Add loop_control.lookup to provide a transition from with_ to loop without explicit lookup call

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/playbook/loop_control.py

##### ADDITIONAL INFORMATION
Example:

Using `with_fileglob`:

```
- debug:
    var: item
  with_fileglob:
    - /path/one/*
    - /path/two/*
```

Using `loop` + lookup:
```
- debug:
    var: item
  loop: '{{ q("fileglob", "/path/one/*", "/path/two/*") }}'
```

Using `loop_control.lookup`:

```
- debug:
    var: item
  loop:
    - /path/one/*
    - /path/two/*
  loop_control:
    lookup: fileglob
```