### PR TITLE
shell plugin now uses config system fully

### DIFF
--- a/changelogs/fragments/shell_env_fix.yml
+++ b/changelogs/fragments/shell_env_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - shell plugins now correctly use config settings, until now it was being overriden by action base class forcing use of keyword.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -682,9 +682,32 @@ DEFAULT_EXECUTABLE:
   description:
     - "This indicates the command to use to spawn a shell under, which is required for Ansible's execution needs on a target.
       Users may need to change this in rare instances when shell usage is constrained, but in most cases, it may be left as is."
-  env: [{name: ANSIBLE_EXECUTABLE}]
+  env:
+    - name: ANSIBLE_SHELL_EXECUTABLE
+      version_added: '2.20'
+    - name: ANSIBLE_EXECUTABLE
   ini:
-  - {key: executable, section: defaults}
+    - {key: executable, section: defaults}
+  vars:
+    - name: ansible_shell_executable
+DEFAULT_FACT_PATH:
+  name: local fact path
+  description:
+    - "This option allows you to globally configure a custom path for 'local_facts' for the implied :ref:`ansible_collections.ansible.builtin.setup_module` task when using fact gathering."
+    - "If not set, it will fallback to the default from the ``ansible.builtin.setup`` module: ``/etc/ansible/facts.d``."
+    - "This does **not** affect  user defined tasks that use the ``ansible.builtin.setup`` module."
+    - The real action being created by the implicit task is currently    ``ansible.legacy.gather_facts`` module, which then calls the configured fact modules,
+      by default this will be ``ansible.builtin.setup`` for POSIX systems but other platforms might have different defaults.
+  env: [{name: ANSIBLE_FACT_PATH}]
+  ini:
+  - {key: fact_path, section: defaults}
+  type: string
+  deprecated:
+    # TODO: when removing set playbook/play.py to default=None
+    why: the module_defaults keyword is a more generic version and can apply to all calls to the
+         M(ansible.builtin.gather_facts) or M(ansible.builtin.setup) actions
+    version: "2.18"
+    alternatives: module_defaults
 DEFAULT_FILTER_PLUGIN_PATH:
   name: Jinja2 Filter Plugins Path
   default: '{{ ANSIBLE_HOME ~ "/plugins/filter:/usr/share/ansible/plugins/filter" }}'

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -356,38 +356,11 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
 
         return module_bits, module_path
 
-    def _compute_environment_string(self, raw_environment_out=None):
-        """
+    def _compute_environment_string(self):
+        '''
         Builds the environment string to be used when executing the remote task.
-        """
-
-        final_environment = dict()
-        if self._task.environment is not None:
-            environments = self._task.environment
-            if not isinstance(environments, list):
-                environments = [environments]
-
-            # The order of environments matters to make sure we merge
-            # in the parent's values first so those in the block then
-            # task 'win' in precedence
-            for environment in environments:
-                if environment is None or len(environment) == 0:
-                    continue
-                temp_environment = self._templar.template(environment)
-                if not isinstance(temp_environment, dict):
-                    raise AnsibleError("environment must be a dictionary, received %s (%s)" % (temp_environment, type(temp_environment)))
-                # very deliberately using update here instead of combine_vars, as
-                # these environment settings should not need to merge sub-dicts
-                final_environment.update(temp_environment)
-
-        if len(final_environment) > 0:
-            final_environment = self._templar.template(final_environment)
-
-        if isinstance(raw_environment_out, dict):
-            raw_environment_out.clear()
-            raw_environment_out.update(final_environment)
-
-        return self._connection._shell.env_prefix(**final_environment)
+        '''
+        return self._connection._shell.env_prefix()
 
     def _early_needs_tmp_path(self):
         """

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -84,7 +84,11 @@ class ShellBase(AnsiblePlugin):
         return 'ansible-tmp-%s-%s-%s' % (time.time(), os.getpid(), secrets.randbelow(2**48))
 
     def env_prefix(self, **kwargs):
-        return ' '.join(['%s=%s' % (k, self.quote(text_type(v))) for k, v in kwargs.items()])
+        # get those set via plugin
+        merged = self.env.copy()
+        # add those set by caller
+        merged.update(kwargs)
+        return ' '.join([f'%s=%s' % (k, self.quote(text_type(v))) for k, v in merged.items()])
 
     def join_path(self, *args):
         return os.path.join(*args)


### PR DESCRIPTION
  removed 'action plugin hack' that did it's own
  inheritance/traversal of environment keywords

  this also allows for plugins to expand/define more sources of config

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/shell