### PR TITLE
[stable-2.13] ansible-test - Fix handling of args after `--` (#78328)

### DIFF
--- a/changelogs/fragments/ansible-test-filter-options.yml
+++ b/changelogs/fragments/ansible-test-filter-options.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Delegation now properly handles arguments given after ``--`` on the command line.

--- a/test/lib/ansible_test/_internal/config.py
+++ b/test/lib/ansible_test/_internal/config.py
@@ -269,8 +269,8 @@ class IntegrationConfig(TestConfig):
         self.tags = args.tags
         self.skip_tags = args.skip_tags
         self.diff = args.diff
-        self.no_temp_workdir = args.no_temp_workdir
-        self.no_temp_unicode = args.no_temp_unicode
+        self.no_temp_workdir = args.no_temp_workdir  # type: bool
+        self.no_temp_unicode = args.no_temp_unicode  # type: bool
 
         if self.list_targets:
             self.explain = True


### PR DESCRIPTION
##### SUMMARY

Backport of #78328

(cherry picked from commit 0012263c7acd971335d9f1c8a0ccc69b7e3325ee)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
