### PR TITLE
ansible-test - Install `acl` on Alpine remotes.

### DIFF
--- a/changelogs/fragments/ansible-test-remote-acl.yml
+++ b/changelogs/fragments/ansible-test-remote-acl.yml
@@ -2,3 +2,4 @@ minor_changes:
   - ansible-test - Remote FreeBSD instances now have ACLs enabled on the root filesystem.
   - ansible-test - Remote Fedora instances now have the ``acl`` package installed.
   - ansible-test - Remote Ubuntu instances now have the ``acl`` package installed.
+  - ansible-test - Remote Alpine instances now have the ``acl`` package installed.

--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -85,6 +85,7 @@ bootstrap_remote_alpine()
     py_pkg_prefix="py3"
 
     packages="
+        acl
         bash
         gcc
         python3-dev


### PR DESCRIPTION
##### SUMMARY

ansible-test - Install `acl` on Alpine remotes.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
