### PR TITLE
Fixes typo on docsite playbook_reuse_roles page

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
@@ -363,7 +363,7 @@ Sample specification
          required: true
          description: "The string value"
 
-   # roles/maypp/tasks/alternate.yml entry point
+   # roles/myapp/tasks/alternate.yml entry point
    alternate:
      short_description: The alternate entry point for the myapp role.
      options:


### PR DESCRIPTION
##### SUMMARY

I found a typo on the docsite [playbooks role argument specification examples section of the playbook_reuse_roles page: playbooks_reuse_roles.html#sample-specification](https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html#sample-specification).

<!--- Describe the change below, including rationale and design decisions --> 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Docs Pull Request

<!--- 
Pick one below and delete the rest
- Bugfix Pull Request 
- Feature Pull Request
- Test Pull Request 
-->

<!--- 
##### COMPONENT NAME

I'm not sure this section is relevant, but I'd be happy to update this with any additional needed info.
 -->
<!--- Write the short name of the module, plugin, task or feature below -->

<!--- 
##### ADDITIONAL INFORMATION
I'm not sure this section is relevant, but I'd be happy to update this with any additional needed info.
 -->

<!--- 
Include additional information to help people understand the change here
A step-by-step reproduction of the problem is helpful if there is no related issue
Paste verbatim command output below, e.g. before and after your change
```paste below

```
-->
