### PR TITLE
[stable-2.13] Use unittest.mock instead of mock. (#77883)

### DIFF
--- a/test/units/_vendor/test_vendor.py
+++ b/test/units/_vendor/test_vendor.py
@@ -9,7 +9,7 @@ import pkgutil
 import pytest
 import sys
 
-from mock import MagicMock, NonCallableMagicMock, patch
+from unittest.mock import MagicMock, NonCallableMagicMock, patch
 
 
 def reset_internal_vendor_package():

--- a/test/units/cli/test_cli.py
+++ b/test/units/cli/test_cli.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 from units.mock.loader import DictDataLoader
 

--- a/test/units/cli/test_console.py
+++ b/test/units/cli/test_console.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import patch
+from unittest.mock import patch
 
 from ansible.cli.console import ConsoleCLI
 

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -41,7 +41,7 @@ from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.utils import context_objects as co
 from ansible.utils.display import Display
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 @pytest.fixture(autouse='function')

--- a/test/units/cli/test_vault.py
+++ b/test/units/cli/test_vault.py
@@ -24,7 +24,7 @@ import os
 import pytest
 
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from units.mock.vault_helper import TextVaultSecret
 
 from ansible import context, errors

--- a/test/units/errors/test_errors.py
+++ b/test/units/errors/test_errors.py
@@ -21,7 +21,7 @@ __metaclass__ = type
 
 
 from units.compat import unittest
-from mock import mock_open, patch
+from unittest.mock import mock_open, patch
 from ansible.errors import AnsibleError
 from ansible.parsing.yaml.objects import AnsibleBaseYAMLObject
 

--- a/test/units/executor/test_interpreter_discovery.py
+++ b/test/units/executor/test_interpreter_discovery.py
@@ -6,7 +6,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from ansible.executor.interpreter_discovery import discover_interpreter
 from ansible.module_utils._text import to_text

--- a/test/units/executor/test_play_iterator.py
+++ b/test/units/executor/test_play_iterator.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 from ansible.executor.play_iterator import HostState, PlayIterator, IteratingStates, FailedStates
 from ansible.playbook import Playbook

--- a/test/units/executor/test_playbook_executor.py
+++ b/test/units/executor/test_playbook_executor.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from ansible.executor.playbook_executor import PlaybookExecutor
 from ansible.playbook import Playbook

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -19,10 +19,10 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import mock
+from unittest import mock
 
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from ansible.errors import AnsibleError
 from ansible.executor.task_executor import TaskExecutor, remove_omit
 from ansible.plugins.loader import action_loader, lookup_loader

--- a/test/units/executor/test_task_queue_manager_callbacks.py
+++ b/test/units/executor/test_task_queue_manager_callbacks.py
@@ -19,7 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 from units.compat import unittest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.playbook import Playbook

--- a/test/units/executor/test_task_result.py
+++ b/test/units/executor/test_task_result.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 from ansible.executor.task_result import TaskResult
 

--- a/test/units/galaxy/test_api.py
+++ b/test/units/galaxy/test_api.py
@@ -16,7 +16,7 @@ import tempfile
 import time
 
 from io import BytesIO, StringIO
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import ansible.constants as C
 from ansible import context

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -15,7 +15,7 @@ import uuid
 
 from hashlib import sha256
 from io import BytesIO
-from mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import ansible.constants as C
 from ansible import context

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -17,7 +17,7 @@ import tarfile
 import yaml
 
 from io import BytesIO, StringIO
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from unittest import mock
 
 import ansible.module_utils.six.moves.urllib.error as urllib_error

--- a/test/units/galaxy/test_token.py
+++ b/test/units/galaxy/test_token.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 import os
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import ansible.constants as C
 from ansible.cli.galaxy import GalaxyCLI, SERVER_DEF

--- a/test/units/mock/path.py
+++ b/test/units/mock/path.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 from ansible.utils.path import unfrackpath
 
 

--- a/test/units/parsing/test_dataloader.py
+++ b/test/units/parsing/test_dataloader.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 import os
 
 from units.compat import unittest
-from mock import patch, mock_open
+from unittest.mock import patch, mock_open
 from ansible.errors import AnsibleParserError, yaml_strings, AnsibleFileNotFound
 from ansible.parsing.vault import AnsibleVaultError
 from ansible.module_utils._text import to_text

--- a/test/units/parsing/vault/test_vault.py
+++ b/test/units/parsing/vault/test_vault.py
@@ -30,7 +30,7 @@ from binascii import hexlify
 import pytest
 
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 from ansible import errors
 from ansible.module_utils import six

--- a/test/units/parsing/vault/test_vault_editor.py
+++ b/test/units/parsing/vault/test_vault_editor.py
@@ -27,7 +27,7 @@ from io import BytesIO, StringIO
 import pytest
 
 from units.compat import unittest
-from mock import patch
+from unittest.mock import patch
 
 from ansible import errors
 from ansible.parsing import vault

--- a/test/units/playbook/role/test_include_role.py
+++ b/test/units/playbook/role/test_include_role.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import patch
+from unittest.mock import patch
 
 from ansible.playbook import Play
 from ansible.playbook.role_include import IncludeRole

--- a/test/units/playbook/role/test_role.py
+++ b/test/units/playbook/role/test_role.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 from collections.abc import Container
 
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.playbook.block import Block

--- a/test/units/playbook/test_conditional.py
+++ b/test/units/playbook/test_conditional.py
@@ -3,7 +3,7 @@ __metaclass__ = type
 
 from units.compat import unittest
 from units.mock.loader import DictDataLoader
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from ansible.template import Templar
 from ansible import errors

--- a/test/units/playbook/test_helpers.py
+++ b/test/units/playbook/test_helpers.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 import os
 
 from units.compat import unittest
-from mock import MagicMock
+from unittest.mock import MagicMock
 from units.mock.loader import DictDataLoader
 
 from ansible import errors

--- a/test/units/playbook/test_included_file.py
+++ b/test/units/playbook/test_included_file.py
@@ -23,7 +23,7 @@ import os
 
 import pytest
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 from units.mock.loader import DictDataLoader
 
 from ansible.playbook.block import Block

--- a/test/units/playbook/test_task.py
+++ b/test/units/playbook/test_task.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import patch
+from unittest.mock import patch
 from ansible.playbook.task import Task
 from ansible.parsing.yaml import objects
 from ansible import errors

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -25,7 +25,7 @@ import re
 
 from ansible import constants as C
 from units.compat import unittest
-from mock import patch, MagicMock, mock_open
+from unittest.mock import patch, MagicMock, mock_open
 
 from ansible.errors import AnsibleError, AnsibleAuthenticationFailure
 from ansible.module_utils.six import text_type

--- a/test/units/plugins/action/test_gather_facts.py
+++ b/test/units/plugins/action/test_gather_facts.py
@@ -19,7 +19,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from ansible import constants as C
 from ansible.playbook.task import Task

--- a/test/units/plugins/action/test_raw.py
+++ b/test/units/plugins/action/test_raw.py
@@ -22,7 +22,7 @@ import os
 
 from ansible.errors import AnsibleActionFail
 from units.compat import unittest
-from mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock
 from ansible.plugins.action.raw import ActionModule
 from ansible.playbook.task import Task
 from ansible.plugins.loader import connection_loader

--- a/test/units/plugins/cache/test_cache.py
+++ b/test/units/plugins/cache/test_cache.py
@@ -23,7 +23,7 @@ import os
 import shutil
 import tempfile
 
-import mock
+from unittest import mock
 
 from units.compat import unittest
 from ansible.errors import AnsibleError

--- a/test/units/plugins/callback/test_callback.py
+++ b/test/units/plugins/callback/test_callback.py
@@ -25,7 +25,7 @@ import textwrap
 import types
 
 from units.compat import unittest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from ansible.executor.task_result import TaskResult
 from ansible.inventory.host import Host

--- a/test/units/plugins/connection/test_psrp.py
+++ b/test/units/plugins/connection/test_psrp.py
@@ -10,7 +10,7 @@ import pytest
 import sys
 
 from io import StringIO
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader

--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -27,7 +27,7 @@ import pytest
 from ansible import constants as C
 from ansible.errors import AnsibleAuthenticationFailure
 from units.compat import unittest
-from mock import patch, MagicMock, PropertyMock
+from unittest.mock import patch, MagicMock, PropertyMock
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
 from ansible.module_utils.compat.selectors import SelectorKey, EVENT_READ
 from ansible.module_utils.six.moves import shlex_quote

--- a/test/units/plugins/connection/test_winrm.py
+++ b/test/units/plugins/connection/test_winrm.py
@@ -12,7 +12,7 @@ import pytest
 
 from io import StringIO
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils._text import to_bytes
 from ansible.playbook.play_context import PlayContext

--- a/test/units/plugins/inventory/test_inventory.py
+++ b/test/units/plugins/inventory/test_inventory.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 import string
 import textwrap
 
-import mock
+from unittest import mock
 
 from ansible import constants as C
 from units.compat import unittest

--- a/test/units/plugins/inventory/test_script.py
+++ b/test/units/plugins/inventory/test_script.py
@@ -22,7 +22,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import pytest
-import mock
+from unittest import mock
 
 from ansible import constants as C
 from ansible.errors import AnsibleError

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -32,7 +32,7 @@ import pytest
 from units.mock.loader import DictDataLoader
 
 from units.compat import unittest
-from mock import mock_open, patch
+from unittest.mock import mock_open, patch
 from ansible.errors import AnsibleError
 from ansible.module_utils.six import text_type
 from ansible.module_utils.six.moves import builtins

--- a/test/units/plugins/strategy/test_linear.py
+++ b/test/units/plugins/strategy/test_linear.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 
 
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 from ansible.executor.play_iterator import PlayIterator
 from ansible.playbook import Playbook

--- a/test/units/plugins/strategy/test_strategy.py
+++ b/test/units/plugins/strategy/test_strategy.py
@@ -23,7 +23,7 @@ from units.mock.loader import DictDataLoader
 import uuid
 
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from ansible.executor.process.worker import WorkerProcess
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.executor.task_result import TaskResult

--- a/test/units/plugins/test_plugins.py
+++ b/test/units/plugins/test_plugins.py
@@ -23,7 +23,7 @@ __metaclass__ = type
 import os
 
 from units.compat import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 from ansible.plugins.loader import PluginLoader, PluginPathContext
 
 

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 from jinja2.runtime import Context
 
 from units.compat import unittest
-from mock import patch
+from unittest.mock import patch
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleUndefinedVariable

--- a/test/units/template/test_vars.py
+++ b/test/units/template/test_vars.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from ansible.template.vars import AnsibleJ2Vars
 

--- a/test/units/utils/collection_loader/test_collection_loader.py
+++ b/test/units/utils/collection_loader/test_collection_loader.py
@@ -17,7 +17,7 @@ from ansible.utils.collection_loader._collection_finder import (
     _get_collection_name_from_path, _get_collection_role_path, _get_collection_metadata, _iter_modules_impl
 )
 from ansible.utils.collection_loader._collection_config import _EventSource
-from mock import MagicMock, NonCallableMagicMock, patch
+from unittest.mock import MagicMock, NonCallableMagicMock, patch
 
 
 # fixture to ensure we always clean up the import stuff when we're done

--- a/test/units/utils/display/test_broken_cowsay.py
+++ b/test/units/utils/display/test_broken_cowsay.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 
 from ansible.utils.display import Display
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 
 def test_display_with_fake_cowsay_binary(capsys, mocker):

--- a/test/units/utils/test_display.py
+++ b/test/units/utils/test_display.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/test/units/utils/test_vars.py
+++ b/test/units/utils/test_vars.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 
 from collections import defaultdict
 
-import mock
+from unittest import mock
 
 from units.compat import unittest
 from ansible.errors import AnsibleError

--- a/test/units/vars/test_variable_manager.py
+++ b/test/units/vars/test_variable_manager.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 import os
 
 from units.compat import unittest
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from ansible.inventory.manager import InventoryManager
 from ansible.module_utils.six import iteritems
 from ansible.playbook.play import Play


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/77883

(cherry picked from commit 3a9a23fb1a7e617479d0ae72dadba0f7a739d13a)

Co-authored-by: Matt Clay <matt@mystile.com>

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

controller unit tests
