### PR TITLE
Don't install lgroupadd for SUSE tests.

### DIFF
--- a/test/integration/targets/group/tasks/tests.yml
+++ b/test/integration/targets/group/tasks/tests.yml
@@ -206,7 +206,7 @@
   args:
     name: libuser
     state: present
-  when: ansible_facts.system in ['Linux'] and ansible_distribution != 'Alpine'
+  when: ansible_facts.system in ['Linux'] and ansible_distribution != 'Alpine' and ansible_os_family != 'Suse'
   tags:
     - user_test_local_mode
 


### PR DESCRIPTION
##### SUMMARY

Don't install lgroupadd for SUSE tests.

It's not used by the tests and is not available as of openSUSE 15.4.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

group integration test