### PR TITLE
Fix 'Permission denied' in user module while generating SSH keys

### DIFF
--- a/changelogs/fragments/permission-denied-spwd-module.yml
+++ b/changelogs/fragments/permission-denied-spwd-module.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - user - Fix error "Permission denied" in user module while generating SSH keys
+  - user - Fix error "Permission denied" in user module while generating SSH keys (https://github.com/ansible/ansible/issues/78017).

--- a/changelogs/fragments/permission-denied-spwd-module.yml
+++ b/changelogs/fragments/permission-denied-spwd-module.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - Fix error "Permission denied" in user module while generating SSH keys


### PR DESCRIPTION
Fix #78017
Use try/except for spwd usage to prevent "Permission denied".

Signed-off-by: Sagi Shnaidman <sshnaidm@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
