### PR TITLE
[2.13] fix ansible-galaxy-collection integration test

### DIFF
--- a/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
+++ b/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
@@ -182,8 +182,6 @@ def sign_manifest(signature_path, manifest_path, module, collection_setup_result
         "--pinentry-mode",
         "loopback",
         "--yes",
-        "--passphrase",
-        "SECRET",
         "--homedir",
         module.params['signature_dir'],
         "--detach-sign",

--- a/test/integration/targets/ansible-galaxy-collection/tasks/revoke_gpg_key.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/revoke_gpg_key.yml
@@ -1,6 +1,6 @@
 - name: generate revocation certificate
   expect:
-    command: "gpg --homedir {{ gpg_homedir }} --output {{ gpg_homedir }}/revoke.asc --gen-revoke {{ fingerprint }}"
+    command: "gpg --homedir {{ gpg_homedir }} --pinentry-mode loopback --output {{ gpg_homedir }}/revoke.asc --gen-revoke {{ fingerprint }}"
     responses:
       "Create a revocation certificate for this key": "y"
       "Please select the reason for the revocation": "0"

--- a/test/integration/targets/ansible-galaxy-collection/tasks/setup_gpg.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/setup_gpg.yml
@@ -12,7 +12,7 @@
   register: user
 
 - name: generate key for user with gpg
-  command: "gpg --no-tty --homedir {{ gpg_homedir }} --passphrase SECRET --pinentry-mode loopback --quick-gen-key {{ user.stdout }} default default"
+  command: "gpg --no-tty --homedir {{ gpg_homedir }} --passphrase '' --pinentry-mode loopback --quick-gen-key {{ user.stdout }} default default"
 
 - name: list gpg keys for user
   command: "gpg --no-tty --homedir {{ gpg_homedir }} --list-keys {{ user.stdout }}"


### PR DESCRIPTION
##### SUMMARY
Backporting #77967 and #77989

Fixes sporadic TTY weirdness and the prompt responses not including the passphrase.

(cherry picked from commit 1706d35fc476e36fcced25435c2f1c2401536376)
(cherry picked from commit a43112290a704294df7154d7ddd7dc624b72251f)

cc @mattclay 

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
ansible-galaxy-collection