### PR TITLE
[stable-2.13] Avoid deprecated method in unit tests.

### DIFF
--- a/test/units/ansible_test/ci/util.py
+++ b/test/units/ansible_test/ci/util.py
@@ -44,10 +44,8 @@ def verify_signature(request, public_key_pem):
 
     public_key = load_pem_public_key(public_key_pem.encode(), default_backend())
 
-    verifier = public_key.verifier(
+    public_key.verify(
         base64.b64decode(signature.encode()),
+        payload_bytes,
         ec.ECDSA(hashes.SHA256()),
     )
-
-    verifier.update(payload_bytes)
-    verifier.verify()


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/77833
 
(cherry picked from commit 5f74350fd5fab5599127eaa43c615d2159e145c6)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

test/units/ansible_test/ci/util.py