### PR TITLE
Add note about differnces in password generation

### DIFF
--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -540,6 +540,8 @@ Ansible ad hoc command is the easiest option:
 .. code-block:: shell-session
 
     ansible all -i localhost, -m debug -a "msg={{ 'mypassword' | password_hash('sha512', 'mysecretsalt') }}"
+    
+.. note:: Due to differences in the underlying tooling this method will, with identical input, generate different passwords on MacOS and Linux! 
 
 The ``mkpasswd`` utility that is available on most Linux systems is also a great option:
 


### PR DESCRIPTION
##### SUMMARY

Linux and MacOS generate different passwords given the same input. This PR makes users aware of that.

Ubuntu
```
ansible all -i localhost, -m debug -a "msg={{ 'mypassword' | password_hash('sha512', 'banana') }}"
localhost | SUCCESS => {
    "msg": "$6$banana$uJt/nOzm2IspNBH6qq5VWGMUPtpnhJGOAPzV1Szwj0Cbrtk/31MmEcuScKpN64OdutYtilukvBtrOceGjXU7H0"
}
```

MacOS
```
ansible all -i localhost, -m debug -a "msg={{ 'mypassword' | password_hash('sha512', 'banana') }}"
Executing playbook __adhoc_playbook__

- Ansible Ad-Hoc on hosts: all -
debug...
  localhost ok: {
    "changed": false,
    "msg": "$6$rounds=656000$banana$3KrBB274jbz2fosZE.WWQSuGUf4iEo9rwBv0pKkOwbmDHafg9vYZGElFh2vY5r7iM4oHIWNy5nXhlmGjI4GvP0"
}
```


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
