### PR TITLE
Accept __future__ annotations as valid imports in plugins

### DIFF
--- a/changelogs/fragments/validate-modules-annotations-future.yml
+++ b/changelogs/fragments/validate-modules-annotations-future.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ansible-test validate-modules - Allow annotations in ``__future__`` import for plugins

--- a/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/col/plugins/connection/annotations.py
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/col/plugins/connection/annotations.py
@@ -1,0 +1,30 @@
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+DOCUMENTATION = '''
+name: annotations
+short_description: validate-modules test with annotations import
+description:
+- This connection plugin tests out a plugin with an annotations import
+author: ansible (@core)
+'''
+
+from ansible.plugins.connection import ConnectionBase
+
+
+class Connection(ConnectionBase):
+
+    transport = 'annotations'
+
+    def exec_command(self, cmd, in_data=None, sudoable=True):
+        return 0, b"", b""
+
+    def put_file(self, in_path, out_path):
+        return
+
+    def fetch_file(self, in_path, out_path):
+        return
+
+    def close(self):
+        return

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
@@ -306,7 +306,7 @@ class ModuleValidator(Validator):
     # win_dsc is a dynamic arg spec, the docs won't ever match
     PS_ARG_VALIDATE_REJECTLIST = frozenset(('win_dsc.ps1', ))
 
-    ACCEPTLIST_FUTURE_IMPORTS = frozenset(('absolute_import', 'division', 'print_function'))
+    ACCEPTLIST_FUTURE_IMPORTS = frozenset(('absolute_import', 'annotations', 'division', 'print_function'))
 
     def __init__(self, path, analyze_arg_spec=False, collection=None, collection_version=None,
                  base_branch=None, git_cache=None, reporter=None, routing=None, plugin_type='module'):


### PR DESCRIPTION
##### SUMMARY
Add the `annotations` as an accept import for `__future__` allowing plugins with type annotations to opt into the string annotated behaviour which is set to become the default for Python in the future.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test validate-modules