### PR TITLE
Updated release_and_maintenance.rst

### DIFF
--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -82,7 +82,7 @@ Ansible Community Package Release       Status                          Core ver
 ==================================      ============================    =========================
 7.0.0                                   In development (unreleased)     2.14
 `6.x Changelogs`_                       Current                         2.13
-`5.x Changelogs`_                       Unmaintained/EOL after 5.10     2.12
+`5.x Changelogs`_                       Unmaintained (end of life)      2.12
 `4.x Changelogs`_                       Unmaintained (end of life)      2.11
 `3.x Changelogs`_                       Unmaintained (end of life)      2.10
 `2.10 Changelogs`_                      Unmaintained (end of life)      2.10


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As Ansible 5.x has reached EOL after the 5.10.0 release, the same has been updated on the release_and_maintenance.rst doc
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- docs/docsite/rst/reference_appendices/release_and_maintenance.rst