### PR TITLE
Supply 'dev' keyword for linux network facts discovery

### DIFF
--- a/changelogs/fragments/77792-fix-facts-discovery-specific-interface-names.yml
+++ b/changelogs/fragments/77792-fix-facts-discovery-specific-interface-names.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - facts - fix IP address discovery for specific interface names (https://github.com/ansible/ansible/issues/77792).

--- a/lib/ansible/module_utils/facts/network/linux.py
+++ b/lib/ansible/module_utils/facts/network/linux.py
@@ -260,19 +260,19 @@ class LinuxNetwork(Network):
 
             ip_path = self.module.get_bin_path("ip")
 
-            args = [ip_path, 'addr', 'show', 'primary', device]
+            args = [ip_path, 'addr', 'show', 'primary', 'dev', device]
             rc, primary_data, stderr = self.module.run_command(args, errors='surrogate_then_replace')
             if rc == 0:
                 parse_ip_output(primary_data)
             else:
                 # possibly busybox, fallback to running without the "primary" arg
                 # https://github.com/ansible/ansible/issues/50871
-                args = [ip_path, 'addr', 'show', device]
+                args = [ip_path, 'addr', 'show', 'dev', device]
                 rc, data, stderr = self.module.run_command(args, errors='surrogate_then_replace')
                 if rc == 0:
                     parse_ip_output(data)
 
-            args = [ip_path, 'addr', 'show', 'secondary', device]
+            args = [ip_path, 'addr', 'show', 'secondary', 'dev', device]
             rc, secondary_data, stderr = self.module.run_command(args, errors='surrogate_then_replace')
             if rc == 0:
                 parse_ip_output(secondary_data, secondary=True)


### PR DESCRIPTION
This avoids incorrect results when the device name conflicts with another 'ip' keyword. For example, if the device name is 'primary'.

Fixes #77792
