### PR TITLE
Docs: Issue 78082 move basic concepts to start (1/3)

### DIFF
--- a/docs/docsite/rst/getting_started/basic_concepts.rst
+++ b/docs/docsite/rst/getting_started/basic_concepts.rst
@@ -1,0 +1,13 @@
+.. _basic_concepts:
+
+****************
+Ansible concepts
+****************
+
+These concepts are common to all uses of Ansible.
+You should understand them before using Ansible or reading the documentation.
+
+.. contents::
+   :local:
+
+.. include:: /shared_snippets/basic_concepts.txt

--- a/docs/docsite/rst/getting_started/index.rst
+++ b/docs/docsite/rst/getting_started/index.rst
@@ -96,3 +96,4 @@ Continue by :ref:`learning how to build an inventory<get_started_inventory>`.
 
    get_started_inventory
    get_started_playbook
+   basic_concepts

--- a/docs/docsite/rst/user_guide/basic_concepts.rst
+++ b/docs/docsite/rst/user_guide/basic_concepts.rst
@@ -1,12 +1,7 @@
-.. _basic_concepts:
+:orphan:
 
 ****************
 Ansible concepts
 ****************
 
-These concepts are common to all uses of Ansible. You need to understand them to use Ansible for any kind of automation. This basic introduction provides the background you need to follow the rest of the User Guide.
-
-.. contents::
-   :local:
-
-.. include:: /shared_snippets/basic_concepts.txt
+This page has moved to :ref:`Getting started with Ansible<basic_concepts>`.

--- a/docs/docsite/rst/user_guide/index.rst
+++ b/docs/docsite/rst/user_guide/index.rst
@@ -80,7 +80,6 @@ Here is the complete list of resources in the Ansible User Guide:
 .. toctree::
    :maxdepth: 2
 
-   basic_concepts
    intro_adhoc
    cheatsheet
    playbooks_intro


### PR DESCRIPTION
##### SUMMARY
Part one of #78082 that moves the basic concepts page to getting started.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Documentation: User Guide: Getting Started

##### ADDITIONAL INFORMATION
Relocates the basic concepts detail to the getting started page.
