### PR TITLE
ansible-config - dump/list galaxy servers

### DIFF
--- a/changelogs/fragments/63288-galaxy-server-config-dump.yml
+++ b/changelogs/fragments/63288-galaxy-server-config-dump.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ansible-config - Add support for dumping or listing Galaxy server config definitions - https://github.com/ansible/ansible/issues/63288

--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -186,7 +186,8 @@ class ConfigCLI(CLI):
         # requested.
         if context.CLIARGS['type'] in ['all', 'galaxy_server']:
             galaxy_server_list = self.config.get_config_value('GALAXY_SERVER_LIST')
-            initialize_galaxy_server_config(self.config, galaxy_server_list)
+            if galaxy_server_list:
+                initialize_galaxy_server_config(self.config, galaxy_server_list)
 
         # run the requested action
         context.CLIARGS['func']()
@@ -290,10 +291,16 @@ class ConfigCLI(CLI):
         if context.CLIARGS['type'] == 'all':
             # now each plugin type
             for ptype in C.CONFIGURABLE_PLUGINS:
-                config_entries['PLUGINS'][ptype.upper()] = self._list_plugin_settings(ptype)
+                loader = getattr(plugin_loader, f'{ptype}_loader')
+                config_entries['PLUGINS'][ptype.upper()] = self._list_plugin_settings(ptype, loader=loader)
         elif context.CLIARGS['type'] not in ('base', 'galaxy_server'):
             # only for requested types
-            config_entries['PLUGINS'][context.CLIARGS['type']] = self._list_plugin_settings(context.CLIARGS['type'], context.CLIARGS['args'])
+            loader = getattr(plugin_loader, f'{context.CLIARGS["type"]}_loader')
+            config_entries['PLUGINS'][context.CLIARGS['type']] = self._list_plugin_settings(
+                context.CLIARGS['type'],
+                context.CLIARGS['args'],
+                loader=loader,
+            )
 
         return config_entries
 

--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -105,7 +105,8 @@ class ConfigCLI(CLI):
         opt_help.add_verbosity_options(common)
         common.add_argument('-c', '--config', dest='config_file',
                             help="path to configuration file, defaults to first file found in precedence.")
-        common.add_argument("-t", "--type", action="store", default='base', dest='type', choices=['all', 'base', 'galaxy_server'] + list(C.CONFIGURABLE_PLUGINS),
+        common.add_argument("-t", "--type", action="store", default='base', dest='type',
+                            choices=['all', 'base', 'galaxy_server'] + list(C.CONFIGURABLE_PLUGINS),
                             help="Filter down to a specific plugin type.")
         common.add_argument('args', help='Specific plugin to target, requires type of plugin to be set', nargs='*')
 
@@ -253,7 +254,7 @@ class ConfigCLI(CLI):
             else:
                 plugin_cs = loader.all(class_only=True)
         else:
-            plugin_cs = plugins
+            plugin_cs = plugins or []
 
         for plugin in plugin_cs:
             # in case of deprecastion they diverge
@@ -502,7 +503,7 @@ class ConfigCLI(CLI):
     def _get_plugin_configs(self, ptype, plugins, loader: t.Optional[PluginLoader] = None):
 
         # acumulators
-        output = []
+        output: t.List[t.Union[str, t.Dict]] = []
         config_entries = self._list_plugin_settings(ptype, plugins, loader=loader)
 
         for name in config_entries.keys():

--- a/test/integration/targets/ansible-config/files/galaxy_server.ini
+++ b/test/integration/targets/ansible-config/files/galaxy_server.ini
@@ -1,0 +1,21 @@
+[galaxy]
+server_list = my_org_hub, release_galaxy, test_galaxy, my_galaxy_ng
+
+[galaxy_server.my_org_hub]
+url=https://automation.my_org/
+username=my_user
+password=my_pass
+
+[galaxy_server.release_galaxy]
+url=https://galaxy.ansible.com/
+token=my_token
+
+[galaxy_server.test_galaxy]
+url=https://galaxy-dev.ansible.com/
+token=my_test_token
+
+[galaxy_server.my_galaxy_ng]
+url=http://my_galaxy_ng:8000/api/automation-hub/
+auth_url=http://my_keycloak:8080/auth/realms/myco/protocol/openid-connect/token
+client_id=galaxy-ng
+token=my_keycloak_access_token

--- a/test/integration/targets/ansible-config/tasks/main.yml
+++ b/test/integration/targets/ansible-config/tasks/main.yml
@@ -56,3 +56,55 @@
       that:
           - valid_env is success
           - invalid_env is failed
+
+- name: dump galaxy_server config
+  ansible.builtin.command: ansible-config dump --type {{ item }} --format json
+  environment:
+    ANSIBLE_CONFIG: '{{ role_path }}/files/galaxy_server.ini'
+  loop:
+  - galaxy_server
+  - all
+  register: galaxy_server_dump
+
+- set_fact:
+    galaxy_server_dump_gs: '{{ (galaxy_server_dump.results[1].stdout | from_json | selectattr("GALAXY_SERVER", "defined") | first).GALAXY_SERVER }}'
+    galaxy_server_dump_all: '{{ (galaxy_server_dump.results[1].stdout | from_json | selectattr("GALAXY_SERVER", "defined") | first).GALAXY_SERVER }}'
+
+- name: assert galaxy server config
+  assert:
+    that:
+    - (galaxy_server_dump_gs | count) == 4
+
+    - galaxy_server_dump_gs[0].keys() | list == ["my_org_hub"]
+    - (galaxy_server_dump_gs[0].my_org_hub | selectattr("name", "equalto", "url"))[0].value == "https://automation.my_org/"
+    - (galaxy_server_dump_gs[0].my_org_hub | selectattr("name", "equalto", "url"))[0].origin == role_path ~ "/files/galaxy_server.ini"
+    - (galaxy_server_dump_gs[0].my_org_hub | selectattr("name", "equalto", "username"))[0].value == "my_user"
+    - (galaxy_server_dump_gs[0].my_org_hub | selectattr("name", "equalto", "username"))[0].origin == role_path ~ "/files/galaxy_server.ini"
+    - (galaxy_server_dump_gs[0].my_org_hub | selectattr("name", "equalto", "password"))[0].value == "my_pass"
+    - (galaxy_server_dump_gs[0].my_org_hub | selectattr("name", "equalto", "password"))[0].origin == role_path ~ "/files/galaxy_server.ini"
+    - (galaxy_server_dump_gs[0].my_org_hub | selectattr("name", "equalto", "api_version"))[0].value == None
+    - (galaxy_server_dump_gs[0].my_org_hub | selectattr("name", "equalto", "api_version"))[0].origin == "default"
+
+    - galaxy_server_dump_gs[1].keys() | list == ["release_galaxy"]
+    - (galaxy_server_dump_gs[1].release_galaxy | selectattr("name", "equalto", "url"))[0].value == "https://galaxy.ansible.com/"
+    - (galaxy_server_dump_gs[1].release_galaxy | selectattr("name", "equalto", "url"))[0].origin == role_path ~ "/files/galaxy_server.ini"
+    - (galaxy_server_dump_gs[1].release_galaxy | selectattr("name", "equalto", "token"))[0].value == "my_token"
+    - (galaxy_server_dump_gs[1].release_galaxy | selectattr("name", "equalto", "token"))[0].origin == role_path ~ "/files/galaxy_server.ini"
+
+    - galaxy_server_dump_gs[2].keys() | list == ["test_galaxy"]
+    - (galaxy_server_dump_gs[2].test_galaxy | selectattr("name", "equalto", "url"))[0].value == "https://galaxy-dev.ansible.com/"
+    - (galaxy_server_dump_gs[2].test_galaxy | selectattr("name", "equalto", "url"))[0].origin == role_path ~ "/files/galaxy_server.ini"
+    - (galaxy_server_dump_gs[2].test_galaxy | selectattr("name", "equalto", "token"))[0].value == "my_test_token"
+    - (galaxy_server_dump_gs[2].test_galaxy | selectattr("name", "equalto", "token"))[0].origin == role_path ~ "/files/galaxy_server.ini"
+
+    - galaxy_server_dump_gs[3].keys() | list == ["my_galaxy_ng"]
+    - (galaxy_server_dump_gs[3].my_galaxy_ng | selectattr("name", "equalto", "url"))[0].value == "http://my_galaxy_ng:8000/api/automation-hub/"
+    - (galaxy_server_dump_gs[3].my_galaxy_ng | selectattr("name", "equalto", "url"))[0].origin == role_path ~ "/files/galaxy_server.ini"
+    - (galaxy_server_dump_gs[3].my_galaxy_ng | selectattr("name", "equalto", "token"))[0].value == "my_keycloak_access_token"
+    - (galaxy_server_dump_gs[3].my_galaxy_ng | selectattr("name", "equalto", "token"))[0].origin == role_path ~ "/files/galaxy_server.ini"
+    - (galaxy_server_dump_gs[3].my_galaxy_ng | selectattr("name", "equalto", "auth_url"))[0].value == "http://my_keycloak:8080/auth/realms/myco/protocol/openid-connect/token"
+    - (galaxy_server_dump_gs[3].my_galaxy_ng | selectattr("name", "equalto", "auth_url"))[0].origin == role_path ~ "/files/galaxy_server.ini"
+    - (galaxy_server_dump_gs[3].my_galaxy_ng | selectattr("name", "equalto", "client_id"))[0].value == "galaxy-ng"
+    - (galaxy_server_dump_gs[3].my_galaxy_ng | selectattr("name", "equalto", "client_id"))[0].origin == role_path ~ "/files/galaxy_server.ini"
+
+    - galaxy_server_dump_gs == galaxy_server_dump_all


### PR DESCRIPTION
##### SUMMARY
Adds support for listing or dumping galaxy server configuration entries using the `-t galaxy_server` or `-t all` "plugin type".

Fixes: https://github.com/ansible/ansible/issues/63288

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-config

##### ADDITIONAL INFO
The dump info looks something like this

```
$ ansible-config dump -t galaxy_server

automation_hub:
______________
auth_url(/home/jborean/dev/ansible-tester/ansible.cfg) = https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
client_id(default) = None
password(default) = None
timeout(default) = 60
token(/home/jborean/dev/ansible-tester/ansible.cfg) = my secret
url(/home/jborean/dev/ansible-tester/ansible.cfg) = https://console.redhat.com/api/automation-hub/
username(default) = None
v3(default) = False
validate_certs(default) = True

galaxy:
______
auth_url(default) = None
client_id(default) = None
password(default) = None
timeout(default) = 60
token(default) = None
url(/home/jborean/dev/ansible-tester/ansible.cfg) = https://galaxy.ansible.com/
username(default) = None
v3(default) = False
validate_certs(default) = True
```

The same `--only-changed` rules apply and these entries appear under the `GALAXY_SERVERS` heading with `--all` is used.