### PR TITLE
apt: Don't produce a "best" version from unspecified version and rele…

### DIFF
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -479,6 +479,9 @@ def package_version_compare(version, other_version):
 
 
 def package_best_match(pkgname, version_cmp, version, release, cache):
+    if not version and not release:
+        # Return no version to let the apt command select the appropriate version
+        return None
     policy = apt_pkg.Policy(cache)
     if release:
         # 990 is the priority used in `apt-get -t`


### PR DESCRIPTION
##### SUMMARY
Fixes #77969

<!--- Describe the change below, including rationale and design decisions -->
Due to the changes in 4a62c4e3e44b01a904aa86e9b87206a24bd41fbc, package version pinning is no longer working even when a version is not specified in the task. In these cases, the changes I made avoid specifying a version to the apt command, and let the apt command decide on the version instead taking into account pinning configuration.

To me this was the most straightforward way to correct the issue I encountered (#77969).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
apt

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
