### PR TITLE
validate-modules - allow raw module return type

### DIFF
--- a/changelogs/fragments/validate-modules-module-raw-return-type.yml
+++ b/changelogs/fragments/validate-modules-module-raw-return-type.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- validate-modules - Allow ``type: raw`` on a module return type definition for values that have a dynamic type

--- a/changelogs/fragments/validate-modules-module-raw-return-type.yml
+++ b/changelogs/fragments/validate-modules-module-raw-return-type.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- validate-modules - Allow ``type: raw`` on a module return type definition for values that have a dynamic type
+- 'validate-modules - Allow ``type: raw`` on a module return type definition for values that have a dynamic type'

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
@@ -674,7 +674,7 @@ def return_contains(v):
 
 def return_schema(for_collection, plugin_type='module'):
     if plugin_type == 'module':
-        return_types = Any('bool', 'complex', 'dict', 'float', 'int', 'list', 'str')
+        return_types = Any('bool', 'complex', 'dict', 'float', 'int', 'list', 'raw', 'str')
         element_types = Any(None, 'bits', 'bool', 'bytes', 'dict', 'float', 'int', 'json', 'jsonarg', 'list', 'path', 'raw', 'sid', 'str')
     else:
         return_types = Any(None, 'boolean', 'bool', 'integer', 'int', 'float', 'list', 'dict', 'dictionary', 'path', 'str', 'string', 'raw')


### PR DESCRIPTION
##### SUMMARY
Adds the `raw` as a valid `type` value for a module return type. This is useful for modules that return values with dynamic types based on the action that is being performed. Using `type: complex` doesn't work because the complex definition requires `contains`.

It would be nice if this could be backported but I understand if it must go through as a feature change.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test
validate-modules