### PR TITLE
Fix file integration test chattr/lsattr check.

### DIFF
--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -151,8 +151,10 @@
     attributes_supported: yes
   when:
     - attribute_A_set is success
+    - attribute_A_set.stdout_lines
     - "'A' in attribute_A_set.stdout_lines[0].split()[0]"
     - attribute_A_unset is success
+    - attribute_A_unset.stdout_lines
     - "'A' not in attribute_A_unset.stdout_lines[0].split()[0]"
 
 - name: explicitly set file attribute "A"


### PR DESCRIPTION
##### SUMMARY

On BusyBox systems such as Alpine, chattr on a tmpfs fails with a status of 0 and output only on stderr.

This change updates the test to not assume output on stdout.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

file integration test
