### PR TITLE
Make PluginLoader pseudo-import more like Python's

### DIFF
--- a/changelogs/fragments/self_referential.yml
+++ b/changelogs/fragments/self_referential.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix PluginLoader to mimic Python import machinery by adding module to sys.modules before exec

--- a/test/integration/targets/plugin_loader/normal/action_plugins/self_referential.py
+++ b/test/integration/targets/plugin_loader/normal/action_plugins/self_referential.py
@@ -1,0 +1,29 @@
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+
+import sys
+
+# reference our own module from sys.modules while it's being loaded to ensure the importer behaves properly
+try:
+    mod = sys.modules[__name__]
+except KeyError:
+    raise Exception(f'module {__name__} is not accessible via sys.modules, likely a pluginloader bug')
+
+
+class ActionModule(ActionBase):
+    TRANSFERS_FILES = False
+
+    def run(self, tmp=None, task_vars=None):
+        if task_vars is None:
+            task_vars = dict()
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        result['changed'] = False
+        result['msg'] = 'self-referential action loaded and ran successfully'
+        return result

--- a/test/integration/targets/plugin_loader/normal/self_referential.yml
+++ b/test/integration/targets/plugin_loader/normal/self_referential.yml
@@ -1,0 +1,5 @@
+- hosts: testhost
+  gather_facts: false
+  tasks:
+    - name: ensure a self-referential action plugin loads properly
+      self_referential:


### PR DESCRIPTION
##### SUMMARY
When PluginLoader was updated to use a non-`imp` import for Py3, the new behavior missed a critical nuance of the Python import machinery. Modules being imported are added to `sys.modules` *before* the code is exec'd to populate the module. This allows the module to refer to itself, and also to avoid a re-entrant import if a child module explicitly imports the parent. 

This change fixes PluginLoader to behave like the Python import does (including removal of the half-baked module from sys.modules if there's an exception during the import/exec phase). For all collections and Ansible-internal cases (basically anything but loading from legacy `X_plugins` dirs), this code path should be bypassed in favor of a direct import, but I'll leave that change for another time...

Without this change, plugins that need to refer to their own module during import (eg, some cases with `dataclasses`) will fail to import.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
PluginLoader

##### ADDITIONAL INFORMATION
