### PR TITLE
Reject python coverage ("*,cover") files

### DIFF
--- a/changelogs/fragments/77966-ignore-coverage-files.yml
+++ b/changelogs/fragments/77966-ignore-coverage-files.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Properly ignore coverage files (.py,cover) (https://github.com/ansible/ansible/issues/77966)"

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -96,7 +96,7 @@ COLOR_CODES = {
     'magenta': u'0;35', 'bright magenta': u'1;35',
     'normal': u'0',
 }
-REJECT_EXTS = ('.pyc', '.pyo', '.swp', '.bak', '~', '.rpm', '.md', '.txt', '.rst')
+REJECT_EXTS = ('.pyc', '.pyo', '.swp', '.bak', '~', '.rpm', '.md', '.txt', '.rst', ",cover")
 BOOL_TRUE = BOOLEANS_TRUE
 COLLECTION_PTYPE_COMPAT = {'module': 'modules'}
 


### PR DESCRIPTION
##### SUMMARY

Fixes https://github.com/ansible/ansible/issues/77966

Make ansible-test ignore "*.py,cover" files.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
Only detected via ansible-test, I don't know if there's others.
