### PR TITLE
swallow all exceptions in type annotation support shim imports

### DIFF
--- a/changelogs/fragments/type_shim_exception_swallow.yml
+++ b/changelogs/fragments/type_shim_exception_swallow.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- prevent type annotation shim failures from causing runtime failures (https://github.com/ansible/ansible/pull/77860)

--- a/lib/ansible/module_utils/compat/typing.py
+++ b/lib/ansible/module_utils/compat/typing.py
@@ -4,12 +4,15 @@ __metaclass__ = type
 
 # pylint: disable=wildcard-import,unused-wildcard-import
 
+# catch *all* exceptions to prevent type annotation support module bugs causing runtime failures
+# (eg, https://github.com/ansible/ansible/issues/77857)
+
 try:
     from typing_extensions import *
-except ImportError:
+except Exception:  # pylint: disable=broad-except
     pass
 
 try:
     from typing import *  # type: ignore[misc]
-except ImportError:
+except Exception:  # pylint: disable=broad-except
     pass


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

fixes #77857 

Underlying problem was an upstream `typing_extensions` bug that was quickly fixed, but this should prevent any future errors there from causing Ansible runtime errors.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
type extensions

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
