### PR TITLE
Move undefined check from concat to finalize

### DIFF
--- a/changelogs/fragments/78156-undefined-check-in-finalize.yml
+++ b/changelogs/fragments/78156-undefined-check-in-finalize.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Move undefined check from concat to finalize (https://github.com/ansible/ansible/issues/78156)

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -673,7 +673,7 @@ class AnsibleNativeEnvironment(AnsibleEnvironment):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.finalize = _unroll_iterator(lambda thing: _fail_on_undefined(thing))
+        self.finalize = _unroll_iterator(_fail_on_undefined(thing))
 
 
 class Templar:

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -673,7 +673,7 @@ class AnsibleNativeEnvironment(AnsibleEnvironment):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.finalize = _unroll_iterator(_fail_on_undefined(thing))
+        self.finalize = lambda thing: _unroll_iterator(_fail_on_undefined(thing))
 
 
 class Templar:

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -609,6 +609,28 @@ def get_fqcr_and_name(resource, collection='ansible.builtin'):
     return fqcr, name
 
 
+def _fail_on_undefined(data):
+    """Recursively find an undefined value in a nested data structure
+    and properly raise the undefined exception.
+    """
+    if isinstance(data, Mapping):
+        for value in data.values():
+            _fail_on_undefined(value)
+    elif is_sequence(data):
+        for item in data:
+            _fail_on_undefined(item)
+    else:
+        if isinstance(data, StrictUndefined):
+            # To actually raise the undefined exception we need to
+            # access the undefined object otherwise the exception would
+            # be raised on the next access which might not be properly
+            # handled.
+            # See https://github.com/ansible/ansible/issues/52158
+            # and StrictUndefined implementation in upstream Jinja2.
+            str(data)
+    return data
+
+
 @_unroll_iterator
 def _ansible_finalize(thing):
     """A custom finalize function for jinja2, which prevents None from being
@@ -622,7 +644,7 @@ def _ansible_finalize(thing):
     which can produce a generator in the middle of a template are already
     wrapped with ``_unroll_generator`` in ``JinjaPluginIntercept``.
     """
-    return thing if thing is not None else ''
+    return thing if _fail_on_undefined(thing) is not None else ''
 
 
 class AnsibleEnvironment(NativeEnvironment):
@@ -651,7 +673,7 @@ class AnsibleNativeEnvironment(AnsibleEnvironment):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.finalize = _unroll_iterator(lambda thing: thing)
+        self.finalize = _unroll_iterator(lambda thing: _fail_on_undefined(thing))
 
 
 class Templar:

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -673,7 +673,7 @@ class AnsibleNativeEnvironment(AnsibleEnvironment):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.finalize = lambda thing: _unroll_iterator(_fail_on_undefined(thing))
+        self.finalize = _unroll_iterator(_fail_on_undefined)
 
 
 class Templar:

--- a/test/integration/targets/template/runme.sh
+++ b/test/integration/targets/template/runme.sh
@@ -42,3 +42,5 @@ ansible-playbook unsafe.yml -v "$@"
 ansible-playbook in_template_overrides.yml -v "$@"
 
 ansible-playbook lazy_eval.yml -i ../../inventory -v "$@"
+
+ansible-playbook undefined_in_import.yml -i ../../inventory -v "$@"

--- a/test/integration/targets/template/undefined_in_import-import.j2
+++ b/test/integration/targets/template/undefined_in_import-import.j2
@@ -1,0 +1,1 @@
+{{ undefined_variable }}

--- a/test/integration/targets/template/undefined_in_import.j2
+++ b/test/integration/targets/template/undefined_in_import.j2
@@ -1,0 +1,1 @@
+{% import 'undefined_in_import-import.j2' as t %}

--- a/test/integration/targets/template/undefined_in_import.yml
+++ b/test/integration/targets/template/undefined_in_import.yml
@@ -1,0 +1,11 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - debug:
+        msg: "{{ lookup('template', 'undefined_in_import.j2') }}"
+      ignore_errors: true
+      register: res
+
+    - assert:
+        that:
+          - "\"'undefined_variable' is undefined\" in res.msg"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In the classic Jinja2's Environment str() is called on the return value of the
finalize method to potentially trigger the undefined error. That is not
the case in NativeEnvironment where string conversion of the return value is
not desired. We workaround that by checking for Undefined in all of our concat
functions. It seems simpler to do it earlier in the finalize method(s) instead.
As a side-effect it fixes an undefined variable detection in imported templates.

Fixes #78156

ci_complete
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/template/__init__.py`
`lib/ansible/template/native_helpers.py`
