### PR TITLE
ssh retry docs addition

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -174,7 +174,10 @@ DOCUMENTATION = '''
             - name: ssh_extra_args
           default: ''
       reconnection_retries:
-          description: Number of attempts to connect. Ansible retries connections only if it gets an SSH error with a return code of 255.
+          description:
+            - Number of attempts to connect.
+            - Ansible retries connections only if it gets an SSH error with a return code of 255.
+            - Any errors with return codes other than 255 indicate an issue with program execution.
           default: 0
           type: integer
           env:

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -174,7 +174,7 @@ DOCUMENTATION = '''
             - name: ssh_extra_args
           default: ''
       reconnection_retries:
-          description: Number of attempts to connect.
+          description: Number of attempts to connect. Ansible retries connections only if it gets an SSH error with a return code of 255.
           default: 0
           type: integer
           env:


### PR DESCRIPTION
##### SUMMARY
Fixes issue #77149 by documenting that Ansible only retries an SSH connection if it gets a 255 response code.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Documentation for the SSH builtin module.