### PR TITLE
clear_host_errors - fix handling unreachable errors

### DIFF
--- a/changelogs/fragments/78075-fix-clear_host_errors-unreachable.yml
+++ b/changelogs/fragments/78075-fix-clear_host_errors-unreachable.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - clear_host_errors - Fix clearing unreachable host errors for subsequent plays. Previously, unreachable hosts would resume the play in which they failed, following the unreachable task. (https://github.com/ansible/ansible/issues/35086)

--- a/lib/ansible/modules/meta.py
+++ b/lib/ansible/modules/meta.py
@@ -33,7 +33,8 @@ options:
         - V(clear_facts) (added in Ansible 2.1) causes the gathered facts for the hosts specified in the play's list of hosts to be cleared,
           including the fact cache.
         - V(clear_host_errors) (added in Ansible 2.1) clears the failed state (if any) from hosts specified in the play's list of hosts.
-          This will make them available for targeting in subsequent plays, but not continue execution in the current play.
+          This will make them available for targeting in subsequent plays, but not continue execution in the current play unless the failed host is not yet
+          removed from the play. For example, running clear_host_errors in a block with a rescue section could prevent the rescue section from running.
         - V(end_play) (added in Ansible 2.2) causes the play to end without failing the host(s). Note that this affects all hosts.
         - V(reset_connection) (added in Ansible 2.3) interrupts a persistent connection (i.e. ssh + control persist)
         - V(end_host) (added in Ansible 2.8) is a per-host variation of V(end_play). Causes the play to end for the current host without failing it.

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -600,7 +600,7 @@ class StrategyBase:
                 ignore_unreachable = original_task.ignore_unreachable
                 if not ignore_unreachable:
                     self._tqm._unreachable_hosts[original_host.name] = True
-                    iterator._play._removed_hosts.append(original_host.name)
+                    iterator.end_host(original_host.name)
                     self._tqm._stats.increment('dark', original_host.name)
                 else:
                     self._tqm._stats.increment('ok', original_host.name)

--- a/test/integration/targets/ignore_unreachable/test_base_loop_cannot_connect.yml
+++ b/test/integration/targets/ignore_unreachable/test_base_loop_cannot_connect.yml
@@ -29,6 +29,12 @@
 
   - meta: clear_host_errors
 
+  - name: Test unreachable host does not execute task following clear_host_errors (skip)
+    fail:
+    when: inventory_hostname == 'nonexistent'
+
+- hosts: nonexistent
+  tasks:
   - assert:
       that:
         - unreachable_ignored is not unreachable
@@ -38,4 +44,3 @@
         - unreachable_last["results"][-1] is unreachable
         - unreachable_last["results"][0] is not unreachable
         - unreachable_last is unreachable
-    when: inventory_hostname == 'nonexistent'

--- a/test/integration/targets/meta_tasks/runme.sh
+++ b/test/integration/targets/meta_tasks/runme.sh
@@ -73,6 +73,16 @@ for test_strategy in linear free; do
   grep -qv 'Failed to end_batch' <<< "$out"
 done
 
+# test clear_host_errors meta task
+for playbook in test_clear_host_errors/*; do
+  for strategy in linear free; do
+    ansible-playbook "$playbook" -i inventory.yml -e test_strategy="$strategy" "$@" || {
+      echo "Test $playbook failed using strategy $strategy"
+      exit 1
+    }
+  done
+done
+
 # test refresh
 ansible-playbook -i inventory_refresh.yml refresh.yml "$@"
 ansible-playbook -i inventory_refresh.yml refresh_preserve_dynamic.yml "$@"

--- a/test/integration/targets/meta_tasks/test_clear_host_errors/failed_host.yml
+++ b/test/integration/targets/meta_tasks/test_clear_host_errors/failed_host.yml
@@ -1,0 +1,40 @@
+- name: Use clear_host_errors to clear host failures for a subsequent play
+  hosts:
+    - testhost
+    - testhost2
+  gather_facts: no
+  strategy: "{{ test_strategy }}"
+  tasks:
+    - name: Delay host responsible for executing clear_host_errors
+      wait_for:
+        timeout: 1
+      when:
+        - test_strategy == 'free'
+        - inventory_hostname == 'testhost'
+
+    - name: Fail one host to test clearing errors for the next play
+      fail:
+      when: inventory_hostname == 'testhost2'
+
+    - meta: clear_host_errors
+
+    - name: Test recovered host does not resume in this play
+      fail:
+      when: inventory_hostname == 'testhost2'
+
+- name: Test recovered host is available
+  hosts: testhost2
+  gather_facts: no
+  tasks:
+    - set_fact:
+        recovered_in_subsequent_play: True
+      delegate_to: testhost
+      delegate_facts: True
+
+- name: Validate previous play executed
+  hosts: testhost
+  gather_facts: no
+  tasks:
+    - assert:
+        that:
+          - recovered_in_subsequent_play | default(False)

--- a/test/integration/targets/meta_tasks/test_clear_host_errors/failed_host_active_state.yml
+++ b/test/integration/targets/meta_tasks/test_clear_host_errors/failed_host_active_state.yml
@@ -1,0 +1,38 @@
+- name: Use clear_host_errors to clear active host failures
+  hosts:
+    - testhost
+    - testhost2
+  gather_facts: no
+  strategy: "{{ test_strategy }}"
+  tasks:
+    - name: Delay host responsible for executing clear_host_errors
+      wait_for:
+        timeout: 1
+      when:
+        - test_strategy == 'free'
+        - inventory_hostname == 'testhost'
+
+    - block:
+        - name: Fail a host in a block that has an always section
+          fail:
+          when: inventory_hostname == 'testhost2'
+
+        - meta: clear_host_errors
+      always:
+        - debug:
+            msg: 'Running always'
+
+    - name: Set a fact for the failed host
+      set_fact:
+        recovered_within_same_play: True
+      delegate_to: testhost
+      delegate_facts: True
+      when: inventory_hostname == 'testhost2'
+
+- name: Test failed host with an active run state completed the previous play
+  hosts: testhost
+  gather_facts: no
+  tasks:
+    - assert:
+        that:
+          - recovered_within_same_play | default(False)

--- a/test/integration/targets/meta_tasks/test_clear_host_errors/unreachable_host.yml
+++ b/test/integration/targets/meta_tasks/test_clear_host_errors/unreachable_host.yml
@@ -1,0 +1,44 @@
+- name: Use clear_host_errors to clear unreachable errors for a subsequent play
+  hosts:
+    - testhost
+    - testhost2
+  gather_facts: no
+  strategy: "{{ test_strategy }}"
+  tasks:
+    - name: Delay host responsible for executing clear_host_errors
+      wait_for:
+        timeout: 1
+      when:
+        - test_strategy == 'free'
+        - inventory_hostname == 'testhost'
+
+    - name: Fail one host to test clearing errors for the next play
+      ping:
+      vars:
+        ansible_connection: ssh
+        ansible_ssh_timeout: 1
+        ansible_host: 192.0.2.1  # use reserved IP
+      when: inventory_hostname == 'testhost2'
+
+    - meta: clear_host_errors
+
+    - name: Test recovered host does not resume in this play
+      fail:
+      when: inventory_hostname == 'testhost2'
+
+- name: Test recovered host is available
+  hosts: testhost2
+  gather_facts: no
+  tasks:
+    - set_fact:
+        recovered_in_subsequent_play: True
+      delegate_to: testhost
+      delegate_facts: True
+
+- name: Validate previous play executed
+  hosts: testhost
+  gather_facts: no
+  tasks:
+    - assert:
+        that:
+          - recovered_in_subsequent_play | default(False)


### PR DESCRIPTION
##### SUMMARY
Fixes #35086
Fixes #86208

On devel, unreachable hosts pick up where they left off.

On this branch, unreachable hosts pick up at the next play.

I'm not sure if this is the right behavior, because ~I can imagine content relying on the behavior of devel (it's the only mechanism to recover an unreachable host, and it could be intuitive using the free strategy), and~ people using the linear strategy could expect the host should start at the task following the next applicable task following the clear_host_errors task instead of the next play.

I'd also be open to just documenting the current behavior or making it configurable.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
