### PR TITLE
[backport][2.12] Fail fast in stuck `ansible-galaxy-collection`

### DIFF
--- a/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
+++ b/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
@@ -85,6 +85,10 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_bytes
 from functools import partial
 from multiprocessing import dummy as threading
+from multiprocessing import TimeoutError
+
+
+COLLECTIONS_BUILD_AND_PUBLISH_TIMEOUT = 120
 
 
 def publish_collection(module, collection):
@@ -182,7 +186,14 @@ def run_module():
 
     pool = threading.Pool(4)
     publish_func = partial(publish_collection, module)
-    result['results'] = pool.map(publish_func, module.params['collections'])
+    try:
+        result['results'] = pool.map_async(
+            publish_func, module.params['collections'],
+        ).get(timeout=COLLECTIONS_BUILD_AND_PUBLISH_TIMEOUT)
+    except TimeoutError as timeout_err:
+        module.fail_json(
+            'Timed out waiting for collections to be provisioned.',
+        )
 
     failed = bool(sum(
         r['build']['rc'] + r['publish']['rc'] for r in result['results']


### PR DESCRIPTION
##### SUMMARY

This specific integration test gets stuck periodically causing the
Galaxy jobs to be killed on timeout wasting an hour of runtime. The
module that gets stuck waiting on Pulp is an in-test one, called
`setup_collections`. When it works, the task is complete in around 70
seconds but when it doesn't, it just freezes the whole play.

This patch attempts to make it fail faster by putting a reasonable
timeout value of 2 minutes.

(cherry picked from commit f1c56e988dbbb769b34a3c80baa40c916b4d0c88)

This is a backport of #78616

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test/integration/targets/ansible-galaxy-collection/library/setup_collections.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A