### PR TITLE
ansible-config init fixes

### DIFF
--- a/changelogs/fragments/fix_init_commented.yml
+++ b/changelogs/fragments/fix_init_commented.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "`ansible-config init -f vars` will now use shorthand format"
+  - ansible-configi init should now skip internal reserved config entries

--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -36,7 +36,7 @@ display = Display()
 
 
 def yaml_dump(data, default_flow_style=True):
-    return yaml.dump(data, Dumper=AnsibleDumper, default_flow_style=default_flow_style)
+    return yaml.dump(data, Dumper=AnsibleDumper, default_flow_style=default_flow_style, default_style="''")
 
 
 def get_constants():
@@ -263,7 +263,7 @@ class ConfigCLI(CLI):
 
         for setting in settings:
 
-            if not settings[setting].get('description'):
+            if not settings[setting].get('description') or setting.startswith('_'):
                 continue
 
             default = settings[setting].get('default', '')
@@ -299,9 +299,13 @@ class ConfigCLI(CLI):
 
                 # TODO: might need quoting and value coercion depending on type
                 if subkey == 'env':
+                    if entry.startswith('_ANSIBLE_'):
+                        continue
                     data.append('%s%s=%s' % (prefix, entry, default))
                 elif subkey == 'vars':
-                    data.append(prefix + to_text(yaml_dump({entry: default}, default_flow_style=False), errors='surrogate_or_strict'))
+                    if entry.startswith('_ansible_'):
+                        continue
+                    data.append(prefix + '%s: %s' % (entry, to_text(yaml_dump(default), errors='surrogate_or_strict')))
                 data.append('')
 
         return data

--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -263,7 +263,7 @@ class ConfigCLI(CLI):
 
         for setting in settings:
 
-            if not settings[setting].get('description') or setting.startswith('_'):
+            if not settings[setting].get('description'):
                 continue
 
             default = settings[setting].get('default', '')


### PR DESCRIPTION
  now handles --disabled correctly for 'vars' format
  also does not display internal config entries anymore

  fixes #78438


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-config