### PR TITLE
Fix invalid characters warning when using suggested inventory group names on python_3_support.rst

### DIFF
--- a/docs/docsite/rst/reference_appendices/python_3_support.rst
+++ b/docs/docsite/rst/reference_appendices/python_3_support.rst
@@ -52,11 +52,11 @@ Using Python 3 on the managed machines with commands and playbooks
     localhost-py3 ansible_host=localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3
 
     # Example of setting a group of hosts to use Python3
-    [py3-hosts]
+    [py3_hosts]
     ubuntu16
     fedora27
 
-    [py3-hosts:vars]
+    [py3_hosts:vars]
     ansible_python_interpreter=/usr/bin/python3
 
 .. seealso:: :ref:`intro_inventory` for more information.


### PR DESCRIPTION
##### SUMMARY
Fix invalid characters warning when using example group names. (Replace dashes in example group name with underscores.)


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
Fix "[WARNING]: Invalid characters..." warning notice when using suggested "py3-hosts" group name.
Replaced dashes with underscores in example group name.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Python 3 documentation
