### PR TITLE
tests: Fix `test_ansible_version()` when run within a git checkout

### DIFF
--- a/test/units/cli/test_adhoc.py
+++ b/test/units/cli/test_adhoc.py
@@ -93,7 +93,7 @@ def test_run_no_extra_vars():
     assert exec_info.value.code == 2
 
 
-def test_ansible_version(capsys, mocker):
+def test_ansible_version(capsys):
     adhoc_cli = AdHocCLI(args=['/bin/ansible', '--version'])
     with pytest.raises(SystemExit):
         adhoc_cli.run()
@@ -105,7 +105,7 @@ def test_ansible_version(capsys, mocker):
         version_lines = version[0].splitlines()
 
     assert len(version_lines) == 9, 'Incorrect number of lines in "ansible --version" output'
-    assert re.match(r'ansible \[core [0-9.a-z]+\]$', version_lines[0]), 'Incorrect ansible version line in "ansible --version" output'
+    assert re.match(r'ansible \[core [0-9.a-z]+\]', version_lines[0]), 'Incorrect ansible version line in "ansible --version" output'
     assert re.match('  config file = .*$', version_lines[1]), 'Incorrect config file line in "ansible --version" output'
     assert re.match('  configured module search path = .*$', version_lines[2]), 'Incorrect module search path in "ansible --version" output'
     assert re.match('  ansible python module location = .*$', version_lines[3]), 'Incorrect python module location in "ansible --version" output'


### PR DESCRIPTION
##### SUMMARY

When running the unit tests locally, in a git clone, `ansible --test` prints additionl information about the git revision, e.g.

```
~/src/ansible$ ansible --version
ansible 2.10.8
...
~/src/ansible$ source hacking/env-setup
...

Setting up Ansible to run out of checkout...
...
~/src/ansible$ ansible --version
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
ansible [core 2.14.0.dev0] (test_ansible_version-devel df497ea13b) last updated 2022/08/25 10:37:07 (GMT +100)
...
```

which causes `test_ansible_version()` to fail.

Also removed an unused argument from previous parameterisation.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test

##### ADDITIONAL INFORMATION
