### PR TITLE
Limit gssapi below v1.8.0 @ tests under Python 3.6

### DIFF
--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -15,3 +15,4 @@ mock >= 2.0.0 # needed for features backported from Python 3.6 unittest.mock (as
 pytest-mock >= 1.4.0 # needed for mock_use_standalone_module pytest option
 setuptools < 45 ; python_version == '2.7' # setuptools 45 and later require python 3.5 or later
 pyspnego >= 0.1.6 ; python_version >= '3.10' # bug in older releases breaks on Python 3.10
+gssapi < 1.8.0; python_version == '3.6'  # our test env only fails under RHEL+Python 3.6


### PR DESCRIPTION
##### SUMMARY

The new release of `gssapi` isn't buildable in our CI, in the test envs that use old pip not supporting PEP 517/518. This patch excludes the said version.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`prepare_http_tests` helper in integration tests

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Ref: https://github.com/pythongssapi/python-gssapi/issues/299
