### PR TITLE
Point to Kerberos as a safer winrm setup method

### DIFF
--- a/docs/docsite/rst/user_guide/windows_setup.rst
+++ b/docs/docsite/rst/user_guide/windows_setup.rst
@@ -137,7 +137,7 @@ for these options are located at the top of the script itself.
 .. Note:: The ConfigureRemotingForAnsible.ps1 script is intended for training and
     development purposes only and should not be used in a
     production environment, since it enables settings (like ``Basic`` authentication)
-    that can be inherently insecure. Kerberos is considered a safer production setup. ( see https://docs.ansible.com/ansible/latest/user_guide/windows_winrm.html#kerberos )
+    that can be inherently insecure. Kerberos is considered a safer production setup. See :ref:`winrm_kerberos for details.
 
 
 WinRM Listener

--- a/docs/docsite/rst/user_guide/windows_setup.rst
+++ b/docs/docsite/rst/user_guide/windows_setup.rst
@@ -137,7 +137,7 @@ for these options are located at the top of the script itself.
 .. Note:: The ConfigureRemotingForAnsible.ps1 script is intended for training and
     development purposes only and should not be used in a
     production environment, since it enables settings (like ``Basic`` authentication)
-    that can be inherently insecure. Kerberos is considered a safer production setup. See :ref:`winrm_kerberos for details.
+    that can be inherently insecure. Kerberos is considered a safer production setup. See :ref:`winrm_kerberos` for details.
 
 
 WinRM Listener

--- a/docs/docsite/rst/user_guide/windows_setup.rst
+++ b/docs/docsite/rst/user_guide/windows_setup.rst
@@ -137,7 +137,8 @@ for these options are located at the top of the script itself.
 .. Note:: The ConfigureRemotingForAnsible.ps1 script is intended for training and
     development purposes only and should not be used in a
     production environment, since it enables settings (like ``Basic`` authentication)
-    that can be inherently insecure.
+    that can be inherently insecure. Kerberos is considered a safer production setup. ( see https://docs.ansible.com/ansible/latest/user_guide/windows_winrm.html#kerberos )
+
 
 WinRM Listener
 --------------


### PR DESCRIPTION
##### SUMMARY
<!--- Your description here -->
Only noting that the provided 'ConfigureRemotingForAnsible.ps1' script is not safe for production use, is not a very good default. The majority of installs will use the provided 'ConfigureRemotingForAnsible.ps1' script and at best only use basic auth, which is very bad from a security stand point and is also being depreciated left right and center. We should really point to where we describe how to do this more securely for live production installs.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
