### PR TITLE
find module: Zero length excludes same as no excludes (fixes #78014)

### DIFF
--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -254,7 +254,7 @@ def pfilter(f, patterns=None, excludes=None, use_regex=False):
         return True
 
     if use_regex:
-        if patterns and not excludes:
+        if patterns and (not excludes or len(excludes) == 0):
             for p in patterns:
                 r = re.compile(p)
                 if r.match(f):
@@ -271,7 +271,7 @@ def pfilter(f, patterns=None, excludes=None, use_regex=False):
                     return True
 
     else:
-        if patterns and not excludes:
+        if patterns and (not excludes or len(excludes) == 0):
             for p in patterns:
                 if fnmatch.fnmatch(f, p):
                     return True


### PR DESCRIPTION
##### SUMMARY
This PR will modify the behavior of zero-length exclude lists to the find module. Currently, exclude lists with no entries exclude everything. This behavior seems incorrect, as a zero entry list of excludes should be treated the same as if no exclude list was passed at all. fixes #78014 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/find.py

##### ADDITIONAL INFORMATION
See below for the simplest example I could create. This is not a real world example. In the real world, if you submit a list from a variable or structure which has no elements, it acts the same as a "*" entry. A zero length list would be better represented as being the same as not including the exclusions argument at all. There are times when passing exclusions as a variable is needed. In those cases, users of the find module would be better served if it behaved in an intuitive manner.
```
---
- name: Demonstrate zero length find lists
  find:
    paths: /etc
    recurse: no
    file_type: file
    patterns: "*.conf"
    excludes: "{{ [] }}"
```
Command line example:
ansible {hostname} -vvv -m find -a 'paths=/etc recurse=no file_type=file patterns="*.conf" excludes="{{ [] }}"'