### PR TITLE
Add GALAXY_COLLECTIONS_PATH_WARNINGS option.

### DIFF
--- a/changelogs/fragments/78487-galaxy-collections-path-warnings.yml
+++ b/changelogs/fragments/78487-galaxy-collections-path-warnings.yml
@@ -1,4 +1,6 @@
 ---
 minor_changes:
-  - "Add ``GALAXY_COLLECTIONS_PATH_WARNING`` option to enable/disable
-    ``ansbile-galaxy collection install`` collections_paths warnings."
+- >-
+  Add ``GALAXY_COLLECTIONS_PATH_WARNING`` option to disable the warning
+  given by ``ansible-galaxy collection install`` when installing a collection
+  to a path that isn't in the configured collection paths.

--- a/changelogs/fragments/78487-galaxy-collections-path-warnings.yml
+++ b/changelogs/fragments/78487-galaxy-collections-path-warnings.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "Add ``GALAXY_COLLECTIONS_PATH_WARNING`` option to enable/disable
+    ``ansbile-galaxy collection install`` collections_paths warnings."

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1393,7 +1393,10 @@ class GalaxyCLI(CLI):
         upgrade = context.CLIARGS.get('upgrade', False)
 
         collections_path = C.COLLECTIONS_PATHS
-        if len([p for p in collections_path if p.startswith(path)]) == 0:
+        if (
+            C.GALAXY_COLLECTIONS_PATH_WARNING
+            and len([p for p in collections_path if p.startswith(path)]) == 0
+        ):
             display.warning("The specified collections path '%s' is not part of the configured Ansible "
                             "collections paths '%s'. The installed collection will not be picked up in an Ansible "
                             "run, unless within a playbook-adjacent collections directory." % (to_text(path), to_text(":".join(collections_path))))

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1366,6 +1366,16 @@ GALAXY_COLLECTION_SKELETON_IGNORE:
   ini:
   - {key: collection_skeleton_ignore, section: galaxy}
   type: list
+GALAXY_COLLECTIONS_PATH_WARNING:
+  name: "ansible-galaxy collection install colections path warnings"
+  description: "whether ``ansible-galaxy collection install`` should warn about ``--collection-path`` missing from configured :ref:`collections_paths`"
+  default: true
+  type: bool
+  env: [{name: ANSIBLE_GALAXY_COLLECTIONS_PATH_WARNING}]
+  ini:
+    - {key: collections_path_warning, section: galaxy}
+  version_added: "2.16"
+
 # TODO: unused?
 #GALAXY_SCMS:
 #  name: Galaxy SCMS

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1368,14 +1368,13 @@ GALAXY_COLLECTION_SKELETON_IGNORE:
   type: list
 GALAXY_COLLECTIONS_PATH_WARNING:
   name: "ansible-galaxy collection install colections path warnings"
-  description: "whether ``ansible-galaxy collection install`` should warn about ``--collection-path`` missing from configured :ref:`collections_paths`"
+  description: "whether ``ansible-galaxy collection install`` should warn about ``--collections-path`` missing from configured :ref:`collections_paths`"
   default: true
   type: bool
   env: [{name: ANSIBLE_GALAXY_COLLECTIONS_PATH_WARNING}]
   ini:
     - {key: collections_path_warning, section: galaxy}
   version_added: "2.16"
-
 # TODO: unused?
 #GALAXY_SCMS:
 #  name: Galaxy SCMS


### PR DESCRIPTION
##### SUMMARY
This allows users to disable warnings from `ansible-galaxy collection
install` about `--collections_path` missing from Ansible's configured
collections_paths.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-galaxy

##### ADDITIONAL INFORMATION
In Fedora, we package collections as RPMs and use `ansible-galaxy collection install -p %{buildroot}usr/share/ansible/collections` (`%{buildroot}` is the directory that becomes `/` in the package) to install them. Because the destination directory is not part of the builder's `collections_paths`, `ansible-galaxy` prints out useless warnings.