### PR TITLE
[2.13] Fix 'ansible-config dump --only-changed -t all' verbosity (#77898)

### DIFF
--- a/changelogs/fragments/77898-ansible-config-dump-only-changed-all-types.yml
+++ b/changelogs/fragments/77898-ansible-config-dump-only-changed-all-types.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-config dump - Only display plugin type headers when plugin options are changed if --only-changed is specified.

--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -479,8 +479,10 @@ class ConfigCLI(CLI):
             text = self._get_global_configs()
             # deal with plugins
             for ptype in C.CONFIGURABLE_PLUGINS:
-                text.append('\n%s:\n%s' % (ptype.upper(), '=' * len(ptype)))
-                text.extend(self._get_plugin_configs(ptype, context.CLIARGS['args']))
+                plugin_list = self._get_plugin_configs(ptype, context.CLIARGS['args'])
+                if not context.CLIARGS['only_changed'] or plugin_list:
+                    text.append('\n%s:\n%s' % (ptype.upper(), '=' * len(ptype)))
+                    text.extend(plugin_list)
         else:
             # deal with plugins
             text = self._get_plugin_configs(context.CLIARGS['type'], context.CLIARGS['args'])

--- a/test/integration/targets/config/runme.sh
+++ b/test/integration/targets/config/runme.sh
@@ -19,6 +19,10 @@ ANSIBLE_CONFIG=nonexistent.cfg ansible-config dump --only-changed -v | grep 'No 
 # https://github.com/ansible/ansible/pull/73715
 ANSIBLE_CONFIG=inline_comment_ansible.cfg ansible-config dump --only-changed | grep "'ansibull'"
 
+# test type headers are only displayed with --only-changed -t all for changed options
+env -i PATH="$PATH" PYTHONPATH="$PYTHONPATH" ansible-config dump --only-changed -t all | grep -v "CONNECTION"
+env -i PATH="$PATH" PYTHONPATH="$PYTHONPATH" ANSIBLE_SSH_PIPELINING=True ansible-config dump --only-changed -t all | grep "CONNECTION"
+
 # test the config option validation
 ansible-playbook validation.yml "$@"
 


### PR DESCRIPTION
##### SUMMARY
Backport #77898

This didn't cherry-pick cleanly, so the diff is slightly different than 77898 and could use a quick review before merging.

* Fix 'ansible-config dump --only-changed -t all' to only display headers if plugin options are changed

* changelog

* add a test

(cherry picked from commit 1214b63f4f38073866e2b88dbc368278161a40a6)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-config