### PR TITLE
Change the language used in the unarchive test.

### DIFF
--- a/test/integration/targets/unarchive/tasks/test_different_language_var.yml
+++ b/test/integration/targets/unarchive/tasks/test_different_language_var.yml
@@ -1,9 +1,9 @@
 - name: test non-ascii with different LANGUAGE
   when: ansible_os_family == 'Debian'
   block:
-    - name: install de language pack
+    - name: install fr language pack
       apt: 
-        name: language-pack-de 
+        name: language-pack-fr
         state: present
       
     - name: create our unarchive destination
@@ -38,4 +38,4 @@
         state: absent
 
   environment:
-    LANGUAGE: de_DE:en
+    LANGUAGE: fr_FR:fr


### PR DESCRIPTION
##### SUMMARY

The current language pack fails to install on Ubuntu 22.04.
However, since the langauge only needs to be non-English, changing it preserves the test functionality.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

unarchive integration test
