### PR TITLE
[2.12 backport] fix pip module resolution (#78000)

### DIFF
--- a/changelogs/fragments/pip-lazy-import.yml
+++ b/changelogs/fragments/pip-lazy-import.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- pip - fix cases where resolution of pip Python module fails when importlib.util has not already been imported

--- a/lib/ansible/modules/pip.py
+++ b/lib/ansible/modules/pip.py
@@ -455,15 +455,15 @@ def _get_pip(module, env=None, executable=None):
 def _have_pip_module():  # type: () -> bool
     """Return True if the `pip` module can be found using the current Python interpreter, otherwise return False."""
     try:
-        import importlib
+        from importlib.util import find_spec
     except ImportError:
-        importlib = None
+        find_spec = None  # type: ignore[assignment] # type: ignore[no-redef]
 
-    if importlib:
+    if find_spec:
         # noinspection PyBroadException
         try:
             # noinspection PyUnresolvedReferences
-            found = bool(importlib.util.find_spec('pip'))
+            found = bool(find_spec('pip'))
         except Exception:
             found = False
     else:


### PR DESCRIPTION
##### SUMMARY
backport of #78000

* `importlib.util` appears to be lazily imported and is sometimes unavailable as an attribute of `importlib` without an explicit import

(cherry picked from commit 6e78425f8d6edbfd95faf5c3c2c05c6d3f038758)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
