### PR TITLE
Prefer unittest.mock over mock.

### DIFF
--- a/test/units/compat/mock.py
+++ b/test/units/compat/mock.py
@@ -1,0 +1,23 @@
+"""
+Compatibility shim for mock imports in modules and module_utils.
+This can be removed once support for Python 2.7 is dropped.
+"""
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+try:
+    from unittest.mock import (
+        call,
+        patch,
+        mock_open,
+        MagicMock,
+        Mock,
+    )
+except ImportError:
+    from mock import (
+        call,
+        patch,
+        mock_open,
+        MagicMock,
+        Mock,
+    )

--- a/test/units/module_utils/basic/test_argument_spec.py
+++ b/test/units/module_utils/basic/test_argument_spec.py
@@ -12,7 +12,7 @@ import os
 
 import pytest
 
-from mock import MagicMock
+from units.compat.mock import MagicMock
 from ansible.module_utils import basic
 from ansible.module_utils.api import basic_auth_argument_spec, rate_limit_argument_spec, retry_argument_spec
 from ansible.module_utils.common import warnings

--- a/test/units/module_utils/basic/test_filesystem.py
+++ b/test/units/module_utils/basic/test_filesystem.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 from units.mock.procenv import ModuleTestCase
 
-from mock import patch, MagicMock
+from units.compat.mock import patch, MagicMock
 from ansible.module_utils.six.moves import builtins
 
 realimport = builtins.__import__

--- a/test/units/module_utils/basic/test_get_module_path.py
+++ b/test/units/module_utils/basic/test_get_module_path.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 from units.mock.procenv import ModuleTestCase
 
-from mock import patch
+from units.compat.mock import patch
 from ansible.module_utils.six.moves import builtins
 
 realimport = builtins.__import__

--- a/test/units/module_utils/basic/test_imports.py
+++ b/test/units/module_utils/basic/test_imports.py
@@ -12,7 +12,7 @@ import sys
 from units.mock.procenv import ModuleTestCase
 
 from units.compat import unittest
-from mock import patch
+from units.compat.mock import patch
 from ansible.module_utils.six.moves import builtins
 
 realimport = builtins.__import__

--- a/test/units/module_utils/basic/test_platform_distribution.py
+++ b/test/units/module_utils/basic/test_platform_distribution.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 import pytest
 
-from mock import patch
+from units.compat.mock import patch
 
 from ansible.module_utils.six.moves import builtins
 

--- a/test/units/module_utils/basic/test_selinux.py
+++ b/test/units/module_utils/basic/test_selinux.py
@@ -11,7 +11,7 @@ import errno
 import json
 import pytest
 
-from mock import mock_open, patch
+from units.compat.mock import mock_open, patch
 
 from ansible.module_utils import basic
 from ansible.module_utils.common.text.converters import to_bytes

--- a/test/units/module_utils/basic/test_set_cwd.py
+++ b/test/units/module_utils/basic/test_set_cwd.py
@@ -13,7 +13,7 @@ import tempfile
 
 import pytest
 
-from mock import patch, MagicMock
+from units.compat.mock import patch, MagicMock
 from ansible.module_utils._text import to_bytes
 
 from ansible.module_utils import basic

--- a/test/units/module_utils/basic/test_tmpdir.py
+++ b/test/units/module_utils/basic/test_tmpdir.py
@@ -13,7 +13,7 @@ import tempfile
 
 import pytest
 
-from mock import patch, MagicMock
+from units.compat.mock import patch, MagicMock
 from ansible.module_utils._text import to_bytes
 
 from ansible.module_utils import basic

--- a/test/units/module_utils/common/test_locale.py
+++ b/test/units/module_utils/common/test_locale.py
@@ -5,7 +5,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from mock import MagicMock
+from units.compat.mock import MagicMock
 
 from ansible.module_utils.common.locale import get_best_parsable_locale
 

--- a/test/units/module_utils/common/test_sys_info.py
+++ b/test/units/module_utils/common/test_sys_info.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 import pytest
 
-from mock import patch
+from units.compat.mock import patch
 
 from ansible.module_utils.six.moves import builtins
 

--- a/test/units/module_utils/facts/base.py
+++ b/test/units/module_utils/facts/base.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import Mock, patch
+from units.compat.mock import Mock, patch
 
 
 class BaseFactsTest(unittest.TestCase):

--- a/test/units/module_utils/facts/hardware/test_linux.py
+++ b/test/units/module_utils/facts/hardware/test_linux.py
@@ -19,7 +19,7 @@ __metaclass__ = type
 import os
 
 from units.compat import unittest
-from mock import Mock, patch
+from units.compat.mock import Mock, patch
 
 from ansible.module_utils.facts import timeout
 

--- a/test/units/module_utils/facts/network/test_fc_wwn.py
+++ b/test/units/module_utils/facts/network/test_fc_wwn.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.facts.network import fc_wwn
-from mock import Mock
+from units.compat.mock import Mock
 
 
 # AIX lsdev

--- a/test/units/module_utils/facts/network/test_generic_bsd.py
+++ b/test/units/module_utils/facts/network/test_generic_bsd.py
@@ -18,7 +18,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from mock import Mock
+from units.compat.mock import Mock
 from units.compat import unittest
 
 from ansible.module_utils.facts.network import generic_bsd

--- a/test/units/module_utils/facts/network/test_iscsi_get_initiator.py
+++ b/test/units/module_utils/facts/network/test_iscsi_get_initiator.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.facts.network import iscsi
-from mock import Mock
+from units.compat.mock import Mock
 
 
 # AIX # lsattr -E -l iscsi0

--- a/test/units/module_utils/facts/other/test_facter.py
+++ b/test/units/module_utils/facts/other/test_facter.py
@@ -19,7 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from mock import Mock, patch
+from units.compat.mock import Mock, patch
 
 from .. base import BaseFactsTest
 

--- a/test/units/module_utils/facts/other/test_ohai.py
+++ b/test/units/module_utils/facts/other/test_ohai.py
@@ -19,7 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from mock import Mock, patch
+from units.compat.mock import Mock, patch
 
 from .. base import BaseFactsTest
 

--- a/test/units/module_utils/facts/system/distribution/conftest.py
+++ b/test/units/module_utils/facts/system/distribution/conftest.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 import pytest
 
-from mock import Mock
+from units.compat.mock import Mock
 
 
 @pytest.fixture

--- a/test/units/module_utils/facts/system/test_lsb.py
+++ b/test/units/module_utils/facts/system/test_lsb.py
@@ -19,7 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from mock import Mock, patch
+from units.compat.mock import Mock, patch
 
 from .. base import BaseFactsTest
 

--- a/test/units/module_utils/facts/test_ansible_collector.py
+++ b/test/units/module_utils/facts/test_ansible_collector.py
@@ -21,7 +21,7 @@ __metaclass__ = type
 
 # for testing
 from units.compat import unittest
-from mock import Mock, patch
+from units.compat.mock import Mock, patch
 
 from ansible.module_utils.facts import collector
 from ansible.module_utils.facts import ansible_collector

--- a/test/units/module_utils/facts/test_collectors.py
+++ b/test/units/module_utils/facts/test_collectors.py
@@ -21,7 +21,7 @@ __metaclass__ = type
 
 import pytest
 
-from mock import Mock, patch
+from units.compat.mock import Mock, patch
 
 from . base import BaseFactsTest
 

--- a/test/units/module_utils/facts/test_facts.py
+++ b/test/units/module_utils/facts/test_facts.py
@@ -26,7 +26,7 @@ import pytest
 
 # for testing
 from units.compat import unittest
-from mock import Mock, patch
+from units.compat.mock import Mock, patch
 
 from ansible.module_utils import facts
 from ansible.module_utils.facts import hardware

--- a/test/units/module_utils/facts/test_sysctl.py
+++ b/test/units/module_utils/facts/test_sysctl.py
@@ -26,7 +26,7 @@ import pytest
 
 # for testing
 from units.compat import unittest
-from mock import patch, MagicMock, mock_open, Mock
+from units.compat.mock import patch, MagicMock, mock_open, Mock
 
 from ansible.module_utils.facts.sysctl import get_sysctl
 

--- a/test/units/module_utils/facts/test_utils.py
+++ b/test/units/module_utils/facts/test_utils.py
@@ -18,7 +18,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import patch
+from units.compat.mock import patch
 
 from ansible.module_utils.facts import utils
 

--- a/test/units/module_utils/urls/test_Request.py
+++ b/test/units/module_utils/urls/test_Request.py
@@ -13,7 +13,7 @@ from ansible.module_utils.urls import (Request, open_url, urllib_request, HAS_SS
 from ansible.module_utils.urls import SSLValidationHandler, HTTPSClientAuthHandler, RedirectHandlerFactory
 
 import pytest
-from mock import call
+from units.compat.mock import call
 
 
 if HAS_SSLCONTEXT:

--- a/test/units/module_utils/urls/test_fetch_url.py
+++ b/test/units/module_utils/urls/test_fetch_url.py
@@ -14,7 +14,7 @@ from ansible.module_utils.six.moves.http_client import HTTPMessage
 from ansible.module_utils.urls import fetch_url, urllib_error, ConnectionError, NoSSLError, httplib
 
 import pytest
-from mock import MagicMock
+from units.compat.mock import MagicMock
 
 
 class AnsibleModuleExit(Exception):

--- a/test/units/modules/test_apt.py
+++ b/test/units/modules/test_apt.py
@@ -4,8 +4,7 @@ __metaclass__ = type
 import collections
 import sys
 
-import mock
-
+from units.compat.mock import Mock
 from units.compat import unittest
 
 try:
@@ -41,14 +40,14 @@ class AptExpandPkgspecTestCase(unittest.TestCase):
 
     def test_pkgname_wildcard_version_wildcard(self):
         foo = ["apt*=1.0*"]
-        m_mock = mock.Mock()
+        m_mock = Mock()
         self.assertEqual(
             expand_pkgspec_from_fnmatches(m_mock, foo, self.fake_cache),
             ['apt', 'apt-utils'])
 
     def test_pkgname_expands(self):
         foo = ["apt*"]
-        m_mock = mock.Mock()
+        m_mock = Mock()
         self.assertEqual(
             expand_pkgspec_from_fnmatches(m_mock, foo, self.fake_cache),
             ["apt", "apt-utils"])

--- a/test/units/modules/test_apt_key.py
+++ b/test/units/modules/test_apt_key.py
@@ -3,8 +3,7 @@ __metaclass__ = type
 
 import os
 
-import mock
-
+from units.compat.mock import patch, Mock
 from units.compat import unittest
 
 from ansible.modules import apt_key
@@ -16,11 +15,11 @@ def returnc(x):
 
 class AptKeyTestCase(unittest.TestCase):
 
-    @mock.patch.object(apt_key, 'apt_key_bin', '/usr/bin/apt-key')
-    @mock.patch.object(apt_key, 'lang_env', returnc)
-    @mock.patch.dict(os.environ, {'HTTP_PROXY': 'proxy.example.com'})
+    @patch.object(apt_key, 'apt_key_bin', '/usr/bin/apt-key')
+    @patch.object(apt_key, 'lang_env', returnc)
+    @patch.dict(os.environ, {'HTTP_PROXY': 'proxy.example.com'})
     def test_import_key_with_http_proxy(self):
-        m_mock = mock.Mock()
+        m_mock = Mock()
         m_mock.run_command.return_value = (0, '', '')
         apt_key.import_key(
             m_mock, keyring=None, keyserver='keyserver.example.com',

--- a/test/units/modules/test_async_wrapper.py
+++ b/test/units/modules/test_async_wrapper.py
@@ -11,7 +11,7 @@ import tempfile
 
 import pytest
 
-from mock import patch, MagicMock
+from units.compat.mock import patch, MagicMock
 from ansible.modules import async_wrapper
 
 from pprint import pprint

--- a/test/units/modules/test_hostname.py
+++ b/test/units/modules/test_hostname.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import tempfile
 
-from mock import patch, MagicMock, mock_open
+from units.compat.mock import patch, MagicMock, mock_open
 from ansible.module_utils import basic
 from ansible.module_utils.common._utils import get_all_subclasses
 from ansible.modules import hostname

--- a/test/units/modules/test_iptables.py
+++ b/test/units/modules/test_iptables.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from mock import patch
+from units.compat.mock import patch
 from ansible.module_utils import basic
 from ansible.modules import iptables
 from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args

--- a/test/units/modules/test_service_facts.py
+++ b/test/units/modules/test_service_facts.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from units.compat import unittest
-from mock import patch
+from units.compat.mock import patch
 
 from ansible.module_utils import basic
 from ansible.modules.service_facts import AIXScanService

--- a/test/units/modules/utils.py
+++ b/test/units/modules/utils.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 import json
 
 from units.compat import unittest
-from mock import patch
+from units.compat.mock import patch
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
 


### PR DESCRIPTION
##### SUMMARY

This allows tests under newer Python versions to use the standard library `unittest.mock` instead of the third-party `mock`.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

module and module_utils unit tests
