### PR TITLE
systemctl reset-failed feature

### DIFF
--- a/lib/ansible/modules/systemd_service.py
+++ b/lib/ansible/modules/systemd_service.py
@@ -48,6 +48,7 @@ options:
         type: bool
         default: no
         aliases: [ reset-failed ]
+        version_added: 2.14
     daemon_reload:
         description:
             - Run daemon-reload before doing any other operations, to make sure systemd has read any changes.


### PR DESCRIPTION
##### SUMMARY
Added reset-failed feature to systemd builtin module

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
systemd_service.py new option - reset_failed
##### ADDITIONAL INFORMATION
n/a
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
