### PR TITLE
Update Ansible release version to v2.12.6rc1.post0.

### DIFF
--- a/lib/ansible/release.py
+++ b/lib/ansible/release.py
@@ -19,6 +19,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-__version__ = '2.12.6rc1'
+__version__ = '2.12.6rc1.post0'
 __author__ = 'Ansible, Inc.'
 __codename__ = 'Dazed and Confused'


### PR DESCRIPTION
##### SUMMARY
Release version bump to tag 2.12.6rc1.post0 . Resets version to post0.

##### ISSUE TYPE

- Release Pull Request
