### PR TITLE
dont rely on path to set config defs for plugins

### DIFF
--- a/changelogs/fragments/config_load_by_name.yml
+++ b/changelogs/fragments/config_load_by_name.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - plugin loader will now load config data for plugin by name instead of by file to avoid issues with the same file being loaded under different names (fqcn + short name).

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -819,10 +819,12 @@ class PluginLoader:
 
         if path not in self._module_cache:
             self._module_cache[path] = self._load_module_source(name, path)
-            self._load_config_defs(name, self._module_cache[path], path)
             found_in_cache = False
 
+        self._load_config_defs(name, self._module_cache[path], path)
+
         obj = getattr(self._module_cache[path], self.class_name)
+
         if self.base_class:
             # The import path is hardcoded and should be the right place,
             # so we are not expecting an ImportError.

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -391,7 +391,7 @@ class PluginLoader:
             type_name = get_plugin_class(self.class_name)
 
             # if type name != 'module_doc_fragment':
-            if type_name in C.CONFIGURABLE_PLUGINS:
+            if type_name in C.CONFIGURABLE_PLUGINS and not C.config.get_configuration_definition(type_name, name):
                 dstring = AnsibleLoader(getattr(module, 'DOCUMENTATION', ''), file_name=path).get_single_data()
                 if dstring:
                     add_fragments(dstring, path, fragment_loader=fragment_loader, is_module=(type_name == 'module'))
@@ -949,15 +949,18 @@ class PluginLoader:
                     else:
                         full_name = basename
                     module = self._load_module_source(full_name, path)
-                    self._load_config_defs(basename, module, path)
                 except Exception as e:
                     display.warning("Skipping plugin (%s) as it seems to be invalid: %s" % (path, to_text(e)))
                     continue
                 self._module_cache[path] = module
                 found_in_cache = False
+            else:
+                module = self._module_cache[path]
+
+            self._load_config_defs(basename, module, path)
 
             try:
-                obj = getattr(self._module_cache[path], self.class_name)
+                obj = getattr(module, self.class_name)
             except AttributeError as e:
                 display.warning("Skipping plugin (%s) as it seems to be invalid: %s" % (path, to_text(e)))
                 continue

--- a/test/integration/targets/plugin_loader/runme.sh
+++ b/test/integration/targets/plugin_loader/runme.sh
@@ -33,4 +33,4 @@ do
 done
 
 # test config loading
-ansible-playbook use_coll_name.yml -i '127.0.0.2,' "$@"
+ansible-playbook use_coll_name.yml -i ../../inventory -e 'ansible_connection=ansible.builtin.ssh' "$@"

--- a/test/integration/targets/plugin_loader/runme.sh
+++ b/test/integration/targets/plugin_loader/runme.sh
@@ -31,3 +31,6 @@ do
 		exit 1
 	fi
 done
+
+# test config loading
+ansible-playbook use_coll_name.yml -i '127.0.0.2,' "$@"

--- a/test/integration/targets/plugin_loader/use_coll_name.yml
+++ b/test/integration/targets/plugin_loader/use_coll_name.yml
@@ -1,0 +1,5 @@
+- name: ensure configuration is loaded when we use FQCN and have already loaded using 'short namne' (which is case will all builtin connection plugins)
+  hosts: all # Do not use implicit `localhost` as `local` plugin won't make configuration lookup in default configuration
+  connection: ansible.builtin.ssh
+  tasks:
+    - ping:

--- a/test/integration/targets/plugin_loader/use_coll_name.yml
+++ b/test/integration/targets/plugin_loader/use_coll_name.yml
@@ -1,5 +1,7 @@
 - name: ensure configuration is loaded when we use FQCN and have already loaded using 'short namne' (which is case will all builtin connection plugins)
   hosts: all
+  gather_facts: false
   tasks:
     - name: relies on extra var being passed in with connection and fqcn
       ping:
+      ignore_unreachable: True

--- a/test/integration/targets/plugin_loader/use_coll_name.yml
+++ b/test/integration/targets/plugin_loader/use_coll_name.yml
@@ -1,5 +1,5 @@
 - name: ensure configuration is loaded when we use FQCN and have already loaded using 'short namne' (which is case will all builtin connection plugins)
-  hosts: all # Do not use implicit `localhost` as `local` plugin won't make configuration lookup in default configuration
-  connection: ansible.builtin.ssh
+  hosts: all
   tasks:
-    - ping:
+    - name: relies on extra var being passed in with connection and fqcn
+      ping:


### PR DESCRIPTION
Avoids issue with plugins being accessed via different names

note: it does create duplicates of config base, another solution is to try 'normalize' to 'one name'

related https://github.com/ansible/ansible-runner/issues/1032
fixes #77669

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugin loader