### PR TITLE
make winrm use the realm variable

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -248,6 +248,10 @@ class Connection(ConnectionBase):
         self._winrm_user = self.get_option('remote_user')
         self._winrm_pass = self.get_option('remote_password')
 
+        if self.get_option('_extras')['ansible_winrm_realm'] and '@' not in self.get_option('remote_user'):
+	        if 'ansible_winrm_realm' in self.get_option('_extras') and '@' not in self.get_option('remote_user'):
+                self._winrm_user = self.get_option('remote_user') + '@' + self.get_option('_extras')['ansible_winrm_realm']   
+
         self._winrm_port = self.get_option('port')
 
         self._winrm_scheme = self.get_option('scheme')

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -248,9 +248,8 @@ class Connection(ConnectionBase):
         self._winrm_user = self.get_option('remote_user')
         self._winrm_pass = self.get_option('remote_password')
 
-        if self.get_option('_extras')['ansible_winrm_realm'] and '@' not in self.get_option('remote_user'):
-	        if 'ansible_winrm_realm' in self.get_option('_extras') and '@' not in self.get_option('remote_user'):
-                self._winrm_user = self.get_option('remote_user') + '@' + self.get_option('_extras')['ansible_winrm_realm']   
+        if 'ansible_winrm_realm' in self.get_option('_extras') and '@' not in self.get_option('remote_user'):
+            self._winrm_user = self.get_option('remote_user') + '@' + self.get_option('_extras')['ansible_winrm_realm']   
 
         self._winrm_port = self.get_option('port')
 

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -249,7 +249,7 @@ class Connection(ConnectionBase):
         self._winrm_pass = self.get_option('remote_password')
 
         if 'ansible_winrm_realm' in self.get_option('_extras') and '@' not in self.get_option('remote_user'):
-            self._winrm_user = self.get_option('remote_user') + '@' + self.get_option('_extras')['ansible_winrm_realm']   
+            self._winrm_user = self.get_option('remote_user') + '@' + self.get_option('_extras')['ansible_winrm_realm']
 
         self._winrm_port = self.get_option('port')
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
These changes allow a windows admin to have the same user in multiple domains.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
winrm connection plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This is mostly useful for environments with multiple active directory domains. 

Considering the following scenario: You are a application administrator with a lot of windows servers. Those windows servers are in different active directory domains. Some domains trust each other some do not. These changes enable the administrator to have rollout across all their servers even if their servers are in different domains.

You just set the variable ansible_winrm_realm to your active directory domain in uppercase. Usually the variable would be set as a host variable or group variable. Of course your user must be the same in all domains. Same with the user password.