### PR TITLE
Require blocking IO for ansible CLI.

### DIFF
--- a/changelogs/fragments/ansible-require-blocking-io.yml
+++ b/changelogs/fragments/ansible-require-blocking-io.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ansible - At startup the stdin/stdout/stderr file handles are checked to verify they are using blocking IO.
+              If not, the process exits with an error reporting which file handle(s) are using non-blocking IO.

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -34,7 +34,7 @@ def check_blocking_io():
             handles.append(getattr(handle, 'name', None) or '#%s' % fd)
 
     if handles:
-        raise SystemExit('Ansible requires blocking IO on stdin/stdout/stderr. Non-blocking file handles detected: %s' % ', '.join(_io for _io in handles))
+        raise SystemExit('ERROR: Ansible requires blocking IO on stdin/stdout/stderr. Non-blocking file handles detected: %s' % ', '.join(_io for _io in handles))
 
 
 check_blocking_io()

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -34,7 +34,8 @@ def check_blocking_io():
             handles.append(getattr(handle, 'name', None) or '#%s' % fd)
 
     if handles:
-        raise SystemExit('ERROR: Ansible requires blocking IO on stdin/stdout/stderr. Non-blocking file handles detected: %s' % ', '.join(_io for _io in handles))
+        raise SystemExit('ERROR: Ansible requires blocking IO on stdin/stdout/stderr. '
+                         'Non-blocking file handles detected: %s' % ', '.join(_io for _io in handles))
 
 
 check_blocking_io()

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -7,6 +7,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import os
 import sys
 
 # Used for determining if the system is running a new enough python version
@@ -16,6 +17,27 @@ if sys.version_info < (3, 8):
         'ERROR: Ansible requires Python 3.8 or newer on the controller. '
         'Current version: %s' % ''.join(sys.version.splitlines())
     )
+
+
+def check_blocking_io():
+    """Check stdin/stdout/stderr to make sure they are using blocking IO."""
+    handles = []
+
+    for handle in (sys.stdin, sys.stdout, sys.stderr):
+        # noinspection PyBroadException
+        try:
+            fd = handle.fileno()
+        except Exception:
+            continue  # not a real file handle, such as during the import sanity test
+
+        if not os.get_blocking(fd):
+            handles.append(getattr(handle, 'name', None) or '#%s' % fd)
+
+    if handles:
+        raise SystemExit('Ansible requires blocking IO on stdin/stdout/stderr. Non-blocking file handles detected: %s' % ', '.join(_io for _io in handles))
+
+
+check_blocking_io()
 
 from importlib.metadata import version
 from ansible.module_utils.compat.version import LooseVersion
@@ -31,7 +53,6 @@ if jinja2_version < LooseVersion('3.0'):
 
 import errno
 import getpass
-import os
 import subprocess
 import traceback
 from abc import ABC, abstractmethod


### PR DESCRIPTION
##### SUMMARY

Ansible requires blocking IO on stdin/stdout/stderr to function properly.

If non-blocking IO is used, errors can occur, such as when writing large amounts of output:

`ERROR! Unexpected Exception, this is probably a bug: [Errno 11] write could not complete without blocking`

This PR simply enforces this requirement by checking it up-front in the CLI entry points. This will hopefully make it more obvious to users that their environment is not properly configured, rather than encountering data loss (to the console) or other unpredictable and possibly intermittent errors later.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible

##### ADDITIONAL INFORMATION

One way for stdin/stdout/stderr to end up non-blocking is through the use of `ssh`, which switches to non-blocking IO while running. It is possible that when `ssh` exits it may not restore stdin/stdout/stderr to their previous state.

This check could be removed in the future if support for non-blocking IO is implemented in Ansible.