### PR TITLE
Make ignore_unreachable to ignore the task

### DIFF
--- a/changelogs/fragments/77693-actually-ignore-unreachable.yml
+++ b/changelogs/fragments/77693-actually-ignore-unreachable.yml
@@ -1,0 +1,4 @@
+breaking_changes:
+  - >-
+    strategy plugins - Make ``ignore_unreachable`` to increase ``ignored`` and ``ok`` and  counter,
+    not ``skipped`` and ``unreachable``. (https://github.com/ansible/ansible/issues/77690)

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -130,6 +130,9 @@ class CallbackModule(CallbackBase):
         msg = "fatal: [%s]: UNREACHABLE! => %s" % (host_label, self._dump_results(result._result))
         self._display.display(msg, color=C.COLOR_UNREACHABLE, stderr=self.get_option('display_failed_stderr'))
 
+        if result._task.ignore_unreachable:
+            self._display.display("...ignoring", color=C.COLOR_SKIP)
+
     def v2_playbook_on_no_hosts_matched(self):
         self._display.display("skipping: no hosts matched", color=C.COLOR_SKIP)
 

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -631,10 +631,10 @@ class StrategyBase:
                 if not ignore_unreachable:
                     self._tqm._unreachable_hosts[original_host.name] = True
                     iterator._play._removed_hosts.append(original_host.name)
+                    self._tqm._stats.increment('dark', original_host.name)
                 else:
-                    self._tqm._stats.increment('skipped', original_host.name)
-                    task_result._result['skip_reason'] = 'Host %s is unreachable' % original_host.name
-                self._tqm._stats.increment('dark', original_host.name)
+                    self._tqm._stats.increment('ok', original_host.name)
+                    self._tqm._stats.increment('ignored', original_host.name)
                 self._tqm.send_callback('v2_runner_on_unreachable', task_result)
             elif task_result.is_skipped():
                 self._tqm._stats.increment('skipped', original_host.name)


### PR DESCRIPTION
##### SUMMARY

Currently, `ignore_unreachable` will increase `unreachable` and `skipped` counters.

Let's make it behave like `ignore_errors` does, by:

1. Counting towards `ignored` and `ok` counters instead
2. Displaying "...ignored" via default callback module

Fixes #77690

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
 
stats

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

If following task would result in unreachable

```yaml
- name: ignored unreachable task
  action: ping
  ignore_unreachable: true
```

then this PR would change the output like so (just as ignore_errors does):

```diff
TASK [ignored unreachable task] ************************************************
fatal: [localhost]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: Warning: Permanently added 'localhost' (ED25519) to the list of known hosts.\r\nnon-existent-user@localhost: Permission denied (publickey,password).", "unreachable": true}
+...ignoring

PLAY RECAP *********************************************************************
-localhost                  : ok=0    changed=0    unreachable=1    failed=0    skipped=1    rescued=0    ignored=0   
+localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=1   
```