### PR TITLE
Catch KeyError when wantlist=False with lookup dict (#77789)

### DIFF
--- a/changelogs/fragments/77789-catch-keyerror-lookup-dict.yml
+++ b/changelogs/fragments/77789-catch-keyerror-lookup-dict.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - lookup plugin - catch KeyError when lookup returns dictionary (https://github.com/ansible/ansible/pull/77789).

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -1014,6 +1014,11 @@ class Templar:
                 else:
                     ran = wrap_var(ran)
 
+            except KeyError:
+                # Lookup Plugin returned a dict.  Return comma-separated string.
+                # See https://github.com/ansible/ansible/pull/77789
+                ran = wrap_var(",".join(ran))
+
         return ran
 
     def _make_undefined(self, hint=None):

--- a/test/integration/targets/templating_lookups/runme.sh
+++ b/test/integration/targets/templating_lookups/runme.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-ANSIBLE_ROLES_PATH=./ UNICODE_VAR=café ansible-playbook runme.yml "$@"
+ANSIBLE_LOOKUP_PLUGINS=. ANSIBLE_ROLES_PATH=./ UNICODE_VAR=café ansible-playbook runme.yml "$@"
 
 ansible-playbook template_lookup_vaulted/playbook.yml --vault-password-file template_lookup_vaulted/test_vault_pass "$@"
 

--- a/test/integration/targets/templating_lookups/template_lookups/mock_lookup_plugins/77788.py
+++ b/test/integration/targets/templating_lookups/template_lookups/mock_lookup_plugins/77788.py
@@ -1,0 +1,6 @@
+from ansible.plugins.lookup import LookupBase
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables, **kwargs):
+        return {'one': 1, 'two': 2}

--- a/test/integration/targets/templating_lookups/template_lookups/tasks/main.yml
+++ b/test/integration/targets/templating_lookups/template_lookups/tasks/main.yml
@@ -87,4 +87,15 @@
     that:
       - password1 != password2
 
+# 77788 - KeyError when wantlist=False with dict returned
+- name: Test that dicts can be parsed with wantlist false
+  set_fact:
+    dict_wantlist_true: "{{ lookup('77788', wantlist=True) }}"
+    dict_wantlist_false: "{{ lookup('77788', wantlist=False) }}"
+
+- assert:
+    that:
+      - dict_wantlist_true is mapping
+      - dict_wantlist_false is string
+
 - include_tasks: ./errors.yml


### PR DESCRIPTION
##### SUMMARY
Catch KeyError when lookup return data is a dictionary

(cherry picked from commit c9ce7d08a256646abdaccc80b480b8b9c2df9f1b)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
template/__init__.py