### PR TITLE
--filter support added

### DIFF
--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -207,6 +207,11 @@ options:
         type: path
         version_added: "2.7"
 
+    git_filter:
+        description:
+            - Can be used for partial clone of a git repo
+        type: str
+
     gpg_whitelist:
         description:
            - A list of trusted GPG fingerprints to compare to the fingerprint of the

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -616,7 +616,8 @@ def clone(git_path, module, repo, dest, remote, depth, version, bare,
             # git before 1.7.5 doesn't have separate-git-dir argument, do fallback
             needs_separate_git_dir_fallback = True
         else:
-            cmd.append('--separate-git-dir=%s' % separate_git_dir)    
+            cmd.append('--separate-git-dir=%s' % separate_git_dir)
+
     if git_filter:
         cmd.append('--filter=%s' % git_filter)
 

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -567,7 +567,7 @@ def get_submodule_versions(git_path, module, dest, version='HEAD'):
 
 
 def clone(git_path, module, repo, dest, remote, depth, version, bare,
-          reference, refspec, git_version_used, verify_commit, separate_git_dir, result, gpg_whitelist, single_branch):
+          reference, refspec, git_version_used, verify_commit, separate_git_dir, result, gpg_whitelist, single_branch, git_filter):
     ''' makes a new git repo if it does not already exist '''
     dest_dirname = os.path.dirname(dest)
     try:
@@ -617,6 +617,9 @@ def clone(git_path, module, repo, dest, remote, depth, version, bare,
             needs_separate_git_dir_fallback = True
         else:
             cmd.append('--separate-git-dir=%s' % separate_git_dir)
+    
+    if git_filter:
+        cmd.append('--filter=%s' % git_filter)
 
     cmd.extend([repo, dest])
     module.run_command(cmd, check_rc=True, cwd=dest_dirname)
@@ -1197,6 +1200,7 @@ def main():
             archive=dict(type='path'),
             archive_prefix=dict(),
             separate_git_dir=dict(type='path'),
+            git_filter=dict(default=None, required = False),
         ),
         mutually_exclusive=[('separate_git_dir', 'bare'), ('accept_hostkey', 'accept_newhostkey')],
         required_by={'archive_prefix': ['archive']},
@@ -1224,6 +1228,7 @@ def main():
     archive = module.params['archive']
     archive_prefix = module.params['archive_prefix']
     separate_git_dir = module.params['separate_git_dir']
+    git_filter = module.params['git_filter']
 
     result = dict(changed=False, warnings=list())
 

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -616,8 +616,7 @@ def clone(git_path, module, repo, dest, remote, depth, version, bare,
             # git before 1.7.5 doesn't have separate-git-dir argument, do fallback
             needs_separate_git_dir_fallback = True
         else:
-            cmd.append('--separate-git-dir=%s' % separate_git_dir)
-    
+            cmd.append('--separate-git-dir=%s' % separate_git_dir)    
     if git_filter:
         cmd.append('--filter=%s' % git_filter)
 
@@ -1200,7 +1199,7 @@ def main():
             archive=dict(type='path'),
             archive_prefix=dict(),
             separate_git_dir=dict(type='path'),
-            git_filter=dict(default=None, required = False),
+            git_filter=dict(default=None, required=False),
         ),
         mutually_exclusive=[('separate_git_dir', 'bare'), ('accept_hostkey', 'accept_newhostkey')],
         required_by={'archive_prefix': ['archive']},

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -1331,7 +1331,7 @@ def main():
             module.exit_json(**result)
         # there's no git config, so clone
         clone(git_path, module, repo, dest, remote, depth, version, bare, reference,
-              refspec, git_version_used, verify_commit, separate_git_dir, result, gpg_whitelist, single_branch)
+              refspec, git_version_used, verify_commit, separate_git_dir, result, gpg_whitelist, single_branch, git_filter=git_filter)
     elif not update:
         # Just return having found a repo already in the dest path
         # this does no checking that the repo is the actual repo


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
#78267 Feature support added
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
git
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
We can now use the argument 'git_filter' for partial cloning of a git repo.

- name: Blobless checkout
  git:
    repo: 'https://foosball.example.org/path/to/repo.git'
    dest: /srv/checkout
    git_filter: 'blob:none'
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
