### PR TITLE
Delete core-ci `query` param from ansible-test

### DIFF
--- a/test/lib/ansible_test/_internal/core_ci.py
+++ b/test/lib/ansible_test/_internal/core_ci.py
@@ -298,7 +298,6 @@ class AnsibleCoreCI:
                 version=self.version,
                 architecture=self.arch,
                 public_key=self.ssh_key.pub_contents,
-                query=False,
                 winrm_config=winrm_config,
             )
         )


### PR DESCRIPTION
##### SUMMARY

This change cleans up the deprecated `query` param from the requests that `ansible-test` sends to core-ci for VM provisioning.

Ref: https://github.com/ansible/ansible-core-ci/pull/343

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Maintenance Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-test

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A