### PR TITLE
Added Kylin Linux Advanced Server Support

### DIFF
--- a/changelogs/fragments/kylin_linux_advanced_server_distribution_support.yml
+++ b/changelogs/fragments/kylin_linux_advanced_server_distribution_support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Added Kylin Linux Advanced Server OS in RedHat OS Family.

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -511,7 +511,7 @@ class Distribution(object):
                                 'Ascendos', 'CloudLinux', 'PSBM', 'OracleLinux', 'OVS',
                                 'OEL', 'Amazon', 'Virtuozzo', 'XenServer', 'Alibaba',
                                 'EulerOS', 'openEuler', 'AlmaLinux', 'Rocky', 'TencentOS',
-                                'EuroLinux'],
+                                'EuroLinux', 'Kylin Linux Advanced Server'],
                      'Debian': ['Debian', 'Ubuntu', 'Raspbian', 'Neon', 'KDE neon',
                                 'Linux Mint', 'SteamOS', 'Devuan', 'Kali', 'Cumulus Linux',
                                 'Pop!_OS', 'Parrot', 'Pardus GNU/Linux', 'Uos', 'Deepin'],

--- a/test/units/module_utils/facts/system/distribution/fixtures/kylin_linux_advanced_server_v10.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/kylin_linux_advanced_server_v10.json
@@ -1,0 +1,38 @@
+{
+    "name": "Kylin Linux Advanced Server V10",
+    "distro": {
+        "codename": "Sword",
+        "id": "kylin",
+        "name": "Kylin Linux Advanced Server",
+        "version": "V10",
+        "version_best": "V10",
+        "lsb_release_info": {},
+        "os_release_info": {
+            "name": "Kylin Linux Advanced Server",
+            "version": "V10 (Sword)",
+            "id": "kylin",
+            "version_id": "V10",
+            "pretty_name": "Kylin Linux Advanced Server V10 (Sword)",
+            "ansi_color": "0;31",
+            "codename": "Sword"
+        }
+    },
+    "input": {
+        "/etc/system-release": "Kylin Linux Advanced Server release V10 (Sword)\n",
+        "/etc/os-release": "NAME=\"Kylin Linux Advanced Server\"\nVERSION=\"V10 (Sword)\"\nID=\"kylin\"\nVERSION_ID=\"V10\"\nPRETTY_NAME=\"Kylin Linux Advanced Server V10 (Sword)\"\nANSI_COLOR=\"0;31\"\n\n",
+        "/etc/lsb-release": "DISTRIB_ID=Kylin\nDISTRIB_RELEASE=V10\nDISTRIB_CODENAME=juniper\nDISTRIB_DESCRIPTION=\"Kylin V10\"\nDISTRIB_KYLIN_RELEASE=V10\nDISTRIB_VERSION_TYPE=enterprise\nDISTRIB_VERSION_MODE=normal\n"
+    },
+    "platform.dist": [
+        "kylin",
+        "V10",
+        "Sword"
+    ],
+    "result": {
+        "distribution": "Kylin Linux Advanced Server",
+        "distribution_version": "V10",
+        "distribution_release": "Sword",
+        "distribution_major_version": "V10",
+        "os_family": "RedHat"
+    },
+    "platform.release": "4.19.90-24.4.v2101.ky10.x86_64"
+}


### PR DESCRIPTION
##### SUMMARY

Detect os_family for Kylin Linux Advanced Server as 'RedHat', instead of 'Kylin Linux Advanced Server'.

Signed-off-by: Kay Yan [kay.yan@daocloud.io](mailto:kay.yan@daocloud.io)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

changelogs/fragments/kylin_linux_advanced_server_distribution_support.yml
lib/ansible/module_utils/facts/system/distribution.py
test/units/module_utils/facts/system/distribution/fixtures/kylin_linux_advanced_server_v10.json