### PR TITLE
ansible-test - Update distro containers to 4.3.0.

### DIFF
--- a/changelogs/fragments/ansible-test-distro-containers-hosts.yml
+++ b/changelogs/fragments/ansible-test-distro-containers-hosts.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Distribution specific test containers no longer contain a ``/etc/ansible/hosts`` file.

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,12 +1,12 @@
 base image=quay.io/ansible/base-test-container:3.2.0 python=3.10,2.7,3.5,3.6,3.7,3.8,3.9,3.11 seccomp=unconfined
 default image=quay.io/ansible/default-test-container:6.4.0 python=3.10,2.7,3.5,3.6,3.7,3.8,3.9,3.11 seccomp=unconfined context=collection
 default image=quay.io/ansible/ansible-core-test-container:6.4.0 python=3.10,2.7,3.5,3.6,3.7,3.8,3.9,3.11 seccomp=unconfined context=ansible-core
-alpine3 image=quay.io/ansible/alpine3-test-container:4.2.0 python=3.10
-centos7 image=quay.io/ansible/centos7-test-container:4.1.0 python=2.7 seccomp=unconfined
+alpine3 image=quay.io/ansible/alpine3-test-container:4.3.0 python=3.10
+centos7 image=quay.io/ansible/centos7-test-container:4.3.0 python=2.7 seccomp=unconfined
 fedora34 image=quay.io/ansible/fedora34-test-container:4.0.0 python=3.9 seccomp=unconfined
-fedora35 image=quay.io/ansible/fedora35-test-container:4.1.0 python=3.10 seccomp=unconfined
-fedora36 image=quay.io/ansible/fedora36-test-container:4.1.0 python=3.10 seccomp=unconfined
-opensuse15 image=quay.io/ansible/opensuse15-test-container:4.2.0 python=3.6
+fedora35 image=quay.io/ansible/fedora35-test-container:4.3.0 python=3.10 seccomp=unconfined
+fedora36 image=quay.io/ansible/fedora36-test-container:4.3.0 python=3.10 seccomp=unconfined
+opensuse15 image=quay.io/ansible/opensuse15-test-container:4.3.0 python=3.6
 ubuntu1804 image=quay.io/ansible/ubuntu1804-test-container:3.1.0 python=3.6 seccomp=unconfined
-ubuntu2004 image=quay.io/ansible/ubuntu2004-test-container:4.1.0 python=3.8 seccomp=unconfined
-ubuntu2204 image=quay.io/ansible/ubuntu2204-test-container:4.1.0 python=3.10 seccomp=unconfined
+ubuntu2004 image=quay.io/ansible/ubuntu2004-test-container:4.3.0 python=3.8 seccomp=unconfined
+ubuntu2204 image=quay.io/ansible/ubuntu2204-test-container:4.3.0 python=3.10 seccomp=unconfined


### PR DESCRIPTION
##### SUMMARY

The primary change in this update is removal of `/etc/ansible/hosts` from the containers.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
