### PR TITLE
Fix wording for :ref|term: substitution (#78216)

### DIFF
--- a/changelogs/fragments/fix_adoc_text.yml
+++ b/changelogs/fragments/fix_adoc_text.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-doc will not add 'website for' in ":ref:" substitutions as it made them confusing.

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -408,10 +408,10 @@ class DocCLI(CLI, RoleMixin):
         t = cls._RULER.sub("\n{0}\n".format("-" * 13), t)   # HORIZONTALLINE => -------
 
         # remove rst
-        t = cls._RST_SEEALSO.sub(r"See website for:", t)   # seealso is special and need to break
-        t = cls._RST_NOTE.sub(r"Note:", t)                 # .. note:: to note:
-        t = cls._RST_ROLES.sub(r"website for `", t)        # remove :ref: and other tags
-        t = cls._RST_DIRECTIVES.sub(r"", t)                # remove .. stuff:: in general
+        t = cls._RST_SEEALSO.sub(r"See also:", t)   # seealso to See also:
+        t = cls._RST_NOTE.sub(r"Note:", t)          # .. note:: to note:
+        t = cls._RST_ROLES.sub(r"`", t)             # remove :ref: and other tags, keep tilde to match ending one
+        t = cls._RST_DIRECTIVES.sub(r"", t)         # remove .. stuff:: in general
 
         return t
 

--- a/test/units/cli/test_doc.py
+++ b/test/units/cli/test_doc.py
@@ -29,9 +29,9 @@ TTY_IFY_DATA = {
     'L(the user guide, https://docs.ansible.com/)': 'the user guide <https://docs.ansible.com/>',
     'R(the user guide, user-guide)': 'the user guide',
     # de-rsty refs and anchors
-    'yolo :ref:`my boy` does stuff': 'yolo website for `my boy` does stuff',
-    '.. seealso:: Something amazing': 'See website for: Something amazing',
-    '.. seealso:: Troublesome multiline\n Stuff goes htere': 'See website for: Troublesome multiline\n Stuff goes htere',
+    'yolo :ref:`my boy` does stuff': 'yolo `my boy` does stuff',
+    '.. seealso:: Something amazing': 'See also: Something amazing',
+    '.. seealso:: Troublesome multiline\n Stuff goes htere': 'See also: Troublesome multiline\n Stuff goes htere',
     '.. note:: boring stuff': 'Note: boring stuff',
 }
 


### PR DESCRIPTION
* Fix workding for :ref|term: subsitution

 now matches 'seealso' and makes more sense:

  ```
  delay:
  applies_to:
  - Task
  description: Number of seconds to delay between retries. This setting is only used
    in combination with `until`.
  ```
 vs
  ```
  delay:
  applies_to:
  - Task
  description: Number of seconds to delay between retries. This setting is only used
    in combination with website for `until`.
  ```

* updated unit tests

* match see also

* more sanity

(cherry picked from commit d26801e9943a4603975965a24d8ad83ac8798dba)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-doc