### PR TITLE
Fix validate-modules version_added test

### DIFF
--- a/changelogs/fragments/validate-modules-version_added.yaml
+++ b/changelogs/fragments/validate-modules-version_added.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - validate-modules - fix validating version_added for new options.


### PR DESCRIPTION
##### SUMMARY
The temp file didn't end with a known extension, so [read_docstring](https://github.com/ansible/ansible/blob/devel/lib/ansible/parsing/plugin_docs.py#L158)  couldn't load module options.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Test Pull Request

##### COMPONENT NAME
validate-modules