### PR TITLE
Remove double spaces in errormessage

### DIFF
--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -338,7 +338,7 @@ class _ComputedReqKindsMixin:
                     'not an FQCN. A valid collection name must be in '
                     'the format <namespace>.<collection>. Please make '
                     'sure that the namespace and the collection name '
-                    ' contain characters from [a-zA-Z0-9_] only.'
+                    'contain characters from [a-zA-Z0-9_] only.'
                     '{extra_tip!s}'.format(extra_tip=tip),
                 )
 

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/requirements.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/requirements.yml
@@ -30,7 +30,7 @@
         nor 'source' point to a concrete resolvable collection artifact.
         Also 'name' is not an FQCN. A valid collection name must be in
         the format <namespace>.<collection>. Please make sure that the
-        namespace and the collection name  contain characters from
+        namespace and the collection name contain characters from
         [a-zA-Z0-9_] only." in result.stderr
 
 - name: test source is not a git repo even if name is provided

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -1093,7 +1093,7 @@ def test_parse_requirements_without_mandatory_name_key(requirements_cli, require
 
     expected = "Neither the collection requirement entry key 'name', nor 'source' point to a concrete resolvable collection artifact. "
     expected += r"Also 'name' is not an FQCN\. A valid collection name must be in the format <namespace>\.<collection>\. "
-    expected += r"Please make sure that the namespace and the collection name  contain characters from \[a\-zA\-Z0\-9_\] only\."
+    expected += r"Please make sure that the namespace and the collection name contain characters from \[a\-zA\-Z0\-9_\] only\."
 
     with pytest.raises(AnsibleError, match=expected):
         requirements_cli._parse_requirements_file(requirements_file)

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -631,7 +631,7 @@ def test_invalid_collection_name_install(name, expected, tmp_path_factory):
     # Used to be: expected = "Invalid collection name '%s', name must be in the format <namespace>.<collection>" % expected
     expected = "Neither the collection requirement entry key 'name', nor 'source' point to a concrete resolvable collection artifact. "
     expected += r"Also 'name' is not an FQCN\. A valid collection name must be in the format <namespace>\.<collection>\. "
-    expected += r"Please make sure that the namespace and the collection name  contain characters from \[a\-zA\-Z0\-9_\] only\."
+    expected += r"Please make sure that the namespace and the collection name contain characters from \[a\-zA\-Z0\-9_\] only\."
 
     gc = GalaxyCLI(args=['ansible-galaxy', 'collection', 'install', name, '-p', os.path.join(install_path, 'install')])
     with pytest.raises(AnsibleError, match=expected):


### PR DESCRIPTION
##### SUMMARY
Right now, an errormessage can contain ".. name  contain.." which contains a double space. Squashed this.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

