### PR TITLE
[PoC] Allow connection plugins to decline pipelining dynamically

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -291,11 +291,16 @@ class ActionBase(ABC):
                                                                             **become_kwargs)
                 break
             except InterpreterDiscoveryRequiredError as idre:
-                self._discovered_interpreter = AnsibleUnsafeText(discover_interpreter(
-                    action=self,
-                    interpreter_name=idre.interpreter_name,
-                    discovery_mode=idre.discovery_mode,
-                    task_vars=use_vars))
+                if self._connection.disallow_pipelining():
+                    display.vvv(msg=f'Connection plugin {self._connection._load_name} cannot support pipelining', host=self._connection.host)
+                    self._discovered_interpreter = '/usr/bin/python'
+
+                else:
+                    self._discovered_interpreter = AnsibleUnsafeText(discover_interpreter(
+                        action=self,
+                        interpreter_name=idre.interpreter_name,
+                        discovery_mode=idre.discovery_mode,
+                        task_vars=use_vars))
 
                 # update the local task_vars with the discovered interpreter (which might be None);
                 # we'll propagate back to the controller in the task result
@@ -361,6 +366,10 @@ class ActionBase(ABC):
         '''
         Determines if we are required and can do pipelining
         '''
+
+        if self._connection.disallow_pipelining():
+            display.vvv(msg=f'Connection plugin {self._connection._load_name} cannot support pipelining', host=self._connection.host)
+            return False
 
         try:
             is_enabled = self._connection.get_option('pipelining')

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -261,6 +261,9 @@ class ConnectionBase(AnsiblePlugin):
                 display.debug('Set connection var {0} to {1}'.format(varname, value))
                 variables[varname] = value
 
+    def disallow_pipelining(self):
+        return False
+
 
 class NetworkConnectionBase(ConnectionBase):
     """

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1408,7 +1408,7 @@ class Connection(ConnectionBase):
         if args.t:
             return True
 
-        for arg in args.o:
+        for arg in args.o or []:
             val = arg.split('=', 1)
             if val[0].lower() == 'requesttty':
                 if val[1].lower() in ('yes', 'force'):

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -360,6 +360,7 @@ DOCUMENTATION = '''
           - name: ansible_ssh_pkcs11_provider
 '''
 
+import argparse
 import errno
 import fcntl
 import hashlib
@@ -397,6 +398,10 @@ b_NOT_SSH_ERRORS = (b'Traceback (most recent call last):',  # Python-2.6 when th
 
 SSHPASS_AVAILABLE = None
 SSH_DEBUG = re.compile(r'^debug\d+: .*')
+
+tty_parser = argparse.ArgumentParser()
+tty_parser.add_argument('-t', action='count')
+tty_parser.add_argument('-o', action='append')
 
 
 class AnsibleControlPersistBrokenPipeError(AnsibleError):
@@ -1390,3 +1395,23 @@ class Connection(ConnectionBase):
 
     def close(self):
         self._connected = False
+
+    def disallow_pipelining(self):
+        opts = []
+        for opt in ('ssh_args', 'ssh_common_args', 'ssh_extra_args'):
+            attr = self.get_option(opt)
+            if attr is not None:
+                opts.extend(self._split_ssh_args(attr))
+
+        args, dummy = tty_parser.parse_known_args(opts)
+
+        if args.t:
+            return True
+
+        for arg in args.o:
+            val = arg.split('=', 1)
+            if val[0].lower() == 'requesttty':
+                if val[1].lower() in ('yes', 'force'):
+                    return True
+
+        return False


### PR DESCRIPTION
##### SUMMARY
Allow connection plugins to decline pipelining dynamically

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
Allows a plugin, regardless of the `pipelining` configuration, to decline the ability to use pipelining dynamically.  Such as the event where `-tt` or `-o RequestTTY=force` is providing in `ansible_ssh_extra_args`