### PR TITLE
Ensure sudo is installed for become_unprivileged integration test

### DIFF
--- a/test/integration/targets/become_unprivileged/setup_unpriv_users.yml
+++ b/test/integration/targets/become_unprivileged/setup_unpriv_users.yml
@@ -12,6 +12,7 @@
         name: sudo
         state: present
       delegate_to: localhost
+      when: ansible_distribution not in ["MacOSX", "Alpine"]
 
     - name: Create groups for unprivileged users
       group:

--- a/test/integration/targets/become_unprivileged/setup_unpriv_users.yml
+++ b/test/integration/targets/become_unprivileged/setup_unpriv_users.yml
@@ -7,6 +7,12 @@
   gather_facts: yes
   remote_user: root
   tasks:
+    - name: Ensure sudo is available
+      package:
+        name: sudo
+        state: present
+      delegate_to: localhost
+
     - name: Create groups for unprivileged users
       group:
         name: "{{ item }}"


### PR DESCRIPTION
##### SUMMARY
The default docker container doesn't have sudo installed, so this test suite fails in #77586 since it's being used as the controller.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/integration/become_unprivileged
