### PR TITLE
base64 filter docs: _input is not a positional argument

### DIFF
--- a/lib/ansible/plugins/filter/b64decode.yml
+++ b/lib/ansible/plugins/filter/b64decode.yml
@@ -9,7 +9,6 @@ DOCUMENTATION:
     - Trying to store a binary blob in a string most likely corrupts the binary. To base64 decode a binary blob,
       use the ``base64`` command  and pipe the encoded data through standard input. 
       For example, in the ansible.builtin.shell`` module, ``cmd="base64 --decode > myfile.bin" stdin="{{ encoded }}"``.
-  positional: _input
   options:
     _input:
       description: A base64 string to decode.

--- a/lib/ansible/plugins/filter/b64encode.yml
+++ b/lib/ansible/plugins/filter/b64encode.yml
@@ -5,7 +5,6 @@ DOCUMENTATION:
   short_description: Encode a string as base64
   description:
     - Base64 encoding function.
-  positional: _input
   options:
     _input:
       description: A string to encode.


### PR DESCRIPTION
##### SUMMARY
_input is the test/filter input, not a positional argument.

CC @bcoca

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
b64encode
b64decode
