### PR TITLE
Docsite: update links to community docs

### DIFF
--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -142,14 +142,14 @@ The Ansible community holds regular meetings on various topics on Matrix/IRC, an
 Ansible Community Topics
 ========================
 
-The :ref:`Ansible Community Steering Committee<steering_responsibilties>` uses the `community-topics repository <https://github.com/ansible-community/community-topics/issues>`_ to asynchronously discuss with the Community and vote on Community topics in corresponding issues.
+The :ref:`Ansible Community Steering Committee<steering_responsibilities>` uses the `community-topics repository <https://github.com/ansible-community/community-topics/issues>`_ to asynchronously discuss with the Community and vote on Community topics in corresponding issues.
 
 Create a new issue in the `repository <https://github.com/ansible-community/community-topics/issues>`_ if you want to discuss an idea that impacts any of the following:
 
 * Ansible Community
 * Community collection best practices and `requirements <https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst>`_
 * `Community collection inclusion policy <https://github.com/ansible-collections/ansible-inclusion/blob/main/README.md>`_
-* :ref:`The Community governance<steering_responsibilties>`
+* :ref:`The Community governance<steering_responsibilities>`
 * Other proposals of importance that need the Committee or overall Ansible community attention
 
 Ansible Automation Platform support questions

--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -142,14 +142,14 @@ The Ansible community holds regular meetings on various topics on Matrix/IRC, an
 Ansible Community Topics
 ========================
 
-The `Ansible Community Steering Committee <https://docs.ansible.com/ansible/devel/community/steering/community_steering_committee.html>`_ uses the `community-topics repository <https://github.com/ansible-community/community-topics/issues>`_ to asynchronously discuss with the Community and vote on Community topics in corresponding issues.
+The :ref:`Ansible Community Steering Committee<steering_responsibilties>` uses the `community-topics repository <https://github.com/ansible-community/community-topics/issues>`_ to asynchronously discuss with the Community and vote on Community topics in corresponding issues.
 
 Create a new issue in the `repository <https://github.com/ansible-community/community-topics/issues>`_ if you want to discuss an idea that impacts any of the following:
 
 * Ansible Community
 * Community collection best practices and `requirements <https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst>`_
 * `Community collection inclusion policy <https://github.com/ansible-collections/ansible-inclusion/blob/main/README.md>`_
-* `The Community governance <https://docs.ansible.com/ansible/devel/community/steering/community_steering_committee.html>`_
+* :ref:`The Community governance<steering_responsibilties>`
 * Other proposals of importance that need the Committee or overall Ansible community attention
 
 Ansible Automation Platform support questions

--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -142,14 +142,14 @@ The Ansible community holds regular meetings on various topics on Matrix/IRC, an
 Ansible Community Topics
 ========================
 
-The :ref:`Ansible Community Steering Committee<steering_responsibilities>` uses the `community-topics repository <https://github.com/ansible-community/community-topics/issues>`_ to asynchronously discuss with the Community and vote on Community topics in corresponding issues.
+The `Ansible Community Steering Committee <https://docs.ansible.com/ansible/devel/community/steering/community_steering_committee.html>`_ uses the `community-topics repository <https://github.com/ansible-community/community-topics/issues>`_ to asynchronously discuss with the Community and vote on Community topics in corresponding issues.
 
 Create a new issue in the `repository <https://github.com/ansible-community/community-topics/issues>`_ if you want to discuss an idea that impacts any of the following:
 
 * Ansible Community
 * Community collection best practices and `requirements <https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst>`_
 * `Community collection inclusion policy <https://github.com/ansible-collections/ansible-inclusion/blob/main/README.md>`_
-* :ref:`The Community governance<steering_responsibilities>`
+* `The Community governance <https://docs.ansible.com/ansible/devel/community/steering/community_steering_committee.html>`_
 * Other proposals of importance that need the Committee or overall Ansible community attention
 
 Ansible Automation Platform support questions

--- a/docs/docsite/rst/community/maintainers_workflow.rst
+++ b/docs/docsite/rst/community/maintainers_workflow.rst
@@ -8,8 +8,8 @@ Each collection community can set its own rules and workflow for managing pull r
 
 * :ref:`code_of_conduct`
 * :ref:`maintainer_requirements`
-* :ref:`Committer guidelines <committer_general_rules>`.
-* `PR review checklist <https://github.com/ansible/community-docs/blob/main/review_checklist.rst>`_
+* :ref:`Committer guidelines <committer_general_rules>`
+* :ref:`PR review checklist<review_checklist>`
 
 There can be two kinds of maintainers: :ref:`collection_maintainers` and :ref:`module_maintainers`.
 


### PR DESCRIPTION
##### SUMMARY
Docsite: update links to community docs

I don't put a space between texts and anchors because in the[ RST doc](https://sublime-and-sphinx-guide.readthedocs.io/en/latest/references.html) it's said:
```
Do not include a space between the last word of the link text and the opening angle bracket for the anchor text.
```
though not sure if it's really important

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/community/communication.rst
docs/docsite/rst/community/maintainers_workflow.rst