### PR TITLE
Add a warning for collections not installed

### DIFF
--- a/changelogs/fragments/78018-add-warning-missing-collections.yml
+++ b/changelogs/fragments/78018-add-warning-missing-collections.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Display a warning for missing collections that are referenced using the collections keyword (https://github.com/ansible/ansible/issues/71483).

--- a/lib/ansible/playbook/collectionsearch.py
+++ b/lib/ansible/playbook/collectionsearch.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from ansible.module_utils.compat.importlib import import_module
 from ansible.module_utils.six import string_types
 from ansible.playbook.attribute import FieldAttribute
 from ansible.utils.collection_loader import AnsibleCollectionConfig
@@ -58,5 +59,13 @@ class CollectionSearch:
             if is_template(collection_name, env):
                 display.warning('"collections" is not templatable, but we found: %s, '
                                 'it will not be templated and will be used "as is".' % (collection_name))
+
+            if collection_name in ('ansible.builtin', 'ansible.legacy',):
+                continue
+
+            try:
+                import_module('ansible_collections.' + collection_name)
+            except ImportError:
+                display.warning(f"Unable to import collection {collection_name}")
 
         return ds

--- a/lib/ansible/playbook/collectionsearch.py
+++ b/lib/ansible/playbook/collectionsearch.py
@@ -3,13 +3,13 @@
 
 from __future__ import annotations
 
-from ansible.module_utils.compat.importlib import import_module
 from ansible.module_utils.six import string_types
 from ansible.playbook.attribute import FieldAttribute
 from ansible.utils.collection_loader import AnsibleCollectionConfig
 from ansible.template import is_template
 from ansible.utils.display import Display
 
+from importlib.util import find_spec
 from jinja2.nativetypes import NativeEnvironment
 
 display = Display()
@@ -64,8 +64,11 @@ class CollectionSearch:
                 continue
 
             try:
-                import_module('ansible_collections.' + collection_name)
-            except ImportError:
+                spec = find_spec('ansible_collections.' + collection_name)
+                if spec is None:
+                    # only the namespace exists
+                    raise ImportError
+            except (ImportError, ValueError):
                 display.warning(f"Unable to import collection {collection_name}")
 
         return ds

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -187,13 +187,6 @@ class StrategyModule(StrategyBase):
 
                     task_action = templar.template(task.action)
 
-                    try:
-                        action = action_loader.get(task_action, class_only=True, collection_list=task.collections)
-                    except KeyError:
-                        # we don't care here, because the action may simply not have a
-                        # corresponding action plugin
-                        action = None
-
                     if task_action in C._ACTION_META:
                         # for the linear strategy, we run meta tasks just once and for
                         # all hosts currently being iterated over rather than one host
@@ -210,6 +203,13 @@ class StrategyModule(StrategyBase):
                             else:
                                 skip_rest = True
                                 break
+
+                        try:
+                            action = action_loader.get(task_action, class_only=True, collection_list=task.collections)
+                        except KeyError:
+                            # we don't care here, because the action may simply not have a
+                            # corresponding action plugin
+                            action = None
 
                         run_once = templar.template(task.run_once) or action and getattr(action, 'BYPASS_HOST_LOOP', False)
 

--- a/test/integration/targets/collections/runme.sh
+++ b/test/integration/targets/collections/runme.sh
@@ -151,3 +151,20 @@ fi
 ./vars_plugin_tests.sh
 
 ./test_task_resolved_plugin.sh
+
+cat << EOF > "test_collections_exist.yml"
+---
+- hosts: localhost
+  gather_facts: no
+  collections:
+    - testns.testcoll
+    - testns.content_adj
+    - testns.coll_in_sys
+    - idont.exist
+    - testns.missing
+EOF
+
+ANSIBLE_COLLECTIONS_PATH=$PWD/collection_root_user:$PWD/collection_root_sys ansible-playbook test_collections_exist.yml 2>&1 "$@" | tee out.txt
+grep out.txt -e "\[WARNING\]: Unable to import collection idont\.exist"
+grep out.txt -e "\[WARNING\]: Unable to import collection testns\.missing"
+test "$(grep out.txt -ce 'Unable to import collection')" == 2


### PR DESCRIPTION
##### SUMMARY
Fixes #71483

Adds a warning if any of the collections in the collections list can't be found. Also removes an unnecessary plugin lookup for `meta` keyword.
I also noticed we're doing an unnecessary lookup for non-fqcn "meta" action plugins. Should a collection be able to use an action plugin called "meta" in conjunction with the collections keyword? This keeps the current behavior as treating it like a special keyword, just removed the extra plugin lookup in that case.

##### ISSUE TYPE
- Bugfix Pull Request
