### PR TITLE
validate meta/main.yml dependencies and meta/requirements.yml are lists

### DIFF
--- a/changelogs/fragments/handle-role-dependency-type-error.yml
+++ b/changelogs/fragments/handle-role-dependency-type-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - Fix unhandled traceback if a role's dependencies in meta/main.yml or meta/requirements.yml are not lists.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1376,9 +1376,10 @@ class GalaxyCLI(CLI):
             # install dependencies, if we want them
             if not no_deps and installed:
                 if not role.metadata:
+                    # NOTE: the meta file is also required for installing the role, not just dependencies
                     display.warning("Meta file %s is empty. Skipping dependencies." % role.path)
                 else:
-                    role_dependencies = (role.metadata.get('dependencies') or []) + role.requirements
+                    role_dependencies = role.metadata_dependencies + role.requirements
                     for dep in role_dependencies:
                         display.debug('Installing dep %s' % dep)
                         dep_req = RoleRequirement()

--- a/lib/ansible/playbook/role/metadata.py
+++ b/lib/ansible/playbook/role/metadata.py
@@ -72,6 +72,7 @@ class RoleMetadata(Base, CollectionSearch):
                 raise AnsibleParserError("Expected role dependencies to be a list.", obj=self._ds)
 
             for role_def in ds:
+                # FIXME: consolidate with ansible-galaxy to keep this in sync
                 if isinstance(role_def, string_types) or 'role' in role_def or 'name' in role_def:
                     roles.append(role_def)
                     continue


### PR DESCRIPTION
##### SUMMARY
Fix an unhandled traceback and give a clear error when installing roles dependencies that are in collection + role requirement file format, e.g.
```yaml
collections:
  - ns.coll
roles:
  - role
```
This matches role runtime behavior for meta/main.yml dependencies which must be a list of roles.

Alternative approach to #73480, which adds support for that format with a warning if collections key is provided.
Closes #73480

##### ISSUE TYPE
- Bugfix Pull Request
