### PR TITLE
Fix fetch integration test on macOS.

### DIFF
--- a/test/integration/targets/fetch/roles/fetch_tests/tasks/setup.yml
+++ b/test/integration/targets/fetch/roles/fetch_tests/tasks/setup.yml
@@ -18,6 +18,7 @@
   user:
     name: fetcher
     create_home: yes
+    group: "{{ _fetch_group | default(omit) }}"
     groups: "{{ _fetch_additional_groups | default(omit) }}"
     append: "{{ True if _fetch_additional_groups else False }}"
     password: "{{ password | default(omit) }}"

--- a/test/integration/targets/fetch/roles/fetch_tests/vars/Darwin.yml
+++ b/test/integration/targets/fetch/roles/fetch_tests/vars/Darwin.yml
@@ -1,3 +1,4 @@
 # macOS requires users to be in an additional group for ssh access
 
+_fetch_group: staff
 _fetch_additional_groups: com.apple.access_ssh


### PR DESCRIPTION
##### SUMMARY

Fix fetch integration test on macOS.

The test can now run split.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

fetch integration test
