### PR TITLE
Clarify that sbin directories are always looked at in get_bin_path

### DIFF
--- a/lib/ansible/module_utils/common/process.py
+++ b/lib/ansible/module_utils/common/process.py
@@ -16,6 +16,8 @@ def get_bin_path(arg, opt_dirs=None, required=None):
        - required:  [Deprecated] Prior to 2.10, if executable is not found and required is true it raises an Exception.
                     In 2.10 and later, an Exception is always raised. This parameter will be removed in 2.14.
        - opt_dirs:  optional list of directories to search in addition to PATH
+    In addition to PATH and opt_dirs, this function also looks through /sbin, /usr/sbin and /usr/local/sbin. A lot of
+    modules, especially for gathering facts, depend on this behaviour.
     If found return full path, otherwise raise ValueError.
     '''
     opt_dirs = [] if opt_dirs is None else opt_dirs


### PR DESCRIPTION
~~get_bin_path, according to it's documentation, is looking for a binary
in the $PATH. It actually also checks in /sbin, /usr/sbin and
/usr/local/sbin, which breaks stuff if you explicitly need to not look
in those directories either.~~

~~See #78169~~

After some discussion in this issue and the IRC/Matrix channel, we've come to the conclusion that a documentation change is better suited.


##### ISSUE TYPE
- Docs Pull Request