### PR TITLE
stat only returns pw_name/gr_name if those can be looked up

### DIFF
--- a/lib/ansible/modules/stat.py
+++ b/lib/ansible/modules/stat.py
@@ -322,12 +322,12 @@ stat:
             sample: 50ba294cdf28c0d5bcde25708df53346825a429f
         pw_name:
             description: User name of owner
-            returned: success, path exists and user can read stats and installed python supports it
+            returned: success, path exists, user can read stats, owner name can be looked up and installed python supports it
             type: str
             sample: httpd
         gr_name:
             description: Group name of owner
-            returned: success, path exists and user can read stats and installed python supports it
+            returned: success, path exists, user can read stats, owner group can be looked up and installed python supports it
             type: str
             sample: www-data
         mimetype:


### PR DESCRIPTION


##### SUMMARY
if a path is owned by a UID/GID that cannot be looked up to a user/group name, `pw_name`/`gr_name` won't be set
##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
stat

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
