### PR TITLE
Galaxy metadata awareness

### DIFF
--- a/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
@@ -581,7 +581,7 @@ Sharing roles: Ansible Galaxy
 
 The client ``ansible-galaxy`` is included in Ansible. The Galaxy client allows you to download roles from Ansible Galaxy, and also provides an excellent default framework for creating your own roles.
 
-Read the `Ansible Galaxy documentation <https://galaxy.ansible.com/docs/>`_ page for more information. One page there which refers back to this one frequently is the Galaxy Roles document which explains the required metadata your role needs for use in Galaxy <https://galaxy.ansible.com/docs/contributing/creating_role.html>. 
+Read the `Ansible Galaxy documentation <https://galaxy.ansible.com/docs/>`_ page for more information. A page that refers back to this one frequently is the Galaxy Roles document which explains the required metadata your role needs for use in Galaxy <https://galaxy.ansible.com/docs/contributing/creating_role.html>. 
 
 .. seealso::
 

--- a/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/user_guide/playbooks_reuse_roles.rst
@@ -32,7 +32,7 @@ By default Ansible will look in each directory within a role for a ``main.yml`` 
 - ``vars/main.yml`` - other variables for the role (see :ref:`playbooks_variables` for more information).
 - ``files/main.yml`` - files that the role deploys.
 - ``templates/main.yml`` - templates that the role deploys.
-- ``meta/main.yml`` - metadata for the role, including role dependencies.
+- ``meta/main.yml`` - metadata for the role, including role dependencies, and optional Galaxy metadata such as platforms supported etc.
 
 You can add other YAML files in some directories. For example, you can place platform-specific tasks in separate files and refer to them in the ``tasks/main.yml`` file:
 
@@ -581,7 +581,7 @@ Sharing roles: Ansible Galaxy
 
 The client ``ansible-galaxy`` is included in Ansible. The Galaxy client allows you to download roles from Ansible Galaxy, and also provides an excellent default framework for creating your own roles.
 
-Read the `Ansible Galaxy documentation <https://galaxy.ansible.com/docs/>`_ page for more information
+Read the `Ansible Galaxy documentation <https://galaxy.ansible.com/docs/>`_ page for more information. One page there which refers back to this one frequently is the Galaxy Roles document which explains the required metadata your role needs for use in Galaxy <https://galaxy.ansible.com/docs/contributing/creating_role.html>. 
 
 .. seealso::
 

--- a/docs/docsite/rst/user_guide/shared_snippets/role_directory.txt
+++ b/docs/docsite/rst/user_guide/shared_snippets/role_directory.txt
@@ -16,7 +16,7 @@
           defaults/         #
               main.yml      #  <-- default lower priority variables for this role
           meta/             #
-              main.yml      #  <-- role dependencies
+              main.yml      #  <-- role dependencies and optional Galaxy info
           library/          # roles can also include custom modules
           module_utils/     # roles can also include custom module_utils
           lookup_plugins/   # or other types of plugins, like lookup in this case


### PR DESCRIPTION


##### SUMMARY
This is a tweak based on my experience of reading the basic ansible user guide for roles, understanding it, building plenty of them, and then having no idea that Galaxy roles needed some special metadata sauce in order for things like requirements.yml to work. Having to google it and finding that Galaxy.ansible.com/docs has a doc about how to Create Roles made me say "I've already read an official doc about creating roles, wtf, why doesn't it even reference this". To be fair the Galaxy Creating Roles doc references back but the Ansible>User Guide>Roles document a lot, but the that one doesn't make any mention of the Galaxy Role Creation doc and it's non-optional metadata need. So I put in a few tweaks mentioning the optional Galaxy metadata and making it explicit that for roles going into Galaxy, or just using the `ansible-galaxy` tool, the guide for creating the role continues at that site. 

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
The Roles docs iin the basic User Guide now connects better with the Galaxy Role doc. 

##### ADDITIONAL INFORMATION

