### PR TITLE
[stable-2.13] swallow all exceptions in type annotation support shim imports (#77860)

### DIFF
--- a/changelogs/fragments/type_shim_exception_swallow.yml
+++ b/changelogs/fragments/type_shim_exception_swallow.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- prevent type annotation shim failures from causing runtime failures (https://github.com/ansible/ansible/pull/77860)

--- a/lib/ansible/module_utils/compat/typing.py
+++ b/lib/ansible/module_utils/compat/typing.py
@@ -4,12 +4,15 @@ __metaclass__ = type
 
 # pylint: disable=wildcard-import,unused-wildcard-import
 
+# catch *all* exceptions to prevent type annotation support module bugs causing runtime failures
+# (eg, https://github.com/ansible/ansible/issues/77857)
+
 try:
     from typing_extensions import *
-except ImportError:
+except Exception:  # pylint: disable=broad-except
     pass
 
 try:
     from typing import *  # type: ignore[misc]
-except ImportError:
+except Exception:  # pylint: disable=broad-except
     pass


### PR DESCRIPTION
Fixes #78372

* swallow all exceptions in type annotation support shim imports

* add changelog
(cherry picked from commit 813afcb)


Co-authored-by: Matt Davis <6775756+nitzmahone@users.noreply.github.com>