### PR TITLE
Pin antsibull so 2.10 docs build works again

### DIFF
--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -1,0 +1,18 @@
+# pip packages required to build docsite
+# tested April 14 2022
+
+antsibull==0.42.0
+# version floats free, since we control features and releases
+docutils==0.16
+# check unordered lists when testing more recent docutils versions
+# see https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
+jinja2==3.0.1
+Pygments==2.9.0
+PyYAML==5.4.1
+resolvelib==0.5.4
+rstcheck==3.3.1
+sphinx==4.0.2
+sphinx-notfound-page==0.7.1 # must be >= 0.6
+sphinx-intl==2.0.1
+sphinx-ansible-theme===0.7.0
+straight.plugin==1.5.0 # Needed for hacking/build-ansible.py which is the backend build script

--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -11,7 +11,7 @@ Pygments==2.9.0
 PyYAML==5.4.1
 resolvelib==0.5.4
 rstcheck==3.3.1
-sphinx==4.0.2
+sphinx==2.1.2
 sphinx-notfound-page==0.7.1 # must be >= 0.6
 sphinx-intl==2.0.1
 sphinx-ansible-theme===0.7.0

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -6,5 +6,5 @@ sphinx==2.1.2
 sphinx-notfound-page
 Pygments >= 2.4.0
 straight.plugin # Needed for hacking/build-ansible.py which is the backend build script
-antsibull >= 0.15.0
+antsibull == 0.15.0
 docutils==0.16 # pin for now until sphinx_rtd_theme is compatible with 0.17 or later

--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -6,5 +6,5 @@ sphinx==2.1.2
 sphinx-notfound-page
 Pygments >= 2.4.0
 straight.plugin # Needed for hacking/build-ansible.py which is the backend build script
-antsibull == 0.15.0
+antsibull >= 0.15.0
 docutils==0.16 # pin for now until sphinx_rtd_theme is compatible with 0.17 or later


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Sadly, docs won't build because we never pinned antsibull, amongst other things.

This last-minute PR is so we can have buildable docs (should we need them) . There will be separate PR to add the 'EOL' banner to stable-2.10 as well when that happens.

And I mostly copied the known_good file used on other builds, so there might be 'excess pinning' but it works with an updated jenkins job...

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request



##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs/docsite/known_good_reqs.txt

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
