### PR TITLE
apt: fix virtual package install version detection (#76781)

### DIFF
--- a/changelogs/fragments/apt_virtual_fix.yml
+++ b/changelogs/fragments/apt_virtual_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - apt module now correctly handles virtual packages.

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -507,3 +507,25 @@
     that:
       - "allow_change_held_packages_no_update is not changed"
       - "allow_change_held_packages_hello_version.stdout == allow_change_held_packages_hello_version_again.stdout"
+
+# Virtual package
+- name: Install a virtual package
+  apt:
+    package:
+      - emacs-nox
+      - yaml-mode # <- the virtual package
+    state: latest
+  register: install_virtual_package_result
+
+- name: Check the virtual package install result
+  assert:
+    that:
+      - install_virtual_package_result is changed
+
+- name: Clean up virtual-package install
+  apt:
+    package:
+      - emacs-nox
+      - elpa-yaml-mode
+    state: absent
+    purge: yes


### PR DESCRIPTION
* apt: fix virtual package install version detection

Change 4a62c4e3e44b01a904aa86e9b87206a24bd41fbc introduced version
matching in installation.

The problem stems from

 if version_installable or version:
     pkg_list.append("'%s=%s'" % (name, version_installable or version))

When the package is a virtual-package, package_status() is returning
the "version_installable" of the package *satisfying* the
virtual-package; but then this is trying to install the
virtual-package with this version pin.

For example, "yaml-mode" is a virtual package satisifed by
"elpa-yaml-mode" (currently 0.0.14-1) and trying to install it fails
with

 $ usr/bin/apt-get -y ... install 'yaml-mode=0.0.14-1'
 ... failed: E: Version '0.0.14-1' for 'yaml-mode' was not found ...

In the case of a virtual-package with nothing installed to satisfy it,
we should just return blank values to allow apt-get to do it's thing.

The tests are updated to install and remove this package.

Fixes: #76779
(cherry picked from commit e4c0bbf8858612133941c9d5a9bf14f90a62494c)



##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
modules/apt
