### PR TITLE
ansible-test - Improve pip bootstrap download.

### DIFF
--- a/changelogs/fragments/ansible-test-pip-bootstrap.yml
+++ b/changelogs/fragments/ansible-test-pip-bootstrap.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ansible-test - An improved error message is shown when the download of a pip bootstrap script fails.
+                   The download now uses ``urllib2`` instead of ``urllib`` on Python 2.


### PR DESCRIPTION
##### SUMMARY

An improved error message is shown when the download of a pip bootstrap script fails. It includes enough information for users to work around the lack of proxy support in the pip bootstrap process.

Users that encounter pip bootstrapping issues due to proxy use are encouraged to comment on: https://github.com/ansible/ansible/issues/77304

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
