### PR TITLE
Updated the document 'src' in URI

### DIFF
--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -148,6 +148,7 @@ options:
   src:
     description:
       - Path to file to be submitted to the remote server.
+      - Cannot be used with I(body).
       - Should be used with I(force_basic_auth) to ensure success when the remote end sends a 401.
     type: path
     version_added: '2.7'

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -148,7 +148,7 @@ options:
   src:
     description:
       - Path to file to be submitted to the remote server.
-      - Cannot be used with I(body).
+      - Should be used with I(force_basic_auth) to ensure success when the remote end sends a 401.
     type: path
     version_added: '2.7'
   remote_src:


### PR DESCRIPTION
The URI module supports an 'src' option to open a file on disk. If the remote end sends a 401 requiring authentication because force_basic_auth is not set then the remote end will never get the file on the retry when urlllib sends the headers again with the Authentication data

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I just documented that src in URI won't work properly on 401

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #76451

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/uri.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
