### PR TITLE
ansible-test - No locale warning with delegation.

### DIFF
--- a/test/lib/ansible_test/_internal/__init__.py
+++ b/test/lib/ansible_test/_internal/__init__.py
@@ -47,6 +47,10 @@ from .provisioning import (
     PrimeContainers,
 )
 
+from .config import (
+    TestConfig,
+)
+
 
 def main(cli_args: t.Optional[list[str]] = None) -> None:
     """Main program function."""
@@ -60,7 +64,7 @@ def main(cli_args: t.Optional[list[str]] = None) -> None:
         display.color = config.color
         display.fd = sys.stderr if config.display_stderr else sys.stdout
         configure_timeout(config)
-        report_locale()
+        report_locale(isinstance(config, TestConfig) and not config.delegate)
 
         display.info('RLIMIT_NOFILE: %s' % (CURRENT_RLIMIT_NOFILE,), verbosity=2)
 

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -657,12 +657,12 @@ def common_environment():
     return env
 
 
-def report_locale() -> None:
+def report_locale(show_warning: bool) -> None:
     """Report the configured locale and the locale warning, if applicable."""
 
     display.info(f'Configured locale: {CONFIGURED_LOCALE}', verbosity=1)
 
-    if LOCALE_WARNING:
+    if LOCALE_WARNING and show_warning:
         display.warning(LOCALE_WARNING)
 
 


### PR DESCRIPTION
##### SUMMARY

ansible-test - No locale warning with delegation.

The locale warning for the origin host is not relevant when delegation is used.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
