### PR TITLE
[2.12 backport] fix SELinux facts tests

### DIFF
--- a/test/integration/targets/module_utils_facts.system.selinux/aliases
+++ b/test/integration/targets/module_utils_facts.system.selinux/aliases
@@ -1,5 +1,1 @@
 shippable/posix/group1
-skip/osx
-skip/macos
-skip/freebsd
-skip/docker

--- a/test/integration/targets/module_utils_facts.system.selinux/tasks/main.yml
+++ b/test/integration/targets/module_utils_facts.system.selinux/tasks/main.yml
@@ -18,11 +18,12 @@
 
 - name: check selinux policy type
   shell: grep '^SELINUXTYPE=' /etc/selinux/config | cut -d'=' -f2
+  ignore_errors: yes
   register: r
 
 - set_fact:
     selinux_policytype: "{{ r.stdout_lines[0] }}"
-  when: r.changed
+  when: r is success and r.stdout_lines
 
 - assert:
     that:


### PR DESCRIPTION
##### SUMMARY
backport of #77704

* make the pre-flight sniffing more robust to different failure conditions (was failing on Ubuntu 22.04 VMs)
* remove skip aliases (the test needs to function everywhere to assert that the selinux facts bits behave properly when it's N/A)

(cherry picked from commit 4ff10fcd31cdfc41c62ff6d9b710c1951c83c3c5)

##### ISSUE TYPE

- Test Pull Request

