### PR TITLE
Replace mock with unittest.mock.

### DIFF
--- a/test/lib/ansible_test/_data/pytest.ini
+++ b/test/lib/ansible_test/_data/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
 xfail_strict = true
-mock_use_standalone_module = true
 junit_family = xunit1

--- a/test/units/_vendor/test_vendor.py
+++ b/test/units/_vendor/test_vendor.py
@@ -9,7 +9,7 @@ import pkgutil
 import pytest
 import sys
 
-from mock import MagicMock, NonCallableMagicMock, patch
+from unittest.mock import MagicMock, NonCallableMagicMock, patch
 
 
 def reset_internal_vendor_package():

--- a/test/units/cli/test_cli.py
+++ b/test/units/cli/test_cli.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 from units.mock.loader import DictDataLoader
 

--- a/test/units/cli/test_console.py
+++ b/test/units/cli/test_console.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import patch
+from unittest.mock import patch
 
 from ansible.cli.console import ConsoleCLI
 

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -41,7 +41,7 @@ from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.utils import context_objects as co
 from ansible.utils.display import Display
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 @pytest.fixture(autouse='function')

--- a/test/units/cli/test_vault.py
+++ b/test/units/cli/test_vault.py
@@ -24,7 +24,7 @@ import os
 import pytest
 
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from units.mock.vault_helper import TextVaultSecret
 
 from ansible import context, errors

--- a/test/units/errors/test_errors.py
+++ b/test/units/errors/test_errors.py
@@ -21,7 +21,7 @@ __metaclass__ = type
 
 
 from units.compat import unittest
-from mock import mock_open, patch
+from unittest.mock import mock_open, patch
 from ansible.errors import AnsibleError
 from ansible.parsing.yaml.objects import AnsibleBaseYAMLObject
 

--- a/test/units/executor/test_interpreter_discovery.py
+++ b/test/units/executor/test_interpreter_discovery.py
@@ -6,7 +6,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from ansible.executor.interpreter_discovery import discover_interpreter
 from ansible.module_utils._text import to_text

--- a/test/units/executor/test_play_iterator.py
+++ b/test/units/executor/test_play_iterator.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 from ansible.executor.play_iterator import HostState, PlayIterator, IteratingStates, FailedStates
 from ansible.playbook import Playbook

--- a/test/units/executor/test_playbook_executor.py
+++ b/test/units/executor/test_playbook_executor.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from ansible.executor.playbook_executor import PlaybookExecutor
 from ansible.playbook import Playbook

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -19,10 +19,10 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import mock
+from unittest import mock
 
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from ansible.errors import AnsibleError
 from ansible.executor.task_executor import TaskExecutor, remove_omit
 from ansible.plugins.loader import action_loader, lookup_loader

--- a/test/units/executor/test_task_queue_manager_callbacks.py
+++ b/test/units/executor/test_task_queue_manager_callbacks.py
@@ -19,7 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 from units.compat import unittest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook import Playbook

--- a/test/units/executor/test_task_result.py
+++ b/test/units/executor/test_task_result.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 from ansible.executor.task_result import TaskResult
 

--- a/test/units/galaxy/test_api.py
+++ b/test/units/galaxy/test_api.py
@@ -16,7 +16,7 @@ import tempfile
 import time
 
 from io import BytesIO, StringIO
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import ansible.constants as C
 from ansible import context

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -16,7 +16,7 @@ import uuid
 
 from hashlib import sha256
 from io import BytesIO
-from mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import ansible.constants as C
 from ansible import context

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -17,7 +17,7 @@ import tarfile
 import yaml
 
 from io import BytesIO, StringIO
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from unittest import mock
 
 import ansible.module_utils.six.moves.urllib.error as urllib_error

--- a/test/units/galaxy/test_token.py
+++ b/test/units/galaxy/test_token.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 import os
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import ansible.constants as C
 from ansible.cli.galaxy import GalaxyCLI, SERVER_DEF

--- a/test/units/mock/path.py
+++ b/test/units/mock/path.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 from ansible.utils.path import unfrackpath
 
 

--- a/test/units/module_utils/basic/test_argument_spec.py
+++ b/test/units/module_utils/basic/test_argument_spec.py
@@ -12,7 +12,7 @@ import os
 
 import pytest
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 from ansible.module_utils import basic
 from ansible.module_utils.api import basic_auth_argument_spec, rate_limit_argument_spec, retry_argument_spec
 from ansible.module_utils.common import warnings

--- a/test/units/module_utils/basic/test_filesystem.py
+++ b/test/units/module_utils/basic/test_filesystem.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 from units.mock.procenv import ModuleTestCase
 
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from ansible.module_utils.six.moves import builtins
 
 realimport = builtins.__import__

--- a/test/units/module_utils/basic/test_get_module_path.py
+++ b/test/units/module_utils/basic/test_get_module_path.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 from units.mock.procenv import ModuleTestCase
 
-from mock import patch
+from unittest.mock import patch
 from ansible.module_utils.six.moves import builtins
 
 realimport = builtins.__import__

--- a/test/units/module_utils/basic/test_imports.py
+++ b/test/units/module_utils/basic/test_imports.py
@@ -12,7 +12,7 @@ import sys
 from units.mock.procenv import ModuleTestCase
 
 from units.compat import unittest
-from mock import patch
+from unittest.mock import patch
 from ansible.module_utils.six.moves import builtins
 
 realimport = builtins.__import__

--- a/test/units/module_utils/basic/test_platform_distribution.py
+++ b/test/units/module_utils/basic/test_platform_distribution.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 import pytest
 
-from mock import patch
+from unittest.mock import patch
 
 from ansible.module_utils.six.moves import builtins
 

--- a/test/units/module_utils/basic/test_selinux.py
+++ b/test/units/module_utils/basic/test_selinux.py
@@ -11,7 +11,7 @@ import errno
 import json
 import pytest
 
-from mock import mock_open, patch
+from unittest.mock import mock_open, patch
 
 from ansible.module_utils import basic
 from ansible.module_utils.common.text.converters import to_bytes

--- a/test/units/module_utils/basic/test_set_cwd.py
+++ b/test/units/module_utils/basic/test_set_cwd.py
@@ -13,7 +13,7 @@ import tempfile
 
 import pytest
 
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from ansible.module_utils._text import to_bytes
 
 from ansible.module_utils import basic

--- a/test/units/module_utils/basic/test_tmpdir.py
+++ b/test/units/module_utils/basic/test_tmpdir.py
@@ -13,7 +13,7 @@ import tempfile
 
 import pytest
 
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from ansible.module_utils._text import to_bytes
 
 from ansible.module_utils import basic

--- a/test/units/module_utils/common/test_locale.py
+++ b/test/units/module_utils/common/test_locale.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from ansible.module_utils.common.locale import get_best_parsable_locale
 

--- a/test/units/module_utils/common/test_sys_info.py
+++ b/test/units/module_utils/common/test_sys_info.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 import pytest
 
-from mock import patch
+from unittest.mock import patch
 
 from ansible.module_utils.six.moves import builtins
 

--- a/test/units/module_utils/facts/base.py
+++ b/test/units/module_utils/facts/base.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 
 class BaseFactsTest(unittest.TestCase):

--- a/test/units/module_utils/facts/hardware/test_linux.py
+++ b/test/units/module_utils/facts/hardware/test_linux.py
@@ -19,7 +19,7 @@ __metaclass__ = type
 import os
 
 from units.compat import unittest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from ansible.module_utils.facts import timeout
 

--- a/test/units/module_utils/facts/network/test_fc_wwn.py
+++ b/test/units/module_utils/facts/network/test_fc_wwn.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.facts.network import fc_wwn
-from mock import Mock
+from unittest.mock import Mock
 
 
 # AIX lsdev

--- a/test/units/module_utils/facts/network/test_generic_bsd.py
+++ b/test/units/module_utils/facts/network/test_generic_bsd.py
@@ -18,7 +18,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from mock import Mock
+from unittest.mock import Mock
 from units.compat import unittest
 
 from ansible.module_utils.facts.network import generic_bsd

--- a/test/units/module_utils/facts/network/test_iscsi_get_initiator.py
+++ b/test/units/module_utils/facts/network/test_iscsi_get_initiator.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.facts.network import iscsi
-from mock import Mock
+from unittest.mock import Mock
 
 
 # AIX # lsattr -E -l iscsi0

--- a/test/units/module_utils/facts/other/test_facter.py
+++ b/test/units/module_utils/facts/other/test_facter.py
@@ -19,7 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from .. base import BaseFactsTest
 

--- a/test/units/module_utils/facts/other/test_ohai.py
+++ b/test/units/module_utils/facts/other/test_ohai.py
@@ -19,7 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from .. base import BaseFactsTest
 

--- a/test/units/module_utils/facts/system/distribution/conftest.py
+++ b/test/units/module_utils/facts/system/distribution/conftest.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 import pytest
 
-from mock import Mock
+from unittest.mock import Mock
 
 
 @pytest.fixture

--- a/test/units/module_utils/facts/system/test_lsb.py
+++ b/test/units/module_utils/facts/system/test_lsb.py
@@ -19,7 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from .. base import BaseFactsTest
 

--- a/test/units/module_utils/facts/test_ansible_collector.py
+++ b/test/units/module_utils/facts/test_ansible_collector.py
@@ -21,7 +21,7 @@ __metaclass__ = type
 
 # for testing
 from units.compat import unittest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from ansible.module_utils.facts import collector
 from ansible.module_utils.facts import ansible_collector

--- a/test/units/module_utils/facts/test_collectors.py
+++ b/test/units/module_utils/facts/test_collectors.py
@@ -21,7 +21,7 @@ __metaclass__ = type
 
 import pytest
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from . base import BaseFactsTest
 

--- a/test/units/module_utils/facts/test_facts.py
+++ b/test/units/module_utils/facts/test_facts.py
@@ -26,7 +26,7 @@ import pytest
 
 # for testing
 from units.compat import unittest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from ansible.module_utils import facts
 from ansible.module_utils.facts import hardware

--- a/test/units/module_utils/facts/test_sysctl.py
+++ b/test/units/module_utils/facts/test_sysctl.py
@@ -26,7 +26,7 @@ import pytest
 
 # for testing
 from units.compat import unittest
-from mock import patch, MagicMock, mock_open, Mock
+from unittest.mock import patch, MagicMock, mock_open, Mock
 
 from ansible.module_utils.facts.sysctl import get_sysctl
 

--- a/test/units/module_utils/facts/test_utils.py
+++ b/test/units/module_utils/facts/test_utils.py
@@ -18,7 +18,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import patch
+from unittest.mock import patch
 
 from ansible.module_utils.facts import utils
 

--- a/test/units/module_utils/urls/test_Request.py
+++ b/test/units/module_utils/urls/test_Request.py
@@ -13,7 +13,7 @@ from ansible.module_utils.urls import (Request, open_url, urllib_request, HAS_SS
 from ansible.module_utils.urls import SSLValidationHandler, HTTPSClientAuthHandler, RedirectHandlerFactory
 
 import pytest
-from mock import call
+from unittest.mock import call
 
 
 if HAS_SSLCONTEXT:

--- a/test/units/module_utils/urls/test_fetch_url.py
+++ b/test/units/module_utils/urls/test_fetch_url.py
@@ -14,7 +14,7 @@ from ansible.module_utils.six.moves.http_client import HTTPMessage
 from ansible.module_utils.urls import fetch_url, urllib_error, ConnectionError, NoSSLError, httplib
 
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 
 class AnsibleModuleExit(Exception):

--- a/test/units/modules/test_apt.py
+++ b/test/units/modules/test_apt.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 import collections
 import sys
 
-import mock
+from unittest import mock
 
 from units.compat import unittest
 

--- a/test/units/modules/test_apt_key.py
+++ b/test/units/modules/test_apt_key.py
@@ -3,7 +3,7 @@ __metaclass__ = type
 
 import os
 
-import mock
+from unittest import mock
 
 from units.compat import unittest
 

--- a/test/units/modules/test_async_wrapper.py
+++ b/test/units/modules/test_async_wrapper.py
@@ -11,7 +11,7 @@ import tempfile
 
 import pytest
 
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from ansible.modules import async_wrapper
 
 from pprint import pprint

--- a/test/units/modules/test_hostname.py
+++ b/test/units/modules/test_hostname.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import tempfile
 
-from mock import patch, MagicMock, mock_open
+from unittest.mock import patch, MagicMock, mock_open
 from ansible.module_utils import basic
 from ansible.module_utils.common._utils import get_all_subclasses
 from ansible.modules import hostname

--- a/test/units/modules/test_iptables.py
+++ b/test/units/modules/test_iptables.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from mock import patch
+from unittest.mock import patch
 from ansible.module_utils import basic
 from ansible.modules import iptables
 from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args

--- a/test/units/modules/test_service_facts.py
+++ b/test/units/modules/test_service_facts.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import patch
+from unittest.mock import patch
 
 from ansible.module_utils import basic
 from ansible.modules.service_facts import AIXScanService

--- a/test/units/modules/utils.py
+++ b/test/units/modules/utils.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 import json
 
 from units.compat import unittest
-from mock import patch
+from unittest.mock import patch
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
 

--- a/test/units/parsing/test_dataloader.py
+++ b/test/units/parsing/test_dataloader.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 import os
 
 from units.compat import unittest
-from mock import patch, mock_open
+from unittest.mock import patch, mock_open
 from ansible.errors import AnsibleParserError, yaml_strings, AnsibleFileNotFound
 from ansible.parsing.vault import AnsibleVaultError
 from ansible.module_utils._text import to_text

--- a/test/units/parsing/vault/test_vault.py
+++ b/test/units/parsing/vault/test_vault.py
@@ -30,7 +30,7 @@ from binascii import hexlify
 import pytest
 
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 from ansible import errors
 from ansible.module_utils import six

--- a/test/units/parsing/vault/test_vault_editor.py
+++ b/test/units/parsing/vault/test_vault_editor.py
@@ -27,7 +27,7 @@ from io import BytesIO, StringIO
 import pytest
 
 from units.compat import unittest
-from mock import patch
+from unittest.mock import patch
 
 from ansible import errors
 from ansible.parsing import vault

--- a/test/units/playbook/role/test_include_role.py
+++ b/test/units/playbook/role/test_include_role.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import patch
+from unittest.mock import patch
 
 from ansible.playbook import Play
 from ansible.playbook.role_include import IncludeRole

--- a/test/units/playbook/role/test_role.py
+++ b/test/units/playbook/role/test_role.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 from collections.abc import Container
 
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.playbook.block import Block

--- a/test/units/playbook/test_conditional.py
+++ b/test/units/playbook/test_conditional.py
@@ -3,7 +3,7 @@ __metaclass__ = type
 
 from units.compat import unittest
 from units.mock.loader import DictDataLoader
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from ansible.template import Templar
 from ansible import errors

--- a/test/units/playbook/test_helpers.py
+++ b/test/units/playbook/test_helpers.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 import os
 
 from units.compat import unittest
-from mock import MagicMock
+from unittest.mock import MagicMock
 from units.mock.loader import DictDataLoader
 
 from ansible import errors

--- a/test/units/playbook/test_included_file.py
+++ b/test/units/playbook/test_included_file.py
@@ -23,7 +23,7 @@ import os
 
 import pytest
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 from units.mock.loader import DictDataLoader
 
 from ansible.playbook.block import Block

--- a/test/units/playbook/test_task.py
+++ b/test/units/playbook/test_task.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import patch
+from unittest.mock import patch
 from ansible.playbook.task import Task
 from ansible.parsing.yaml import objects
 from ansible import errors

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -25,7 +25,7 @@ import re
 
 from ansible import constants as C
 from units.compat import unittest
-from mock import patch, MagicMock, mock_open
+from unittest.mock import patch, MagicMock, mock_open
 
 from ansible.errors import AnsibleError, AnsibleAuthenticationFailure
 from ansible.module_utils.six import text_type

--- a/test/units/plugins/action/test_gather_facts.py
+++ b/test/units/plugins/action/test_gather_facts.py
@@ -19,7 +19,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from ansible import constants as C
 from ansible.playbook.task import Task

--- a/test/units/plugins/action/test_raw.py
+++ b/test/units/plugins/action/test_raw.py
@@ -22,7 +22,7 @@ import os
 
 from ansible.errors import AnsibleActionFail
 from units.compat import unittest
-from mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock
 from ansible.plugins.action.raw import ActionModule
 from ansible.playbook.task import Task
 from ansible.plugins.loader import connection_loader

--- a/test/units/plugins/cache/test_cache.py
+++ b/test/units/plugins/cache/test_cache.py
@@ -23,7 +23,7 @@ import os
 import shutil
 import tempfile
 
-import mock
+from unittest import mock
 
 from units.compat import unittest
 from ansible.errors import AnsibleError

--- a/test/units/plugins/callback/test_callback.py
+++ b/test/units/plugins/callback/test_callback.py
@@ -25,7 +25,7 @@ import textwrap
 import types
 
 from units.compat import unittest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from ansible.executor.task_result import TaskResult
 from ansible.inventory.host import Host

--- a/test/units/plugins/connection/test_psrp.py
+++ b/test/units/plugins/connection/test_psrp.py
@@ -10,7 +10,7 @@ import pytest
 import sys
 
 from io import StringIO
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader

--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -27,7 +27,7 @@ import pytest
 from ansible import constants as C
 from ansible.errors import AnsibleAuthenticationFailure
 from units.compat import unittest
-from mock import patch, MagicMock, PropertyMock
+from unittest.mock import patch, MagicMock, PropertyMock
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
 from ansible.module_utils.compat.selectors import SelectorKey, EVENT_READ
 from ansible.module_utils.six.moves import shlex_quote

--- a/test/units/plugins/connection/test_winrm.py
+++ b/test/units/plugins/connection/test_winrm.py
@@ -12,7 +12,7 @@ import pytest
 
 from io import StringIO
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_bytes
 from ansible.playbook.play_context import PlayContext

--- a/test/units/plugins/inventory/test_inventory.py
+++ b/test/units/plugins/inventory/test_inventory.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 import string
 import textwrap
 
-import mock
+from unittest import mock
 
 from ansible import constants as C
 from units.compat import unittest

--- a/test/units/plugins/inventory/test_script.py
+++ b/test/units/plugins/inventory/test_script.py
@@ -22,7 +22,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import pytest
-import mock
+from unittest import mock
 
 from ansible import constants as C
 from ansible.errors import AnsibleError

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -32,7 +32,7 @@ import pytest
 from units.mock.loader import DictDataLoader
 
 from units.compat import unittest
-from mock import mock_open, patch
+from unittest.mock import mock_open, patch
 from ansible.errors import AnsibleError
 from ansible.module_utils.six import text_type
 from ansible.module_utils.six.moves import builtins

--- a/test/units/plugins/strategy/test_linear.py
+++ b/test/units/plugins/strategy/test_linear.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 
 
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 from ansible.executor.play_iterator import PlayIterator
 from ansible.playbook import Playbook

--- a/test/units/plugins/strategy/test_strategy.py
+++ b/test/units/plugins/strategy/test_strategy.py
@@ -23,7 +23,7 @@ from units.mock.loader import DictDataLoader
 import uuid
 
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from ansible.executor.process.worker import WorkerProcess
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.executor.task_result import TaskResult

--- a/test/units/plugins/test_plugins.py
+++ b/test/units/plugins/test_plugins.py
@@ -23,7 +23,7 @@ __metaclass__ = type
 import os
 
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from ansible.plugins.loader import PluginLoader, PluginPathContext
 
 

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 from jinja2.runtime import Context
 
 from units.compat import unittest
-from mock import patch
+from unittest.mock import patch
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleUndefinedVariable

--- a/test/units/template/test_vars.py
+++ b/test/units/template/test_vars.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from ansible.template.vars import AnsibleJ2Vars
 

--- a/test/units/utils/collection_loader/test_collection_loader.py
+++ b/test/units/utils/collection_loader/test_collection_loader.py
@@ -17,7 +17,7 @@ from ansible.utils.collection_loader._collection_finder import (
     _get_collection_name_from_path, _get_collection_role_path, _get_collection_metadata, _iter_modules_impl
 )
 from ansible.utils.collection_loader._collection_config import _EventSource
-from mock import MagicMock, NonCallableMagicMock, patch
+from unittest.mock import MagicMock, NonCallableMagicMock, patch
 
 
 # fixture to ensure we always clean up the import stuff when we're done

--- a/test/units/utils/display/test_broken_cowsay.py
+++ b/test/units/utils/display/test_broken_cowsay.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 
 from ansible.utils.display import Display
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 
 def test_display_with_fake_cowsay_binary(capsys, mocker):

--- a/test/units/utils/test_display.py
+++ b/test/units/utils/test_display.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/test/units/utils/test_vars.py
+++ b/test/units/utils/test_vars.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 
 from collections import defaultdict
 
-import mock
+from unittest import mock
 
 from units.compat import unittest
 from ansible.errors import AnsibleError

--- a/test/units/vars/test_variable_manager.py
+++ b/test/units/vars/test_variable_manager.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 import os
 
 from units.compat import unittest
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from ansible.inventory.manager import InventoryManager
 from ansible.module_utils.six import iteritems
 from ansible.playbook.play import Play


### PR DESCRIPTION
##### SUMMARY
mock is a backport of the standard library unittest.mock module, which is available in Python 3.3 and above. I do not think there is a compelling reason to use mock when we only support Python 3.8 and above. Prior to the removal of units.compat.mock (https://github.com/ansible/ansible/pull/77118), `mock` was only used when `unittest.mock` was unavailable, but now `mock` is unconditionally used.

Furthermore, `mock` has been deprecated in Fedora and was completely removed from RHEL 9, as it's redundant for the versions of python available in those distributions. Alongside the Fedora specific information, there is some general information about this issue in the [Deprecate python-mock Change Proposal](https://fedoraproject.org/wiki/Changes/DeprecatePythonMock) which you can take a look at. In the meantime, I plan on downstream patching the Fedora ansible-core package which I co-maintain.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
unit tests
