### PR TITLE
[stable-2.13] Fix --role-file arg detection (#78475)

### DIFF
--- a/changelogs/fragments/78204-galaxy-role-file-detection.yml
+++ b/changelogs/fragments/78204-galaxy-role-file-detection.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- ansible-galaxy - Fix detection of ``--role-file`` in arguments for implicit role invocation
+  (https://github.com/ansible/ansible/issues/78204)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -487,7 +487,12 @@ class GalaxyCLI(CLI):
         else:
             install_parser.add_argument('-r', '--role-file', dest='requirements',
                                         help='A file containing a list of roles to be installed.')
-            if self._implicit_role and ('-r' in self._raw_args or '--role-file' in self._raw_args):
+
+            r_re = re.compile(r'^(?<!-)-[a-zA-Z]*r[a-zA-Z]*')  # -r, -fr
+            contains_r = bool([a for a in self._raw_args if r_re.match(a)])
+            role_file_re = re.compile(r'--role-file($|=)')  # --role-file foo, --role-file=foo
+            contains_role_file = bool([a for a in self._raw_args if role_file_re.match(a)])
+            if self._implicit_role and (contains_r or contains_role_file):
                 # Any collections in the requirements files will also be installed
                 install_parser.add_argument('--keyring', dest='keyring', default=C.GALAXY_GPG_KEYRING,
                                             help='The keyring used during collection signature verification')
@@ -1315,7 +1320,16 @@ class GalaxyCLI(CLI):
         ignore_errors = context.CLIARGS['ignore_errors']
         no_deps = context.CLIARGS['no_deps']
         force_with_deps = context.CLIARGS['force_with_deps']
-        disable_gpg_verify = context.CLIARGS['disable_gpg_verify']
+        try:
+            disable_gpg_verify = context.CLIARGS['disable_gpg_verify']
+        except KeyError:
+            if self._implicit_role:
+                raise AnsibleError(
+                    'Unable to properly parse command line arguments. Please use "ansible-galaxy collection install" '
+                    'instead of "ansible-galaxy install".'
+                )
+            raise
+
         # If `ansible-galaxy install` is used, collection-only options aren't available to the user and won't be in context.CLIARGS
         allow_pre_release = context.CLIARGS.get('allow_pre_release', False)
         upgrade = context.CLIARGS.get('upgrade', False)

--- a/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
@@ -423,6 +423,15 @@
     - (install_req_actual.results[0].content | b64decode | from_json).collection_info.version == '1.0.0'
     - (install_req_actual.results[1].content | b64decode | from_json).collection_info.version == '1.0.0'
 
+- name: Test deviations on -r and --role-file without collection or role sub command
+  command: '{{ cmd }}'
+  loop:
+    - ansible-galaxy install -vr '{{ galaxy_dir }}/ansible_collections/requirements.yaml' -s '{{ test_name }}' -vv
+    - ansible-galaxy install --role-file '{{ galaxy_dir }}/ansible_collections/requirements.yaml' -s '{{ test_name }}' -vvv
+    - ansible-galaxy install --role-file='{{ galaxy_dir }}/ansible_collections/requirements.yaml' -s '{{ test_name }}' -vvv
+  loop_control:
+    loop_var: cmd
+
 - name: uninstall collections for next requirements file test
   file:
     path: '{{ galaxy_dir }}/ansible_collections/{{ collection }}/name'


### PR DESCRIPTION
* Fix --role-file arg detection. Fixes #78204

* Do not traceback, give better error

* Add coverage for compound shortopts to match -r. Fixes #78491
(cherry picked from commit 86298b7)


Co-authored-by: Matt Martz <matt@sivel.net>