### PR TITLE
[stable-2.11] yum: fix parsing of check-update with subsequent empty lines (#75452)

### DIFF
--- a/changelogs/fragments/70949-yum-parsing-check-update-output-multiple-empty-lines.yml
+++ b/changelogs/fragments/70949-yum-parsing-check-update-output-multiple-empty-lines.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - yum - fix parsing of multiple subsequent empty lines from ``yum check-update`` output (https://github.com/ansible/ansible/issues/70949)

--- a/lib/ansible/modules/yum.py
+++ b/lib/ansible/modules/yum.py
@@ -1221,37 +1221,28 @@ class YumModule(YumDnf):
 
     @staticmethod
     def parse_check_update(check_update_output):
-        updates = {}
-        obsoletes = {}
+        # preprocess string and filter out empty lines so the regex below works
+        out = '\n'.join((l for l in check_update_output.splitlines() if l))
 
-        # remove incorrect new lines in longer columns in output from yum check-update
-        # yum line wrapping can move the repo to the next line
-        #
-        # Meant to filter out sets of lines like:
+        # Remove incorrect new lines in longer columns in output from yum check-update
+        # yum line wrapping can move the repo to the next line:
         #  some_looooooooooooooooooooooooooooooooooooong_package_name   1:1.2.3-1.el7
         #                                                                    some-repo-label
-        #
-        # But it also needs to avoid catching lines like:
-        # Loading mirror speeds from cached hostfile
-        #
-        # ceph.x86_64                               1:11.2.0-0.el7                    ceph
+        out = re.sub(r'\n\W+(.*)', r' \1', out)
 
-        # preprocess string and filter out empty lines so the regex below works
-        out = re.sub(r'\n[^\w]\W+(.*)', r' \1', check_update_output)
-
-        available_updates = out.split('\n')
-
-        # build update dictionary
-        for line in available_updates:
+        updates = {}
+        obsoletes = {}
+        for line in out.split('\n'):
             line = line.split()
-            # ignore irrelevant lines
-            # '*' in line matches lines like mirror lists:
-            #      * base: mirror.corbina.net
-            # len(line) != 3 or 6 could be junk or a continuation
-            # len(line) = 6 is package obsoletes
-            #
-            # FIXME: what is  the '.' not in line  conditional for?
-
+            """
+            Ignore irrelevant lines:
+              - '*' in line matches lines like mirror lists: "* base: mirror.corbina.net"
+              - len(line) != 3 or 6 could be strings like:
+                  "This system is not registered with an entitlement server..."
+              - len(line) = 6 is package obsoletes
+              - checking for '.' in line[0] (package name) likely ensures that it is of format:
+                  "package_name.arch" (coreutils.x86_64)
+            """
             if '*' in line or len(line) not in [3, 6] or '.' not in line[0]:
                 continue
 

--- a/test/units/modules/test_yum.py
+++ b/test/units/modules/test_yum.py
@@ -118,6 +118,17 @@ Security: kernel-3.10.0-327.28.2.el7.x86_64 is an installed security update
 Security: kernel-3.10.0-327.22.2.el7.x86_64 is the currently running version
 """
 
+wrapped_output_multiple_empty_lines = """
+Loaded plugins: langpacks, product-id, search-disabled-repos, subscription-manager
+
+This system is not registered with an entitlement server. You can use subscription-manager to register.
+
+
+screen.x86_64                         4.1.0-0.23.20120314git3c2946.el7_2
+                                                            rhelosp-rhel-7.2-z
+sos.noarch                            3.2-36.el7ost.2       rhelosp-9.0-puddle
+"""
+
 longname = """
 Loaded plugins: fastestmirror, priorities, rhnplugin
 This system is receiving updates from RHN Classic or Red Hat Satellite.
@@ -205,3 +216,7 @@ class TestYumUpdateCheckParse(unittest.TestCase):
             res
         )
         self._assert_expected(unwrapped_output_rhel7_expected_old_obsoletes_pkgs, obs)
+
+    def test_wrapped_output_multiple_empty_lines(self):
+        res, obs = YumModule.parse_check_update(wrapped_output_multiple_empty_lines)
+        self._assert_expected(['screen', 'sos'], res)


### PR DESCRIPTION
##### SUMMARY

Rather than adding further complexity to the regex, preprocess the output to
remove any empty lines. Now the only purpose of the regex is to fix
wrapped lines.

Fixes #70949

Backport of https://github.com/ansible/ansible/pull/75452

(cherry picked from commit 51f2f1ac5ee1416f097587ff81b721b3ccc36971)

Co-authored-by: Martin Krizek <martin.krizek@gmail.com>

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

yum
