### PR TITLE
ansible-galaxy-collection - use --pinentry-mode loopback when revoking key

### DIFF
--- a/test/integration/targets/ansible-galaxy-collection/tasks/revoke_gpg_key.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/revoke_gpg_key.yml
@@ -1,6 +1,6 @@
 - name: generate revocation certificate
   expect:
-    command: "gpg --homedir {{ gpg_homedir }} --output {{ gpg_homedir }}/revoke.asc --gen-revoke {{ fingerprint }}"
+    command: "gpg --homedir {{ gpg_homedir }} --pinentry-mode loopback --output {{ gpg_homedir }}/revoke.asc --gen-revoke {{ fingerprint }}"
     responses:
       "Create a revocation certificate for this key": "y"
       "Please select the reason for the revocation": "0"


### PR DESCRIPTION
##### SUMMARY
This might fix https://dev.azure.com/ansible/ansible/_build/results?buildId=44011&view=logs&j=712ded60-3f57-5b3e-77fd-2737baae5f5b&s=8f7735a0-3e62-50b4-2420-6c668e043f7f&t=e0efd6e2-a097-5291-a123-21996731942d&l=34657

The error 
```
34:36         "gpg: signing failed: Required environment variable not set",
34:36         "gpg: make_keysig_packet failed: Required environment variable not set"
```
seems to be the one documented here https://github.com/gpg/libgpg-error/blob/libgpg-error-1.42/doc/errorref.txt#L1027-L1029.

The other places CI is using gpg either use --no-tty or --pinentry-mode loopback already, which would explain why this is the only one failing (though, hard to tell since it's transient).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
ansible-galaxy-collection
