### PR TITLE
Raise a proper error when include/import_role is used as a handler

### DIFF
--- a/changelogs/fragments/better-msg-role-in-handler.yml
+++ b/changelogs/fragments/better-msg-role-in-handler.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Raise a proper error when ``include_role`` or ``import_role`` is used as a handler.

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -275,6 +275,9 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                     task_list.append(t)
 
             elif action in C._ACTION_ALL_PROPER_INCLUDE_IMPORT_ROLES:
+                if use_handlers:
+                    raise AnsibleParserError(f"Using '{action}' as a handler is not supported.", obj=task_ds)
+
                 ir = IncludeRole.load(
                     task_ds,
                     block=block,

--- a/test/integration/targets/handlers/runme.sh
+++ b/test/integration/targets/handlers/runme.sh
@@ -114,3 +114,7 @@ grep out.txt -e "ERROR! The requested handler 'handler name with myvar' was not 
 grep out.txt -e "\[WARNING\]: Handler 'handler name with {{ test_var }}' is unusable"
 [ "$(grep out.txt -ce 'handler ran')" = "0" ]
 [ "$(grep out.txt -ce 'handler with var ran')" = "0" ]
+
+# Test include_role and import_role cannot be used as handlers
+ansible-playbook test_role_as_handler.yml "$@"  2>&1 | tee out.txt
+grep out.txt -e "ERROR! Using 'include_role' as a handler is not supported."

--- a/test/integration/targets/handlers/test_role_as_handler.yml
+++ b/test/integration/targets/handlers/test_role_as_handler.yml
@@ -1,0 +1,11 @@
+- name: test include_role and import_role cannot be used as handlers
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - command: "echo"
+      notify:
+        - role_handler
+  handlers:
+    - name: role_handler
+      include_role:
+        name: doesnotmatter_fails_at_parse_time

--- a/test/units/playbook/test_helpers.py
+++ b/test/units/playbook/test_helpers.py
@@ -301,12 +301,14 @@ class TestLoadListOfTasks(unittest.TestCase, MixinForMocks):
 
     def test_one_bogus_include_role_use_handlers(self):
         ds = [{'include_role': {'name': 'bogus_role'}, 'collections': []}]
-        res = helpers.load_list_of_tasks(ds, play=self.mock_play, use_handlers=True,
-                                         block=self.mock_block,
-                                         variable_manager=self.mock_variable_manager,
-                                         loader=self.fake_role_loader)
-        self.assertEqual(len(res), 1)
-        self._assert_is_task_list_or_blocks(res)
+
+        self.assertRaises(errors.AnsibleError, helpers.load_list_of_tasks,
+                          ds,
+                          self.mock_play,
+                          True,  # use_handlers
+                          self.mock_block,
+                          self.mock_variable_manager,
+                          self.fake_role_loader)
 
 
 class TestLoadListOfRoles(unittest.TestCase, MixinForMocks):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ci_complete
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/playbook/helpers.py`

##### ADDITIONAL INFORMATION
Before:
```
PLAY [localhost] ***********************************************************************************************************
ERROR! Invalid handler definition for 'include_role : doesnotmatter'. 'IncludeRole' object has no attribute 'notified_hosts'
```

After:
```
ERROR! Using 'include_role' as a handler is not supported.

The error appears to be in '/Users/mkrizek/src/ansible/test_handlers.yml': line 9, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  handlers:
    - include_role:
      ^ here
```