### PR TITLE
Replace incidental_inventory_aws_ec2 with intentional coverage

### DIFF
--- a/test/integration/targets/inventory/host_vars_constructed.yml
+++ b/test/integration/targets/inventory/host_vars_constructed.yml
@@ -1,0 +1,6 @@
+plugin: ansible.legacy.contructed_with_hostvars
+groups:
+  host_var1_defined: host_var1 is defined
+keyed_groups:
+  - key: host_var2
+    prefix: host_var2

--- a/test/integration/targets/inventory/inv_with_host_vars.yml
+++ b/test/integration/targets/inventory/inv_with_host_vars.yml
@@ -1,0 +1,5 @@
+all:
+  hosts:
+    host1:
+      host_var1: 'defined'
+      host_var2: 'defined'

--- a/test/integration/targets/inventory/inventory_plugins/contructed_with_hostvars.py
+++ b/test/integration/targets/inventory/inventory_plugins/contructed_with_hostvars.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2022 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    name: constructed_with_hostvars
+    options:
+      plugin:
+        description: the load name of the plugin
+    extends_documentation_fragment:
+      - constructed
+'''
+
+from ansible.errors import AnsibleParserError
+from ansible.module_utils._text import to_native
+from ansible.plugins.inventory import BaseInventoryPlugin, Constructable
+
+
+class InventoryModule(BaseInventoryPlugin, Constructable):
+
+    NAME = 'constructed_with_hostvars'
+
+    def verify_file(self, path):
+        return super(InventoryModule, self).verify_file(path) and path.endswith(('constructed.yml', 'constructed.yaml'))
+
+    def parse(self, inventory, loader, path, cache=True):
+        super(InventoryModule, self).parse(inventory, loader, path, cache)
+        config = self._read_config_data(path)
+
+        strict = self.get_option('strict')
+        try:
+            for host in inventory.hosts:
+                hostvars = {}
+
+                # constructed groups based on conditionals
+                self._add_host_to_composed_groups(self.get_option('groups'), hostvars, host, strict=strict, fetch_hostvars=True)
+
+                # constructed groups based variable values
+                self._add_host_to_keyed_groups(self.get_option('keyed_groups'), hostvars, host, strict=strict, fetch_hostvars=True)
+
+        except Exception as e:
+            raise AnsibleParserError("failed to parse %s: %s " % (to_native(path), to_native(e)), orig_exc=e)

--- a/test/integration/targets/inventory/runme.sh
+++ b/test/integration/targets/inventory/runme.sh
@@ -44,6 +44,14 @@ ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS=never ansible-playbook -i ../../inventory 
 # test extra vars
 ansible-inventory -i testhost, -i ./extra_vars_constructed.yml --list -e 'from_extras=hey ' "$@"|grep '"example": "hellohey"'
 
+# test host vars from previous inventory sources
+ansible-inventory -i ./inv_with_host_vars.yml -i ./host_vars_constructed.yml --graph "$@" | tee out.txt
+if [[ "$(grep out.txt -ce '.*host_var[1|2]_defined')" != 2 ]]; then
+    cat out.txt
+    echo "Expected groups host_var1_defined and host_var2_defined to both exist"
+    exit 1
+fi
+
 # Do not fail when all inventories fail to parse.
 # Do not fail when any inventory fails to parse.
 ANSIBLE_INVENTORY_UNPARSED_FAILED=False ANSIBLE_INVENTORY_ANY_UNPARSED_IS_FAILED=False ansible -m ping localhost -i /idontexist "$@"
@@ -67,6 +75,16 @@ ANSIBLE_INVENTORY_UNPARSED_FAILED=True ANSIBLE_INVENTORY_ANY_UNPARSED_IS_FAILED=
 if ANSIBLE_INVENTORY_ANY_UNPARSED_IS_FAILED=True ansible -m ping localhost -i /idontexist -i ../../inventory; then
     echo "One inventory failed/did not exist, should NOT cause failure"
     echo "ran with: ANSIBLE_INVENTORY_UNPARSED_FAILED=True ANSIBLE_INVENTORY_ANY_UNPARSED_IS_FAILED=False"
+    exit 1
+fi
+
+# Test parsing an empty config
+set +e
+ANSIBLE_INVENTORY_UNPARSED_FAILED=True ANSIBLE_INVENTORY_ENABLED=constructed ansible-inventory -i ./test_empty.yml --list "$@"
+rc_failed_inventory="$?"
+set -e
+if [[ "$rc_failed_inventory" != 1 ]]; then
+    echo "Config was empty so inventory was not parsed, should cause failure"
     exit 1
 fi
 

--- a/test/integration/targets/module_utils/library/test_network.py
+++ b/test/integration/targets/module_utils/library/test_network.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2021, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.network import to_subnet
+
+
+def main():
+    module = AnsibleModule(argument_spec=dict(
+        subnet=dict(),
+    ))
+
+    subnet = module.params['subnet']
+
+    if subnet is not None:
+        split_addr = subnet.split('/')
+        if len(split_addr) != 2:
+            module.fail_json("Invalid CIDR notation: expected a subnet mask (e.g. 10.0.0.0/32)")
+        module.exit_json(resolved=to_subnet(split_addr[0], split_addr[1]))
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/module_utils/module_utils_common_network.yml
+++ b/test/integration/targets/module_utils/module_utils_common_network.yml
@@ -1,0 +1,10 @@
+- hosts: testhost
+  gather_facts: no
+  tasks:
+    - test_network:
+        subnet: "10.0.0.2/24"
+      register: subnet
+
+    - assert:
+        that:
+          - subnet.resolved == "10.0.0.0/24"

--- a/test/integration/targets/module_utils/runme.sh
+++ b/test/integration/targets/module_utils/runme.sh
@@ -15,3 +15,5 @@ ansible-playbook module_utils_test.yml -i ../../inventory -v "$@"
 ANSIBLE_MODULE_UTILS=other_mu_dir ansible-playbook module_utils_envvar.yml -i ../../inventory -v "$@"
 
 ansible-playbook module_utils_common_dict_transformation.yml -i ../../inventory "$@"
+
+ansible-playbook module_utils_common_network.yml -i ../../inventory "$@"

--- a/test/integration/targets/module_utils_ansible_release/aliases
+++ b/test/integration/targets/module_utils_ansible_release/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group1
+context/target

--- a/test/integration/targets/module_utils_ansible_release/library/ansible_release.py
+++ b/test/integration/targets/module_utils_ansible_release/library/ansible_release.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2021, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: ansible_release
+short_description: Get ansible_release info from module_utils
+description: Get ansible_release info from module_utils
+author:
+- Ansible Project
+'''
+
+EXAMPLES = r'''
+#
+'''
+
+RETURN = r'''
+#
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ansible_release import __version__, __author__, __codename__
+
+
+def main():
+    module = AnsibleModule(argument_spec={})
+    result = {
+        'version': __version__,
+        'author': __author__,
+        'codename': __codename__,
+    }
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/module_utils_ansible_release/tasks/main.yml
+++ b/test/integration/targets/module_utils_ansible_release/tasks/main.yml
@@ -1,0 +1,9 @@
+- name: Get module_utils ansible_release vars
+  ansible_release:
+  register: ansible_release
+
+- assert:
+    that:
+      - ansible_release['version'][0]|int != 0
+      - ansible_release['author'] == 'Ansible, Inc.'
+      - ansible_release['codename']|length > 0


### PR DESCRIPTION
##### SUMMARY
Adding coverage to replace test/integration/targets/incidental_inventory_aws_ec2/

Revamped #72223
Closes #74673

`lib/ansible/plugins/inventory/__init__.py`
- Test parsing an empty config with _read_config
- Test using vars from a previous inventory source with constructed features

`lib/ansible/module_utils/common/network.py`
- Added unit tests from https://github.com/ansible/ansible/pull/74673

`lib/ansible/module_utils/ansible_release.py`
- Added integration tests from https://github.com/ansible/ansible/pull/74673

##### ISSUE TYPE
- Test Pull Request