### PR TITLE
Add RHEL 9.0 to ansible-test and CI.

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -94,6 +94,8 @@ stages:
               test: rhel/8.5@3.6
             - name: RHEL 8.5 py38
               test: rhel/8.5@3.8
+            - name: RHEL 9.0
+              test: rhel/9.0
             - name: FreeBSD 12.3
               test: freebsd/12.3
             - name: FreeBSD 13.0

--- a/changelogs/fragments/ansible-test-rhel-9.yaml
+++ b/changelogs/fragments/ansible-test-rhel-9.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Add RHEL 9.0 remote support.

--- a/test/integration/targets/connection_ssh/runme.sh
+++ b/test/integration/targets/connection_ssh/runme.sh
@@ -46,14 +46,18 @@ fi
 
 set -e
 
-# temporary work-around for issues due to new scp filename checking
-# https://github.com/ansible/ansible/issues/52640
-if [[ "$(scp -T 2>&1)" == "usage: scp "* ]]; then
+if [[ "$(scp -O 2>&1)" == "usage: scp "* ]]; then
+    # scp supports the -O option (and thus the -T option as well)
+    # work-around required
+    # see: https://www.openssh.com/txt/release-9.0
+    scp_args=("-e" "ansible_scp_extra_args=-TO")
+elif [[ "$(scp -T 2>&1)" == "usage: scp "* ]]; then
     # scp supports the -T option
     # work-around required
+    # see: https://github.com/ansible/ansible/issues/52640
     scp_args=("-e" "ansible_scp_extra_args=-T")
 else
-    # scp does not support the -T option
+    # scp does not support the -T or -O options
     # no work-around required
     # however we need to put something in the array to keep older versions of bash happy
     scp_args=("-e" "")

--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -54,8 +54,10 @@
     - ansible_distribution_major_version is version('23', '>=')
 
 - include_tasks: modularity.yml
-  when: (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('29', '>=')) or
-        (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
+  when:
+    - astream_name is defined
+    - (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('29', '>=')) or
+      (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
   tags:
     - dnf_modularity
 

--- a/test/integration/targets/dnf/vars/RedHat-9.yml
+++ b/test/integration/targets/dnf/vars/RedHat-9.yml
@@ -1,2 +1,3 @@
-astream_name: '@container-tools:latest/common'
-astream_name_no_stream: '@container-tools/common'
+# RHEL9.0 contains no modules, to be re-introduced in 9.1
+# astream_name: '@container-tools:latest/common'
+# astream_name_no_stream: '@container-tools/common'

--- a/test/integration/targets/hostname/tasks/test_normal.yml
+++ b/test/integration/targets/hostname/tasks/test_normal.yml
@@ -1,5 +1,5 @@
 - name: Ensure hostname doesn't confuse NetworkManager
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version is version('8')
   block:
     - name: slurp /var/log/messages
       slurp:
@@ -23,7 +23,7 @@
   register: current_after_hn2
 
 - name: Ensure hostname doesn't confuse NetworkManager
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version is version('8')
   block:
     - name: slurp /var/log/messages
       slurp:

--- a/test/integration/targets/rpm_key/tasks/rpm_key.yaml
+++ b/test/integration/targets/rpm_key/tasks/rpm_key.yaml
@@ -29,11 +29,6 @@
     url: https://ci-files.testing.ansible.com/test/integration/targets/rpm_key/sl-5.02-1.el7.x86_64.rpm
     dest: /tmp/sl.rpm
 
-- name: download Mono key
-  get_url:
-    url: https://ci-files.testing.ansible.com/test/integration/targets/rpm_key/mono.gpg
-    dest: /tmp/mono.gpg
-
 - name: remove EPEL GPG key from keyring
   rpm_key:
     state: absent
@@ -69,21 +64,11 @@
   rpm_key:
     state: present
     key: /tmp/RPM-GPG-KEY-EPEL-7
-
-- name: add Mono gpg key
-  rpm_key:
-      state: present
-      key: /tmp/mono.gpg
-
-- name: add Mono gpg key
-  rpm_key:
-      state: present
-      key: /tmp/mono.gpg
-  register: mono_indempotence
+  register: key_idempotence
 
 - name: verify idempotence
   assert:
-    that: "not mono_indempotence.changed"
+    that: "not key_idempotence.changed"
 
 - name: check GPG signature of sl. Should return okay
   shell: "rpm --checksig /tmp/sl.rpm"

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -5,4 +5,5 @@ macos/12.0 python=3.10 python_dir=/usr/local/bin provider=parallels
 macos python_dir=/usr/local/bin provider=parallels
 rhel/7.9 python=2.7 provider=aws
 rhel/8.5 python=3.6,3.8,3.9 provider=aws
+rhel/9.0 python=3.9 provider=aws
 rhel provider=aws


### PR DESCRIPTION
##### SUMMARY

Add RHEL 9.0 to ansible-test and CI.

Backport of https://github.com/ansible/ansible/pull/77851 (RHEL 9.0 part only, excludes FreeBSD 13.1 part)
Backport of https://github.com/ansible/ansible/pull/77853

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
