### PR TITLE
[stable-2.13] ansible-doc: list modules in collections recursively

### DIFF
--- a/changelogs/fragments/78137-ansible-doc-list-modules-recursively.yml
+++ b/changelogs/fragments/78137-ansible-doc-list-modules-recursively.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - "ansible-doc - when listing modules in collections, proceed recursively. This fixes module listing for community.general 5.x.y and community.network 4.x.y (https://github.com/ansible/ansible/pull/78137)."
+  - "ansible-doc - no longer list module and plugin aliases that are created with symlinks (https://github.com/ansible/ansible/pull/78137)."

--- a/changelogs/fragments/78137-ansible-doc-list-modules-recursively.yml
+++ b/changelogs/fragments/78137-ansible-doc-list-modules-recursively.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "ansible-doc - when listing modules in collections, proceed recursively. This fixes module listing for community.general 5.x.y and community.network 4.x.y (https://github.com/ansible/ansible/pull/78137)."

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -969,9 +969,8 @@ class DocCLI(CLI, RoleMixin):
                 continue
             elif plugin in C.IGNORE_FILES:
                 continue
-            elif plugin .startswith('_'):
-                if os.path.islink(full_path):  # avoids aliases
-                    continue
+            elif os.path.islink(full_path):  # avoids aliases
+                continue
 
             plugin = os.path.splitext(plugin)[0]  # removes the extension
             plugin = plugin.lstrip('_')  # remove underscore from deprecated plugins


### PR DESCRIPTION
##### SUMMARY
This backports the recursive listing behavior from devel to stable-2.13. This fixes listing modules in community.general 5.x.y and community.network 4.x.y.

The code is very similar to how listing works in devel (in devel the listing code is in https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/list.py#L30-L131).

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
ansible-doc
