### PR TITLE
user module - give an error for missing permissions to ensure requested state

### DIFF
--- a/changelogs/fragments/fix-silent-error-changing-user-password-expiration.yml
+++ b/changelogs/fragments/fix-silent-error-changing-user-password-expiration.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - Give an error if the password expiration may need to be updated but the shadow file can't be read.

--- a/test/integration/targets/user/tasks/test_expires.yml
+++ b/test/integration/targets/user/tasks/test_expires.yml
@@ -145,3 +145,30 @@
         that:
           - bsd_account_expiration.stdout == '0'
   when: ansible_facts.os_family == 'FreeBSD'
+
+- block:
+    - name: create an unprivileged user for next test
+      user:
+        name: unpriv
+        state: present
+
+    # https://github.com/ansible/ansible/pull/40341
+    - name: test modifying password expiration without permission is an error
+      user:
+        name: ansibulluser
+        expires: -1
+      become_user: unpriv
+      become: yes
+      ignore_errors: yes
+      register: password_exp_failed
+
+    - assert:
+        that:
+          - password_exp_failed is failed
+          #- password_exp_failed.rc == 13 os-dependent
+  always:
+    - name: remove unprivileged user
+      user:
+        name: unpriv
+        state: absent
+        remove: yes

--- a/test/integration/targets/user/tasks/test_expires.yml
+++ b/test/integration/targets/user/tasks/test_expires.yml
@@ -165,7 +165,7 @@
     - assert:
         that:
           - password_exp_failed is failed
-          #- password_exp_failed.rc == 13 os-dependent
+          - password_exp_failed.rc == 13
   always:
     - name: remove unprivileged user
       user:

--- a/test/integration/targets/user/tasks/test_expires_min_max.yml
+++ b/test/integration/targets/user/tasks/test_expires_min_max.yml
@@ -71,3 +71,42 @@
         that:
           - ansible_facts.getent_shadow['ansibulluser'][2] == '0'
           - ansible_facts.getent_shadow['ansibulluser'][3] == '0'
+
+    - block:
+        - name: create an unprivileged user for next test
+          user:
+            name: unpriv
+            state: present
+
+        # https://github.com/ansible/ansible/issues/78222
+        - name: test modifying password expiration without permission is an error
+          user:
+            name: ansibulluser
+            password_expire_min: 10
+            password_expire_max: 20
+          become_user: unpriv
+          become: yes
+          ignore_errors: yes
+          register: password_exp_failed
+
+        # https://github.com/ansible/ansible/issues/78017
+        - name: test permission error getting shadow info is ignored if password_expire_min and password_expire_max are None
+          user:
+            name: ansibulluser
+          become_user: unpriv
+          become: yes
+          ignore_errors: yes
+          register: password_exp_unchanged
+
+        - assert:
+            that:
+              - password_exp_unchanged is success
+              - not password_exp_unchanged.changed
+              - password_exp_failed is failed
+              #- password_exp_failed.rc == 13
+      always:
+        - name: remove unprivileged user
+          user:
+            name: unpriv
+            state: absent
+            remove: yes

--- a/test/integration/targets/user/tasks/test_expires_min_max.yml
+++ b/test/integration/targets/user/tasks/test_expires_min_max.yml
@@ -103,7 +103,7 @@
               - password_exp_unchanged is success
               - not password_exp_unchanged.changed
               - password_exp_failed is failed
-              #- password_exp_failed.rc == 13
+              - password_exp_failed.rc == 13
       always:
         - name: remove unprivileged user
           user:


### PR DESCRIPTION
##### SUMMARY
Fixes #78222

* Give an error instead of silently succeed when trying to modify password_expire_min/password_expire_max without permission.
* Fix unhandled traceback for expires option + lack of permission.

##### ISSUE TYPE
- Bugfix Pull Request
- Test Pull Request
