### PR TITLE
[2.11-only] Prepare Alpine signing keys for installs from edge

### DIFF
--- a/test/integration/targets/group/tasks/tests.yml
+++ b/test/integration/targets/group/tasks/tests.yml
@@ -211,12 +211,15 @@
     - user_test_local_mode
 
 - name: Ensure lgroupadd is present - Alpine
-  # NOTE: The `libuser` package is currently only available in the
-  # NOTE: `edge` branch.
-  # FIXME: If it ever becomes available in the `main` repository for
-  # FIXME: currently tested Alpine versions, the `--repository=...`
-  # FIXME: option can be dropped.
-  command: apk add -U libuser --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
+  block:
+    - name: Get the latest Alpine package signing keys
+      command: apk add -U -l -u alpine-keys
+      tags:
+        - user_test_local_mode
+    - name: Install libuser - Alpine
+      command: apk add -U libuser --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
+      tags:
+        - user_test_local_mode
   when: ansible_distribution == 'Alpine'
   tags:
     - user_test_local_mode

--- a/test/integration/targets/group/tasks/tests.yml
+++ b/test/integration/targets/group/tasks/tests.yml
@@ -211,6 +211,11 @@
     - user_test_local_mode
 
 - name: Ensure lgroupadd is present - Alpine
+  # NOTE: The `libuser` package is currently only available in the
+  # NOTE: `edge` branch.
+  # FIXME: If it ever becomes available in the `main` repository for
+  # FIXME: currently tested Alpine versions, the `--repository=...`
+  # FIXME: option can be dropped.
   command: apk add -U libuser --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
   when: ansible_distribution == 'Alpine'
   tags:

--- a/test/integration/targets/setup_cron/tasks/main.yml
+++ b/test/integration/targets/setup_cron/tasks/main.yml
@@ -27,6 +27,11 @@
       when: ansible_distribution != 'Alpine'
 
     - name: install faketime packages - Alpine
+      # NOTE: The `faketime` package is currently only available in the
+      # NOTE: `edge` branch.
+      # FIXME: If it ever becomes available in the `main` repository for
+      # FIXME: currently tested Alpine versions, the `--repository=...`
+      # FIXME: option can be dropped.
       command: apk add -U {{ faketime_pkg }} --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
       when: ansible_distribution == 'Alpine'
 

--- a/test/integration/targets/setup_cron/tasks/main.yml
+++ b/test/integration/targets/setup_cron/tasks/main.yml
@@ -32,7 +32,11 @@
       # FIXME: If it ever becomes available in the `main` repository for
       # FIXME: currently tested Alpine versions, the `--repository=...`
       # FIXME: option can be dropped.
-      command: apk add -U {{ faketime_pkg }} --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
+      block:
+        - name: Get the latest Alpine package signing keys
+          command: apk add -U -l -u alpine-keys
+        - name: Install {{ faketime_pkg }} - Alpine
+          command: apk add -U {{ faketime_pkg }} --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing
       when: ansible_distribution == 'Alpine'
 
     - name: Find libfaketime path


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Before this patch, the Ansible Core CI Alpine image integrated into
this branch only had old package signing keys pre-installed.
On July 14, 2022, Apline has rotated their RSA keys to the new
4096-bit ones[1]. This resulted in older unprepared systems being
unable to verify package downloads, causing the following in the logs:

    ERROR: http://dl-cdn.alpinelinux.org/alpine/edge/community:
    UNTRUSTED signature

This patch updates the system-trusted keys by upgrading the
`alpine-keys` package to the latest version. With the change, the old
package installs succeed again. In particular, this concerns the
`faketime` and `libuser` packages that are used in `group` and
`setup_cron` integration tests.

This change is only applied to ansible-core 2.11 since all the newer
release streams have an updated version of the Alpine container that
does not need this hack.

[1]: https://www.alpinelinux.org/posts/Alpine-edge-signing-keys-rotated.html


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`group` and `setup_cron` integration tests

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A
