### PR TITLE
Fix escaped asterisk in code block demonstrating wildcards

### DIFF
--- a/docs/docsite/rst/user_guide/intro_patterns.rst
+++ b/docs/docsite/rst/user_guide/intro_patterns.rst
@@ -82,9 +82,9 @@ You can use wildcard patterns with FQDNs or IP addresses, as long as the hosts a
 
 .. code-block:: yaml
 
-   192.0.\*
-   \*.example.com
-   \*.com
+   192.0.*
+   *.example.com
+   *.com
 
 You can mix wildcard patterns and groups at the same time:
 


### PR DESCRIPTION
##### SUMMARY

The code block is rendered verbatim. This currently results in `\*` being shown, which is incorrect (i.e., not parsed as a wildcard pattern).
Removing the superfluous `\` fixes the rendering.
This PR fixes all instances of this issue on that page.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr
