### PR TITLE
[2.13] Pin PyYAML version compatible with Python 3.8+ (#77936)

### DIFF
--- a/changelogs/fragments/77936-add-pyyaml-version.yml
+++ b/changelogs/fragments/77936-add-pyyaml-version.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Add PyYAML >= 5.1 as a dependency of ansible-core to be compatible with Python 3.8+.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # packages, not optional ones, and with the widest range of versions that could
 # be suitable)
 jinja2 >= 3.0.0
-PyYAML
+PyYAML >= 5.1  # PyYAML 5.1 is required for Python 3.8+ support
 cryptography
 packaging
 # NOTE: resolvelib 0.x version bumps should be considered major/breaking

--- a/test/lib/ansible_test/_data/requirements/ansible.txt
+++ b/test/lib/ansible_test/_data/requirements/ansible.txt
@@ -4,7 +4,7 @@
 # packages, not optional ones, and with the widest range of versions that could
 # be suitable)
 jinja2 >= 3.0.0
-PyYAML
+PyYAML >= 5.1  # PyYAML 5.1 is required for Python 3.8+ support
 cryptography
 packaging
 # NOTE: resolvelib 0.x version bumps should be considered major/breaking


### PR DESCRIPTION
##### SUMMARY
Backporting #77936

Pin PyYAML version compatible with Python 3.8+ (#77936)

Co-authored-by: Brian Coca <bcoca@users.noreply.github.com>
Co-authored-by: Matt Clay <matt@mystile.com>
(cherry picked from commit e89176caacbe068b2094bb4cc31e9a104aa3b295)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
requirements.txt