### PR TITLE
Remove MacOSX-specific cleanup for unarchive test

### DIFF
--- a/test/integration/targets/unarchive/tasks/test_unprivileged_user.yml
+++ b/test/integration/targets/unarchive/tasks/test_unprivileged_user.yml
@@ -79,9 +79,10 @@
       become: yes
       become_user: root
 
-    - name: Remove user home directory on macOS
-      file:
-        path: /Users/unarchivetest1
-        state: absent
-      become: no
-      when: ansible_facts.distribution == 'MacOSX'
+    - name: ensure home directory has been removed
+      stat:
+        path: "{{ user.home }}"
+      become: yes
+      become_user: root
+      register: home_dir
+      failed_when: home_dir.stat.exists


### PR DESCRIPTION
##### SUMMARY
There was a bug in the `user` module that prevented the home dir from getting cleaned up on MacOSX. Removing the test to see if that's still broken.

##### ISSUE TYPE
- Test Pull Request