### PR TITLE
Fix use of deprecated antsibull-docs option.

### DIFF
--- a/hacking/build_library/build_ansible/command_plugins/docs_build.py
+++ b/hacking/build_library/build_ansible/command_plugins/docs_build.py
@@ -119,7 +119,7 @@ def generate_base_docs(args):
 
         # Generate the plugin rst
         return antsibull_docs.run(['antsibull-docs', 'stable', '--deps-file', modified_deps_file,
-                                   '--ansible-base-source', str(args.top_dir),
+                                   '--ansible-core-source', str(args.top_dir),
                                    '--dest-dir', args.output_dir])
 
         # If we make this more than just a driver for antsibull:
@@ -170,7 +170,7 @@ def generate_full_docs(args):
 
         # Generate the plugin rst
         return antsibull_docs.run(['antsibull-docs'] + params +
-                                  ['--ansible-base-source', str(args.top_dir),
+                                  ['--ansible-core-source', str(args.top_dir),
                                    '--dest-dir', args.output_dir])
 
         # If we make this more than just a driver for antsibull:


### PR DESCRIPTION
##### SUMMARY

Fix use of deprecated antsibull-docs option.

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

hacking/build_library/build_ansible/command_plugins/docs_build.py