### PR TITLE
docs: Update ansible-core release date in Ansible roadmap

### DIFF
--- a/docs/docsite/rst/roadmap/COLLECTIONS_6.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_6.rst
@@ -21,8 +21,8 @@ Release schedule
 :2022-05-02: First ansible-core release candidate.
 :2022-05-03: Ansible-6.0.0 alpha2.
 :2022-05-11: Community Meeting topic: Decide what contingencies to activate for any blockers that do not meet the deadline.
+:2022-05-16: Ansible-core-2.13 released.
 :2022-05-17: Ansible-6.0.0 alpha3.
-:2022-05-23: Ansible-core-2.13 released.
 :2022-05-23: Last day for collections to make backwards incompatible releases that will be accepted into Ansible-6. This includes adding new collections to Ansible 6.0.0; from now on new collections have to wait for 6.1.0 or later.
 :2022-05-24: Create the ansible-build-data directory and files for Ansible-7.
 :2022-05-24: Ansible-6.0.0 beta1 -- feature freeze [1]_ (weekly beta releases; collection owners and interested users should test for bugs).


### PR DESCRIPTION
##### SUMMARY
There was an update to the ansible-core roadmap, advancing the release
date by a week in 75bc6305650607c550f002aa06dfdbc399efe758 (https://github.com/ansible/ansible/pull/77772).

Let's update the community package roadmap accordingly.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docsite