### PR TITLE
Add optional params key_name and value_name to customize dict lookup plugin

### DIFF
--- a/changelogs/fragments/78397-add-keys-param.yaml
+++ b/changelogs/fragments/78397-add-keys-param.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - add optional parameters key_name and value_name to dict lookup plugin

--- a/lib/ansible/plugins/lookup/__init__.py
+++ b/lib/ansible/plugins/lookup/__init__.py
@@ -67,10 +67,10 @@ class LookupBase(AnsiblePlugin):
         return results
 
     @staticmethod
-    def _flatten_hash_to_list(terms):
+    def _flatten_hash_to_list(terms, key_name='key', value_name='value'):
         ret = []
         for key in terms:
-            ret.append({'key': key, 'value': terms[key]})
+            ret.append({key_name: key, value_name: terms[key]})
         return ret
 
     @abstractmethod

--- a/lib/ansible/plugins/lookup/dict.py
+++ b/lib/ansible/plugins/lookup/dict.py
@@ -65,7 +65,7 @@ class LookupModule(LookupBase):
 
         key_name = kwargs.get('key_name', 'key')
         value_name = kwargs.get('value_name', 'value')
-        
+
         # NOTE: can remove if with_ is removed
         if not isinstance(terms, list):
             terms = [terms]

--- a/lib/ansible/plugins/lookup/dict.py
+++ b/lib/ansible/plugins/lookup/dict.py
@@ -18,11 +18,11 @@ DOCUMENTATION = """
             required: True
         key_name:
             description:
-                - Use it to override the 'key' key name in the dictionaries.
+                - Use it to override the 'key' key name in the dictionaries. By default it will be set to 'key'.
             required: False
         value_name:
             description:
-                - Use it to override the 'key' key name in the dictionaries.
+                - Use it to override the 'key' key name in the dictionaries. By default it will be set to 'value'.
             required: False
 """
 
@@ -51,6 +51,12 @@ tasks:
     ansible.builtin.set_fact:
       alice_exists: true
     loop: "{{ lookup('ansible.builtin.dict', users) }}"
+    when: "'alice' in item.key"
+  # Set key_name and value_name example
+  - name: set_fact when alice in key
+    ansible.builtin.set_fact:
+      alice_exists: true
+    loop: "{{ lookup('ansible.builtin.dict', users, key_name='user', value_name='user_data0') }}"
     when: "'alice' in item.key"
 """
 

--- a/lib/ansible/plugins/lookup/dict.py
+++ b/lib/ansible/plugins/lookup/dict.py
@@ -16,14 +16,16 @@ DOCUMENTATION = """
             description:
                 - A list of dictionaries
             required: True
-        key_name:
-            description:
-                - Use it to override the 'key' key name in the dictionaries. By default it will be set to 'key'.
-            required: False
         value_name:
             description:
                 - Use it to override the 'key' key name in the dictionaries. By default it will be set to 'value'.
             required: False
+            default: 'value'
+        key_name:
+            description:
+                - Use it to override the 'key' key name in the dictionaries. By default it will be set to 'key'.
+            required: False
+            default: 'key'
 """
 
 EXAMPLES = """
@@ -56,7 +58,7 @@ tasks:
   - name: set_fact when alice in key
     ansible.builtin.set_fact:
       alice_exists: true
-    loop: "{{ lookup('ansible.builtin.dict', users, key_name='user', value_name='user_data0') }}"
+    loop: "{{ lookup('ansible.builtin.dict', users, key_name='user', value_name='user_data') }}"
     when: "'alice' in item.key"
 """
 
@@ -76,9 +78,9 @@ from ansible.plugins.lookup import LookupBase
 class LookupModule(LookupBase):
 
     def run(self, terms, variables=None, **kwargs):
-
-        key_name = kwargs.get('key_name', 'key')
-        value_name = kwargs.get('value_name', 'value')
+        self.set_options(var_options=variables, direct=kwargs)
+        value_name = self.get_option('value_name')
+        key_name = self.get_option('key_name')
 
         # NOTE: can remove if with_ is removed
         if not isinstance(terms, list):

--- a/lib/ansible/plugins/lookup/dict.py
+++ b/lib/ansible/plugins/lookup/dict.py
@@ -63,6 +63,9 @@ class LookupModule(LookupBase):
 
     def run(self, terms, variables=None, **kwargs):
 
+        key_name = kwargs.get('key_name', 'key')
+        value_name = kwargs.get('value_name', 'value')
+        
         # NOTE: can remove if with_ is removed
         if not isinstance(terms, list):
             terms = [terms]
@@ -73,5 +76,5 @@ class LookupModule(LookupBase):
             if not isinstance(term, Mapping):
                 raise AnsibleError("with_dict expects a dict")
 
-            results.extend(self._flatten_hash_to_list(term))
+            results.extend(self._flatten_hash_to_list(term, key_name=key_name, value_name=value_name))
         return results

--- a/lib/ansible/plugins/lookup/dict.py
+++ b/lib/ansible/plugins/lookup/dict.py
@@ -10,12 +10,20 @@ DOCUMENTATION = """
     short_description: returns key/value pair items from dictionaries
     description:
         - Takes dictionaries as input and returns a list with each item in the list being a dictionary with 'key' and 'value' as
-          keys to the previous dictionary's structure.
+          keys to the previous dictionary's structure. The new keys 'key' and 'value' can be overridden using the optional parameters key_name and value_name.
     options:
         _terms:
             description:
                 - A list of dictionaries
             required: True
+        key_name:
+            description:
+                - Use it to override the 'key' key name in the dictionaries.
+            required: False
+        value_name:
+            description:
+                - Use it to override the 'key' key name in the dictionaries.
+            required: False
 """
 
 EXAMPLES = """


### PR DESCRIPTION
Hello there, 

In my playbooks I am using the following data `{{ lookup('dict', ansible_devices) }}` to filter and query the devices in my systems.

It would be cool for me if I could use something like this `{{ lookup('dict', ansible_devices, key_name='device', value_name='device_info') }}`, it would help me improve my playbook readability.

It would make sense to me having optional parameters to customize the behaviour of the key and the value created by the lookup plugin dict.

Let me know your thoughts.

Kind regards,