### PR TITLE
Update vault.rst

### DIFF
--- a/docs/docsite/rst/user_guide/vault.rst
+++ b/docs/docsite/rst/user_guide/vault.rst
@@ -476,7 +476,7 @@ You can set the following Emacs options to avoid cases of disclosure. There may 
 Using encrypted variables and files
 ===================================
 
-When you run a task or playbook that uses encrypted variables or files, you must provide the passwords to decrypt the variables or files. You can do this at the command line or in the playbook itself.
+When you run a task or playbook that uses encrypted variables or files, you must provide the passwords to decrypt the variables or files. You can do this at the command line, in the playbook itself, or by setting a default password source in a config option or an environment variable.
 
 Passing a single password
 -------------------------
@@ -575,7 +575,7 @@ If you use one vault ID more frequently than any other, you can set the config o
 Setting a default password source
 ---------------------------------
 
-If you use one vault password file more frequently than any other, you can set the :ref:`DEFAULT_VAULT_PASSWORD_FILE` config option or the :envvar:`ANSIBLE_VAULT_PASSWORD_FILE` environment variable to specify that file. For example, if you set ``ANSIBLE_VAULT_PASSWORD_FILE=~/.vault_pass.txt``, Ansible will automatically search for the password in that file. This is useful if, for example, you use Ansible from a continuous integration system such as Jenkins.
+If you don't want to provide the password file on the command line or if you use one vault password file more frequently than any other you can set the :ref:`DEFAULT_VAULT_PASSWORD_FILE` config option or the :envvar:`ANSIBLE_VAULT_PASSWORD_FILE` environment variable to specify a default file to use. For example, if you set ``ANSIBLE_VAULT_PASSWORD_FILE=~/.vault_pass.txt``, Ansible will automatically search for the password in that file. This is useful if, for example, you use Ansible from a continuous integration system such as Jenkins.
 
 When are encrypted files made visible?
 ======================================

--- a/docs/docsite/rst/user_guide/vault.rst
+++ b/docs/docsite/rst/user_guide/vault.rst
@@ -476,7 +476,7 @@ You can set the following Emacs options to avoid cases of disclosure. There may 
 Using encrypted variables and files
 ===================================
 
-When you run a task or playbook that uses encrypted variables or files, you must provide the passwords to decrypt the variables or files. You can do this at the command line, in the playbook itself, or by setting a default password source in a config option or an environment variable.
+When you run a task or playbook that uses encrypted variables or files, you must provide the passwords to decrypt the variables or files. You can do this at the command line or by setting a default password source in a config option or an environment variable.
 
 Passing a single password
 -------------------------
@@ -576,6 +576,8 @@ Setting a default password source
 ---------------------------------
 
 If you don't want to provide the password file on the command line or if you use one vault password file more frequently than any other, you can set the :ref:`DEFAULT_VAULT_PASSWORD_FILE` config option or the :envvar:`ANSIBLE_VAULT_PASSWORD_FILE` environment variable to specify a default file to use. For example, if you set ``ANSIBLE_VAULT_PASSWORD_FILE=~/.vault_pass.txt``, Ansible will automatically search for the password in that file. This is useful if, for example, you use Ansible from a continuous integration system such as Jenkins.
+
+The file that you reference can be either a file containing the password (in plain text), or it can be a script (with executable permissions set) that returns the password.
 
 When are encrypted files made visible?
 ======================================

--- a/docs/docsite/rst/user_guide/vault.rst
+++ b/docs/docsite/rst/user_guide/vault.rst
@@ -575,7 +575,7 @@ If you use one vault ID more frequently than any other, you can set the config o
 Setting a default password source
 ---------------------------------
 
-If you don't want to provide the password file on the command line or if you use one vault password file more frequently than any other you can set the :ref:`DEFAULT_VAULT_PASSWORD_FILE` config option or the :envvar:`ANSIBLE_VAULT_PASSWORD_FILE` environment variable to specify a default file to use. For example, if you set ``ANSIBLE_VAULT_PASSWORD_FILE=~/.vault_pass.txt``, Ansible will automatically search for the password in that file. This is useful if, for example, you use Ansible from a continuous integration system such as Jenkins.
+If you don't want to provide the password file on the command line or if you use one vault password file more frequently than any other, you can set the :ref:`DEFAULT_VAULT_PASSWORD_FILE` config option or the :envvar:`ANSIBLE_VAULT_PASSWORD_FILE` environment variable to specify a default file to use. For example, if you set ``ANSIBLE_VAULT_PASSWORD_FILE=~/.vault_pass.txt``, Ansible will automatically search for the password in that file. This is useful if, for example, you use Ansible from a continuous integration system such as Jenkins.
 
 When are encrypted files made visible?
 ======================================


### PR DESCRIPTION
##### SUMMARY
I read this documentation and felt that it was unclear how to provide a vault file password by any means other than a command line option.  The information is there but it is a bit obscure.  I propose this change to fix that.

I also note that the paragraph following "Using encrypted variables and files" says you can set the password file in a playbook - I don't think that information on how to do this is on this page.  If it is I couldn't find it.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Documentation for providing password for opening vault password files