### PR TITLE
2.13 GA has been bumped up a week to release on May 16

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_13.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_13.rst
@@ -37,9 +37,8 @@ Release Phase
 - 2022-04-25 Beta 2 (if necessary)
 
 - 2022-05-02 Release Candidate 1
-- 2022-05-16 Release Candidate 2 (if necessary)
 
-- 2022-05-23 Release
+- 2022-05-16 Release
 
 Release Manager
 ===============


### PR DESCRIPTION
##### SUMMARY
2.13 GA has been bumped up a week to release on May 16

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/roadmap/ROADMAP_2_13.rst

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
