### PR TITLE
Fix plugin dev examples

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -225,7 +225,7 @@ but with an extra option so you can see how configuration works in Ansible versi
 
     # not only visible to ansible-doc, it also 'declares' the options the plugin requires and how to configure them.
     DOCUMENTATION = '''
-    callback: timer
+    name: timer
     callback_type: aggregate
     requirements:
         - enable in configuration
@@ -357,8 +357,8 @@ Here's a simple lookup plugin implementation --- this lookup returns the content
     __metaclass__ = type
 
     DOCUMENTATION = """
-      lookup: file
-      author: Daniel Hokka Zakrisson <daniel@hozac.com>
+      name: file
+      author: Daniel Hokka Zakrisson (dhozac) <daniel@hozac.com>
       version_added: "0.9"  # for collections, use the collection version, not the Ansible version
       short_description: read file contents
       description:

--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -358,7 +358,7 @@ Here's a simple lookup plugin implementation --- this lookup returns the content
 
     DOCUMENTATION = """
       name: file
-      author: Daniel Hokka Zakrisson (dhozac) <daniel@hozac.com>
+      author: Daniel Hokka Zakrisson (@dhozac) <daniel@hozac.com>
       version_added: "0.9"  # for collections, use the collection version, not the Ansible version
       short_description: read file contents
       description:

--- a/docs/docsite/rst/dev_guide/module_lifecycle.rst
+++ b/docs/docsite/rst/dev_guide/module_lifecycle.rst
@@ -53,7 +53,7 @@ To deprecate a module in a collection, you must:
                        removal_version: 2.0.0
                        warning_text: Use foo.bar.new_cloud instead.
 
-   For other plugin types, you have to replace ``modules:`` with ``name:``.
+   For other plugin types, you have to replace ``modules:`` with ``<plugin_type>:``, for example ``lookup:`` for lookup plugins.
 
    Instead of ``removal_version``, you can also use ``removal_date`` with an ISO 8601 formatted date after which the module will be removed in a new major version of the collection.
 

--- a/docs/docsite/rst/dev_guide/module_lifecycle.rst
+++ b/docs/docsite/rst/dev_guide/module_lifecycle.rst
@@ -53,7 +53,7 @@ To deprecate a module in a collection, you must:
                        removal_version: 2.0.0
                        warning_text: Use foo.bar.new_cloud instead.
 
-   For other plugin types, you have to replace ``modules:`` with ``<plugin_type>:``, for example ``lookup:`` for lookup plugins.
+   For other plugin types, you have to replace ``modules:`` with ``name:``.
 
    Instead of ``removal_version``, you can also use ``removal_date`` with an ISO 8601 formatted date after which the module will be removed in a new major version of the collection.
 


### PR DESCRIPTION
##### SUMMARY
Now that plugins are sanity-checked, too, I've seen some failures with plugins that looked like in the examples. I think this:

```
DOCUMENTATION = """
  lookup: file
  author: Daniel Hokka Zakrisson <daniel@hozac.com>
```

Should look like this:

```
DOCUMENTATION = """
  name: file
  author: Daniel Hokka Zakrisson (@GitHubID) <daniel@hozac.com>
```

Otherwise, the sanity checks fail. When someone wants to write a plugin like in the example, it would be impossible to succeed the sanity tests.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/developing_plugins.rst

##### ADDITIONAL INFORMATION
see [here](https://github.com/ansible-collections/vmware.vmware_rest/pull/331#issuecomment-1119459111) and the following comments