### PR TITLE
Slip data tagging to 2.15

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_14.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_14.rst
@@ -48,7 +48,6 @@ Release Manager
 Planned work
 ============
 
-* Data Tagging
 * Implement sidecar docs to support documenting filter/test plugins, as well as non Python modules
 * Proxy Display over queue from forks
 * Move handler processing into new PlayIterator phase to use the configured strategy
@@ -61,4 +60,4 @@ Delayed work
 
 The following work has been delayed and retargeted for a future release:
 
-* N/A
+* Data Tagging


### PR DESCRIPTION
##### SUMMARY
Slip data tagging to 2.15

Will likely ship in fallible first, maybe shortly after 2.14 releases.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/roadmap/ROADMAP_2_14.rst

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
