### PR TITLE
Fixes parameter name in expect module examples

### DIFF
--- a/lib/ansible/modules/expect.py
+++ b/lib/ansible/modules/expect.py
@@ -90,7 +90,7 @@ author: "Matt Martz (@sivel)"
 EXAMPLES = r'''
 - name: Case insensitive password string match
   ansible.builtin.expect:
-    ansible.builtin.command: passwd username
+    command: passwd username
     responses:
       (?i)password: "MySekretPa$$word"
   # you don't want to show passwords in your logs
@@ -98,7 +98,7 @@ EXAMPLES = r'''
 
 - name: Generic question with multiple different responses
   ansible.builtin.expect:
-    ansible.builtin.command: /path/to/custom/command
+    command: /path/to/custom/command
     responses:
       Question:
         - response1


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (ansible.builtin.expect) module: ansible.builtin.command Supported parameters include: chdir, command, creates, echo, removes, responses, timeout"}
```
