### PR TITLE
Fix setting timeout in ansible.cfg ssh_connection section

### DIFF
--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -252,7 +252,7 @@ def add_connect_options(parser):
                                help='connect as this user (default=%s)' % C.DEFAULT_REMOTE_USER)
     connect_group.add_argument('-c', '--connection', dest='connection', default=C.DEFAULT_TRANSPORT,
                                help="connection type to use (default=%s)" % C.DEFAULT_TRANSPORT)
-    connect_group.add_argument('-T', '--timeout', type=int, default=C.DEFAULT_TIMEOUT, dest='timeout',
+    connect_group.add_argument('-T', '--timeout', default=C.DEFAULT_TIMEOUT, type=int, dest='timeout',
                                help="override the connection timeout in seconds (default=%s)" % C.DEFAULT_TIMEOUT)
 
     # ssh only

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -252,7 +252,8 @@ def add_connect_options(parser):
                                help='connect as this user (default=%s)' % C.DEFAULT_REMOTE_USER)
     connect_group.add_argument('-c', '--connection', dest='connection', default=C.DEFAULT_TRANSPORT,
                                help="connection type to use (default=%s)" % C.DEFAULT_TRANSPORT)
-    connect_group.add_argument('-T', '--timeout', default=C.DEFAULT_TIMEOUT, type=int, dest='timeout',
+    # The connection plugin may not set its own default, and will fallback to C.DEFAULT_TIMEOUT via PlayContext.timeout
+    connect_group.add_argument('-T', '--timeout', type=int, dest='timeout',
                                help="override the connection timeout in seconds (default=%s)" % C.DEFAULT_TIMEOUT)
 
     # ssh only

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -252,8 +252,7 @@ def add_connect_options(parser):
                                help='connect as this user (default=%s)' % C.DEFAULT_REMOTE_USER)
     connect_group.add_argument('-c', '--connection', dest='connection', default=C.DEFAULT_TRANSPORT,
                                help="connection type to use (default=%s)" % C.DEFAULT_TRANSPORT)
-    # The connection plugin may not set its own default, and will fallback to C.DEFAULT_TIMEOUT via PlayContext.timeout
-    connect_group.add_argument('-T', '--timeout', type=int, dest='timeout',
+    connect_group.add_argument('-T', '--timeout', type=int, default=C.DEFAULT_TIMEOUT, dest='timeout',
                                help="override the connection timeout in seconds (default=%s)" % C.DEFAULT_TIMEOUT)
 
     # ssh only

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -371,15 +371,6 @@ class ConfigManager(object):
                         options.append(option_name)
         return options
 
-    def get_plugin_options_from_cli(self, plugin_type, name, cli_option):
-        options = []
-        for option_name, pdef in self.get_configuration_definitions(plugin_type, name).items():
-            if 'cli' in pdef and pdef['cli']:
-                for cli_entry in pdef['cli']:
-                    if cli_option == cli_entry['name']:
-                        options.append(option_name)
-        return options
-
     def get_configuration_definition(self, name, plugin_type=None, plugin_name=None):
 
         ret = {}

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -371,6 +371,15 @@ class ConfigManager(object):
                         options.append(option_name)
         return options
 
+    def get_plugin_options_from_cli(self, plugin_type, name, cli_option):
+        options = []
+        for option_name, pdef in self.get_configuration_definitions(plugin_type, name).items():
+            if 'cli' in pdef and pdef['cli']:
+                for cli_entry in pdef['cli']:
+                    if cli_option == cli_entry['name']:
+                        options.append(option_name)
+        return options
+
     def get_configuration_definition(self, name, plugin_type=None, plugin_name=None):
 
         ret = {}

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -153,6 +153,7 @@ MAGIC_VARIABLE_MAPPING = dict(
     password=('ansible_ssh_pass', 'ansible_password'),
     port=('ansible_ssh_port', 'ansible_port'),
     pipelining=('ansible_ssh_pipelining', 'ansible_pipelining'),
+    # TODO: Maybe deprecate PlayContext.timeout and rename to connection_timeout?
     timeout=('ansible_ssh_timeout', 'ansible_timeout'),
     private_key_file=('ansible_ssh_private_key_file', 'ansible_private_key_file'),
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -1037,15 +1037,6 @@ class TaskExecutor:
         option_vars = C.config.get_plugin_vars('connection', self._connection._load_name)
         varnames.extend(option_vars)
 
-        # This seems like it should be fixed more generally (or maybe made into a validate-modules error).
-        # This is special-casing timeout, so connection plugins that use the cli option can also set their own default value.
-        timeout_options = C.config.get_plugin_options_from_cli('connection', self._connection._load_name, 'timeout')
-        timeout_options_no_default = []
-        for option in timeout_options:
-            option_definition = C.config.get_configuration_definition(option, plugin_type='connection', plugin_name=self._connection._load_name)
-            if 'default' not in option_definition:
-                timeout_options_no_default.append(option)
-
         # create dict of 'templated vars'
         options = {'_extras': {}}
         for k in option_vars:
@@ -1073,10 +1064,6 @@ class TaskExecutor:
 
         # set options with 'templated vars' specific to this plugin and dependent ones
         self._connection.set_options(task_keys=task_keys, var_options=options)
-        for option in timeout_options_no_default:
-            if self._connection.get_option(option) is None:
-                # Hopefully no connection plugin allows None as a valid configured timeout, making this not the implicit default...
-                self._connection.set_option(option, C.DEFAULT_TIMEOUT)
 
         varnames.extend(self._set_plugin_options('shell', variables, templar, task_keys))
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -1037,6 +1037,15 @@ class TaskExecutor:
         option_vars = C.config.get_plugin_vars('connection', self._connection._load_name)
         varnames.extend(option_vars)
 
+        # This seems like it should be fixed more generally (or maybe made into a validate-modules error).
+        # This is special-casing timeout, so connection plugins that use the cli option can also set their own default value.
+        timeout_options = C.config.get_plugin_options_from_cli('connection', self._connection._load_name, 'timeout')
+        timeout_options_no_default = []
+        for option in timeout_options:
+            option_definition = C.config.get_configuration_definition(option, plugin_type='connection', plugin_name=self._connection._load_name)
+            if 'default' not in option_definition:
+                timeout_options_no_default.append(option)
+
         # create dict of 'templated vars'
         options = {'_extras': {}}
         for k in option_vars:
@@ -1064,9 +1073,10 @@ class TaskExecutor:
 
         # set options with 'templated vars' specific to this plugin and dependent ones
         self._connection.set_options(task_keys=task_keys, var_options=options)
-        if 'timeout' in self._connection._options and self._connection.get_option('timeout') is None:
-            task_keys.update({'timeout': self._play_context.timeout})
-            self._connection.set_options(task_keys=task_keys, var_options=options)
+        for option in timeout_options_no_default:
+            if self._connection.get_option(option) is None:
+                # Hopefully no connection plugin allows None as a valid configured timeout, making this not the implicit default...
+                self._connection.set_option(option, C.DEFAULT_TIMEOUT)
 
         varnames.extend(self._set_plugin_options('shell', variables, templar, task_keys))
 

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -188,8 +188,9 @@ class BaseMeta(type):
 
         # now create the attributes based on the FieldAttributes
         # available, including from parent (and grandparent) objects
-        _create_attrs(dct, dct)
         _process_parents(parents, dct)
+        # Prefer own attribute details
+        _create_attrs(dct, dct)
 
         return super(BaseMeta, cls).__new__(cls, name, parents, dct)
 

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -324,20 +324,18 @@ DOCUMENTATION = '''
           - name: ansible_ssh_use_tty
             version_added: '2.7'
       timeout:
+        # default has no effect and is only for documentation purposes. The value must reflect the default of --timeout.
         default: 10
         description:
             - This is the default amount of time we will wait while establishing an SSH connection.
             - It also controls how long we can wait to access reading the connection once established (select on the socket).
+        # env has no effect and is only for documentation purposes (reflects --timeout)
         env:
-            - name: ANSIBLE_TIMEOUT
-            - name: ANSIBLE_SSH_TIMEOUT
-              version_added: '2.11'
+             - name: ANSIBLE_TIMEOUT
+        # ini has no effect and is only for documentation purposes (reflects --timeout)
         ini:
             - key: timeout
               section: defaults
-            - key: timeout
-              section: ssh_connection
-              version_added: '2.11'
         vars:
           - name: ansible_ssh_timeout
             version_added: '2.11'

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -324,18 +324,20 @@ DOCUMENTATION = '''
           - name: ansible_ssh_use_tty
             version_added: '2.7'
       timeout:
-        # default has no effect and is only for documentation purposes. The value must reflect the default of --timeout.
         default: 10
         description:
             - This is the default amount of time we will wait while establishing an SSH connection.
             - It also controls how long we can wait to access reading the connection once established (select on the socket).
-        # env has no effect and is only for documentation purposes (reflects --timeout)
         env:
-             - name: ANSIBLE_TIMEOUT
-        # ini has no effect and is only for documentation purposes (reflects --timeout)
+            - name: ANSIBLE_TIMEOUT
+            - name: ANSIBLE_SSH_TIMEOUT
+              version_added: '2.11'
         ini:
             - key: timeout
               section: defaults
+            - key: timeout
+              section: ssh_connection
+              version_added: '2.11'
         vars:
           - name: ansible_ssh_timeout
             version_added: '2.11'

--- a/lib/ansible/plugins/lookup/config.py
+++ b/lib/ansible/plugins/lookup/config.py
@@ -92,6 +92,8 @@ def _get_plugin_config(pname, ptype, config, variables):
         p = loader.get(pname, class_only=True)
         if p is None:
             raise AnsibleLookupError('Unable to load %s plugin "%s"' % (ptype, pname))
+
+        # FIXME: seems like variables don't necessarily reflect the vars used for setting connection options so the result may be wrong
         result = C.config.get_config_value(config, plugin_type=ptype, plugin_name=p._load_name, variables=variables)
     except AnsibleLookupError:
         raise

--- a/test/integration/targets/connection_ssh/runme.sh
+++ b/test/integration/targets/connection_ssh/runme.sh
@@ -70,7 +70,7 @@ ANSIBLE_SSH_TRANSFER_METHOD=piped ./posix.sh "$@"
 ansible-playbook check_ssh_defaults.yml "$@" -i test_connection.inventory
 
 # ensure we can load from ini cfg
-ANSIBLE_CONFIG=./test_ssh_defaults.cfg ansible-playbook verify_config.yml "$@"
+ANSIBLE_CONFIG=./test_ssh_defaults.cfg ansible-playbook -i ssh_host, verify_config.yml "$@"
 
 # ensure we handle cp with spaces correctly, otherwise would fail with
 # `"Failed to connect to the host via ssh: command-line line 0: keyword controlpath extra arguments at end of line"`

--- a/test/integration/targets/connection_ssh/test_ssh_defaults.cfg
+++ b/test/integration/targets/connection_ssh/test_ssh_defaults.cfg
@@ -1,4 +1,6 @@
 [ssh_connection]
+pipelining=True
+timeout=1
 ssh_common_args=fromconfig
 ssh_extra_args=fromconfig
 scp_extra_args=fromconfig

--- a/test/integration/targets/connection_ssh/verify_config.yml
+++ b/test/integration/targets/connection_ssh/verify_config.yml
@@ -1,21 +1,41 @@
-- hosts: localhost
+- hosts: ssh_host
+  connection: ssh
   gather_facts: false
   vars:
-    ssh_configs:
+    str_ssh_configs:
       - ssh_common_args
       - ssh_extra_args
       - sftp_extra_args
       - scp_extra_args
+    bool_ssh_configs:
+      - pipelining
+    int_ssh_configs:
+      - timeout
   tasks:
     - debug:
         msg: '{{item ~ ": " ~ lookup("config", item, plugin_type="connection", plugin_name="ssh")}}'
         verbosity: 3
-      loop: '{{ssh_configs}}'
+      loop: '{{str_ssh_configs + bool_ssh_configs}}'
       tags: [ configfile ]
 
     - name: check config from file
       assert:
         that:
           - 'lookup("config", item, plugin_type="connection", plugin_name="ssh") == "fromconfig"'
-      loop: '{{ssh_configs}}'
+      loop: '{{str_ssh_configs}}'
       tags: [ configfile ]
+
+    - name: check bool config from file
+      assert:
+        that:
+          - 'lookup("config", item, plugin_type="connection", plugin_name="ssh") == True'
+      loop: '{{bool_ssh_configs}}'
+      tags: [ configfile ]
+
+    # FIXME - timeout is correct in connection plugin, but not config lookup
+    # - name: check int config from file
+    #   assert:
+    #     that:
+    #       - 'lookup("config", item, plugin_type="connection", plugin_name="ssh") == 1'
+    #   loop: '{{int_ssh_configs}}'
+    #   tags: [ configfile ]


### PR DESCRIPTION
##### SUMMARY
 Attempt to fix a couple issues that prevent setting `timeout` in the `ssh_connection` ansible.cfg section (though, this could apply to any connection plugin).
 
* The CLI option `--timeout` overrides other configuration methods.
  Since `--timeout` had a default, PC would always use this value.

* FAs preferred parent FA defaults even if they defined their own.
  PlayContext uses the same name as a FA for Base, but they're unrelated (connection timeout vs task timeout), so PC should be able to set its own attribute options.

Related to #76590 (which fixed magic vars taking precedence too).

Connection plugin options that use the key `timeout` also couldn't set their own default since PlayContext.timeout was always passed in task_keys.

Still looking if there's a way to fix the value the config lookup retrieves.

##### ISSUE TYPE
- Bugfix Pull Request