### PR TITLE
Deprecate use of Python crypt

### DIFF
--- a/changelogs/fragments/deprecate-crypt-support.yml
+++ b/changelogs/fragments/deprecate-crypt-support.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+- Encryption - Deprecate use of the Python crypt module due to it's impending removal from Python 3.13

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -99,6 +99,15 @@ class CryptHash(BaseHash):
 
         if algorithm not in self.algorithms:
             raise AnsibleError("crypt.crypt does not support '%s' algorithm" % self.algorithm)
+
+        display.deprecated(
+            "Encryption using the Python crypt module is deprecated. The "
+            "Python crypt module is deprecated and will be removed from "
+            "Python 3.13. Install the passlib library for continued "
+            "encryption functionality.",
+            version=2.17
+        )
+
         self.algo_data = self.algorithms[algorithm]
 
     def hash(self, secret, salt=None, salt_size=None, rounds=None, ident=None):


### PR DESCRIPTION
##### SUMMARY
Deprecate use of Python crypt

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/utils/encrypt.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
