### PR TITLE
ansible-test - Drop Python 3.8 controller support.

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -93,8 +93,8 @@ stages:
               test: rhel/7.9
             - name: RHEL 8.6 py36
               test: rhel/8.6@3.6
-            - name: RHEL 8.6 py38
-              test: rhel/8.6@3.8
+            - name: RHEL 8.6 py39
+              test: rhel/8.6@3.9
             - name: RHEL 9.0
               test: rhel/9.0
             - name: FreeBSD 12.3
@@ -142,7 +142,6 @@ stages:
           nameFormat: Python {0}
           testFormat: galaxy/{0}/1
           targets:
-            - test: 3.8
             - test: 3.9
             - test: '3.10'
             - test: 3.11
@@ -154,7 +153,6 @@ stages:
           nameFormat: Python {0}
           testFormat: generic/{0}/1
           targets:
-            - test: 3.8
             - test: 3.9
             - test: '3.10'
             - test: 3.11

--- a/changelogs/fragments/ansible-test-drop-python-3.8-controller.yml
+++ b/changelogs/fragments/ansible-test-drop-python-3.8-controller.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Remove support for Python 3.8 on the controller.

--- a/test/lib/ansible_test/_internal/commands/sanity/mypy.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/mypy.py
@@ -101,16 +101,8 @@ class MypyTest(SanityMultipleVersion):
             display.warning(f'Skipping sanity test "{self.name}" due to missing virtual environment support on Python {args.controller_python.version}.')
             return SanitySkipped(self.name, python.version)
 
-        # Temporary hack to make Python 3.8 a remote-only Python version since we'll be dropping controller support for it soon.
-        # This avoids having to change annotations or add ignores for issues that are specific to that version.
-
-        change_version = '3.8'
-
-        if change_version not in CONTROLLER_PYTHON_VERSIONS or change_version in REMOTE_ONLY_PYTHON_VERSIONS:
-            raise Exception(f'Remove this hack now that Python {change_version} is not supported by the controller.')
-
-        controller_python_versions = tuple(version for version in CONTROLLER_PYTHON_VERSIONS if version != change_version)
-        remote_only_python_versions = REMOTE_ONLY_PYTHON_VERSIONS + (change_version,)
+        controller_python_versions = CONTROLLER_PYTHON_VERSIONS
+        remote_only_python_versions = REMOTE_ONLY_PYTHON_VERSIONS
 
         contexts = (
             MyPyContext('ansible-test', ['test/lib/ansible_test/_util/target/sanity/import/'], controller_python_versions),

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -27,7 +27,7 @@ from struct import unpack, pack
 from termios import TIOCGWINSZ
 
 try:
-    from typing_extensions import TypeGuard  # TypeGuard was added in Python 3.9
+    from typing_extensions import TypeGuard  # TypeGuard was added in Python 3.10
 except ImportError:
     TypeGuard = None
 

--- a/test/lib/ansible_test/_util/target/common/constants.py
+++ b/test/lib/ansible_test/_util/target/common/constants.py
@@ -10,10 +10,10 @@ REMOTE_ONLY_PYTHON_VERSIONS = (
     '3.5',
     '3.6',
     '3.7',
+    '3.8',
 )
 
 CONTROLLER_PYTHON_VERSIONS = (
-    '3.8',
     '3.9',
     '3.10',
     '3.11',

--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -159,10 +159,6 @@ bootstrap_remote_freebsd()
         # Declare platform/python version combinations which do not have supporting OS packages available.
         # For these combinations ansible-test will use pip to install the requirements instead.
         case "${platform_version}/${python_version}" in
-            "12.3/3.8")
-                ;;
-            "13.1/3.8")
-                ;;
             *)
                 jinja2_pkg=""  # not available
                 cryptography_pkg=""  # not available


### PR DESCRIPTION
##### SUMMARY

ansible-test - Drop Python 3.8 controller support.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
