### PR TITLE
Fix windows connection options (#77844)

### DIFF
--- a/changelogs/fragments/windows_conn_option_fix.yml
+++ b/changelogs/fragments/windows_conn_option_fix.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - winrm connection now handles default to inventory_hostname correctly.
+  - psrp connection now handles default to inventory_hostname correctly.

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -25,6 +25,7 @@ options:
     default: inventory_hostname
     type: str
     vars:
+    - name: inventory_hostname
     - name: ansible_host
     - name: ansible_psrp_host
   remote_user:

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -25,6 +25,7 @@ DOCUMENTATION = """
             - Address of the windows machine
         default: inventory_hostname
         vars:
+            - name: inventory_hostname
             - name: ansible_host
             - name: ansible_winrm_host
         type: str


### PR DESCRIPTION
* winrm, psrps added missing var entry

 this handles issue with the default being set to inventory_hostname
 but defaults not being templated implicitly

 fixes #77841

(cherry picked from commit eecbaee7f4b1e36be504d4576f92b329e1ad2b79)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
winrm psrp