### PR TITLE
pip module - editable now applies to all packages

### DIFF
--- a/changelogs/fragments/77755-pip-module-editable-flag-fix.yml
+++ b/changelogs/fragments/77755-pip-module-editable-flag-fix.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - pip - when editable set to true, '-e' flag is passed before each package.
+    When requirments file is used, editable flag does not pass '-e' to avoid
+    errors.


### PR DESCRIPTION
##### SUMMARY
When editable is set to true, -e flag should be passed to all packages. This change passes -e flag before each package name. However, if a requirements file is used, then editable flag raises errors. Therefore, editable and requirements are now mutually exclusive.

Fixes #77755

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
While fixing the bug, I noticed that `-e` flag was being passed when using requirements file with editable options on. This results in an error. To avoid having this error, `requirements` and `editable` are now mutually exclusive.

This is the error:
```
$ pip install -e -r requirements.txt 
ERROR: -r is not a valid editable requirement. It should either be a path to a local project or a VCS URL (beginning with bzr+http, bzr+https, bzr+ssh, bzr+sftp, bzr+ftp, bzr+lp, bzr+file, git+http, git+https, git+ssh, git+git, git+file, hg+file, hg+http, hg+https, hg+ssh, hg+static-http, svn+ssh, svn+http, svn+https, svn+svn, svn+file).
```