### PR TITLE
Allow user to disable console text wrapping

### DIFF
--- a/changelogs/fragments/nowrap.yml
+++ b/changelogs/fragments/nowrap.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Allow users to disable implicit terminal wrapping.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -542,6 +542,14 @@ DEFAULT_CALLBACK_PLUGIN_PATH:
   - {key: callback_plugins, section: defaults}
   type: pathspec
   yaml: {key: plugins.callback.path}
+DEFAULT_TEXT_WRAP:
+  name: Wrap output text based on reported terminal width.
+  default: True
+  type: boolean
+  env: [{name: ANSIBLE_TEXT_WRAP}]
+  ini:
+  - {key: text_wrap, section: defaults}
+  version_added: "2.13.3"
 CALLBACKS_ENABLED:
   name: Enable callback plugins that require it.
   default: []

--- a/lib/ansible/errors/yaml_strings.py
+++ b/lib/ansible/errors/yaml_strings.py
@@ -34,15 +34,15 @@ Syntax Error while loading YAML.
   %s"""
 
 YAML_POSITION_DETAILS = """\
-The error appears to be in '%s': line %s, column %s, but may
+The error appears to be in '%s': line %s, column %s, but may \
 be elsewhere in the file depending on the exact syntax problem.
 """
 
 YAML_COMMON_DICT_ERROR = """\
-This one looks easy to fix. YAML thought it was looking for the start of a
-hash/dictionary and was confused to see a second "{". Most likely this was
-meant to be an ansible template evaluation instead, so we have to give the
-parser a small hint that we wanted a string instead. The solution here is to
+This one looks easy to fix. YAML thought it was looking for the start of a \
+hash/dictionary and was confused to see a second "{". Most likely this was \
+meant to be an ansible template evaluation instead, so we have to give the \
+parser a small hint that we wanted a string instead. The solution here is to \
 just quote the entire value.
 
 For instance, if the original line was:
@@ -55,8 +55,8 @@ It should be written as:
 """
 
 YAML_COMMON_UNQUOTED_VARIABLE_ERROR = """\
-We could be wrong, but this one looks like it might be an issue with
-missing quotes. Always quote template expression brackets when they
+We could be wrong, but this one looks like it might be an issue with \
+missing quotes. Always quote template expression brackets when they \
 start a value. For instance:
 
     with_items:
@@ -69,9 +69,9 @@ Should be written as:
 """
 
 YAML_COMMON_UNQUOTED_COLON_ERROR = """\
-This one looks easy to fix. There seems to be an extra unquoted colon in the line
-and this is confusing the parser. It was only expecting to find one free
-colon. The solution is just add some quotes around the colon, or quote the
+This one looks easy to fix. There seems to be an extra unquoted colon in the line \
+and this is confusing the parser. It was only expecting to find one free \
+colon. The solution is just add some quotes around the colon, or quote the \
 entire line after the first colon.
 
 For instance, if the original line was:
@@ -88,8 +88,8 @@ Or:
 """
 
 YAML_COMMON_PARTIALLY_QUOTED_LINE_ERROR = """\
-This one looks easy to fix. It seems that there is a value started
-with a quote, and the YAML parser is expecting to see the line ended
+This one looks easy to fix. It seems that there is a value started \
+with a quote, and the YAML parser is expecting to see the line ended \
 with the same kind of quote. For instance:
 
     when: "ok" in result.stdout
@@ -104,9 +104,9 @@ Or equivalently:
 """
 
 YAML_COMMON_UNBALANCED_QUOTES_ERROR = """\
-We could be wrong, but this one looks like it might be an issue with
-unbalanced quotes. If starting a value with a quote, make sure the
-line ends with the same set of quotes. For instance this arbitrary
+We could be wrong, but this one looks like it might be an issue with \
+unbalanced quotes. If starting a value with a quote, make sure the \
+line ends with the same set of quotes. For instance this arbitrary \
 example:
 
     foo: "bad" "wolf"

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -26,7 +26,6 @@ import os
 import random
 import subprocess
 import sys
-import textwrap
 import threading
 import time
 
@@ -42,6 +41,27 @@ from ansible.utils.multiprocessing import context as multiprocessing_context
 from ansible.utils.singleton import Singleton
 from ansible.utils.unsafe_proxy import wrap_var
 
+if getattr(C, 'DEFAULT_TEXT_WRAP'):
+    from textwrap import wrap
+
+    def wrappy(
+            text: str,
+            width: int = 70,
+            replace_whitespace: bool = True,
+            drop_whitespace: bool = True) -> list[str]:
+        return wrap(
+            text,
+            width=width,
+            replace_whitespace=replace_whitespace,
+            drop_whitespace=drop_whitespace)
+else:
+    def wrappy(
+            text: str,
+            width: int = 70,
+            replace_whitespace: bool = True,
+            drop_whitespace: bool = True) -> list[str]:
+        """Fake wrap that does no wrapping."""
+        return [text]
 
 _LIBC = ctypes.cdll.LoadLibrary(ctypes.util.find_library('c'))
 # Set argtypes, to avoid segfault if the wrong type is provided,
@@ -364,7 +384,7 @@ class Display(metaclass=Singleton):
         if removed:
             raise AnsibleError(message_text)
 
-        wrapped = textwrap.wrap(message_text, self.columns, drop_whitespace=False)
+        wrapped = wrappy(message_text, self.columns, drop_whitespace=False)
         message_text = "\n".join(wrapped) + "\n"
 
         if message_text not in self._deprecations:
@@ -375,7 +395,7 @@ class Display(metaclass=Singleton):
 
         if not formatted:
             new_msg = "[WARNING]: %s" % msg
-            wrapped = textwrap.wrap(new_msg, self.columns)
+            wrapped = wrappy(new_msg, self.columns)
             new_msg = "\n".join(wrapped) + "\n"
         else:
             new_msg = "\n[WARNING]: \n%s" % msg
@@ -431,7 +451,7 @@ class Display(metaclass=Singleton):
     def error(self, msg, wrap_text=True):
         if wrap_text:
             new_msg = u"\n[ERROR]: %s" % msg
-            wrapped = textwrap.wrap(new_msg, self.columns)
+            wrapped = wrappy(new_msg, self.columns)
             new_msg = u"\n".join(wrapped) + u"\n"
         else:
             new_msg = u"ERROR! %s" % msg

--- a/test/units/errors/test_errors.py
+++ b/test/units/errors/test_errors.py
@@ -63,7 +63,7 @@ class TestErrors(unittest.TestCase):
         e = AnsibleError(self.message, self.obj)
         self.assertEqual(
             e.message,
-            ("This is the error message\n\nThe error appears to be in 'foo.yml': line 1, column 19, but may\nbe elsewhere in the "
+            ("This is the error message\n\nThe error appears to be in 'foo.yml': line 1, column 19, but may be elsewhere in the "
              "file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n- lineinfile: line=foo path=bar\n"
              "                  ^ here\n\n"
              "There appears to be both 'k=v' shorthand syntax and YAML in this task. Only one syntax may be used.\n")
@@ -78,7 +78,7 @@ class TestErrors(unittest.TestCase):
 
         self.assertEqual(
             e.message,
-            ("This is the error message\n\nThe error appears to be in 'foo.yml': line 1, column 1, but may\nbe elsewhere in the file depending on the "
+            ("This is the error message\n\nThe error appears to be in 'foo.yml': line 1, column 1, but may be elsewhere in the file depending on the "
              "exact syntax problem.\n\nThe offending line appears to be:\n\n\nthis is line 1\n^ here\n")
         )
 
@@ -92,7 +92,7 @@ class TestErrors(unittest.TestCase):
             e = AnsibleError(self.message, self.obj)
             self.assertEqual(
                 e.message,
-                ("This is the error message\n\nThe error appears to be in 'foo.yml': line 1, column 1, but may\nbe elsewhere in the file depending on "
+                ("This is the error message\n\nThe error appears to be in 'foo.yml': line 1, column 1, but may be elsewhere in the file depending on "
                  "the exact syntax problem.\n\nThe offending line appears to be:\n\n\nthis is line 1\n^ here\n")
             )
 
@@ -102,7 +102,7 @@ class TestErrors(unittest.TestCase):
                 e = AnsibleError(self.message, self.obj)
                 self.assertEqual(
                     e.message,
-                    ("This is the error message\n\nThe error appears to be in 'foo.yml': line 2, column 1, but may\nbe elsewhere in the file depending on "
+                    ("This is the error message\n\nThe error appears to be in 'foo.yml': line 2, column 1, but may be elsewhere in the file depending on "
                      "the exact syntax problem.\n\n(specified line no longer in file, maybe it changed?)")
                 )
 
@@ -115,7 +115,7 @@ class TestErrors(unittest.TestCase):
             e = AnsibleError(self.unicode_message, self.obj)
             self.assertEqual(
                 e.message,
-                ("This is an error with \xf0\x9f\x98\xa8 in it\n\nThe error appears to be in 'foo.yml': line 1, column 1, but may\nbe elsewhere in the "
+                ("This is an error with \xf0\x9f\x98\xa8 in it\n\nThe error appears to be in 'foo.yml': line 1, column 1, but may be elsewhere in the "
                  "file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\nthis line has unicode \xf0\x9f\x98\xa8 in it!\n^ "
                  "here\n")
             )
@@ -131,7 +131,7 @@ class TestErrors(unittest.TestCase):
             e = AnsibleError(self.message, self.obj)
             self.assertEqual(
                 e.message,
-                ("This is the error message\n\nThe error appears to be in 'foo.yml': line 4, column 1, but may\nbe elsewhere in the file depending on "
+                ("This is the error message\n\nThe error appears to be in 'foo.yml': line 4, column 1, but may be elsewhere in the file depending on "
                  "the exact syntax problem.\n\nThe offending line appears to be:\n\nthis is line 2\nthis is line 3\n^ here\n")
             )
 
@@ -145,6 +145,6 @@ class TestErrors(unittest.TestCase):
             e = AnsibleError(self.message, self.obj)
             self.assertEqual(
                 e.message,
-                ("This is the error message\n\nThe error appears to be in 'foo.yml': line 5, column 1, but may\nbe elsewhere in the file depending on "
+                ("This is the error message\n\nThe error appears to be in 'foo.yml': line 5, column 1, but may be elsewhere in the file depending on "
                  "the exact syntax problem.\n\nThe offending line appears to be:\n\nthis is line 2\nthis is line 3\n^ here\n")
             )


### PR DESCRIPTION
##### SUMMARY

Allow user to disable console text wrapping by defining `ANSIBLE_TEXT_WRAP=False`. This change is important because current behaviour negatively impacts other tooling including ansible-navigator, ansible-lint, molecule and vscode-ansible.

Fixes: #71461

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
utils/display

##### ADDITIONAL INFORMATION

Related:
* https://github.com/ansible/ansible/pull/69259
* https://github.com/ansible/proposals/issues/33#issuecomment-1211645791
* https://github.com/ansible/ansible/issues/69258