### PR TITLE
add canonical url to 2.3 to direct google to latest

### DIFF
--- a/docs/docsite/_themes/srtd/layout.html
+++ b/docs/docsite/_themes/srtd/layout.html
@@ -33,6 +33,7 @@
   {% if favicon %}
     <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>
   {% endif %}
+  <link rel="canonical" href="https://docs.ansible.com/ansible/latest/{{ pagename }}.html"/>
 
   {# CSS #}
   <link href='https://fonts.googleapis.com/css?family=Lato:400,700|Roboto+Slab:400,700|Inconsolata:400,700' rel='stylesheet' type='text/css'>

--- a/docs/docsite/_themes/srtd/layout.html
+++ b/docs/docsite/_themes/srtd/layout.html
@@ -38,6 +38,9 @@
   <link href='https://fonts.googleapis.com/css?family=Lato:400,700|Roboto+Slab:400,700|Inconsolata:400,700' rel='stylesheet' type='text/css'>
   <link href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.0.3/css/font-awesome.min.css' rel='stylesheet' type='text/css'>
 
+  {# CANONICAL URL #}
+  <link rel="canonical" href="https://docs.ansible.com/ansible/latest/index.html">
+  
   {# JS #}
   {% if not embedded %}
 

--- a/docs/docsite/_themes/srtd/layout.html
+++ b/docs/docsite/_themes/srtd/layout.html
@@ -38,9 +38,6 @@
   <link href='https://fonts.googleapis.com/css?family=Lato:400,700|Roboto+Slab:400,700|Inconsolata:400,700' rel='stylesheet' type='text/css'>
   <link href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.0.3/css/font-awesome.min.css' rel='stylesheet' type='text/css'>
 
-  {# CANONICAL URL #}
-  <link rel="canonical" href="https://docs.ansible.com/ansible/latest/index.html">
-  
   {# JS #}
   {% if not embedded %}
 

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -1,0 +1,295 @@
+.. _@{ module }@:
+
+{% if short_description %}
+{% set title = module + ' - ' + short_description|convert_symbols_to_format %}
+{% else %}
+{% set title = module %}
+{% endif %}
+{% set title_len = title|length %}
+
+@{ title }@
+@{ '+' * title_len }@
+
+{% if version_added is defined -%}
+.. versionadded:: @{ version_added }@
+{% endif %}
+
+
+.. contents::
+   :local:
+   :depth: 2
+
+{# ------------------------------------------
+ #
+ # Please note: this looks like a core dump
+ # but it isn't one.
+ #
+ --------------------------------------------#}
+
+{% if deprecated is defined -%}
+DEPRECATED
+----------
+
+@{ deprecated | convert_symbols_to_format }@
+{% endif %}
+
+Synopsis
+--------
+
+{% for desc in description -%}
+ * @{ desc | convert_symbols_to_format }@
+{% endfor %}
+
+{% if aliases is defined -%}
+Aliases: @{ ','.join(aliases) }@
+{% endif %}
+
+{% if requirements %}
+Requirements (on host that executes module)
+-------------------------------------------
+
+{% for req in requirements %}
+  * @{ req | convert_symbols_to_format }@
+{% endfor %}
+{% endif %}
+
+
+{% if options -%}
+Options
+-------
+
+.. raw:: html
+
+    <table border=1 cellpadding=4>
+
+    <tr>
+    <th class="head">parameter</th>
+    <th class="head">required</th>
+    <th class="head">default</th>
+    <th class="head">choices</th>
+    <th class="head">comments</th>
+    </tr>
+{% for k in option_keys -%}
+{% set v = options[k] -%}
+{% if not v['suboptions'] %}
+
+    <tr>
+    <td>@{ k }@<br/><div style="font-size: small;">{% if v['version_added'] -%} (added in @{v['version_added']}@){% endif -%}</div></td>
+    <td>{% if v.get('required', False) -%}yes{% else %}no{% endif -%}</td>
+    <td>{% if v['default'] -%}@{ v['default'] }@{% endif -%}</td>
+{% if v.get('type', 'not_bool') == 'bool' %}
+    <td><ul><li>yes</li><li>no</li></ul></td>
+{% else %}
+    <td>{% if v['choices'] -%}<ul>{% for choice in v.get('choices',[]) -%}<li>@{ choice }@</li>{% endfor -%}</ul>{% endif -%}</td>
+{% endif %}
+    <td>
+{% if v.description is string %}
+        <div>@{ v.description | replace('\n', '\n    ') | html_ify }@</div>
+{% else %}
+{% for desc in v.description %}
+        <div>@{ desc | replace('\n', '\n    ') | html_ify }@</div>
+{% endfor %}
+{% endif %}
+{% if 'aliases' in v and v.aliases %}
+        </br><div style="font-size: small;">aliases: @{ v.aliases|join(', ') }@</div>
+{% endif %}
+{% else %}
+
+    <tr>
+    <td rowspan="2">@{ k }@<br/><div style="font-size: small;">{% if v['version_added'] -%} (added in @{v['version_added']}@){% endif -%}</div></td>
+    <td>{% if v.get('required', False) -%}yes{% else -%}no{% endif -%}</td>
+    <td></td>
+    <td></td>
+    <td>
+{% for desc in v.description %}
+        <div>@{ desc | replace('\n', '\n    ') | html_ify }@</div>
+{% endfor %}
+{% if 'aliases' in v and v.aliases %}
+        </br><div style="font-size: small;">aliases: @{ v.aliases|join(', ') }@</div>
+{% endif %}
+    </tr>
+
+    <tr>
+    <td colspan="5">
+        <table border=1 cellpadding=4>
+        <caption><b>Dictionary object @{ k }@</b></caption>
+
+        <tr>
+        <th class="head">parameter</th>
+        <th class="head">required</th>
+        <th class="head">default</th>
+        <th class="head">choices</th>
+        <th class="head">comments</th>
+        </tr>
+{% for k2 in v['suboptions'] %}
+{% set v2 = v['suboptions'] [k2] %}
+
+        <tr>
+        <td>@{ k2 }@<br/><div style="font-size: small;">{% if v2['version_added'] -%} (added in @{v2['version_added']}@){% endif -%}</div></td>
+        <td>{% if v2.get('required', False) -%}yes{% else -%}no{% endif -%}</td>
+        <td>{% if v2['default'] -%}@{ v2['default'] }@{% endif -%}</td>
+{% if v2.get('type', 'not_bool') == 'bool' %}
+        <td><ul><li>yes</li><li>no</li></ul></td>
+{% else %}
+        <td>{% if v2['choices'] -%}<ul>{% for choice in v2.get('choices',[]) -%}<li>@{ choice }@</li>{% endfor -%}</ul>{% endif -%}</td>
+{% endif %}
+        <td>
+{% if v2.description is string %}
+        <div>@{ v2.description | replace('\n', '\n    ') | html_ify }@</div>
+{% else %}
+{% for desc in v2.description %}
+            <div>@{ desc | replace('\n', '\n    ') | html_ify }@</div>
+{% endfor %}
+{% endif %}
+{% if 'aliases' in v and v2.aliases %}
+            </br><div style="font-size: small;">aliases: @{ v2.aliases|join(', ') }@</div>
+{% endif %}
+        </td>
+        </tr>
+{% endfor %}
+
+        </table>
+
+    </td>
+    </tr>
+{% endif %}
+    </td>
+    </tr>
+{% endfor %}
+
+    </table>
+    </br>
+
+{% endif %}
+
+
+{% if examples or plainexamples -%}
+Examples
+--------
+
+ ::
+
+{% for example in examples %}
+{% if example['description'] %}@{ example['description'] | indent(4, True) }@{% endif %}
+@{ example['code'] | escape | indent(4, True) }@
+{% endfor %}
+{% if plainexamples %}@{ plainexamples | indent(4, True) }@{% endif %}
+{% endif %}
+
+
+{% if returndocs -%}
+Return Values
+-------------
+
+Common return values are documented here :doc:`common_return_values`, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=1 cellpadding=4>
+
+    <tr>
+    <th class="head">name</th>
+    <th class="head">description</th>
+    <th class="head">returned</th>
+    <th class="head">type</th>
+    <th class="head">sample</th>
+    </tr>
+{% for entry, unusedvalue in returndocs|dictsort %}
+
+    <tr>
+    <td>@{ entry }@</td>
+    <td>
+{% if returndocs[entry].description is string %}
+        <div>@{ returndocs[entry].description | replace('\n', '\n    ') | html_ify }@</div>
+{% else %}
+{% for desc in returndocs[entry].description %}
+        <div>@{ desc | replace('\n', '\n    ') | html_ify }@</div>
+{% endfor %}
+{% endif %}
+    </td>
+    <td align=center>@{ returndocs[entry].returned }@</td>
+    <td align=center>@{ returndocs[entry].type }@</td>
+    <td align=center>@{ returndocs[entry].sample | replace('\n', '\n    ') | html_ify }@</td>
+    </tr>
+{% if returndocs[entry].type == 'complex' %}
+
+    <tr>
+    <td>contains:</td>
+    <td colspan=4>
+        <table border=1 cellpadding=2>
+
+        <tr>
+        <th class="head">name</th>
+        <th class="head">description</th>
+        <th class="head">returned</th>
+        <th class="head">type</th>
+        <th class="head">sample</th>
+        </tr>
+{% for sub in returndocs[entry].contains %}
+
+        <tr>
+        <td>@{ sub }@</td>
+        <td>
+{% if returndocs[entry].contains[sub].description is string %}
+            <div>@{ returndocs[entry].contains[sub].description | replace('\n', '\n    ') | html_ify }@</div>
+{% else %}
+{% for desc in returndocs[entry].contains[sub].description %}
+            <div>@{ desc | replace('\n', '\n    ') | html_ify }@</div>
+{% endfor %}
+{% endif %}
+        </td>
+        <td align=center>@{ returndocs[entry].contains[sub].returned }@</td>
+        <td align=center>@{ returndocs[entry].contains[sub].type }@</td>
+        <td align=center>@{ returndocs[entry].contains[sub].sample }@</td>
+        </tr>
+{% endfor %}
+
+        </table>
+    </td>
+    </tr>
+{% endif %}
+{% endfor %}
+
+    </table>
+    </br>
+    </br>
+{% endif %}
+
+{% if notes -%}
+Notes
+-----
+
+.. note::
+{% for note in notes %}
+    - @{ note | convert_symbols_to_format }@
+{% endfor %}
+{% endif %}
+
+{% if not deprecated %}
+{% set support = { 'core': 'The Ansible Core Team', 'network': 'The Ansible Network Team', 'certified': 'an Ansible Partner', 'community': 'The Ansible Community', 'curated': 'A Third Party'} %}
+{% set module_states = { 'preview': 'it is not guaranteed to have a backwards compatible interface', 'stableinterface': 'the maintainers for this module guarantee that no backward incompatible interface changes will be made'} %}
+
+{% if metadata %}
+{% if metadata.status %}
+
+Status
+~~~~~~
+
+{% for cur_state in  metadata.status %}
+This module is flagged as **@{cur_state}@** which means that @{module_states[cur_state]}@.
+{% endfor %}
+{% endif %}
+{% if metadata.supported_by in ('core', 'network') %}
+
+Maintenance Info
+~~~~~~~~~~~~~~~~
+
+For more information about Red Hat's this support of this module, please
+refer to this `knowledge base article<https://access.redhat.com/articles/rhel-top-support-policies>`
+
+{% endif %}
+{% endif %}
+{% endif %}
+
+For help in developing on modules, should you be so inclined, please read :doc:`community`, :doc:`dev_guide/testing` and :doc:`dev_guide/developing_modules`.
+


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We are still getting some top google search hits to 2.3 docs. This is the first cut attempt to teach search engines to use /latest/ instead.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request



##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs/docsite/_themes/srtd/layout.html
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
