### PR TITLE
Note that `become_user` is required for `runas`

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_privilege_escalation.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_privilege_escalation.rst
@@ -389,7 +389,7 @@ Since Ansible 2.3, ``become`` can be used on Windows hosts through the
 invocation arguments as ``become`` on a non-Windows host, so the setup and
 variable names are the same as what is defined in this document with the exception
 of ``become_user``. As there is no sensible default for ``become_user`` on Windows
-it is required when using ``become``.
+it is required when using ``become``. See :ref:`ansible.builtin.runas become plugin <ansible_collections.ansible.builtin.runas_become>` for details.
 
 While ``become`` can be used to assume the identity of another user, there are other uses for
 it with Windows hosts. One important use is to bypass some of the

--- a/docs/docsite/rst/playbook_guide/playbooks_privilege_escalation.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_privilege_escalation.rst
@@ -387,7 +387,9 @@ Become and Windows
 Since Ansible 2.3, ``become`` can be used on Windows hosts through the
 ``runas`` method. Become on Windows uses the same inventory setup and
 invocation arguments as ``become`` on a non-Windows host, so the setup and
-variable names are the same as what is defined in this document.
+variable names are the same as what is defined in this document with the exception
+of ``become_user``. As there is no sensible default for ``become_user`` on Windows
+it is required when using ``become``.
 
 While ``become`` can be used to assume the identity of another user, there are other uses for
 it with Windows hosts. One important use is to bypass some of the


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add that `become_user` is required on Windows when using the `runas` plugin in the `Become and Windows` section.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
