### PR TITLE
ansible-doc stay 3.8 python compatible

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -1004,7 +1004,7 @@ class DocCLI(CLI, RoleMixin):
             if doc is None:
                 # handle test/filters that are in file with diff name
                 base = plugin.split('.')[-1]
-                basefile = filename.with_stem(base)
+                basefile = filename.with_name(base + filename.suffix)
                 for extension in ('.py', '.yml', '.yaml'):  # TODO: constant?
                     docfile = basefile.with_suffix(extension)
                     try:

--- a/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/plugins/filter/grouped.py
+++ b/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/plugins/filter/grouped.py
@@ -1,0 +1,27 @@
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.utils.display import Display
+
+display = Display()
+
+
+def nochange(a):
+    return a
+
+
+def meaningoflife(a):
+    return 42
+
+
+class FilterModule(object):
+    ''' Ansible core jinja2 filters '''
+
+    def filters(self):
+        return {
+            'noop': nochange,
+            'ultimatequestion': meaningoflife
+        }

--- a/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/plugins/filter/ultimatequestion.yml
+++ b/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/plugins/filter/ultimatequestion.yml
@@ -1,0 +1,21 @@
+DOCUMENTATION:
+  name: ultimatequestion
+  author: Terry Prachet
+  version_added: 'histerical'
+  short_description: Ask any question but it will only respond with the answer to the ulitmate one
+  description:
+    - read the book
+  options:
+    _input:
+      description: Anything you want, goign to ignore it anywayss ...
+      type: raw
+      required: true
+
+EXAMPLES: |
+  # set first 10 volumes rw, rest as dp
+  meaning: "{{ (stuff|ulmtimatequestion }}"
+
+RETURN:
+  _value:
+    description: guess
+    type: int

--- a/test/integration/targets/ansible-doc/runme.sh
+++ b/test/integration/targets/ansible-doc/runme.sh
@@ -32,7 +32,7 @@ ansible-doc --list testns.testcol.fakemodule  --playbook-dir ./ 2>&1 | grep "Inv
 
 
 # test listing diff plugin types from collection
-for ptype in cache inventory lookup vars
+for ptype in cache inventory lookup vars filter
 do
 	# each plugin type adds 1 from collection
 	# FIXME pre=$(ansible-doc -l -t ${ptype}|wc -l)

--- a/test/integration/targets/ansible-doc/runme.sh
+++ b/test/integration/targets/ansible-doc/runme.sh
@@ -38,10 +38,14 @@ do
 	# FIXME pre=$(ansible-doc -l -t ${ptype}|wc -l)
 	# FIXME post=$(ansible-doc -l -t ${ptype} --playbook-dir ./|wc -l)
 	# FIXME test "$pre" -eq $((post - 1))
-
+	if [ "${ptype}" == "filter" ]; then
+		expected=2
+	else
+		expected=1
+	fi
 	# ensure we ONLY list from the collection
 	justcol=$(ansible-doc -l -t ${ptype} --playbook-dir ./ testns.testcol|wc -l)
-	test "$justcol" -eq 1
+	test "$justcol" -eq "$expected"
 
 	# ensure we get error if passinginvalid collection, much less any plugins
 	ansible-doc -l -t ${ptype} testns.testcol  2>&1 | grep "unable to locate collection"


### PR DESCRIPTION
remove `with_stem` which is only available starting at Python 3.9
add tests to list filters so we hit this issue sooner

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-doc