### PR TITLE
Revert "Re-enable strategy units (#78293)"

### DIFF
--- a/test/units/plugins/strategy/test_strategy.py
+++ b/test/units/plugins/strategy/test_strategy.py
@@ -35,6 +35,8 @@ from ansible.plugins.strategy import StrategyBase
 
 import pytest
 
+pytestmark = pytest.mark.skipif(True, reason="Temporarily disabled due to fragile tests that need rewritten")
+
 
 class TestStrategyBase(unittest.TestCase):
 


### PR DESCRIPTION
##### SUMMARY

This reverts commit c6c9d90ca4cb21e796a5f1bda441250e04f97189.

The tests still fail periodically in CI:

```
12:11 =================================== FAILURES ===================================
12:11 _________ TestStrategyBase.test_strategy_base_process_pending_results __________
12:11 [gw1] linux -- Python 3.8.10 /usr/bin/python3.8
12:11 :-1: running the test CRASHED with signal 9
```

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

unit tests