### PR TITLE
ansible-console - Fix arg name to match base class.

### DIFF
--- a/changelogs/fragments/ansible-console-renamed-arg.yml
+++ b/changelogs/fragments/ansible-console-renamed-arg.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-console - Renamed the first argument of ``ConsoleCLI.default`` from ``arg`` to ``line`` to match the first
+                      argument of the same method on the base class ``Cmd``.

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -153,9 +153,9 @@ class ConsoleCLI(CLI, cmd.Cmd):
     def list_modules(self):
         return list_plugins('module', self.collections)
 
-    def default(self, arg, forceshell=False):
+    def default(self, line, forceshell=False):
         """ actually runs modules """
-        if arg.startswith("#"):
+        if line.startswith("#"):
             return False
 
         if not self.cwd:
@@ -164,10 +164,10 @@ class ConsoleCLI(CLI, cmd.Cmd):
 
         # defaults
         module = 'shell'
-        module_args = arg
+        module_args = line
 
         if forceshell is not True:
-            possible_module, *possible_args = arg.split()
+            possible_module, *possible_args = line.split()
             if module_loader.find_plugin(possible_module):
                 # we found module!
                 module = possible_module


### PR DESCRIPTION
##### SUMMARY

ansible-console - Fix arg name to match base class.

The base class defines `line` as the first positional argument for the `default` method. This renames the `arg` argument in the derived class to match.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-console
