### PR TITLE
Fix lusermod using a group name and not id (#61965)

### DIFF
--- a/changelogs/fragments/61965-user-module-fails-to-change-primary-group.yml
+++ b/changelogs/fragments/61965-user-module-fails-to-change-primary-group.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- prevent lusermod from using group name instead of group id (https://github.com/ansible/ansible/pull/77914)

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -821,7 +821,7 @@ class User(object):
             ginfo = self.group_info(self.group)
             if info[3] != ginfo[2]:
                 cmd.append('-g')
-                cmd.append(self.group)
+                cmd.append(ginfo[2])
 
         if self.groups is not None:
             # get a list of all groups for the user, including the primary

--- a/test/integration/targets/user/tasks/test_local.yml
+++ b/test/integration/targets/user/tasks/test_local.yml
@@ -132,6 +132,18 @@
   tags:
     - user_test_local_mode
 
+# If we don't re-assign, then "Set user expiration" will
+# fail.
+- name: Re-assign named group for local_ansibulluser
+  user:
+    name: local_ansibulluser
+    state: present
+    local: yes
+    group: local_ansibulluser
+  ignore_errors: yes
+  tags:
+    - user_test_local_mode
+
 - name: Remove local_ansibulluser again
   user:
     name: local_ansibulluser

--- a/test/integration/targets/user/tasks/test_local.yml
+++ b/test/integration/targets/user/tasks/test_local.yml
@@ -85,6 +85,7 @@
     - testgroup2
     - testgroup3
     - testgroup4
+    - testgroup5
   tags:
     - user_test_local_mode
 
@@ -121,6 +122,16 @@
   tags:
     - user_test_local_mode
 
+- name: Assign named group for local_ansibulluser
+  user:
+    name: local_ansibulluser
+    state: present
+    local: yes
+    group: testgroup5
+  register: local_user_test_6
+  tags:
+    - user_test_local_mode
+
 - name: Remove local_ansibulluser again
   user:
     name: local_ansibulluser
@@ -139,6 +150,7 @@
     - testgroup2
     - testgroup3
     - testgroup4
+    - testgroup5
   tags:
     - user_test_local_mode
 
@@ -149,6 +161,7 @@
       - local_user_test_2 is not changed
       - local_user_test_3 is changed
       - local_user_test_4 is changed
+      - local_user_test_6 is changed
       - local_user_test_remove_1 is changed
       - local_user_test_remove_2 is not changed
   tags:

--- a/test/integration/targets/user/tasks/test_local_expires.yml
+++ b/test/integration/targets/user/tasks/test_local_expires.yml
@@ -11,6 +11,13 @@
   tags:
     - user_test_local_mode
 
+- name: Remove local_ansibulluser group
+  group:
+    name: local_ansibulluser
+    state: absent
+  tags:
+    - user_test_local_mode
+
 - name: Set user expiration
   user:
     name: local_ansibulluser

--- a/test/integration/targets/user/tasks/test_local_expires.yml
+++ b/test/integration/targets/user/tasks/test_local_expires.yml
@@ -11,13 +11,6 @@
   tags:
     - user_test_local_mode
 
-- name: Remove local_ansibulluser group
-  group:
-    name: local_ansibulluser
-    state: absent
-  tags:
-    - user_test_local_mode
-
 - name: Set user expiration
   user:
     name: local_ansibulluser


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/ansible/issues/61965

lusermod will not convert group name to a group id. luseradd doesn't care if it's a group name or group id.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ansible.builtin.user

