### PR TITLE
add support for tsflags in yum and dnf modules

### DIFF
--- a/lib/ansible/module_utils/yumdnf.py
+++ b/lib/ansible/module_utils/yumdnf.py
@@ -45,6 +45,7 @@ yumdnf_argument_spec = dict(
         releasever=dict(default=None),
         security=dict(type='bool', default=False),
         skip_broken=dict(type='bool', default=False),
+        tsflags=dict(type='list', elements='str', default=[], choices=['noscripts', 'nocrypto', 'nocontexts', 'justdb', 'nodocs', 'notriggers']),
         # removed==absent, installed==present, these are accepted as aliases
         state=dict(type='str', default=None, choices=['absent', 'installed', 'latest', 'present', 'removed']),
         update_cache=dict(type='bool', default=False, aliases=['expire-cache']),
@@ -92,6 +93,7 @@ class YumDnf(with_metaclass(ABCMeta, object)):  # type: ignore[misc]
         self.releasever = self.module.params['releasever']
         self.security = self.module.params['security']
         self.skip_broken = self.module.params['skip_broken']
+        self.tsflags = self.module.params['tsflags']
         self.state = self.module.params['state']
         self.update_only = self.module.params['update_only']
         self.update_cache = self.module.params['update_cache']

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -113,6 +113,14 @@ options:
     type: bool
     default: "no"
     version_added: "2.7"
+  tsflags:
+    description:
+      - List of flags to be forwarded to RPM
+    type: list
+    elements: str
+    choices: ['noscripts', 'nocrypto', 'nocontexts', 'justdb', 'nodocs', 'notriggers']
+    default: []
+    version_added: "2.14"
   update_cache:
     description:
       - Force dnf to check if cache is out of date and redownload if needed.
@@ -667,6 +675,12 @@ class DnfModule(YumDnf):
         # Set skip_broken (in dnf this is strict=0)
         if self.skip_broken:
             conf.strict = 0
+
+        for flag in self.tsflags:
+            if flag in conf.tsflags:
+                continue
+            else:
+                conf.tsflags.append(flag)
 
         # Set best
         if self.nobest:

--- a/lib/ansible/modules/yum.py
+++ b/lib/ansible/modules/yum.py
@@ -102,6 +102,14 @@ options:
     type: bool
     default: "no"
     version_added: "2.3"
+  tsflags:
+    description:
+      - List of flags to be forwarded to RPM
+    type: list
+    elements: str
+    choices: ['noscripts', 'nocrypto', 'nocontexts', 'justdb', 'nodocs', 'notriggers']
+    default: []
+    version_added: "2.14"
   update_cache:
     description:
       - Force yum to check if cache is out of date and redownload if needed.
@@ -1575,6 +1583,9 @@ class YumModule(YumDnf):
 
         if self.skip_broken:
             self.yum_basecmd.extend(['--skip-broken'])
+
+        if self.tsflags:
+            self.yum_basecmd.extend(['--setopt=tsflags=%s' % ','.join(self.tsflags)])
 
         if self.disablerepo:
             self.yum_basecmd.extend(['--disablerepo=%s' % ','.join(self.disablerepo)])


### PR DESCRIPTION
##### SUMMARY
Add support for tsflags in DNF & YUM modules
Fixes: #77345 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`yum` `dnf`

##### ADDITIONAL INFORMATION
These modules should allow to forward tsflags to rpm, done in cli with `--setopt=tsflags=flag1,flag2,<...>` with dnf & yum.

Usage example with the change
```yaml
  - name: test dnf
    dnf:
      name: somepkg
      tsflags:
        - nocrypto
        - nodocs
```