### PR TITLE
connection_pipelining: fix default value documentation for pipelining

### DIFF
--- a/lib/ansible/plugins/doc_fragments/connection_pipelining.py
+++ b/lib/ansible/plugins/doc_fragments/connection_pipelining.py
@@ -10,7 +10,7 @@ class ModuleDocFragment(object):
     DOCUMENTATION = """
 options:
     pipelining:
-          default: ANSIBLE_PIPELINING
+          default: false
           description:
             - Pipelining reduces the number of connection operations required to execute a module on the remote server,
               by executing many Ansible modules without actual file transfers.


### PR DESCRIPTION
##### SUMMARY
The `pipelining` option's (type: `bool`) default value is currently `ANSIBLE_PIPELINING`.

Since `boolean(strict=False)` (https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/parsing/convert_bool.py#L16) converts arbitrary other elements to `False`, the config manager converts this value to `False`. It does not use the default value of `ANSIBLE_PIPELINING` as defined in lib/ansible/config/base.yml, or something else.

So I think this value should really be `false` in the first place (or `False` or `no` or anything else that's obviously a false YAML value), and not `ANSIBLE_PIPELINING`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/plugins/doc_fragments/connection_pipelining.py
