### PR TITLE
Fix removing existing dir/files with `ansible-galaxy collection init --force`

### DIFF
--- a/changelogs/fragments/ansible-galaxy-collection-init-force.yml
+++ b/changelogs/fragments/ansible-galaxy-collection-init-force.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - ansible-galaxy - Fix reinitializing the whole collection directory with `ansible-galaxy collection init ns.coll --force`.
+  - ansible-galaxy - Fix reinitializing the whole collection directory with ``ansible-galaxy collection init ns.coll --force``.
     Now directories and files that are not included in the collection skeleton will be removed.

--- a/changelogs/fragments/ansible-galaxy-collection-init-force.yml
+++ b/changelogs/fragments/ansible-galaxy-collection-init-force.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-galaxy - Fix reinitializing the whole collection directory with `ansible-galaxy collection init ns.coll --force`.
+    Now directories and files that are not included in the collection skeleton will be removed.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1079,6 +1079,7 @@ class GalaxyCLI(CLI):
                                    "You can use --force to re-initialize this directory,\n"
                                    "however it will reset any main.yml files that may have\n"
                                    "been modified there already." % to_native(obj_path))
+            shutil.rmtree(b_obj_path)
 
         if obj_skeleton is not None:
             own_skeleton = False

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1079,7 +1079,15 @@ class GalaxyCLI(CLI):
                                    "You can use --force to re-initialize this directory,\n"
                                    "however it will reset any main.yml files that may have\n"
                                    "been modified there already." % to_native(obj_path))
-            shutil.rmtree(b_obj_path)
+
+            # delete the contents rather than the collection root in case init was run from the root (--init-path ../../)
+            for root, dirs, files in os.walk(b_obj_path, topdown=True):
+                for old_dir in dirs:
+                    path = os.path.join(root, old_dir)
+                    shutil.rmtree(path)
+                for old_file in files:
+                    path = os.path.join(root, old_file)
+                    os.unlink(path)
 
         if obj_skeleton is not None:
             own_skeleton = False

--- a/test/integration/targets/ansible-galaxy-collection/tasks/init.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/init.yml
@@ -43,6 +43,30 @@
     - (init_custom_path_actual.files | map(attribute='path') | list)[1] | basename in ['docs', 'plugins', 'roles']
     - (init_custom_path_actual.files | map(attribute='path') | list)[2] | basename in ['docs', 'plugins', 'roles']
 
+- name: add a directory to the init collection path to test that --force removes it
+  file:
+    state: directory
+    path: "{{ galaxy_dir }}/scratch/custom-init-dir/ansible_test2/my_collection/remove_me"
+
+- name: create collection with custom init path
+  command: ansible-galaxy collection init ansible_test2.my_collection --init-path "{{ galaxy_dir }}/scratch/custom-init-dir" --force {{ galaxy_verbosity }}
+  register: init_custom_path
+
+- name: get result of create default skeleton
+  find:
+    path: '{{ galaxy_dir }}/scratch/custom-init-dir/ansible_test2/my_collection'
+    file_type: directory
+  register: init_custom_path_actual
+
+- name: assert create collection with custom init path
+  assert:
+    that:
+    - '"Collection ansible_test2.my_collection was created successfully" in init_custom_path.stdout'
+    - init_custom_path_actual.files | length == 3
+    - (init_custom_path_actual.files | map(attribute='path') | list)[0] | basename in ['docs', 'plugins', 'roles']
+    - (init_custom_path_actual.files | map(attribute='path') | list)[1] | basename in ['docs', 'plugins', 'roles']
+    - (init_custom_path_actual.files | map(attribute='path') | list)[2] | basename in ['docs', 'plugins', 'roles']
+
 - name: create collection for ignored files and folders
   command: ansible-galaxy collection init ansible_test.ignore
   args:

--- a/test/integration/targets/ansible-galaxy-collection/tasks/init.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/init.yml
@@ -67,6 +67,27 @@
     - (init_custom_path_actual.files | map(attribute='path') | list)[1] | basename in ['docs', 'plugins', 'roles']
     - (init_custom_path_actual.files | map(attribute='path') | list)[2] | basename in ['docs', 'plugins', 'roles']
 
+- name: create collection in cwd with custom init path
+  command: ansible-galaxy collection init ansible_test2.my_collection --init-path ../../ --force {{ galaxy_verbosity }}
+  args:
+    chdir: "{{ galaxy_dir }}/scratch/custom-init-dir/ansible_test2/my_collection"
+  register: init_custom_path
+
+- name: get result of create default skeleton
+  find:
+    path: '{{ galaxy_dir }}/scratch/custom-init-dir/ansible_test2/my_collection'
+    file_type: directory
+  register: init_custom_path_actual
+
+- name: assert create collection with custom init path
+  assert:
+    that:
+    - '"Collection ansible_test2.my_collection was created successfully" in init_custom_path.stdout'
+    - init_custom_path_actual.files | length == 3
+    - (init_custom_path_actual.files | map(attribute='path') | list)[0] | basename in ['docs', 'plugins', 'roles']
+    - (init_custom_path_actual.files | map(attribute='path') | list)[1] | basename in ['docs', 'plugins', 'roles']
+    - (init_custom_path_actual.files | map(attribute='path') | list)[2] | basename in ['docs', 'plugins', 'roles']
+
 - name: create collection for ignored files and folders
   command: ansible-galaxy collection init ansible_test.ignore
   args:


### PR DESCRIPTION
##### SUMMARY
Fixes a bug where `ansible-galaxy collection init ns.coll --force` would not remove existing directories/files that aren't in the collection skeleton.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy collection init --force