### PR TITLE
Bump antsibull-docs version to 1.1.0 to support sidecar docs

### DIFF
--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -3,7 +3,7 @@
 # if you want known good versions of these dependencies
 # use known_good_reqs.txt instead
 
-antsibull-docs >= 1.0.0, < 2.0.0
+antsibull-docs >= 1.1.0, < 2.0.0
 docutils
 jinja2
 pygments >= 2.10.0

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -5,7 +5,7 @@ aiosignal==1.2.0
 alabaster==0.7.12
 ansible-pygments==0.1.0
 antsibull-core==1.0.0
-antsibull-docs==1.0.0
+antsibull-docs==1.1.0
 async-timeout==4.0.1
 asyncio-pool==0.5.2
 attrs==21.2.0


### PR DESCRIPTION
##### SUMMARY
Some of the results: https://ansible.fontein.de/collections/ansible/builtin/#filter-plugins

Merge requires default test container (for ansible-core) to be rebuilt.

CC @samccann 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs build
