### PR TITLE
Fix run_once in strategy

### DIFF
--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -175,7 +175,7 @@ class StrategyModule(StrategyBase):
                             # we don't care if it just shows the raw name
                             display.debug("templating failed for some reason", host=host_name)
 
-                        run_once = templar.template(task.run_once) or action and getattr(action, 'BYPASS_HOST_LOOP', False)
+                        run_once = task.get_validated_value('run_once', task._run_once, task.run_once, templar) or action and getattr(action, 'BYPASS_HOST_LOOP', False)
                         if run_once:
                             if action and getattr(action, 'BYPASS_HOST_LOOP', False):
                                 raise AnsibleError("The '%s' module bypasses the host loop, which is currently not supported in the free strategy "

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -288,8 +288,8 @@ class StrategyModule(StrategyBase):
                                 skip_rest = True
                                 break
 
-                        run_once = templar.template(task.run_once) or action and getattr(action, 'BYPASS_HOST_LOOP', False)
-
+                        run_once = task.get_validated_value('run_once', task._run_once, task.run_once, templar) or action and getattr(action, 'BYPASS_HOST_LOOP', False)
+                        
                         if (task.any_errors_fatal or run_once) and not task.ignore_errors:
                             any_errors_fatal = True
 


### PR DESCRIPTION
Signed-off-by: bo.jiang <bo.jiang@daocloud.io>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
this PR is mainly used to solve the inability to take effect when the variable of run_once is false in the loop task.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #78492

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
* free strategy plugin
* linear strategy plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
