### PR TITLE
Don't call python just to do isatty() in integration test

### DIFF
--- a/test/integration/targets/ansible-test-no-tty/runme.py
+++ b/test/integration/targets/ansible-test-no-tty/runme.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-
-import sys
-
-assert not sys.stdin.isatty()
-assert not sys.stdout.isatty()
-assert not sys.stderr.isatty()

--- a/test/integration/targets/ansible-test-no-tty/runme.sh
+++ b/test/integration/targets/ansible-test-no-tty/runme.sh
@@ -2,4 +2,7 @@
 
 set -eux
 
-./runme.py
+unexpected=
+test ! -t 0 || ${unexpected:?stdin is a tty}
+test ! -t 1 || ${unexpected:?stdout is a tty}
+test ! -t 2 || ${unexpected:?stderr is a tty}


### PR DESCRIPTION
##### SUMMARY

Don't unnecessarily invoke python.

I don't see why one would need python here. Either it should be documented, or dropped.

##### COMPONENT NAME

Integration test.
