### PR TITLE
Fix 'ansible-config dump --only-changed -t all' verbosity

### DIFF
--- a/changelogs/fragments/77898-ansible-config-dump-only-changed-all-types.yml
+++ b/changelogs/fragments/77898-ansible-config-dump-only-changed-all-types.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-config dump - Only display plugin type headers when plugin options are changed if --only-changed is specified.

--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -392,7 +392,7 @@ class ConfigCLI(CLI):
 
         entries = []
         for setting in sorted(config):
-            changed = (config[setting].origin != 'default')
+            changed = (config[setting].origin not in ('default', 'REQUIRED'))
 
             if context.CLIARGS['format'] == 'display':
                 if isinstance(config[setting], Setting):
@@ -512,8 +512,9 @@ class ConfigCLI(CLI):
             for ptype in C.CONFIGURABLE_PLUGINS:
                 plugin_list = self._get_plugin_configs(ptype, context.CLIARGS['args'])
                 if context.CLIARGS['format'] == 'display':
-                    output.append('\n%s:\n%s' % (ptype.upper(), '=' * len(ptype)))
-                    output.extend(plugin_list)
+                    if not context.CLIARGS['only_changed'] or plugin_list:
+                        output.append('\n%s:\n%s' % (ptype.upper(), '=' * len(ptype)))
+                        output.extend(plugin_list)
                 else:
                     if ptype in ('modules', 'doc_fragments'):
                         pname = ptype.upper()

--- a/test/integration/targets/config/runme.sh
+++ b/test/integration/targets/config/runme.sh
@@ -19,6 +19,10 @@ ANSIBLE_CONFIG=nonexistent.cfg ansible-config dump --only-changed -v | grep 'No 
 # https://github.com/ansible/ansible/pull/73715
 ANSIBLE_CONFIG=inline_comment_ansible.cfg ansible-config dump --only-changed | grep "'ansibull'"
 
+# test type headers are only displayed with --only-changed -t all for changed options
+env -i PATH="$PATH" PYTHONPATH="$PYTHONPATH" ansible-config dump --only-changed -t all | grep -v "CONNECTION"
+env -i PATH="$PATH" PYTHONPATH="$PYTHONPATH" ANSIBLE_SSH_PIPELINING=True ansible-config dump --only-changed -t all | grep "CONNECTION"
+
 # test the config option validation
 ansible-playbook validation.yml "$@"
 


### PR DESCRIPTION
##### SUMMARY
Only display headers if plugin options are changed. Looking at adding a test.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-config