### PR TITLE
Using '--venv' Is Missing Packages To Work Correctly

### DIFF
--- a/test/lib/ansible_test/_internal/python_requirements.py
+++ b/test/lib/ansible_test/_internal/python_requirements.py
@@ -415,7 +415,9 @@ def get_venv_packages(python):  # type: (PythonConfig) -> t.Dict[str, str]
     #       See: https://github.com/ansible/base-test-container/blob/main/files/installer.py
 
     default_packages = dict(
+        packaging='21.3',
         pip='21.3.1',
+        pyyaml='6.0',
         setuptools='60.8.2',
         wheel='0.37.1',
     )


### PR DESCRIPTION
This resolves #78334 but it likely is not the most precise area to put these requirements.

##### SUMMARY
Running `ansible-test` with `--venv` and without `--venv-system-site-packages` will result in a failure due to missing packages in the virtual environment. This adds those packages. It may be prudent to put these in overrides instead.

Fixes #78334 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
ansible-test

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
To see the error this should suffice - it's resolved by this patch using the same commands but targeting the rebuilt `ansible-test`

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
cd `mktemp -d`
git clone https://github.com/ansible-collections/community.hashi_vault.git ansible_collections/community/hashi_vault
cd ansible_collections/community/hashi_vault
ansible-test units --venv --requirements
```
