### PR TITLE
Fix documentation with misleading data type

### DIFF
--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -268,7 +268,7 @@ mode:
     description: Permissions of the target, after execution.
     returned: success
     type: str
-    sample: 0644
+    sample: "0644"
 size:
     description: Size of the target, after execution.
     returned: success


### PR DESCRIPTION
##### SUMMARY
The sample value given for the 'mode' parameter is shown without quotes, but the data type is string. If you actually try to use an unquoted numeric string for this value (and don't use leading-0 octal notation...) you're in for a nasty surprise! I added quotation marks to the sample value.
##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
