### PR TITLE
Address inactive but legacy print calls found with code checking.

### DIFF
--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -548,9 +548,7 @@ class DnfModule(YumDnf):
             e2 = str(e2)
         v2 = str(v2)
         r2 = str(r2)
-        # print('%s, %s, %s vs %s, %s, %s' % (e1, v1, r1, e2, v2, r2))
         rc = dnf.rpm.rpm.labelCompare((e1, v1, r1), (e2, v2, r2))
-        # print('%s, %s, %s vs %s, %s, %s = %s' % (e1, v1, r1, e2, v2, r2, rc))
         return rc
 
     def _ensure_dnf(self):

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -548,9 +548,9 @@ class DnfModule(YumDnf):
             e2 = str(e2)
         v2 = str(v2)
         r2 = str(r2)
-        # print '%s, %s, %s vs %s, %s, %s' % (e1, v1, r1, e2, v2, r2)
+        # print('%s, %s, %s vs %s, %s, %s' % (e1, v1, r1, e2, v2, r2))
         rc = dnf.rpm.rpm.labelCompare((e1, v1, r1), (e2, v2, r2))
-        # print '%s, %s, %s vs %s, %s, %s = %s' % (e1, v1, r1, e2, v2, r2, rc)
+        # print('%s, %s, %s vs %s, %s, %s = %s' % (e1, v1, r1, e2, v2, r2, rc))
         return rc
 
     def _ensure_dnf(self):

--- a/lib/ansible/modules/service_facts.py
+++ b/lib/ansible/modules/service_facts.py
@@ -142,7 +142,7 @@ class ServiceScanService(BaseService):
 
     def _list_rh(self, services):
 
-        # print '%s --status-all | grep -E "is (running|stopped)"' % service_path
+        # print('%s --status-all | grep -E "is (running|stopped)"' % service_path)
         p = re.compile(
             r'(?P<service>.*?)\s+[0-9]:(?P<rl0>on|off)\s+[0-9]:(?P<rl1>on|off)\s+[0-9]:(?P<rl2>on|off)\s+'
             r'[0-9]:(?P<rl3>on|off)\s+[0-9]:(?P<rl4>on|off)\s+[0-9]:(?P<rl5>on|off)\s+[0-9]:(?P<rl6>on|off)')

--- a/lib/ansible/modules/service_facts.py
+++ b/lib/ansible/modules/service_facts.py
@@ -142,7 +142,6 @@ class ServiceScanService(BaseService):
 
     def _list_rh(self, services):
 
-        # print('%s --status-all | grep -E "is (running|stopped)"' % service_path)
         p = re.compile(
             r'(?P<service>.*?)\s+[0-9]:(?P<rl0>on|off)\s+[0-9]:(?P<rl1>on|off)\s+[0-9]:(?P<rl2>on|off)\s+'
             r'[0-9]:(?P<rl3>on|off)\s+[0-9]:(?P<rl4>on|off)\s+[0-9]:(?P<rl5>on|off)\s+[0-9]:(?P<rl6>on|off)')


### PR DESCRIPTION
##### SUMMARY

Change legacy usage of `print` in comments to work with modern Python. Found during code checking.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
NA

##### ADDITIONAL INFORMATION
Usage of `print result` should be `print(result)`

Would be found if the commented out troubleshooting usage was uncommented to validate something.
