### PR TITLE
fix documentation on password_hash inconsistency #76863 

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/user_guide/playbooks_filters.rst
@@ -1583,7 +1583,16 @@ Some hash types allow providing a rounds parameter:
     {{ 'secretpassword' | password_hash('sha256', 'mysecretsalt', rounds=10000) }}
     # => "$5$rounds=10000$mysecretsalt$Tkm80llAxD4YHll6AgNIztKn0vzAACsuuEfYeGP7tm7"
 
-Hash type 'blowfish' (BCrypt) provides the facility to specify the version of the BCrypt algorithm
+The filter `password_hash` produces different results depending on whether you installed `passlib` or not.
+
+To ensure idempotency, specify `rounds` to be neither `crypt`'s nor `passlib`'s default, which is `5000` for `crypt` and a variable value (`535000` for sha256, `656000` for sha512) for `passlib`:
+
+.. code-block:: yaml+jinja
+
+    {{ 'secretpassword' | password_hash('sha256', 'mysecretsalt', rounds=5001) }}
+    # => "$5$rounds=5001$mysecretsalt$wXcTWWXbfcR8er5IVf7NuquLvnUA6s8/qdtOhAZ.xN."
+
+Hash type 'blowfish' (BCrypt) provides the facility to specify the version of the BCrypt algorithm.
 
 .. code-block:: yaml+jinja
 


### PR DESCRIPTION
##### SUMMARY
mention different results for `password_hash` depending on library used

Fixes #76863 

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
[docs/docsite/rst/user_guide/playbooks_filters.rst](https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/user_guide/playbooks_filters.rst)

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
