### PR TITLE
add --dry-run to collection install and add collection name search

### DIFF
--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -220,7 +220,7 @@ class GalaxyError(AnsibleError):
 # them in different formats.
 CollectionMetadata = collections.namedtuple('CollectionMetadata', ['namespace', 'name', 'created_str', 'modified_str'])
 # add deprecated and latest_version to metadata instead?
-CollectionSearch = collections.namedtuple('CollectionSearch', ['created_str', 'modified_str', 'deprecated', 'latest_version'])
+CollectionSearch = collections.namedtuple('CollectionSearch', ['created', 'modified', 'deprecated', 'latest_version'])
 
 
 class CollectionVersionMetadata:
@@ -654,10 +654,13 @@ class GalaxyAPI:
             if not next_link:
                 for info in data[results_key]:
                     name = f"{info['namespace']['name']}.{info['name']}"
-                    result = CollectionSearch(
-                        created_str=info['created'], modified_str=info['modified'], latest_version=info['latest_version']['version'], deprecated=info['deprecated']
-                    )
-                    yield name, result
+                    display_info = {
+                        'created': info['created'],
+                        'modified': info['modified'],
+                        'latest_version': info['latest_version']['version'],
+                        'deprecated': info['deprecated'],
+                    }
+                    yield name, CollectionSearch(**display_info)
                 break
 
             next_url = urlparse(collections_url)
@@ -669,10 +672,13 @@ class GalaxyAPI:
 
             for info in data[results_key]:
                 name = f"{info['namespace']['name']}.{info['name']}"
-                result = CollectionSearch(
-                    created_str=info['created'], modified_str=info['modified'], latest_version=info['latest_version']['version'], deprecated=info['deprecated']
-                )
-                yield name, result
+                display_info = {
+                    'created': info['created'],
+                    'modified': info['modified'],
+                    'latest_version': info['latest_version']['version'],
+                    'deprecated': info['deprecated'],
+                }
+                yield name, CollectionSearch(**display_info)
 
     @g_connect(['v2', 'v3'])
     def publish_collection(self, collection_path):

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -630,6 +630,7 @@ def install_collections(
         allow_pre_release,  # type: bool
         artifacts_manager,  # type: ConcreteArtifactsManager
         disable_gpg_verify,  # type: bool
+        dry_run=False,  # type: bool
 ):  # type: (...) -> None
     """Install Ansible collections to the path specified.
 
@@ -736,6 +737,9 @@ def install_collections(
                     "or disable signature verification. "
                     "Skipping signature verification."
                 )
+            if dry_run:
+                display.display(f"{to_text(collection)} was installed successfully (dry run)")
+                continue
 
             try:
                 install(concrete_coll_pin, output_path, artifacts_manager)

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -738,7 +738,7 @@ def install_collections(
                     "Skipping signature verification."
                 )
             if dry_run:
-                display.display(f"{to_text(collection)} was installed successfully (dry run)")
+                display.display(f"{to_text(concrete_coll_pin)} was installed successfully (dry run)")
                 continue
 
             try:


### PR DESCRIPTION
##### SUMMARY
Needs discussion + tests, but adding a check mode option to `ansible-galaxy collection install` and using the GalaxyAPI interface for implementing `ansible-galaxy collection search` were suggested in passing when #75632 came up in backlog.

Between search/dry run + upgrade options, fixes #75632

Alternative to #77064 if the search UI won't be usable.

This allows getting the full collection metadata from a req:

    ansible-galaxy collection search amazon.aws
    ansible-galaxy collection search "amazon.aws:<=3.0.0"

And searching for namespaces for using a regex:

    ansible-galaxy collection search --pattern community\..+

* [ ] Tests
* [ ] Documentation
* [ ] Changelog

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
