### PR TITLE
Remove deprecated loading cache plugins directly without cache_loader

### DIFF
--- a/changelogs/fragments/remove-import-cache-plugin-directly.yml
+++ b/changelogs/fragments/remove-import-cache-plugin-directly.yml
@@ -1,0 +1,2 @@
+removed_features:
+  - Remove deprecated functionality that allows loading cache plugins directly without using ``cache_loader``.

--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -43,12 +43,6 @@ class BaseCacheModule(AnsiblePlugin):
     _display = display
 
     def __init__(self, *args, **kwargs):
-        # Third party code is not using cache_loader to load plugin - fall back to previous behavior
-        if not hasattr(self, '_load_name'):
-            display.deprecated('Rather than importing custom CacheModules directly, use ansible.plugins.loader.cache_loader',
-                               version='2.14', collection_name='ansible.builtin')
-            self._load_name = self.__module__.rsplit('.', 1)[-1]
-            self._load_name = resource_from_fqcr(self.__module__)
         super(BaseCacheModule, self).__init__()
         self.set_options(var_options=args, direct=kwargs)
 

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -331,6 +331,5 @@ lib/ansible/module_utils/compat/_selectors2.py mypy-3.8:assignment  # vendored c
 lib/ansible/module_utils/compat/_selectors2.py mypy-3.9:assignment  # vendored code
 lib/ansible/module_utils/compat/_selectors2.py mypy-3.10:assignment  # vendored code
 lib/ansible/module_utils/compat/_selectors2.py mypy-2.7:attr-defined  # vendored code
-lib/ansible/plugins/cache/__init__.py pylint:ansible-deprecated-version
 lib/ansible/plugins/callback/default.py pylint:ansible-deprecated-version
 test/support/integration/plugins/modules/ec2.py pylint:ansible-deprecated-version

--- a/test/units/plugins/cache/test_cache.py
+++ b/test/units/plugins/cache/test_cache.py
@@ -28,7 +28,6 @@ import mock
 from units.compat import unittest
 from ansible.errors import AnsibleError
 from ansible.plugins.cache import CachePluginAdjudicator
-from ansible.plugins.cache.base import BaseCacheModule
 from ansible.plugins.cache.memory import CacheModule as MemoryCache
 from ansible.plugins.loader import cache_loader
 from ansible.vars.fact_cache import FactCache
@@ -196,54 +195,5 @@ class TestFactCache(unittest.TestCase):
         assert self.cache['cache_key']['key2'] == 'updatedvalue'
 
 
-class TestAbstractClass(unittest.TestCase):
-
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        pass
-
-    def test_subclass_error(self):
-        class CacheModule1(BaseCacheModule):
-            pass
-        with self.assertRaises(TypeError):
-            CacheModule1()  # pylint: disable=abstract-class-instantiated
-
-        class CacheModule2(BaseCacheModule):
-            def get(self, key):
-                super(CacheModule2, self).get(key)
-
-        with self.assertRaises(TypeError):
-            CacheModule2()  # pylint: disable=abstract-class-instantiated
-
-    def test_subclass_success(self):
-        class CacheModule3(BaseCacheModule):
-            def get(self, key):
-                super(CacheModule3, self).get(key)
-
-            def set(self, key, value):
-                super(CacheModule3, self).set(key, value)
-
-            def keys(self):
-                super(CacheModule3, self).keys()
-
-            def contains(self, key):
-                super(CacheModule3, self).contains(key)
-
-            def delete(self, key):
-                super(CacheModule3, self).delete(key)
-
-            def flush(self):
-                super(CacheModule3, self).flush()
-
-            def copy(self):
-                super(CacheModule3, self).copy()
-
-        self.assertIsInstance(CacheModule3(), CacheModule3)
-
-    def test_memory_cachemodule(self):
-        self.assertIsInstance(MemoryCache(), MemoryCache)
-
-    def test_memory_cachemodule_with_loader(self):
-        self.assertIsInstance(cache_loader.get('memory'), MemoryCache)
+def test_memory_cachemodule_with_loader():
+    assert isinstance(cache_loader.get('memory'), MemoryCache)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
`lib/ansible/plugins/cache/__init__.py`
