### PR TITLE
Fix boolean condition so that ansible-galaxy collection install works when a valid resolvelib is installed

### DIFF
--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1606,7 +1606,7 @@ def _resolve_depenency_map(
                 raise AnsibleError(
                     f"ansible-galaxy requires resolvelib<{RESOLVELIB_UPPERBOUND.vstring},>={RESOLVELIB_LOWERBOUND.vstring}"
                 )
-        elif req.specifier.contains(RESOLVELIB_VERSION.vstring):
+        elif not req.specifier.contains(RESOLVELIB_VERSION.vstring):
             raise AnsibleError(f"ansible-galaxy requires {req.name}{req.specifier}")
 
     collection_dep_resolver = build_collection_dependency_resolver(


### PR DESCRIPTION
##### SUMMARY
Fixes problems caused in community.network and podman collection CIs caused by #77630.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/galaxy/collection/__init__.py`
