### PR TITLE
apt - fix installing preferred candidate if no version is specified

### DIFF
--- a/changelogs/fragments/78319-apt-fix-installing-unspecified-version.yml
+++ b/changelogs/fragments/78319-apt-fix-installing-unspecified-version.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - apt - if the user hasn't specified a version, let the Python apt library determine the best candidate when installing/upgrading a package (https://github.com/ansible/ansible/issues/77969).

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -471,6 +471,19 @@ def package_split(pkgspec):
     return parts[0], None, None
 
 
+def package_versions(pkgname, pkg, pkg_cache):
+    try:
+        versions = set(p.version for p in pkg.versions)
+    except AttributeError:
+        # assume older version of python-apt is installed
+        # apt.package.Package#versions require python-apt >= 0.7.9.
+        pkg_cache_list = (p for p in pkg_cache.Packages if p.Name == pkgname)
+        pkg_versions = (p.VersionList for p in pkg_cache_list)
+        versions = set(p.VerStr for p in itertools.chain(*pkg_versions))
+
+    return versions
+
+
 def package_version_compare(version, other_version):
     try:
         return apt_pkg.version_compare(version, other_version)
@@ -478,7 +491,7 @@ def package_version_compare(version, other_version):
         return apt_pkg.VersionCompare(version, other_version)
 
 
-def package_best_match(pkgname, version_cmp, version, release, cache):
+def package_best_match(pkgname, version_cmp, version, release, cache, installed_version):
     policy = apt_pkg.Policy(cache)
     if release:
         # 990 is the priority used in `apt-get -t`
@@ -488,6 +501,27 @@ def package_best_match(pkgname, version_cmp, version, release, cache):
         policy.create_pin('Version', pkgname, version, 991)
     pkg = cache[pkgname]
     pkgver = policy.get_candidate_ver(pkg)
+
+    if version_cmp == ">=":
+        # Try to find version that satisfies current request and pinned versions
+        # Maybe Instead docs should have a note that pkg=ver/pkg>=ver disregard apt preferences?
+        dep_cache = apt_pkg.DepCache(cache)
+        better_ver = dep_cache.get_candidate_ver(pkg)
+        
+        if better_ver is not None and apt_pkg.version_compare(better_ver.ver_str, version) >= 0:
+            pkgver = better_ver
+    elif version_cmp is None and version and installed_version and pkgver is None:
+        # Make sure we indicate if any upgrade is available when version_cmp is None
+        versions = package_versions(pkgname, pkg, cache)
+        avail_upgrades = fnmatch.filter(versions, version)
+
+        for candidate in avail_upgrades:
+            if package_version_compare(candidate, installed_version) > 0:
+                # We delegate to apt to find the best match when version_cmp is None,
+                # so this candidate is not necessarily the one that will be installed.
+                pkgver = candidate
+                break
+
     if not pkgver:
         return None
     if version_cmp == "=" and not fnmatch.fnmatch(pkgver.ver_str, version):
@@ -548,15 +582,17 @@ def package_status(m, pkgname, version_cmp, version, default_release, cache, sta
             # assume older version of python-apt is installed
             package_is_installed = pkg.isInstalled
 
-    version_best = package_best_match(pkgname, version_cmp, version, default_release, cache._cache)
-    version_is_installed = False
-    version_installable = None
+    installed_version = None
     if package_is_installed:
         try:
             installed_version = pkg.installed.version
         except AttributeError:
             installed_version = pkg.installedVersion
 
+    version_best = package_best_match(pkgname, version_cmp, version, default_release, cache._cache, installed_version)
+    version_is_installed = False
+    version_installable = None
+    if package_is_installed:
         if version_cmp == "=":
             # check if the version is matched as well
             version_is_installed = fnmatch.fnmatch(installed_version, version)
@@ -688,7 +724,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         package_names.append(name)
         installed, installed_version, version_installable, has_files = package_status(m, name, version_cmp, version, default_release, cache, state='install')
         if (not installed and not only_upgrade) or (installed and not installed_version) or (upgrade and version_installable):
-            if version_installable or version:
+            if version_cmp is not None and (version_installable or version):
                 pkg_list.append("'%s=%s'" % (name, version_installable or version))
             else:
                 pkg_list.append("'%s'" % name)

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -507,7 +507,7 @@ def package_best_match(pkgname, version_cmp, version, release, cache, installed_
         # Maybe Instead docs should have a note that pkg=ver/pkg>=ver disregard apt preferences?
         dep_cache = apt_pkg.DepCache(cache)
         better_ver = dep_cache.get_candidate_ver(pkg)
-        
+
         if better_ver is not None and apt_pkg.version_compare(better_ver.ver_str, version) >= 0:
             pkgver = better_ver
     elif version_cmp is None and version and installed_version and pkgver is None:

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -693,7 +693,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         package_names.append(name)
         installed, installed_version, version_installable, has_files = package_status(m, name, version_cmp, version, default_release, cache, state='install')
         if (not installed and not only_upgrade) or (installed and not installed_version) or (upgrade and version_installable):
-            if version_cmp is not None and (version_installable or version):
+            if (version_cmp or default_release) and (version_installable or version):
                 pkg_list.append("'%s=%s'" % (name, version_installable or version))
             else:
                 pkg_list.append("'%s'" % name)

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -487,7 +487,12 @@ def package_best_match(pkgname, version_cmp, version, release, cache):
         # You can't pin to a minimum version, only equality with a glob
         policy.create_pin('Version', pkgname, version, 991)
     pkg = cache[pkgname]
-    pkgver = policy.get_candidate_ver(pkg)
+    if version_cmp or release:
+        pkgver = policy.get_candidate_ver(pkg)
+    else:
+        # Look for upgrades, respecting pinned versions
+        dep_cache = apt_pkg.DepCache(cache)
+        pkgver = dep_cache.get_candidate_ver(pkg)
     if not pkgver:
         return None
     if version_cmp == "=" and not fnmatch.fnmatch(pkgver.ver_str, version):

--- a/test/integration/targets/apt/tasks/repo.yml
+++ b/test/integration/targets/apt/tasks/repo.yml
@@ -72,32 +72,9 @@
       name: foo
       state: absent
 
-  - name: Test preferring pinned version when possible with >=
-    apt:
-      name: foo>=1.0.0
-      state: latest
-    register: apt_result
-
-  - name: Check install with dpkg
-    shell: dpkg-query -l foo
-    register: dpkg_result
-
-  - name: Check if install was successful
-    assert:
-      that:
-        - "apt_result is success"
-        - "dpkg_result is success"
-        # NOTE: latest version is not installed
-        - "'1.0.0' in dpkg_result.stdout"
-
-  - name: Remove foo between tests
-    apt:
-      name: foo
-      state: absent
-
   - name: Override pin with >=
     apt:
-      name: foo>=1.0.1
+      name: foo>=1.0.0
       state: latest
 
   - name: Check install with dpkg

--- a/test/integration/targets/apt/tasks/repo.yml
+++ b/test/integration/targets/apt/tasks/repo.yml
@@ -46,11 +46,30 @@
     copy:
       content: |-
               Package: foo
-              Pin: version 1.0.0
+              Pin: version 0.9.0
               Pin-Priority: 1001
       dest: /etc/apt/preferences.d/foo
 
+  # Test install code path
   - name: Install unspecified version
+    apt:
+      name: foo
+      state: present
+    register: apt_result
+
+  - name: Check install with dpkg
+    shell: dpkg-query -l foo
+    register: dpkg_result
+
+  - name: Check if install was successful
+    assert:
+      that:
+        - "apt_result is success"
+        - "dpkg_result is success"
+        - "'0.9.0' in dpkg_result.stdout"
+
+  # Test upgrade code path when no change is made
+  - name: Install unspecified version (idempotence)
     apt:
       name: foo
       state: latest
@@ -63,16 +82,40 @@
   - name: Check if install was successful
     assert:
       that:
-        - "apt_result is success"
-        - "dpkg_result is success"
-        - "'1.0.0' in dpkg_result.stdout"
+        - apt_result is success
+        - not apt_result.changed
+        - dpkg_result is success
+        - "'0.9.0' in dpkg_result.stdout"
 
-  - name: Remove foo between tests
+  - name: Update the pin to test upgrading with an unspecified version
+    copy:
+      content: |-
+              Package: foo
+              Pin: version 1.0.0
+              Pin-Priority: 1001
+      dest: /etc/apt/preferences.d/foo
+
+  # Test upgrade code path when a change is made
+  - name: Upgrade unspecified version
     apt:
       name: foo
-      state: absent
+      state: latest
+    register: apt_result
 
-  - name: Override pin with >=
+  - name: Check install with dpkg
+    shell: dpkg-query -l foo
+    register: dpkg_result
+
+  - name: Check if install was successful
+    assert:
+      that:
+        - apt_result is success
+        - apt_result.changed
+        - dpkg_result is success
+        - "'1.0.0' in dpkg_result.stdout"
+
+  # Test a specific version requested with >= ignores pinned versions
+  - name: Upgrade to latest version by specifying version
     apt:
       name: foo>=1.0.0
       state: latest
@@ -87,15 +130,16 @@
         - "dpkg_result is success"
         - "'1.0.1' in dpkg_result.stdout"
 
-  - name: Remove foo between tests
+  - name: Remove foo for next test
     apt:
       name: foo
       state: absent
 
-  - name: Override pin with =
+  # Test a specific version requested with = ignores pinned versions
+  - name: Install specific version
     apt:
       name: foo=1.0.1
-      state: latest
+      state: present
 
   - name: Check install with dpkg
     shell: dpkg-query -l foo

--- a/test/integration/targets/apt/tasks/repo.yml
+++ b/test/integration/targets/apt/tasks/repo.yml
@@ -40,6 +40,106 @@
         state: absent
         allow_unauthenticated: yes
 
+# https://github.com/ansible/ansible/issues/77969
+- block:
+  - name: Pin the preferred version of foo
+    copy:
+      content: |-
+              Package: foo
+              Pin: version 1.0.0
+              Pin-Priority: 1001
+      dest: /etc/apt/preferences.d/foo
+
+  - name: Install unspecified version
+    apt:
+      name: foo
+      state: latest
+    register: apt_result
+
+  - name: Check install with dpkg
+    shell: dpkg-query -l foo
+    register: dpkg_result
+
+  - name: Check if install was successful
+    assert:
+      that:
+        - "apt_result is success"
+        - "dpkg_result is success"
+        - "'1.0.0' in dpkg_result.stdout"
+
+  - name: Remove foo between tests
+    apt:
+      name: foo
+      state: absent
+
+  - name: Test preferring pinned version when possible with >=
+    apt:
+      name: foo>=1.0.0
+      state: latest
+    register: apt_result
+
+  - name: Check install with dpkg
+    shell: dpkg-query -l foo
+    register: dpkg_result
+
+  - name: Check if install was successful
+    assert:
+      that:
+        - "apt_result is success"
+        - "dpkg_result is success"
+        # NOTE: latest version is not installed
+        - "'1.0.0' in dpkg_result.stdout"
+
+  - name: Remove foo between tests
+    apt:
+      name: foo
+      state: absent
+
+  - name: Override pin with >=
+    apt:
+      name: foo>=1.0.1
+      state: latest
+
+  - name: Check install with dpkg
+    shell: dpkg-query -l foo
+    register: dpkg_result
+
+  - name: Check if install was successful
+    assert:
+      that:
+        - "dpkg_result is success"
+        - "'1.0.1' in dpkg_result.stdout"
+
+  - name: Remove foo between tests
+    apt:
+      name: foo
+      state: absent
+
+  - name: Override pin with =
+    apt:
+      name: foo=1.0.1
+      state: latest
+
+  - name: Check install with dpkg
+    shell: dpkg-query -l foo
+    register: dpkg_result
+
+  - name: Check if install was successful
+    assert:
+      that:
+        - "dpkg_result is success"
+        - "'1.0.1' in dpkg_result.stdout"
+  always:
+  - name: Clean up package
+    apt:
+      name: foo
+      state: absent
+      allow_unauthenticated: yes
+
+  - name: Clean up file
+    file:
+      path: /etc/apt/preferences.d/foo
+      state: absent
 
 # https://github.com/ansible/ansible/issues/30638
 - block:
@@ -105,7 +205,11 @@
       - ["=1.0.0", null, false, null]
       - ["=1.0.0", null, true, null]
       - ["=1.0.1", null, false, "1.0.1"]
-      #- ["=1.0.*", null, false, null] # legacy behavior. should not upgrade without state=latest
+      # legacy behavior that should be deprecated
+      # should not upgrade without state=latest
+      - ["=1.0.*", null, false, "1.0.1"]
+      # uncomment correct assertion once deprecation period is complete
+      # - ["=1.0.*", null, false, null]
       - ["=1.0.*", null, true, "1.0.1"]
       - [">=1.0.0", null, false, null]
       - [">=1.0.0", null, true, "1.0.1"]

--- a/test/integration/targets/setup_deb_repo/files/package_specs/stable/foo-0.9.0
+++ b/test/integration/targets/setup_deb_repo/files/package_specs/stable/foo-0.9.0
@@ -1,0 +1,10 @@
+Section: misc
+Priority: optional
+Standards-Version: 2.3.3
+
+Package: foo
+Version: 0.9.0
+Section: system
+Maintainer: John Doe <john@doe.com>
+Architecture: all
+Description: Dummy package


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/ansible/commit/4a62c4e3e44b01a904aa86e9b87206a24bd41fbc added a new feature to specify a new comparison operator (>=), but also changed the "best version" if no comparison operator is specified, instead of delegating to apt. This fixes that.

Fixes #77969

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
