### PR TITLE
improve set_password_expire() exec condition

### DIFF
--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1081,17 +1081,14 @@ class User(object):
         return info
 
     def set_password_expire(self):
-        min_needs_change = self.password_expire_min is not None
-        max_needs_change = self.password_expire_max is not None
-
         if HAVE_SPWD:
             try:
                 shadow_info = getspnam(to_bytes(self.name))
             except ValueError:
                 return None, '', ''
 
-            min_needs_change &= self.password_expire_min != shadow_info.sp_min
-            max_needs_change &= self.password_expire_max != shadow_info.sp_max
+            min_needs_change = self.password_expire_min != shadow_info.sp_min
+            max_needs_change = self.password_expire_max != shadow_info.sp_max
 
         if not (min_needs_change or max_needs_change):
             return (None, '', '')  # target state already reached
@@ -3235,7 +3232,8 @@ def main():
             result['ssh_key_file'] = user.get_ssh_key_path()
             result['ssh_public_key'] = user.get_ssh_public_key()
 
-        (rc, out, err) = user.set_password_expire()
+        if not (user.password_expire_min is None and user.password_expire_max is None):
+            (rc, out, err) = user.set_password_expire()
         if rc is None:
             pass  # target state reached, nothing to do
         else:


### PR DESCRIPTION
##### SUMMARY
If you do not pass password_expire_min and password_expire_max options, the /etc/shadow file will still be read. This crashes when the code runs without /etc/shadow permission(like non-root user) and also reads the /etc/shadow file unnecessarily

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
user

##### ADDITIONAL INFORMATION
Run from non-root user when user is exist:
```
ansible -m user localhost -a 'user=user' 
[WARNING]: No inventory was parsed, only implicit localhost is available
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: PermissionError: [Errno 13] Permission denied
localhost | FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/home/user/.ansible/tmp/ansible-tmp-1657220735.5098321-483-38456786289530/AnsiballZ_user.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/home/user/.ansible/tmp/ansible-tmp-1657220735.5098321-483-38456786289530/AnsiballZ_user.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/user/.ansible/tmp/ansible-tmp-1657220735.5098321-483-38456786289530/AnsiballZ_user.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible.modules.user', init_globals=dict(_module_fqn='ansible.modules.user', _modlib_path=modlib_path),\n  File \"/usr/lib64/python3.10/runpy.py\", line 209, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.10/runpy.py\", line 96, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib64/python3.10/runpy.py\", line 86, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_user_payload_a9jzdk81/ansible_user_payload.zip/ansible/modules/user.py\", line 3222, in <module>\n  File \"/tmp/ansible_user_payload_a9jzdk81/ansible_user_payload.zip/ansible/modules/user.py\", line 3208, in main\n  File \"/tmp/ansible_user_payload_a9jzdk81/ansible_user_payload.zip/ansible/modules/user.py\", line 1055, in set_password_expire\nPermissionError: [Errno 13] Permission denied\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
```
