### PR TITLE
Pause silent output

### DIFF
--- a/lib/ansible/modules/pause.py
+++ b/lib/ansible/modules/pause.py
@@ -36,6 +36,11 @@ options:
     type: bool
     default: 'yes'
     version_added: 2.5
+  silent:
+    description:
+      - Silent the help info
+    type: bool
+    default: 'no'
 author: "Tim Bielawa (@tbielawa)"
 extends_documentation_fragment:
   -  action_common_attributes

--- a/lib/ansible/modules/pause.py
+++ b/lib/ansible/modules/pause.py
@@ -41,6 +41,7 @@ options:
       - Do not show info output before pausing
     type: bool
     default: 'no'
+    version_added: 2.14
 author: "Tim Bielawa (@tbielawa)"
 extends_documentation_fragment:
   -  action_common_attributes

--- a/lib/ansible/modules/pause.py
+++ b/lib/ansible/modules/pause.py
@@ -38,7 +38,7 @@ options:
     version_added: 2.5
   silent:
     description:
-      - Silent the help info
+      - Do not show info output before pausing
     type: bool
     default: 'no'
 author: "Tim Bielawa (@tbielawa)"

--- a/lib/ansible/modules/pause.py
+++ b/lib/ansible/modules/pause.py
@@ -38,7 +38,9 @@ options:
     version_added: 2.5
   silent:
     description:
-      - Do not show info output before pausing
+      - Controls whether or not the duration and how to interrupt the timeout is shown.
+      - Has no effect unless 'seconds' or 'minutes' is set.
+      - Has no effect on the final message if the timer is interrupted with ctrl+C.
     type: bool
     default: 'no'
     version_added: 2.14

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -124,6 +124,7 @@ class ActionModule(ActionBase):
                 'minutes': {'type': int},  # Don't break backwards compat, allow floats, by using int callable
                 'seconds': {'type': int},  # Don't break backwards compat, allow floats, by using int callable
                 'prompt': {'type': 'str'},
+                'silent': {'type': bool, 'default': False},
             },
             mutually_exclusive=(
                 ('minutes', 'seconds'),
@@ -133,6 +134,7 @@ class ActionModule(ActionBase):
         duration_unit = 'minutes'
         prompt = None
         seconds = None
+        silent = 0
         echo = new_module_args['echo']
         echo_prompt = ''
         result.update(dict(
@@ -181,8 +183,11 @@ class ActionModule(ActionBase):
                 signal.alarm(seconds)
 
                 # show the timer and control prompts
-                display.display("Pausing for %d seconds%s" % (seconds, echo_prompt))
-                display.display("(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)\r"),
+                display.display("New_module_args_seconds is %d silent is %s" % (new_module_args['seconds'], silent))
+                display.display("New_module_args_silent is %d silent is %s" % (new_module_args['silent'], silent))
+                if new_module_args['silent'] == silent:
+                    display.display("Pausingggggg for %d seconds%s" % (seconds, echo_prompt))
+                    display.display("(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)\r"),
 
                 # show the prompt specified in the task
                 if new_module_args['prompt']:

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -140,7 +140,6 @@ class ActionModule(ActionBase):
         result.update(dict(
             changed=False,
             rc=0,
-            silent=silent,
             stderr='',
             stdout='',
             start=None,

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -124,7 +124,7 @@ class ActionModule(ActionBase):
                 'minutes': {'type': int},  # Don't break backwards compat, allow floats, by using int callable
                 'seconds': {'type': int},  # Don't break backwards compat, allow floats, by using int callable
                 'prompt': {'type': 'str'},
-                'silent': {'type': bool, 'default': False},
+                'silent': {'type': 'bool', 'default': False},
             },
             mutually_exclusive=(
                 ('minutes', 'seconds'),
@@ -134,12 +134,13 @@ class ActionModule(ActionBase):
         duration_unit = 'minutes'
         prompt = None
         seconds = None
-        silent = 0
+        silent = new_module_args['silent']
         echo = new_module_args['echo']
         echo_prompt = ''
         result.update(dict(
             changed=False,
             rc=0,
+            silent=silent,
             stderr='',
             stdout='',
             start=None,
@@ -183,10 +184,8 @@ class ActionModule(ActionBase):
                 signal.alarm(seconds)
 
                 # show the timer and control prompts
-                display.display("New_module_args_seconds is %d silent is %s" % (new_module_args['seconds'], silent))
-                display.display("New_module_args_silent is %d silent is %s" % (new_module_args['silent'], silent))
-                if new_module_args['silent'] == silent:
-                    display.display("Pausingggggg for %d seconds%s" % (seconds, echo_prompt))
+                if not silent:
+                    display.display("Pausing for %d seconds%s" % (seconds, echo_prompt))
                     display.display("(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)\r"),
 
                 # show the prompt specified in the task


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We want to use **pause** module, but because we wait for json output, unnecessary output "_Pausing for x seconds_" breaks our logic in internal tools. This PR adds option to silence this output. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pause
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Added new flag 'silent' for pause module. When set to **true**, silences default output.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
BEFORE:
> ansible localhost -m pause -a 'seconds=2'
Pausing for 2 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
localhost | SUCCESS => {...}

AFTER:
> ansible localhost -m pause -a 'seconds=2 silent=True'
localhost | SUCCESS => {...}
```
