### PR TITLE
Allow force deletion of group

### DIFF
--- a/changelogs/fragments/78172-allow-force-deletion-of-group.yaml
+++ b/changelogs/fragments/78172-allow-force-deletion-of-group.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Allow force deletion of a group even when it is the primary group of a user. (https://github.com/ansible/ansible/issues/77849)

--- a/lib/ansible/modules/group.py
+++ b/lib/ansible/modules/group.py
@@ -41,7 +41,7 @@ options:
             - Only applicable on platforms which implement a --force flag on the group deletion command.
         type: bool
         default: false
-        version_added: "2.14"
+        version_added: "2.15"
     system:
         description:
             - If I(yes), indicates that the group created is a system group.

--- a/lib/ansible/modules/group.py
+++ b/lib/ansible/modules/group.py
@@ -35,6 +35,13 @@ options:
         type: str
         choices: [ absent, present ]
         default: present
+    force:
+        description:
+            - Whether to delete a group even if it is the primary group of a user.
+            - Only applicable on platforms which implement a --force flag on the group deletion command.
+        type: bool
+        default: false
+        version_added: "2.14"
     system:
         description:
             - If I(yes), indicates that the group created is a system group.
@@ -140,6 +147,7 @@ class Group(object):
         self.module = module
         self.state = module.params['state']
         self.name = module.params['name']
+        self.force = module.params['force']
         self.gid = module.params['gid']
         self.system = module.params['system']
         self.local = module.params['local']
@@ -242,6 +250,31 @@ class Group(object):
         except KeyError:
             return False
         return info
+
+
+# ===========================================
+
+class Linux(Group):
+    """
+    This is a Linux Group manipulation class. This is to apply the '-f' parameter to the groupdel command
+
+    This overrides the following methods from the generic class:-
+        - group_del()
+    """
+
+    platform = 'Linux'
+    distribution = None
+
+    def group_del(self):
+        if self.local:
+            command_name = 'lgroupdel'
+        else:
+            command_name = 'groupdel'
+        cmd = [self.module.get_bin_path(command_name, True)]
+        if self.force:
+            cmd.append('-f')
+        cmd.append(self.name)
+        return self.execute_command(cmd)
 
 
 # ===========================================
@@ -596,6 +629,7 @@ def main():
         argument_spec=dict(
             state=dict(type='str', default='present', choices=['absent', 'present']),
             name=dict(type='str', required=True),
+            force=dict(type='bool', default=False),
             gid=dict(type='int'),
             system=dict(type='bool', default=False),
             local=dict(type='bool', default=False),
@@ -606,6 +640,9 @@ def main():
             ['non_unique', True, ['gid']],
         ],
     )
+
+    if module.params['force'] and module.params['local']:
+        module.fail_json(msg='force is not a valid option for local, force=True and local=True are mutually exclusive')
 
     group = Group(module)
 

--- a/test/integration/targets/group/tasks/tests.yml
+++ b/test/integration/targets/group/tasks/tests.yml
@@ -345,6 +345,49 @@
       # only applicable to Linux, limit further to CentOS where 'lgroupadd' is installed
       when: ansible_distribution == 'CentOS'
 
+    # https://github.com/ansible/ansible/pull/78172
+    - block:
+        - name: Create a group
+          group:
+            name: groupdeltest
+            state: present
+
+        - name: Create user with primary group of groupdeltest
+          user:
+            name: groupdeluser
+            group: groupdeltest
+            state: present
+
+        - name: Show we can't delete the group usually
+          group:
+            name: groupdeltest
+            state: absent
+          ignore_errors: true
+          register: failed_delete
+
+        - name: assert we couldn't delete the group
+          assert:
+            that:
+              - failed_delete is failed
+
+        - name: force delete the group
+          group:
+            name: groupdeltest
+            force: true
+            state: absent
+
+      always:
+        - name: Cleanup user
+          user:
+            name: groupdeluser
+            state: absent
+
+        - name: Cleanup group
+          group:
+            name: groupdeltest
+            state: absent
+      when: ansible_distribution not in ["MacOSX", "Alpine", "FreeBSD"]
+
     # create system group
 
     - name: remove group


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allow force deletion of group if it is he primary group of a user.
fixes #77849 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
group

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
**before**
```
    - ansible.builtin.group:
        name: mygroup
        state: absent
```

```
fatal: [controller]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "force": false,
            "gid": null,
            "local": false,
            "name": "mygroup",
            "non_unique": false,
            "state": "absent",
            "system": false
        }
    },
    "msg": "groupdel: cannot remove the primary group of user 'myuser'\n",
    "name": "mygroup"
}
```

**after**
```
    - ansible.builtin.group:
        name: mygroup
        state: absent
        force: true
```

```paste below
changed: [controller] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "force": true,
            "gid": null,
            "local": false,
            "name": "mygroup",
            "non_unique": false,
            "state": "absent",
            "system": false
        }
    },
    "name": "mygroup",
    "state": "absent"
}
```
