### PR TITLE
update the out-of-date ansible-test sanity ignores

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/ignores.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/ignores.rst
@@ -85,7 +85,8 @@ Below are some example skip entries for an Ansible collection::
 
     plugins/module_utils/my_util.py validate-modules!skip # waiting for bug fix in module validator
     plugins/lookup/my_plugin.py compile-2.6!skip # Python 2.6 is not supported on the controller
-    For a full list of sanity tests and test names, see :ref:`all_sanity_tests <https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/index.html#all-sanity-tests>`
+
+For a full list of sanity tests and test names, see :ref:`all_sanity_tests <https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/index.html#all-sanity-tests>`
 
 Ignore File Errors
 ------------------

--- a/docs/docsite/rst/dev_guide/testing/sanity/ignores.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/ignores.rst
@@ -74,7 +74,7 @@ If the named test uses error codes then the error code to ignore must be appende
 Below are some example ignore entries for an Ansible collection::
 
     roles/my_role/files/my_script.sh shellcheck:SC2154 # ignore undefined variable
-    plugins/modules/my_module.py validate-modules:E105 # ignore license check
+    plugins/modules/my_module.py validate-modules:missing-gplv3-license # ignore license check
     plugins/modules/my_module.py import-3.8 # needs update to support collections.abc on Python 3.8+
 
 It is also possible to skip a sanity test for a specific file.
@@ -85,6 +85,7 @@ Below are some example skip entries for an Ansible collection::
 
     plugins/module_utils/my_util.py validate-modules!skip # waiting for bug fix in module validator
     plugins/lookup/my_plugin.py compile-2.6!skip # Python 2.6 is not supported on the controller
+    For a full list of sanity tests and test names, see :ref:`all_sanity_tests <https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/index.html#all-sanity-tests>`
 
 Ignore File Errors
 ------------------

--- a/docs/docsite/rst/dev_guide/testing/sanity/ignores.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/ignores.rst
@@ -86,7 +86,7 @@ Below are some example skip entries for an Ansible collection::
     plugins/module_utils/my_util.py validate-modules!skip # waiting for bug fix in module validator
     plugins/lookup/my_plugin.py compile-2.6!skip # Python 2.6 is not supported on the controller
 
-For a full list of sanity tests and test names, see :ref:`all_sanity_tests <https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/index.html#all-sanity-tests>`
+See the full list of :ref:`sanity tests <all_sanity_tests>`, which details the various tests and details how to fix identified issues.
 
 Ignore File Errors
 ------------------


### PR DESCRIPTION
##### SUMMARY
Examples in ansible-test sanity ignores are out-of-date

Fixes #78198 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/dev_guide/testing/sanity/ignores.rst

##### ADDITIONAL INFORMATION
- Change 'E105' to 'missing-gplv3-license' at https://github.com/ansible/ansible/blame/devel/docs/docsite/rst/dev_guide/testing/sanity/ignores.rst#L77
-  Add link for reference of `all_sanity_tests` at https://github.com/ansible/ansible/blame/devel/docs/docsite/rst/dev_guide/testing/sanity/ignores.rst#L88
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
