### PR TITLE
Install acl on Ubuntu for copy integration test.

### DIFF
--- a/test/integration/targets/copy/tasks/acls.yml
+++ b/test/integration/targets/copy/tasks/acls.yml
@@ -1,4 +1,9 @@
 - block:
+  - name: Install the acl package on Ubuntu
+    apt:
+      name: acl
+    when: ansible_distribution in ('Ubuntu')
+
   - block:
     - name: Testing ACLs
       copy:


### PR DESCRIPTION
##### SUMMARY

Install acl on Ubuntu for copy integration test.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

copy integration test
