### PR TITLE
Update PSF-license.txt to version from CPython 3.9.5

### DIFF
--- a/licenses/PSF-license.txt
+++ b/licenses/PSF-license.txt
@@ -12,9 +12,9 @@ analyze, test, perform and/or display publicly, prepare derivative works,
 distribute, and otherwise use Python alone or in any derivative version,
 provided, however, that PSF's License Agreement and PSF's notice of copyright,
 i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
-2011, 2012, 2013, 2014, 2015, 2016, 2017 Python Software Foundation; All Rights
-Reserved" are retained in Python alone or in any derivative version prepared by
-Licensee.
+2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021 Python Software Foundation;
+All Rights Reserved" are retained in Python alone or in any derivative version
+prepared by Licensee.
 
 3. In the event Licensee prepares a derivative work that is based on
 or incorporates Python or any part thereof, and wants to make


### PR DESCRIPTION
##### SUMMARY
As pointed out by @gotmax23 in https://github.com/ansible-collections/community.general/pull/4675#issuecomment-1127245658, the licenses/PSF-license.txt file is outdated and does not match what lib/ansible/module_utils/compat/version.py should be covered with.

IANAL but I guess updating it doesn't hurt :-)

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
licenses/PSF-license.txt
