### PR TITLE
Make fuzzy plugin matching deterministic.

### DIFF
--- a/changelogs/fragments/plugin-loader-deterministic-fuzzy-match.yml
+++ b/changelogs/fragments/plugin-loader-deterministic-fuzzy-match.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - plugin loader - Sort results when fuzzy matching plugin names (https://github.com/ansible/ansible/issues/77966).

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -543,6 +543,8 @@ class PluginLoader:
         if not found_files:
             return plugin_load_context.nope('failed fuzzy extension match for {0} in {1}'.format(full_name, acr.collection))
 
+        found_files = sorted(found_files)  # sort to ensure deterministic results, with the shortest match first
+
         if len(found_files) > 1:
             # TODO: warn?
             pass


### PR DESCRIPTION
##### SUMMARY

Sort the matching plugins when performing fuzzy matching in plugin loader to ensure deterministic results. This also ensures that the shortest filename found is matched. Doing so avoids issues with longer extensions that match being used over shorter ones when the longer ones are returned first due to filesystem order.

Resolves https://github.com/ansible/ansible/issues/77966

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/plugins/loader.py
