### PR TITLE
shift to ansible_core_version

### DIFF
--- a/hacking/build_library/build_ansible/command_plugins/docs_build.py
+++ b/hacking/build_library/build_ansible/command_plugins/docs_build.py
@@ -112,7 +112,7 @@ def generate_base_docs(args):
 
         # The _ansible_version doesn't matter since we're only building docs for base
         deps_file_contents = {'_ansible_version': ansible_base__version__,
-                              '_ansible_base_version': ansible_base__version__}
+                              '_ansible_core_version': ansible_base__version__}
 
         with open(modified_deps_file, 'w') as f:
             f.write(yaml.dump(deps_file_contents))
@@ -161,7 +161,7 @@ def generate_full_docs(args):
             with open(modified_deps_file, 'r') as f:
                 deps_data = yaml.safe_load(f.read())
 
-            deps_data['_ansible_base_version'] = ansible_base__version__
+            deps_data['_ansible_core_version'] = ansible_base__version__
 
             with open(modified_deps_file, 'w') as f:
                 f.write(yaml.dump(deps_data))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Based on chat discussion, this fixes a problem with the docs builds that shows up in stable branches.

Will need backport to stable-2.13
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hacking/build_library/build_ansible/command_plugins/docs_build.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
