### PR TITLE
doc: Correct mixed up commentary and task name

### DIFF
--- a/lib/ansible/modules/replace.py
+++ b/lib/ansible/modules/replace.py
@@ -110,8 +110,7 @@ notes:
 '''
 
 EXAMPLES = r'''
-# NOTE: Before Ansible 2.3, option 'dest', 'destfile' or 'name' was used instead of 'path'
-- name: Replace old hostname with new hostname
+- name: Replace old hostname with new hostname (requires Ansible >= 2.4)
   ansible.builtin.replace:
     path: /etc/hosts
     regexp: '(\s+)old\.host\.name(\s+.*)?$'

--- a/lib/ansible/modules/replace.py
+++ b/lib/ansible/modules/replace.py
@@ -110,7 +110,8 @@ notes:
 '''
 
 EXAMPLES = r'''
-- name: Before Ansible 2.3, option 'dest', 'destfile' or 'name' was used instead of 'path'
+# NOTE: Before Ansible 2.3, option 'dest', 'destfile' or 'name' was used instead of 'path'
+- name: Replace old hostname with new hostname
   ansible.builtin.replace:
     path: /etc/hosts
     regexp: '(\s+)old\.host\.name(\s+.*)?$'


### PR DESCRIPTION
##### SUMMARY
In the documentation for the replace module, the example section had a case of comment and task name being mixed up. This is now corrected.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
In the documentation for the replace module, the example section had a case of comment and task name being mixed up. This is now corrected.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ansible.builtin.replace

##### ADDITIONAL INFORMATION
N/A