### PR TITLE
ansible-test - Allow docstring in docs-only module

### DIFF
--- a/changelogs/fragments/ansible-test-validate-modules-docs-only-docstring.yml
+++ b/changelogs/fragments/ansible-test-validate-modules-docs-only-docstring.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-test - validate-modules - Documentation-only modules, used for documenting actions,
+    are now allowed to have docstrings (https://github.com/ansible/ansible/issues/77972).

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
@@ -412,6 +412,10 @@ class ModuleValidator(Validator):
         try:
             for child in self.ast.body:
                 if not isinstance(child, ast.Assign):
+                    # allow string constant expressions (these are docstrings)
+                    if isinstance(child, ast.Expr) and isinstance(child.value, ast.Constant) and isinstance(child.value.value, str):
+                        continue
+
                     # allowed from __future__ imports
                     if isinstance(child, ast.ImportFrom) and child.module == '__future__':
                         for future_import in child.names:


### PR DESCRIPTION
##### SUMMARY

ansible-test - Allow docstring in docs-only module

Resolves https://github.com/ansible/ansible/issues/77972

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
