### PR TITLE
With antsibull-changelog >= 0.14.0 and the sidecar docs feature, test and filter plugins are detected if they have version_added

### DIFF
--- a/docs/docsite/rst/community/collection_development_process.rst
+++ b/docs/docsite/rst/community/collection_development_process.rst
@@ -61,7 +61,7 @@ More precisely:
 
 * Every bugfix PR must have a changelog fragment. The only exception are fixes to a change that has not yet been included in a release.
 * Every feature PR must have a changelog fragment.
-* New modules and plugins (including jinja2 filter and test plugins) must have ``versions_added`` set correctly in their documenation, and do not need a changelog fragment. The tooling detects new modules and plugins by their ``versions_added`` value and announces them in the next release's changelog automatically.
+* New modules and plugins (including jinja2 filter and test plugins) must have ``version_added`` entries set correctly in their documentation, and do not need a changelog fragment. The tooling detects new modules and plugins by their ``version_added`` values and announces them in the next release's changelog automatically.
 
 We build short summary changelogs for minor releases as well as for major releases. If you backport a bugfix, include a changelog fragment with the backport PR.
 

--- a/docs/docsite/rst/community/collection_development_process.rst
+++ b/docs/docsite/rst/community/collection_development_process.rst
@@ -61,8 +61,7 @@ More precisely:
 
 * Every bugfix PR must have a changelog fragment. The only exception are fixes to a change that has not yet been included in a release.
 * Every feature PR must have a changelog fragment.
-* New modules and plugins (except jinja2 filter and test plugins) must have ``versions_added`` set correctly, and do not need a changelog fragment. The tooling detects new modules and plugins by their ``versions_added`` value and announces them in the next release's changelog automatically.
-* New jinja2 filter and test plugins, and also new roles and playbooks (for collections) must have a changelog fragment. See :ref:`changelogs_how_to_format_j2_roles_playbooks` or the `antsibull-changelog documentation for such changelog fragments <https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#adding-new-roles-playbooks-test-and-filter-plugins>`_ for information on what the fragments should look like.
+* New modules and plugins (including jinja2 filter and test plugins) must have ``versions_added`` set correctly in their documenation, and do not need a changelog fragment. The tooling detects new modules and plugins by their ``versions_added`` value and announces them in the next release's changelog automatically.
 
 We build short summary changelogs for minor releases as well as for major releases. If you backport a bugfix, include a changelog fragment with the backport PR.
 

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -161,7 +161,7 @@ More precisely:
 
 * Every bugfix PR must have a changelog fragment. The only exception are fixes to a change that has not yet been included in a release.
 * Every feature PR must have a changelog fragment.
-* New modules and plugins (including jinja2 filter and test plugins) must have ``versions_added`` set correctly in their documentation, and do not need a changelog fragment. The tooling detects new modules and plugins by their ``versions_added`` value and announces them in the next release's changelog automatically.
+* New modules and plugins (including jinja2 filter and test plugins) must have ``version_added`` entries set correctly in their documentation, and do not need a changelog fragment. The tooling detects new modules and plugins by their ``version_added`` values and announces them in the next release's changelog automatically.
 
 We build short summary changelogs for minor releases as well as for major releases. If you backport a bugfix, include a changelog fragment with the backport PR.
 

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -161,8 +161,7 @@ More precisely:
 
 * Every bugfix PR must have a changelog fragment. The only exception are fixes to a change that has not yet been included in a release.
 * Every feature PR must have a changelog fragment.
-* New modules and plugins (except jinja2 filter and test plugins) must have ``versions_added`` set correctly, and do not need a changelog fragment. The tooling detects new modules and plugins by their ``versions_added`` value and announces them in the next release's changelog automatically.
-* New jinja2 filter and test plugins, and also new roles and playbooks (for collections) must have a changelog fragment. See :ref:`changelogs_how_to_format_j2_roles_playbooks` or the `antsibull-changelog documentation for such changelog fragments <https://github.com/ansible-community/antsibull-changelog/blob/main/docs/changelogs.rst#adding-new-roles-playbooks-test-and-filter-plugins>`_ for information on what the fragments should look like.
+* New modules and plugins (including jinja2 filter and test plugins) must have ``versions_added`` set correctly in their documentation, and do not need a changelog fragment. The tooling detects new modules and plugins by their ``versions_added`` value and announces them in the next release's changelog automatically.
 
 We build short summary changelogs for minor releases as well as for major releases. If you backport a bugfix, include a changelog fragment with the backport PR.
 
@@ -300,43 +299,14 @@ You can find more example changelog fragments in the `changelog directory <https
 
 After you have written the changelog fragment for your PR, commit the file and include it with the pull request.
 
-.. _changelogs_how_to_format_j2_roles_playbooks:
+.. _changelogs_how_to_format_playbooks:
 
-Changelog fragment entry format for new jinja2 plugins, roles, and playbooks
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog fragment entry format for new playbooks
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-While new modules and plugins that are not jinja2 filter or test plugins are mentioned automatically in the generated changelog, jinja2 filter and test plugins, roles, and playbooks are not. To make sure they are mentioned, a changelog fragment in a specific format is needed:
+While new modules, plugins, and roles are mentioned automatically in the generated changelog, playbooks are not. To make sure they are mentioned, a changelog fragment in a specific format is needed:
 
 .. code-block:: yaml
-
-    # A new jinja2 filter plugin:
-    add plugin.filter:
-      - # The following needs to be the name of the filter itself, not of the file
-        # the filter is included in!
-        name: to_time_unit
-        # The description should be in the same format as short_description for
-        # other plugins and modules: it should start with an upper-case letter and
-        # not have a period at the end.
-        description: Converts a time expression to a given unit
-
-    # A new jinja2 test plugin:
-    add plugin.test:
-      - # The following needs to be the name of the test itself, not of the file
-        # the test is included in!
-        name: asn1time
-        # The description should be in the same format as short_description for
-        # other plugins and modules: it should start with an upper-case letter and
-        # not have a period at the end.
-        description: Check whether the given string is an ASN.1 time
-
-    # A new role:
-    add object.role:
-      - # This should be the short (non-FQCN) name of the role.
-        name: nginx
-        # The description should be in the same format as short_description for
-        # plugins and modules: it should start with an upper-case letter and
-        # not have a period at the end.
-        description: A nginx installation role
 
     # A new playbook:
     add object.playbook:


### PR DESCRIPTION
##### SUMMARY
Assuming you use the devel branch, milestone branch, or ansible-core >= 2.14 once released :)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/community/collection_development_process.rst
docs/docsite/rst/community/development_process.rst
