### PR TITLE
Ensure atomic writes for cache file (#78208)

### DIFF
--- a/changelogs/fragments/atomic_cache_files.yml
+++ b/changelogs/fragments/atomic_cache_files.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - file backed cache plugins now handle concurrent access by making atomic updates to the files.


### PR DESCRIPTION
* Ensure atomic writes for cache file

 helps avoid errors in highly concurrent environments

(cherry picked from commit f6419a53f6e954e5fae8cd3102619dadb6938272)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cache plugins