### PR TITLE
[2.13] Add basic docs on how to create a collection docsite with antsibull-docs

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections.rst
@@ -16,6 +16,7 @@ You can create a collection and publish it to `Ansible Galaxy <https://galaxy.an
    developing_collections_shared
    developing_collections_testing
    developing_collections_distributing
+   developing_collections_documenting
 
 .. toctree::
    :maxdepth: 2

--- a/docs/docsite/rst/dev_guide/developing_collections_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_documenting.rst
@@ -23,7 +23,7 @@ You can use `antsibull-docs <https://pypi.org/project/antsibull-docs>`_ to build
 
 #. Create your collection and make sure you can use it with ansible-core by adding it to your :ref:`COLLECTIONS_PATHS`.
 #. Create a directory ``dest`` and run ``antsibull-docs sphinx-init --use-current --dest-dir dest namespace.name``, where ``namespace.name`` is the name of your collection.
-#. Go into ``dest`` and run ``pip -r requirements.txt``. You might want to create a venv and activate it first to avoid installing this globally.
+#. Go into ``dest`` and run ``pip install -r requirements.txt``. You might want to create a venv and activate it first to avoid installing this globally.
 #. Then run ``./build.sh``.
 #. Open ``build/html/index.html`` in a browser of your choice.
 

--- a/docs/docsite/rst/dev_guide/developing_collections_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_documenting.rst
@@ -1,0 +1,30 @@
+.. _documenting_collections:
+
+***********************
+Documenting collections
+***********************
+
+Documenting modules and plugins
+===============================
+
+Documenting modules is thoroughly documented in :ref:`module_documenting`. Plugins can be documented the same way as modules, that is with ``DOCUMENTATION``, ``EXAMPLES``, and ``RETURN`` blocks.
+
+Documenting roles
+=================
+
+To document a role, you have to add a role argument spec by creating a file ``meta/argument_specs.yml`` in your role. As an example, you can look at `the argument specs file <https://github.com/sensu/sensu-go-ansible/blob/master/roles/install/meta/argument_specs.yml>`_ of the :ref:`sensu.sensu_go.install role <ansible_collections.sensu.sensu_go.install_role>` on GitHub.
+
+.. _build_collection_docsite:
+
+Build a docsite with antsibull-docs
+===================================
+
+You can use `antsibull-docs <https://pypi.org/project/antsibull-docs>`_ to build a Sphinx-based docsite for your collection:
+
+#. Create your collection and make sure you can use it with ansible-core by adding it to your :ref:`COLLECTIONS_PATHS`.
+#. Create a directory ``dest`` and run ``antsibull-docs sphinx-init --use-current --dest-dir dest namespace.name``, where ``namespace.name`` is the name of your collection.
+#. Go into ``dest`` and run ``pip -r requirements.txt``. You might want to create a venv and activate it first to avoid installing this globally.
+#. Then run ``./build.sh``.
+#. Open ``build/html/index.html`` in a browser of your choice.
+
+If you want to add additional documentation to your collection next to the plugin, module, and role documentation, see :ref:`collections_doc_dir`.

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -447,4 +447,4 @@ The use of "wildcard" imports such as ``from module_utils.basic import *`` is no
 Testing module documentation
 ============================
 
-To test Ansible documentation locally please :ref:`follow instruction<testing_module_documentation>`.
+To test Ansible documentation locally please :ref:`follow instruction<testing_module_documentation>`. To test documentation in collections, please see :ref:`build_collection_docsite`.


### PR DESCRIPTION
##### SUMMARY
Backport of #78387 to stable-2.13.

Since `docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst` does not exist in stable-2.13, I removed the

> See :ref:`role_argument_spec` for details.

part and the label added to that file.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
dev guide
