### PR TITLE
[2.13] Make unit test for missing git executable more generic (#78173)

### DIFF
--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -181,13 +181,14 @@ def test_concrete_artifact_manager_scm_no_executable(monkeypatch):
     monkeypatch.setattr(collection.concrete_artifact_manager.subprocess, 'check_call', mock_subprocess_check_call)
     mock_mkdtemp = MagicMock(return_value='')
     monkeypatch.setattr(collection.concrete_artifact_manager, 'mkdtemp', mock_mkdtemp)
+    mock_get_bin_path = MagicMock(side_effect=[ValueError('Failed to find required executable')])
+    monkeypatch.setattr(collection.concrete_artifact_manager, 'get_bin_path', mock_get_bin_path)
 
     error = re.escape(
         "Could not find git executable to extract the collection from the Git repository `https://github.com/org/repo`"
     )
-    with mock.patch.dict(os.environ, {"PATH": ""}):
-        with pytest.raises(AnsibleError, match=error):
-            collection.concrete_artifact_manager._extract_collection_from_git(url, version, b'path')
+    with pytest.raises(AnsibleError, match=error):
+        collection.concrete_artifact_manager._extract_collection_from_git(url, version, b'path')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
##### SUMMARY
Backport for #78173

* Make unit test for missing git executable more generic

* use MagicMock side_effect to raise exception instead

(cherry picked from commit 1562672bd1d5a6bd300c09112e812ac040893ef6)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Test Pull Request
