### PR TITLE
added --allow-change-held-packages for apt remove

### DIFF
--- a/changelogs/fragments/apt-remove_allow-change-held-packages.yml
+++ b/changelogs/fragments/apt-remove_allow-change-held-packages.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - apt - add allow-change-held-packages option to apt remove (https://github.com/ansible/ansible/issues/78131)

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -893,7 +893,8 @@ def install_deb(
 
 
 def remove(m, pkgspec, cache, purge=False, force=False,
-           dpkg_options=expand_dpkg_options(DPKG_OPTIONS), autoremove=False):
+           dpkg_options=expand_dpkg_options(DPKG_OPTIONS), autoremove=False,
+           allow_change_held_packages=False):
     pkg_list = []
     pkgspec = expand_pkgspec_from_fnmatches(m, pkgspec, cache)
     for package in pkgspec:
@@ -926,7 +927,21 @@ def remove(m, pkgspec, cache, purge=False, force=False,
         else:
             check_arg = ''
 
-        cmd = "%s -q -y %s %s %s %s %s remove %s" % (APT_GET_CMD, dpkg_options, purge, force_yes, autoremove, check_arg, packages)
+        if allow_change_held_packages:
+            allow_change_held_packages = '--allow-change-held-packages'
+        else:
+            allow_change_held_packages = ''
+
+        cmd = "%s -q -y %s %s %s %s %s %s remove %s" % (
+            APT_GET_CMD,
+            dpkg_options,
+            purge,
+            force_yes,
+            autoremove,
+            check_arg,
+            allow_change_held_packages,
+            packages
+        )
 
         with PolicyRcD(m):
             rc, out, err = m.run_command(cmd)
@@ -1433,7 +1448,16 @@ def main():
                 else:
                     module.fail_json(**retvals)
             elif p['state'] == 'absent':
-                remove(module, packages, cache, p['purge'], force=force_yes, dpkg_options=dpkg_options, autoremove=autoremove)
+                remove(
+                    module,
+                    packages,
+                    cache,
+                    p['purge'],
+                    force=force_yes,
+                    dpkg_options=dpkg_options,
+                    autoremove=autoremove,
+                    allow_change_held_packages=allow_change_held_packages
+                )
 
         except apt.cache.LockFailedException as lockFailedException:
             if time.time() < deadline:

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -356,7 +356,7 @@
       - libcaca-dev
       - libslang2-dev
 
-# https://github.com/ansible/ansible/issues/38995
+# # https://github.com/ansible/ansible/issues/38995
 - name: build-dep for a package
   apt:
     name: tree
@@ -508,18 +508,35 @@
       - "allow_change_held_packages_no_update is not changed"
       - "allow_change_held_packages_hello_version.stdout == allow_change_held_packages_hello_version_again.stdout"
 
+# Remove pkg on hold
+- name: Put hello on hold
+  shell: apt-mark hold hello
+
+- name: Get hold list
+  shell: apt-mark showhold
+  register: hello_hold
+
+- name: Check that the package hello is on the hold list
+  assert:
+    that:
+      - "'hello' in hello_hold.stdout"
+
 - name: Try removing package hello
   apt:
     name: hello
     state: absent
   register: package_removed
-  check_mode: yes
-  ignore_errors: True
+  ignore_errors: true
+
+- name: verify the package is not removed with dpkg
+  shell: dpkg -l hello
+  register: dpkg_result
 
 - name: Verify that package was not removed
   assert:
     that:
     - package_removed is failed
+    - dpkg_result is success
 
 - name: Try removing package (allow_change_held_packages=yes)
   apt:
@@ -527,12 +544,18 @@
     state: absent
     allow_change_held_packages: yes
   register: package_removed
-  check_mode: yes
 
-- name: Verify that package was removed
+- name: verify the package is removed with dpkg
+  shell: dpkg -l hello
+  register: dpkg_result
+  ignore_errors: true
+
+- name: Verify that package removal was succesfull
   assert:
     that:
     - package_removed is success
+    - dpkg_result is failed
+    - package_removed.changed
 
 # Virtual package
 - name: Install a virtual package

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -508,6 +508,32 @@
       - "allow_change_held_packages_no_update is not changed"
       - "allow_change_held_packages_hello_version.stdout == allow_change_held_packages_hello_version_again.stdout"
 
+- name: Try removing package hello
+  apt:
+    name: hello
+    state: absent
+  register: package_removed
+  check_mode: yes
+  ignore_errors: True
+
+- name: Verify that package was not removed
+  assert:
+    that:
+    - package_removed is failed
+
+- name: Try removing package (allow_change_held_packages=yes)
+  apt:
+    name: hello
+    state: absent
+    allow_change_held_packages: yes
+  register: package_removed
+  check_mode: yes
+
+- name: Verify that package was removed
+  assert:
+    that:
+    - package_removed is success
+
 # Virtual package
 - name: Install a virtual package
   apt:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changed the apt module.
now when using apt remove (i.e. state=absent) it is possible to use the "allow-change-held-packages" parameter

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
fixes #78131

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
apt

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
