### PR TITLE
Handle null values when generating keyed groups

### DIFF
--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -403,7 +403,7 @@ class Constructable(object):
                     trailing_separator = keyed.get('trailing_separator')
                     if trailing_separator is not None and default_value_name is not None:
                         raise AnsibleParserError("parameters are mutually exclusive for keyed groups: default_value|trailing_separator")
-                    if key or (key == '' and default_value_name is not None):
+                    if key or default_value_name:
                         prefix = keyed.get('prefix', '')
                         sep = keyed.get('separator', '_')
                         raw_parent_name = keyed.get('parent_group', None)
@@ -422,16 +422,21 @@ class Constructable(object):
                                 new_raw_group_names.append(default_value_name)
                             else:
                                 new_raw_group_names.append(key)
+                        elif key is None and default_value_name is not None:
+                            new_raw_group_names.append(default_value_name)
                         elif isinstance(key, list):
                             for name in key:
-                                # if list item is empty, 'default_value' will be used as group name
-                                if name == '' and default_value_name is not None:
+                                # if list item is empty or null, 'default_value' will be used as group name
+                                if not name and default_value_name is not None:
                                     new_raw_group_names.append(default_value_name)
                                 else:
                                     new_raw_group_names.append(name)
                         elif isinstance(key, Mapping):
                             for (gname, gval) in key.items():
+                                if gval is None:
+                                    gval = ''
                                 bare_name = '%s%s%s' % (gname, sep, gval)
+
                                 if gval == '':
                                     # key's value is empty
                                     if default_value_name is not None:

--- a/test/integration/targets/inventory_constructed/runme.sh
+++ b/test/integration/targets/inventory_constructed/runme.sh
@@ -43,7 +43,6 @@ ansible-inventory -i tag_inventory.yml -i keyed_group_str_default_value.yml --gr
 
 grep '@host_fedora' out.txt
 
-
 # keyed group with 'trailing_separator' set to 'False' for key's value empty
 ansible-inventory -i tag_inventory.yml -i keyed_group_trailing_separator.yml --graph | tee out.txt
 
@@ -51,6 +50,31 @@ grep '@tag_name_host0' out.txt
 grep '@tag_environment_test' out.txt
 grep '@tag_status' out.txt
 
+# keyed group with default value for key's value null (dict)
+ansible-inventory -i tag_inventory_null.yml -i keyed_group_default_value.yml --graph | tee out.txt
+
+grep '@tag_name_host0' out.txt
+grep '@tag_environment_test' out.txt
+grep '@tag_status_running' out.txt
+
+# keyed group with default value for key's value null (list)
+ansible-inventory -i tag_inventory_null.yml -i keyed_group_list_default_value.yml --graph | tee out.txt
+
+grep '@host_db' out.txt
+grep '@host_web' out.txt
+grep '@host_storage' out.txt
+
+# keyed group with default value for key's value null (str)
+ansible-inventory -i tag_inventory_null.yml -i keyed_group_str_default_value.yml --graph | tee out.txt
+
+grep '@host_fedora' out.txt
+
+# keyed group with 'trailing_separator' set to 'False' for key's value null
+ansible-inventory -i tag_inventory_null.yml -i keyed_group_trailing_separator.yml --graph | tee out.txt
+
+grep '@tag_name_host0' out.txt
+grep '@tag_environment_test' out.txt
+grep '@tag_status' out.txt
 
 # test using use_vars_plugins
 ansible-inventory -i invs/1/one.yml -i invs/2/constructed.yml --graph | tee out.txt

--- a/test/integration/targets/inventory_constructed/tag_inventory_null.yml
+++ b/test/integration/targets/inventory_constructed/tag_inventory_null.yml
@@ -1,0 +1,12 @@
+all:
+  hosts:
+    host0:
+      tags:
+        name: "host0"
+        environment: "test"
+        status: null
+      os: null
+      roles:
+        - db
+        - web
+        - null

--- a/test/units/plugins/inventory/test_constructed.py
+++ b/test/units/plugins/inventory/test_constructed.py
@@ -228,7 +228,7 @@ def test_keyed_group_exclusive_argument(inventory_module):
 
 def test_keyed_group_empty_value(inventory_module):
     inventory_module.inventory.add_host('server0')
-    inventory_module.inventory.set_variable('server0', 'tags', {'environment': 'prod', 'status': ''})
+    inventory_module.inventory.set_variable('server0', 'tags', {'environment': 'prod', 'status': '', 'last_status': None})
     host = inventory_module.inventory.get_host('server0')
     keyed_groups = [
         {
@@ -240,13 +240,13 @@ def test_keyed_group_empty_value(inventory_module):
     inventory_module._add_host_to_keyed_groups(
         keyed_groups, host.vars, host.name, strict=False
     )
-    for group_name in ('tag_environment_prod', 'tag_status_'):
+    for group_name in ('tag_environment_prod', 'tag_status_', 'tag_last_status_'):
         assert group_name in inventory_module.inventory.groups
 
 
 def test_keyed_group_dict_with_default_value(inventory_module):
     inventory_module.inventory.add_host('server0')
-    inventory_module.inventory.set_variable('server0', 'tags', {'environment': 'prod', 'status': ''})
+    inventory_module.inventory.set_variable('server0', 'tags', {'environment': 'prod', 'status': '', 'last_status': None})
     host = inventory_module.inventory.get_host('server0')
     keyed_groups = [
         {
@@ -259,7 +259,7 @@ def test_keyed_group_dict_with_default_value(inventory_module):
     inventory_module._add_host_to_keyed_groups(
         keyed_groups, host.vars, host.name, strict=False
     )
-    for group_name in ('tag_environment_prod', 'tag_status_running'):
+    for group_name in ('tag_environment_prod', 'tag_status_running', 'tag_last_status_running'):
         assert group_name in inventory_module.inventory.groups
 
 
@@ -320,7 +320,7 @@ def test_keyed_group_list_with_default_value(inventory_module):
 
 def test_keyed_group_with_trailing_separator(inventory_module):
     inventory_module.inventory.add_host('server0')
-    inventory_module.inventory.set_variable('server0', 'tags', {'environment': 'prod', 'status': ''})
+    inventory_module.inventory.set_variable('server0', 'tags', {'environment': 'prod', 'status': '', 'last_status': None})
     host = inventory_module.inventory.get_host('server0')
     keyed_groups = [
         {
@@ -333,5 +333,5 @@ def test_keyed_group_with_trailing_separator(inventory_module):
     inventory_module._add_host_to_keyed_groups(
         keyed_groups, host.vars, host.name, strict=False
     )
-    for group_name in ('tag_environment_prod', 'tag_status'):
+    for group_name in ('tag_environment_prod', 'tag_status', 'tag_last_status'):
         assert group_name in inventory_module.inventory.groups


### PR DESCRIPTION
##### SUMMARY
Support for using default values when generating keyed groups with an empty key value was added in https://github.com/ansible/ansible/pull/74005, but it does not support `null`/`None` values. This causes `null` values to be ignored or when enabling `strict` mode, the dynamic inventory plugin to fail. This Pull Request adds the functionality to treat `null` values as empty strings (`''`).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`lib/ansible/plugins/inventory/__init__.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
