### PR TITLE
[stable-2.13] Fix file integration test chattr/lsattr check. (#78614)

### DIFF
--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -151,8 +151,10 @@
     attributes_supported: yes
   when:
     - attribute_A_set is success
+    - attribute_A_set.stdout_lines
     - "'A' in attribute_A_set.stdout_lines[0].split()[0]"
     - attribute_A_unset is success
+    - attribute_A_unset.stdout_lines
     - "'A' not in attribute_A_unset.stdout_lines[0].split()[0]"
 
 - name: explicitly set file attribute "A"


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/78614

On BusyBox systems such as Alpine, chattr on a tmpfs fails with a status of 0 and output only on stderr.

This change updates the test to not assume output on stdout.

(cherry picked from commit 2e536c0afb9008884a0f12e8e650541e0ead76c9)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

file integration test
