### PR TITLE
Module/plugin docs: 

### DIFF
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -332,7 +332,12 @@ stdout:
     description: output from apt
     returned: success, when needed
     type: str
-    sample: "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following extra packages will be installed:\n  apache2-bin ..."
+    sample: |-
+        Reading package lists...
+        Building dependency tree...
+        Reading state information...
+        The following extra packages will be installed:
+          apache2-bin ...
 stderr:
     description: error output from apt
     returned: success, when needed

--- a/lib/ansible/modules/assemble.py
+++ b/lib/ansible/modules/assemble.py
@@ -57,7 +57,7 @@ options:
     description:
     - Assemble files only if C(regex) matches the filename.
     - If not set, all files are assembled.
-    - Every "\" (backslash) must be escaped as "\\" to comply to YAML syntax.
+    - Every C(\) (backslash) must be escaped as C(\\) to comply to YAML syntax.
     - Uses L(Python regular expressions,https://docs.python.org/3/library/re.html).
     type: str
   ignore_hidden:

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -35,19 +35,19 @@ options:
               least one of the patterns specified. Multiple patterns can be specified using a list.
             - The pattern is matched against the file base name, excluding the directory.
             - When using regexen, the pattern MUST match the ENTIRE file name, not just parts of it. So
-              if you are looking to match all files ending in .default, you'd need to use '.*\.default'
-              as a regexp and not just '\.default'.
+              if you are looking to match all files ending in .default, you'd need to use C(.*\.default)
+              as a regexp and not just C(\.default).
             - This parameter expects a list, which can be either comma separated or YAML. If any of the
               patterns contain a comma, make sure to put them in a list to avoid splitting the patterns
               in undesirable ways.
-            - Defaults to '*' when C(use_regex=False), or '.*' when C(use_regex=True).
+            - Defaults to C(*) when I(use_regex=False), or C(.*) when I(use_regex=True).
         type: list
         aliases: [ pattern ]
         elements: str
     excludes:
         description:
-            - One or more (shell or regex) patterns, which type is controlled by C(use_regex) option.
-            - Items whose basenames match an C(excludes) pattern are culled from C(patterns) matches.
+            - One or more (shell or regex) patterns, which type is controlled by I(use_regex) option.
+            - Items whose basenames match an I(excludes) pattern are culled from I(patterns) matches.
               Multiple patterns can be specified using a list.
         type: list
         aliases: [ exclude ]

--- a/lib/ansible/modules/getent.py
+++ b/lib/ansible/modules/getent.py
@@ -36,7 +36,7 @@ options:
         version_added: "2.9"
     split:
         description:
-            - "Character used to split the database values into lists/arrays such as ':' or '\t', otherwise  it will try to pick one depending on the database."
+            - "Character used to split the database values into lists/arrays such as C(:) or C(\t), otherwise  it will try to pick one depending on the database."
         type: str
     fail_key:
         description:

--- a/lib/ansible/modules/getent.py
+++ b/lib/ansible/modules/getent.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: getent
 short_description: A wrapper to the unix getent utility

--- a/lib/ansible/modules/getent.py
+++ b/lib/ansible/modules/getent.py
@@ -36,7 +36,8 @@ options:
         version_added: "2.9"
     split:
         description:
-            - "Character used to split the database values into lists/arrays such as C(:) or C(\t), otherwise  it will try to pick one depending on the database."
+            - Character used to split the database values into lists/arrays such as C(:) or C(\t),
+              otherwise it will try to pick one depending on the database.
         type: str
     fail_key:
         description:

--- a/lib/ansible/modules/setup.py
+++ b/lib/ansible/modules/setup.py
@@ -113,7 +113,7 @@ author:
     - "Michael DeHaan"
 '''
 
-EXAMPLES = """
+EXAMPLES = r"""
 # Display facts from all hosts and store them indexed by I(hostname) at C(/tmp/facts).
 # ansible all -m ansible.builtin.setup --tree /tmp/facts
 
@@ -158,8 +158,8 @@ EXAMPLES = """
 # Collect no facts, even the default minimum subset of facts:
 # ansible all -m ansible.builtin.setup -a 'gather_subset=!all,!min'
 
-# Display facts from Windows hosts with custom facts stored in C:\\custom_facts.
-# ansible windows -m ansible.builtin.setup -a "fact_path='c:\\custom_facts'"
+# Display facts from Windows hosts with custom facts stored in C:\custom_facts.
+# ansible windows -m ansible.builtin.setup -a "fact_path='c:\custom_facts'"
 
 # Gathers facts for the machines in the dbservers group (a.k.a Delegating facts)
 - hosts: app_servers

--- a/lib/ansible/modules/setup.py
+++ b/lib/ansible/modules/setup.py
@@ -158,7 +158,7 @@ EXAMPLES = """
 # Collect no facts, even the default minimum subset of facts:
 # ansible all -m ansible.builtin.setup -a 'gather_subset=!all,!min'
 
-# Display facts from Windows hosts with custom facts stored in C(C:\\custom_facts).
+# Display facts from Windows hosts with custom facts stored in C:\\custom_facts.
 # ansible windows -m ansible.builtin.setup -a "fact_path='c:\\custom_facts'"
 
 # Gathers facts for the machines in the dbservers group (a.k.a Delegating facts)

--- a/lib/ansible/modules/template.py
+++ b/lib/ansible/modules/template.py
@@ -25,7 +25,7 @@ options:
     default: no
     version_added: '2.4'
 notes:
-- For Windows you can use M(ansible.windows.win_template) which uses C(\\r\\n) as C(newline_sequence) by default.
+- For Windows you can use M(ansible.windows.win_template) which uses C(\r\n) as C(newline_sequence) by default.
 - The C(jinja2_native) setting has no effect. Native types are never used in the C(template) module which is by design used for generating text files.
   For working with templates and utilizing Jinja2 native types see the C(jinja2_native) parameter of the C(template lookup).
 seealso:

--- a/lib/ansible/modules/template.py
+++ b/lib/ansible/modules/template.py
@@ -25,7 +25,7 @@ options:
     default: no
     version_added: '2.4'
 notes:
-- For Windows you can use M(ansible.windows.win_template) which uses '\\r\\n' as C(newline_sequence) by default.
+- For Windows you can use M(ansible.windows.win_template) which uses C(\\r\\n) as C(newline_sequence) by default.
 - The C(jinja2_native) setting has no effect. Native types are never used in the C(template) module which is by design used for generating text files.
   For working with templates and utilizing Jinja2 native types see the C(jinja2_native) parameter of the C(template lookup).
 seealso:

--- a/lib/ansible/plugins/doc_fragments/shell_windows.py
+++ b/lib/ansible/plugins/doc_fragments/shell_windows.py
@@ -9,13 +9,13 @@ class ModuleDocFragment(object):
     # Windows shell documentation fragment
     # FIXME: set_module_language don't belong here but must be set so they don't fail when someone
     #  get_option('set_module_language') on this plugin
-    DOCUMENTATION = """
+    DOCUMENTATION = r"""
 options:
   async_dir:
     description:
     - Directory in which ansible will keep async job information.
-    - Before Ansible 2.8, this was set to C(remote_tmp + "\\.ansible_async").
-    default: '%USERPROFILE%\\.ansible_async'
+    - Before Ansible 2.8, this was set to C(remote_tmp + "\.ansible_async").
+    default: '%USERPROFILE%\.ansible_async'
     ini:
     - section: powershell
       key: async_dir

--- a/lib/ansible/plugins/lookup/csvfile.py
+++ b/lib/ansible/plugins/lookup/csvfile.py
@@ -4,7 +4,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
     name: csvfile
     author: Jan-Piet Mens (@jpmens) <jpmens(at)gmail.com>
     version_added: "1.5"
@@ -20,7 +20,7 @@ DOCUMENTATION = """
       default:
         description: what to return if the value is not found in the file.
       delimiter:
-        description: field separator in the file, for a tab you can specify C(TAB) or C(\\t).
+        description: field separator in the file, for a tab you can specify C(TAB) or C(\t).
         default: TAB
       file:
         description: name of the CSV/TSV file to open.


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/ansible/pull/77719#issuecomment-1195253853 and the following comment showed that some escaping done in current module docs is wrong. Some of these can be fixed by using raw strings. While searching for potential problems I also found some missing or wrongly used formatting sequences.

CC @bcoca @samccann 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
apt module
assemble module
find module
getent module
setup module
template module
lib/ansible/plugins/doc_fragments/shell_windows.py
lib/ansible/plugins/lookup/csvfile.py
