### PR TITLE
feat: Add crc32 filter

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -35,7 +35,7 @@ from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.template import recursive_check_defined
 from ansible.utils.display import Display
 from ansible.utils.encrypt import passlib_or_crypt
-from ansible.utils.hashing import md5s, checksum_s
+from ansible.utils.hashing import md5s, checksum_s, crc32s
 from ansible.utils.unicode import unicode_wrap
 from ansible.utils.vars import merge_hash
 
@@ -621,6 +621,8 @@ class FilterModule(object):
             'sha1': checksum_s,
             # checksum of string as used by ansible for checksumming files
             'checksum': checksum_s,
+            # crc32 hex digest of string
+            'crc32': crc32s,
             # generic hashing
             'password_hash': get_encrypted_password,
             'hash': get_hash,

--- a/lib/ansible/utils/hashing.py
+++ b/lib/ansible/utils/hashing.py
@@ -22,6 +22,7 @@ __metaclass__ = type
 import os
 
 from hashlib import sha1
+from zlib import crc32
 
 try:
     from hashlib import md5 as _md5
@@ -87,3 +88,8 @@ def md5(filename):
     if not _md5:
         raise ValueError('MD5 not available.  Possibly running in FIPS mode')
     return secure_hash(filename, _md5)
+
+
+def crc32s(data):
+    data = to_bytes(data, errors='surrogate_or_strict')
+    return "{0:x}".format(crc32(data))


### PR DESCRIPTION
##### SUMMARY

In order to create a [subscription](https://docs.ansible.com/ansible/latest/collections/community/postgresql/postgresql_subscription_module.html) on PostgreSQL, we have to provide a `slot_name` (by default, it's the same name as the ones in `publications`).

This name:
* can contain only lower case alphanumeric characters and the underscore sign
* is silently truncated to **63 chars**

Object names on PostgreSQL, including publications, can contain invalid characters for a replication slot name.

To solve this issue, [pglogical](https://github.com/2ndQuadrant/pglogical):
* [replaces all invalid chars with underscores](https://github.com/2ndQuadrant/pglogical/blob/REL2_4_1/pglogical_functions.c#L2386-L2394)
* [creates short hashes when size of a name is bigger than a threshold (16 chars)](https://github.com/2ndQuadrant/pglogical/blob/REL2_4_1/pglogical_functions.c#L2380-L2382)

In Ansible, what hashes algorithms do we have?
* md5: **32 chars**
* sha1: **40 chars**
* checksum: **40 chars** (alias of sha1)
* password_hash: contains invalid chars
* hash: choices between sha1 (default) and md5

There is no hash algorithm producing less than 16 chars like pglogical does. An alternative option is to truncate the result to the desired number of chars. But having a native algorithm is better, right?

This commit includes the CRC32 algorithm to Ansible to produce **8 chars** checksums.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-core

##### ADDITIONAL INFORMATION
Playbook:
```yaml
---
- hosts: localhost
  tasks:
    - debug:
        msg: "{{ 'test' | crc32 }}"
```

Output:
```
ok: [localhost] => {
    "msg": "d87f7e0c"
}
```