### PR TITLE
fix fqcr builtin/legacy connection plugins that accept extra variables

### DIFF
--- a/changelogs/fragments/78602-fix-connection-extra-vars.yml
+++ b/changelogs/fragments/78602-fix-connection-extra-vars.yml
@@ -4,7 +4,7 @@ bugfixes:
   (https://github.com/ansible/ansible/issues/78566).
 deprecated_features:
 - >-
-  Determining extra vars for connection plugins is deprecated.
+  Determining extra vars for connection plugins using the plugin name is deprecated.
   Instead of setting the class attribute allow_extras to True, set allow_extras
   to a list of tuple pairs.
   The first item in each pair is a regex to match variable names, and the second

--- a/changelogs/fragments/78602-fix-connection-extra-vars.yml
+++ b/changelogs/fragments/78602-fix-connection-extra-vars.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - winrm/psrp - fix using extra variables with fully qualified connection names (https://github.com/ansible/ansible/issues/78566).

--- a/changelogs/fragments/78602-fix-connection-extra-vars.yml
+++ b/changelogs/fragments/78602-fix-connection-extra-vars.yml
@@ -9,6 +9,6 @@ deprecated_features:
   to a list of tuple pairs.
   The first item in each pair is a regex to match variable names, and the second
   item is the replacement string.
-  For example, to match all variable names starting with 'prefix_' and remove the
-  the prefix, set allow_extras to [(r'^prefix_', '')].
-  To keep the prefix, allow_extras can be set to [(r'(^prefix_)', r'\1')].
+  For example, to match all variable names starting with ``prefix_`` and remove the
+  the prefix, set allow_extras to ``[(r'^prefix_', '')]``.
+  To keep the prefix, allow_extras can be set to ``[(r'(^prefix_)', r'\1')]``.

--- a/changelogs/fragments/78602-fix-connection-extra-vars.yml
+++ b/changelogs/fragments/78602-fix-connection-extra-vars.yml
@@ -1,2 +1,14 @@
 bugfixes:
-  - winrm/psrp - fix using extra variables with fully qualified connection names (https://github.com/ansible/ansible/issues/78566).
+- >-
+  winrm/psrp - fix using extra variables with fully qualified connection names
+  (https://github.com/ansible/ansible/issues/78566).
+deprecated_features:
+- >-
+  Determining extra vars for connection plugins is deprecated.
+  Instead of setting the class attribute allow_extras to True, set allow_extras
+  to a list of tuple pairs.
+  The first item in each pair is a regex to match variable names, and the second
+  item is the replacement string.
+  For example, to match all variable names starting with 'prefix_' and remove the
+  the prefix, set allow_extras to [(r'^prefix_', '')].
+  To keep the prefix, allow_extras can be set to [(r'(^prefix_)', r'\1')].

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -352,28 +352,6 @@ class ConfigManager(object):
 
         return options
 
-    def get_extra_vars(self, plugin_type, name, available_var_names):
-        extra_vars = []
-        for opt, pdef in self.get_configuration_definitions(plugin_type, name).items():
-            if 'meta_vars' in pdef and pdef['meta_vars']:
-                if pdef.get('type', 'str') != 'dict':
-                    raise AnsibleOptionsError(
-                        f"Invalid option definition for {plugin_type} plugin {name}. Option '{opt}' has type "
-                        f"{pdef.get('type', 'str')} but defined meta_vars which are only supported by type 'dict'."
-                    )
-
-                for var_entry in pdef['meta_vars']:
-                    if 'name' in var_entry and 'prefix' in var_entry:
-                        raise AnsibleOptionsError(f"Unsupported variable for {plugin_type} '{name}': {var_entry}")
-                    if 'prefix' in var_entry:
-                        for var_name in available_var_names:
-                            if not var_name.startswith(var_entry['prefix']):
-                                continue
-                            extra_vars.append((opt, var_name,))
-                    elif var_entry['name'] in available_var_names:
-                        extra_vars.append((opt, var_entry['name']))
-        return extra_vars
-
     def get_plugin_vars(self, plugin_type, name):
 
         pvars = []
@@ -387,14 +365,6 @@ class ConfigManager(object):
 
         options = []
         for option_name, pdef in self.get_configuration_definitions(plugin_type, name).items():
-            if 'meta_vars' in pdef and pdef['meta_vars']:
-                for var_entry in pdef['meta_vars']:
-                    if 'name' in var_entry and 'prefix' in var_entry:
-                        raise AnsibleOptionsError(f"Unsupported variable for {plugin_type} '{name}'. : {var_entry}")
-                    if 'name' in var_entry and variable == var_entry['name']:
-                        options.append(option_name)
-                    if 'prefix' in var_entry and variable.startswith(var_entry['prefix']):
-                        options.append(option_name)
             if 'vars' in pdef and pdef['vars']:
                 for var_entry in pdef['vars']:
                     if variable == var_entry['name']:
@@ -431,40 +401,15 @@ class ConfigManager(object):
 
         return ret
 
-    def _loop_entries(self, container, entry_list, meta_vars=False):
+    def _loop_entries(self, container, entry_list):
         ''' repeat code for value entry assignment '''
+
         value = None
         origin = None
-
-        if meta_vars:
-            combined_value = {}
-            entry_keys = ['name', 'prefix']  # mutually exclusive
-        else:
-            entry_keys = []
-
         for entry in entry_list:
-            for entry_key in entry_keys:
-                if entry_key in entry:
-                    name = entry.get(entry_key)
-                    break
-            else:
-                entry_key = 'name'
-                name = entry.get('name', None)
+            name = entry.get('name')
             try:
-                if entry_key == 'name':
-                    if meta_vars:
-                        temp_value = None
-                        if name in container:
-                            temp_value = {name: container[name]}
-                    else:
-                        temp_value = container.get(name, None)
-                elif entry_key == 'prefix':
-                    temp_value = None
-                    for container_key in container:
-                        if container_key.startswith(name):
-                            if temp_value is None:
-                                temp_value = {}
-                            temp_value.update({container_key: container[container_key]})
+                temp_value = container.get(name, None)
             except UnicodeEncodeError:
                 self.WARNINGS.add(u'value for config entry {0} contains invalid characters, ignoring...'.format(to_text(name)))
                 continue
@@ -479,11 +424,6 @@ class ConfigManager(object):
                 # deal with deprecation of setting source, if used
                 if 'deprecated' in entry:
                     self.DEPRECATED.append((entry['name'], entry['deprecated']))
-
-                if meta_vars:
-                    combined_value.update(temp_value)
-        if meta_vars:
-            return combined_value
 
         return value, origin
 
@@ -527,10 +467,6 @@ class ConfigManager(object):
                     if direct_aliases:
                         value = direct_aliases[0]
                         origin = 'Direct'
-
-            if value is None and variables and defs[config].get('meta_vars'):
-                value = self._loop_entries(variables, defs[config]['meta_vars'], meta_vars=True)
-                origin = 'meta var: %s' % ','.join([var_name for var_name in value.keys()])
 
             if value is None and variables and defs[config].get('vars'):
                 # Use 'variable overrides' if present, highest precedence, but only present when querying running play

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -94,7 +94,6 @@ class TaskExecutor:
         self._loader = loader
         self._shared_loader_obj = shared_loader_obj
         self._connection = None
-        self._connection_fqcn = None
         self._final_q = final_q
         self._loop_eval_error = None
 
@@ -952,7 +951,6 @@ class TaskExecutor:
             task_uuid=self._task._uuid,
             ansible_playbook_pid=to_text(os.getppid())
         )
-        self._connection_fqcn = plugin_load_context.resolved_fqcn
 
         if not connection:
             raise AnsibleError("the connection plugin '%s' was not found" % conn_type)
@@ -1032,12 +1030,12 @@ class TaskExecutor:
             if self._connection.allow_extras is True:
                 display.deprecated(
                     "Using the connection plugin's _load_name to determine extra vars is deprecated. "
-                    f"Use the porting guide to update {self._connection_fqcn}'s allow_extras attribute "
+                    f"Use the porting guide to update {self._connection.ansible_name}'s allow_extras attribute "
                     "from a boolean to a list regex pairs.",
                     version="2.18"
                 )
                 # Remove the namespace.collection and join the remainder to handle subdir.plugin
-                plugin_name = '.'.join(self._connection_fqcn.split('.')[2:])
+                plugin_name = '.'.join(self._connection.ansible_name.split('.')[2:])
                 match_extras = [(r'(^ansible_%s_)' % re.escape(plugin_name), r'\1')]
             else:
                 match_extras = self._connection.allow_extras
@@ -1048,7 +1046,7 @@ class TaskExecutor:
                     any(len(item) != 2 for item in match_extras)
             ):
                 raise AnsibleError(
-                    f"Unable to load extra vars for {self._connection_fqcn}. "
+                    f"Unable to load extra vars for {self._connection.ansible_name}. "
                     "Set the plugin's allow_extras attribute to a list of tuple pairs or a boolean. "
                     f"Got: {match_extras}"
                 )

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -1025,9 +1025,13 @@ class TaskExecutor:
                 options[k] = templar.template(variables[k])
 
         # add extras if plugin supports them
-        ns = '.'.join(self._connection_fqcn.split('.')[0:2])
+        if '.' in self._connection_fqcn:
+            ns = '.'.join(self._connection_fqcn.split('.')[0:2])
+        else:
+            # ansible.legacy plugins do not include 'ansible.legacy.' in the resolved plugin name
+            ns = ''
         plugin_name = self._connection_fqcn.split(ns + '.', 1)[-1]
-        if getattr(self._connection, 'allow_extras', False) and ns in ('ansible.builtin', 'ansible.legacy'):
+        if getattr(self._connection, 'allow_extras', False) and ns in ('ansible.builtin', ''):
             for k in variables:
                 if k.startswith('ansible_%s_' % plugin_name) and k not in options:
                     options['_extras'][k] = templar.template(variables[k])

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -1022,7 +1022,7 @@ class TaskExecutor:
         options = {'_extras': {}}
 
         extra_option_vars = C.config.get_extra_vars('connection', self._connection._load_name, variables.keys())
-        varnames.extend([var for opt, var_name in extra_option_vars])
+        varnames.extend([var_name for opt, var_name in extra_option_vars])
         extras = {}
         for name, var_name in extra_option_vars:
             if name not in extras:

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -1045,7 +1045,7 @@ class TaskExecutor:
             if (
                     not isinstance(match_extras, Iterable) or
                     any(not isinstance(item, Iterable) for item in match_extras) or
-                    any(not len(item) == 2 for item in match_extras)
+                    any(len(item) != 2 for item in match_extras)
             ):
                 raise AnsibleError(
                     f"Unable to load extra vars for {self._connection_fqcn}. "

--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -53,7 +53,7 @@ def get_plugin_class(obj):
 class AnsiblePlugin(ABC):
 
     # allow extra passthrough parameters
-    allow_extras = False
+    allow_extras = False  # type: t.Union[bool, t.List[t.Tuple[str, str]]]
 
     def __init__(self):
         self._options = {}

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -303,6 +303,13 @@ options:
     vars:
     - name: ansible_psrp_configuration_name
     default: Microsoft.PowerShell
+  _extras:
+    description:
+      - Supports any additional variables permitted by the version of psrp.
+        The prefix "ansible_psrp_" (which is used to find the variables) is stripped before psrp uses them.
+    type: dict
+    meta_vars:
+      - prefix: ansible_psrp_
 """
 
 import base64
@@ -343,7 +350,6 @@ class Connection(ConnectionBase):
     module_implementation_preferences = ('.ps1', '.exe', '')
     allow_executable = False
     has_pipelining = True
-    allow_extras = True
 
     def __init__(self, *args, **kwargs):
         self.always_pipeline_modules = True

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -752,7 +752,7 @@ if ($bytes_read -gt 0) {
         supported_args = []
         for auth_kwarg in AUTH_KWARGS.values():
             supported_args.extend(auth_kwarg)
-        extra_args = {v for v in self.get_option('_extras')}
+        extra_args = set(self.get_option('_extras'))
         unsupported_args = extra_args.difference(supported_args)
 
         for arg in unsupported_args:

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -303,14 +303,6 @@ options:
     vars:
     - name: ansible_psrp_configuration_name
     default: Microsoft.PowerShell
-  _extras:
-    description:
-      - Supports any additional variables permitted by the version of psrp.
-        The prefix "ansible_psrp_" (which is used to find the variables) is stripped before psrp uses them.
-    type: dict
-    default: {}
-    meta_vars:
-      - prefix: ansible_psrp_
 """
 
 import base64
@@ -351,6 +343,7 @@ class Connection(ConnectionBase):
     module_implementation_preferences = ('.ps1', '.exe', '')
     allow_executable = False
     has_pipelining = True
+    allow_extras = [(r'(^ansible_psrp_)', r'')]
 
     def __init__(self, *args, **kwargs):
         self.always_pipeline_modules = True
@@ -759,7 +752,7 @@ if ($bytes_read -gt 0) {
         supported_args = []
         for auth_kwarg in AUTH_KWARGS.values():
             supported_args.extend(auth_kwarg)
-        extra_args = {v.replace('ansible_psrp_', '') for v in self.get_option('_extras')}
+        extra_args = {v for v in self.get_option('_extras')}
         unsupported_args = extra_args.difference(supported_args)
 
         for arg in unsupported_args:
@@ -806,7 +799,7 @@ if ($bytes_read -gt 0) {
 
         # add in the extra args that were set
         for arg in extra_args.intersection(supported_args):
-            option = self.get_option('_extras')['ansible_psrp_%s' % arg]
+            option = self.get_option('_extras')[arg]
             self._psrp_conn_kwargs[arg] = option
 
     def _exec_psrp_script(self, script, input_data=None, use_local_scope=True, arguments=None):

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -308,6 +308,7 @@ options:
       - Supports any additional variables permitted by the version of psrp.
         The prefix "ansible_psrp_" (which is used to find the variables) is stripped before psrp uses them.
     type: dict
+    default: {}
     meta_vars:
       - prefix: ansible_psrp_
 """

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -302,7 +302,7 @@ class Connection(ConnectionBase):
         argspec = getfullargspec(Protocol.__init__)
         supported_winrm_args = set(argspec.args)
         supported_winrm_args.update(internal_kwarg_mask)
-        passed_winrm_args = {v for v in self.get_option('_extras')}
+        passed_winrm_args = set(self.get_option('_extras'))
         unsupported_args = passed_winrm_args.difference(supported_winrm_args)
 
         # warn for kwargs unsupported by the installed version of pywinrm

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -143,6 +143,7 @@ DOCUMENTATION = """
           - Supports any additional variables permitted by the version of pywinrm.
             The prefix "ansible_winrm_" (which is used to find the variables) is stripped before pywinrm uses them.
         type: dict
+        default: {}
         meta_vars:
           - prefix: ansible_winrm_
 """

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -138,6 +138,13 @@ DOCUMENTATION = """
         vars:
           - name: ansible_winrm_connection_timeout
         type: int
+      _extras:
+        description:
+          - Supports any additional variables permitted by the version of pywinrm.
+            The prefix "ansible_winrm_" (which is used to find the variables) is stripped before pywinrm uses them.
+        type: dict
+        meta_vars:
+          - prefix: ansible_winrm_
 """
 
 import base64
@@ -222,7 +229,6 @@ class Connection(ConnectionBase):
     module_implementation_preferences = ('.ps1', '.exe', '')
     allow_executable = False
     has_pipelining = True
-    allow_extras = True
 
     def __init__(self, *args, **kwargs):
 

--- a/test/integration/targets/connection_winrm/runme.sh
+++ b/test/integration/targets/connection_winrm/runme.sh
@@ -2,10 +2,11 @@
 
 set -eux
 
+for INV in test_connection.inventory.j2 test_fqcn_connection.inventory.j2; do
 # make sure hosts are using winrm connections
 ansible -i ../../inventory.winrm localhost \
     -m template \
-    -a "src=test_connection.inventory.j2 dest=${OUTPUT_DIR}/test_connection.inventory" \
+    -a "src=$INV dest=${OUTPUT_DIR}/test_connection.inventory" \
     "$@"
 
 cd ../connection
@@ -21,3 +22,4 @@ cd ../connection_winrm
 
 ansible-playbook -i "${OUTPUT_DIR}/test_connection.inventory" tests.yml \
     "$@"
+done

--- a/test/integration/targets/connection_winrm/test_fqcn_connection.inventory.j2
+++ b/test/integration/targets/connection_winrm/test_fqcn_connection.inventory.j2
@@ -1,0 +1,10 @@
+[windows]
+{% for host in vars.groups.windows %}
+{{ host }}  ansible_host={{ hostvars[host]['ansible_host'] }} ansible_port={{ hostvars[host]['ansible_port'] }} ansible_user={{ hostvars[host]['ansible_user'] }} ansible_password={{ hostvars[host]['ansible_password'] }}
+{% endfor %}
+
+[windows:vars]
+ansible_connection=ansible.builtin.winrm
+# we don't know if we're using an encrypted connection or not, so we'll use message encryption
+ansible_winrm_transport=ntlm
+ansible_winrm_server_cert_validation=ignore

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -358,6 +358,7 @@ class TestTaskExecutor(unittest.TestCase):
         )
 
         te._get_connection = MagicMock(return_value=mock_connection)
+        te._connection_fqcn = MagicMock()
         context = MagicMock()
         te._get_action_handler_with_context = MagicMock(return_value=get_with_context_result(mock_action, context))
 

--- a/test/units/plugins/connection/test_psrp.py
+++ b/test/units/plugins/connection/test_psrp.py
@@ -151,7 +151,7 @@ class TestConnectionPSRP(object):
         ),
         # psrp extras
         (
-            {'_extras': {'ansible_psrp_mock_test1': True}},
+            {'_extras': {'mock_test1': True}},
             {
                 '_psrp_conn_kwargs': {
                     'server': 'inventory_hostname',
@@ -223,7 +223,7 @@ class TestConnectionPSRP(object):
         new_stdin = StringIO()
 
         conn = connection_loader.get('psrp', pc, new_stdin)
-        conn.set_options(var_options={'_extras': {'ansible_psrp_mock_test3': True}})
+        conn.set_options(var_options={'_extras': {'mock_test3': True}})
 
         mock_display = MagicMock()
         monkeypatch.setattr(Display, "warning", mock_display)

--- a/test/units/plugins/connection/test_winrm.py
+++ b/test/units/plugins/connection/test_winrm.py
@@ -149,8 +149,8 @@ class TestConnectionWinRM(object):
         ),
         # winrm extras
         (
-            {'_extras': {'ansible_winrm_server_cert_validation': 'ignore',
-                         'ansible_winrm_service': 'WSMAN'}},
+            {'_extras': {'server_cert_validation': 'ignore',
+                         'service': 'WSMAN'}},
             {},
             {
                 '_winrm_kwargs': {'username': None, 'password': None,
@@ -229,7 +229,7 @@ class TestWinRMKerbAuth(object):
          (["kinit", "user@domain"],)],
         [{"_extras": {}, 'ansible_winrm_kinit_cmd': 'kinit2'},
          (["kinit2", "user@domain"],)],
-        [{"_extras": {'ansible_winrm_kerberos_delegation': True}},
+        [{"_extras": {'kerberos_delegation': True}},
          (["kinit", "-f", "user@domain"],)],
         [{"_extras": {}, 'ansible_winrm_kinit_args': '-f -p'},
          (["kinit", "-f", "-p", "user@domain"],)],
@@ -266,7 +266,7 @@ class TestWinRMKerbAuth(object):
          ("kinit", ["user@domain"],)],
         [{"_extras": {}, 'ansible_winrm_kinit_cmd': 'kinit2'},
          ("kinit2", ["user@domain"],)],
-        [{"_extras": {'ansible_winrm_kerberos_delegation': True}},
+        [{"_extras": {'kerberos_delegation': True}},
          ("kinit", ["-f", "user@domain"],)],
         [{"_extras": {}, 'ansible_winrm_kinit_args': '-f -p'},
          ("kinit", ["-f", "-p", "user@domain"],)],


### PR DESCRIPTION
##### SUMMARY
Fixes #78566

* fix builtin/legacy connection plugins that accept extra variables when using the fqcr

* add a test for winrm extra vars

I checked 2.9 to see if there were any migrated connection plugins using this. `vmware_tools` sets allow_extras to True, but never appears to have used extra vars so I just fixed it for builtin/legacy. Plugins in collections can use config to get specific variables.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
connection plugins