### PR TITLE
ansible-galaxy: support x.yy versions and write min_ansible_version as a string

### DIFF
--- a/changelogs/fragments/meta-ansible_version.yml
+++ b/changelogs/fragments/meta-ansible_version.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - write ``min_ansible_version`` in semantic version format and as a string in
+    ``meta/main.yml``, instead of a float (https://github.com/ansible/ansible/pull/78081).

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1006,20 +1006,28 @@ class GalaxyCLI(CLI):
             description='your {0} description'.format(galaxy_type),
             ansible_plugin_list_dir=get_versioned_doclink('plugins/plugins.html'),
         )
-        if galaxy_type == 'role':
-            inject_data.update(dict(
-                author='your name',
-                company='your company (optional)',
-                license='license (GPL-2.0-or-later, MIT, etc)',
-                role_name=obj_name,
-                role_type=context.CLIARGS['role_type'],
-                issue_tracker_url='http://example.com/issue/tracker',
-                repository_url='http://example.com/repository',
-                documentation_url='http://docs.example.com',
-                homepage_url='http://example.com',
-                min_ansible_version=ansible_version[:3],  # x.y
-                dependencies=[],
-            ))
+
+        if galaxy_type == "role":
+            if len(str(ansible_version)) <= 3:
+                min_ansible_version = '"' + ansible_version[:3] + '"'  # x.y
+            else:
+                min_ansible_version = '"' + ansible_version[:4] + '"'  # x.yy
+
+            inject_data.update(
+                dict(
+                    author="your name",
+                    company="your company (optional)",
+                    license="license (GPL-2.0-or-later, MIT, etc)",
+                    role_name=obj_name,
+                    role_type=context.CLIARGS["role_type"],
+                    issue_tracker_url="http://example.com/issue/tracker",
+                    repository_url="http://example.com/repository",
+                    documentation_url="http://docs.example.com",
+                    homepage_url="http://example.com",
+                    min_ansible_version=min_ansible_version,
+                    dependencies=[],
+                )
+            )
 
             skeleton_ignore_expressions = C.GALAXY_ROLE_SKELETON_IGNORE
             obj_path = os.path.join(init_path, obj_name)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1010,7 +1010,7 @@ class GalaxyCLI(CLI):
 
         if galaxy_type == "role":
             semantic_version = SemanticVersion.from_loose_version(LooseVersion(ansible_version))
-            min_ansible_version=f"{semantic_version.major}.{semantic_version.minor}"
+            min_ansible_version = f"{semantic_version.major}.{semantic_version.minor}"
             inject_data.update(
                 dict(
                     author="your name",

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -57,6 +57,7 @@ from ansible.template import Templar
 from ansible.utils.collection_loader import AnsibleCollectionConfig
 from ansible.utils.display import Display
 from ansible.utils.plugin_docs import get_versioned_doclink
+from ansible.utils.version import SemanticVersion, LooseVersion
 
 display = Display()
 urlparse = six.moves.urllib.parse.urlparse
@@ -1008,11 +1009,8 @@ class GalaxyCLI(CLI):
         )
 
         if galaxy_type == "role":
-            if len(str(ansible_version)) <= 3:
-                min_ansible_version = '"' + ansible_version[:3] + '"'  # x.y
-            else:
-                min_ansible_version = '"' + ansible_version[:4] + '"'  # x.yy
-
+            semantic_version = SemanticVersion.from_loose_version(LooseVersion(ansible_version))
+            min_ansible_version=f"{semantic_version.major}.{semantic_version.minor}"
             inject_data.update(
                 dict(
                     author="your name",
@@ -1024,7 +1022,7 @@ class GalaxyCLI(CLI):
                     repository_url="http://example.com/repository",
                     documentation_url="http://docs.example.com",
                     homepage_url="http://example.com",
-                    min_ansible_version=min_ansible_version,
+                    min_ansible_version='"' + min_ansible_version + '"',
                     dependencies=[],
                 )
             )


### PR DESCRIPTION
##### SUMMARY

Current code writes `min_ansible_version: 2.1` to `meta/main.yml` which triggers an `ansible-lint` error: `schema: 2.1 is not of type 'string' (schema[meta])` and causes issues when uploading to Galaxy (e.g https://github.com/ansible/galaxy/issues/2881).

With this PR the `meta/main.yml` value will instead be `min_ansible_version: "2.14"`, adding support for `x.yy` versions as well.


##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Galaxy

##### ADDITIONAL INFORMATION

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>