### PR TITLE
Fix docs links for the steering committee

### DIFF
--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -142,14 +142,14 @@ The Ansible community holds regular meetings on various topics on Matrix/IRC, an
 Ansible Community Topics
 ========================
 
-The :ref:`Ansible Community Steering Committee <steering_responsibilties>` uses the `community-topics repository <https://github.com/ansible-community/community-topics/issues>`_ to asynchronously discuss with the Community and vote on Community topics in corresponding issues.
+The :ref:`Ansible Community Steering Committee <steering_responsibilities>` uses the `community-topics repository <https://github.com/ansible-community/community-topics/issues>`_ to asynchronously discuss with the Community and vote on Community topics in corresponding issues.
 
 Create a new issue in the `repository <https://github.com/ansible-community/community-topics/issues>`_ if you want to discuss an idea that impacts any of the following:
 
 * Ansible Community
 * Community collection best practices and `requirements <https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst>`_
 * `Community collection inclusion policy <https://github.com/ansible-collections/ansible-inclusion/blob/main/README.md>`_
-* :ref:`The Community governance <steering_responsibilties>`
+* :ref:`The Community governance <steering_responsibilities>`
 * Other proposals of importance that need the Committee or overall Ansible community attention
 
 Ansible Automation Platform support questions

--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -142,14 +142,14 @@ The Ansible community holds regular meetings on various topics on Matrix/IRC, an
 Ansible Community Topics
 ========================
 
-The `Ansible Community Steering Committee <https://github.com/ansible/community-docs/blob/main/ansible_community_steering_committee.rst>`_ uses the `community-topics repository <https://github.com/ansible-community/community-topics/issues>`_ to asynchronously discuss with the Community and vote on Community topics in corresponding issues.
+The :ref:`Ansible Community Steering Committee <steering_responsibilties>` uses the `community-topics repository <https://github.com/ansible-community/community-topics/issues>`_ to asynchronously discuss with the Community and vote on Community topics in corresponding issues.
 
 Create a new issue in the `repository <https://github.com/ansible-community/community-topics/issues>`_ if you want to discuss an idea that impacts any of the following:
 
 * Ansible Community
 * Community collection best practices and `requirements <https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst>`_
 * `Community collection inclusion policy <https://github.com/ansible-collections/ansible-inclusion/blob/main/README.md>`_
-* `The Community governance <https://github.com/ansible/community-docs/blob/main/ansible_community_steering_committee.rst>`_
+* :ref:`The Community governance <steering_responsibilties>`
 * Other proposals of importance that need the Committee or overall Ansible community attention
 
 Ansible Automation Platform support questions

--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -142,14 +142,14 @@ The Ansible community holds regular meetings on various topics on Matrix/IRC, an
 Ansible Community Topics
 ========================
 
-The :ref:`Ansible Community Steering Committee <steering_responsibilities>` uses the `community-topics repository <https://github.com/ansible-community/community-topics/issues>`_ to asynchronously discuss with the Community and vote on Community topics in corresponding issues.
+The `Ansible Community Steering Committee <https://docs.ansible.com/ansible/devel/community/steering/community_steering_committee.html>`_ uses the `community-topics repository <https://github.com/ansible-community/community-topics/issues>`_ to asynchronously discuss with the Community and vote on Community topics in corresponding issues.
 
 Create a new issue in the `repository <https://github.com/ansible-community/community-topics/issues>`_ if you want to discuss an idea that impacts any of the following:
 
 * Ansible Community
 * Community collection best practices and `requirements <https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst>`_
 * `Community collection inclusion policy <https://github.com/ansible-collections/ansible-inclusion/blob/main/README.md>`_
-* :ref:`The Community governance <steering_responsibilities>`
+* `The Community governance <https://docs.ansible.com/ansible/devel/community/steering/community_steering_committee.html>`_
 * Other proposals of importance that need the Committee or overall Ansible community attention
 
 Ansible Automation Platform support questions

--- a/docs/docsite/rst/community/contributor_path.rst
+++ b/docs/docsite/rst/community/contributor_path.rst
@@ -95,7 +95,7 @@ Become a steering committee member
 
   You do NOT have to be a programmer to become a steering committee member.
 
-The `Steering Committee <community_steering_committee>` member status reflects the highest level of trust which allows contributors to lead the project through making very important `decisions <https://github.com/ansible-community/community-topics/issues>`_ for the Ansible project. The Committee members are the community leaders who shape the project's future and the future of automation in the IT world in general.
+The `Steering Committee <community_steering_committee>`_ member status reflects the highest level of trust which allows contributors to lead the project through making very important `decisions <https://github.com/ansible-community/community-topics/issues>`_ for the Ansible project. The Committee members are the community leaders who shape the project's future and the future of automation in the IT world in general.
 
 To reach the status, as the current Committee members did before getting it, along with the things mentioned in this document, you should:
 

--- a/docs/docsite/rst/community/maintainers_guidelines.rst
+++ b/docs/docsite/rst/community/maintainers_guidelines.rst
@@ -55,7 +55,7 @@ See :ref:`communication` for more details on these communication channels.
 Community Topics
 ----------------
 
-The Community and the `Steering Committee <https://github.com/ansible/community-docs/blob/main/ansible_community_steering_committee.rst>`_ asynchronously discuss and vote on the `Community Topics <https://github.com/ansible-community/community-topics/issues>`_ which impact the whole project or its parts including collections and packaging.
+The Community and the :ref:`Steering Committee <steering_responsibilties>` asynchronously discuss and vote on the `Community Topics <https://github.com/ansible-community/community-topics/issues>`_ which impact the whole project or its parts including collections and packaging.
 
 Share your opinion and vote on the topics to help the community make the best decisions.
 

--- a/docs/docsite/rst/community/maintainers_guidelines.rst
+++ b/docs/docsite/rst/community/maintainers_guidelines.rst
@@ -55,7 +55,7 @@ See :ref:`communication` for more details on these communication channels.
 Community Topics
 ----------------
 
-The Community and the :ref:`Steering Committee <steering_responsibilities>` asynchronously discuss and vote on the `Community Topics <https://github.com/ansible-community/community-topics/issues>`_ which impact the whole project or its parts including collections and packaging.
+The Community and the `Steering Committee <https://docs.ansible.com/ansible/devel/community/steering/community_steering_committee.html>`_ asynchronously discuss and vote on the `Community Topics <https://github.com/ansible-community/community-topics/issues>`_ which impact the whole project or its parts including collections and packaging.
 
 Share your opinion and vote on the topics to help the community make the best decisions.
 

--- a/docs/docsite/rst/community/maintainers_guidelines.rst
+++ b/docs/docsite/rst/community/maintainers_guidelines.rst
@@ -55,7 +55,7 @@ See :ref:`communication` for more details on these communication channels.
 Community Topics
 ----------------
 
-The Community and the :ref:`Steering Committee <steering_responsibilties>` asynchronously discuss and vote on the `Community Topics <https://github.com/ansible-community/community-topics/issues>`_ which impact the whole project or its parts including collections and packaging.
+The Community and the :ref:`Steering Committee <steering_responsibilities>` asynchronously discuss and vote on the `Community Topics <https://github.com/ansible-community/community-topics/issues>`_ which impact the whole project or its parts including collections and packaging.
 
 Share your opinion and vote on the topics to help the community make the best decisions.
 

--- a/docs/docsite/rst/community/steering/community_steering_committee.rst
+++ b/docs/docsite/rst/community/steering/community_steering_committee.rst
@@ -1,5 +1,5 @@
 
-.. _steering_responsibilties:
+.. _steering_responsibilities:
  
 Steering Committee mission and responsibilities
 ===============================================

--- a/docs/docsite/rst/community/steering/steering_committee_membership.rst
+++ b/docs/docsite/rst/community/steering/steering_committee_membership.rst
@@ -3,7 +3,7 @@
 Steering Committee membership guidelines
 ==========================================
 
-This document describes the expectations and policies related to membership in the :ref:`Ansible Community Steering Committee <steering_responsibilties>` (hereinafter the Committee).
+This document describes the expectations and policies related to membership in the :ref:`Ansible Community Steering Committee <steering_responsibilities>` (hereinafter the Committee).
 
 .. contents:: Topics:
 

--- a/docs/docsite/rst/community/steering/steering_committee_membership.rst
+++ b/docs/docsite/rst/community/steering/steering_committee_membership.rst
@@ -3,7 +3,7 @@
 Steering Committee membership guidelines
 ==========================================
 
-This document describes the expectations and policies related to membership in the `Ansible Community Steering Committee <https://github.com/ansible/community-docs/blob/main/ansible_community_steering_committee.rst>`_ (hereinafter the Committee).
+This document describes the expectations and policies related to membership in the :ref:`Ansible Community Steering Committee <steering_responsibilties>` (hereinafter the Committee).
 
 .. contents:: Topics:
 


### PR DESCRIPTION
##### SUMMARY
1. The link in https://docs.ansible.com/ansible/devel/community/contributor_path.html#become-a-steering-committee-member is broken
2. There are several links to https://github.com/ansible/community-docs/blob/main/ansible_community_steering_committee.rst, which links back to the docsite. Directly replace the links to https://github.com/ansible/community-docs/blob/main/ansible_community_steering_committee.rst to the new label.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
community docs
