### PR TITLE
Update dpkg_selections.py

### DIFF
--- a/lib/ansible/modules/dpkg_selections.py
+++ b/lib/ansible/modules/dpkg_selections.py
@@ -50,7 +50,7 @@ EXAMPLES = '''
 - name: Allow python to be upgraded
   ansible.builtin.dpkg_selections:
     name: python
-    selection: install        
+    selection: install
 '''
 
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/dpkg_selections.py
+++ b/lib/ansible/modules/dpkg_selections.py
@@ -46,6 +46,11 @@ EXAMPLES = '''
   ansible.builtin.dpkg_selections:
     name: python
     selection: hold
+
+- name: Allow python to be upgraded
+  ansible.builtin.dpkg_selections:
+    name: python
+    selection: install        
 '''
 
 from ansible.module_utils.basic import AnsibleModule


### PR DESCRIPTION
##### SUMMARY
Update dpkg_selections.py to include a syntax example showing how to remove package holds

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
dpkg_selections

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
While building my playbook I:

- Installed docker packages via apt
- Set them as on hold using dpkg_selections

I wanted to test removing the packages when it was time for an update but the apt task in the playbook failed stating that the packages were on hold.  When I went to look at the syntax there was no record of the syntax to remove the hold.

Some googling revealed on [askUbuntu](https://askubuntu.com/questions/164587/how-can-you-unhold-remove-a-hold-on-a-package) that you need to set the status to installed to remove the hold status

This pull request adds an example for this to the docs.