### PR TITLE
Docsite: move a stepped down steering committee member to past members

### DIFF
--- a/docs/docsite/rst/community/steering/community_steering_committee.rst
+++ b/docs/docsite/rst/community/steering/community_steering_committee.rst
@@ -51,8 +51,6 @@ The following table lists the current Steering Committee members. See :ref:`stee
   +------------------+---------------+-------------+
   | James Cassell    | jamescassell  | 2021        |
   +------------------+---------------+-------------+
-  | Jill Rouleau     | jillr         | 2021        |
-  +------------------+---------------+-------------+
   | John Barker      | gundalow      | 2021        |
   +------------------+---------------+-------------+
   | Mario Lenz       | mariolenz     | 2022        |

--- a/docs/docsite/rst/community/steering/steering_committee_past_members.rst
+++ b/docs/docsite/rst/community/steering/steering_committee_past_members.rst
@@ -12,9 +12,11 @@ people for their great service to the Community and the project!
   +------------------+-----------+-------------------+
   | Name             | GitHub    | Years of service  |
   +==================+===========+===================+
-  | Toshio Kuratomi  | abadger   | 2021              |
+  | Jill Rouleau     | jillr     | 2021-2022         |
   +------------------+-----------+-------------------+
   | Tadej Borovšak   | tadeboro  | 2021-2022         |
+  +------------------+-----------+-------------------+
+  | Toshio Kuratomi  | abadger   | 2021              |
   +------------------+-----------+-------------------+
 
 


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-community/community-topics/issues/95

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/community/steering/community_steering_committee.rst
docs/docsite/rst/community/steering/steering_committee_past_members.rst