### PR TITLE
[2.13] Decode vaulted args before sending over ansible-connection. (#78236)

### DIFF
--- a/changelogs/fragments/ansible-connection_decode.yml
+++ b/changelogs/fragments/ansible-connection_decode.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-connection - decrypt vaulted parameters before sending over the socket, as
+    vault secrets are not available on the other side.

--- a/lib/ansible/module_utils/connection.py
+++ b/lib/ansible/module_utils/connection.py
@@ -144,7 +144,7 @@ class Connection(object):
             )
 
         try:
-            data = json.dumps(req, cls=AnsibleJSONEncoder)
+            data = json.dumps(req, cls=AnsibleJSONEncoder, vault_to_text=True)
         except TypeError as exc:
             raise ConnectionError(
                 "Failed to encode some variables as JSON for communication with ansible-connection. "


### PR DESCRIPTION
I'm not aware of a way to easily get vault secrets decoded on the
ansible-connection side without sending the vault secrets over the
connection in the same way, so just decode them for transport.

(cherry picked from commit fff14d7c1ddec30a8645a622f1742c927a18f059)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-connection