### PR TITLE
[stable-2.12] Make fuzzy plugin matching deterministic.

### DIFF
--- a/changelogs/fragments/plugin-loader-deterministic-fuzzy-match.yml
+++ b/changelogs/fragments/plugin-loader-deterministic-fuzzy-match.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - plugin loader - Sort results when fuzzy matching plugin names (https://github.com/ansible/ansible/issues/77966).

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -536,6 +536,8 @@ class PluginLoader:
         if not found_files:
             return plugin_load_context.nope('failed fuzzy extension match for {0} in {1}'.format(full_name, acr.collection))
 
+        found_files = sorted(found_files)  # sort to ensure deterministic results, with the shortest match first
+
         if len(found_files) > 1:
             # TODO: warn?
             pass


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/77981

(cherry picked from commit 5a0b230e240664ea4b316fe1592ce84003c9946c)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/plugins/loader.py
