### PR TITLE
Skip libuser tests on openSUSE 15.4+

### DIFF
--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -37,5 +37,6 @@
 - import_tasks: test_password_lock.yml
 - import_tasks: test_password_lock_new_user.yml
 - import_tasks: test_local.yml
+  when: not (ansible_distribution == 'openSUSE Leap' and ansible_distribution_version is version('15.4', '>='))
 - import_tasks: test_umask.yml
   when: ansible_facts.system == 'Linux'


### PR DESCRIPTION
##### SUMMARY

Skip libuser tests on openSUSE 15.4+

The libuser package is not available.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

user integration test