### PR TITLE
[2.12] Drop custom repo from libuser install @ Alpine CI

### DIFF
--- a/test/integration/targets/group/tasks/tests.yml
+++ b/test/integration/targets/group/tasks/tests.yml
@@ -211,7 +211,7 @@
     - user_test_local_mode
 
 - name: Ensure lgroupadd is present - Alpine
-  command: apk add -U libuser --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
+  command: apk add -U libuser
   when: ansible_distribution == 'Alpine'
   tags:
     - user_test_local_mode

--- a/test/integration/targets/setup_cron/tasks/main.yml
+++ b/test/integration/targets/setup_cron/tasks/main.yml
@@ -27,6 +27,11 @@
       when: ansible_distribution != 'Alpine'
 
     - name: install faketime packages - Alpine
+      # NOTE: The `faketime` package is currently only available in the
+      # NOTE: `edge` branch.
+      # FIXME: If it ever becomes available in the `main` repository for
+      # FIXME: currently tested Alpine versions, the `--repository=...`
+      # FIXME: option can be dropped.
       command: apk add -U {{ faketime_pkg }} --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
       when: ansible_distribution == 'Alpine'
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`group` and `setup_cron` integration tests currently install `libuser` and `faketime`
packages respectively, from the non-default edge/testing repositories. It is no
longer necessary to do so for the former so this patch drops the repo option. As
for the latter, this patch includes a note explaining when the same could be done
for it too.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Integration tests w/ Alpine package installs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

It's a backport of https://github.com/ansible/ansible/pull/78305.