### PR TITLE
Fix invalid-ansiblemodule-schema sanity errors.

### DIFF
--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -869,7 +869,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             name=dict(type='str', required=True),
-            use=dict(type='str', choices=STRATS.keys())
+            use=dict(type='str', choices=list(STRATS.keys()))
         ),
         supports_check_mode=True,
     )

--- a/lib/ansible/modules/pip.py
+++ b/lib/ansible/modules/pip.py
@@ -641,7 +641,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec=dict(
-            state=dict(type='str', default='present', choices=state_map.keys()),
+            state=dict(type='str', default='present', choices=list(state_map.keys())),
             name=dict(type='list', elements='str'),
             version=dict(type='str'),
             requirements=dict(type='str'),

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -39,14 +39,12 @@ lib/ansible/modules/git.py pylint:disallowed-name
 lib/ansible/modules/git.py use-argspec-type-path
 lib/ansible/modules/git.py validate-modules:doc-missing-type
 lib/ansible/modules/git.py validate-modules:doc-required-mismatch
-lib/ansible/modules/hostname.py validate-modules:invalid-ansiblemodule-schema
 lib/ansible/modules/iptables.py pylint:disallowed-name
 lib/ansible/modules/lineinfile.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/lineinfile.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/lineinfile.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/package_facts.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/pip.py pylint:disallowed-name
-lib/ansible/modules/pip.py validate-modules:invalid-ansiblemodule-schema
 lib/ansible/modules/replace.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/service.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/service.py validate-modules:use-run-command-not-popen


### PR DESCRIPTION
##### SUMMARY

The validate-modules sanity test expects a list not a dict_keys iterable.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

pip module
hostname module
