### PR TITLE
Ensure atomic writes for cache file (#78208)

### DIFF
--- a/changelogs/fragments/atomic_cache_files.yml
+++ b/changelogs/fragments/atomic_cache_files.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - file backed cache plugins now handle concurrent access by making atomic updates to the files.

--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -19,9 +19,10 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import copy
-import os
-import time
 import errno
+import os
+import tempfile
+import time
 
 from abc import abstractmethod
 from collections.abc import MutableMapping
@@ -162,10 +163,21 @@ class BaseFileCacheModule(BaseCacheModule):
         self._cache[key] = value
 
         cachefile = self._get_cache_file_name(key)
+        tmpfile_handle, tmpfile_path = tempfile.mkstemp(dir=os.path.dirname(cachefile))
         try:
-            self._dump(value, cachefile)
-        except (OSError, IOError) as e:
-            display.warning("error in '%s' cache plugin while trying to write to %s : %s" % (self.plugin_name, cachefile, to_bytes(e)))
+            try:
+                self._dump(value, tmpfile_path)
+            except (OSError, IOError) as e:
+                display.warning("error in '%s' cache plugin while trying to write to '%s' : %s" % (self.plugin_name, tmpfile_path, to_bytes(e)))
+            try:
+                os.rename(tmpfile_path, cachefile)
+            except (OSError, IOError) as e:
+                display.warning("error in '%s' cache plugin while trying to move '%s' to '%s' : %s" % (self.plugin_name, tmpfile_path, cachefile, to_bytes(e)))
+        finally:
+            try:
+                os.unlink(tmpfile_path)
+            except OSError:
+                pass
 
     def has_expired(self, key):
 


### PR DESCRIPTION
* Ensure atomic writes for cache file

 helps avoid errors in highly concurrent environments

(cherry picked from commit f6419a53f6e954e5fae8cd3102619dadb6938272)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cache plugins